### PR TITLE
[MODEL-22089] Update ETE tests to use DRLLMGatewayMCPClient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.32"
+version = "0.2.33"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
@@ -68,6 +68,26 @@ def get_openai_llm_client_config() -> dict[str, str]:
     return config
 
 
+def get_dr_llm_gateway_client_config() -> dict[str, str]:
+    """Get DataRobot LLM Gateway client configuration."""
+    datarobot_api_token = os.environ.get("DATAROBOT_API_TOKEN")
+    datarobot_endpoint = os.environ.get("DATAROBOT_ENDPOINT")
+    save_llm_responses = os.environ.get("SAVE_LLM_RESPONSES", "false").lower() == "true"
+
+    if not datarobot_api_token:
+        raise ValueError("Missing required environment variable: DATAROBOT_API_TOKEN")
+
+    config: dict[str, str] = {
+        "datarobot_api_token": datarobot_api_token,
+        "save_llm_responses": str(save_llm_responses),
+    }
+
+    if datarobot_endpoint:
+        config["datarobot_endpoint"] = datarobot_endpoint
+
+    return config
+
+
 def get_headers() -> dict[str, str]:
     # When the MCP server is deployed in DataRobot, we have to include the API token in headers for
     # authentication.

--- a/tests/drmcp/acceptance/conftest.py
+++ b/tests/drmcp/acceptance/conftest.py
@@ -17,18 +17,18 @@ from typing import Any
 
 import pytest
 
-from datarobot_genai.drmcp.test_utils.clients.openai import OpenAILLMMCPClient
-from datarobot_genai.drmcp.test_utils.mcp_utils_ete import get_openai_llm_client_config
+from datarobot_genai.drmcp.test_utils.clients.dr_gateway import DRLLMGatewayMCPClient
+from datarobot_genai.drmcp.test_utils.mcp_utils_ete import get_dr_llm_gateway_client_config
 
 
 @pytest.fixture(scope="session")
-def openai_llm_client() -> OpenAILLMMCPClient:
-    """Create OpenAI LLM MCP client for the test session."""
+def llm_client() -> DRLLMGatewayMCPClient:
+    """Create DataRobot LLM Gateway MCP client for the test session."""
     try:
-        config = get_openai_llm_client_config()
-        return OpenAILLMMCPClient(str(config))
+        config = get_dr_llm_gateway_client_config()
+        return DRLLMGatewayMCPClient(str(config))
     except ValueError as e:
-        raise ValueError(f"Missing required OpenAI environment variables: {e}") from e
+        raise ValueError(f"Missing required DataRobot environment variables: {e}") from e
     except Exception as e:
         raise ConnectionError(f"Failed to create LLM MCP client: {str(e)}") from e
 

--- a/tests/drmcp/acceptance/test_auth.py
+++ b/tests/drmcp/acceptance/test_auth.py
@@ -101,7 +101,7 @@ class TestAuthContextE2E(ToolBaseE2E):
     )
     async def test_auth_context_tool_with_valid_token(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_auth_context_tool_success: ETETestExpectations,
         prompt: str,
         auth_token: str,
@@ -115,7 +115,7 @@ class TestAuthContextE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_auth_context_tool_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]

--- a/tests/drmcp/acceptance/test_confluence_tools.py
+++ b/tests/drmcp/acceptance/test_confluence_tools.py
@@ -89,7 +89,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
 
     async def test_confluence_get_page_by_id_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_confluence_get_page_by_id_success: ETETestExpectations,
         confluence_page_id: str,
     ) -> None:
@@ -101,14 +101,14 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_confluence_get_page_by_id_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
 
     async def test_confluence_get_page_by_title_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_confluence_get_page_by_title_success: ETETestExpectations,
         confluence_page_title: str,
         confluence_space_key: str,
@@ -126,14 +126,14 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_confluence_get_page_by_title_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
 
     async def test_confluence_search_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
     ) -> None:
         """Test searching Confluence content with CQL query."""
         cql_query = 'type=page AND title ~ "MCP Acceptance"'
@@ -163,7 +163,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -171,7 +171,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
     @pytest.mark.skip(reason="Creates real pages in Confluence without cleanup - run manually")
     async def test_confluence_create_page_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         confluence_space_key: str,
     ) -> None:
         """Test creating a new Confluence page.
@@ -212,7 +212,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -220,7 +220,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
     @pytest.mark.skip(reason="Creates real comments in Confluence without cleanup - run manually")
     async def test_confluence_add_comment_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         confluence_page_id: str,
     ) -> None:
         """Test adding a comment to a Confluence page.
