### PR TITLE
[BUZZOK-28322] Move NAT agent to datarobot-genai

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.11', '3.12' ]
         module: [ 'core', 'crewai', 'langgraph', 'llamaindex', 'drmcp', 'nat']
+        exclude:
+          - python-version: '3.10'
+            module: 'nat'
     permissions:
       contents: read
       pull-requests: read

--- a/.mkfiles/tests.mk
+++ b/.mkfiles/tests.mk
@@ -1,14 +1,24 @@
 ##@ Tests
 
+PYTHON_MINOR_VERSION := $(shell uv run $(UV_RUN_OPTS) python -c 'import sys; print(sys.version_info.minor)')
+ifeq ($(PYTHON_MINOR_VERSION), 10)
+    NAT_IGNORED_TESTS := tests/nat
+    COV_FAIL_UNDER := 78
+else
+    NAT_IGNORED_TESTS := tests/nat/integration
+    COV_FAIL_UNDER := 80
+endif
+
+
 RESULTS := test-results.xml
 JUNIT_REPORT ?= test_results/$(RESULTS)
 JUNIT_FLAGS := --junitxml=$(JUNIT_REPORT)
 PYTEST_OPTS ?= $(JUNIT_FLAGS) -vv -s
-PYTEST_OPTS_W_COVERAGE ?= $(JUNIT_FLAGS) --cov=datarobot_genai --cov-branch --cov-fail-under=79 --no-cov-on-fail
+PYTEST_OPTS_W_COVERAGE ?= $(JUNIT_FLAGS) --cov=datarobot_genai --cov-branch --cov-fail-under=$(COV_FAIL_UNDER) --no-cov-on-fail
 
 .PHONY: test
 test: ## Run repo unit tests via pytest
-	uv run $(UV_RUN_OPTS) pytest $(PYTEST_OPTS_W_COVERAGE) tests --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
+	uv run $(UV_RUN_OPTS) pytest $(PYTEST_OPTS_W_COVERAGE) tests --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=$(NAT_IGNORED_TESTS)
 
 test-module: ## Run repo unit tests via pytest for a specific module
