### PR TITLE
[MODEL-21141] Use DataRobotAppFrameworkBaseSettings for the MCPConfig 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.60"
+version = "0.1.61"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/mcp/common.py
+++ b/src/datarobot_genai/core/mcp/common.py
@@ -132,15 +132,15 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
                 "headers": headers,
             }
             return config
-        elif self.mcp_deployment_id and self.datarobot_api_token:
+        elif self.mcp_deployment_id:
             # DataRobot deployment ID - requires authentication
             if self.datarobot_endpoint is None:
                 raise ValueError(
-                    "When using a DataRobot hosted MCP deployment, api_base must be set."
+                    "When using a DataRobot hosted MCP deployment, datarobot_endpoint must be set."
                 )
             if self.datarobot_api_token is None:
                 raise ValueError(
-                    "When using a DataRobot hosted MCP deployment, api_key must be set."
+                    "When using a DataRobot hosted MCP deployment, datarobot_api_token must be set."
                 )
             base_url = self.datarobot_endpoint.rstrip("/")
             if not base_url.endswith("/api/v2"):

--- a/src/datarobot_genai/core/mcp/common.py
+++ b/src/datarobot_genai/core/mcp/common.py
@@ -73,7 +73,7 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
         candidate = value.strip()
 
         if not re.fullmatch(r"[0-9a-fA-F]{24}", candidate):
-            msg = "mcp_deployment_id must be a valid 24-character hex ObjectId"
+            msg = "mcp_deployment_id must be a valid 24-character hex ID"
             raise ValueError(msg)
 
         return candidate

--- a/src/datarobot_genai/core/mcp/common.py
+++ b/src/datarobot_genai/core/mcp/common.py
@@ -90,13 +90,13 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
         return {"Authorization": auth}
 
     @property
-    def auth_context_handler(self):
+    def auth_context_handler(self) -> AuthContextHeaderHandler:
         if self._auth_context_handler is None:
             self._auth_context_handler = AuthContextHeaderHandler()
         return self._auth_context_handler
 
     @property
-    def server_config(self):
+    def server_config(self) -> dict[str, Any] | None:
         if self._server_config is None:
             self._server_config = self._build_server_config()
         return self._server_config

--- a/src/datarobot_genai/core/mcp/common.py
+++ b/src/datarobot_genai/core/mcp/common.py
@@ -36,6 +36,7 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
     mcp_deployment_id: str | None = None
     datarobot_endpoint: str | None = None
     datarobot_api_token: str | None = None
+    authorization_context: dict[str, Any] | None = None
 
     _auth_context_handler: AuthContextHeaderHandler | None = None
     _server_config: dict[str, Any] | None = None

--- a/src/datarobot_genai/crewai/base.py
+++ b/src/datarobot_genai/crewai/base.py
@@ -92,8 +92,6 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
         # Use MCP context manager to handle connection lifecycle
         with mcp_tools_context(
-            api_base=self.api_base,
-            api_key=self.api_key,
             authorization_context=self._authorization_context,
         ) as mcp_tools:
             # Set MCP tools for all agents if MCP is not configured this is effectively a no-op

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -32,10 +32,7 @@ def mcp_tools_context(
     authorization_context: dict[str, Any] | None = None,
 ) -> Generator[list[Any], None, None]:
     """Context manager for MCP tools that handles connection lifecycle."""
-    config = MCPConfig(
-        authorization_context=authorization_context
-    )
-
+    config = MCPConfig(authorization_context=authorization_context)
     # If no MCP server configured, return empty tools list
     if not config.server_config:
         print("No MCP server configured, using empty tools list", flush=True)

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -29,13 +29,11 @@ from datarobot_genai.core.mcp.common import MCPConfig
 
 @contextmanager
 def mcp_tools_context(
-    api_base: str | None = None,
-    api_key: str | None = None,
     authorization_context: dict[str, Any] | None = None,
 ) -> Generator[list[Any], None, None]:
     """Context manager for MCP tools that handles connection lifecycle."""
     config = MCPConfig(
-        api_base=api_base, api_key=api_key, authorization_context=authorization_context
+        authorization_context=authorization_context
     )
 
     # If no MCP server configured, return empty tools list
