### PR TITLE
[MODEL-20916] Integrate MCP with the langgraph agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.35"
+version = "0.1.36"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.34"
+version = "0.1.35"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -18,17 +18,20 @@ import os
 from collections.abc import AsyncGenerator
 from collections.abc import Mapping
 from typing import Any
+from typing import Generic
 from typing import TypedDict
+from typing import TypeVar
 from typing import cast
 
-from langchain_core.tools import BaseTool
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
 
 from datarobot_genai.core.utils.urls import get_api_base
 
+TTool = TypeVar("TTool")
 
-class BaseAgent(abc.ABC):
+
+class BaseAgent(Generic[TTool], abc.ABC):
     """BaseAgent centralizes common initialization for agent templates.
 
     Fields:
@@ -61,13 +64,13 @@ class BaseAgent(abc.ABC):
             self.verbose = True
         else:
             self.verbose = bool(verbose)
-        self._mcp_tools: list[BaseTool] = []
+        self._mcp_tools: list[TTool] = []
 
-    def set_mcp_tools(self, tools: list[Any]) -> None:
+    def set_mcp_tools(self, tools: list[TTool]) -> None:
         self._mcp_tools = tools
 
     @property
-    def mcp_tools(self) -> list[Any]:
+    def mcp_tools(self) -> list[TTool]:
         """Return the list of MCP tools available to this agent.
 
         Subclasses can use this to wire tools into CrewAI agents/tasks during

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -21,6 +21,7 @@ from typing import Any
 from typing import TypedDict
 from typing import cast
 
+from langchain_core.tools import BaseTool
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
 
@@ -60,6 +61,19 @@ class BaseAgent(abc.ABC):
             self.verbose = True
         else:
             self.verbose = bool(verbose)
+        self._mcp_tools: list[BaseTool] = []
+
+    def set_mcp_tools(self, tools: list[Any]) -> None:
+        self._mcp_tools = tools
+
+    @property
+    def mcp_tools(self) -> list[Any]:
+        """Return the list of MCP tools available to this agent.
+
+        Subclasses can use this to wire tools into CrewAI agents/tasks during
+        workflow construction inside ``build_crewai_workflow``.
+        """
+        return self._mcp_tools
 
     def litellm_api_base(self, deployment_id: str | None) -> str:
         return get_api_base(self.api_base, deployment_id)

--- a/src/datarobot_genai/crewai/base.py
+++ b/src/datarobot_genai/crewai/base.py
@@ -52,22 +52,6 @@ class CrewAIAgent(BaseAgent, abc.ABC):
     construction.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._mcp_tools: list[Any] = []
-
-    def set_mcp_tools(self, tools: list[Any]) -> None:
-        self._mcp_tools = tools
-
-    @property
-    def mcp_tools(self) -> list[Any]:
-        """Return the list of MCP tools available to this agent.
-
-        Subclasses can use this to wire tools into CrewAI agents/tasks during
-        workflow construction inside ``build_crewai_workflow``.
-        """
-        return self._mcp_tools
-
     @property
     @abc.abstractmethod
     def agents(self) -> list[Any]:  # CrewAI Agent list

--- a/src/datarobot_genai/crewai/base.py
+++ b/src/datarobot_genai/crewai/base.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from crewai import Crew
 from crewai.events.event_bus import CrewAIEventsBus
+from crewai.tools import BaseTool
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
 
@@ -44,7 +45,7 @@ from .agent import create_pipeline_interactions_from_messages
 from .mcp import mcp_tools_context
 
 
-class CrewAIAgent(BaseAgent, abc.ABC):
+class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
     """Abstract base agent for CrewAI workflows.
 
     Subclasses should define the ``agents`` and ``tasks`` properties

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -18,7 +18,6 @@ MCP integration for CrewAI using MCPServerAdapter.
 This module provides MCP server connection management for CrewAI agents.
 """
 
