### PR TITLE
SESSION KEY missing causing deployment to break with underling DataRobot auth exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.73"
+version = "0.1.74"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -65,16 +65,23 @@ class AuthContextHeaderHandler:
             JWT algorithm. Default is "HS256".
         validate_signature : bool
             Whether to validate JWT signatures. Default is True.
-
-        Raises
-        ------
-        ValueError
-            If algorithm is 'none' (insecure).
         """
-        if algorithm is None:
-            raise ValueError("Algorithm None is not allowed. Use a secure algorithm like HS256.")
+        # Get secret key from parameter, config, or environment variable
+        # Handle the case where AuthContextConfig() initialization fails due to
+        # a bug in the datarobot package when SESSION_SECRET_KEY is not set
+        if secret_key:
+            self.secret_key = secret_key
+        else:
+            try:
+                config = AuthContextConfig()
+                self.secret_key = config.session_secret_key or ""
+            except (TypeError, AttributeError, Exception):
+                # Fallback to reading environment variable directly if config initialization fails
+                # This can happen when SESSION_SECRET_KEY is not set and the datarobot package's
+                # getenv function encounters a bug with None values
+                # it tries to check if "apiToken" in payload: when payload is None
+                self.secret_key = ""
 
-        self.secret_key = secret_key or AuthContextConfig().session_secret_key
         self.algorithm = algorithm
         self.validate_signature = validate_signature
 

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -65,7 +65,15 @@ class AuthContextHeaderHandler:
             JWT algorithm. Default is "HS256".
         validate_signature : bool
             Whether to validate JWT signatures. Default is True.
+
+        Raises
+        ------
+        ValueError
+            If algorithm is 'none' (insecure).
         """
+        if algorithm is None:
+            raise ValueError("Algorithm None is not allowed. Use a secure algorithm like HS256.")
+
         # Get secret key from parameter, config, or environment variable
         # Handle the case where AuthContextConfig() initialization fails due to
         # a bug in the datarobot package when SESSION_SECRET_KEY is not set

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.72"
+version = "0.1.74"
 source = { editable = "." }
 dependencies = [
     { name = "datarobot" },


### PR DESCRIPTION
# RATIONALE
```
 Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/code/app/main.py", line 29, in <module>
    server = create_mcp_server(
             ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/datarobot_genai/drmcp/core/dr_mcp_server.py", line 309, in create_mcp_server
    return DataRobotMCPServer(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/datarobot_genai/drmcp/core/dr_mcp_server.py", line 122, in __init__
    initialize_oauth_middleware(mcp)
  File "/usr/lib/python3.12/site-packages/datarobot_genai/drmcp/core/auth.py", line 164, in initialize_oauth_middleware
    mcp.add_middleware(OAuthMiddleWare())
                       ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/datarobot_genai/drmcp/core/auth.py", line 51, in __init__
    self.auth_handler = auth_handler or AuthContextHeaderHandler()
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/datarobot_genai/core/utils/auth.py", line 77, in __init__
    self.secret_key = secret_key or AuthContextConfig().session_secret_key
                                    ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/pydantic_settings/main.py", line 194, in __init__
    **__pydantic_self__._settings_build_values(
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/pydantic_settings/main.py", line 390, in _settings_build_values
    sources = self.settings_customise_sources(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/datarobot/core/config.py", line 198, in settings_customise_sources
    GetenvSettingsSource(settings_cls),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/pydantic_settings/sources/providers/env.py", line 58, in __init__
    self.env_vars = self._load_env_vars()
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/datarobot/core/config.py", line 150, in _load_env_vars
    value = getenv(env_key)
            ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/datarobot/core/config.py", line 55, in getenv
    if "apiToken" in payload:
       ^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```
## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