-	uv run $(UV_RUN_OPTS) pytest tests/$(MODULE) --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
+	uv run $(UV_RUN_OPTS) pytest tests/$(MODULE) --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=$(NAT_IGNORED_TESTS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.28"
+version = "0.1.29"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -1,0 +1,97 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import abc
+import logging
+from pathlib import Path
+from typing import Any
+
+from nat.runtime.loader import load_workflow
+from nat.utils.type_utils import StrPath
+from openai.types.chat import CompletionCreateParams
+
+from datarobot_genai.core.agents.base import BaseAgent
+from datarobot_genai.core.agents.base import InvokeReturn
+from datarobot_genai.core.agents.base import default_usage_metrics
+
+logger = logging.getLogger(__name__)
+
+
+class NatAgent(BaseAgent, abc.ABC):
+    async def invoke(self, completion_create_params: CompletionCreateParams) -> InvokeReturn:
+        """Run the agent with the provided completion parameters.
+
+        [THIS METHOD IS REQUIRED FOR THE AGENT TO WORK WITH DRUM SERVER]
+
+        Args:
+            completion_create_params: The completion request parameters including input topic
+            and settings.
+
+        Returns
+        -------
+            For streaming requests, returns a generator yielding tuples of (response_text,
+            pipeline_interactions, usage_metrics).
+            For non-streaming requests, returns a single tuple of (response_text,
+            pipeline_interactions, usage_metrics).
+
+        """
+        # Retrieve the starting user prompt from the CompletionCreateParams
+        user_messages = [
+            msg
+            for msg in completion_create_params["messages"]
+            # You can use other roles as needed (e.g. "system", "assistant")
+            if msg.get("role") == "user"
+        ]
+        user_prompt: Any = user_messages[0] if user_messages else {}
+        user_prompt_content = user_prompt.get("content", {})
+
+        # Print commands may need flush=True to ensure they are displayed in real-time.
+        print("Running agent with user prompt:", user_prompt_content, flush=True)
+
+        # Get the config file path
+        config_file = Path(__file__).parent / "workflow.yaml"
+
+        # Create and invoke the NAT (Nemo Agent Toolkit) Agentic Workflow with the inputs
+        result = await self.run_nat_workflow(config_file, user_prompt_content)
+
+        # Create a list of events from the event listener
+        events: list[Any]
+        events = []  # This should be populated with the agent's events/messages
+
+        usage_metrics = default_usage_metrics()
+        pipeline_interactions = self.create_pipeline_interactions_from_events(events)
+
+        return result, pipeline_interactions, usage_metrics
+
+    async def run_nat_workflow(self, config_file: StrPath, input_str: str) -> str:
+        """Run the NAT workflow with the provided config file and input string.
+
+        Args:
+            config_file: Path to the NAT workflow configuration file
+            input_str: Input string to process through the workflow
+
+        Returns
+        -------
+            str: The result from the NAT workflow
+        """
+        async with load_workflow(config_file) as workflow:
+            async with workflow.run(input_str) as runner:
+                runner_outputs = await runner.result(to_type=str)
+
+        line = f"{'-' * 50}"
+        prefix = f"{line}\nWorkflow Result:\n"
+        suffix = f"\n{line}"
+
+        print(f"{prefix}{runner_outputs}{suffix}")
+
+        return runner_outputs

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import abc
 import logging
 from typing import Any
 
@@ -26,7 +25,7 @@ from datarobot_genai.core.agents.base import default_usage_metrics
 logger = logging.getLogger(__name__)
 
 
-class NatAgent(BaseAgent, abc.ABC):
+class NatAgent(BaseAgent):
     def __init__(
         self,
         *,

--- a/tests/nat/test_agent.py
+++ b/tests/nat/test_agent.py
@@ -12,27 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ruff: noqa: E402
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-try:
-    from datarobot_genai.nat.agent import NatAgent
-
-    has_nat = True
-except ImportError:
-    has_nat = False
-
-
-# Skip the entire module if the Python version is 3.10
-pytestmark = pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor == 10 and not has_nat,
-    reason="NAT is not available for Python 3.10",
-)
+from datarobot_genai.nat.agent import NatAgent
 
 
 @pytest.fixture

--- a/tests/nat/test_agent.py
+++ b/tests/nat/test_agent.py
@@ -12,13 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: E402
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from datarobot_genai.nat.agent import NatAgent
+try:
+    from datarobot_genai.nat.agent import NatAgent
+
+    has_nat = True
+except ImportError:
+    has_nat = False
+
+
+# Skip the entire module if the Python version is 3.10
+pytestmark = pytest.mark.skipif(
+    sys.version_info.major == 3 and sys.version_info.minor == 10 and not has_nat,
+    reason="NAT is not available for Python 3.10",
+)
 
 
 @pytest.fixture

--- a/tests/nat/test_agent.py
+++ b/tests/nat/test_agent.py
@@ -1,0 +1,71 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.nat.agent import NatAgent
+
+
+@pytest.fixture
+def workflow_path():
+    return Path("some_path") / "workflow.yaml"
+
+
+@pytest.fixture
+def agent(workflow_path):
+    return NatAgent(workflow_path=workflow_path)
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_init_with_additional_kwargs(workflow_path):
+    """Test initialization with additional keyword arguments."""
+    # Setup
+    additional_kwargs = {"extra_param1": "value1", "extra_param2": 42}
+
+    # Execute
+    agent = NatAgent(workflow_path=workflow_path, **additional_kwargs)
+
+    # Verify that the extra parameters don't create attributes
+    with pytest.raises(AttributeError):
+        _ = agent.extra_param1
+
+
+async def test_run_method(agent, workflow_path):
+    # Patch the run_nat_workflow method
+    with patch.object(NatAgent, "run_nat_workflow", return_value="success"):
+        # Call the run method with test inputs
+        completion_create_params = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Artificial Intelligence"}],
+            "environment_var": True,
+        }
+        result, pipeline_interactions, usage = await agent.invoke(completion_create_params)
+
+        # Verify run_nat_workflow was called with the right inputs
+        agent.run_nat_workflow.assert_called_once_with(
+            workflow_path,
+            "Artificial Intelligence",
+        )
+
+        assert result == "success"
+        assert pipeline_interactions is None
+        assert usage == {
+            "completion_tokens": 0,
+            "prompt_tokens": 0,
+            "total_tokens": 0,
+        }

--- a/tests/nat/test_nat_adaptors.py
+++ b/tests/nat/test_nat_adaptors.py
@@ -12,32 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ruff: noqa: E402
-import sys
+from crewai import LLM
+from langchain_openai import ChatOpenAI
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.workflow_builder import WorkflowBuilder
 
-import pytest
-
-try:
-    from crewai import LLM
-    from langchain_openai import ChatOpenAI
-    from nat.builder.framework_enum import LLMFrameworkEnum
-    from nat.builder.workflow_builder import WorkflowBuilder
-
-    from datarobot_genai.nat.datarobot_llm_clients import DataRobotLiteLLM
-    from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMDeploymentModelConfig
-    from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMGatewayModelConfig
-    from datarobot_genai.nat.datarobot_llm_providers import DataRobotNIMModelConfig
-
-    has_nat = True
-except ImportError:
-    has_nat = False
-
-
-# Skip the entire module if the Python version is 3.10
-pytestmark = pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor == 10 and not has_nat,
-    reason="NAT is not available for Python 3.10",
-)
+from datarobot_genai.nat.datarobot_llm_clients import DataRobotLiteLLM
+from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMDeploymentModelConfig
+from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMGatewayModelConfig
+from datarobot_genai.nat.datarobot_llm_providers import DataRobotNIMModelConfig
 
 
 async def test_datarobot_llm_gateway_langchain():

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -939,7 +939,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE
The non-specific code should reside in the library. For the NAT template this is everything except the `workflow.yaml`.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Define the `NatAgent` based on the code in `af-component-agent`.
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

---

## REVIEWERS

- Code Owners team: @datarobot-oss/buzok
- Code Owners users: @cavitcakir, @jpclemens0
