### PR TITLE
[BUZZOK-28087] Fixes related to OAuth

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -1,5 +1,8 @@
 version: '3'
 
+env:
+  SESSION_SECRET_KEY: acceptance-test-secret
+
 tasks:
   drmcp-install:
     desc: "🔧 Install drmcp and dev dependencies for development"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.59"
+version = "0.1.60"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -23,12 +23,20 @@ from datarobot.auth.session import AuthCtx
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from datarobot.models.genai.agent.auth import ToolAuth
 from datarobot.models.genai.agent.auth import get_authorization_context
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 
 class AuthContextConfig(DataRobotAppFrameworkBaseSettings):
     session_secret_key: str = ""
+
+
+class DRAppCtx(BaseModel):
+    """DataRobot application context from authorization metadata."""
+
+    email: str | None = None
+    api_key: str | None = None
 
 
 class AuthContextHeaderHandler:

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -16,8 +16,12 @@ import warnings
 from typing import Any
 
 import jwt
+from datarobot.auth.datarobot.oauth import AsyncOAuth as DatarobotAsyncOAuthClient
+from datarobot.auth.identity import Identity
+from datarobot.auth.oauth import AsyncOAuthComponent
 from datarobot.auth.session import AuthCtx
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from datarobot.models.genai.agent.auth import ToolAuth
 from datarobot.models.genai.agent.auth import get_authorization_context
 
 logger = logging.getLogger(__name__)
@@ -146,6 +150,7 @@ class AuthContextHeaderHandler:
 
         auth_ctx_dict = self.decode(token)
         if not auth_ctx_dict:
+            logger.debug("Failed to decode auth context from token")
             return None
 
         try:
@@ -153,3 +158,54 @@ class AuthContextHeaderHandler:
         except Exception as e:
             logger.error(f"Failed to create AuthCtx from decoded token: {e}", exc_info=True)
             return None
+
+
+class AsyncOAuthTokenProvider:
+    """Manages OAuth access tokens using generic OAuth client."""
+
+    def __init__(self, auth_ctx: AuthCtx) -> None:
+        self.auth_ctx = auth_ctx
+        self.oauth_client = self._create_oauth_client()
+
+    def _get_identity(self, provider_type: str | None) -> Identity:
+        """Retrieve the appropriate identity from the authentication context."""
+        identities = [x for x in self.auth_ctx.identities if x.provider_identity_id is not None]
+
+        if not identities:
+            raise ValueError("No identities found in authorization context.")
+
+        if provider_type is None:
+            if len(identities) > 1:
+                raise ValueError(
+                    "Multiple identities found. Please specify 'provider_type' parameter."
+                )
+            return identities[0]
+
+        identity = next((id for id in identities if id.provider_type == provider_type), None)
+
+        if identity is None:
+            raise ValueError(f"No identity found for provider '{provider_type}'.")
+
+        return identity
+
+    async def get_token(self, auth_type: ToolAuth, provider_type: str | None = None) -> str:
+        """Get OAuth access token using the specified method."""
+        if auth_type != ToolAuth.OBO:
+            raise ValueError(
+                f"Unsupported auth type: {auth_type}. Only {ToolAuth.OBO} is supported."
+            )
+
+        identity = self._get_identity(provider_type)
+        token_data = await self.oauth_client.refresh_access_token(
+            identity_id=identity.provider_identity_id
+        )
+        return token_data.access_token
+
+    def _create_oauth_client(self) -> AsyncOAuthComponent:
+        """Create either DataRobot or Authlib OAuth client based on
+        authorization context.
+
+        Note: at the moment, only DataRobot OAuth client is supported.
+        """
+        logger.debug("Using DataRobot OAuth client")
+        return DatarobotAsyncOAuthClient()

--- a/src/datarobot_genai/drmcp/core/auth.py
+++ b/src/datarobot_genai/drmcp/core/auth.py
@@ -18,7 +18,6 @@ import logging
 from typing import Any
 
 from datarobot.auth.session import AuthCtx
-from datarobot.models.genai.agent.auth import OAuthAccessTokenProvider
 from datarobot.models.genai.agent.auth import ToolAuth
 from fastmcp.server.dependencies import get_context
 from fastmcp.server.dependencies import get_http_headers
@@ -27,10 +26,13 @@ from fastmcp.server.middleware import Middleware
 from fastmcp.server.middleware import MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 
