### PR TITLE
APP-5397: Enable real-time task progress during crew execution

### DIFF
--- a/src/datarobot_genai/crewai/base.py
+++ b/src/datarobot_genai/crewai/base.py
@@ -25,11 +25,17 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import json
+import threading
 from collections.abc import AsyncGenerator
 from typing import Any
 
 from crewai import Crew
+from crewai.events import crewai_event_bus
 from crewai.events.event_bus import CrewAIEventsBus
+from crewai.events.event_listener import event_listener
+from crewai.events.types.task_events import TaskCompletedEvent
+from crewai.events.types.task_events import TaskStartedEvent
 from crewai.tools import BaseTool
 from openai.types.chat import CompletionCreateParams
 from ragas import MultiTurnSample
@@ -51,7 +57,16 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
     Subclasses should define the ``agents`` and ``tasks`` properties
     and may override ``build_crewai_workflow`` to customize the workflow
     construction.
+
+    Args:
+        emit_task_progress: When True, yields task progress events during
+            execution.
+        **kwargs: Passed to BaseAgent.
     """
+
+    def __init__(self, *, emit_task_progress: bool = False, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.emit_task_progress = emit_task_progress
 
     @property
     @abc.abstractmethod
@@ -142,6 +157,9 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
             crew = self.build_crewai_workflow()
 
+            if self.emit_task_progress:
+                return self._invoke_with_task_progress(crew, user_prompt_content)
+
             if is_streaming(completion_create_params):
 
                 async def _gen() -> AsyncGenerator[
@@ -157,3 +175,62 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
             crew_output = crew.kickoff(inputs=self.make_kickoff_inputs(user_prompt_content))
             return self._process_crew_output(crew_output)
+
+    async def _invoke_with_task_progress(
+        self, crew: Crew, user_prompt_content: str
+    ) -> AsyncGenerator[tuple[str, MultiTurnSample | None, UsageMetrics], None]:
+        """Run crew yielding task progress events, then final result."""
+        loop = asyncio.get_running_loop()
+        event_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+
+        def on_task_started(source: Any, event: Any) -> None:
+            task_name = (event.task.name if event.task and event.task.name else None) or "Task"
+            agent_name = (
+                event.task.agent.role if event.task and event.task.agent else None
+            ) or "Agent"
+            loop.call_soon_threadsafe(
+                event_queue.put_nowait,
+                {"type": "task_started", "task_name": task_name, "agent_name": agent_name},
+            )
+
+        def on_task_completed(source: Any, event: Any) -> None:
+            task_name = (event.task.name if event.task and event.task.name else None) or "Task"
+            agent_name = (
+                event.task.agent.role if event.task and event.task.agent else None
+            ) or "Agent"
+            loop.call_soon_threadsafe(
+                event_queue.put_nowait,
+                {"type": "task_completed", "task_name": task_name, "agent_name": agent_name},
+            )
+
+        crew_result: Any = None
+        crew_error: Exception | None = None
+
+        def run_crew() -> None:
+            nonlocal crew_result, crew_error
+            try:
+                with crewai_event_bus.scoped_handlers():
+                    # scoped_handlers() clears ALL handlers including CrewAI's default ones,
+                    # re-register to preserve nice console logging of the Crew progress
+                    event_listener.setup_listeners(crewai_event_bus)
+                    crewai_event_bus.on(TaskStartedEvent)(on_task_started)
+                    crewai_event_bus.on(TaskCompletedEvent)(on_task_completed)
+                    crew_result = crew.kickoff(inputs=self.make_kickoff_inputs(user_prompt_content))
+            except Exception as e:
+                crew_error = e
+            finally:
+                loop.call_soon_threadsafe(event_queue.put_nowait, None)
+
+        thread = threading.Thread(target=run_crew, daemon=True)
+        thread.start()
+
+        empty_usage = default_usage_metrics()
+        while (event := await event_queue.get()) is not None:
+            yield (json.dumps({"task_progress": event}), None, empty_usage)
+
+        await asyncio.to_thread(thread.join)
+
+        if crew_error:
+            raise crew_error
+
+        yield self._process_crew_output(crew_result)

--- a/tests/crewai/test_invoke.py
+++ b/tests/crewai/test_invoke.py
@@ -1,0 +1,157 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for emit_task_progress feature."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import datarobot_genai.crewai.base as base_mod
+from datarobot_genai.core.agents.base import UsageMetrics
+from datarobot_genai.crewai.base import CrewAIAgent
+
+
+class _Crew:
+    def kickoff(self, *, inputs: dict[str, Any]) -> Any:  # noqa: ARG002
+        class Output:
+            raw = "Agent response"
+            token_usage = None
+
+        return Output()
+
+
+class _Agent(CrewAIAgent):
+    @property
+    def agents(self) -> list[Any]:
+        return []
+
+    @property
+    def tasks(self) -> list[Any]:
+        return []
+
+    def build_crewai_workflow(self) -> Any:
+        return _Crew()
+
+    def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+        return {}
+
+
+async def test_crewai_emit_task_progress(mock_mcp_context: Any) -> None:
+    """Verify task progress events are yielded when emit_task_progress is True.
+
+    Tests that:
+    - scoped_handlers() is used for proper handler cleanup
+    - verbose handlers are re-registered inside the scope
+    - task progress handlers are registered and fire correctly
+    """
+    from crewai.events.types.task_events import TaskCompletedEvent  # noqa: PLC0415
+    from crewai.events.types.task_events import TaskStartedEvent  # noqa: PLC0415
+
+    registered_handlers: dict[type, Any] = {}
+    scoped_handlers_entered = False
+    scoped_handlers_exited = False
+
+    class MockEventBus:
+        @staticmethod
+        def scoped_handlers() -> Any:
+            class ScopedCtx:
+                def __enter__(self) -> None:
+                    nonlocal scoped_handlers_entered
+                    scoped_handlers_entered = True
+
+                def __exit__(self, *args: Any) -> None:
+                    nonlocal scoped_handlers_exited
+                    scoped_handlers_exited = True
+
+            return ScopedCtx()
+
+        @staticmethod
+        def on(event_type: type) -> Any:
+            def decorator(fn: Any) -> Any:
+                registered_handlers[event_type] = fn
+                return fn
+
+            return decorator
+
+    class _CrewEmittingEvents:
+        def kickoff(self, *, inputs: dict[str, Any]) -> Any:
+            task = MagicMock()
+            task.name = "Search Files"
+            task.agent.role = "File Agent"
+
+            if TaskStartedEvent in registered_handlers:
+                event = MagicMock()
+                event.task = task
+                registered_handlers[TaskStartedEvent](None, event)
+
+            if TaskCompletedEvent in registered_handlers:
+                event = MagicMock()
+                event.task = task
+                registered_handlers[TaskCompletedEvent](None, event)
+
+            class Output:
+                raw = "Final response"
+                token_usage = None
+
+            return Output()
+
+    class _AgentWithTaskProgress(_Agent):
+        def __init__(self) -> None:
+            super().__init__(emit_task_progress=True)
+
+        def build_crewai_workflow(self) -> Any:
+            return _CrewEmittingEvents()
+
+    mock_event_listener = MagicMock()
+    with (
+        patch.object(base_mod, "crewai_event_bus", MockEventBus),
+        patch.object(base_mod, "event_listener", mock_event_listener),
+    ):
+        agent = _AgentWithTaskProgress()
+        gen = await agent.invoke(
+            {
+                "model": "m",
+                "messages": [{"role": "user", "content": "{}"}],
+            }
+        )
+        chunks = [c async for c in cast(AsyncGenerator[tuple[str, Any, UsageMetrics], None], gen)]
+
+    # Verify scoped_handlers was used for proper cleanup
+    assert scoped_handlers_entered, "scoped_handlers() should be entered"
+    assert scoped_handlers_exited, "scoped_handlers() should be exited for cleanup"
+
+    # Verify verbose handlers were re-registered
+    mock_event_listener.setup_listeners.assert_called_once()
+
+    # Verify handlers were registered for correct event types
+    assert TaskStartedEvent in registered_handlers
+    assert TaskCompletedEvent in registered_handlers
+
+    # Should yield: task_started, task_completed, final response
+    assert len(chunks) == 3
+
+    progress1 = json.loads(chunks[0][0])["task_progress"]
+    assert progress1["type"] == "task_started"
+    assert progress1["task_name"] == "Search Files"
+
+    progress2 = json.loads(chunks[1][0])["task_progress"]
+    assert progress2["type"] == "task_completed"
+
+    assert chunks[2][0] == "Final response"


### PR DESCRIPTION
# RATIONALE

CrewAI crews can take a long time to execute, but there was no way to show progress to users - they had to wait with no feedback until the entire crew finished.

Added `emit_task_progress` parameter to `CrewAIAgent base` class. When enabled, yields JSON task events during execution, allowing UIs to show real-time progress like "Searching files...", "Analyzing content...".

Uses a thread/queue bridge to emit sync CrewAI events from the async generator, with `scoped_handlers()` for proper handler cleanup to prevent memory leaks in long-running services.

Yielded events:

```
json
  {"task_progress": {"type": "task_started", "task_name": "Searching files", "agent_name": "Files Agent"}}
  {"task_progress": {"type": "task_completed", "task_name": "Searching files", "agent_name": "Files Agent"}}
  "Final response content..."
```
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
