### PR TITLE
[BUZZOK-28689] Use headers from MCP config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.6"
+version = "0.2.7"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/nat/datarobot_auth_provider.py
+++ b/src/datarobot_genai/nat/datarobot_auth_provider.py
@@ -11,12 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import AsyncGenerator
+from typing import Any
+
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from nat.authentication.api_key.api_key_auth_provider import APIKeyAuthProvider
 from nat.authentication.api_key.api_key_auth_provider_config import APIKeyAuthProviderConfig
+from nat.authentication.interfaces import AuthProviderBase
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_auth_provider
+from nat.data_models.authentication import AuthProviderBaseConfig
+from nat.data_models.authentication import AuthResult
+from nat.data_models.authentication import HeaderCred
 from pydantic import Field
+
+from datarobot_genai.core.mcp.common import MCPConfig
 
 
 class Config(DataRobotAppFrameworkBaseSettings):
@@ -49,5 +58,53 @@ class DataRobotAPIKeyAuthProviderConfig(APIKeyAuthProviderConfig, name="datarobo
 @register_auth_provider(config_type=DataRobotAPIKeyAuthProviderConfig)
 async def datarobot_api_key_client(
     config: DataRobotAPIKeyAuthProviderConfig, builder: Builder
-) -> APIKeyAuthProviderConfig:
+) -> AsyncGenerator[APIKeyAuthProvider]:
     yield APIKeyAuthProvider(config=config)
+
+
+mcp_config = MCPConfig().server_config
+
+
+class DataRobotMCPAuthProviderConfig(AuthProviderBaseConfig, name="datarobot_mcp_auth"):  # type: ignore[call-arg]
+    headers: dict[str, str] | None = Field(
+        description=("Headers to be used for authentication. "),
+        default=mcp_config["headers"] if mcp_config else None,
+    )
+    default_user_id: str | None = Field(default="default-user", description="Default user ID")
+    allow_default_user_id_for_tool_calls: bool = Field(
+        default=True, description="Allow default user ID for tool calls"
+    )
+
+
+class DataRobotMCPAuthProvider(AuthProviderBase[DataRobotMCPAuthProviderConfig]):
+    def __init__(
+        self, config: DataRobotMCPAuthProviderConfig, config_name: str | None = None
+    ) -> None:
+        assert isinstance(config, DataRobotMCPAuthProviderConfig), (
+            "Config is not DataRobotMCPAuthProviderConfig"
+        )
+        super().__init__(config)
+
+    async def authenticate(self, user_id: str | None = None, **kwargs: Any) -> AuthResult | None:
+        """
+        Authenticate the user using the API key credentials.
+
+        Args:
+            user_id (str): The user ID to authenticate.
+
+        Returns
+        -------
+            AuthenticatedContext: The authenticated context containing headers
+        """
+        return AuthResult(
+            credentials=[
+                HeaderCred(name=name, value=value) for name, value in self.config.headers.items()
+            ]
+        )
+
+
+@register_auth_provider(config_type=DataRobotMCPAuthProviderConfig)
+async def datarobot_mcp_auth_provider(
+    config: DataRobotMCPAuthProviderConfig, builder: Builder
+) -> AsyncGenerator[DataRobotMCPAuthProvider]:
+    yield DataRobotMCPAuthProvider(config=config)

--- a/tests/nat/integration/test_agent.py
+++ b/tests/nat/integration/test_agent.py
@@ -89,7 +89,8 @@ async def test_run_method(agent):
 
 
 async def test_run_method_with_mcp(agent_with_mcp):
-    # Call the run method with test inputs
+    # You probably need to comment out the disable_env_file conftest fixture to pick up
+    # MCP settings from .env.
     completion_create_params = {
         "model": "test-model",
         "messages": [{"role": "user", "content": "List the projects"}],

--- a/tests/nat/integration/workflow_with_mcp.yaml
+++ b/tests/nat/integration/workflow_with_mcp.yaml
@@ -21,8 +21,8 @@ function_groups:
   mcp_tools:
     _type: datarobot_mcp_client
 authentication:
-  datarobot_api_key:
-    _type: datarobot_api_key
+  datarobot_mcp_auth:
+    _type: datarobot_mcp_auth
 llms:
   datarobot_llm:
     _type: datarobot-llm-gateway

--- a/tests/nat/test_mcp_client.py
+++ b/tests/nat/test_mcp_client.py
@@ -20,6 +20,7 @@ from nat.plugins.mcp.client_base import MCPBaseClient
 from nat.plugins.mcp.client_impl import MCPFunctionGroup
 from pydantic import BaseModel
 
+from datarobot_genai.nat.datarobot_auth_provider import DataRobotAPIKeyAuthProviderConfig
 from datarobot_genai.nat.datarobot_mcp_client import DataRobotMCPClientConfig
 from datarobot_genai.nat.datarobot_mcp_client import DataRobotMCPServerConfig
 
@@ -86,7 +87,9 @@ async def test_datarobot_mcp_client():
         )
         server_config = DataRobotMCPServerConfig()
         config = DataRobotMCPClientConfig(server=server_config)
+        auth_provider_config = DataRobotAPIKeyAuthProviderConfig()
         async with WorkflowBuilder() as builder:
+            await builder.add_auth_provider("datarobot_api_key", auth_provider_config)
             await builder.add_function_group("datarobot_mcp_tools", config)
             function_group = await builder.get_function_group("datarobot_mcp_tools")
             assert isinstance(function_group, MCPFunctionGroup)

--- a/tests/nat/test_mcp_client.py
+++ b/tests/nat/test_mcp_client.py
@@ -20,7 +20,6 @@ from nat.plugins.mcp.client_base import MCPBaseClient
 from nat.plugins.mcp.client_impl import MCPFunctionGroup
 from pydantic import BaseModel
 
-from datarobot_genai.nat.datarobot_auth_provider import DataRobotAPIKeyAuthProviderConfig
 from datarobot_genai.nat.datarobot_mcp_client import DataRobotMCPClientConfig
 from datarobot_genai.nat.datarobot_mcp_client import DataRobotMCPServerConfig
 
@@ -87,9 +86,7 @@ async def test_datarobot_mcp_client():
         )
         server_config = DataRobotMCPServerConfig()
         config = DataRobotMCPClientConfig(server=server_config)
-        auth_provider_config = DataRobotAPIKeyAuthProviderConfig()
         async with WorkflowBuilder() as builder:
-            await builder.add_auth_provider("datarobot_api_key", auth_provider_config)
             await builder.add_function_group("datarobot_mcp_tools", config)
             function_group = await builder.get_function_group("datarobot_mcp_tools")
             assert isinstance(function_group, MCPFunctionGroup)

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
# RATIONALE
Instead of using the DR API token for MCP auth with NAT use the headers from the MCP server config.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
