### PR TITLE
Resource cleanup exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.69"
+version = "0.1.70"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server_logo.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server_logo.py
@@ -38,7 +38,7 @@ def _apply_green(text: str) -> str:
     return "\n".join(colored_lines)
 
 
-DR_LOGO_ASCII = _apply_green("""\
+DR_LOGO_ASCII = _apply_green(r"""
  ____        _        ____       _           _   
 |  _ \  __ _| |_ __ _|  _ \ ___ | |__   ___ | |_ 
 | | | |/ _` | __/ _` | |_) / _ \| '_ \ / _ \| __|

--- a/uv.lock
+++ b/uv.lock
@@ -1042,7 +1042,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.69"
+version = "0.1.70"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE

I spotted these errors during testing

```
+ Exception Group Traceback (most recent call last):
  |   File "/Users/rabih.aboufakher/workspace/recipe-datarobot-agent-application/writer_agent/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 781, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/rabih.aboufakher/workspace/recipe-datarobot-agent-application/writer_agent/.venv/lib/python3.12/site-packages/mcp/client/streamable_http.py", line 502, in streamablehttp_client
    |     yield (
    |   File "/Users/rabih.aboufakher/workspace/recipe-datarobot-agent-application/writer_agent/.venv/lib/python3.12/site-packages/langchain_mcp_adapters/sessions.py", line 320, in _create_streamable_http_session
    |     ClientSession(read, write, **(session_kwargs or {})) as session,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/rabih.aboufakher/workspace/recipe-datarobot-agent-application/writer_agent/.venv/lib/python3.12/site-packages/mcp/shared/session.py", line 218, in __aexit__
    |     return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/rabih.aboufakher/workspace/recipe-datarobot-agent-application/writer_agent/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 792, in __aexit__
    |     return self.cancel_scope.__exit__(exc_type, exc_val, exc_tb)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/rabih.aboufakher/workspace/recipe-datarobot-agent-application/writer_agent/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 459, in __exit__
    |     raise RuntimeError(
    | RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
    +------------------------------------
```

And

```
dr_mcp_server_logo.py:43: SyntaxWarning: invalid escape sequence '\ '
```
## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
