### PR TITLE
[BUZZOK-29122] Make sure that Nat Agent forwards `X-DataRobot-Identity-Token` header when calling LLM deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.3.1"
+version = "0.3.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -75,9 +75,7 @@ class BaseAgent(Generic[TTool], abc.ABC):
         self._mcp_tools: list[TTool] = []
         self._authorization_context = authorization_context or {}
         self._forwarded_headers: dict[str, str] = forwarded_headers or {}
-        self._identity_header: dict[str, str] = prepare_identity_header(
-            self._forwarded_headers
-        )
+        self._identity_header: dict[str, str] = prepare_identity_header(self._forwarded_headers)
 
     def set_mcp_tools(self, tools: list[TTool]) -> None:
         self._mcp_tools = tools

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -30,6 +30,7 @@ from ag_ui.core import Event
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
 
+from datarobot_genai.core.utils.auth import prepare_identity_header
 from datarobot_genai.core.utils.urls import get_api_base
 
 TTool = TypeVar("TTool")
@@ -74,6 +75,9 @@ class BaseAgent(Generic[TTool], abc.ABC):
         self._mcp_tools: list[TTool] = []
         self._authorization_context = authorization_context or {}
         self._forwarded_headers: dict[str, str] = forwarded_headers or {}
+        self._identity_header: dict[str, str] = prepare_identity_header(
+            self._forwarded_headers
+        )
 
     def set_mcp_tools(self, tools: list[TTool]) -> None:
         self._mcp_tools = tools

--- a/src/datarobot_genai/core/custom_model.py
+++ b/src/datarobot_genai/core/custom_model.py
@@ -109,7 +109,7 @@ def chat_entrypoint(
     )
     # Keep only allowed headers from the forwarded_headers.
     incoming_headers = kwargs.get("headers", {}) or {}
-    allowed_headers = {"x-datarobot-api-token", "x-datarobot-api-key"}
+    allowed_headers = {"x-datarobot-api-token", "x-datarobot-api-key", "x-datarobot-identity-token"}
     forwarded_headers = {k: v for k, v in incoming_headers.items() if k.lower() in allowed_headers}
     completion_create_params["forwarded_headers"] = forwarded_headers
 

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -389,3 +389,13 @@ class AsyncOAuthTokenProvider:
         identity = self._get_identity(provider_type)
         token_data = await self._retriever.refresh_access_token(identity)
         return token_data.access_token
+
+
+def prepare_identity_header(forwarded_headers: dict[str, str]) -> dict[str, str]:
+    identity_header_name = "X-DataRobot-Identity-Token"
+
+    for _name, _value in forwarded_headers.items():
+        if _name.lower() == identity_header_name.lower():
+            return {identity_header_name: _value}
+
+    return {}