-import traceback
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
@@ -43,21 +42,12 @@ def mcp_tools_context(
 
     print(f"Connecting to MCP server: {config.server_config['url']}", flush=True)
 
-    try:
-        # Use MCPServerAdapter as context manager with the server config
-        adapter_setting = config.server_config.copy()
-        adapter_setting["transport"] = "streamable-http"
-        with MCPServerAdapter(adapter_setting) as tools:
-            print(
-                f"Successfully connected to MCP server, got {len(tools)} tools",
-                flush=True,
-            )
-            yield tools
-
-    except Exception as e:
+    # Use MCPServerAdapter as context manager with the server config
+    adapter_setting = config.server_config.copy()
+    adapter_setting["transport"] = "streamable-http"
+    with MCPServerAdapter(adapter_setting) as tools:
         print(
-            f"Warning: Failed to connect to MCP server {config.server_config['url']}: {e}"
-            f"\n{traceback.format_exc()}",
+            f"Successfully connected to MCP server, got {len(tools)} tools",
             flush=True,
         )
-        yield []
+        yield tools

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -30,6 +30,7 @@ from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
+from datarobot_genai.langgraph.mcp import mcp_tools_context
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,11 @@ class LangGraphAgent(BaseAgent, abc.ABC):
             For non-streaming requests, returns a single tuple of (response_text,
             pipeline_interactions, usage_metrics).
         """
+        async with mcp_tools_context(api_base=self.api_base, api_key=self.api_key) as mcp_tools:
+            self.set_mcp_tools(mcp_tools)
+            return await self._invoke(completion_create_params)
+
+    async def _invoke(self, completion_create_params: CompletionCreateParams) -> InvokeReturn:
         input_command = self.convert_input_message(completion_create_params)
         logger.info(
             f"Running a langgraph agent with a command: {input_command}",

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -178,7 +178,8 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
         messages = []
         for e in events:
             for _, v in e.items():
-                messages.extend(v.get("messages", []))
+                if v is not None:
+                    messages.extend(v.get("messages", []))
         messages = [m for m in messages if not isinstance(m, ToolMessage)]
         ragas_trace = convert_to_ragas_messages(messages)
         return MultiTurnSample(user_input=ragas_trace)

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -16,6 +16,7 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from langchain.tools import BaseTool
 from langchain_core.messages import AIMessageChunk
 from langchain_core.messages import ToolMessage
 from langchain_core.prompts import ChatPromptTemplate
@@ -35,7 +36,7 @@ from datarobot_genai.langgraph.mcp import mcp_tools_context
 logger = logging.getLogger(__name__)
 
 
-class LangGraphAgent(BaseAgent, abc.ABC):
+class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
     @property
     @abc.abstractmethod
     def workflow(self) -> StateGraph[MessagesState]:

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import traceback
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -50,15 +49,8 @@ async def mcp_tools_context(
     else:
         raise RuntimeError("Unsupported MCP transport specified.")
 
-    try:
-        async with create_session(connection=connection) as session:
-            # Use the connection to load available MCP tools
-            tools = await load_mcp_tools(session=session)
-            print(f"Successfully loaded {len(tools)} MCP tools", flush=True)
-            yield tools
-    except Exception as e:
-        print(
-            f"Warning: Failed to load MCP tools from {url}: {e}\n{traceback.format_exc()}",
-            flush=True,
-        )
-        yield []
+    async with create_session(connection=connection) as session:
+        # Use the connection to load available MCP tools
+        tools = await load_mcp_tools(session=session)
+        print(f"Successfully loaded {len(tools)} MCP tools", flush=True)
+        yield tools

--- a/src/datarobot_genai/llama_index/base.py
+++ b/src/datarobot_genai/llama_index/base.py
@@ -27,6 +27,7 @@ import inspect
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from llama_index.core.tools import BaseTool
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
 
@@ -40,7 +41,7 @@ from datarobot_genai.core.agents.base import is_streaming
 from .agent import create_pipeline_interactions_from_events
 
 
-class LlamaIndexAgent(BaseAgent, abc.ABC):
+class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
     """Abstract base agent for LlamaIndex workflows."""
 
     @abc.abstractmethod

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -25,7 +25,7 @@ from datarobot_genai.core.agents.base import default_usage_metrics
 logger = logging.getLogger(__name__)
 
 
-class NatAgent(BaseAgent):
+class NatAgent(BaseAgent[None]):
     def __init__(
         self,
         *,

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -100,15 +100,6 @@ class TestMCPToolsContext:
                 assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
                 assert call_args["headers"]["X-DataRobot-Authorization-Context"] is not None
 
-    def test_mcp_tools_context_connection_error(self, mock_adapter):
-        """Test context manager handles connection errors gracefully."""
-        mock_adapter.side_effect = Exception("Connection failed")
-
-        test_url = "https://mcp-server.example.com/mcp"
-        with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            with mcp_tools_context() as tools:
-                assert tools == []
-
     def test_mcp_tools_context_with_parameters(self, mock_adapter):
         """Test context manager with explicit api_base and api_key parameters."""
         deployment_id = "abc123def456789012345678"

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -164,15 +164,6 @@ class TestMCPToolsContext:
                     session=setup_session_and_tools["session_instance"]
                 )
 
-    async def test_mcp_tools_context_connection_error(self, mock_session, mock_connections):
-        # Mock session to raise an exception
-        mock_session.side_effect = Exception("Connection failed")
-        external_url = "https://mcp-server.example.com/mcp"
-
-        with patch.dict(os.environ, {"EXTERNAL_MCP_URL": external_url}, clear=True):
-            async with mcp_tools_context() as tools:
-                assert tools == []
-
     async def test_mcp_tools_context_with_parameters(
         self, mock_connections, setup_session_and_tools, agent_auth_context_data
     ):


### PR DESCRIPTION
# RATIONALE
After [this previous PR ](https://github.com/datarobot-oss/datarobot-genai/pull/36)added the mcp_tools_context for langgraph, this PR uses it in the langgraph agent. [This PR](https://github.com/datarobot-community/af-component-agent/pull/280) contains the changes necessary in the af-component repository to make everything work E2E.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

---

## REVIEWERS

- Code Owners team: @datarobot-oss/buzok
- Code Owners users: @cavitcakir, @jpclemens0
