### PR TITLE
[MODEL-21640] Add Confluence add comment MCP tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.15"
+version = "0.2.16"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/tests/drmcp/acceptance/test_confluence_tools.py
+++ b/tests/drmcp/acceptance/test_confluence_tools.py
@@ -187,3 +187,49 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
                 session,
                 test_name,
             )
+
+    @pytest.mark.skip(reason="Creates real comments in Confluence without cleanup - run manually")
+    async def test_confluence_add_comment_success(
+        self,
+        openai_llm_client: Any,
+        confluence_page_id: str,
+    ) -> None:
+        """Test adding a comment to a Confluence page.
+
+        Note: This test creates a real comment in Confluence. Comments created by
+        this test will need to be manually cleaned up or will remain on the page.
+        """
+        comment_body = f"<p>MCP E2E Test Comment {uuid.uuid4().hex[:8]}</p>"
+
+        expectations = ETETestExpectations(
+            tool_calls_expected=[
+                ToolCallTestExpectations(
+                    name="confluence_add_comment",
+                    parameters={
+                        "page_id": confluence_page_id,
+                        "comment_body": comment_body,
+                    },
+                    result=SHOULD_NOT_BE_EMPTY,
+                ),
+            ],
+            llm_response_content_contains_expectations=[
+                "comment",
+                "added",
+            ],
+        )
+
+        prompt = (
+            f"Add a comment to the Confluence page with ID `{confluence_page_id}` "
+            f"with the following content: `{comment_body}`."
+        )
+
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_confluence_add_comment_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations,
+                openai_llm_client,
+                session,
+                test_name,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.15"
+version = "0.2.16"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
# RATIONALE
Adds the ability to add comments to Confluence pages via the MCP server.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
New  MCP tool: `confluence_add_comment(page_id, comment_body)` - adds comments to Confluence pages

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
