### PR TITLE
[BUZZOK-28087] Initialize MCP Server OAuth middleware on startup and propagate headers in CrewAI MCP configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.28"
+version = "0.1.31"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -37,7 +37,6 @@ class AuthContextHeaderHandler:
         secret_key: str | None = None,
         algorithm: str = DEFAULT_ALGORITHM,
         validate_signature: bool = True,
-        token_expiration_seconds: int | None = None,
     ) -> None:
         """Initialize the handler.
 

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os
+import warnings
 from typing import Any
 
 import jwt
@@ -57,7 +58,7 @@ class AuthContextHeaderHandler:
         if algorithm is None:
             raise ValueError("Algorithm None is not allowed. Use a secure algorithm like HS256.")
 
-        self.secret_key = secret_key or os.getenv("SESSION_SECRET_KEY")
+        self.secret_key = secret_key or os.getenv("SESSION_SECRET_KEY", "")
         self.algorithm = algorithm
         self.validate_signature = validate_signature
 
@@ -80,10 +81,11 @@ class AuthContextHeaderHandler:
         if not auth_context:
             return None
 
-        if self.secret_key is None:
-            logger.warning(
-                "No secret key provided. JWT tokens will be unsigned. "
-                "This is insecure and should only be used for testing."
+        if not self.secret_key:
+            warnings.warn(
+                "No secret key provided. Please make sure SESSION_SECRET_KEY is set. "
+                "JWT tokens will be signed with an empty key. This is insecure and should "
+                "only be used for testing."
             )
 
         return jwt.encode(auth_context, self.secret_key, algorithm=self.algorithm)
@@ -93,7 +95,7 @@ class AuthContextHeaderHandler:
         if not token:
             return None
 
-        if self.secret_key is None and self.validate_signature:
+        if not self.secret_key and self.validate_signature:
             logger.error(
                 "No secret key provided. Cannot validate signature. "
                 "Provide a secret key or set validate_signature to False."

--- a/src/datarobot_genai/drmcp/core/auth.py
+++ b/src/datarobot_genai/drmcp/core/auth.py
@@ -145,3 +145,18 @@ async def get_access_token(provider: str | None = None) -> str:
     token_provider = OAuthAccessTokenProvider(await get_auth_context())
     access_token = token_provider.get_token(ToolAuth.OBO, provider)
     return access_token
+
+
+def initialize_oauth_middleware(mcp: Any, secret_key: str | None = None) -> None:
+    """Initialize and register OAuth middleware with the MCP server.
+
+    Parameters
+    ----------
+    mcp : FastMCP
+        The FastMCP server instance to register the middleware with.
+    secret_key : Optional[str]
+        Secret key for JWT validation. If None, uses the value from config.
+    """
+    middleware = OAuthMiddleWare(secret_key=secret_key)
+    mcp.add_middleware(middleware)
+    logger.info("OAuth middleware registered successfully")

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -23,6 +23,7 @@ from typing import Any
 from fastmcp import FastMCP
 from starlette.middleware import Middleware
 
+from .auth import initialize_oauth_middleware
 from .config import get_config
 from .credentials import get_credentials
 from .dynamic_tools.deployment.register import register_tools_of_datarobot_deployments
@@ -114,6 +115,9 @@ class DataRobotMCPServer:
 
         # Initialize telemetry
         initialize_telemetry(mcp)
+
+        # Initialize OAuth middleware
+        initialize_oauth_middleware(mcp)
 
         # Initialize memory manager if AWS credentials are available
         self._memory_manager: MemoryManager | None = None

--- a/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
@@ -69,10 +69,22 @@ def get_headers() -> dict[str, str]:
 
 
 @asynccontextmanager
-async def ete_test_mcp_session() -> AsyncGenerator[ClientSession, None]:
-    """Create an MCP session for each test."""
+async def ete_test_mcp_session(
+    additional_headers: dict[str, str] | None = None,
+) -> AsyncGenerator[ClientSession, None]:
+    """Create an MCP session for each test.
+
+    Parameters
+    ----------
+    additional_headers : dict[str, str], optional
+        Additional headers to include in the MCP session (e.g., auth headers for testing).
+    """
     try:
-        async with streamablehttp_client(url=get_dr_mcp_server_url(), headers=get_headers()) as (
+        headers = get_headers()
+        if additional_headers:
+            headers.update(additional_headers)
+
+        async with streamablehttp_client(url=get_dr_mcp_server_url(), headers=headers) as (
             read_stream,
             write_stream,
             _,

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -208,7 +208,9 @@ class TestMCPToolsContext:
                 assert call_args["transport"] == "streamable-http"
 
     @patch("datarobot_genai.crewai.mcp.MCPServerAdapter")
-    def test_mcp_tools_context_with_datarobot_deployment(self, mock_adapter, auth_context_data):
+    def test_mcp_tools_context_with_datarobot_deployment(
+        self, mock_adapter, agent_auth_context_data
+    ):
         """Test context manager with DataRobot deployment ID."""
         mock_tools = [MagicMock()]
         mock_adapter_instance = MagicMock()
@@ -223,7 +225,7 @@ class TestMCPToolsContext:
 
         # When the agent is initialized, it sets the authorization context for the
         # process, so subsequent tools and MCP calls receive it via a dedicated header.
-        set_authorization_context(auth_context_data)
+        set_authorization_context(agent_auth_context_data)
 
         with patch.dict(
             os.environ,

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -42,10 +42,6 @@ class TestMCPConfig:
     def empty_agent_auth_context(self):
         set_authorization_context({})
 
-    @pytest.fixture
-    def agent_auth_context(self, auth_context_data):
-        set_authorization_context(auth_context_data)
-
     def test_mcp_config_without_configuration(self):
         """Test MCP config when no environment variables are set."""
         with patch.dict(os.environ, {}, clear=True):
@@ -181,6 +177,10 @@ class TestMCPConfig:
 
 class TestMCPToolsContext:
     """Test MCP tools context manager."""
+
+    @pytest.fixture(autouse=True)
+    def empty_agent_auth_context(self):
+        set_authorization_context({})
 
     def test_mcp_tools_context_no_configuration(self):
         """Test context manager when no MCP server is configured."""

--- a/tests/drmcp/acceptance/test_auth.py
+++ b/tests/drmcp/acceptance/test_auth.py
@@ -1,0 +1,144 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import os
+from typing import Any
+from unittest.mock import patch
+
+import jwt
+import pytest
+
+from datarobot_genai.drmcp.core.auth import get_auth_context
+from datarobot_genai.drmcp.core.mcp_instance import mcp
+from datarobot_genai.drmcp.test_utils.mcp_utils_ete import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
+from datarobot_genai.drmcp.test_utils.tool_base_ete import ETETestExpectations
+from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolBaseE2E
+from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectations
+
+
+# Register a test tool that uses auth context
+@mcp.tool(
+    name="get_auth_context_user_info",
+    description="Tool that returns user information from auth context",
+)
+async def test_auth_context_tool() -> str:
+    """
+    Test tool that retrieves and returns user info from the authorization context.
+
+    Returns
+    -------
+    String with user information from the auth context.
+    """
+    auth_ctx = await get_auth_context()
+    return (
+        f"User ID: {auth_ctx.user.id}, "
+        f"User Name: {auth_ctx.user.name}, "
+        f"User Email: {auth_ctx.user.email}"
+    )
+
+
+@pytest.fixture(scope="session")
+def secret_key() -> str:
+    """Return a test secret key for JWT signing."""
+    return "acceptance-test-secret-key-12345"
+
+
+@pytest.fixture(scope="session")
+def auth_context_data() -> dict[str, Any]:
+    """Return sample authorization context data matching AuthCtx structure."""
+    return {
+        "user": {
+            "id": "acc_user_456",
+            "name": "Acceptance Test User",
+            "email": "acceptance@example.com",
+        },
+        "identities": [
+            {
+                "id": "identity_789",
+                "type": "user",
+                "provider_type": "google",
+                "provider_user_id": "google_user_123",
+            }
+        ],
+        "metadata": {"session_id": "acceptance_session_999"},
+    }
+
+
+@pytest.fixture(scope="session")
+def auth_token(auth_context_data: dict[str, Any], secret_key: str) -> str:
+    """Generate a valid JWT token from auth context data using PyJWT."""
+    return jwt.encode(auth_context_data, secret_key, algorithm="HS256")
+
+
+@pytest.fixture(scope="session")
+def expectations_for_auth_context_tool_success(
+    auth_context_data: dict[str, Any],
+) -> ETETestExpectations:
+    """Return expected results when tool is called with valid auth token."""
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="get_auth_context_user_info",
+                parameters={},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            auth_context_data["user"]["id"],
+            auth_context_data["user"]["name"],
+            auth_context_data["user"]["email"],
+        ],
+    )
+
+
+@pytest.mark.asyncio
+class TestAuthContextE2E(ToolBaseE2E):
+    """End-to-end acceptance tests for OAuth middleware and auth context propagation."""
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            """Please help me check my user info within auth context using
+            available tools. I need to know my user ID, name, and email.
+            """
+        ],
+    )
+    async def test_auth_context_tool_with_valid_token(
+        self,
+        openai_llm_client: Any,
+        expectations_for_auth_context_tool_success: ETETestExpectations,
+        prompt: str,
+        auth_token: str,
+        secret_key: str,
+    ) -> None:
+        """Test OAuth middleware processes auth header and tool accesses auth context."""
+        # Set the secret key in environment so the server can validate tokens
+        with patch.dict(os.environ, {"SESSION_SECRET_KEY": secret_key}, clear=False):
+            # Create MCP session with auth headers
+            async with ete_test_mcp_session(
+                additional_headers={"X-DataRobot-Authorization-Context": auth_token}
+            ) as session:
+                await self._run_test_with_expectations(
+                    prompt,
+                    expectations_for_auth_context_tool_success,
+                    openai_llm_client,
+                    session,
+                    (
+                        inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
+                        if inspect.currentframe()
+                        else "test_auth_context_tool_with_valid_token"
+                    ),
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -939,7 +939,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.29"
+version = "0.1.31"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },

--- a/uv.lock
+++ b/uv.lock
@@ -939,7 +939,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE
In the previous [PR](https://github.com/datarobot-oss/datarobot-genai/pull/26) introduced middleware and utils needed for authorization context propagation. This is a follow up where the middleware is initialized.

Separate change is instrumenting CrewAI Agent to propagate authorization headers to the MCP Server.

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

---

## REVIEWERS

- Code Owners team: @datarobot-oss/buzok
- Code Owners users: @cavitcakir, @jpclemens0