+from datarobot_genai.core.utils.auth import AsyncOAuthTokenProvider
 from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
-from datarobot_genai.drmcp import get_config
 
 logger = logging.getLogger(__name__)
+
+
+AUTH_CTX_KEY = "authorization_context"
 
 
 class OAuthMiddleWare(Middleware):
@@ -45,16 +47,8 @@ class OAuthMiddleWare(Middleware):
         Handler for encoding/decoding JWT tokens containing auth context.
     """
 
-    def __init__(self, secret_key: str | None = None) -> None:
-        """Initialize the middleware with authentication handler.
-
-        Parameters
-        ----------
-        secret_key : Optional[str]
-            Secret key for JWT validation. If None, uses the value from config.
-        """
-        secret_key = secret_key or get_config().session_secret_key
-        self.auth_handler = AuthContextHeaderHandler(secret_key)
+    def __init__(self) -> None:
+        self.auth_handler = AuthContextHeaderHandler()
 
     async def on_call_tool(
         self, context: MiddlewareContext, call_next: CallNext[Any, ToolResult]
@@ -76,7 +70,12 @@ class OAuthMiddleWare(Middleware):
         auth_context = self._extract_auth_context()
 
         if context.fastmcp_context is not None:
-            context.fastmcp_context.auth_context = auth_context
+            context.fastmcp_context.set_state(AUTH_CTX_KEY, auth_context)
+            logger.debug(
+                f"Authorization context attached to state: {auth_context.model_dump()}"
+                if auth_context
+                else "No authorization context found."
+            )
 
         return await call_next(context)
 
@@ -99,8 +98,8 @@ class OAuthMiddleWare(Middleware):
             return None
 
 
-async def get_auth_context() -> AuthCtx:
-    """Retrieve the AuthCtx from the current request context, if available.
+async def must_get_auth_context() -> AuthCtx:
+    """Retrieve the AuthCtx from the current request context or raise error.
 
     Raises
     ------
@@ -113,14 +112,17 @@ async def get_auth_context() -> AuthCtx:
         The authorization context associated with the current request.
     """
     context = get_context()
-    auth_ctx = getattr(context, "auth_context", None)
+    if not context:
+        raise RuntimeError("No authorization context available.")
+
+    auth_ctx = context.get_state(AUTH_CTX_KEY)
     if not auth_ctx:
-        raise RuntimeError("No authorization context found.")
+        raise RuntimeError("Could not retrieve authorization context from FastMCP context state.")
 
     return auth_ctx
 
 
-async def get_access_token(provider: str | None = None) -> str:
+async def get_oauth_access_token(provider_type: str | None = None) -> str:
     """Retrieve access token from the DataRobot OAuth Provider Service.
 
     OAuth access tokens can be retrieved only for providers where the user completed
@@ -132,7 +134,7 @@ async def get_access_token(provider: str | None = None) -> str:
 
     Parameters
     ----------
-    provider : str, optional
+    provider_type : str, optional
         The name of the OAuth provider. It should match the name of the provider configured
         during provider setup. If no value is provided and only one OAuth provider exists, that
         provider will be used. If multiple providers exist and none is specified, an error will be
@@ -142,12 +144,18 @@ async def get_access_token(provider: str | None = None) -> str:
     -------
     The oauth access token.
     """
-    token_provider = OAuthAccessTokenProvider(await get_auth_context())
-    access_token = token_provider.get_token(ToolAuth.OBO, provider)
-    return access_token
+    auth_ctx = await must_get_auth_context()
+    logger.debug("Retrieved authorization context")
+
+    oauth_token_provider = AsyncOAuthTokenProvider(auth_ctx)
+    oauth_access_token = await oauth_token_provider.get_token(
+        auth_type=ToolAuth.OBO,
+        provider_type=provider_type,
+    )
+    return oauth_access_token
 
 
-def initialize_oauth_middleware(mcp: Any, secret_key: str | None = None) -> None:
+def initialize_oauth_middleware(mcp: Any) -> None:
     """Initialize and register OAuth middleware with the MCP server.
 
     Parameters
@@ -157,6 +165,5 @@ def initialize_oauth_middleware(mcp: Any, secret_key: str | None = None) -> None
     secret_key : Optional[str]
         Secret key for JWT validation. If None, uses the value from config.
     """
