### PR TITLE
[BUZZOK-28520] Import threaded telemetry to fix traces resetting during asynchronous calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "pyjwt>=2.10.1",
   "pypdf>=6.1.3",  # CVE BUZZOK-28182
   "datarobot-drum>=1.17.5",
+  "opentelemetry-instrumentation-threading>=0.59b0",
   "opentelemetry-instrumentation-requests>=0.43b0",
   "opentelemetry-instrumentation-aiohttp-client>=0.43b0",
   "opentelemetry-instrumentation-httpx>=0.43b0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.56"
+version = "0.1.57"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"


### PR DESCRIPTION
# RATIONALE
Fix tracing producing multiple threads.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Add opentelemetry-instrumentation-threading>=0.59b0 as req
- Add telemetry import to `instrument()`

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
