### PR TITLE
[BUZZOK-28983] Prepare removal of config.agent_endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.33"
+version = "0.2.34"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/cli/agent_kernel.py
+++ b/src/datarobot_genai/core/cli/agent_kernel.py
@@ -107,7 +107,10 @@ class AgentKernel:
         stream: bool = False,
         config: Any | None = None,
     ) -> ChatCompletion | Stream[ChatCompletionChunk]:
-        chat_api_url = config.agent_endpoint if config else self.base_url
+        if config is not None:
+            chat_api_url = f"http://localhost:{config.local_dev_port}",
+        else:
+            chat_api_url = self.base_url
         print(chat_api_url)
 
         return self._do_chat_completion(chat_api_url, user_prompt, completion_json, stream=stream)

--- a/src/datarobot_genai/core/cli/agent_kernel.py
+++ b/src/datarobot_genai/core/cli/agent_kernel.py
@@ -108,7 +108,7 @@ class AgentKernel:
         config: Any | None = None,
     ) -> ChatCompletion | Stream[ChatCompletionChunk]:
         if config is not None:
-            chat_api_url = f"http://localhost:{config.local_dev_port}",
+            chat_api_url = f"http://localhost:{config.local_dev_port}"
         else:
             chat_api_url = self.base_url
         print(chat_api_url)

--- a/tests/core/cli/test_agent_kernel.py
+++ b/tests/core/cli/test_agent_kernel.py
@@ -249,7 +249,7 @@ class TestAgentKernel:
         mock_completions.create.return_value = mock_completion_obj
 
         # Execute
-        result = kernel.local(user_prompt, config=Mock(agent_endpoint="http://localhost:8842"))
+        result = kernel.local(user_prompt, config=Mock(local_dev_port=8842))
 
         # Assert
         # Verify OpenAI client was created with correct parameters
@@ -300,9 +300,7 @@ class TestAgentKernel:
         mock_completions.create.return_value = mock_completion_obj
 
         # Execute
-        result = kernel.local(
-            user_prompt, stream=True, config=Mock(agent_endpoint="http://localhost:8842")
-        )
+        result = kernel.local(user_prompt, stream=True, config=Mock(local_dev_port=8842))
 
         # Assert
         # Verify OpenAI client was created with correct parameters
@@ -351,7 +349,7 @@ class TestAgentKernel:
         mock_completions.create.return_value = Mock(spec=ChatCompletion)
 
         # Execute
-        kernel.local(user_prompt, config=Mock(agent_endpoint="http://localhost:8842"))
+        kernel.local(user_prompt, config=Mock(local_dev_port=8842))
 
         # Assert print statements were called with expected arguments
         expected_api_url = "http://localhost:8842"
@@ -376,7 +374,7 @@ class TestAgentKernel:
 
         # Execute and Assert
         with pytest.raises(ValueError, match="Test error"):
-            kernel.local(user_prompt, config=Mock(agent_endpoint="http://localhost:8842"))
+            kernel.local(user_prompt, config=Mock(local_dev_port=8842))
 
     @patch("datarobot_genai.core.cli.agent_kernel.requests.post")
     @patch("datarobot_genai.core.cli.agent_kernel.requests.get")

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.33"
+version = "0.2.34"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
# RATIONALE
For the agent templates, we want to align how ports are configured for the different components. For the agent there is currently an agent_endpoint variable, which we want to change to a port variable as it is done for the other services. This PR prepares [the changes in the templates](https://github.com/datarobot-community/af-component-agent/pull/363).
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