-    middleware = OAuthMiddleWare(secret_key=secret_key)
-    mcp.add_middleware(middleware)
+    mcp.add_middleware(OAuthMiddleWare())
     logger.info("OAuth middleware registered successfully")

--- a/src/datarobot_genai/drmcp/core/auth.py
+++ b/src/datarobot_genai/drmcp/core/auth.py
@@ -118,7 +118,7 @@ async def must_get_auth_context() -> AuthCtx:
     return auth_ctx
 
 
-async def get_oauth_access_token(provider_type: str | None = None) -> str:
+async def get_access_token(provider_type: str | None = None) -> str:
     """Retrieve access token from the DataRobot OAuth Provider Service.
 
     OAuth access tokens can be retrieved only for providers where the user completed

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -196,14 +196,6 @@ class MCPServerConfig(BaseSettings):
         ),
         description="Enable/disable predictive tools",
     )
-    session_secret_key: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices(
-            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "SESSION_SECRET_KEY",
-            "SESSION_SECRET_KEY",
-        ),
-        description="Session secret key for the MCP server",
-    )
 
     @field_validator(
         "otel_attributes",

--- a/tests/drmcp/acceptance/test_auth.py
+++ b/tests/drmcp/acceptance/test_auth.py
@@ -14,8 +14,8 @@
 
 import inspect
 import os
+import warnings
 from typing import Any
-from unittest.mock import patch
 
 import jwt
 import pytest
@@ -31,7 +31,12 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectati
 @pytest.fixture(scope="session")
 def secret_key() -> str:
     """Return a test secret key for JWT signing."""
-    return "acceptance-test-secret-key-12345"
+    secret_key = os.environ.get("SESSION_SECRET_KEY")
+    if not secret_key:
+        warnings.warn(
+            "SESSION_SECRET_KEY env variable is not set. The authorization context tests may fail."
+        )
+    return secret_key
 
 
 @pytest.fixture(scope="session")
@@ -103,20 +108,18 @@ class TestAuthContextE2E(ToolBaseE2E):
         secret_key: str,
     ) -> None:
         """Test OAuth middleware processes auth header and tool accesses auth context."""
-        # Set the secret key in environment so the server can validate tokens
-        with patch.dict(os.environ, {"SESSION_SECRET_KEY": secret_key}, clear=False):
-            # Create MCP session with auth headers
-            async with ete_test_mcp_session(
-                additional_headers={"X-DataRobot-Authorization-Context": auth_token}
-            ) as session:
-                await self._run_test_with_expectations(
-                    prompt,
-                    expectations_for_auth_context_tool_success,
-                    openai_llm_client,
-                    session,
-                    (
-                        inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
-                        if inspect.currentframe()
-                        else "test_auth_context_tool_with_valid_token"
-                    ),
-                )
+        # Create MCP session with auth headers
+        async with ete_test_mcp_session(
+            additional_headers={"X-DataRobot-Authorization-Context": auth_token}
+        ) as session:
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_auth_context_tool_success,
+                openai_llm_client,
+                session,
+                (
+                    inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
+                    if inspect.currentframe()
+                    else "test_auth_context_tool_with_valid_token"
+                ),
+            )

--- a/tests/drmcp/acceptance/test_auth.py
+++ b/tests/drmcp/acceptance/test_auth.py
@@ -82,7 +82,6 @@ def expectations_for_auth_context_tool_success(
     )
 
 
-@pytest.mark.skip(reason="RuntimeError: No authorization context found.")
 @pytest.mark.asyncio
 class TestAuthContextE2E(ToolBaseE2E):
     """End-to-end acceptance tests for OAuth middleware and auth context propagation."""

--- a/tests/drmcp/acceptance/test_tools.py
+++ b/tests/drmcp/acceptance/test_tools.py
@@ -18,7 +18,7 @@ Test tools for acceptance/E2E tests.
 These tools are loaded by the MCP server and are available for testing purposes.
 """
 
