### PR TITLE
[BUZZOK-28724] Add azure-ai-inference and anthropic packages to crewai

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ datarobot_auth_provider = "datarobot_genai.nat.datarobot_auth_provider"
 
 [project.optional-dependencies]
 crewai = [
-  "anthropic~=0.71.0,<1.0.0",  # Neede for integration with anthropic endpoints
+  "anthropic~=0.71.0,<1.0.0",  # Needed for integration with anthropic endpoints
   "azure-ai-inference>=1.0.0b9,<2.0.0",  # Needed for integration with azure endpoints
   "crewai>=1.1.0",
   "crewai-tools[mcp]>=0.69.0,<0.77.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.7"
+version = "0.2.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ datarobot_auth_provider = "datarobot_genai.nat.datarobot_auth_provider"
 
 [project.optional-dependencies]
 crewai = [
-  "anthropic~=0.71.0,<1.0.0"  # Neede for integration with anthropic endpoints
-  "azure-ai-inference>=1.0.0b9,<2.0.0"  # Needed for integration with azure endpoints
+  "anthropic~=0.71.0,<1.0.0",  # Neede for integration with anthropic endpoints
+  "azure-ai-inference>=1.0.0b9,<2.0.0",  # Needed for integration with azure endpoints
   "crewai>=1.1.0",
   "crewai-tools[mcp]>=0.69.0,<0.77.0",
   "opentelemetry-instrumentation-crewai>=0.40.5,<1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ datarobot_auth_provider = "datarobot_genai.nat.datarobot_auth_provider"
 
 [project.optional-dependencies]
 crewai = [
+  "azure-ai-inference>=1.0.0b9,<2.0.0"
   "crewai>=1.1.0",
   "crewai-tools[mcp]>=0.69.0,<0.77.0",
   "opentelemetry-instrumentation-crewai>=0.40.5,<1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ datarobot_auth_provider = "datarobot_genai.nat.datarobot_auth_provider"
 
 [project.optional-dependencies]
 crewai = [
+  "anthropic~=0.71.0,<1.0.0"  # Neede for integration with anthropic endpoints
   "azure-ai-inference>=1.0.0b9,<2.0.0"  # Needed for integration with azure endpoints
   "crewai>=1.1.0",
   "crewai-tools[mcp]>=0.69.0,<0.77.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ datarobot_auth_provider = "datarobot_genai.nat.datarobot_auth_provider"
 
 [project.optional-dependencies]
 crewai = [
-  "azure-ai-inference>=1.0.0b9,<2.0.0"
+  "azure-ai-inference>=1.0.0b9,<2.0.0"  # Needed for integration with azure endpoints
   "crewai>=1.1.0",
   "crewai-tools[mcp]>=0.69.0,<0.77.0",
   "opentelemetry-instrumentation-crewai>=0.40.5,<1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.72.0"
+version = "0.71.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -238,9 +238,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/07/61f3ca8e69c5dcdaec31b36b79a53ea21c5b4ca5e93c7df58c71f43bf8d8/anthropic-0.72.0.tar.gz", hash = "sha256:8971fe76dcffc644f74ac3883069beb1527641115ae0d6eb8fa21c1ce4082f7a", size = 493721, upload-time = "2025-10-28T19:13:01.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/4b/19620875841f692fdc35eb58bf0201c8ad8c47b8443fecbf1b225312175b/anthropic-0.71.1.tar.gz", hash = "sha256:a77d156d3e7d318b84681b59823b2dee48a8ac508a3e54e49f0ab0d074e4b0da", size = 493294, upload-time = "2025-10-28T17:28:42.213Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/b7/160d4fb30080395b4143f1d1a4f6c646ba9105561108d2a434b606c03579/anthropic-0.72.0-py3-none-any.whl", hash = "sha256:0e9f5a7582f038cab8efbb4c959e49ef654a56bfc7ba2da51b5a7b8a84de2e4d", size = 357464, upload-time = "2025-10-28T19:13:00.215Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/b2f988b13325f9ac9921b1e87f0b7994468014e1b5bd3bdbd2472f5baf45/anthropic-0.71.1-py3-none-any.whl", hash = "sha256:6ca6c579f0899a445faeeed9c0eb97aa4bdb751196262f9ccc96edfc0bb12679", size = 355020, upload-time = "2025-10-28T17:28:40.653Z" },
 ]
 
 [[package]]
@@ -313,6 +313,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/3f/1d3bbd0bf23bdd99276d4def22f29c27a914067b4cf66f753ff9b8bbd0f3/authlib-1.6.5.tar.gz", hash = "sha256:6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b", size = 164553, upload-time = "2025-10-02T13:36:09.489Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/aa/5082412d1ee302e9e7d80b6949bc4d2a8fa1149aaab610c5fc24709605d6/authlib-1.6.5-py2.py3-none-any.whl", hash = "sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a", size = 243608, upload-time = "2025-10-02T13:36:07.637Z" },
+]
+
+[[package]]
+name = "azure-ai-inference"
+version = "1.0.0b9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/6a/ed85592e5c64e08c291992f58b1a94dab6869f28fb0f40fd753dced73ba6/azure_ai_inference-1.0.0b9.tar.gz", hash = "sha256:1feb496bd84b01ee2691befc04358fa25d7c344d8288e99364438859ad7cd5a4", size = 182408, upload-time = "2025-02-15T00:37:28.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/0f/27520da74769db6e58327d96c98e7b9a07ce686dff582c9a5ec60b03f9dd/azure_ai_inference-1.0.0b9-py3-none-any.whl", hash = "sha256:49823732e674092dad83bb8b0d1b65aa73111fab924d61349eb2a8cdc0493990", size = 124885, upload-time = "2025-02-15T00:37:29.964Z" },
 ]
 
 [[package]]
@@ -1049,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -1072,6 +1086,8 @@ dependencies = [
 
 [package.optional-dependencies]
 crewai = [
+    { name = "anthropic" },
+    { name = "azure-ai-inference" },
     { name = "crewai" },
     { name = "crewai-tools", extra = ["mcp"] },
     { name = "opentelemetry-instrumentation-crewai" },
@@ -1145,7 +1161,9 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.9.0,<4.0.0" },
     { name = "aiohttp-retry", marker = "extra == 'drmcp'", specifier = ">=2.8.3,<3.0.0" },
     { name = "aiosignal", marker = "extra == 'drmcp'", specifier = ">=1.3.1,<2.0.0" },
+    { name = "anthropic", marker = "extra == 'crewai'", specifier = "~=0.71.0,<1.0.0" },
     { name = "anyio", marker = "extra == 'nat'", specifier = "==4.11.0" },
+    { name = "azure-ai-inference", marker = "extra == 'crewai'", specifier = ">=1.0.0b9,<2.0.0" },
     { name = "boto3", marker = "extra == 'drmcp'", specifier = ">=1.34.0,<2.0.0" },
     { name = "crewai", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = ">=1.1.0" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=1.1.0" },


### PR DESCRIPTION
# RATIONALE

`AzureAI` and `Anthropic` are default supported backends inside and outside the LLM Gateway (https://github.com/datarobot-community/af-component-llm/blob/main/template/.datarobot/cli/llm.yml.jinja#L69). CrewAI now requires an extra package to support this.

When using these backends you need to explicitly import these providers. We also need `OpenAI` but its already imported by default in the main package.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
