### PR TITLE
[MODEL-21637] Add Confluence get page MCP tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.9"
+version = "0.2.10"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/drmcp/tools/clients/confluence.py
+++ b/src/datarobot_genai/drmcp/tools/clients/confluence.py
@@ -12,3 +12,160 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Async client for interacting with Confluence Cloud REST API.
+
+Note: We use httpx directly instead of the atlassian-python-api SDK
+because the SDK does not support async operations.
+"""
+
+import logging
+from typing import Any
+
+import httpx
+from pydantic import BaseModel
+from pydantic import Field
+
+from datarobot_genai.drmcp.tools.clients.atlassian import ATLASSIAN_API_BASE
+from datarobot_genai.drmcp.tools.clients.atlassian import get_atlassian_cloud_id
+
+logger = logging.getLogger(__name__)
+
+
+class ConfluencePage(BaseModel):
+    """Pydantic model for Confluence page."""
+
+    page_id: str = Field(..., description="The unique page ID")
+    title: str = Field(..., description="Page title")
+    space_id: str = Field(..., description="Space ID where the page resides")
+    space_key: str | None = Field(None, description="Space key (if available)")
+    body: str = Field(..., description="Page content in storage format (HTML-like)")
+
+
+class ConfluenceClient:
+    """Async client for Confluence REST API using OAuth access token."""
+
+    EXPAND_FIELDS = "body.storage,space"
+
+    def __init__(self, access_token: str):
+        """
+        Initialize Confluence client with access token.
+
+        Args:
+            access_token: OAuth access token for Atlassian API
+        """
+        self.access_token = access_token
+        self._client = httpx.AsyncClient(
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/json",
+            },
+            timeout=30.0,
+        )
+        self._cloud_id: str | None = None
+
+    async def _get_cloud_id(self) -> str:
+        """Get the cloud ID for the authenticated Atlassian Confluence instance."""
+        if self._cloud_id:
+            return self._cloud_id
+
+        self._cloud_id = await get_atlassian_cloud_id(self._client, service_type="confluence")
+        return self._cloud_id
+
+    def _parse_response(self, data: dict) -> ConfluencePage:
+        """Parse API response into ConfluencePage."""
+        body_content = ""
+        body = data.get("body", {})
+        if isinstance(body, dict):
+            storage = body.get("storage", {})
+            if isinstance(storage, dict):
+                body_content = storage.get("value", "")
+
+        space = data.get("space", {})
+        space_key = space.get("key") if isinstance(space, dict) else None
+        space_id = space.get("id", "") if isinstance(space, dict) else data.get("spaceId", "")
+
+        return ConfluencePage(
+            page_id=str(data.get("id", "")),
+            title=data.get("title", ""),
+            space_id=str(space_id),
+            space_key=space_key,
+            body=body_content,
+        )
+
+    async def get_page_by_id(self, page_id: str) -> ConfluencePage:
+        """
+        Get a Confluence page by its ID.
+
+        Args:
+            page_id: The numeric page ID
+
+        Returns
+        -------
+            ConfluencePage with page data
+
+        Raises
+        ------
+            ValueError: If page is not found
+            httpx.HTTPStatusError: If the API request fails
+        """
+        cloud_id = await self._get_cloud_id()
+        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/content/{page_id}"
+
+        response = await self._client.get(url, params={"expand": self.EXPAND_FIELDS})
+
+        if response.status_code == 404:
+            raise ValueError(f"Page with ID '{page_id}' not found")
+
+        response.raise_for_status()
+        return self._parse_response(response.json())
+
+    async def get_page_by_title(self, title: str, space_key: str) -> ConfluencePage:
+        """
+        Get a Confluence page by its title within a specific space.
+
+        Args:
+            title: The exact page title
+            space_key: The space key where the page resides
+
+        Returns
+        -------
+            ConfluencePage with page data
+
+        Raises
+        ------
+            ValueError: If the page is not found
+            httpx.HTTPStatusError: If the API request fails
+        """
+        cloud_id = await self._get_cloud_id()
+        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/content"
+
+        response = await self._client.get(
+            url,
+            params={
+                "title": title,
+                "spaceKey": space_key,
+                "expand": self.EXPAND_FIELDS,
+            },
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        results = data.get("results", [])
+
+        if not results:
+            raise ValueError(f"Page with title '{title}' not found in space '{space_key}'")
+
+        return self._parse_response(results[0])
+
+    async def __aenter__(self) -> "ConfluenceClient":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Async context manager exit."""
+        await self._client.aclose()