@@ -258,7 +258,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -266,7 +266,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
     @pytest.mark.skip(reason="Skipped by default to avoid modifying real Confluence data")
     async def test_confluence_update_page_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         confluence_page_id: str,
     ) -> None:
         """Test updating a Confluence page -- requires real page ID."""
@@ -303,7 +303,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_data.py
+++ b/tests/drmcp/acceptance/test_data.py
@@ -124,7 +124,7 @@ class TestDataE2E(ToolBaseE2E):
     )
     async def test_upload_dataset_to_ai_catalog_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_upload_dataset_to_ai_catalog_success: ETETestExpectations,
         prompt_template: str,
         diabetes_scoring_small_file_path: str,
@@ -134,7 +134,7 @@ class TestDataE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_upload_dataset_to_ai_catalog_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
@@ -154,7 +154,7 @@ class TestDataE2E(ToolBaseE2E):
     )
     async def test_upload_dataset_to_ai_catalog_success_from_url(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_upload_dataset_to_ai_catalog_success_from_url: ETETestExpectations,
         prompt_template: str,
     ) -> None:
@@ -165,7 +165,7 @@ class TestDataE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_upload_dataset_to_ai_catalog_success_from_url,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
@@ -185,7 +185,7 @@ class TestDataE2E(ToolBaseE2E):
     )
     async def test_upload_dataset_to_ai_catalog_failure(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_upload_dataset_to_ai_catalog_failure: ETETestExpectations,
         prompt_template: str,
         nonexistent_file_path: str,
@@ -195,7 +195,7 @@ class TestDataE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_upload_dataset_to_ai_catalog_failure,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
@@ -216,7 +216,7 @@ class TestDataE2E(ToolBaseE2E):
     )
     async def test_list_ai_catalog_items_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_list_ai_catalog_items_success: ETETestExpectations,
         prompt: str,
     ) -> None:
@@ -224,7 +224,7 @@ class TestDataE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_list_ai_catalog_items_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]

--- a/tests/drmcp/acceptance/test_deployment.py
+++ b/tests/drmcp/acceptance/test_deployment.py
@@ -102,7 +102,7 @@ class TestDeploymentE2E(ToolBaseE2E):
     )
     async def test_list_deployments_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_list_deployments_success: ETETestExpectations,
         prompt: str,
     ) -> None:
@@ -110,7 +110,7 @@ class TestDeploymentE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_list_deployments_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
@@ -131,7 +131,7 @@ class TestDeploymentE2E(ToolBaseE2E):
     )
     async def test_get_model_info_from_deployment_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_model_info_from_deployment_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
@@ -142,7 +142,7 @@ class TestDeploymentE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_model_info_from_deployment_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
@@ -163,7 +163,7 @@ class TestDeploymentE2E(ToolBaseE2E):
     )
     async def test_get_model_info_from_deployment_failure(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_model_info_from_deployment_failure: ETETestExpectations,
         nonexistent_deployment_id: str,
         prompt_template: str,
@@ -174,7 +174,7 @@ class TestDeploymentE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_model_info_from_deployment_failure,
-                openai_llm_client,
+                llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]

--- a/tests/drmcp/acceptance/test_deployment_info.py
+++ b/tests/drmcp/acceptance/test_deployment_info.py
@@ -135,7 +135,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
     )
     async def test_get_deployment_features_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_deployment_features_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
@@ -148,7 +148,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_deployment_features_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -165,7 +165,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
     )
     async def test_generate_prediction_data_template_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_generate_prediction_data_template_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
@@ -180,7 +180,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_generate_prediction_data_template_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -203,7 +203,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
     )
     async def test_validate_prediction_data_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_validate_prediction_data_success: ETETestExpectations,
         deployment_id: str,
         diabetes_scoring_small_file_path: str,
@@ -220,7 +220,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_validate_prediction_data_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -237,7 +237,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
     )
     async def test_validate_prediction_data_failure(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_validate_prediction_data_failure: ETETestExpectations,
         deployment_id: str,
         nonexistent_file_path: str,
@@ -254,7 +254,7 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_validate_prediction_data_failure,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_gdrive_tools.py
+++ b/tests/drmcp/acceptance/test_gdrive_tools.py
@@ -100,7 +100,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
     )
     async def test_gdrive_find_contents_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_gdrive_list_files_success: ETETestExpectations,
         gdrive_folder_id: str,
         list_files_no_of_results: int,
