### PR TITLE
[BUZZOK-28521] Fix URL construction for internal MCP servers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.57"
+version = "0.1.58"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
@@ -20,7 +20,6 @@ dependencies = [
   "pyjwt>=2.10.1",
   "pypdf>=6.1.3",  # CVE BUZZOK-28182
   "datarobot-drum>=1.17.5",
-  "opentelemetry-instrumentation-threading>=0.59b0",
   "opentelemetry-instrumentation-requests>=0.43b0",
   "opentelemetry-instrumentation-aiohttp-client>=0.43b0",
   "opentelemetry-instrumentation-httpx>=0.43b0",

--- a/src/datarobot_genai/core/mcp/common.py
+++ b/src/datarobot_genai/core/mcp/common.py
@@ -44,7 +44,7 @@ class MCPConfig:
         self.external_mcp_transport = os.environ.get("EXTERNAL_MCP_TRANSPORT", "streamable-http")
         self.mcp_deployment_id = os.environ.get("MCP_DEPLOYMENT_ID")
         self.api_base = api_base or os.environ.get(
-            "DATAROBOT_ENDPOINT", "https://app.datarobot.com"
+            "DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2/"
         )
         self.api_key = api_key or os.environ.get("DATAROBOT_API_TOKEN")
         self.authorization_context = authorization_context
@@ -91,6 +91,8 @@ class MCPConfig:
         elif self.mcp_deployment_id and self.api_key:
             # DataRobot deployment ID - requires authentication
             base_url = self.api_base.rstrip("/")
+            if not base_url.endswith("/api/v2"):
+                base_url = base_url + "/api/v2"
             url = f"{base_url}/deployments/{self.mcp_deployment_id}/directAccess/mcp"
 
             headers = {

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -121,10 +121,16 @@ class TestMCPConfig:
             config = MCPConfig()
             assert config.server_config is None
 
-    def test_mcp_config_url_construction_with_trailing_slash(self):
+    @pytest.mark.parametrize('api_base', [
+        pytest.param('https://app.datarobot.com/api/v2', id='no-trailing-slash'),
+        pytest.param('https://app.datarobot.com/api/v2/', id='with-trailing-slash'),
+        pytest.param('https://app.datarobot.com/', id='with-trailing-slash-no-api-v2'),
+        pytest.param('https://app.datarobot.com', id='no-trailing-slash-no-api-v2'),
+    ])
+    def test_mcp_config_url_construction(self, api_base):
         """Test URL construction when api_base has trailing slash."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://app.datarobot.com/api/v2/"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "test-api-key"
 
         with patch.dict(
@@ -203,7 +209,7 @@ class TestMCPConfig:
 
     def test_mcp_config_with_direct_params(self):
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
         with patch.dict(
             os.environ,
@@ -217,7 +223,7 @@ class TestMCPConfig:
 
     def test_mcp_config_with_bearer_only_api_key(self):
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "Bearer fake_api_key"
         with patch.dict(
             os.environ,
@@ -229,7 +235,7 @@ class TestMCPConfig:
 
     def test_mcp_config_with_whitespace_api_key(self):
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
         with patch.dict(
             os.environ,
@@ -260,7 +266,7 @@ class TestMCPConfig:
     def test_mcp_config_with_direct_authorization_context(self, agent_auth_context_data):
         """Test MCPConfig with direct authorization_context parameter."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
         secret_key = "test-secret-key"
 
@@ -293,7 +299,7 @@ class TestMCPConfig:
     ):
         """Test that direct authorization_context param takes priority over ContextVar."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
         secret_key = "test-secret-key"
 
@@ -326,7 +332,7 @@ class TestMCPConfig:
     def test_mcp_config_with_empty_authorization_context(self):
         """Test MCPConfig with empty authorization_context dict."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
 
         with patch.dict(
@@ -347,7 +353,7 @@ class TestMCPConfig:
     def test_mcp_config_with_none_authorization_context(self, agent_auth_context_data):
         """Test MCPConfig with None authorization_context falls back to ContextVar."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
         secret_key = "test-secret-key"
 
@@ -380,7 +386,7 @@ class TestMCPConfig:
     def test_mcp_config_authorization_context_with_complex_data(self):
         """Test authorization_context with complex nested data structures."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
         secret_key = "test-secret-key"
 
@@ -445,7 +451,7 @@ class TestMCPConfig:
     def test_mcp_config_authorization_context_roundtrip(self, agent_auth_context_data):
         """Test full encode-decode roundtrip of authorization_context."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
         secret_key = "test-secret-key"
 
@@ -480,7 +486,7 @@ class TestMCPConfig:
     ):
         """Test authorization_context encoding with missing secret key shows warning."""
         deployment_id = "abc123def456789012345678"
-        api_base = "https://custom.api/v2"
+        api_base = "https://app.datarobot.com/api/v2"
         api_key = "fake_api_key"
 
         with patch.dict(

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -121,12 +121,15 @@ class TestMCPConfig:
             config = MCPConfig()
             assert config.server_config is None
 
-    @pytest.mark.parametrize('api_base', [
-        pytest.param('https://app.datarobot.com/api/v2', id='no-trailing-slash'),
-        pytest.param('https://app.datarobot.com/api/v2/', id='with-trailing-slash'),
-        pytest.param('https://app.datarobot.com/', id='with-trailing-slash-no-api-v2'),
-        pytest.param('https://app.datarobot.com', id='no-trailing-slash-no-api-v2'),
-    ])
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            pytest.param("https://app.datarobot.com/api/v2", id="no-trailing-slash"),
+            pytest.param("https://app.datarobot.com/api/v2/", id="with-trailing-slash"),
+            pytest.param("https://app.datarobot.com/", id="with-trailing-slash-no-api-v2"),
+            pytest.param("https://app.datarobot.com", id="no-trailing-slash-no-api-v2"),
+        ],
+    )
     def test_mcp_config_url_construction(self, api_base):
         """Test URL construction when api_base has trailing slash."""
         deployment_id = "abc123def456789012345678"


### PR DESCRIPTION
# RATIONALE
For the agent-templates, internal MCP servers are currently broken, because the constructed path for accessing the MCP server is missing api/v2 in it.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