-from datarobot_genai.drmcp.core.auth import get_auth_context
+from datarobot_genai.drmcp.core.auth import must_get_auth_context
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
 
 
@@ -35,7 +35,7 @@ async def get_auth_context_user_info() -> str:
     String with user information from the auth context in the format:
     "User ID: <id>, User Name: <name>, User Email: <email>"
     """
-    auth_ctx = await get_auth_context()
+    auth_ctx = await must_get_auth_context()
     return (
         f"User ID: {auth_ctx.user.id}, "
         f"User Name: {auth_ctx.user.name}, "

--- a/tests/drmcp/integration/test_auth.py
+++ b/tests/drmcp/integration/test_auth.py
@@ -61,9 +61,26 @@ def auth_token(auth_context_data: dict[str, Any], secret_key: str) -> str:
 @pytest.fixture
 def middleware_with_secret(secret_key: str) -> OAuthMiddleWare:
     """Create an OAuthMiddleware instance for integration testing."""
-    with patch("datarobot_genai.drmcp.core.auth.get_config") as mock_config:
-        mock_config.return_value.session_secret_key = secret_key
-        return OAuthMiddleWare(secret_key=secret_key)
+    with patch("datarobot_genai.core.utils.auth.AuthContextConfig") as mock_config_class:
+        mock_config = MagicMock()
+        mock_config.session_secret_key = secret_key
+        mock_config_class.return_value = mock_config
+        return OAuthMiddleWare()
+
+
+@pytest.fixture
+def mock_middleware_context() -> MiddlewareContext:
+    """Create a mocked MiddlewareContext for testing."""
+    mock_message = MagicMock()
+    mock_fastmcp_context = MagicMock()
+    return MiddlewareContext(message=mock_message, fastmcp_context=mock_fastmcp_context)
+
+
+@pytest.fixture
+def mock_call_next() -> AsyncMock:
+    """Create a mocked call_next function that returns a test result."""
+    expected_result = ToolResult(content="test_result")
+    return AsyncMock(return_value=expected_result)
 
 
 @pytest.mark.asyncio
@@ -76,8 +93,17 @@ class TestOAuthMiddlewareIntegration:
     - Context propagation through the middleware chain
     """
 
+    @pytest.mark.parametrize(
+        "header_name",
+        ["X-DataRobot-Authorization-Context", "x-datarobot-authorization-context"],
+    )
     async def test_middleware_full_flow_with_valid_auth(
-        self, middleware_with_secret: OAuthMiddleWare, auth_token: str
+        self,
+        middleware_with_secret: OAuthMiddleWare,
+        auth_token: str,
+        header_name: str,
+        mock_middleware_context: MiddlewareContext,
+        mock_call_next: AsyncMock,
     ) -> None:
         """Test complete middleware flow: headers -> JWT decode -> AuthCtx -> fastmcp_context.
 
@@ -85,73 +111,79 @@ class TestOAuthMiddlewareIntegration:
         1. Middleware extracts headers
         2. AuthContextHeaderHandler decodes the JWT token
         3. AuthCtx is properly created from decoded token
-        4. AuthCtx is attached to fastmcp_context
+        4. AuthCtx is stored in fastmcp_context state
         5. Middleware propagates the result correctly
         """
-        headers = {"X-DataRobot-Authorization-Context": auth_token}
-
-        # Create real MiddlewareContext (integration test)
-        mock_message = MagicMock()
-        mock_fastmcp_context = MagicMock()
-        context = MiddlewareContext(message=mock_message, fastmcp_context=mock_fastmcp_context)
-
-        # Mock call_next
-        expected_result = ToolResult(content="integration_test_result")
-        call_next = AsyncMock(return_value=expected_result)
+        headers = {header_name: auth_token}
 
         with patch("datarobot_genai.drmcp.core.auth.get_http_headers", return_value=headers):
-            result = await middleware_with_secret.on_call_tool(context, call_next)
+            result = await middleware_with_secret.on_call_tool(
+                mock_middleware_context, mock_call_next
+            )
 
-            # Verify the full integration
-            assert mock_fastmcp_context.auth_context is not None, "Auth context should be attached"
-            assert mock_fastmcp_context.auth_context.user.id == "integration_user_123"
-            assert mock_fastmcp_context.auth_context.user.name == "Integration Test User"
-            assert mock_fastmcp_context.auth_context.identities[0].id == "1234567890"
+            # Verify auth context was stored with correct key
+            mock_fastmcp_context = mock_middleware_context.fastmcp_context
+            mock_fastmcp_context.set_state.assert_called_once()
+            key, auth_ctx = mock_fastmcp_context.set_state.call_args[0]
 
