### PR TITLE
[MODEL-20916] Port async changes from the template to the library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ dev = [
 disallow_untyped_defs = true
 disable_error_code = ["import-untyped"]
 ignore_missing_imports = true
+pretty = true
+show_absolute_path = true
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.26"
+version = "0.1.27"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/chat/responses.py
+++ b/src/datarobot_genai/core/chat/responses.py
@@ -101,14 +101,14 @@ def to_custom_model_streaming_response(
         "total_tokens": 0,
     }
     try:
-        agent_response = streaming_response_generator.__aiter__()
+        agent_response = aiter(streaming_response_generator)
         while True:
             try:
                 (
                     response_text,
                     pipeline_interactions,
                     usage_metrics,
-                ) = event_loop.run_until_complete(agent_response.__anext__())
+                ) = event_loop.run_until_complete(anext(agent_response))
                 last_pipeline_interactions = pipeline_interactions
                 last_usage_metrics = usage_metrics
 
@@ -130,6 +130,7 @@ def to_custom_model_streaming_response(
                     )
             except StopAsyncIteration:
                 break
+        event_loop.run_until_complete(streaming_response_generator.aclose())
         # Yield final chunk indicating end of stream
         choice = ChunkChoice(
             index=0,

--- a/src/datarobot_genai/core/chat/responses.py
+++ b/src/datarobot_genai/core/chat/responses.py
@@ -131,7 +131,7 @@ def to_custom_model_streaming_response(
             except StopAsyncIteration:
                 break
         # Yield final chunk indicating end of stream
-        choice = Choice(
+        choice = ChunkChoice(
             index=0,
             delta=ChoiceDelta(role="assistant"),
             finish_reason="stop",
@@ -152,7 +152,7 @@ def to_custom_model_streaming_response(
     except Exception as e:
         tb.print_exc()
         created = int(time.time())
-        choice = Choice(
+        choice = ChunkChoice(
             index=0,
             delta=ChoiceDelta(role="assistant", content=str(e), refusal="error"),
             finish_reason="stop",

--- a/tests/core/chat/test_client.py
+++ b/tests/core/chat/test_client.py
@@ -45,7 +45,8 @@ def test_tool_client_config(base_url: str, api_key: str) -> None:
 
 
 def test_tool_client_config_defaults() -> None:
-    tool_client = ToolClient()
-    assert tool_client.api_key is None
-    assert tool_client.base_url == "https://app.datarobot.com/"
-    assert tool_client.datarobot_api_endpoint == "https://app.datarobot.com/api/v2"
+    with patch.dict(os.environ,{}, clear=True):
+        tool_client = ToolClient()
+        assert tool_client.api_key is None
+        assert tool_client.base_url == "https://app.datarobot.com/"
+        assert tool_client.datarobot_api_endpoint == "https://app.datarobot.com/api/v2"

--- a/tests/core/chat/test_client.py
+++ b/tests/core/chat/test_client.py
@@ -45,7 +45,7 @@ def test_tool_client_config(base_url: str, api_key: str) -> None:
 
 
 def test_tool_client_config_defaults() -> None:
-    with patch.dict(os.environ,{}, clear=True):
+    with patch.dict(os.environ, {}, clear=True):
         tool_client = ToolClient()
         assert tool_client.api_key is None
         assert tool_client.base_url == "https://app.datarobot.com/"


### PR DESCRIPTION
# RATIONALE
- In af-components we changed `to_custom_model_streaming_response` in order to allow agent.invoke to be an async function. This PR syncs back the changes done in the af-component repository..
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

---

## REVIEWERS

- Code Owners team: @datarobot-oss/buzok
- Code Owners users: @cavitcakir, @jpclemens0
