### PR TITLE
[BUZZOK-28660] Event streaming for langgraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.75"
+version = "0.1.76"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
@@ -24,6 +24,7 @@ dependencies = [
   "opentelemetry-instrumentation-aiohttp-client>=0.43b0,<1.0.0",
   "opentelemetry-instrumentation-httpx>=0.43b0,<1.0.0",
   "opentelemetry-instrumentation-openai>=0.40.5,<1.0.0",
+  "ag-ui-protocol>=0.1.9,<0.2.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.1.76"
+version = "0.2.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -23,7 +23,7 @@ from typing import TypedDict
 from typing import TypeVar
 from typing import cast
 
-from ag_ui.core import BaseEvent
+from ag_ui.core import Event
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
 
@@ -168,7 +168,7 @@ class UsageMetrics(TypedDict):
 
 # Canonical return type for DRUM-compatible invoke implementations
 InvokeReturn = (
-    AsyncGenerator[tuple[str | BaseEvent, MultiTurnSample | None, UsageMetrics], None]
+    AsyncGenerator[tuple[str | Event, MultiTurnSample | None, UsageMetrics], None]
     | tuple[str, MultiTurnSample | None, UsageMetrics]
 )
 

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -23,6 +23,7 @@ from typing import TypedDict
 from typing import TypeVar
 from typing import cast
 
+from ag_ui.core import BaseEvent
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
 
@@ -167,7 +168,7 @@ class UsageMetrics(TypedDict):
 
 # Canonical return type for DRUM-compatible invoke implementations
 InvokeReturn = (
-    AsyncGenerator[tuple[str, MultiTurnSample | None, UsageMetrics], None]
+    AsyncGenerator[tuple[str | BaseEvent, MultiTurnSample | None, UsageMetrics], None]
     | tuple[str, MultiTurnSample | None, UsageMetrics]
 )
 

--- a/src/datarobot_genai/core/chat/responses.py
+++ b/src/datarobot_genai/core/chat/responses.py
@@ -28,6 +28,7 @@ from typing import Any
 from typing import TypeVar
 
 from ag_ui.core import BaseEvent
+from ag_ui.core import Event
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
 from openai.types import CompletionUsage
@@ -48,7 +49,7 @@ class CustomModelChatResponse(ChatCompletion):
 
 class CustomModelStreamingResponse(ChatCompletionChunk):
     pipeline_interactions: str | None = None
-    event: BaseEvent | None = None
+    event: Event | None = None
 
 
 def to_custom_model_chat_response(
@@ -92,7 +93,7 @@ def to_custom_model_streaming_response(
     thread_pool_executor: ThreadPoolExecutor,
     event_loop: AbstractEventLoop,
     streaming_response_generator: AsyncGenerator[
-        tuple[str | BaseEvent, MultiTurnSample | None, dict[str, int]], None
+        tuple[str | Event, MultiTurnSample | None, dict[str, int]], None
     ],
     model: str | object | None,
 ) -> Iterator[CustomModelStreamingResponse]:

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -44,54 +44,103 @@ def authorization_context() -> dict[str, Any]:
 class SimpleLangGraphAgent(LangGraphAgent):
     @cached_property
     def workflow(self) -> StateGraph[MessagesState]:
-        def to_message_chunk(s):
-            return AIMessageChunk(content=s, id="123456")
-
         async def mock_stream_generator():
             # stream the first agent
+            # tool call and respose
             yield (
                 "first_agent",
                 "messages",
-                (to_message_chunk("Here is the information"), {}),
+                (
+                    AIMessageChunk(
+                        content="",
+                        id="000",
+                        tool_call_chunks=[
+                            {"name": "get_info_about_city", "id": "tool_call_111", "args": None}
+                        ],
+                    ),
+                    {},
+                ),
             )
             yield (
                 "first_agent",
                 "messages",
-                (to_message_chunk(" you requested about Paris....."), {}),
+                (
+                    AIMessageChunk(
+                        content="",
+                        id="000",
+                        tool_call_chunks=[{"name": "", "id": "", "args": "{'name': 'Paris'}"}],
+                    ),
+                    {},
+                ),
             )
+            yield (
+                "first_agent",
+                "messages",
+                (
+                    ToolMessage(
+                        tool_call_id="tool_call_111",
+                        id="000",
+                        content="Paris is the capital city of France.",
+                    ),
+                    {},
+                ),
+            )
+            # tool call end
+            yield (
+                "first_agent",
+                "messages",
+                (AIMessageChunk(content="Here is the information", id="111"), {}),
+            )
+            yield (
+                "first_agent",
+                "messages",
+                (AIMessageChunk(content=" you requested about Paris.....", id="111"), {}),
+            )
+
             yield (
                 "first_agent",
                 "updates",
                 {
                     "first_agent": {
+                        "usage": {
+                            "total_tokens": 100,
+                            "prompt_tokens": 50,
+                            "completion_tokens": 50,
+                        },
                         "messages": [
                             HumanMessage(content="Hi, tell me about Paris."),
                             AIMessage(
-                                content="Here is the information you requested about Paris....."
+                                content="Here is the information you requested about Paris.....",
+                                id="111",
                             ),
-                        ]
+                        ],
                     }
                 },
             )
             yield (
                 "final_agent",
                 "messages",
-                (to_message_chunk("Paris is the capital"), {}),
+                (AIMessageChunk(content="Paris is the capital", id="222"), {}),
             )
             yield (
                 "final_agent",
                 "messages",
-                (to_message_chunk(" city of France."), {}),
+                (AIMessageChunk(content=" city of France.", id="222"), {}),
             )
             yield (
                 "final_agent",
                 "updates",
                 {
                     "final_agent": {
+                        "usage": {
+                            "total_tokens": 100,
+                            "prompt_tokens": 50,
+                            "completion_tokens": 50,
+                        },
                         "messages": [
                             HumanMessage(content="Hi, tell me about Paris."),
-                            AIMessage(content="Paris is the capital city of France."),
-                        ]
+                            AIMessage(content="Paris is the capital city of France.", id="222"),
+                        ],
                     }
                 },
             )