@@ -47,10 +45,8 @@ def mcp_tools_context(
     print(f"Connecting to MCP server: {config.server_config['url']}", flush=True)
 
     # Use MCPServerAdapter as context manager with the server config
-    adapter_setting = config.server_config.copy()
-    adapter_setting["transport"] = "streamable-http"
     try:
-        with MCPServerAdapter(adapter_setting) as tools:
+        with MCPServerAdapter(config.server_config) as tools:
             print(
                 f"Successfully connected to MCP server, got {len(tools)} tools",
                 flush=True,

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -84,8 +84,6 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
                 tuple[str, Any | None, UsageMetrics], None
             ]:
                 async with mcp_tools_context(
-                    api_base=self.api_base,
-                    api_key=self.api_key,
                     authorization_context=self._authorization_context,
                 ) as mcp_tools:
                     self.set_mcp_tools(mcp_tools)
@@ -104,8 +102,6 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
         else:
             # For non-streaming, use async with directly
             async with mcp_tools_context(
-                api_base=self.api_base,
-                api_key=self.api_key,
                 authorization_context=self._authorization_context,
             ) as mcp_tools:
                 self.set_mcp_tools(mcp_tools)

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -27,8 +27,6 @@ from datarobot_genai.core.mcp.common import MCPConfig
 
 @asynccontextmanager
 async def mcp_tools_context(
-    api_base: str | None = None,
-    api_key: str | None = None,
     authorization_context: dict[str, Any] | None = None,
 ) -> AsyncGenerator[list[BaseTool], None]:
     """Yield a list of LangChain BaseTool instances loaded via MCP.
@@ -45,7 +43,7 @@ async def mcp_tools_context(
         Authorization context to use for MCP connections
     """
     mcp_config = MCPConfig(
-        api_base=api_base, api_key=api_key, authorization_context=authorization_context
+        authorization_context=authorization_context
     )
     server_config = mcp_config.server_config
 

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -35,16 +35,10 @@ async def mcp_tools_context(
 
     Parameters
     ----------
-    api_base : str | None
-        Base URL for the DataRobot API
-    api_key : str | None
-        API key for authentication
     authorization_context : dict[str, Any] | None
         Authorization context to use for MCP connections
     """
-    mcp_config = MCPConfig(
-        authorization_context=authorization_context
-    )
+    mcp_config = MCPConfig(authorization_context=authorization_context)
     server_config = mcp_config.server_config
 
     if not server_config:

--- a/src/datarobot_genai/llama_index/base.py
+++ b/src/datarobot_genai/llama_index/base.py
@@ -83,8 +83,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
         # Load MCP tools (if configured) asynchronously before building workflow
         mcp_tools = await load_mcp_tools(
-            api_base=self.api_base,
-            api_key=self.api_key,
             authorization_context=self._authorization_context,
         )
         self.set_mcp_tools(mcp_tools)

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -41,9 +41,7 @@ async def load_mcp_tools(
     -------
         List of MCP tools, or empty list if no MCP configuration is present.
     """
-    config = MCPConfig(
-        authorization_context=authorization_context
-    )
+    config = MCPConfig(authorization_context=authorization_context)
     server_params = config.server_config
 
     if not server_params:

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -29,16 +29,12 @@ from datarobot_genai.core.mcp.common import MCPConfig
 
 
 async def load_mcp_tools(
-    api_base: str | None = None,
-    api_key: str | None = None,
     authorization_context: dict[str, Any] | None = None,
 ) -> list[Any]:
     """
     Asynchronously load MCP tools for LlamaIndex.
 
     Args:
-        api_base: Optional DataRobot API base URL
-        api_key: Optional DataRobot API token
         authorization_context: Optional authorization context for MCP connections
 
     Returns
@@ -46,7 +42,7 @@ async def load_mcp_tools(
         List of MCP tools, or empty list if no MCP configuration is present.
     """
     config = MCPConfig(
-        api_base=api_base, api_key=api_key, authorization_context=authorization_context
+        authorization_context=authorization_context
     )
     server_params = config.server_config
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,8 @@ def agent_auth_context_data() -> dict[str, Any]:
         ],
     }
 
