### PR TITLE
[MODEL-22351] Fix dynamic tool registration for multilabel deployments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.3.9"
+version = "0.3.10"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/adapters/drum.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/adapters/drum.py
@@ -30,6 +30,7 @@ class DrumTargetType(str, Enum):
     ANOMALY = "anomaly"
     UNSTRUCTURED = "unstructured"
     MULTICLASS = "multiclass"
+    MULTILABEL = "multilabel"
     TEXT_GENERATION = "textgeneration"
     GEO_POINT = "geopoint"
     VECTOR_DATABASE = "vectordatabase"
@@ -43,6 +44,7 @@ class DrumTargetType(str, Enum):
             DrumTargetType.REGRESSION,
             DrumTargetType.ANOMALY,
             DrumTargetType.MULTICLASS,
+            DrumTargetType.MULTILABEL,
             DrumTargetType.TEXT_GENERATION,
             DrumTargetType.GEO_POINT,
             DrumTargetType.VECTOR_DATABASE,
@@ -195,6 +197,7 @@ class DrumMetadataAdapter(MetadataBase):
             DrumTargetType.REGRESSION: predictions_endpoint,
             DrumTargetType.ANOMALY: predictions_endpoint,
             DrumTargetType.MULTICLASS: predictions_endpoint,
+            DrumTargetType.MULTILABEL: predictions_endpoint,
             DrumTargetType.TEXT_GENERATION: predictions_endpoint,
             DrumTargetType.GEO_POINT: predictions_endpoint,
             DrumTargetType.UNSTRUCTURED: "/predictionsUnstructured",

--- a/tests/drmcp/unit/dynamic_tools/test_adapters.py
+++ b/tests/drmcp/unit/dynamic_tools/test_adapters.py
@@ -143,6 +143,7 @@ class TestDrumMetadataAdapter:
             pytest.param("binary", "/predictions", id="binary"),
             pytest.param("regression", "/predictions", id="regression"),
             pytest.param("multiclass", "/predictions", id="multiclass"),
+            pytest.param("multilabel", "/predictions", id="multilabel"),
             pytest.param("textgeneration", "/predictions", id="text_generation"),
             pytest.param("unstructured", "/predictionsUnstructured", id="unstructured"),
             pytest.param("vectordatabase", "/predictions", id="vector_database"),

--- a/uv.lock
+++ b/uv.lock
@@ -1076,7 +1076,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.3.8"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
# RATIONALE
Adds support for missing `multilabel` predictive deployment type

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