@@ -160,9 +209,9 @@ async def test_langgraph_non_streaming():
     assert response.choices[0].message.content == "Paris is the capital city of France."
     # THEN the pipeline interactions are not None
     assert response.pipeline_interactions is not None
-    assert response.usage.completion_tokens == 0
-    assert response.usage.prompt_tokens == 0
-    assert response.usage.total_tokens == 0
+    assert response.usage.completion_tokens == 100
+    assert response.usage.prompt_tokens == 100
+    assert response.usage.total_tokens == 200
 
 
 async def test_langgraph_streaming():
@@ -212,28 +261,46 @@ async def test_langgraph_streaming():
         if isinstance(response_event, BaseEvent):
             events.append(response_event)
 
-    assert len(events) == 8
-    assert events[0].type == EventType.TEXT_MESSAGE_START
-    assert events[0].message_id == "123456"
-    assert events[1].type == EventType.TEXT_MESSAGE_CONTENT
-    assert events[1].delta == "Here is the information"
-    assert events[1].message_id == "123456"
-    assert events[2].type == EventType.TEXT_MESSAGE_CONTENT
-    assert events[2].delta == " you requested about Paris....."
-    assert events[2].message_id == "123456"
-    assert events[3].type == EventType.TEXT_MESSAGE_END
+    assert len(events) == 12
+    assert events[0].type == EventType.TOOL_CALL_START
+    assert events[0].tool_call_id == "tool_call_111"
+    assert events[0].tool_call_name == "get_info_about_city"
+    assert events[0].parent_message_id == "000"
+    assert events[1].type == EventType.TOOL_CALL_ARGS
+    assert events[1].tool_call_id == "tool_call_111"
+    assert events[1].delta == "{'name': 'Paris'}"
+    assert events[2].type == EventType.TOOL_CALL_END
+    assert events[2].tool_call_id == "tool_call_111"
+    assert events[3].type == EventType.TOOL_CALL_RESULT
+    assert events[3].tool_call_id == "tool_call_111"
+    assert events[3].content == "Paris is the capital city of France."
+    assert events[3].role == "tool"
     assert events[4].type == EventType.TEXT_MESSAGE_START
-    assert events[4].message_id == "123456"
+    assert events[4].message_id == "111"
     assert events[5].type == EventType.TEXT_MESSAGE_CONTENT
-    assert events[5].delta == "Paris is the capital"
-    assert events[5].message_id == "123456"
+    assert events[5].delta == "Here is the information"
+    assert events[5].message_id == "111"
     assert events[6].type == EventType.TEXT_MESSAGE_CONTENT
-    assert events[6].delta == " city of France."
-    assert events[6].message_id == "123456"
+    assert events[6].delta == " you requested about Paris....."
+    assert events[6].message_id == "111"
     assert events[7].type == EventType.TEXT_MESSAGE_END
-    assert events[7].message_id == "123456"
+    assert events[7].message_id == "111"
+    assert events[8].type == EventType.TEXT_MESSAGE_START
+    assert events[8].message_id == "222"
+    assert events[9].type == EventType.TEXT_MESSAGE_CONTENT
+    assert events[9].delta == "Paris is the capital"
+    assert events[9].message_id == "222"
+    assert events[10].type == EventType.TEXT_MESSAGE_CONTENT
+    assert events[10].delta == " city of France."
+    assert events[10].message_id == "222"
+    assert events[11].type == EventType.TEXT_MESSAGE_END
+    assert events[11].message_id == "222"
 
     assert pipeline_interactions is not None
+    assert usage_metrics is not None
+    assert usage_metrics["total_tokens"] == 200
+    assert usage_metrics["prompt_tokens"] == 100
+    assert usage_metrics["completion_tokens"] == 100
 
 
 async def test_invoke_calls_mcp_tools_context_and_sets_tools(authorization_context):

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.76"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },

--- a/uv.lock
+++ b/uv.lock
@@ -1040,9 +1040,10 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.1.75"
+version = "0.1.76"
 source = { editable = "." }
 dependencies = [
+    { name = "ag-ui-protocol" },
     { name = "datarobot" },
     { name = "datarobot-drum" },
     { name = "datarobot-predict" },
@@ -1127,6 +1128,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ag-ui-protocol", specifier = ">=0.1.9,<0.2.0" },
     { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiohttp-retry", marker = "extra == 'drmcp'", specifier = ">=2.8.3,<3.0.0" },
     { name = "aiosignal", marker = "extra == 'drmcp'", specifier = ">=1.3.1,<2.0.0" },


### PR DESCRIPTION
# RATIONALE
This PR updates the agent interface to allow not just chunk streaming but also more complex interaction. This is done by emiting AG-UI `Event` objects instead of strings. When transformed to chat completions, this object is serialized as a part of a chunk. It is still compatible with plain `chat/completion` clients: if text is preset in an Event it is sent as delta

The event streaming is implemented for one agent: `langgraph`. I only did tools: we can later work on adding steps and thinking events.

This also fixes usage tokens count for langgraph.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