@@ -116,7 +116,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_gdrive_list_files_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -130,7 +130,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
     )
     async def test_gdrive_read_content_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_gdrive_read_content_success: ETETestExpectations,
         gdrive_pdf_file_id: str,
         prompt_template: str,
@@ -143,7 +143,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_gdrive_read_content_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -158,7 +158,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
     )
     async def test_gdrive_create_file_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         prompt_template: str,
     ) -> None:
         expectations = ETETestExpectations(
@@ -181,7 +181,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt_template,
                 expectations,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -196,7 +196,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
     )
     async def test_gdrive_update_metadata_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         prompt_template: str,
     ) -> None:
         # Note: Replace with a real file ID when running manually
@@ -224,7 +224,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -236,7 +236,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
     )
     async def test_gdrive_manage_access_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         prompt_template: str,
     ) -> None:
         # Note: Replace with a real file ID and email when running manually
@@ -266,7 +266,7 @@ class TestGdriveToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_jira_tools.py
+++ b/tests/drmcp/acceptance/test_jira_tools.py
@@ -169,7 +169,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
     )
     async def test_jira_issue_search_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_jira_search_issues_success: ETETestExpectations,
         project_key: str,
         search_no_of_results: int,
@@ -187,7 +187,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_jira_search_issues_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -198,7 +198,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
     )
     async def test_jira_issue_get_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_jira_get_issue_success: ETETestExpectations,
         jira_issue_key: str,
         prompt_template: str,
@@ -211,7 +211,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_jira_get_issue_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -225,7 +225,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
     )
     async def test_jira_issue_create_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_jira_create_issue_success: ETETestExpectations,
         project_key: str,
         jira_new_ticket_name: str,
@@ -239,7 +239,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_jira_create_issue_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -253,7 +253,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
     )
     async def test_jira_issue_update_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_jira_update_issue_success: ETETestExpectations,
         jira_issue_key: str,
         jira_updated_ticket_name: str,
@@ -269,7 +269,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_jira_update_issue_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -283,7 +283,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
     )
     async def test_jira_issue_transition_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_jira_transition_issue_success: ETETestExpectations,
         jira_issue_key: str,
         jira_updated_ticket_status: str,
@@ -299,7 +299,7 @@ class TestJiraToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_jira_transition_issue_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_microsoft_graph_tools.py
+++ b/tests/drmcp/acceptance/test_microsoft_graph_tools.py
@@ -53,7 +53,7 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
     )
     async def test_microsoft_graph_search_content_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_microsoft_graph_search_content_success: ETETestExpectations,
         prompt_template: str,
     ) -> None:
@@ -67,7 +67,7 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_microsoft_graph_search_content_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_model.py
+++ b/tests/drmcp/acceptance/test_model.py
@@ -142,7 +142,7 @@ class TestModelE2E(ToolBaseE2E):
     )
     async def test_get_best_model_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_best_model_success: ETETestExpectations,
         classification_project_id: str,
         prompt_template: str,
@@ -155,7 +155,7 @@ class TestModelE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_best_model_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -172,7 +172,7 @@ class TestModelE2E(ToolBaseE2E):
     )
     async def test_get_best_model_failure(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_best_model_failure: ETETestExpectations,
         nonexistent_project_id: str,
         prompt_template: str,
@@ -185,7 +185,7 @@ class TestModelE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_best_model_failure,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -208,7 +208,7 @@ class TestModelE2E(ToolBaseE2E):
     )
     async def test_score_dataset_with_model_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_score_dataset_with_model_success: ETETestExpectations,
         classification_project_id: str,
         model_id: str,
@@ -227,7 +227,7 @@ class TestModelE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_score_dataset_with_model_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -244,7 +244,7 @@ class TestModelE2E(ToolBaseE2E):
     )
     async def test_score_dataset_with_model_failure(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_score_dataset_with_model_failure: ETETestExpectations,
         classification_project_id: str,
         nonexistent_model_id: str,
@@ -263,7 +263,7 @@ class TestModelE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_score_dataset_with_model_failure,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_predict.py
+++ b/tests/drmcp/acceptance/test_predict.py
@@ -128,7 +128,7 @@ class TestPredictE2E(ToolBaseE2E):
     )
     async def test_predict_by_file_path_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_predict_by_file_path_success: ETETestExpectations,
         deployment_id: str,
         classification_predict_file_path: Path,
