### PR TITLE
[BUZZOK-28367] Add LLM component that picks up either gateway or deployed LLM from config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.70"
+version = "0.1.71"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/tests/nat/test_nat_adaptors.py
+++ b/tests/nat/test_nat_adaptors.py
@@ -18,6 +18,7 @@ from nat.builder.workflow_builder import WorkflowBuilder
 
 from datarobot_genai.nat.datarobot_llm_clients import DataRobotChatOpenAI
 from datarobot_genai.nat.datarobot_llm_clients import DataRobotLiteLLM
+from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMComponentModelConfig
 from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMDeploymentModelConfig
 from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMGatewayModelConfig
 from datarobot_genai.nat.datarobot_llm_providers import DataRobotNIMModelConfig
@@ -95,6 +96,30 @@ async def test_datarobot_nim_crewai():
 
 async def test_datarobot_nim_llamaindex():
     llm_config = DataRobotNIMModelConfig(temperature=0.0, api_key="some_token")
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
+        assert isinstance(llm, DataRobotLiteLLM)
+
+
+async def test_datarobot_llm_component_langchain_use_gateway():
+    llm_config = DataRobotLLMComponentModelConfig()
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+        assert isinstance(llm, DataRobotChatOpenAI)
+
+
+async def test_datarobot_llm_component_crewai():
+    llm_config = DataRobotLLMComponentModelConfig()
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.CREWAI)
+        assert isinstance(llm, LLM)
+
+
+async def test_datarobot_llm_component_llamaindex():
+    llm_config = DataRobotLLMComponentModelConfig()
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
         llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)

--- a/tests/nat/test_nat_adaptors.py
+++ b/tests/nat/test_nat_adaptors.py
@@ -103,7 +103,7 @@ async def test_datarobot_nim_llamaindex():
 
 
 async def test_datarobot_llm_component_langchain_use_gateway():
-    llm_config = DataRobotLLMComponentModelConfig()
+    llm_config = DataRobotLLMComponentModelConfig(api_key="some_token")
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
         llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LANGCHAIN)
@@ -111,7 +111,7 @@ async def test_datarobot_llm_component_langchain_use_gateway():
 
 
 async def test_datarobot_llm_component_crewai():
-    llm_config = DataRobotLLMComponentModelConfig()
+    llm_config = DataRobotLLMComponentModelConfig(api_key="some_token")
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
         llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.CREWAI)
@@ -119,7 +119,7 @@ async def test_datarobot_llm_component_crewai():
 
 
 async def test_datarobot_llm_component_llamaindex():
-    llm_config = DataRobotLLMComponentModelConfig()
+    llm_config = DataRobotLLMComponentModelConfig(api_key="some_token")
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
         llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)

--- a/uv.lock
+++ b/uv.lock
@@ -1042,7 +1042,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.70"
+version = "0.1.71"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE
We want the NAT agent template to use whatever LLM is configured via `af-component-llm`. This is either directly through the LLM gateway or a deployment.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Add `DataRobotLLMComponentModelConfig` provider and clients that access the LLM gateway or a deployment depending on the configuration. Pick up the config from the environment or runtime parameters.
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
