### PR TITLE
Add DataRobot client for tools and only accept api header for routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.4.1"
+version = "0.4.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
@@ -87,11 +87,13 @@ async def delete_registered_prompt_template(prompt_template_id: str) -> bool:
     return True
 
 
-async def refresh_registered_prompt_template() -> None:
+async def refresh_registered_prompt_template(headers_auth_only: bool = False) -> None:
     """Refresh all registered prompt templates in the MCP instance."""
     prompt_templates = get_datarobot_prompt_templates()
     prompt_templates_ids = {p.id for p in prompt_templates}
-    prompt_templates_versions = get_datarobot_prompt_template_versions(list(prompt_templates_ids))
+    prompt_templates_versions = get_datarobot_prompt_template_versions(
+        list(prompt_templates_ids), headers_auth_only=headers_auth_only
+    )
 
     mcp_prompt_templates_mappings = await mcp.get_prompt_mapping()
 

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/dr_lib.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/dr_lib.py
@@ -27,6 +27,7 @@ def get_datarobot_prompt_templates() -> list[dr.genai.PromptTemplate]:
 
 def get_datarobot_prompt_template_versions(
     prompt_template_ids: list[str],
+    headers_auth_only: bool = False,
 ) -> dict[str, list[dr.genai.PromptTemplateVersion]]:
     # Still missing in SDK
     prompt_template_versions_data = dr.utils.pagination.unpaginate(
@@ -34,7 +35,7 @@ def get_datarobot_prompt_template_versions(
         initial_params={
             "promptTemplateIds": prompt_template_ids,
         },
-        client=get_api_client(),
+        client=get_api_client(headers_auth_only=headers_auth_only),
     )
     prompt_template_versions = defaultdict(list)
     for prompt_template_version in prompt_template_versions_data:

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
@@ -39,7 +39,7 @@ async def register_tool_for_deployment_id(deployment_id: str) -> Tool:
     -------
         The registered Tool instance.
     """
-    deployment = get_sdk_client().Deployment.get(deployment_id)
+    deployment = get_sdk_client(headers_auth_only=True).Deployment.get(deployment_id)
     registered_tool = await register_tool_of_datarobot_deployment(deployment)
     return registered_tool
 

--- a/src/datarobot_genai/drmcp/tools/clients/datarobot.py
+++ b/src/datarobot_genai/drmcp/tools/clients/datarobot.py
@@ -1,0 +1,82 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DataRobot API client and utilities for tools (e.g. predictive tools)."""
+
+import logging
+from typing import Any
+
+import datarobot as dr
+from datarobot.context import Context as DRContext
+from fastmcp.exceptions import ToolError
+
+from datarobot_genai.drmcp.core.clients import resolve_token_from_headers
+from datarobot_genai.drmcp.core.credentials import get_credentials
+
+logger = logging.getLogger(__name__)
+
+
+async def get_datarobot_access_token() -> str:
+    """
+    Get DataRobot API token from HTTP headers.
+
+    Uses the same token extraction as core (auth headers and authorization
+    context metadata). For use in tools only; core modules use get_sdk_client()
+    from drmcp.core.clients.
+
+    Returns
+    -------
+        API token string
+
+    Raises
+    ------
+        ToolError: If no API token is found in headers
+    """
+    token = resolve_token_from_headers()
+    if not token:
+        logger.warning("DataRobot API token not found in headers")
+        raise ToolError(
+            "DataRobot API token not found in headers. "
+            "Please provide it via 'Authorization' (Bearer), 'x-datarobot-api-token' headers."
+        )
+    return token
+
+
+class DataRobotClient:
+    """Client for interacting with DataRobot API in tools.
+
+    Wraps the DataRobot Python SDK (datarobot package). Obtain the token
+    via get_datarobot_access_token() and pass it to the constructor.
+    """
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def get_client(self) -> Any:
+        """
+        Configure the DataRobot SDK with this client's token and return the dr module.
+
+        The returned value is the global datarobot module (dr) after
+        dr.Client(token=..., endpoint=...) has been called. Use it as
+        client.Project.list(), client.Deployment.get(...), etc.
+
+        Returns
+        -------
+            The datarobot module (dr) configured for the current token and endpoint.
+        """
+        credentials = get_credentials()
+        dr.Client(token=self._token, endpoint=credentials.datarobot.endpoint)
+        # Avoid use-case context from trafaret affecting tool calls
+        DRContext.use_case = None
+        return dr

--- a/src/datarobot_genai/drmcp/tools/predictive/data.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/data.py
@@ -20,8 +20,9 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.drmcp import dr_mcp_tool
-from datarobot_genai.drmcp.core.clients import get_sdk_client
 from datarobot_genai.drmcp.core.utils import is_valid_url
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,8 @@ async def upload_dataset_to_ai_catalog(
         raise ToolError("Please provide either file_path or file_url, not both.")
 
     # Get client
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     catalog_item = None
     # If file path is provided, create dataset from file.
     if file_path:
@@ -70,7 +72,8 @@ async def upload_dataset_to_ai_catalog(
 @dr_mcp_tool(tags={"predictive", "data", "read", "list", "catalog"})
 async def list_ai_catalog_items() -> ToolResult:
     """List all AI Catalog items (datasets) for the authenticated user."""
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     datasets = client.Dataset.list()
 
     if not datasets:
@@ -105,7 +108,8 @@ async def list_ai_catalog_items() -> ToolResult:
 #         a resource id that can be used to retrieve the list of AI Catalog items using the
 #         get_resource tool
 #     """
-#     client = get_sdk_client()
+#     token = await get_datarobot_access_token()
+#     client = DataRobotClient(token).get_client()
 #     datasets = client.Dataset.list()
 #     if not datasets:
 #         logger.info("No AI Catalog items found")

--- a/src/datarobot_genai/drmcp/tools/predictive/deployment.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/deployment.py
@@ -19,7 +19,8 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.drmcp import dr_mcp_tool
-from datarobot_genai.drmcp.core.clients import get_sdk_client
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,8 @@ logger = logging.getLogger(__name__)
 @dr_mcp_tool(tags={"predictive", "deployment", "read", "management", "list"})
 async def list_deployments() -> ToolResult:
     """List all DataRobot deployments for the authenticated user."""
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     deployments = client.Deployment.list()
     if not deployments:
         return ToolResult(
@@ -48,7 +50,8 @@ async def get_model_info_from_deployment(
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     deployment = client.Deployment.get(deployment_id)
     return ToolResult(
         structured_content=deployment.model,
@@ -68,7 +71,8 @@ async def deploy_model(
     if not label:
         raise ToolError("Model label must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     try:
         prediction_servers = client.PredictionServer.list()
         if not prediction_servers:

--- a/src/datarobot_genai/drmcp/tools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/deployment_info.py
@@ -28,7 +28,8 @@ from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 
 from datarobot_genai.drmcp import dr_mcp_tool
-from datarobot_genai.drmcp.core.clients import get_sdk_client
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,8 @@ async def get_deployment_info(
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     deployment = client.Deployment.get(deployment_id)
 
     # get features from the deployment

--- a/src/datarobot_genai/drmcp/tools/predictive/model.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/model.py
@@ -22,7 +22,8 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.drmcp import dr_mcp_tool
-from datarobot_genai.drmcp.core.clients import get_sdk_client
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,8 @@ async def get_best_model(
     if not project_id:
         raise ToolError("Project ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     if not project:
         raise ToolError(f"Project with ID {project_id} not found.")
@@ -126,7 +128,8 @@ async def score_dataset_with_model(
     if not dataset_url:
         raise ToolError("Dataset URL must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     model = client.Model.get(project, model_id)
     job = model.score(dataset_url)
@@ -150,7 +153,8 @@ async def list_models(
     if not project_id:
         raise ToolError("Project ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     models = project.get_models()
 

--- a/src/datarobot_genai/drmcp/tools/predictive/predict.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/predict.py
@@ -26,8 +26,9 @@ from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.drmcp import dr_mcp_tool
 from datarobot_genai.drmcp.core.clients import get_credentials
-from datarobot_genai.drmcp.core.clients import get_sdk_client
 from datarobot_genai.drmcp.core.utils import generate_presigned_url
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drmcp.tools.clients.s3 import get_s3_bucket_info
 
 logger = logging.getLogger(__name__)
@@ -153,8 +154,9 @@ async def predict_by_ai_catalog(
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     output_settings, bucket, key = make_output_settings(get_or_create_s3_credential())
-    client = get_sdk_client()
     dataset = client.Dataset.get(dataset_id)
     job = dr.BatchPredictionJob.score(
         deployment=deployment_id,
@@ -198,6 +200,8 @@ async def predict_from_project_data(
     if not project_id:
         raise ToolError("Project ID must be provided")
 
+    token = await get_datarobot_access_token()
+    DataRobotClient(token).get_client()
     output_settings, bucket, key = make_output_settings(get_or_create_s3_credential())
     intake_settings: dict[str, Any] = {
         "type": "dss",
@@ -238,7 +242,8 @@ async def get_prediction_explanations(
     -------
         JSON string containing the prediction explanations for each row.
     """
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     model = client.Model.get(project=project, model_id=model_id)
     try:

--- a/src/datarobot_genai/drmcp/tools/predictive/predict_realtime.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/predict_realtime.py
@@ -27,8 +27,9 @@ from fastmcp.tools.tool import ToolResult
 from pydantic import BaseModel
 
 from datarobot_genai.drmcp import dr_mcp_tool
-from datarobot_genai.drmcp.core.clients import get_sdk_client
 from datarobot_genai.drmcp.core.utils import predictions_result_response
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drmcp.tools.clients.s3 import get_s3_bucket_info
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,8 @@ async def predict_by_ai_catalog_rt(
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     dataset = client.Dataset.get(dataset_id)
 
     # 1. Preferred: built-in DataFrame helper (newer SDKs)
@@ -279,7 +281,8 @@ async def predict_realtime(
     if series_id_column and series_id_column not in df.columns:
         raise ValueError(f"series_id_column '{series_id_column}' not found in input data.")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     deployment = client.Deployment.get(deployment_id=deployment_id)
 
     # Check if this is a time series prediction or regular prediction

--- a/src/datarobot_genai/drmcp/tools/predictive/project.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/project.py
@@ -19,7 +19,8 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.drmcp import dr_mcp_tool
-from datarobot_genai.drmcp.core.clients import get_sdk_client
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,8 @@ logger = logging.getLogger(__name__)
 @dr_mcp_tool(tags={"predictive", "project", "read", "management", "list"})
 async def list_projects() -> ToolResult:
     """List all DataRobot projects for the authenticated user."""
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     projects = client.Project.list()
     projects = {p.id: p.project_name for p in projects}
 
@@ -52,7 +54,8 @@ async def get_project_dataset_by_name(
     if not dataset_name:
         raise ToolError("Dataset name is required.")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     all_datasets = []
     source_dataset = project.get_dataset()

--- a/src/datarobot_genai/drmcp/tools/predictive/training.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/training.py
@@ -25,7 +25,8 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.drmcp import dr_mcp_tool
-from datarobot_genai.drmcp.core.clients import get_sdk_client
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +96,8 @@ async def analyze_dataset(
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     dataset, df = _get_dataset_or_raise(client, dataset_id)
 
     # Analyze dataset structure
@@ -146,7 +148,8 @@ async def suggest_use_cases(
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     dataset, df = _get_dataset_or_raise(client, dataset_id)
 
     # Get dataset insights first
@@ -176,7 +179,8 @@ async def get_exploratory_insights(
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     dataset, df = _get_dataset_or_raise(client, dataset_id)
 
     # Get dataset insights first
@@ -501,7 +505,8 @@ async def start_autopilot(
     | None = None,
 ) -> ToolError | ToolResult:
     """Start automated model training (Autopilot) for a project."""
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
 
     if not project_id:
         if not dataset_url and not dataset_id:
@@ -563,7 +568,8 @@ async def get_model_roc_curve(
     if not model_id:
         raise ToolError("Model ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     model = client.Model.get(project=project, model_id=model_id)
 
@@ -614,7 +620,8 @@ async def get_model_feature_impact(
     if not model_id:
         raise ToolError("Model ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     model = client.Model.get(project=project, model_id=model_id)
     # Get feature impact
@@ -646,7 +653,8 @@ async def get_model_lift_chart(
     if not model_id:
         raise ToolError("Model ID must be provided")
 
-    client = get_sdk_client()
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
     model = client.Model.get(project=project, model_id=model_id)
 

--- a/tests/drmcp/acceptance/test_routes.py
+++ b/tests/drmcp/acceptance/test_routes.py
@@ -31,13 +31,13 @@ def _create_prompt_template_with_versions() -> Iterator[tuple[str, str, str, str
     new_prompt_api = create_prompt_template(new_prompt_api_name)
     new_prompt_api_id = new_prompt_api["id"]
     first_version = get_or_create_prompt_template_version(
-        new_prompt_api_id, "prompt text 1", variables=[]
+        new_prompt_api_id, "prompt text 1", variables=[], headers_auth_only=True
     )
     second_version = get_or_create_prompt_template_version(
-        new_prompt_api_id, "prompt text 2", variables=[]
+        new_prompt_api_id, "prompt text 2", variables=[], headers_auth_only=True
     )
     third_version = get_or_create_prompt_template_version(
-        new_prompt_api_id, "prompt text 3", variables=[]
+        new_prompt_api_id, "prompt text 3", variables=[], headers_auth_only=True
     )
     yield new_prompt_api_id, first_version["id"], second_version["id"], third_version["id"]
     delete_prompt_template(new_prompt_api_id)

--- a/tests/drmcp/integration/helper.py
+++ b/tests/drmcp/integration/helper.py
@@ -52,10 +52,12 @@ def get_or_create_prompt_template(name: str) -> dict:
 
 
 def get_or_create_prompt_template_version(
-    prompt_template_id: str, prompt_text: str, variables: list[str]
+    prompt_template_id: str, prompt_text: str, variables: list[str], headers_auth_only: bool = False
 ) -> dict:
     try:
-        all_prompt_template_versions = get_datarobot_prompt_template_versions([prompt_template_id])
+        all_prompt_template_versions = get_datarobot_prompt_template_versions(
+            [prompt_template_id], headers_auth_only=headers_auth_only
+        )
         prompt_template_versions = all_prompt_template_versions[prompt_template_id]
         for prompt_template_version in prompt_template_versions:
             if (

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -25,7 +26,14 @@ from datarobot_genai.drmcp.tools.predictive import data
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_success() -> None:
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client") as mock_get_client,
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"
+        ) as mock_data_robot_client,
         patch("datarobot_genai.drmcp.tools.predictive.data.os.path.exists", return_value=True),
     ):
         mock_client = MagicMock()
@@ -36,7 +44,7 @@ async def test_upload_dataset_to_ai_catalog_success() -> None:
         mock_catalog_item.version_id = None
         mock_catalog_item.name = "somefile.csv"
         mock_client.Dataset.create_from_file.return_value = mock_catalog_item
-        mock_get_client.return_value = mock_client
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.upload_dataset_to_ai_catalog(file_path="somefile.csv")
         mock_client.Dataset.create_from_file.assert_called_once_with("somefile.csv")
@@ -51,7 +59,14 @@ async def test_upload_dataset_to_ai_catalog_success() -> None:
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_success_with_url() -> None:
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client") as mock_get_client,
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"
+        ) as mock_data_robot_client,
     ):
         mock_client = MagicMock()
         mock_catalog_item = MagicMock()
@@ -59,7 +74,7 @@ async def test_upload_dataset_to_ai_catalog_success_with_url() -> None:
         mock_catalog_item.version_id = None
         mock_catalog_item.name = "somefile.csv"
         mock_client.Dataset.create_from_url.return_value = mock_catalog_item
-        mock_get_client.return_value = mock_client
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.upload_dataset_to_ai_catalog(
             file_url="https://example.com/somefile.csv"
@@ -78,7 +93,14 @@ async def test_upload_dataset_to_ai_catalog_success_with_url() -> None:
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_error_with_url() -> None:
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client") as mock_get_client,
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"
+        ) as mock_data_robot_client,
     ):
         mock_client = MagicMock()
         mock_catalog_item = MagicMock()
@@ -86,7 +108,7 @@ async def test_upload_dataset_to_ai_catalog_error_with_url() -> None:
         mock_catalog_item.version_id = None
         mock_catalog_item.name = "somefile.csv"
         mock_client.Dataset.create_from_url.return_value = mock_catalog_item
-        mock_get_client.return_value = mock_client
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         with pytest.raises(
             ToolError,
@@ -101,7 +123,12 @@ async def test_upload_dataset_to_ai_catalog_error_with_url() -> None:
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_error_no_file_path_or_url() -> None:
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client"),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"),
     ):
         with pytest.raises(
             ToolError,
@@ -116,7 +143,12 @@ async def test_upload_dataset_to_ai_catalog_error_no_file_path_or_url() -> None:
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_error_both_file_path_and_url() -> None:
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client"),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"),
     ):
         with pytest.raises(
             ToolError,
@@ -133,7 +165,12 @@ async def test_upload_dataset_to_ai_catalog_error_both_file_path_and_url() -> No
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_file_not_found() -> None:
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client"),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"),
         patch("datarobot_genai.drmcp.tools.predictive.data.os.path.exists", return_value=False),
     ):
         with pytest.raises(
@@ -146,12 +183,19 @@ async def test_upload_dataset_to_ai_catalog_file_not_found() -> None:
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_error() -> None:
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client") as mock_get_client,
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"
+        ) as mock_data_robot_client,
         patch("datarobot_genai.drmcp.tools.predictive.data.os.path.exists", return_value=True),
     ):
         mock_client = MagicMock()
         mock_client.Dataset.create_from_file.side_effect = Exception("fail")
-        mock_get_client.return_value = mock_client
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         with pytest.raises(Exception) as exc_info:
             await data.upload_dataset_to_ai_catalog(file_path="somefile.csv")
@@ -160,7 +204,16 @@ async def test_upload_dataset_to_ai_catalog_error() -> None:
 
 @pytest.mark.asyncio
 async def test_list_ai_catalog_items_success() -> None:
-    with patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"
+        ) as mock_data_robot_client,
+    ):
         mock_client = MagicMock()
         mock_ds1 = MagicMock()
         mock_ds1.id = "1"
@@ -169,7 +222,7 @@ async def test_list_ai_catalog_items_success() -> None:
         mock_ds2.id = "2"
         mock_ds2.name = "ds2"
         mock_client.Dataset.list.return_value = [mock_ds1, mock_ds2]
-        mock_get_client.return_value = mock_client
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items()
         assert result.structured_content["count"] == 2
@@ -180,10 +233,19 @@ async def test_list_ai_catalog_items_success() -> None:
 
 @pytest.mark.asyncio
 async def test_list_ai_catalog_items_empty() -> None:
-    with patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"
+        ) as mock_data_robot_client,
+    ):
         mock_client = MagicMock()
         mock_client.Dataset.list.return_value = []
-        mock_get_client.return_value = mock_client
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items()
         assert result.structured_content["datasets"] == []
@@ -191,10 +253,19 @@ async def test_list_ai_catalog_items_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_list_ai_catalog_items_error() -> None:
-    with patch("datarobot_genai.drmcp.tools.predictive.data.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.data.DataRobotClient"
+        ) as mock_data_robot_client,
+    ):
         mock_client = MagicMock()
         mock_client.Dataset.list.side_effect = Exception("fail")
-        mock_get_client.return_value = mock_client
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         with pytest.raises(Exception) as exc_info:
             await data.list_ai_catalog_items()

--- a/tests/drmcp/unit/predictive_tools/test_deployment.py
+++ b/tests/drmcp/unit/predictive_tools/test_deployment.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -19,7 +20,6 @@ import pytest
 from dotenv import load_dotenv
 from fastmcp.exceptions import ToolError
 
-from datarobot_genai.drmcp.core.clients import get_sdk_client
 from datarobot_genai.drmcp.tools.predictive import deployment
 
 
@@ -29,14 +29,19 @@ def test_load_dotenv() -> None:
 
 @pytest.mark.asyncio
 async def test_list_deployments_success() -> None:
-    with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client"
-    ) as mock_get_client:
-        mock_client = MagicMock()
-        mock_dep1 = MagicMock(id="1", label="dep1")
-        mock_dep2 = MagicMock(id="2", label="dep2")
-        mock_client.Deployment.list.return_value = [mock_dep1, mock_dep2]
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_dep1 = MagicMock(id="1", label="dep1")
+    mock_dep2 = MagicMock(id="2", label="dep2")
+    mock_client.Deployment.list.return_value = [mock_dep1, mock_dep2]
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.deployment.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await deployment.list_deployments()
         assert result.structured_content["deployments"]["1"] == "dep1"
         assert result.structured_content["deployments"]["2"] == "dep2"
@@ -44,12 +49,17 @@ async def test_list_deployments_success() -> None:
 
 @pytest.mark.asyncio
 async def test_list_deployments_empty() -> None:
-    with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client"
-    ) as mock_get_client:
-        mock_client = MagicMock()
-        mock_client.Deployment.list.return_value = []
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_client.Deployment.list.return_value = []
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.deployment.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await deployment.list_deployments()
         assert result.structured_content["deployments"] == []
 
@@ -57,7 +67,8 @@ async def test_list_deployments_empty() -> None:
 @pytest.mark.asyncio
 async def test_list_deployments_error() -> None:
     with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client",
+        "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+        new_callable=AsyncMock,
         side_effect=Exception("fail"),
     ):
         with pytest.raises(ToolError) as exc_info:
@@ -67,14 +78,19 @@ async def test_list_deployments_error() -> None:
 
 @pytest.mark.asyncio
 async def test_get_model_info_from_deployment_success() -> None:
-    with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client"
-    ) as mock_get_client:
-        mock_client = MagicMock()
-        mock_deployment = MagicMock()
-        mock_deployment.model = {"project_id": "pid", "model_id": "mid"}
-        mock_client.Deployment.get.return_value = mock_deployment
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_deployment = MagicMock()
+    mock_deployment.model = {"project_id": "pid", "model_id": "mid"}
+    mock_client.Deployment.get.return_value = mock_deployment
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.deployment.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await deployment.get_model_info_from_deployment(deployment_id="dep_id")
         mock_client.Deployment.get.assert_called_once_with("dep_id")
         assert "project_id" in result.content[0].text
@@ -83,14 +99,17 @@ async def test_get_model_info_from_deployment_success() -> None:
 
 @pytest.mark.asyncio
 async def test_get_model_info_from_deployment_not_found() -> None:
-    with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client"
-    ) as mock_get_client:
-        mock_client = MagicMock()
-        mock_client.Deployment.get.side_effect = Exception(
-            "404 client error: {'message': 'Not Found'}"
-        )
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_client.Deployment.get.side_effect = Exception("404 client error: {'message': 'Not Found'}")
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.deployment.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         with pytest.raises(ToolError) as exc_info:
             await deployment.get_model_info_from_deployment(deployment_id="dep_id")
         assert (
@@ -102,7 +121,8 @@ async def test_get_model_info_from_deployment_not_found() -> None:
 @pytest.mark.asyncio
 async def test_get_model_info_from_deployment_error() -> None:
     with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client",
+        "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+        new_callable=AsyncMock,
         side_effect=Exception("fail"),
     ):
         with pytest.raises(ToolError) as exc_info:
@@ -112,15 +132,20 @@ async def test_get_model_info_from_deployment_error() -> None:
 
 @pytest.mark.asyncio
 async def test_deploy_model_success() -> None:
-    with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client"
-    ) as mock_get_client:
-        mock_client = MagicMock()
-        mock_server = MagicMock(id="srv1")
-        mock_client.PredictionServer.list.return_value = [mock_server]
-        mock_deployment = MagicMock(id="dep123")
-        mock_client.Deployment.create_from_learning_model.return_value = mock_deployment
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_server = MagicMock(id="srv1")
+    mock_client.PredictionServer.list.return_value = [mock_server]
+    mock_deployment = MagicMock(id="dep123")
+    mock_client.Deployment.create_from_learning_model.return_value = mock_deployment
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.deployment.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await deployment.deploy_model(
             model_id="model123", label="Test Deployment", description="desc"
         )
@@ -130,12 +155,17 @@ async def test_deploy_model_success() -> None:
 
 @pytest.mark.asyncio
 async def test_deploy_model_no_prediction_servers() -> None:
-    with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client"
-    ) as mock_get_client:
-        mock_client = MagicMock()
-        mock_client.PredictionServer.list.return_value = []
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_client.PredictionServer.list.return_value = []
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.deployment.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         with pytest.raises(ToolError) as exc_info:
             await deployment.deploy_model(model_id="model123", label="Test Deployment")
         assert "No prediction servers available" in str(exc_info.value)
@@ -143,81 +173,17 @@ async def test_deploy_model_no_prediction_servers() -> None:
 
 @pytest.mark.asyncio
 async def test_deploy_model_error() -> None:
-    with patch(
-        "datarobot_genai.drmcp.tools.predictive.deployment.get_sdk_client"
-    ) as mock_get_client:
-        mock_client = MagicMock()
-        mock_client.PredictionServer.list.side_effect = Exception("fail servers")
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_client.PredictionServer.list.side_effect = Exception("fail servers")
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.deployment.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.deployment.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         with pytest.raises(ToolError) as exc_info:
             await deployment.deploy_model(model_id="model123", label="Test Deployment")
         assert "fail servers" in str(exc_info.value)
-
-
-@pytest.mark.asyncio
-async def test_get_sdk_client_uses_bearer_token() -> None:
-    with (
-        patch("datarobot.Client") as mock_client,
-        patch("datarobot_genai.drmcp.core.clients.get_http_headers") as mock_get_headers,
-        patch("datarobot_genai.drmcp.core.clients.get_credentials") as mock_get_creds,
-    ):
-        mock_get_headers.return_value = {"authorization": "Bearer test-user-token"}
-        mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "test-endpoint"
-        mock_get_creds.return_value = mock_creds
-        get_sdk_client()
-        mock_client.assert_called_once()
-        args, kwargs = mock_client.call_args
-        assert kwargs["token"] == "test-user-token"
-
-
-@pytest.mark.asyncio
-async def test_get_sdk_client_uses_x_datarobot_api_token() -> None:
-    with (
-        patch("datarobot.Client") as mock_client,
-        patch("datarobot_genai.drmcp.core.clients.get_http_headers") as mock_get_headers,
-        patch("datarobot_genai.drmcp.core.clients.get_credentials") as mock_get_creds,
-    ):
-        mock_get_headers.return_value = {"x-datarobot-api-token": "Bearer test-user-token"}
-        mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "test-endpoint"
-        mock_get_creds.return_value = mock_creds
-        get_sdk_client()
-        mock_client.assert_called_once()
-        args, kwargs = mock_client.call_args
-        assert kwargs["token"] == "test-user-token"
-
-
-@pytest.mark.asyncio
-async def test_get_sdk_client_raises_when_no_token_in_headers() -> None:
-    """get_sdk_client raises when no token in headers (no credentials fallback)."""
-    with (
-        patch("datarobot_genai.drmcp.core.clients.get_http_headers") as mock_get_headers,
-        patch("datarobot_genai.drmcp.core.clients.get_credentials") as mock_get_creds,
-    ):
-        mock_get_headers.return_value = {}
-        mock_creds = MagicMock()
-        mock_creds.datarobot.application_api_token = "env-token"
-        mock_creds.datarobot.endpoint = "env-endpoint"
-        mock_get_creds.return_value = mock_creds
-        with pytest.raises(ValueError, match="No API token found"):
-            get_sdk_client()
-
-
-@pytest.mark.asyncio
-async def test_get_sdk_client_uses_token_from_headers() -> None:
-    """get_sdk_client uses token from headers when present."""
-    with (
-        patch("datarobot.Client") as mock_client,
-        patch("datarobot_genai.drmcp.core.clients.get_http_headers") as mock_get_headers,
-        patch("datarobot_genai.drmcp.core.clients.get_credentials") as mock_get_creds,
-    ):
-        mock_get_headers.return_value = {"authorization": "Bearer header-token"}
-        mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "env-endpoint"
-        mock_get_creds.return_value = mock_creds
-        get_sdk_client()
-        mock_client.assert_called_once()
-        _, kwargs = mock_client.call_args
-        assert kwargs["token"] == "header-token"
-        assert kwargs["endpoint"] == "env-endpoint"

--- a/tests/drmcp/unit/predictive_tools/test_project.py
+++ b/tests/drmcp/unit/predictive_tools/test_project.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -23,36 +24,51 @@ from datarobot_genai.drmcp.tools.predictive import project
 
 @pytest.mark.asyncio
 async def test_list_projects_success() -> None:
-    with patch("datarobot_genai.drmcp.tools.predictive.project.get_sdk_client") as mock_get_client:
-        mock_client = MagicMock()
-        mock_proj1 = MagicMock(id="1", project_name="proj1")
-        mock_proj2 = MagicMock(id="2", project_name="proj2")
-        mock_client.Project.list.return_value = [mock_proj1, mock_proj2]
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_proj1 = MagicMock(id="1", project_name="proj1")
+    mock_proj2 = MagicMock(id="2", project_name="proj2")
+    mock_client.Project.list.return_value = [mock_proj1, mock_proj2]
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.project.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.project.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await project.list_projects()
-        assert hasattr(result, "structured_content")
-        projects_dict = result.structured_content
-        assert "1" in projects_dict
-        assert projects_dict["1"] == "proj1"
-        assert "2" in projects_dict
-        assert projects_dict["2"] == "proj2"
+    assert hasattr(result, "structured_content")
+    projects_dict = result.structured_content
+    assert "1" in projects_dict
+    assert projects_dict["1"] == "proj1"
+    assert "2" in projects_dict
+    assert projects_dict["2"] == "proj2"
 
 
 @pytest.mark.asyncio
 async def test_list_projects_empty() -> None:
-    with patch("datarobot_genai.drmcp.tools.predictive.project.get_sdk_client") as mock_get_client:
-        mock_client = MagicMock()
-        mock_client.Project.list.return_value = []
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_client.Project.list.return_value = []
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.project.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.project.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await project.list_projects()
-        assert hasattr(result, "structured_content")
-        assert result.structured_content == {}
+    assert hasattr(result, "structured_content")
+    assert result.structured_content == {}
 
 
 @pytest.mark.asyncio
 async def test_list_projects_error() -> None:
     with patch(
-        "datarobot_genai.drmcp.tools.predictive.project.get_sdk_client",
+        "datarobot_genai.drmcp.tools.predictive.project.get_datarobot_access_token",
+        new_callable=AsyncMock,
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:
@@ -62,46 +78,60 @@ async def test_list_projects_error() -> None:
 
 @pytest.mark.asyncio
 async def test_get_project_dataset_by_name_success() -> None:
-    with patch("datarobot_genai.drmcp.tools.predictive.project.get_sdk_client") as mock_get_client:
-        mock_client = MagicMock()
-        mock_project = MagicMock()
-        mock_ds1 = MagicMock()
-        mock_ds1.name = "training_data"
-        mock_ds1.id = "dsid"
-        mock_project.get_datasets.return_value = [mock_ds1]
-        mock_project.get_dataset.return_value = None
-        mock_client.Project.get.return_value = mock_project
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_project = MagicMock()
+    mock_ds1 = MagicMock()
+    mock_ds1.name = "training_data"
+    mock_ds1.id = "dsid"
+    mock_project.get_datasets.return_value = [mock_ds1]
+    mock_project.get_dataset.return_value = None
+    mock_client.Project.get.return_value = mock_project
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.project.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.project.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await project.get_project_dataset_by_name(
             project_id="pid", dataset_name="training"
         )
-        mock_client.Project.get.assert_called_once_with("pid")
-        assert hasattr(result, "structured_content")
-        assert result.structured_content["dataset_id"] == "dsid"
+    mock_client.Project.get.assert_called_once_with("pid")
+    assert hasattr(result, "structured_content")
+    assert result.structured_content["dataset_id"] == "dsid"
 
 
 @pytest.mark.asyncio
 async def test_get_project_dataset_by_name_not_found() -> None:
-    with patch("datarobot_genai.drmcp.tools.predictive.project.get_sdk_client") as mock_get_client:
-        mock_client = MagicMock()
-        mock_project = MagicMock()
-        mock_project.get_datasets.return_value = []
-        mock_project.get_dataset.return_value = None
-        mock_client.Project.get.return_value = mock_project
-        mock_get_client.return_value = mock_client
+    mock_client = MagicMock()
+    mock_project = MagicMock()
+    mock_project.get_datasets.return_value = []
+    mock_project.get_dataset.return_value = None
+    mock_client.Project.get.return_value = mock_project
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.project.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.project.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = mock_client
         with pytest.raises(ToolError) as exc_info:
             await project.get_project_dataset_by_name(project_id="pid", dataset_name="training")
-        assert (
-            str(exc_info.value)
-            == "Error in get_project_dataset_by_name: ToolError: Dataset with name "
-            "containing 'training' not found in project pid."
-        )
+    assert (
+        str(exc_info.value) == "Error in get_project_dataset_by_name: ToolError: Dataset with name "
+        "containing 'training' not found in project pid."
+    )
 
 
 @pytest.mark.asyncio
 async def test_get_project_dataset_by_name_error() -> None:
     with patch(
-        "datarobot_genai.drmcp.tools.predictive.project.get_sdk_client",
+        "datarobot_genai.drmcp.tools.predictive.project.get_datarobot_access_token",
+        new_callable=AsyncMock,
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:

--- a/tests/drmcp/unit/predictive_tools/test_training.py
+++ b/tests/drmcp/unit/predictive_tools/test_training.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -37,11 +38,17 @@ async def test_analyze_dataset() -> None:
     )
     mock_dataset.get_as_dataframe.return_value = mock_df
 
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
         mock_client = MagicMock()
         mock_client.Dataset.get.return_value = mock_dataset
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.analyze_dataset(dataset_id="test_dataset_id")
         assert hasattr(result, "structured_content")
         insights = result.structured_content
@@ -84,7 +91,12 @@ async def test_suggest_use_cases() -> None:
     )
 
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client,
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
         patch(
             "datarobot_genai.drmcp.tools.predictive.training.analyze_dataset",
             return_value=mock_insights,
@@ -92,8 +104,7 @@ async def test_suggest_use_cases() -> None:
     ):
         mock_client = MagicMock()
         mock_client.Dataset.get.return_value = mock_dataset
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.suggest_use_cases(dataset_id="test_dataset_id")
         assert hasattr(result, "structured_content")
         suggestions = result.structured_content["use_case_suggestions"]
@@ -126,7 +137,12 @@ async def test_get_exploratory_insights() -> None:
     )
 
     with (
-        patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client,
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
         patch(
             "datarobot_genai.drmcp.tools.predictive.training.analyze_dataset",
             return_value=mock_insights,
@@ -134,8 +150,7 @@ async def test_get_exploratory_insights() -> None:
     ):
         mock_client = MagicMock()
         mock_client.Dataset.get.return_value = mock_dataset
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.get_exploratory_insights(
             dataset_id="test_dataset_id", target_col="target"
         )
@@ -158,12 +173,18 @@ async def test_start_autopilot_new_project() -> None:
     mock_project.get_status.return_value = "running"
     mock_project.use_case_id = None
 
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
         mock_client = MagicMock()
         mock_client.Dataset.create_from_url.return_value = mock_dataset
         mock_client.Project.create_from_dataset.return_value = mock_project
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.start_autopilot(
             target="target",
             dataset_url="http://test.com/data.csv",
@@ -185,11 +206,17 @@ async def test_start_autopilot_existing_project() -> None:
     mock_project.get_status.return_value = "running"
     mock_project.use_case_id = None
 
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
         mock_client = MagicMock()
         mock_client.Project.get.return_value = mock_project
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.start_autopilot(
             target="target", project_id="test_project_id", mode="comprehensive"
         )
@@ -220,12 +247,18 @@ async def test_get_model_roc_curve() -> None:
     mock_roc_curve.positive_class_predictions = [0.8, 0.9]
     mock_model.get_roc_curve.return_value = mock_roc_curve
 
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
         mock_client = MagicMock()
         mock_client.Project.get.return_value = mock_project
         mock_client.Model.get.return_value = mock_model
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.get_model_roc_curve(
             project_id="test_project_id", model_id="test_model_id"
         )
@@ -247,12 +280,18 @@ async def test_get_model_feature_impact() -> None:
     ]
     mock_model.get_or_request_feature_impact.return_value = mock_feature_impact
 
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
         mock_client = MagicMock()
         mock_client.Project.get.return_value = mock_project
         mock_client.Model.get.return_value = mock_model
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.get_model_feature_impact(
             project_id="test_project_id", model_id="test_model_id"
         )
@@ -276,12 +315,18 @@ async def test_get_model_lift_chart() -> None:
     mock_lift_chart.target_class = "class1"
     mock_model.get_lift_chart.return_value = mock_lift_chart
 
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
         mock_client = MagicMock()
         mock_client.Project.get.return_value = mock_project
         mock_client.Model.get.return_value = mock_model
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await training.get_model_lift_chart(
             project_id="test_project_id", model_id="test_model_id"
         )
@@ -297,7 +342,15 @@ async def test_get_model_lift_chart() -> None:
 async def test_start_autopilot_validation() -> None:
     """Test validation of input parameters for start_autopilot."""
     # Test missing dataset info for new project
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client"):
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
+        mock_drc.return_value.get_client.return_value = MagicMock()
         with pytest.raises(
             ToolError,
             match=(
@@ -340,13 +393,19 @@ async def test_suggest_use_cases_dataset_not_found() -> None:
             self.status_code = status_code
             super().__init__(f"{status_code} client error: {message}")
 
-    with patch("datarobot_genai.drmcp.tools.predictive.training.get_sdk_client") as mock_get_client:
+    with (
+        patch(
+            "datarobot_genai.drmcp.tools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drmcp.tools.predictive.training.DataRobotClient") as mock_drc,
+    ):
         mock_client = MagicMock()
         mock_client.Dataset.get.side_effect = MockClientError(
             "{'message': 'Not Found'}", status_code=404
         )
-        mock_get_client.return_value = mock_client
-
+        mock_drc.return_value.get_client.return_value = mock_client
         with pytest.raises(
             ToolError,
             match=r"Dataset 'nonexistent_dataset_id' not found",

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -19,6 +19,7 @@ import pytest
 
 from datarobot_genai.drmcp.core import config as config_module
 from datarobot_genai.drmcp.core.config import MCPServerConfig
+from datarobot_genai.drmcp.core.config import _apply_mcp_cli_configs_overrides
 from datarobot_genai.drmcp.core.config import get_config
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 
@@ -247,7 +248,9 @@ class TestMCPCLIConfigs:
         """When MCP_CLI_CONFIGS is unset, no overrides; all fields keep model defaults."""
         with patch.dict(os.environ, {}, clear=True):
             self._reset_config()
-            config = get_config()
+            # Build config without loading .env so MCP_CLI_CONFIGS is truly unset
+            config = MCPServerConfig(_env_file=None)
+            config = _apply_mcp_cli_configs_overrides(config)
             assert config.mcp_cli_configs == ""
             assert config.mcp_server_register_dynamic_tools_on_startup is False
             assert config.mcp_server_register_dynamic_prompts_on_startup is False

--- a/tests/drmcp/unit/tool_clients/test_datarobot.py
+++ b/tests/drmcp/unit/tool_clients/test_datarobot.py
@@ -1,0 +1,126 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DataRobot tools client (get_datarobot_access_token, DataRobotClient)."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
+from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
+
+
+class TestGetDatarobotAccessToken:
+    """Test get_datarobot_access_token function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_token_when_resolve_token_from_headers_returns_token(self) -> None:
+        """Test successful token retrieval from headers."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.datarobot.resolve_token_from_headers",
+            return_value="bearer-token-123",
+        ):
+            result = await get_datarobot_access_token()
+        assert result == "bearer-token-123"
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_raises_tool_error_when_no_token(self) -> None:
+        """Test that ToolError is raised when resolve_token_from_headers returns None."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.datarobot.resolve_token_from_headers",
+            return_value=None,
+        ):
+            with pytest.raises(ToolError) as exc_info:
+                await get_datarobot_access_token()
+        assert "DataRobot API token not found" in str(exc_info.value)
+        assert "Authorization" in str(exc_info.value) or "x-datarobot-api-token" in str(
+            exc_info.value
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_tool_error_when_empty_token(self) -> None:
+        """Test that ToolError is raised when resolve_token_from_headers returns empty string."""
+        with patch(
+            "datarobot_genai.drmcp.tools.clients.datarobot.resolve_token_from_headers",
+            return_value="",
+        ):
+            with pytest.raises(ToolError) as exc_info:
+                await get_datarobot_access_token()
+        assert "DataRobot API token not found" in str(exc_info.value)
+
+
+class TestDataRobotClient:
+    """Test DataRobotClient class."""
+
+    def test_init_stores_token(self) -> None:
+        """Test that DataRobotClient stores the token."""
+        client = DataRobotClient("my-token")
+        assert client._token == "my-token"
+
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.DRContext")
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.dr")
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.get_credentials")
+    def test_get_client_calls_dr_client_with_token_and_endpoint(
+        self, mock_get_credentials: MagicMock, mock_dr: MagicMock, mock_dr_context: MagicMock
+    ) -> None:
+        """Test that get_client configures dr.Client with token and endpoint from credentials."""
+        mock_creds = MagicMock()
+        mock_creds.datarobot.endpoint = "https://app.datarobot.com/api/v2"
+        mock_get_credentials.return_value = mock_creds
+
+        client = DataRobotClient("token-from-headers")
+        result = client.get_client()
+
+        mock_dr.Client.assert_called_once_with(
+            token="token-from-headers",
+            endpoint="https://app.datarobot.com/api/v2",
+        )
+        assert result is mock_dr
+
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.DRContext")
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.dr")
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.get_credentials")
+    def test_get_client_resets_dr_context_use_case(
+        self, mock_get_credentials: MagicMock, mock_dr: MagicMock, mock_dr_context: MagicMock
+    ) -> None:
+        """Test that get_client sets DRContext.use_case to None."""
+        mock_creds = MagicMock()
+        mock_creds.datarobot.endpoint = "https://app.datarobot.com/api/v2"
+        mock_get_credentials.return_value = mock_creds
+
+        client = DataRobotClient("token")
+        client.get_client()
+
+        # Implementation does DRContext.use_case = None
+        assert mock_dr_context.use_case is None
+
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.DRContext")
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.dr")
+    @patch("datarobot_genai.drmcp.tools.clients.datarobot.get_credentials")
+    def test_get_client_returns_dr_module(
+        self, mock_get_credentials: MagicMock, mock_dr: MagicMock, mock_dr_context: MagicMock
+    ) -> None:
+        """Test that get_client returns the datarobot module."""
+        mock_creds = MagicMock()
+        mock_creds.datarobot.endpoint = "https://example.com/api/v2"
+        mock_get_credentials.return_value = mock_creds
+
+        client = DataRobotClient("any-token")
+        result = client.get_client()
+
+        assert result is mock_dr

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
- Add DataRobot client for tools (the core one require api key from the env), also separate of concerns and follow same approach to other clients.
- Only accept api header for routes.

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
