### PR TITLE
Fix wrong codeowners team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @datarobot-oss/Buzok @cavitcakir @jpclemens0
+* @datarobot-oss/buzok @cavitcakir @jpclemens0

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @datarobot-oss/genai-oss @cavitcakir @jpclemens0
+* @datarobot-oss/Buzok @cavitcakir @jpclemens0

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,5 +20,5 @@ the review may happen while you are asleep / otherwise not able to respond quick
 
 ## REVIEWERS
 
-- Code Owners team: @datarobot-oss/genai-oss
+- Code Owners team: @datarobot-oss/buzok
 - Code Owners users: @cavitcakir, @jpclemens0


### PR DESCRIPTION
# RATIONALE
Should be pointing to `buzok` https://github.com/orgs/datarobot-oss/teams/buzok
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

---

## REVIEWERS

- Code Owners team: @datarobot-oss/genai-oss
- Code Owners users: @cavitcakir, @jpclemens0