-            # Verify middleware didn't break the chain
-            call_next.assert_awaited_once_with(context)
-            assert result is expected_result
+            assert key == "authorization_context", "Should use correct state key"
+            assert auth_ctx is not None, "Auth context should be attached"
+            assert auth_ctx.user.id == "integration_user_123"
+            assert auth_ctx.user.name == "Integration Test User"
+            assert auth_ctx.identities[0].id == "1234567890"
+
+            # Verify middleware chain continues correctly
+            mock_call_next.assert_awaited_once_with(mock_middleware_context)
+            assert result == mock_call_next.return_value
 
     async def test_middleware_flow_with_missing_auth(
-        self, middleware_with_secret: OAuthMiddleWare
+        self,
+        middleware_with_secret: OAuthMiddleWare,
+        mock_middleware_context: MiddlewareContext,
+        mock_call_next: AsyncMock,
     ) -> None:
         """Test that middleware gracefully handles missing auth throughout the full flow."""
         headers = {}  # No auth header
 
-        mock_message = MagicMock()
-        mock_fastmcp_context = MagicMock()
-        context = MiddlewareContext(message=mock_message, fastmcp_context=mock_fastmcp_context)
-
-        expected_result = ToolResult(content="result_without_auth")
-        call_next = AsyncMock(return_value=expected_result)
-
         with patch("datarobot_genai.drmcp.core.auth.get_http_headers", return_value=headers):
-            result = await middleware_with_secret.on_call_tool(context, call_next)
+            result = await middleware_with_secret.on_call_tool(
+                mock_middleware_context, mock_call_next
+            )
 
-            # Verify middleware set auth_context to None
-            assert mock_fastmcp_context.auth_context is None
+            # Verify auth context set to None when missing
+            mock_fastmcp_context = mock_middleware_context.fastmcp_context
+            mock_fastmcp_context.set_state.assert_called_once()
+            key, auth_ctx = mock_fastmcp_context.set_state.call_args[0]
 
-            # Verify middleware still called next handler
-            call_next.assert_awaited_once_with(context)
-            assert result is expected_result
+            assert key == "authorization_context"
+            assert auth_ctx is None, "Auth context should be None when missing"
+
+            # Verify middleware chain continues
+            mock_call_next.assert_awaited_once_with(mock_middleware_context)
+            assert result == mock_call_next.return_value
 
     async def test_middleware_flow_with_malformed_token(
-        self, middleware_with_secret: OAuthMiddleWare
+        self,
+        middleware_with_secret: OAuthMiddleWare,
+        mock_middleware_context: MiddlewareContext,
+        mock_call_next: AsyncMock,
     ) -> None:
         """Test that middleware handles malformed tokens gracefully in the full flow."""
         headers = {"X-DataRobot-Authorization-Context": "this.is.not.a.valid.jwt.token"}
 
-        mock_message = MagicMock()
-        mock_fastmcp_context = MagicMock()
-        context = MiddlewareContext(message=mock_message, fastmcp_context=mock_fastmcp_context)
-
-        expected_result = ToolResult(content="result_with_bad_token")
-        call_next = AsyncMock(return_value=expected_result)
-
         with patch("datarobot_genai.drmcp.core.auth.get_http_headers", return_value=headers):
-            result = await middleware_with_secret.on_call_tool(context, call_next)
+            result = await middleware_with_secret.on_call_tool(
+                mock_middleware_context, mock_call_next
+            )
 
-            # Verify middleware handled the error gracefully
-            assert mock_fastmcp_context.auth_context is None
-            call_next.assert_awaited_once_with(context)
-            assert result is expected_result
+            # Verify auth context set to None for malformed token
+            mock_fastmcp_context = mock_middleware_context.fastmcp_context
+            mock_fastmcp_context.set_state.assert_called_once()
+            key, auth_ctx = mock_fastmcp_context.set_state.call_args[0]
+
+            assert key == "authorization_context"
+            assert auth_ctx is None, "Auth context should be None for malformed token"
+
+            # Verify middleware chain continues
+            mock_call_next.assert_awaited_once_with(mock_middleware_context)
+            assert result == mock_call_next.return_value

--- a/uv.lock
+++ b/uv.lock
@@ -1042,7 +1042,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.58"
+version = "0.1.60"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE
- Fixes after e2e test related to Oauth
- Additional fallback to recover token from auth ctx
- Restored disabled acceptance test


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
