### PR TITLE
[BUZZOK-28596] Extract pipeline interactions for NAT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.61"
+version = "0.1.62"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -60,9 +60,9 @@ def convert_to_ragas_messages(
             last_message = messages
 
         if isinstance(last_message, dict):
-            content = last_message.get("content")
+            content = last_message.get("content") or last_message
         elif hasattr(last_message, "content"):
-            content = getattr(last_message, "content")
+            content = getattr(last_message, "content") or last_message
         else:
             content = last_message
         return str(content)

--- a/tests/nat/integration/test_agent.py
+++ b/tests/nat/integration/test_agent.py
@@ -62,7 +62,7 @@ async def test_run_method(agent):
 
     assert result
     assert isinstance(result, str)
-    assert pipeline_interactions is None
+    assert pipeline_interactions
     assert usage == {
         "completion_tokens": ANY,
         "prompt_tokens": ANY,

--- a/uv.lock
+++ b/uv.lock
@@ -1042,7 +1042,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.61"
+version = "0.1.62"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE
To have parity with other frameworks we should extract pipeline interactions from the event stream.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Extract messages from LLM start and end events.
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