--- a/src/datarobot_genai/drmcp/tools/confluence/tools.py
+++ b/src/datarobot_genai/drmcp/tools/confluence/tools.py
@@ -55,18 +55,16 @@ async def confluence_get_page(
         raise access_token
 
     try:
-        client = ConfluenceClient(access_token)
-
-        if page_id_or_title.isdigit():
-            page_response = await client.get_page_by_id(page_id_or_title)
-        else:
-            if not space_key:
-                raise ToolError(
-                    "Argument validation error: "
-                    "'space_key' is required when identifying a page by title."
-                )
-            page_response = await client.get_page_by_title(page_id_or_title, space_key)
-
+        async with ConfluenceClient(access_token) as client:
+            if page_id_or_title.isdigit():
+                page_response = await client.get_page_by_id(page_id_or_title)
+            else:
+                if not space_key:
+                    raise ToolError(
+                        "Argument validation error: "
+                        "'space_key' is required when identifying a page by title."
+                    )
+                page_response = await client.get_page_by_title(page_id_or_title, space_key)
     except ValueError as e:
         logger.error(f"Value error getting Confluence page: {e}")
         raise ToolError(str(e))
@@ -79,5 +77,5 @@ async def confluence_get_page(
 
     return ToolResult(
         content=f"Successfully retrieved page '{page_response.title}'.",
-        structured_content=page_response.model_dump(),
+        structured_content=page_response.as_flat_dict(),
     )

--- a/src/datarobot_genai/drmcp/tools/confluence/tools.py
+++ b/src/datarobot_genai/drmcp/tools/confluence/tools.py
@@ -69,10 +69,10 @@ async def confluence_get_page(
 
     except ValueError as e:
         logger.error(f"Value error getting Confluence page: {e}")
-        return ToolError(str(e))
+        raise ToolError(str(e))
     except Exception as e:
         logger.error(f"Unexpected error getting Confluence page: {e}")
-        return ToolError(
+        raise ToolError(
             f"An unexpected error occurred while getting Confluence page "
             f"'{page_id_or_title}': {str(e)}"
         )

--- a/src/datarobot_genai/drmcp/tools/confluence/tools.py
+++ b/src/datarobot_genai/drmcp/tools/confluence/tools.py
@@ -11,3 +11,73 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Confluence MCP tools for interacting with Confluence Cloud."""
+
+import logging
+from typing import Annotated
+
+from fastmcp.exceptions import ToolError
+from fastmcp.tools.tool import ToolResult
+
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
+from datarobot_genai.drmcp.tools.clients.atlassian import get_atlassian_access_token
+from datarobot_genai.drmcp.tools.clients.confluence import ConfluenceClient
+
+logger = logging.getLogger(__name__)
+
+
+@dr_mcp_tool(tags={"confluence", "read", "get", "page"})
+async def confluence_get_page(
+    *,
+    page_id_or_title: Annotated[str, "The ID or the exact title of the Confluence page."],
+    space_key: Annotated[
+        str | None,
+        "Required if identifying the page by title. The space key (e.g., 'PROJ').",
+    ] = None,
+) -> ToolResult | ToolError:
+    """Retrieve the content of a specific Confluence page.
+
+    Use this tool to fetch Confluence pages by their numeric ID or by title.
+    Returns page content in HTML storage format.
+
+    Usage:
+        - By ID: page_id_or_title="856391684"
+        - By title: page_id_or_title="Meeting Notes", space_key="TEAM"
+
+    When using a page title, the space_key parameter is required.
+    """
+    if not page_id_or_title:
+        raise ToolError("Argument validation error: 'page_id_or_title' cannot be empty.")
+
+    access_token = await get_atlassian_access_token()
+    if isinstance(access_token, ToolError):
+        raise access_token
+
+    try:
+        client = ConfluenceClient(access_token)
+
+        if page_id_or_title.isdigit():
+            page_response = await client.get_page_by_id(page_id_or_title)
+        else:
+            if not space_key:
+                raise ToolError(
+                    "Argument validation error: "
+                    "'space_key' is required when identifying a page by title."
+                )
+            page_response = await client.get_page_by_title(page_id_or_title, space_key)
+
+    except ValueError as e:
+        logger.error(f"Value error getting Confluence page: {e}")
+        return ToolError(str(e))
+    except Exception as e:
+        logger.error(f"Unexpected error getting Confluence page: {e}")
+        return ToolError(
+            f"An unexpected error occurred while getting Confluence page "
+            f"'{page_id_or_title}': {str(e)}"
+        )
+
+    return ToolResult(
+        content=f"Successfully retrieved page '{page_response.title}'.",
+        structured_content=page_response.model_dump(),
+    )

--- a/tests/drmcp/acceptance/test_confluence_tools.py
+++ b/tests/drmcp/acceptance/test_confluence_tools.py
@@ -1,0 +1,139 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import inspect
+from typing import Any
+
+import pytest
+
+from datarobot_genai.drmcp import ETETestExpectations
+from datarobot_genai.drmcp import ToolBaseE2E
+from datarobot_genai.drmcp import ToolCallTestExpectations
+from datarobot_genai.drmcp import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
+
+
+@pytest.fixture(scope="session")
+def confluence_page_id() -> str:
+    return "856391684"
+
+
+@pytest.fixture(scope="session")
+def confluence_page_title() -> str:
+    return "All check status"
+
+
+@pytest.fixture(scope="session")
+def confluence_space_key() -> str:
+    return "ENGPROD"
+
+
+@pytest.fixture(scope="session")
+def expectations_for_confluence_get_page_by_id_success(
+    confluence_page_id: str,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="confluence_get_page",
+                parameters={"page_id_or_title": confluence_page_id},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "All check status",
+            "0-all-check-status",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_confluence_get_page_by_title_success(
+    confluence_page_title: str,
+    confluence_space_key: str,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="confluence_get_page",
+                parameters={
+                    "page_id_or_title": confluence_page_title,
+                    "space_key": confluence_space_key,
+                },
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "All check status",
+            "0-all-check-status",
+        ],
+    )
+
+
+@pytest.mark.asyncio
+class TestConfluenceToolsE2E(ToolBaseE2E):
+    """End-to-end tests for confluence tools."""
+
+    @pytest.mark.parametrize(
+        "prompt_template",
+        ["Please retrieve the Confluence page with ID `{page_id}`."],
+    )
+    async def test_confluence_get_page_by_id_success(
+        self,
+        openai_llm_client: Any,
+        expectations_for_confluence_get_page_by_id_success: ETETestExpectations,
+        confluence_page_id: str,
+        prompt_template: str,
+    ) -> None:
+        prompt = prompt_template.format(page_id=confluence_page_id)
+
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_confluence_get_page_by_id_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_confluence_get_page_by_id_success,
+                openai_llm_client,
+                session,
+                test_name,
+            )
+
+    @pytest.mark.parametrize(
+        "prompt_template",
+        ["Please retrieve the Confluence page titled `{page_title}` from space `{space_key}`."],
+    )
+    async def test_confluence_get_page_by_title_success(
+        self,
+        openai_llm_client: Any,
+        expectations_for_confluence_get_page_by_title_success: ETETestExpectations,
+        confluence_page_title: str,
+        confluence_space_key: str,
+        prompt_template: str,
+    ) -> None:
+        prompt = prompt_template.format(
+            page_title=confluence_page_title,
+            space_key=confluence_space_key,
+        )
+
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = (
+                frame.f_code.co_name if frame else "test_confluence_get_page_by_title_success"
+            )
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_confluence_get_page_by_title_success,
+                openai_llm_client,
+                session,
+                test_name,
+            )

--- a/tests/drmcp/unit/confluence_tools/test_tools.py
+++ b/tests/drmcp/unit/confluence_tools/test_tools.py
@@ -1,0 +1,147 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.drmcp.core.exceptions import MCPError
+from datarobot_genai.drmcp.tools.clients.confluence import ConfluencePage
+from datarobot_genai.drmcp.tools.confluence.tools import confluence_get_page
+
+
+@pytest.fixture
+def get_atlassian_access_token_mock() -> Iterator[None]:
+    with patch(
+        "datarobot_genai.drmcp.tools.confluence.tools.get_atlassian_access_token",
+        return_value="token",
+    ):
+        yield
+
+
+@pytest.fixture
+def confluence_client_get_page_by_id_mock() -> Iterator[ConfluencePage]:
+    with patch(
+        "datarobot_genai.drmcp.tools.clients.confluence.ConfluenceClient.get_page_by_id"
+    ) as mock:
+        page = ConfluencePage(
+            page_id="12345",
+            title="Test Page",
+            space_id="67890",
+            space_key="TEST",
+            body="<p>Test content</p>",
+        )
+        mock.return_value = page
+        yield page
+
+
+@pytest.fixture
+def confluence_client_get_page_by_title_mock() -> Iterator[ConfluencePage]:
+    with patch(
+        "datarobot_genai.drmcp.tools.clients.confluence.ConfluenceClient.get_page_by_title"
+    ) as mock:
+        page = ConfluencePage(
+            page_id="12345",
+            title="Test Page",
+            space_id="67890",
+            space_key="TEST",
+            body="<p>Test content</p>",
+        )
+        mock.return_value = page
+        yield page
+
+
+@pytest.fixture
+def confluence_client_get_page_error_mock() -> Iterator[None]:
+    with patch(
+        "datarobot_genai.drmcp.tools.clients.confluence.ConfluenceClient.get_page_by_id"
+    ) as mock:
+        mock.side_effect = ValueError("Page not found")
+        yield
+
+
+class TestConfluenceGetPage:
+    """Confluence get page tool tests."""
+
+    @pytest.mark.asyncio
+    async def test_confluence_get_page_by_id_happy_path(
+        self,
+        get_atlassian_access_token_mock: None,
+        confluence_client_get_page_by_id_mock: ConfluencePage,
+    ) -> None:
+        """Confluence get page by ID -- happy path."""
+        page_id = "12345"
+
+        tool_result = await confluence_get_page(page_id_or_title=page_id)
+
+        content, structured_content = tool_result.to_mcp_result()
+        assert content[0].text == "Successfully retrieved page 'Test Page'."
+        assert structured_content == {
+            "page_id": "12345",
+            "title": "Test Page",
+            "space_id": "67890",
+            "space_key": "TEST",
+            "body": "<p>Test content</p>",
+        }
+
+    @pytest.mark.asyncio
+    async def test_confluence_get_page_by_title_happy_path(
+        self,
+        get_atlassian_access_token_mock: None,
+        confluence_client_get_page_by_title_mock: ConfluencePage,
+    ) -> None:
+        """Confluence get page by title -- happy path."""
+        page_title = "Test Page"
+        space_key = "TEST"
+
+        tool_result = await confluence_get_page(page_id_or_title=page_title, space_key=space_key)
+
+        content, structured_content = tool_result.to_mcp_result()
+        assert content[0].text == "Successfully retrieved page 'Test Page'."
+        assert structured_content["title"] == "Test Page"
+        assert structured_content["space_key"] == "TEST"
+
+    @pytest.mark.asyncio
+    async def test_confluence_get_page_by_title_without_space_key(
+        self,
+        get_atlassian_access_token_mock: None,
+    ) -> None:
+        """Confluence get page by title without space_key -- should raise error."""
+        page_title = "Test Page"
+
+        with pytest.raises(MCPError, match="space_key.*required"):
+            await confluence_get_page(page_id_or_title=page_title)
+
+    @pytest.mark.asyncio
+    async def test_confluence_get_page_when_error_in_client(
+        self,
+        get_atlassian_access_token_mock: None,
+        confluence_client_get_page_error_mock: None,
+    ) -> None:
+        """Confluence get page -- error in client."""
+        page_id = "12345"
+
+        with pytest.raises(MCPError, match="Page not found"):
+            await confluence_get_page(page_id_or_title=page_id)
+
+    @pytest.mark.asyncio
+    async def test_confluence_get_page_empty_page_id(
+        self,
+        get_atlassian_access_token_mock: None,
+    ) -> None:
+        """Confluence get page with empty page_id -- should raise error."""
+        page_id = ""
+
+        with pytest.raises(MCPError, match="cannot be empty"):
+            await confluence_get_page(page_id_or_title=page_id)

--- a/tests/drmcp/unit/tool_clients/test_confluence_client.py
+++ b/tests/drmcp/unit/tool_clients/test_confluence_client.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for async Confluence client using httpx."""
-
 from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import httpx
@@ -25,144 +22,137 @@ from datarobot_genai.drmcp.tools.clients.confluence import ConfluenceClient
 from datarobot_genai.drmcp.tools.clients.confluence import ConfluencePage
 
 
-class TestConfluencePageParsing:
-    """Test ConfluenceClient._parse_response method."""
+def make_response(status_code: int, json_data: dict, cloud_id: str) -> httpx.Response:
+    """Create a mock httpx.Response with a request attached."""
+    request = httpx.Request("GET", f"https://api.atlassian.com/ex/confluence/{cloud_id}")
+    return httpx.Response(status_code, json=json_data, request=request)
+
+
+class TestConfluenceClient:
+    """Test ConfluenceClient class."""
 
     @pytest.fixture
-    def client(self) -> ConfluenceClient:
-        """Create client for testing parse method."""
-        return ConfluenceClient("test_token")
-
-    def test_parse_full_response(self, client: ConfluenceClient) -> None:
-        """Test parsing complete API response."""
-        data = {
-            "id": "12345",
-            "title": "Test Page",
-            "space": {"id": "67890", "key": "TEST"},
-            "body": {"storage": {"value": "<p>Content</p>"}},
-        }
-        result = client._parse_response(data)
-
-        assert isinstance(result, ConfluencePage)
-        assert result.page_id == "12345"
-        assert result.title == "Test Page"
-        assert result.space_id == "67890"
-        assert result.space_key == "TEST"
-        assert result.body == "<p>Content</p>"
-
-
-class TestConfluenceClientGetPageById:
-    """Test ConfluenceClient.get_page_by_id method."""
+    def mock_access_token(self) -> str:
+        """Mock access token."""
+        return "test_access_token_456"
 
     @pytest.fixture
     def mock_cloud_id(self) -> str:
-        return "test-cloud-123"
-
-    @pytest.mark.asyncio
-    async def test_get_page_by_id_success(self, mock_cloud_id: str) -> None:
-        """Test successful page retrieval by ID."""
-        mock_page_data = {
-            "id": "12345",
-            "title": "Test Page",
-            "space": {"id": "67890", "key": "TEST"},
-            "body": {"storage": {"value": "<p>Content</p>"}},
-        }
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = mock_page_data
-        mock_response.raise_for_status = MagicMock()
-
-        with patch(
-            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
-            new_callable=AsyncMock,
-            return_value=mock_cloud_id,
-        ):
-            client = ConfluenceClient("test_token")
-            client._client = AsyncMock(spec=httpx.AsyncClient)
-            client._client.get = AsyncMock(return_value=mock_response)
-
-            result = await client.get_page_by_id("12345")
-
-            assert result.page_id == "12345"
-            assert result.title == "Test Page"
-            client._client.get.assert_awaited_once()
-            call_url = client._client.get.call_args[0][0]
-            assert f"/ex/confluence/{mock_cloud_id}/wiki/rest/api/content/12345" in call_url
-
-    @pytest.mark.asyncio
-    async def test_get_page_by_id_not_found(self, mock_cloud_id: str) -> None:
-        """Test 404 error handling."""
-        mock_response = MagicMock()
-        mock_response.status_code = 404
-
-        with patch(
-            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
-            new_callable=AsyncMock,
-            return_value=mock_cloud_id,
-        ):
-            client = ConfluenceClient("test_token")
-            client._client = AsyncMock(spec=httpx.AsyncClient)
-            client._client.get = AsyncMock(return_value=mock_response)
-
-            with pytest.raises(ValueError, match="not found"):
-                await client.get_page_by_id("nonexistent")
-
-
-class TestConfluenceClientGetPageByTitle:
-    """Test ConfluenceClient.get_page_by_title method."""
+        """Mock cloud ID."""
+        return "test-cloud-id-123"
 
     @pytest.fixture
-    def mock_cloud_id(self) -> str:
-        return "test-cloud-123"
-
-    @pytest.mark.asyncio
-    async def test_get_page_by_title_success(self, mock_cloud_id: str) -> None:
-        """Test successful page retrieval by title."""
-        mock_page_data = {
+    def mock_page_response(self) -> dict:
+        """Mock Confluence REST API page response."""
+        return {
             "id": "12345",
             "title": "Test Page",
             "space": {"id": "67890", "key": "TEST"},
             "body": {"storage": {"value": "<p>Content</p>"}},
         }
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"results": [mock_page_data]}
-        mock_response.raise_for_status = MagicMock()
-
-        with patch(
-            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
-            new_callable=AsyncMock,
-            return_value=mock_cloud_id,
-        ):
-            client = ConfluenceClient("test_token")
-            client._client = AsyncMock(spec=httpx.AsyncClient)
-            client._client.get = AsyncMock(return_value=mock_response)
-
-            result = await client.get_page_by_title("Test Page", "TEST")
-
-            assert result.page_id == "12345"
-            assert result.title == "Test Page"
-            # Verify params passed
-            call_kwargs = client._client.get.call_args[1]
-            assert call_kwargs["params"]["title"] == "Test Page"
-            assert call_kwargs["params"]["spaceKey"] == "TEST"
 
     @pytest.mark.asyncio
-    async def test_get_page_by_title_not_found(self, mock_cloud_id: str) -> None:
-        """Test empty results handling."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"results": []}
-        mock_response.raise_for_status = MagicMock()
-
+    async def test_get_page_by_id_success(
+        self, mock_access_token: str, mock_cloud_id: str, mock_page_response: dict
+    ) -> None:
+        """Test successfully getting a page by ID."""
         with patch(
             "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
             new_callable=AsyncMock,
             return_value=mock_cloud_id,
         ):
-            client = ConfluenceClient("test_token")
-            client._client = AsyncMock(spec=httpx.AsyncClient)
-            client._client.get = AsyncMock(return_value=mock_response)
+            async with ConfluenceClient(mock_access_token) as client:
 
-            with pytest.raises(ValueError, match="not found"):
-                await client.get_page_by_title("Nonexistent", "TEST")
+                async def mock_get(_url: str, **_kwargs: dict) -> httpx.Response:
+                    return make_response(200, mock_page_response, mock_cloud_id)
+
+                client._client.get = mock_get
+
+                result = await client.get_page_by_id("12345")
+
+                assert result.page_id == "12345"
+                assert result.title == "Test Page"
+                assert result.space_key == "TEST"
+                assert result.body == "<p>Content</p>"
+
+    @pytest.mark.asyncio
+    async def test_get_page_by_id_not_found(
+        self, mock_access_token: str, mock_cloud_id: str
+    ) -> None:
+        """Test getting a page that doesn't exist."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            async with ConfluenceClient(mock_access_token) as client:
+
+                async def mock_get(_url: str, **_kwargs: dict) -> httpx.Response:
+                    return make_response(404, {"message": "Not found"}, mock_cloud_id)
+
+                client._client.get = mock_get
+
+                with pytest.raises(ValueError, match="not found"):
+                    await client.get_page_by_id("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_get_page_by_title_success(
+        self, mock_access_token: str, mock_cloud_id: str, mock_page_response: dict
+    ) -> None:
+        """Test successfully getting a page by title."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            async with ConfluenceClient(mock_access_token) as client:
+
+                async def mock_get(_url: str, **_kwargs: dict) -> httpx.Response:
+                    return make_response(200, {"results": [mock_page_response]}, mock_cloud_id)
+
+                client._client.get = mock_get
+
+                result = await client.get_page_by_title("Test Page", "TEST")
+
+                assert result.page_id == "12345"
+                assert result.title == "Test Page"
+
+    @pytest.mark.asyncio
+    async def test_get_page_by_title_not_found(
+        self, mock_access_token: str, mock_cloud_id: str
+    ) -> None:
+        """Test getting a page by title that doesn't exist."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            async with ConfluenceClient(mock_access_token) as client:
+
+                async def mock_get(_url: str, **_kwargs: dict) -> httpx.Response:
+                    return make_response(200, {"results": []}, mock_cloud_id)
+
+                client._client.get = mock_get
+
+                with pytest.raises(ValueError, match="not found"):
+                    await client.get_page_by_title("Nonexistent", "TEST")
+
+    def test_as_flat_dict(self) -> None:
+        """Test ConfluencePage.as_flat_dict method."""
+        page = ConfluencePage(
+            page_id="12345",
+            title="Test Page",
+            space_id="67890",
+            space_key="TEST",
+            body="<p>Content</p>",
+        )
+
+        result = page.as_flat_dict()
+
+        assert result == {
+            "page_id": "12345",
+            "title": "Test Page",
+            "space_id": "67890",
+            "space_key": "TEST",
+            "body": "<p>Content</p>",
+        }

--- a/tests/drmcp/unit/tool_clients/test_confluence_client.py
+++ b/tests/drmcp/unit/tool_clients/test_confluence_client.py
@@ -11,3 +11,158 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Tests for async Confluence client using httpx."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from datarobot_genai.drmcp.tools.clients.confluence import ConfluenceClient
+from datarobot_genai.drmcp.tools.clients.confluence import ConfluencePage
+
+
+class TestConfluencePageParsing:
+    """Test ConfluenceClient._parse_response method."""
+
+    @pytest.fixture
+    def client(self) -> ConfluenceClient:
+        """Create client for testing parse method."""
+        return ConfluenceClient("test_token")
+
+    def test_parse_full_response(self, client: ConfluenceClient) -> None:
+        """Test parsing complete API response."""
+        data = {
+            "id": "12345",
+            "title": "Test Page",
+            "space": {"id": "67890", "key": "TEST"},
+            "body": {"storage": {"value": "<p>Content</p>"}},
+        }
+        result = client._parse_response(data)
+
+        assert isinstance(result, ConfluencePage)
+        assert result.page_id == "12345"
+        assert result.title == "Test Page"
+        assert result.space_id == "67890"
+        assert result.space_key == "TEST"
+        assert result.body == "<p>Content</p>"
+
+
+class TestConfluenceClientGetPageById:
+    """Test ConfluenceClient.get_page_by_id method."""
+
+    @pytest.fixture
+    def mock_cloud_id(self) -> str:
+        return "test-cloud-123"
+
+    @pytest.mark.asyncio
+    async def test_get_page_by_id_success(self, mock_cloud_id: str) -> None:
+        """Test successful page retrieval by ID."""
+        mock_page_data = {
+            "id": "12345",
+            "title": "Test Page",
+            "space": {"id": "67890", "key": "TEST"},
+            "body": {"storage": {"value": "<p>Content</p>"}},
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_page_data
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            client = ConfluenceClient("test_token")
+            client._client = AsyncMock(spec=httpx.AsyncClient)
+            client._client.get = AsyncMock(return_value=mock_response)
+
+            result = await client.get_page_by_id("12345")
+
+            assert result.page_id == "12345"
+            assert result.title == "Test Page"
+            client._client.get.assert_awaited_once()
+            call_url = client._client.get.call_args[0][0]
+            assert f"/ex/confluence/{mock_cloud_id}/wiki/rest/api/content/12345" in call_url
+
+    @pytest.mark.asyncio
+    async def test_get_page_by_id_not_found(self, mock_cloud_id: str) -> None:
+        """Test 404 error handling."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            client = ConfluenceClient("test_token")
+            client._client = AsyncMock(spec=httpx.AsyncClient)
+            client._client.get = AsyncMock(return_value=mock_response)
+
+            with pytest.raises(ValueError, match="not found"):
+                await client.get_page_by_id("nonexistent")
+
+
+class TestConfluenceClientGetPageByTitle:
+    """Test ConfluenceClient.get_page_by_title method."""
+
+    @pytest.fixture
+    def mock_cloud_id(self) -> str:
+        return "test-cloud-123"
+
+    @pytest.mark.asyncio
+    async def test_get_page_by_title_success(self, mock_cloud_id: str) -> None:
+        """Test successful page retrieval by title."""
+        mock_page_data = {
+            "id": "12345",
+            "title": "Test Page",
+            "space": {"id": "67890", "key": "TEST"},
+            "body": {"storage": {"value": "<p>Content</p>"}},
+        }
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": [mock_page_data]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            client = ConfluenceClient("test_token")
+            client._client = AsyncMock(spec=httpx.AsyncClient)
+            client._client.get = AsyncMock(return_value=mock_response)
+
+            result = await client.get_page_by_title("Test Page", "TEST")
+
+            assert result.page_id == "12345"
+            assert result.title == "Test Page"
+            # Verify params passed
+            call_kwargs = client._client.get.call_args[1]
+            assert call_kwargs["params"]["title"] == "Test Page"
+            assert call_kwargs["params"]["spaceKey"] == "TEST"
+
+    @pytest.mark.asyncio
+    async def test_get_page_by_title_not_found(self, mock_cloud_id: str) -> None:
+        """Test empty results handling."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.confluence.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            client = ConfluenceClient("test_token")
+            client._client = AsyncMock(spec=httpx.AsyncClient)
+            client._client.get = AsyncMock(return_value=mock_response)
+
+            with pytest.raises(ValueError, match="not found"):
+                await client.get_page_by_title("Nonexistent", "TEST")

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,6 @@ resolution-markers = [
 
 [manifest]
 overrides = [{ name = "ragas", specifier = ">=0.3.8,<0.4.0" }]
-excludes = ["uv"]
 
 [[package]]
 name = "ag-ui-protocol"
@@ -856,6 +855,7 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tomli" },
     { name = "tomli-w" },
+    { name = "uv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/c4/37f5e8e0ccb2804a3e2acc0ccf58f82dc9415a08fad71a3868cdf830c669/crewai-1.6.1.tar.gz", hash = "sha256:b7d73a8a333abf71b30ab20c54086004cd0c016dfd86bba9c035ad5eb31e22a7", size = 4177912, upload-time = "2025-11-29T01:58:25.573Z" }
 wheels = [
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.7"
+version = "0.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -6558,6 +6558,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.9.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/1a/cb0c37ae8513b253bcbc13d42392feb7d95ea696eb398b37535a28df9040/uv-0.9.17.tar.gz", hash = "sha256:6d93ab9012673e82039cfa7f9f66f69b388bc3f910f9e8a2ebee211353f620aa", size = 3815957, upload-time = "2025-12-09T23:01:21.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/e2/b6e2d473bdc37f4d86307151b53c0776e9925de7376ce297e92eab2e8894/uv-0.9.17-py3-none-linux_armv6l.whl", hash = "sha256:c708e6560ae5bc3cda1ba93f0094148ce773b6764240ced433acf88879e57a67", size = 21254511, upload-time = "2025-12-09T23:00:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/40/75f1529a8bf33cc5c885048e64a014c3096db5ac7826c71e20f2b731b588/uv-0.9.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:233b3d90f104c59d602abf434898057876b87f64df67a37129877d6dab6e5e10", size = 20384366, upload-time = "2025-12-09T23:01:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/b3a343893681a569cbb74f8747a1c24e5f18ca9e07de0430aceaf9389ef4/uv-0.9.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4b8e5513d48a267bfa180ca7fefaf6f27b1267e191573b3dba059981143e88ef", size = 18924624, upload-time = "2025-12-09T23:01:10.291Z" },
+    { url = "https://files.pythonhosted.org/packages/21/56/9daf8bbe4a9a36eb0b9257cf5e1e20f9433d0ce996778ccf1929cbe071a4/uv-0.9.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:8f283488bbcf19754910cc1ae7349c567918d6367c596e5a75d4751e0080eee0", size = 20671687, upload-time = "2025-12-09T23:00:51.927Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c8/4050ff7dc692770092042fcef57223b8852662544f5981a7f6cac8fc488d/uv-0.9.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9cf8052ba669dc17bdba75dae655094d820f4044990ea95c01ec9688c182f1da", size = 20861866, upload-time = "2025-12-09T23:01:12.555Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/208e62b7db7a65cb3390a11604c59937e387d07ed9f8b63b54edb55e2292/uv-0.9.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:06749461b11175a884be193120044e7f632a55e2624d9203398808907d346aad", size = 21858420, upload-time = "2025-12-09T23:01:00.009Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2c/91288cd5a04db37dfc1e0dad26ead84787db5832d9836b4cc8e0fa7f3c53/uv-0.9.17-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:35eb1a519688209160e48e1bb8032d36d285948a13b4dd21afe7ec36dc2a9787", size = 23471658, upload-time = "2025-12-09T23:00:49.503Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ba/493eba650ffad1df9e04fd8eabfc2d0aebc23e8f378acaaee9d95ca43518/uv-0.9.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2bfb60a533e82690ab17dfe619ff7f294d053415645800d38d13062170230714", size = 23062950, upload-time = "2025-12-09T23:00:39.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9e/f7f679503c06843ba59451e3193f35fb7c782ff0afc697020d4718a7de46/uv-0.9.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd0f3e380ff148aff3d769e95a9743cb29c7f040d7ef2896cafe8063279a6bc1", size = 22080299, upload-time = "2025-12-09T23:00:44.026Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/76ba33c7d9efe9f17480db1b94d3393025062005e346bb8b3660554526da/uv-0.9.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd2c3d25fbd8f91b30d0fac69a13b8e2c2cd8e606d7e6e924c1423e4ff84e616", size = 22087554, upload-time = "2025-12-09T23:00:41.715Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/ef4aae4a6c49076db2acd2a7b0278ddf3dbf785d5172b3165018b96ba2fb/uv-0.9.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:330e7085857e4205c5196a417aca81cfbfa936a97dd2a0871f6560a88424ebf2", size = 20823225, upload-time = "2025-12-09T23:00:57.041Z" },
+    { url = "https://files.pythonhosted.org/packages/11/73/e0f816cacd802a1cb25e71de9d60e57fa1f6c659eb5599cef708668618cc/uv-0.9.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:45880faa9f6cf91e3cda4e5f947da6a1004238fdc0ed4ebc18783a12ce197312", size = 22004893, upload-time = "2025-12-09T23:01:15.011Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/700f6256ee191136eb06e40d16970a4fc687efdccf5e67c553a258063019/uv-0.9.17-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:8e775a1b94c6f248e22f0ce2f86ed37c24e10ae31fb98b7e1b9f9a3189d25991", size = 20853850, upload-time = "2025-12-09T23:01:02.694Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6a/13f02e2ed6510223c40f74804586b09e5151d9319f93aab1e49d91db13bb/uv-0.9.17-py3-none-musllinux_1_1_i686.whl", hash = "sha256:8650c894401ec96488a6fd84a5b4675e09be102f5525c902a12ba1c8ef8ff230", size = 21322623, upload-time = "2025-12-09T23:00:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/18/2d19780cebfbec877ea645463410c17859f8070f79c1a34568b153d78e1d/uv-0.9.17-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:673066b72d8b6c86be0dae6d5f73926bcee8e4810f1690d7b8ce5429d919cde3", size = 22290123, upload-time = "2025-12-09T23:00:54.394Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/ab79bde3f7b6d2ac89f839ea40411a9cf3e67abede2278806305b6ba797e/uv-0.9.17-py3-none-win32.whl", hash = "sha256:7407d45afeae12399de048f7c8c2256546899c94bd7892dbddfae6766616f5a3", size = 20070709, upload-time = "2025-12-09T23:01:05.105Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a0/ab5b1850197bf407d095361b214352e40805441791fed35b891621cb1562/uv-0.9.17-py3-none-win_amd64.whl", hash = "sha256:22fcc26755abebdf366becc529b2872a831ce8bb14b36b6a80d443a1d7f84d3b", size = 22122852, upload-time = "2025-12-09T23:01:07.783Z" },
+    { url = "https://files.pythonhosted.org/packages/37/ef/813cfedda3c8e49d8b59a41c14fcc652174facfd7a1caf9fee162b40ccbd/uv-0.9.17-py3-none-win_arm64.whl", hash = "sha256:6761076b27a763d0ede2f5e72455d2a46968ff334badf8312bb35988c5254831", size = 20435751, upload-time = "2025-12-09T23:01:19.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# RATIONALE
Adds confluence_get_page MCP tool to retrieve Confluence pages by ID or title.


## CHANGES
- `src/datarobot_genai/drmcp/tools/clients/confluence.py` - Async client with cloud ID caching
- `src/datarobot_genai/drmcp/tools/confluence/tools.py` - MCP tool with Pydantic response model

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