-@pytest.fixture(autouse=True, scope='session')
+
+@pytest.fixture(autouse=True, scope="session")
 def disable_env_file(monkeypatch):
     """Disable loading of .env file for MCPConfig and related settings classes.
 
@@ -38,9 +39,7 @@ def disable_env_file(monkeypatch):
     This fixture patches the class-level config so any implicit .env lookup is skipped.
     """
     # Pydantic v2: model_config is a mapping; ensure env_file fields are disabled.
-    if hasattr(MCPConfig, "model_config") and isinstance(
-        getattr(MCPConfig, "model_config"), dict
-    ):
+    if hasattr(MCPConfig, "model_config") and isinstance(getattr(MCPConfig, "model_config"), dict):
         # Create a shallow copy to avoid mutating original dict in-place across tests.
         new_config = {**MCPConfig.model_config}
         new_config["env_file"] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def agent_auth_context_data() -> dict[str, Any]:
     }
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="function")
 def disable_env_file(monkeypatch):
     """Disable loading of .env file for MCPConfig and related settings classes.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import pytest
 
+from datarobot_genai.core.mcp.common import MCPConfig
+
 
 @pytest.fixture
 def agent_auth_context_data() -> dict[str, Any]:
@@ -26,3 +28,25 @@ def agent_auth_context_data() -> dict[str, Any]:
             {"id": "id123", "type": "user", "provider_type": "github", "provider_user_id": "123"}
         ],
     }
+
+@pytest.fixture(autouse=True, scope='session')
+def disable_env_file(monkeypatch):
+    """Disable loading of .env file for MCPConfig and related settings classes.
+
+    Pydantic BaseSettings uses ``model_config.env_file`` to pull values from an env file.
+    Tests should rely solely on explicit parameters / injected environment variables.
+    This fixture patches the class-level config so any implicit .env lookup is skipped.
+    """
+    # Pydantic v2: model_config is a mapping; ensure env_file fields are disabled.
+    if hasattr(MCPConfig, "model_config") and isinstance(
+        getattr(MCPConfig, "model_config"), dict
+    ):
+        # Create a shallow copy to avoid mutating original dict in-place across tests.
+        new_config = {**MCPConfig.model_config}
+        new_config["env_file"] = None
+        new_config["env_file_encoding"] = None
+        monkeypatch.setattr(MCPConfig, "model_config", new_config, raising=False)
+    else:
+        # Fallback: attempt attribute patching if object-like.
+        monkeypatch.setattr(MCPConfig.model_config, "env_file", None, raising=False)
+        monkeypatch.setattr(MCPConfig.model_config, "env_file_encoding", None, raising=False)

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -226,7 +226,7 @@ class TestMCPConfig:
             {"MCP_DEPLOYMENT_ID": deployment_id},
             clear=True,
         ):
-            config = MCPConfig(api_base=api_base, api_key=api_key)
+            config = MCPConfig()
             expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
             assert config.server_config["url"] == expected_url
             assert config.server_config["headers"]["Authorization"] == f"Bearer {api_key}"

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -29,28 +29,6 @@ class TestMCPConfig:
     def empty_agent_auth_context(self):
         set_authorization_context({})
 
-    @pytest.fixture(autouse=True)
-    def disable_env_file(self, monkeypatch):
-        """Disable loading of .env file for MCPConfig and related settings classes.
-
-        Pydantic BaseSettings uses ``model_config.env_file`` to pull values from an env file.
-        Tests should rely solely on explicit parameters / injected environment variables.
-        This fixture patches the class-level config so any implicit .env lookup is skipped.
-        """
-        # Pydantic v2: model_config is a mapping; ensure env_file fields are disabled.
-        if hasattr(MCPConfig, "model_config") and isinstance(
-            getattr(MCPConfig, "model_config"), dict
-        ):
-            # Create a shallow copy to avoid mutating original dict in-place across tests.
-            new_config = {**MCPConfig.model_config}
-            new_config["env_file"] = None
-            new_config["env_file_encoding"] = None
-            monkeypatch.setattr(MCPConfig, "model_config", new_config, raising=False)
-        else:
-            # Fallback: attempt attribute patching if object-like.
-            monkeypatch.setattr(MCPConfig.model_config, "env_file", None, raising=False)
-            monkeypatch.setattr(MCPConfig.model_config, "env_file_encoding", None, raising=False)
-
     def test_mcp_config_without_configuration(self):
         """Test MCP config when no environment variables are set."""
         with patch.dict(os.environ, {}, clear=True):

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -223,7 +223,11 @@ class TestMCPConfig:
         api_key = "fake_api_key"
         with patch.dict(
             os.environ,
-            {"MCP_DEPLOYMENT_ID": deployment_id},
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "DATAROBOT_ENDPOINT": api_base,
+                "DaTAROBOT_API_TOKEN": api_key,
+            },
             clear=True,
         ):
             config = MCPConfig()
@@ -375,3 +379,221 @@ class TestMCPConfig:
                     **config._authorization_context_header(),
                 }
                 assert headers == {"Authorization": f"Bearer {api_key}"}
+
+    def test_mcp_config_with_direct_authorization_context(self, agent_auth_context_data):
+        """Test MCPConfig with direct authorization_context parameter."""
+        deployment_id = "abc123def456789012345678"
+        secret_key = "test-secret-key"
+
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "SESSION_SECRET_KEY": secret_key,
+            },
+            clear=True,
+        ):
+            config = MCPConfig(
+                authorization_context=agent_auth_context_data,
+            )
+            assert config.authorization_context == agent_auth_context_data
+
+            # Verify header is generated correctly
+            header = config._authorization_context_header()
+            assert "X-DataRobot-Authorization-Context" in header
+
+            # Verify token can be decoded
+            token = header["X-DataRobot-Authorization-Context"]
+            decoded = config.auth_context_handler.decode(token)
+            assert decoded == agent_auth_context_data
+
+    def test_mcp_config_authorization_context_priority_direct_over_contextvar(
+        self, agent_auth_context_data
+    ):
+        """Test that direct authorization_context param takes priority over ContextVar."""
+        deployment_id = "abc123def456789012345678"
+        secret_key = "test-secret-key"
+
+        # Set different context in ContextVar
+        contextvar_auth = {"user": {"id": "999", "name": "contextvar"}, "identities": []}
+        set_authorization_context(contextvar_auth)
+
+        # Create config with explicit authorization_context
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "SESSION_SECRET_KEY": secret_key,
+            },
+            clear=True,
+        ):
+            config = MCPConfig(
+                authorization_context=agent_auth_context_data,
+            )
+
+            # Verify the direct param is used, not the ContextVar
+            header = config._authorization_context_header()
+            token = header["X-DataRobot-Authorization-Context"]
+            decoded = config.auth_context_handler.decode(token)
+            assert decoded == agent_auth_context_data
+            assert decoded != contextvar_auth
+
+    def test_mcp_config_with_empty_authorization_context(self):
+        """Test MCPConfig with empty authorization_context dict."""
+        deployment_id = "abc123def456789012345678"
+
+        with patch.dict(
+            os.environ,
+            {"MCP_DEPLOYMENT_ID": deployment_id},
+            clear=True,
+        ):
+            config = MCPConfig(
+                authorization_context={},
+            )
+
+            # Empty context should not generate a header
+            header = config._authorization_context_header()
+            assert header == {}
+
+    def test_mcp_config_with_none_authorization_context(self, agent_auth_context_data):
+        """Test MCPConfig with None authorization_context falls back to ContextVar."""
+        deployment_id = "abc123def456789012345678"
+        secret_key = "test-secret-key"
+
+        # Set context in ContextVar
+        set_authorization_context(agent_auth_context_data)
+
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "SESSION_SECRET_KEY": secret_key,
+            },
+            clear=True,
+        ):
+            # Pass None explicitly - should fall back to ContextVar
+            config = MCPConfig(
+                authorization_context=None,
+            )
+
+            # Should fall back to ContextVar
+            header = config._authorization_context_header()
+            assert "X-DataRobot-Authorization-Context" in header
+
+            token = header["X-DataRobot-Authorization-Context"]
+            decoded = config.auth_context_handler.decode(token)
+            assert decoded == agent_auth_context_data
+
+    def test_mcp_config_authorization_context_with_complex_data(self):
+        """Test authorization_context with complex nested data structures."""
+        deployment_id = "abc123def456789012345678"
+        secret_key = "test-secret-key"
+
+        complex_auth_context = {
+            "user": {"id": "123", "name": "test", "email": "test@example.com"},
+            "identities": [
+                {
+                    "id": "id123",
+                    "type": "user",
+                    "provider_type": "github",
+                    "provider_user_id": "123",
+                    "metadata": {"repos": ["repo1", "repo2"], "stars": 42},
+                }
+            ],
+            "permissions": ["read", "write", "admin"],
+            "nested": {"level1": {"level2": {"level3": "deep value"}}},
+        }
+
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "SESSION_SECRET_KEY": secret_key,
+            },
+            clear=True,
+        ):
+            config = MCPConfig(
+                authorization_context=complex_auth_context,
+            )
+
+            header = config._authorization_context_header()
+            token = header["X-DataRobot-Authorization-Context"]
+            decoded = config.auth_context_handler.decode(token)
+
+            # Verify all nested data is preserved
+            assert decoded == complex_auth_context
+            assert decoded["nested"]["level1"]["level2"]["level3"] == "deep value"
+
+    def test_mcp_config_authorization_context_with_external_mcp(self, agent_auth_context_data):
+        """Test that authorization_context is stored but not used for external MCP."""
+        test_url = "https://external-mcp.example.com/mcp"
+        secret_key = "test-secret-key"
+
+        with patch.dict(
+            os.environ,
+            {
+                "EXTERNAL_MCP_URL": test_url,
+                "SESSION_SECRET_KEY": secret_key,
+            },
+            clear=True,
+        ):
+            config = MCPConfig(authorization_context=agent_auth_context_data)
+
+            # Config should store the context
+            assert config.authorization_context == agent_auth_context_data
+
+            # But server config should not include the auth context header for external MCP
+            assert "X-DataRobot-Authorization-Context" not in config.server_config["headers"]
+
+    def test_mcp_config_authorization_context_roundtrip(self, agent_auth_context_data):
+        """Test full encode-decode roundtrip of authorization_context."""
+        deployment_id = "abc123def456789012345678"
+        api_base = "https://app.datarobot.com/api/v2"
+        api_key = "fake_api_key"
+        secret_key = "test-secret-key"
+
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "SESSION_SECRET_KEY": secret_key,
+                "DATAROBOT_API_TOKEN": api_key,
+                "DATAROBOT_ENDPOINT": api_base,
+            },
+            clear=True,
+        ):
+            # Create config with auth context
+            config1 = MCPConfig(
+                authorization_context=agent_auth_context_data,
+            )
+
+            # Get the header with JWT token
+            headers = config1.server_config["headers"]
+            jwt_token = headers["X-DataRobot-Authorization-Context"]
+
+            # Create a new config and decode the token
+            config2 = MCPConfig(api_base=api_base, api_key=api_key)
+            decoded_context = config2.auth_context_handler.decode(jwt_token)
+
+            # Verify roundtrip preserves all data
+            assert decoded_context == agent_auth_context_data
+
+    def test_mcp_config_authorization_context_with_missing_secret_key(
+        self, agent_auth_context_data
+    ):
+        """Test authorization_context encoding with missing secret key shows warning."""
+        deployment_id = "abc123def456789012345678"
+
+        with patch.dict(
+            os.environ,
+            {"MCP_DEPLOYMENT_ID": deployment_id},
+            clear=True,
+        ):
+            with pytest.warns(UserWarning, match="No secret key provided"):
+                config = MCPConfig(
+                    authorization_context=agent_auth_context_data,
+                )
+
+                # Should still generate a header, but with empty key (insecure)
+                header = config._authorization_context_header()
+                assert "X-DataRobot-Authorization-Context" in header

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -46,10 +46,10 @@ def test_build_llm_uses_get_api_base_and_params(monkeypatch: Any) -> None:
     assert captured and captured[0] is llm
     assert captured[0].model == "mistral"
     assert (
-        captured[0].api_base
+        captured[0].datarobot_endpoint
         == "https://tenant.datarobot.com/api/v2/deployments/dep-1/chat/completions"
     )
-    assert captured[0].api_key == "tok"
+    assert captured[0].datarobot_api_token == "tok"
     assert captured[0].timeout == 12
 
 

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -46,10 +46,10 @@ def test_build_llm_uses_get_api_base_and_params(monkeypatch: Any) -> None:
     assert captured and captured[0] is llm
     assert captured[0].model == "mistral"
     assert (
-        captured[0].datarobot_endpoint
+        captured[0].api_base
         == "https://tenant.datarobot.com/api/v2/deployments/dep-1/chat/completions"
     )
-    assert captured[0].datarobot_api_token == "tok"
+    assert captured[0].api_key == "tok"
     assert captured[0].timeout == 12
 
 

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -90,12 +90,3 @@ class TestMCPToolsContext:
                 assert call_args["transport"] == "streamable-http"
                 assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
                 assert call_args["headers"]["X-DataRobot-Authorization-Context"] is not None
-
-    def test_mcp_tools_context_with_parameters(self, mock_adapter):
-        """Test context manager with explicit api_base and api_key parameters."""
-        deployment_id = "abc123def456789012345678"
-
-        with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
-            with mcp_tools_context():
-                # Should use the provided parameters instead of environment variables
-                pass  # The test passes if no exception is raised

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -96,8 +96,6 @@ class TestMCPToolsContext:
         deployment_id = "abc123def456789012345678"
 
         with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
-            with mcp_tools_context(
-                api_base="https://custom.datarobot.com/api/v2", api_key="custom-key"
-            ):
+            with mcp_tools_context():
                 # Should use the provided parameters instead of environment variables
                 pass  # The test passes if no exception is raised

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -298,8 +298,6 @@ async def test_invoke_calls_mcp_tools_context_and_sets_tools(authorization_conte
 
             # THEN mcp_tools_context is called with correct parameters
             mock_mcp_context.assert_called_once_with(
-                api_base=agent.api_base,
-                api_key=agent.api_key,
                 authorization_context=authorization_context,
             )
 
@@ -345,8 +343,6 @@ async def test_invoke_streaming_calls_mcp_tools_context_and_cleans_up(authorizat
                 if items_consumed == 1:
                     # Verify mcp_tools_context is called with correct parameters
                     mock_mcp_context.assert_called_once_with(
-                        api_base=agent.api_base,
-                        api_key=agent.api_key,
                         authorization_context=authorization_context,
                     )
                     # Verify context is entered and tools are set

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -147,12 +147,16 @@ class TestMCPConfig:
         custom_api_key = "custom-key"
 
         with patch.dict(os.environ, {}, clear=True):
-            config = MCPConfig(api_base=custom_api_base, api_key=custom_api_key)
+            config = MCPConfig(
+                datarobot_endpoint=custom_api_base, datarobot_api_token=custom_api_key
+            )
             # Without MCP_DEPLOYMENT_ID, should return None
             assert config.server_config is None
 
         with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
-            config = MCPConfig(api_base=custom_api_base, api_key=custom_api_key)
+            config = MCPConfig(
+                datarobot_endpoint=custom_api_base, datarobot_api_token=custom_api_key
+            )
             assert config.server_config is not None
             expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
             assert config.server_config["url"] == expected_url
@@ -252,7 +256,7 @@ class TestLoadMCPTools:
         custom_api_key = "custom-key"
 
         with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
-            tools = await load_mcp_tools(api_base=custom_api_base, api_key=custom_api_key)
+            tools = await load_mcp_tools()
             assert tools == mock_tools
             mock_aget.assert_awaited_once()
             # Check that the function was called with custom parameters

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -86,14 +86,6 @@ class TestMCPConfig:
             config = MCPConfig()
             assert config.server_config["headers"]["Authorization"] == api_key
 
-    def test_mcp_config_with_datarobot_deployment_id_no_api_key(self):
-        """Test MCP config with DataRobot deployment ID but no API key."""
-        deployment_id = "abc123def456789012345678"
-
-        with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
-            config = MCPConfig()
-            assert config.server_config is None
-
     def test_mcp_config_with_datarobot_deployment_id_no_deployment_id(self):
         """Test MCP config with API key but no deployment ID."""
         api_key = "test-api-key"

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -147,16 +147,12 @@ class TestMCPConfig:
         custom_api_key = "custom-key"
 
         with patch.dict(os.environ, {}, clear=True):
-            config = MCPConfig(
-                datarobot_endpoint=custom_api_base, datarobot_api_token=custom_api_key
-            )
+            config = MCPConfig()
             # Without MCP_DEPLOYMENT_ID, should return None
             assert config.server_config is None
 
         with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
-            config = MCPConfig(
-                datarobot_endpoint=custom_api_base, datarobot_api_token=custom_api_key
-            )
+            config = MCPConfig()
             assert config.server_config is not None
             expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
             assert config.server_config["url"] == expected_url

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -151,7 +151,15 @@ class TestMCPConfig:
             # Without MCP_DEPLOYMENT_ID, should return None
             assert config.server_config is None
 
-        with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "DATAROBOT_API_TOKEN": custom_api_key,
+                "DATAROBOT_ENDPOINT": custom_api_base,
+            },
+            clear=True,
+        ):
             config = MCPConfig()
             assert config.server_config is not None
             expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
@@ -251,7 +259,15 @@ class TestLoadMCPTools:
         custom_api_base = "https://custom.datarobot.com/api/v2"
         custom_api_key = "custom-key"
 
-        with patch.dict(os.environ, {"MCP_DEPLOYMENT_ID": deployment_id}, clear=True):
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_DEPLOYMENT_ID": deployment_id,
+                "DATAROBOT_API_TOKEN": custom_api_key,
+                "DATAROBOT_ENDPOINT": custom_api_base,
+            },
+            clear=True,
+        ):
             tools = await load_mcp_tools()
             assert tools == mock_tools
             mock_aget.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1042,7 +1042,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.60"
+version = "0.1.61"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE
Currently, the MCP configuration is implemented in two places:

1. There is a function call in the recipe which takes the RuntimeParameters and sets them as env variables.
2. The env variables are read in the library code via os.environ

This PR simplifies the overall configuration by getting rid of 1. and adding additional validation.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
