### PR TITLE
[BUZZOK-28215] Add slack notifications for PR's

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,37 @@
+name: Notify GenAI team on "Ready for review" PRs
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  notify-slack:
+    if: github.event.label.name == 'Ready for review'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send notification to Slack
+        run: |
+          SLACK_WEBHOOK_URL="${{ secrets.SLACK_WEBHOOK_URL }}"
+          PR_NR="${{ github.event.pull_request.number }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_ADDITIONS="${{ github.event.pull_request.additions }}"
+          PR_DELETIONS="${{ github.event.pull_request.deletions }}"
+          REPO_NAME="${{ github.event.repository.name }}"
+
+          curl -X POST -H 'Content-type: application/json' \
+          --data "{
+            \"text\": \"*Pull Request Ready for Review!*\", 
+            \"blocks\": [
+              {
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \"@buzok-team: :rocket: PR by ${PR_AUTHOR} needs a review: \`+${PR_ADDITIONS} -${PR_DELETIONS}\` <${PR_URL}|${REPO_NAME}#${PR_NR}: ${PR_TITLE}>\"
+                }
+              }
+            ]
+          }" \
+          $SLACK_WEBHOOK_URL


### PR DESCRIPTION
# RATIONALE
Adds github workflow to notify the team on slack about pending OSS reviews.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

---

## REVIEWERS

- Code Owners team: @datarobot-oss/genai-oss
- Code Owners users: @cavitcakir, @jpclemens0
