### PR TITLE
[MODEL-22176] Add Tavily search MCP tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.2.43"
+version = "0.2.44"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
@@ -84,6 +84,7 @@ drmcp = [
   "python-dotenv>=1.1.0,<2.0.0",
   "boto3>=1.34.0,<2.0.0",
   "httpx>=0.28.1,<1.0.0",
+  "tavily-python>=0.7.20,<1.0.0",
   "pydantic>=2.6.1,<3.0.0",
   "pydantic-settings>=2.1.0,<3.0.0",
   "opentelemetry-api>=1.22.0,<2.0.0",

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -79,6 +79,15 @@ class MCPToolConfig(BaseSettings):
         description="Enable/disable Sharepoint tools",
     )
 
+    enable_tavily_tools: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "ENABLE_TAVILY_TOOLS",
+            "ENABLE_TAVILY_TOOLS",
+        ),
+        description="Enable/disable Tavily search tools",
+    )
+
     is_atlassian_oauth_provider_configured: bool = Field(
         default=False,
         validation_alias=AliasChoices(
@@ -131,6 +140,7 @@ class MCPToolConfig(BaseSettings):
         "enable_confluence_tools",
         "enable_gdrive_tools",
         "enable_microsoft_graph_tools",
+        "enable_tavily_tools",
         "is_atlassian_oauth_provider_configured",
         "is_google_oauth_provider_configured",
         "is_microsoft_oauth_provider_configured",

--- a/src/datarobot_genai/drmcp/core/tool_config.py
+++ b/src/datarobot_genai/drmcp/core/tool_config.py
@@ -31,6 +31,7 @@ class ToolType(str, Enum):
     CONFLUENCE = "confluence"
     GDRIVE = "gdrive"
     MICROSOFT_GRAPH = "microsoft_graph"
+    TAVILY = "tavily"
 
 
 class ToolConfig(TypedDict):
@@ -79,6 +80,13 @@ TOOL_CONFIGS: dict[ToolType, ToolConfig] = {
         directory="microsoft_graph",
         package_prefix="datarobot_genai.drmcp.tools.microsoft_graph",
         config_field_name="enable_microsoft_graph_tools",
+    ),
+    ToolType.TAVILY: ToolConfig(
+        name="tavily",
+        oauth_check=None,
+        directory="tavily",
+        package_prefix="datarobot_genai.drmcp.tools.tavily",
+        config_field_name="enable_tavily_tools",
     ),
 }
 

--- a/src/datarobot_genai/drmcp/tools/clients/tavily.py
+++ b/src/datarobot_genai/drmcp/tools/clients/tavily.py
@@ -1,0 +1,199 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tavily API Client and utilities for API key authentication."""
+
+import logging
+from typing import Any
+from typing import Literal
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.dependencies import get_http_headers
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from tavily import AsyncTavilyClient
+
+logger = logging.getLogger(__name__)
+
+MAX_RESULTS: int = 20
+MAX_CHUNKS_PER_SOURCE: int = 3
+
+MAX_RESULTS_DEFAULT: int = 5
+CHUNKS_PER_SOURCE_DEFAULT: int = 1
+
+
+async def get_tavily_access_token() -> str:
+    """
+    Get Tavily API key from HTTP headers.
+
+    Returns
+    -------
+        API key string
+
+    Raises
+    ------
+        ToolError: If API key is not found in headers
+    """
+    headers = get_http_headers()
+
+    api_key = headers.get("x-tavily-api-key")
+    if api_key:
+        return api_key
+
+    logger.warning("Tavily API key not found in headers")
+    raise ToolError(
+        "Tavily API key not found in headers. Please provide it via 'x-tavily-api-key' header."
+    )
+
+
+class TavilySearchResult(BaseModel):
+    """A single search result from Tavily API."""
+
+    title: str
+    url: str
+    content: str
+    score: float
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @classmethod
+    def from_tavily_sdk(cls, result: dict[str, Any]) -> "TavilySearchResult":
+        """Create a TavilySearchResult from Tavily SDK response data."""
+        return cls(
+            title=result.get("title", ""),
+            url=result.get("url", ""),
+            content=result.get("content", ""),
+            score=result.get("score", 0.0),
+        )
+
+    def as_flat_dict(self) -> dict[str, Any]:
+        """Return a flat dictionary representation of the search result."""
+        return self.model_dump(by_alias=True)
+
+
+class TavilyImage(BaseModel):
+    """An image result from Tavily API."""
+
+    url: str
+    description: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @classmethod
+    def from_tavily_sdk(cls, image: dict[str, Any] | str) -> "TavilyImage":
+        """Create a TavilyImage from Tavily SDK response data."""
+        if isinstance(image, str):
+            return cls(url=image)
+        return cls(
+            url=image.get("url", ""),
+            description=image.get("description"),
+        )
+
+
+class TavilyClient:
+    """Client for interacting with Tavily Search API.
+
+    This is a wrapper around the official tavily-python SDK.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self._client = AsyncTavilyClient(api_key=api_key)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        topic: Literal["general", "news", "finance"] = "general",
+        search_depth: Literal["basic", "advanced"] = "basic",
+        max_results: int = MAX_RESULTS_DEFAULT,
+        time_range: Literal["day", "week", "month", "year"] | None = None,
+        include_images: bool = False,
+        include_image_descriptions: bool = False,
+        chunks_per_source: int = CHUNKS_PER_SOURCE_DEFAULT,
+        include_answer: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Perform a web search using Tavily API.
+
+        Args:
+            query: The search query to execute.
+            topic: The category of search ("general", "news", or "finance").
+            search_depth: The depth of search ("basic" or "advanced").
+            max_results: Maximum number of results to return (1-20).
+            time_range: Time range filter ("day", "week", "month", "year").
+            include_images: Whether to include images in results.
+            include_image_descriptions: Whether to include image descriptions.
+            chunks_per_source: Maximum content snippets per URL (1-3).
+            include_answer: Whether to include an AI-generated answer.
+
+        Returns
+        -------
+            Dict with search results from Tavily API.
+
+        Raises
+        ------
+            ValueError: If validation fails.
+            TavilyInvalidAPIKeyError: If the API key is invalid.
+            TavilyUsageLimitExceededError: If usage limit is exceeded.
+            TavilyForbiddenError: If access is forbidden.
+            TavilyBadRequestError: If the request is malformed.
+        """
+        # Validate inputs
+        if not query:
+            raise ValueError("query cannot be empty.")
+        if isinstance(query, str) and not query.strip():
+            raise ValueError("query cannot be empty.")
+        if max_results <= 0:
+            raise ValueError("max_results must be greater than 0.")
+        if max_results > MAX_RESULTS:
+            raise ValueError(f"max_results must be smaller than or equal to {MAX_RESULTS}.")
+        if chunks_per_source <= 0:
+            raise ValueError("chunks_per_source must be greater than 0.")
+        if chunks_per_source > MAX_CHUNKS_PER_SOURCE:
+            raise ValueError(
+                f"chunks_per_source must be smaller than or equal to {MAX_CHUNKS_PER_SOURCE}."
+            )
+
+        # Clamp values to valid ranges
+        max_results = min(max_results, MAX_RESULTS)
+        chunks_per_source = min(chunks_per_source, MAX_CHUNKS_PER_SOURCE)
+
+        # Build search parameters
+        search_kwargs: dict[str, Any] = {
+            "query": query,
+            "topic": topic,
+            "search_depth": search_depth,
+            "max_results": max_results,
+            "include_images": include_images,
+            "include_image_descriptions": include_image_descriptions,
+            "chunks_per_source": chunks_per_source,
+            "include_answer": include_answer,
+        }
+
+        if time_range:
+            search_kwargs["time_range"] = time_range
+
+        return await self._client.search(**search_kwargs)
+
+    async def __aenter__(self) -> "TavilyClient":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
+        """Async context manager exit."""
+        # AsyncTavilyClient doesn't have a close method, but we keep the context manager
+        # pattern for consistency with other clients
+        pass

--- a/src/datarobot_genai/drmcp/tools/tavily/__init__.py
+++ b/src/datarobot_genai/drmcp/tools/tavily/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/datarobot_genai/drmcp/tools/tavily/tools.py
+++ b/src/datarobot_genai/drmcp/tools/tavily/tools.py
@@ -1,0 +1,148 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tavily MCP tools for web search."""
+
+import logging
+from typing import Annotated
+from typing import Literal
+
+from fastmcp.tools.tool import ToolResult
+
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
+from datarobot_genai.drmcp.tools.clients.tavily import CHUNKS_PER_SOURCE_DEFAULT
+from datarobot_genai.drmcp.tools.clients.tavily import MAX_CHUNKS_PER_SOURCE
+from datarobot_genai.drmcp.tools.clients.tavily import MAX_RESULTS
+from datarobot_genai.drmcp.tools.clients.tavily import MAX_RESULTS_DEFAULT
+from datarobot_genai.drmcp.tools.clients.tavily import TavilyClient
+from datarobot_genai.drmcp.tools.clients.tavily import TavilyImage
+from datarobot_genai.drmcp.tools.clients.tavily import TavilySearchResult
+from datarobot_genai.drmcp.tools.clients.tavily import get_tavily_access_token
+
+logger = logging.getLogger(__name__)
+
+
+@dr_mcp_tool(tags={"search", "tavily", "web", "websearch"})
+async def tavily_search(
+    *,
+    query: Annotated[str, "The search query to execute."],
+    topic: Annotated[
+        Literal["general", "news", "finance"],
+        "The category of search. Use 'general' for broad web search, "
+        "'news' for recent news articles, or 'finance' for financial information.",
+    ] = "general",
+    search_depth: Annotated[
+        Literal["basic", "advanced"],
+        "The depth of search. 'basic' is faster and cheaper, "
+        "'advanced' provides more comprehensive results.",
+    ] = "basic",
+    max_results: Annotated[
+        int,
+        f"Maximum number of search results to return (1-{MAX_RESULTS}).",
+    ] = MAX_RESULTS_DEFAULT,
+    time_range: Annotated[
+        Literal["day", "week", "month", "year"] | None,
+        "Filter results by time range. Use 'day' for last 24 hours, "
+        "'week' for last 7 days, 'month' for last 30 days, or 'year' for last year.",
+    ] = None,
+    include_images: Annotated[
+        bool,
+        "Whether to include related images in the search results.",
+    ] = False,
+    include_image_descriptions: Annotated[
+        bool,
+        "Whether to include AI-generated descriptions for images. "
+        "Only applicable when include_images is True.",
+    ] = False,
+    chunks_per_source: Annotated[
+        int,
+        f"Maximum number of content snippets to return per source URL (1-{MAX_CHUNKS_PER_SOURCE}).",
+    ] = CHUNKS_PER_SOURCE_DEFAULT,
+    include_answer: Annotated[
+        bool,
+        "Whether to include an AI-generated answer summarizing the search results.",
+    ] = False,
+) -> ToolResult:
+    """
+    Perform a real-time web search using Tavily API.
+
+    Tavily is optimized for AI agents and provides clean, relevant search results
+    suitable for LLM consumption. Use this tool to search the web for current
+    information, news, financial data, or general knowledge.
+
+    Usage:
+        - Basic search: tavily_search(query="Python best practices 2026")
+        - News search: tavily_search(query="AI regulations", topic="news", time_range="week")
+        - Financial search: tavily_search(query="AAPL stock analysis", topic="finance")
+        - Comprehensive search: tavily_search(
+            query="climate change solutions",
+            search_depth="advanced",
+            max_results=10,
+            include_answer=True
+          )
+
+    Note:
+        - Advanced search depth consumes more API credits but provides better results
+        - Time range filtering is useful for finding recent information
+    """
+    api_key = await get_tavily_access_token()
+
+    async with TavilyClient(api_key) as client:
+        response = await client.search(
+            query=query,
+            topic=topic,
+            search_depth=search_depth,
+            max_results=max_results,
+            time_range=time_range,
+            include_images=include_images,
+            include_image_descriptions=include_image_descriptions,
+            chunks_per_source=chunks_per_source,
+            include_answer=include_answer,
+        )
+
+    results = [TavilySearchResult.from_tavily_sdk(r) for r in response.get("results", [])]
+
+    images: list[TavilyImage] | None = None
+    if include_images and response.get("images"):
+        images = [TavilyImage.from_tavily_sdk(img) for img in response.get("images", [])]
+
+    result_count = len(results)
+    answer = response.get("answer")
+    response_time = response.get("response_time", 0.0)
+
+    answer_info = " with AI-generated answer" if answer else ""
+    image_info = f" and {len(images)} images" if images else ""
+
+    structured_content: dict = {
+        "query": response.get("query", query),
+        "results": [r.as_flat_dict() for r in results],
+        "resultCount": result_count,
+        "responseTime": response_time,
+    }
+
+    if answer:
+        structured_content["answer"] = answer
+
+    if images:
+        structured_content["images"] = [
+            {"url": img.url, "description": img.description} for img in images
+        ]
+
+    return ToolResult(
+        content=(
+            f"Successfully searched for '{query}'. "
+            f"Found {result_count} results{answer_info}{image_info}."
+        ),
+        structured_content=structured_content,
+    )

--- a/tests/drmcp/acceptance/test_tavily_tools.py
+++ b/tests/drmcp/acceptance/test_tavily_tools.py
@@ -1,0 +1,55 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import os
+from typing import Any
+
+import pytest
+
+from datarobot_genai.drmcp import ETETestExpectations
+from datarobot_genai.drmcp import ToolBaseE2E
+from datarobot_genai.drmcp import ToolCallTestExpectations
+from datarobot_genai.drmcp import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
+
+
+@pytest.mark.skipif(not os.getenv("ENABLE_TAVILY_TOOLS"), reason="Tavily tools are not enabled")
+@pytest.mark.asyncio
+class TestTavilyToolsE2E(ToolBaseE2E):
+    """End-to-end tests for Tavily search tools."""
+
+    async def test_tavily_search_success(self, llm_client: Any) -> None:
+        """Test basic Tavily search."""
+        expectations = ETETestExpectations(
+            tool_calls_expected=[
+                ToolCallTestExpectations(
+                    name="tavily_search",
+                    parameters={"query": "DataRobot machine learning"},
+                    result=SHOULD_NOT_BE_EMPTY,
+                ),
+            ],
+            llm_response_content_contains_expectations=["DataRobot"],
+        )
+
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_tavily_search_success"
+            await self._run_test_with_expectations(
+                "Search the web for 'DataRobot machine learning' and summarize what you find.",
+                expectations,
+                llm_client,
+                session,
+                test_name,
+            )

--- a/tests/drmcp/unit/tavily_tools/__init__.py
+++ b/tests/drmcp/unit/tavily_tools/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/drmcp/unit/tavily_tools/test_tools.py
+++ b/tests/drmcp/unit/tavily_tools/test_tools.py
@@ -1,0 +1,78 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.drmcp.tools.tavily.tools import tavily_search
+
+
+@pytest.fixture
+def mock_tavily_auth() -> Iterator[None]:
+    with patch(
+        "datarobot_genai.drmcp.tools.tavily.tools.get_tavily_access_token",
+        return_value="test-api-key",
+    ):
+        yield
+
+
+class TestTavilySearch:
+    """Tests for tavily_search tool."""
+
+    @pytest.mark.asyncio
+    async def test_basic_search(self, mock_tavily_auth: None) -> None:
+        """Test basic search returns expected structure."""
+        mock_response = {
+            "query": "test query",
+            "results": [
+                {
+                    "title": "Result 1",
+                    "url": "https://example.com",
+                    "content": "Content",
+                    "score": 0.9,
+                },
+            ],
+            "response_time": 0.5,
+        }
+
+        with patch("datarobot_genai.drmcp.tools.clients.tavily.TavilyClient.search") as mock:
+            mock.return_value = mock_response
+            result = await tavily_search(query="test query")
+
+        content, structured = result.to_mcp_result()
+        assert "Successfully searched" in content[0].text
+        assert structured["resultCount"] == 1
+
+    @pytest.mark.asyncio
+    async def test_search_with_answer_and_images(self, mock_tavily_auth: None) -> None:
+        """Test search with answer and images."""
+        mock_response = {
+            "query": "test",
+            "results": [{"title": "R1", "url": "https://x.com", "content": "C", "score": 0.9}],
+            "answer": "AI summary",
+            "images": [{"url": "https://img.com/1.jpg", "description": "Desc"}],
+            "response_time": 1.0,
+        }
+
+        with patch("datarobot_genai.drmcp.tools.clients.tavily.TavilyClient.search") as mock:
+            mock.return_value = mock_response
+            result = await tavily_search(query="test", include_images=True, include_answer=True)
+
+        content, structured = result.to_mcp_result()
+        assert "AI-generated answer" in content[0].text
+        assert "1 images" in content[0].text
+        assert structured["answer"] == "AI summary"
+        assert len(structured["images"]) == 1

--- a/tests/drmcp/unit/tool_clients/test_tavily_client.py
+++ b/tests/drmcp/unit/tool_clients/test_tavily_client.py
@@ -1,0 +1,115 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from datarobot_genai.drmcp.tools.clients.tavily import TavilyClient
+from datarobot_genai.drmcp.tools.clients.tavily import TavilyImage
+from datarobot_genai.drmcp.tools.clients.tavily import TavilySearchResult
+from datarobot_genai.drmcp.tools.clients.tavily import get_tavily_access_token
+
+
+class TestGetTavilyAccessToken:
+    """Tests for get_tavily_access_token function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_api_key_from_headers(self) -> None:
+        """Test getting API key from HTTP headers."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.tavily.get_http_headers",
+            return_value={"x-tavily-api-key": "test-api-key-123"},
+        ):
+            result = await get_tavily_access_token()
+            assert result == "test-api-key-123"
+
+    @pytest.mark.asyncio
+    async def test_raises_error_when_missing(self) -> None:
+        """Test that missing API key raises ToolError."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.tavily.get_http_headers",
+            return_value={},
+        ):
+            with pytest.raises(ToolError, match="Tavily API key not found"):
+                await get_tavily_access_token()
+
+
+class TestTavilyModels:
+    """Tests for Tavily data models."""
+
+    def test_search_result_from_sdk(self) -> None:
+        """Test TavilySearchResult.from_tavily_sdk."""
+        result = TavilySearchResult.from_tavily_sdk(
+            {
+                "title": "Test",
+                "url": "https://example.com",
+                "content": "Content",
+                "score": 0.95,
+            }
+        )
+        assert result.title == "Test"
+        assert result.score == pytest.approx(0.95)
+
+    def test_image_from_string(self) -> None:
+        """Test TavilyImage.from_tavily_sdk with string URL."""
+        result = TavilyImage.from_tavily_sdk("https://example.com/img.jpg")
+        assert result.url == "https://example.com/img.jpg"
+        assert result.description is None
+
+    def test_image_from_dict(self) -> None:
+        """Test TavilyImage.from_tavily_sdk with dict."""
+        result = TavilyImage.from_tavily_sdk(
+            {
+                "url": "https://example.com/img.jpg",
+                "description": "A test image",
+            }
+        )
+        assert result.description == "A test image"
+
+
+class TestTavilyClient:
+    """Tests for TavilyClient class."""
+
+    @pytest.mark.asyncio
+    async def test_search_calls_sdk(self) -> None:
+        """Test that search calls the underlying SDK."""
+        mock_response = {"query": "test", "results": [], "response_time": 0.5}
+
+        with patch("datarobot_genai.drmcp.tools.clients.tavily.AsyncTavilyClient") as mock_class:
+            mock_client = MagicMock()
+            mock_client.search = AsyncMock(return_value=mock_response)
+            mock_class.return_value = mock_client
+
+            async with TavilyClient("api-key") as client:
+                result = await client.search("test query")
+
+            assert result == mock_response
+
+    @pytest.mark.asyncio
+    async def test_search_validates_empty_query(self) -> None:
+        """Test that empty query raises ValueError."""
+        async with TavilyClient("api-key") as client:
+            with pytest.raises(ValueError, match="query cannot be empty"):
+                await client.search("")
+
+    @pytest.mark.asyncio
+    async def test_search_validates_max_results(self) -> None:
+        """Test that invalid max_results raises ValueError."""
+        async with TavilyClient("api-key") as client:
+            with pytest.raises(ValueError, match="max_results"):
+                await client.search("test", max_results=0)

--- a/uv.lock
+++ b/uv.lock
@@ -1076,7 +1076,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.2.43"
+version = "0.2.44"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -1121,6 +1121,7 @@ drmcp = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "tavily-python" },
 ]
 langgraph = [
     { name = "langchain-mcp-adapters" },
@@ -1231,6 +1232,7 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'drmcp'", specifier = ">=1.1.0,<2.0.0" },
     { name = "ragas", specifier = ">=0.3.8,<0.4.0" },
     { name = "requests", specifier = ">=2.32.4,<3.0.0" },
+    { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
 ]
 provides-extras = ["crewai", "langgraph", "llamaindex", "nat", "pydanticai", "drmcp"]
 
@@ -6254,6 +6256,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "tavily-python"
+version = "0.7.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "requests" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/c8/30db965667ed5bd5b64e8d7f15db39dcb18286ebf8ed15be416d0ecd1e6f/tavily_python-0.7.20.tar.gz", hash = "sha256:23e231fa34ddfda8d49c0ed052cb04ed0a051b3818eb373a4c5da4ef62de2b19", size = 21043, upload-time = "2026-01-28T19:25:51.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/10/39fec2367b152e989ed7aa825a6a794103ad6bc5203c009a6ca63ae7b6e1/tavily_python-0.7.20-py3-none-any.whl", hash = "sha256:a3735afcac030c229a380d06dd6eac3323f2ce441bba77a069aff134d2ff6e42", size = 17979, upload-time = "2026-01-28T19:25:50.589Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# RATIONALE
This PR adds a Tavily web search MCP tool to enable real-time web search capabilities for AI agents.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
