### PR TITLE
[BUZZOK-28912] Add retry support to NAT LLM adaptors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.12"
+version = "0.2.13"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/nat/datarobot_llm_clients.py
+++ b/src/datarobot_genai/nat/datarobot_llm_clients.py
@@ -22,6 +22,9 @@ from llama_index.llms.litellm import LiteLLM
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_llm_client
+from nat.plugins.langchain.llm import (
+    _patch_llm_based_on_config as langchain_patch_llm_based_on_config,
+)
 
 from ..nat.datarobot_llm_providers import DataRobotLLMComponentModelConfig
 from ..nat.datarobot_llm_providers import DataRobotLLMDeploymentModelConfig
@@ -77,7 +80,8 @@ async def datarobot_llm_gateway_langchain(
     config["base_url"] = config["base_url"] + "/genai/llmgw"
     config["stream_options"] = {"include_usage": True}
     config["model"] = config["model"].removeprefix("datarobot/")
-    yield DataRobotChatOpenAI(**config)
+    client = DataRobotChatOpenAI(**config)
+    yield langchain_patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(
@@ -119,7 +123,8 @@ async def datarobot_llm_deployment_langchain(
     )
     config["stream_options"] = {"include_usage": True}
     config["model"] = config["model"].removeprefix("datarobot/")
-    yield DataRobotChatOpenAI(**config)
+    client = DataRobotChatOpenAI(**config)
+    yield langchain_patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(
@@ -167,7 +172,8 @@ async def datarobot_nim_langchain(
     )
     config["stream_options"] = {"include_usage": True}
     config["model"] = config["model"].removeprefix("datarobot/")
-    yield DataRobotChatOpenAI(**config)
+    client = DataRobotChatOpenAI(**config)
+    yield langchain_patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(config_type=DataRobotNIMModelConfig, wrapper_type=LLMFrameworkEnum.CREWAI)
@@ -212,7 +218,8 @@ async def datarobot_llm_component_langchain(
     config["stream_options"] = {"include_usage": True}
     config["model"] = config["model"].removeprefix("datarobot/")
     config.pop("use_datarobot_llm_gateway")
-    yield DataRobotChatOpenAI(**config)
+    client = DataRobotChatOpenAI(**config)
+    yield langchain_patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(

--- a/src/datarobot_genai/nat/datarobot_llm_clients.py
+++ b/src/datarobot_genai/nat/datarobot_llm_clients.py
@@ -14,6 +14,7 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any
+from typing import TypeVar
 
 from crewai import LLM
 from langchain_openai import ChatOpenAI
@@ -22,14 +23,31 @@ from llama_index.llms.litellm import LiteLLM
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_llm_client
+from nat.data_models.llm import LLMBaseConfig
+from nat.data_models.retry_mixin import RetryMixin
 from nat.plugins.langchain.llm import (
     _patch_llm_based_on_config as langchain_patch_llm_based_on_config,
 )
+from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 
 from ..nat.datarobot_llm_providers import DataRobotLLMComponentModelConfig
 from ..nat.datarobot_llm_providers import DataRobotLLMDeploymentModelConfig
 from ..nat.datarobot_llm_providers import DataRobotLLMGatewayModelConfig
 from ..nat.datarobot_llm_providers import DataRobotNIMModelConfig
+
+ModelType = TypeVar("ModelType")
+
+
+def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> ModelType:
+    if isinstance(llm_config, RetryMixin):
+        client = patch_with_retry(
+            client,
+            retries=llm_config.num_retries,
+            retry_codes=llm_config.retry_on_status_codes,
+            retry_on_messages=llm_config.retry_on_errors,
+        )
+
+    return client
 
 
 class DataRobotChatOpenAI(ChatOpenAI):
@@ -94,7 +112,8 @@ async def datarobot_llm_gateway_crewai(
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     config["base_url"] = config["base_url"].removesuffix("/api/v2")
-    yield LLM(**config)
+    client = LLM(**config)
+    yield _patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(
@@ -107,7 +126,8 @@ async def datarobot_llm_gateway_llamaindex(
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     config["api_base"] = config.pop("base_url").removesuffix("/api/v2")
-    yield DataRobotLiteLLM(**config)
+    client = DataRobotLiteLLM(**config)
+    yield _patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(
@@ -141,7 +161,8 @@ async def datarobot_llm_deployment_crewai(
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     config["api_base"] = config.pop("base_url") + "/chat/completions"
-    yield LLM(**config)
+    client = LLM(**config)
+    yield _patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(
@@ -158,7 +179,8 @@ async def datarobot_llm_deployment_llamaindex(
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     config["api_base"] = config.pop("base_url") + "/chat/completions"
-    yield DataRobotLiteLLM(**config)
+    client = DataRobotLiteLLM(**config)
+    yield _patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(config_type=DataRobotNIMModelConfig, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
@@ -188,7 +210,8 @@ async def datarobot_nim_crewai(
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     config["api_base"] = config.pop("base_url") + "/chat/completions"
-    yield LLM(**config)
+    client = LLM(**config)
+    yield _patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(config_type=DataRobotNIMModelConfig, wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
@@ -203,7 +226,8 @@ async def datarobot_nim_llamaindex(
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     config["api_base"] = config.pop("base_url") + "/chat/completions"
-    yield DataRobotLiteLLM(**config)
+    client = DataRobotLiteLLM(**config)
+    yield _patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(
@@ -236,7 +260,8 @@ async def datarobot_llm_component_crewai(
     else:
         config["api_base"] = config.pop("base_url") + "/chat/completions"
     config.pop("use_datarobot_llm_gateway")
-    yield LLM(**config)
+    client = LLM(**config)
+    yield _patch_llm_based_on_config(client, config)
 
 
 @register_llm_client(
@@ -253,4 +278,5 @@ async def datarobot_llm_component_llamaindex(
     else:
         config["api_base"] = config.pop("base_url") + "/chat/completions"
     config.pop("use_datarobot_llm_gateway")
-    yield DataRobotLiteLLM(**config)
+    client = DataRobotLiteLLM(**config)
+    yield _patch_llm_based_on_config(client, config)

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
# RATIONALE
The LLM adaptors for NAT provide retry (and thinking for some models) support OOTB.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Patch the LLM clients for retries. For langchain LLM adaptors also patch for thinking when the model supports it.
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