--- a/src/datarobot_genai/nat/datarobot_llm_clients.py
+++ b/src/datarobot_genai/nat/datarobot_llm_clients.py
@@ -200,7 +200,7 @@ async def datarobot_llm_deployment_crewai(
 @register_llm_client(
     config_type=DataRobotLLMDeploymentModelConfig, wrapper_type=LLMFrameworkEnum.LLAMA_INDEX
 )
-async def datarobot_llm_deployment_llamaindex_a(
+async def datarobot_llm_deployment_llamaindex(
     llm_config: DataRobotLLMDeploymentModelConfig, builder: Builder
 ) -> AsyncGenerator[LiteLLM]:
     config = llm_config.model_dump(
@@ -212,6 +212,10 @@ async def datarobot_llm_deployment_llamaindex_a(
         config["model"] = "datarobot/" + config["model"]
     config["api_base"] = config.pop("base_url") + "/chat/completions"
     client = _create_datarobot_litellm(config)
+
+    if llm_config.headers:
+        config["????"] = llm_config.headers
+
     yield _patch_llm_based_on_config(client, config)
 
 

--- a/src/datarobot_genai/nat/datarobot_llm_clients.py
+++ b/src/datarobot_genai/nat/datarobot_llm_clients.py
@@ -167,7 +167,7 @@ async def datarobot_llm_deployment_langchain(
     config["model"] = config["model"].removeprefix("datarobot/")
 
     if llm_config.headers:
-        config["default_headers"] = {}
+        config["default_headers"] = llm_config.headers
 
     client = _create_datarobot_chat_openai(config)
     yield langchain_patch_llm_based_on_config(client, config)

--- a/src/datarobot_genai/nat/datarobot_llm_clients.py
+++ b/src/datarobot_genai/nat/datarobot_llm_clients.py
@@ -202,17 +202,17 @@ async def datarobot_llm_deployment_llamaindex(
     llm_config: DataRobotLLMDeploymentModelConfig, builder: Builder
 ) -> AsyncGenerator[LiteLLM]:
     config = llm_config.model_dump(
-        exclude={"type", "thinking"},
+        exclude={"type", "thinking", "headers"},
         by_alias=True,
         exclude_none=True,
     )
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     config["api_base"] = config.pop("base_url") + "/chat/completions"
-    client = _create_datarobot_litellm(config)
     if llm_config.headers:
-        config["????"] = llm_config.headers
+        config["additional_kwargs"] = {"extra_headers": llm_config.headers}
 
+    client = _create_datarobot_litellm(config)
     yield _patch_llm_based_on_config(client, config)
 
 
@@ -327,7 +327,7 @@ async def datarobot_llm_component_llamaindex(
     else:
         config["api_base"] = config.pop("base_url") + "/chat/completions"
         if llm_config.headers:
-            config["????"] = llm_config.headers
+            config["additional_kwargs"] = {"extra_headers": llm_config.headers}
     config.pop("use_datarobot_llm_gateway")
     client = _create_datarobot_litellm(config)
     yield _patch_llm_based_on_config(client, config)

--- a/src/datarobot_genai/nat/datarobot_llm_clients.py
+++ b/src/datarobot_genai/nat/datarobot_llm_clients.py
@@ -279,7 +279,9 @@ async def datarobot_llm_component_langchain(
         _patch_llm_based_on_config as langchain_patch_llm_based_on_config,
     )
 
-    config = llm_config.model_dump(exclude={"type", "thinking", "headers"}, by_alias=True, exclude_none=True)
+    config = llm_config.model_dump(
+        exclude={"type", "thinking", "headers"}, by_alias=True, exclude_none=True
+    )
     if config["use_datarobot_llm_gateway"]:
         config["base_url"] = config["base_url"] + "/genai/llmgw"
     elif llm_config.headers:
@@ -299,7 +301,9 @@ async def datarobot_llm_component_crewai(
 ) -> AsyncGenerator[LLM]:
     from crewai import LLM  # noqa: PLC0415
 
-    config = llm_config.model_dump(exclude={"type", "thinking", "headers"}, by_alias=True, exclude_none=True)
+    config = llm_config.model_dump(
+        exclude={"type", "thinking", "headers"}, by_alias=True, exclude_none=True
+    )
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     if config["use_datarobot_llm_gateway"]:
@@ -319,7 +323,9 @@ async def datarobot_llm_component_crewai(
 async def datarobot_llm_component_llamaindex(
     llm_config: DataRobotLLMComponentModelConfig, builder: Builder
 ) -> AsyncGenerator[LiteLLM]:
-    config = llm_config.model_dump(exclude={"type", "thinking", "headers"}, by_alias=True, exclude_none=True)
+    config = llm_config.model_dump(
+        exclude={"type", "thinking", "headers"}, by_alias=True, exclude_none=True
+    )
     if not config["model"].startswith("datarobot/"):
         config["model"] = "datarobot/" + config["model"]
     if config["use_datarobot_llm_gateway"]:

--- a/src/datarobot_genai/nat/datarobot_llm_providers.py
+++ b/src/datarobot_genai/nat/datarobot_llm_providers.py
@@ -105,6 +105,11 @@ class DataRobotLLMDeploymentModelConfig(OpenAIModelConfig, name="datarobot-llm-d
         default="datarobot-deployed-llm",
     )
 
+    headers: dict[str, str] | None = Field(
+        description="Additional headers send to LLM deployment.",
+        default=None,
+    )
+
 
 @register_llm_provider(config_type=DataRobotLLMDeploymentModelConfig)
 async def datarobot_llm_deployment(

--- a/src/datarobot_genai/nat/datarobot_llm_providers.py
+++ b/src/datarobot_genai/nat/datarobot_llm_providers.py
@@ -59,6 +59,11 @@ class DataRobotLLMComponentModelConfig(OpenAIModelConfig, name="datarobot-llm-co
     )
     use_datarobot_llm_gateway: bool = config.use_datarobot_llm_gateway
 
+    headers: dict[str, str] | None = Field(
+        description="Additional headers send to LLM deployment.",
+        default=None,
+    )
+
 
 @register_llm_provider(config_type=DataRobotLLMComponentModelConfig)
 async def datarobot_llm_component(

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -66,7 +66,9 @@ def add_headers_to_datarobot_mcp_auth(config_yaml: dict, headers: dict[str, str]
                     auth_config["headers"] = headers
 
 
-def add_headers_to_datarobot_llm_deployment(config_yaml: dict, headers: dict[str, str] | None) -> None:
+def add_headers_to_datarobot_llm_deployment(
+    config_yaml: dict, headers: dict[str, str] | None
+) -> None:
     if not headers:
         return
 

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -67,13 +67,16 @@ def add_headers_to_datarobot_mcp_auth(config_yaml: dict, headers: dict[str, str]
 
 
 def add_headers_to_datarobot_llm_deployment(config_yaml: dict, headers: dict[str, str] | None) -> None:
-    if headers:
-        if identity_header := prepare_identity_header(headers):
-            if llms := config_yaml.get("llms"):
-                for llm_name in llms:
-                    llm_config = llms[llm_name]
-                    if llm_config.get("_type") == "datarobot-llm-deployment":
-                        llm_config["headers"] = identity_header
+    if not headers:
+        return
+
+    config_types_to_update = ("datarobot-llm-deployment", "datarobot-llm-component")
+    if identity_header := prepare_identity_header(headers):
+        if llms := config_yaml.get("llms"):
+            for llm_name in llms:
+                llm_config = llms[llm_name]
+                if llm_config.get("_type") in config_types_to_update:
+                    llm_config["headers"] = identity_header
 
 
 @asynccontextmanager

--- a/tests/core/test_custom_model.py
+++ b/tests/core/test_custom_model.py
@@ -117,6 +117,7 @@ def test_chat_entrypoint_keeps_allowed_headers() -> None:
         headers = {
             "x-datarobot-api-key": "scoped-token-123",  # Should be kept
             "x-datarobot-api-token": "scoped-token-456",  # Should be kept
+            "x-datarobot-identity-token": "identity-token-123",  # Should be kept
             "x-custom-header": "custom-value",  # Should be filtered
             "Authorization": "Bearer user-provided-token",  # Should be filtered
             "authorization": "Bearer another-token",  # Should be filtered
@@ -140,6 +141,8 @@ def test_chat_entrypoint_keeps_allowed_headers() -> None:
         assert forwarded_headers["x-datarobot-api-key"] == "scoped-token-123"
         assert "x-datarobot-api-token" in forwarded_headers
         assert forwarded_headers["x-datarobot-api-token"] == "scoped-token-456"
+        assert "x-datarobot-identity-token" in forwarded_headers
+        assert forwarded_headers["x-datarobot-identity-token"] == "identity-token-123"
         # Verify other headers are filtered out
         assert "x-custom-header" not in forwarded_headers
         assert "Authorization" not in forwarded_headers
@@ -170,6 +173,7 @@ def test_chat_entrypoint_only_allows_specific_headers() -> None:
         headers = {
             "x-datarobot-api-key": "scoped-token-123",
             "x-datarobot-api-token": "scoped-token-456",
+            "x-datarobot-identity-token": "identity-token-123",
         }
 
         resp = chat_entrypoint(
@@ -184,9 +188,10 @@ def test_chat_entrypoint_only_allows_specific_headers() -> None:
 
         # Verify both allowed headers are present
         forwarded_headers = captured_params.get("forwarded_headers", {})
-        assert len(forwarded_headers) == 2
+        assert len(forwarded_headers) == 3
         assert forwarded_headers["x-datarobot-api-key"] == "scoped-token-123"
         assert forwarded_headers["x-datarobot-api-token"] == "scoped-token-456"
+        assert forwarded_headers["x-datarobot-identity-token"] == "identity-token-123"
     finally:
         pool.shutdown(wait=False, cancel_futures=True)
         try:

--- a/tests/nat/test_helpers.py
+++ b/tests/nat/test_helpers.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 
 from datarobot_genai.nat.datarobot_auth_provider import DataRobotMCPAuthProviderConfig
-from datarobot_genai.nat.helpers import add_headers_to_datarobot_mcp_auth
+from datarobot_genai.nat.helpers import add_headers_to_datarobot_mcp_auth, add_headers_to_datarobot_llm_deployment
 from datarobot_genai.nat.helpers import load_config
 from datarobot_genai.nat.helpers import load_workflow
 
@@ -59,6 +59,78 @@ from datarobot_genai.nat.helpers import load_workflow
 )
 def test_add_headers_to_datarobot_mcp_auth(config, headers, expected):
     add_headers_to_datarobot_mcp_auth(config, headers)
+    assert config == expected
+
+
+@pytest.mark.parametrize(
+    "config, headers, expected",
+    [
+        ({}, None, {}),
+        (
+            {"llms": {"datarobot_llm": {"_type": "datarobot-llm-component"}}},
+            None,
+            {"llms": {"datarobot_llm": {"_type": "datarobot-llm-component"}}},
+        ),
+        (
+            {"llms": {"datarobot_llm": {"_type": "datarobot-llm-component"}}},
+            {"X-DataRobot-Identity-Token": "identity-123"},
+            {
+                "llms": {
+                    "datarobot_llm": {
+                        "_type": "datarobot-llm-component",
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
+                    }
+                }
+            },
+        ),
+        (
+            {"llms": {"datarobot_llm": {"_type": "datarobot-llm-deployment"}}},
+            {"X-DataRobot-Identity-Token": "identity-123"},
+            {
+                "llms": {
+                    "datarobot_llm": {
+                        "_type": "datarobot-llm-deployment",
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
+                    }
+                }
+            },
+        ),
+        (
+            {
+                "llms": {
+                    "datarobot_llm_1": {"_type": "datarobot-llm-deployment"},
+                    "datarobot_llm_2": {"_type": "datarobot-llm-component"}
+                }
+            },
+            {"X-DataRobot-Identity-Token": "identity-123"},
+            {
+                "llms": {
+                    "datarobot_llm_1": {
+                        "_type": "datarobot-llm-deployment",
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
+                    },
+                    "datarobot_llm_2": {
+                        "_type": "datarobot-llm-component",
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
+                    }
+                }
+            },
+        ),
+        (
+            {"llms": {"datarobot_llm": {"_type": "datarobot-llm-abc"}}},
+            {"X-DataRobot-Identity-Token": "identity-123"},
+            {
+                "llms": {
+                    "datarobot_llm": {
+                        "_type": "datarobot-llm-abc",
+                    },
+                }
+            },
+        ),
+    ],
+)
+def test_add_headers_to_datarobot_llm_deployment(config, headers, expected):
+    add_headers_to_datarobot_llm_deployment(config, headers)
     assert config == expected
 
 

--- a/tests/nat/test_helpers.py
+++ b/tests/nat/test_helpers.py
@@ -17,7 +17,8 @@ from unittest.mock import patch
 import pytest
 
 from datarobot_genai.nat.datarobot_auth_provider import DataRobotMCPAuthProviderConfig
-from datarobot_genai.nat.helpers import add_headers_to_datarobot_mcp_auth, add_headers_to_datarobot_llm_deployment
+from datarobot_genai.nat.helpers import add_headers_to_datarobot_llm_deployment
+from datarobot_genai.nat.helpers import add_headers_to_datarobot_mcp_auth
 from datarobot_genai.nat.helpers import load_config
 from datarobot_genai.nat.helpers import load_workflow
 
@@ -78,7 +79,7 @@ def test_add_headers_to_datarobot_mcp_auth(config, headers, expected):
                 "llms": {
                     "datarobot_llm": {
                         "_type": "datarobot-llm-component",
-                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"},
                     }
                 }
             },
@@ -90,7 +91,7 @@ def test_add_headers_to_datarobot_mcp_auth(config, headers, expected):
                 "llms": {
                     "datarobot_llm": {
                         "_type": "datarobot-llm-deployment",
-                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"},
                     }
                 }
             },
@@ -99,7 +100,7 @@ def test_add_headers_to_datarobot_mcp_auth(config, headers, expected):
             {
                 "llms": {
                     "datarobot_llm_1": {"_type": "datarobot-llm-deployment"},
-                    "datarobot_llm_2": {"_type": "datarobot-llm-component"}
+                    "datarobot_llm_2": {"_type": "datarobot-llm-component"},
                 }
             },
             {"X-DataRobot-Identity-Token": "identity-123"},
@@ -107,12 +108,12 @@ def test_add_headers_to_datarobot_mcp_auth(config, headers, expected):
                 "llms": {
                     "datarobot_llm_1": {
                         "_type": "datarobot-llm-deployment",
-                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"},
                     },
                     "datarobot_llm_2": {
                         "_type": "datarobot-llm-component",
-                        "headers": {"X-DataRobot-Identity-Token": "identity-123"}
-                    }
+                        "headers": {"X-DataRobot-Identity-Token": "identity-123"},
+                    },
                 }
             },
         ),

--- a/tests/nat/test_nat_adaptors.py
+++ b/tests/nat/test_nat_adaptors.py
@@ -67,7 +67,7 @@ async def test_datarobot_llm_deployment_langchain_with_identity_token():
     llm_config = DataRobotLLMDeploymentModelConfig(
         temperature=0.0,
         api_key="some_token",
-        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"},
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -88,7 +88,7 @@ async def test_datarobot_llm_deployment_crewai_with_identity_token():
     llm_config = DataRobotLLMDeploymentModelConfig(
         temperature=0.0,
         api_key="some_token",
-        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"},
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -111,7 +111,7 @@ async def test_datarobot_llm_deployment_llamaindex_with_identity_token():
     llm_config = DataRobotLLMDeploymentModelConfig(
         temperature=0.0,
         api_key="some_token",
-        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"},
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -156,8 +156,7 @@ async def test_datarobot_llm_component_langchain_use_gateway():
 
 async def test_datarobot_llm_component_langchain_with_identity_token():
     llm_config = DataRobotLLMComponentModelConfig(
-        api_key="some_token",
-        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+        api_key="some_token", headers={"X-DataRobot-Identity-Token": "identity-token-123"}
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -176,8 +175,7 @@ async def test_datarobot_llm_component_crewai():
 
 async def test_datarobot_llm_component_crewai_with_identity_token():
     llm_config = DataRobotLLMComponentModelConfig(
-        api_key="some_token",
-        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+        api_key="some_token", headers={"X-DataRobot-Identity-Token": "identity-token-123"}
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -198,8 +196,7 @@ async def test_datarobot_llm_component_llamaindex():
 
 async def test_datarobot_llm_component_llamaindex_with_identity_token():
     llm_config = DataRobotLLMComponentModelConfig(
-        api_key="some_token",
-        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+        api_key="some_token", headers={"X-DataRobot-Identity-Token": "identity-token-123"}
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)

--- a/tests/nat/test_nat_adaptors.py
+++ b/tests/nat/test_nat_adaptors.py
@@ -63,6 +63,19 @@ async def test_datarobot_llm_deployment_langchain():
         assert isinstance(llm, ChatOpenAI)
 
 
+async def test_datarobot_llm_deployment_langchain_with_identity_token():
+    llm_config = DataRobotLLMDeploymentModelConfig(
+        temperature=0.0,
+        api_key="some_token",
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+    )
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+        assert isinstance(llm, ChatOpenAI)
+        assert llm.default_headers == {"X-DataRobot-Identity-Token": "identity-token-123"}
+
+
 async def test_datarobot_llm_deployment_crewai():
     llm_config = DataRobotLLMDeploymentModelConfig(temperature=0.0, api_key="some_token")
     async with WorkflowBuilder() as builder:
@@ -71,12 +84,42 @@ async def test_datarobot_llm_deployment_crewai():
         assert isinstance(llm, LLM)
 
 
+async def test_datarobot_llm_deployment_crewai_with_identity_token():
+    llm_config = DataRobotLLMDeploymentModelConfig(
+        temperature=0.0,
+        api_key="some_token",
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+    )
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.CREWAI)
+        assert isinstance(llm, LLM)
+        assert llm.additional_params["extra_headers"] == {
+            "X-DataRobot-Identity-Token": "identity-token-123"
+        }
+
+
 async def test_datarobot_llm_deployment_llamaindex():
     llm_config = DataRobotLLMDeploymentModelConfig(temperature=0.0, api_key="some_token")
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
         llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
         assert isinstance(llm, LiteLLM)
+
+
+async def test_datarobot_llm_deployment_llamaindex_with_identity_token():
+    llm_config = DataRobotLLMDeploymentModelConfig(
+        temperature=0.0,
+        api_key="some_token",
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+    )
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
+        assert isinstance(llm, LiteLLM)
+        assert llm.additional_kwargs["extra_headers"] == {
+            "X-DataRobot-Identity-Token": "identity-token-123"
+        }
 
 
 async def test_datarobot_nim_langchain():
@@ -111,6 +154,18 @@ async def test_datarobot_llm_component_langchain_use_gateway():
         assert isinstance(llm, ChatOpenAI)
 
 
+async def test_datarobot_llm_component_langchain_with_identity_token():
+    llm_config = DataRobotLLMComponentModelConfig(
+        api_key="some_token",
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+    )
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+        assert isinstance(llm, ChatOpenAI)
+        assert llm.default_headers == {"X-DataRobot-Identity-Token": "identity-token-123"}
+
+
 async def test_datarobot_llm_component_crewai():
     llm_config = DataRobotLLMComponentModelConfig(api_key="some_token")
     async with WorkflowBuilder() as builder:
@@ -119,9 +174,37 @@ async def test_datarobot_llm_component_crewai():
         assert isinstance(llm, LLM)
 
 
+async def test_datarobot_llm_component_crewai_with_identity_token():
+    llm_config = DataRobotLLMComponentModelConfig(
+        api_key="some_token",
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+    )
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.CREWAI)
+        assert isinstance(llm, LLM)
+        assert llm.additional_params["extra_headers"] == {
+            "X-DataRobot-Identity-Token": "identity-token-123"
+        }
+
+
 async def test_datarobot_llm_component_llamaindex():
     llm_config = DataRobotLLMComponentModelConfig(api_key="some_token")
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
         llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
         assert isinstance(llm, LiteLLM)
+
+
+async def test_datarobot_llm_component_llamaindex_with_identity_token():
+    llm_config = DataRobotLLMComponentModelConfig(
+        api_key="some_token",
+        headers={"X-DataRobot-Identity-Token": "identity-token-123"}
+    )
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("datarobot_llm", llm_config)
+        llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
+        assert isinstance(llm, LiteLLM)
+        assert llm.additional_kwargs["extra_headers"] == {
+            "X-DataRobot-Identity-Token": "identity-token-123"
+        }


### PR DESCRIPTION
# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->
When NatAgent makes request to deployed LLM we need to pass additional header `X-DataRobot-Identity-Token`

Flow:
1. Read value of header  `X-DataRobot-Identity-Token` in `chat_entrypoint` and add it to `forwarded_headers` in `BaseAgent`.
2. In `load_workflow` get value of header and update `DataRobotLLMComponentModelConfig`
3. When creating LLM object in `datarobot_llm_component_*/datarobot_llm_deployment_*` add `X-DataRobot-Identity-Token` header as `extra_header` to the request.

## CHANGES
1. Added field `headers` to `DataRobotLLMComponentModelConfig`
2. Added new method `add_headers_to_datarobot_llm_deployment` called from `load_config` that updates field `DataRobotLLMComponentModelConfig.headers` with value of  `X-DataRobot-Identity-Token`
3. Updated `datarobot_llm_component_*`/`datarobot_llm_deployment_*` to create LLM objects using `DataRobotLLMComponentModelConfig.headers` 

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