@@ -145,7 +145,7 @@ class TestPredictE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_predict_by_file_path_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -161,7 +161,7 @@ class TestPredictE2E(ToolBaseE2E):
     )
     async def test_predict_by_ai_catalog_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_predict_by_ai_catalog_success: ETETestExpectations,
         deployment_id: str,
         classification_project_id: str,
@@ -180,7 +180,7 @@ class TestPredictE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_predict_by_ai_catalog_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -196,7 +196,7 @@ class TestPredictE2E(ToolBaseE2E):
     )
     async def test_predict_from_project_data_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_predict_from_project_data_success: ETETestExpectations,
         deployment_id: str,
         classification_project_id: str,
@@ -212,7 +212,7 @@ class TestPredictE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_predict_from_project_data_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -229,7 +229,7 @@ class TestPredictE2E(ToolBaseE2E):
     )
     async def test_get_prediction_explanations_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_prediction_explanations_success: ETETestExpectations,
         classification_project_id: str,
         model_id: str,
@@ -250,7 +250,7 @@ class TestPredictE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_prediction_explanations_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_predict_realtime.py
+++ b/tests/drmcp/acceptance/test_predict_realtime.py
@@ -82,7 +82,7 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
     )
     async def test_predict_realtime_file_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_predict_realtime_file_success: ETETestExpectations,
         deployment_id: str,
         classification_predict_file_path: Path,
@@ -99,7 +99,7 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_predict_realtime_file_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -115,7 +115,7 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
     )
     async def test_predict_by_ai_catalog_rt_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_predict_by_ai_catalog_rt_success: ETETestExpectations,
         deployment_id: str,
         classification_predict_dataset: Any,
@@ -132,7 +132,7 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_predict_by_ai_catalog_rt_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/tests/drmcp/acceptance/test_projects.py
+++ b/tests/drmcp/acceptance/test_projects.py
@@ -147,7 +147,7 @@ class TestProjectsE2E(ToolBaseE2E):
     )
     async def test_list_projects_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_list_projects_success: ETETestExpectations,
         prompt: str,
     ) -> None:
@@ -157,7 +157,7 @@ class TestProjectsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_list_projects_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -173,7 +173,7 @@ class TestProjectsE2E(ToolBaseE2E):
     )
     async def test_get_project_dataset_by_name_success(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_project_dataset_by_name_success: ETETestExpectations,
         classification_project_id: str,
         classification_dataset_name: str,
@@ -192,7 +192,7 @@ class TestProjectsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_project_dataset_by_name_success,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -208,7 +208,7 @@ class TestProjectsE2E(ToolBaseE2E):
     )
     async def test_get_project_dataset_by_name_failure(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_project_dataset_by_name_failure: ETETestExpectations,
         classification_project_id: str,
         nonexistent_dataset_name: str,
@@ -226,7 +226,7 @@ class TestProjectsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_project_dataset_by_name_failure,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )
@@ -242,7 +242,7 @@ class TestProjectsE2E(ToolBaseE2E):
     )
     async def test_get_project_dataset_by_name_success_with_multiple_calls(
         self,
-        openai_llm_client: Any,
+        llm_client: Any,
         expectations_for_get_project_dataset_by_name_success_with_multiple_calls: (
             ETETestExpectations
         ),
@@ -265,7 +265,7 @@ class TestProjectsE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_get_project_dataset_by_name_success_with_multiple_calls,
-                openai_llm_client,
+                llm_client,
                 session,
                 test_name,
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.32"
+version = "0.2.33"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
## Summary
Updates ETE (End-to-End) acceptance tests to use `DRLLMGatewayMCPClient` instead of `OpenAILLMMCPClient`.

## Changes
- Added `get_dr_llm_gateway_client_config()` function in `mcp_utils_ete.py` to read DataRobot credentials
- Updated `conftest.py` to use `DRLLMGatewayMCPClient` and renamed fixture from `openai_llm_client` to `llm_client`
- Updated all 12 acceptance test files to use the new `llm_client` fixture

## Notes
- The `OpenAILLMMCPClient` class is preserved for future use (as requested)
- Both clients share the same `BaseLLMMCPClient` interface, so no test logic changes were needed
- Tests now use `DATAROBOT_API_TOKEN` and `DATAROBOT_ENDPOINT` environment variables

## Related
- Jira: https://datarobot.atlassian.net/browse/MODEL-22089