### PR TITLE
[MODEL-22491] Update dr mcp tool decorator to differentiate mcp tools by category

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.4.3"
+version = "0.4.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/__init__.py
+++ b/src/datarobot_genai/drmcp/__init__.py
@@ -44,6 +44,7 @@ from .core.dr_mcp_server import DataRobotMCPServer
 from .core.dr_mcp_server import create_mcp_server
 from .core.logging import MCPLogging
 from .core.mcp_instance import ToolKwargs
+from .core.mcp_instance import dr_mcp_integration_tool
 from .core.mcp_instance import dr_mcp_tool
 from .core.mcp_instance import register_tools
 
@@ -81,4 +82,5 @@ __all__ = [
     "ToolCallTestExpectations",
     "integration_test_mcp_session",
     "tools",
+    "dr_mcp_integration_tool",
 ]

--- a/src/datarobot_genai/drmcp/core/enums.py
+++ b/src/datarobot_genai/drmcp/core/enums.py
@@ -1,0 +1,22 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from enum import auto
+from enum import Enum
+
+
+class DataRobotMCPToolCategory(Enum):
+    USER_TOOL = auto()
+    DATAROBOT_PREDICTIVE_AI_TOOL = auto()
+    THIRD_PARTY_API_WRAPPER_TOOL = auto()
+    CORE_MCP_SERVER_TOOL = auto()

--- a/src/datarobot_genai/drmcp/core/enums.py
+++ b/src/datarobot_genai/drmcp/core/enums.py
@@ -16,7 +16,6 @@ from enum import auto
 
 
 class DataRobotMCPToolCategory(Enum):
-    USER_TOOL = auto()
-    DATAROBOT_PREDICTIVE_AI_TOOL = auto()
-    THIRD_PARTY_API_WRAPPER_TOOL = auto()
-    CORE_MCP_SERVER_TOOL = auto()
+    USER_TOOL = auto()  # tools created by users
+    INTEGRATION_TOOL = auto()  # tools as a wrapper of external service
+    DYNAMICALLY_LOADED_TOOL = auto()  # tools dynamically loaded after MCP server is up

--- a/src/datarobot_genai/drmcp/core/enums.py
+++ b/src/datarobot_genai/drmcp/core/enums.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from enum import auto
 from enum import Enum
+from enum import auto
 
 
 class DataRobotMCPToolCategory(Enum):

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -265,6 +265,23 @@ class ToolKwargs(TypedDict, total=False):
     enabled: bool | None
 
 
+def dr_core_mcp_tool(
+    **kwargs: Unpack[ToolKwargs],
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Combine decorator that includes mcp.tool() and dr_mcp_extras().
+
+    All keyword arguments are passed through to FastMCP's mcp.tool() decorator.
+    See ToolKwargs for available parameters.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        instrumented = dr_mcp_extras()(func)
+        mcp.tool(**kwargs)(instrumented)
+        return instrumented
+
+    return decorator
+
+
 async def memory_aware_wrapper(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """
     Add memory management capabilities to any async function.
@@ -328,50 +345,16 @@ def dr_mcp_tool(
     return decorator
 
 
-def dr_core_mcp_tool(
+def dr_mcp_integration_tool(
     **kwargs: Unpack[ToolKwargs],
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Decorate the mcp tool of core MCP server functionality.
-    Combine decorator that includes mcp.tool() and dr_mcp_extras().
-
-    All keyword arguments are passed through to FastMCP's mcp.tool() decorator.
-    See ToolKwargs for available parameters.
+    """Decorate mcp tool created as a wrapper of external service API (e.g., DataRobot Predictive
+    AI, github API).
     """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        instrumented = dr_mcp_extras()(func)
-        updated_kwargs = update_mcp_tool_init_args_with_tool_category(
-            DataRobotMCPToolCategory.CORE_MCP_SERVER_TOOL,
-            **kwargs,
-        )
-        mcp.tool(**updated_kwargs)(instrumented)
-        return instrumented
-
-    return decorator
-
-
-def dr_mcp_predictive_ai_tool(
-    **kwargs: Unpack[ToolKwargs],
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Decorate mcp tool created as a wrapper of DataRobot Predictive AI functionalities."""
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         return dr_mcp_tool(
-            tool_category=DataRobotMCPToolCategory.DATAROBOT_PREDICTIVE_AI_TOOL,
-            **kwargs,
-        )(func)
-
-    return decorator
-
-
-def dr_mcp_third_party_api_wrapper_tool(
-    **kwargs: Unpack[ToolKwargs],
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Decorate mcp tool created as a wrapper of 3rd party API (e.g., github)."""
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        return dr_mcp_tool(
-            tool_category=DataRobotMCPToolCategory.THIRD_PARTY_API_WRAPPER_TOOL,
+            tool_category=DataRobotMCPToolCategory.INTEGRATION_TOOL,
             **kwargs,
         )(func)
 

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -350,6 +350,20 @@ def dr_core_mcp_tool(
     return decorator
 
 
+def dr_mcp_predictive_ai_tool(
+    **kwargs: Unpack[ToolKwargs],
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorate mcp tool created as a wrapper of DataRobot Predictive AI functionalities."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        return dr_mcp_tool(
+            tool_category=DataRobotMCPToolCategory.DATAROBOT_PREDICTIVE_AI_TOOL,
+            **kwargs,
+        )(func)
+
+    return decorator
+
+
 def dr_mcp_third_party_api_wrapper_tool(
     **kwargs: Unpack[ToolKwargs],
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -315,7 +315,9 @@ def update_mcp_tool_init_args_with_tool_category(
     meta = mcp_tool_init_args.get("meta")
     if meta and meta.get("tool_category"):
         raise ValueError("tool_category is a reserved field under meta. Please don't override it.")
-    mcp_tool_init_args.update({"meta": {"tool_category": tool_category.name}})
+    meta = meta or {}
+    meta["tool_category"] = tool_category.name
+    mcp_tool_init_args.update({"meta": meta})
 
     return mcp_tool_init_args
 

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -294,12 +294,10 @@ async def memory_aware_wrapper(func: Callable[..., Any], *args: Any, **kwargs: A
 def update_mcp_tool_init_args_with_tool_category(
     tool_category: DataRobotMCPToolCategory,
     **mcp_tool_init_args: Unpack[ToolKwargs],
-) -> Unpack[ToolKwargs]:
-    if mcp_tool_init_args.get("meta", {}).get("tool_category"):
-        raise ValueError(
-            "tool_category is a reserved field under meta. "
-            "Please don't override it."
-        )
+) -> ToolKwargs:
+    meta = mcp_tool_init_args.get("meta")
+    if meta and meta.get("tool_category"):
+        raise ValueError("tool_category is a reserved field under meta. Please don't override it.")
     mcp_tool_init_args.update({"meta": {"tool_category": tool_category}})
 
     return mcp_tool_init_args
@@ -333,9 +331,8 @@ def dr_mcp_tool(
 def dr_core_mcp_tool(
     **kwargs: Unpack[ToolKwargs],
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """This is a decorator for the mcp tool of core MCP server functionality.
-    It is a combine decorator
-    that includes mcp.tool() and dr_mcp_extras().
+    """Decorate the mcp tool of core MCP server functionality.
+    Combine decorator that includes mcp.tool() and dr_mcp_extras().
 
     All keyword arguments are passed through to FastMCP's mcp.tool() decorator.
     See ToolKwargs for available parameters.
@@ -344,7 +341,8 @@ def dr_core_mcp_tool(
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         instrumented = dr_mcp_extras()(func)
         updated_kwargs = update_mcp_tool_init_args_with_tool_category(
-            DataRobotMCPToolCategory.CORE_MCP_SERVER_TOOL, **kwargs,
+            DataRobotMCPToolCategory.CORE_MCP_SERVER_TOOL,
+            **kwargs,
         )
         mcp.tool(**updated_kwargs)(instrumented)
         return instrumented
@@ -355,7 +353,8 @@ def dr_core_mcp_tool(
 def dr_mcp_third_party_api_wrapper_tool(
     **kwargs: Unpack[ToolKwargs],
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """This is a decorator for the mcp tool created as a wrapper of 3rd party API (e.g., github)"""
+    """Decorate mcp tool created as a wrapper of 3rd party API (e.g., github)."""
+
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         return dr_mcp_tool(
             tool_category=DataRobotMCPToolCategory.THIRD_PARTY_API_WRAPPER_TOOL,

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -315,7 +315,7 @@ def update_mcp_tool_init_args_with_tool_category(
     meta = mcp_tool_init_args.get("meta")
     if meta and meta.get("tool_category"):
         raise ValueError("tool_category is a reserved field under meta. Please don't override it.")
-    mcp_tool_init_args.update({"meta": {"tool_category": tool_category}})
+    mcp_tool_init_args.update({"meta": {"tool_category": tool_category.name}})
 
     return mcp_tool_init_args
 
@@ -436,7 +436,7 @@ async def register_tools(
         description=description,
         annotations=annotations,
         tags=tags,
-        meta={"tool_category": DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL},
+        meta={"tool_category": DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL.name},
     )
 
     # Register the tool

--- a/src/datarobot_genai/drmcp/tools/confluence/tools.py
+++ b/src/datarobot_genai/drmcp/tools/confluence/tools.py
@@ -20,7 +20,7 @@ from typing import Annotated
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.atlassian import get_atlassian_access_token
 from datarobot_genai.drmcp.tools.clients.confluence import ConfluenceClient
 from datarobot_genai.drmcp.tools.clients.confluence import ConfluenceError
@@ -28,7 +28,7 @@ from datarobot_genai.drmcp.tools.clients.confluence import ConfluenceError
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"confluence", "read", "get", "page"})
+@dr_mcp_integration_tool(tags={"confluence", "read", "get", "page"})
 async def confluence_get_page(
     *,
     page_id_or_title: Annotated[str, "The ID or the exact title of the Confluence page."],
@@ -71,7 +71,7 @@ async def confluence_get_page(
     )
 
 
-@dr_mcp_tool(tags={"confluence", "write", "create", "page"})
+@dr_mcp_integration_tool(tags={"confluence", "write", "create", "page"})
 async def confluence_create_page(
     *,
     space_key: Annotated[str, "The key of the Confluence space where the new page should live."],
@@ -118,7 +118,7 @@ async def confluence_create_page(
     )
 
 
-@dr_mcp_tool(tags={"confluence", "write", "add", "comment"})
+@dr_mcp_integration_tool(tags={"confluence", "write", "add", "comment"})
 async def confluence_add_comment(
     *,
     page_id: Annotated[str, "The numeric ID of the page where the comment will be added."],
@@ -156,7 +156,7 @@ async def confluence_add_comment(
     )
 
 
-@dr_mcp_tool(tags={"confluence", "search", "content"})
+@dr_mcp_integration_tool(tags={"confluence", "search", "content"})
 async def confluence_search(
     *,
     cql_query: Annotated[
@@ -213,7 +213,7 @@ async def confluence_search(
     )
 
 
-@dr_mcp_tool(tags={"confluence", "write", "update", "page"})
+@dr_mcp_integration_tool(tags={"confluence", "write", "update", "page"})
 async def confluence_update_page(
     *,
     page_id: Annotated[str, "The ID of the Confluence page to update."],

--- a/src/datarobot_genai/drmcp/tools/gdrive/tools.py
+++ b/src/datarobot_genai/drmcp/tools/gdrive/tools.py
@@ -21,7 +21,7 @@ from typing import Literal
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.gdrive import LIMIT
 from datarobot_genai.drmcp.tools.clients.gdrive import MAX_PAGE_SIZE
 from datarobot_genai.drmcp.tools.clients.gdrive import SUPPORTED_FIELDS
@@ -32,7 +32,7 @@ from datarobot_genai.drmcp.tools.clients.gdrive import get_gdrive_access_token
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"google", "gdrive", "list", "search", "files", "find", "contents"})
+@dr_mcp_integration_tool(tags={"google", "gdrive", "list", "search", "files", "find", "contents"})
 async def gdrive_find_contents(
     *,
     page_size: Annotated[
@@ -101,7 +101,7 @@ async def gdrive_find_contents(
     )
 
 
-@dr_mcp_tool(tags={"google", "gdrive", "read", "content", "file", "download"})
+@dr_mcp_integration_tool(tags={"google", "gdrive", "read", "content", "file", "download"})
 async def gdrive_read_content(
     *,
     file_id: Annotated[str, "The ID of the file to read."],
@@ -148,7 +148,9 @@ async def gdrive_read_content(
     )
 
 
-@dr_mcp_tool(tags={"google", "gdrive", "create", "write", "file", "folder"}, enabled=False)
+@dr_mcp_integration_tool(
+    tags={"google", "gdrive", "create", "write", "file", "folder"}, enabled=False
+)
 async def gdrive_create_file(
     *,
     name: Annotated[str, "The name for the new file or folder."],
@@ -220,7 +222,7 @@ async def gdrive_create_file(
     )
 
 
-@dr_mcp_tool(
+@dr_mcp_integration_tool(
     tags={"google", "gdrive", "update", "metadata", "rename", "star", "trash"}, enabled=False
 )
 async def gdrive_update_metadata(
@@ -281,7 +283,7 @@ async def gdrive_update_metadata(
     )
 
 
-@dr_mcp_tool(tags={"google", "gdrive", "manage", "access", "acl"}, enabled=False)
+@dr_mcp_integration_tool(tags={"google", "gdrive", "manage", "access", "acl"}, enabled=False)
 async def gdrive_manage_access(
     *,
     file_id: Annotated[str, "The ID of the file or folder."],

--- a/src/datarobot_genai/drmcp/tools/jira/tools.py
+++ b/src/datarobot_genai/drmcp/tools/jira/tools.py
@@ -19,14 +19,14 @@ from typing import Any
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.atlassian import get_atlassian_access_token
 from datarobot_genai.drmcp.tools.clients.jira import JiraClient
 
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"jira", "search", "issues"})
+@dr_mcp_integration_tool(tags={"jira", "search", "issues"})
 async def jira_search_issues(
     *,
     jql_query: Annotated[
@@ -61,7 +61,7 @@ async def jira_search_issues(
     )
 
 
-@dr_mcp_tool(tags={"jira", "read", "get", "issue"})
+@dr_mcp_integration_tool(tags={"jira", "read", "get", "issue"})
 async def jira_get_issue(
     *, issue_key: Annotated[str, "The key (ID) of the Jira issue to retrieve, e.g., 'PROJ-123'."]
 ) -> ToolResult:
@@ -81,7 +81,7 @@ async def jira_get_issue(
     )
 
 
-@dr_mcp_tool(tags={"jira", "create", "add", "issue"})
+@dr_mcp_integration_tool(tags={"jira", "create", "add", "issue"})
 async def jira_create_issue(
     *,
     project_key: Annotated[str, "The key of the project where the issue should be created."],
@@ -125,7 +125,7 @@ async def jira_create_issue(
     )
 
 
-@dr_mcp_tool(tags={"jira", "update", "edit", "issue"})
+@dr_mcp_integration_tool(tags={"jira", "update", "edit", "issue"})
 async def jira_update_issue(
     *,
     issue_key: Annotated[str, "The key (ID) of the Jira issue to retrieve, e.g., 'PROJ-123'."],
@@ -178,7 +178,7 @@ async def jira_update_issue(
     )
 
 
-@dr_mcp_tool(tags={"jira", "update", "transition", "issue"})
+@dr_mcp_integration_tool(tags={"jira", "update", "transition", "issue"})
 async def jira_transition_issue(
     *,
     issue_key: Annotated[str, "The key (ID) of the Jira issue to transition, e.g. 'PROJ-123'."],

--- a/src/datarobot_genai/drmcp/tools/microsoft_graph/tools.py
+++ b/src/datarobot_genai/drmcp/tools/microsoft_graph/tools.py
@@ -22,7 +22,7 @@ from typing import Literal
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.microsoft_graph import MicrosoftGraphClient
 from datarobot_genai.drmcp.tools.clients.microsoft_graph import get_microsoft_graph_access_token
 from datarobot_genai.drmcp.tools.clients.microsoft_graph import validate_site_url
@@ -30,7 +30,7 @@ from datarobot_genai.drmcp.tools.clients.microsoft_graph import validate_site_ur
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(
+@dr_mcp_integration_tool(
     tags={
         "microsoft",
         "graph api",
@@ -181,7 +181,9 @@ async def microsoft_graph_search_content(
     )
 
 
-@dr_mcp_tool(tags={"microsoft", "graph api", "sharepoint", "onedrive", "share"}, enabled=False)
+@dr_mcp_integration_tool(
+    tags={"microsoft", "graph api", "sharepoint", "onedrive", "share"}, enabled=False
+)
 async def microsoft_graph_share_item(
     *,
     file_id: Annotated[str, "The ID of the file or folder to share."],
@@ -237,7 +239,7 @@ async def microsoft_graph_share_item(
     )
 
 
-@dr_mcp_tool(
+@dr_mcp_integration_tool(
     tags={
         "microsoft",
         "graph api",
@@ -316,7 +318,7 @@ async def microsoft_create_file(
     )
 
 
-@dr_mcp_tool(
+@dr_mcp_integration_tool(
     tags={
         "microsoft",
         "graph api",

--- a/src/datarobot_genai/drmcp/tools/perplexity/tools.py
+++ b/src/datarobot_genai/drmcp/tools/perplexity/tools.py
@@ -21,7 +21,7 @@ from typing import Literal
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.perplexity import MAX_QUERIES
 from datarobot_genai.drmcp.tools.clients.perplexity import MAX_RESULTS
 from datarobot_genai.drmcp.tools.clients.perplexity import MAX_RESULTS_DEFAULT
@@ -34,7 +34,7 @@ from datarobot_genai.drmcp.tools.clients.perplexity import get_perplexity_access
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"perplexity", "web", "search", "websearch"})
+@dr_mcp_integration_tool(tags={"perplexity", "web", "search", "websearch"})
 async def perplexity_search(
     *,
     query: Annotated[
@@ -117,7 +117,7 @@ async def perplexity_search(
     )
 
 
-@dr_mcp_tool(tags={"perplexity", "think", "research", "answer"})
+@dr_mcp_integration_tool(tags={"perplexity", "think", "research", "answer"})
 async def perplexity_think(
     *,
     prompt: Annotated[str, "The research prompt or instruction."],

--- a/src/datarobot_genai/drmcp/tools/tavily/tools.py
+++ b/src/datarobot_genai/drmcp/tools/tavily/tools.py
@@ -20,7 +20,7 @@ from typing import Literal
 
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.tavily import CHUNKS_PER_SOURCE_DEFAULT
 from datarobot_genai.drmcp.tools.clients.tavily import MAX_CHUNKS_PER_SOURCE
 from datarobot_genai.drmcp.tools.clients.tavily import MAX_RESULTS
@@ -31,7 +31,7 @@ from datarobot_genai.drmcp.tools.clients.tavily import get_tavily_access_token
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"tavily", "search", "web", "websearch"})
+@dr_mcp_integration_tool(tags={"tavily", "search", "web", "websearch"})
 async def tavily_search(
     *,
     query: Annotated[str, "The search query to execute."],
@@ -116,7 +116,7 @@ async def tavily_search(
     )
 
 
-@dr_mcp_tool(tags={"extract", "tavily", "web", "content"})
+@dr_mcp_integration_tool(tags={"extract", "tavily", "web", "content"})
 async def tavily_extract(
     *,
     urls: Annotated[
@@ -174,7 +174,7 @@ async def tavily_extract(
     return ToolResult(structured_content=response.as_flat_dict())
 
 
-@dr_mcp_tool(tags={"map", "tavily", "discovery"})
+@dr_mcp_integration_tool(tags={"map", "tavily", "discovery"})
 async def tavily_map(
     *,
     url: Annotated[str, "The root URL to begin mapping."],
@@ -200,7 +200,7 @@ async def tavily_map(
     return ToolResult(structured_content=response.as_flat_dict())
 
 
-@dr_mcp_tool(tags={"crawl", "tavily", "web", "rag"})
+@dr_mcp_integration_tool(tags={"crawl", "tavily", "web", "rag"})
 async def tavily_crawl(
     *,
     url: Annotated[str, "The root URL to begin the traversal."],

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -193,7 +193,7 @@ class TestMCPToolDecorator:
         )
 
         actual_tool_category = updated_tool_init_args["meta"]["tool_category"]
-        assert expected_tool_category == actual_tool_category
+        assert expected_tool_category.name == actual_tool_category
 
     def test_dr_mcp_tool(
         self,

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -154,7 +154,7 @@ class TestMCPToolDecorator:
             yield mock_decorator
 
     @pytest.fixture
-    def mock_mcp_server_tool(self) -> Iterator[Mock]:
+    def mock_datarobot_mcp_server_tool(self) -> Iterator[Mock]:
         with patch.object(DataRobotMCP, "tool") as mock_func:
             yield mock_func
 
@@ -166,6 +166,10 @@ class TestMCPToolDecorator:
             f"{module_under_test}.update_mcp_tool_init_args_with_tool_category"
         ) as mock_func:
             yield mock_func
+
+    @pytest.fixture
+    def mock_mcp_tool_callable(self) -> Iterator[Mock]:
+        yield Mock(return_value=Mock())
 
     def test_update_mcp_tool_init_args_raises_error_if_tool_category_reserved_field_is_overridden(
         self,
@@ -191,15 +195,11 @@ class TestMCPToolDecorator:
         actual_tool_category = updated_tool_init_args["meta"]["tool_category"]
         assert expected_tool_category == actual_tool_category
 
-    @pytest.fixture
-    def mock_mcp_tool_callable(self) -> Iterator[Mock]:
-        yield Mock(return_value=Mock())
-
     def test_dr_mcp_tool(
         self,
         mock_mcp_tool_callable: Mock,
         mock_dr_mcp_extras: Mock,
-        mock_mcp_server_tool: Mock,
+        mock_datarobot_mcp_server_tool: Mock,
         mock_update_mcp_tool_init_args_with_tool_category: Mock,
     ) -> None:
         mock_mcp_tool_callable_args = {}
@@ -212,10 +212,10 @@ class TestMCPToolDecorator:
         (inner_wrapper_func,) = dr_mcp_extras_decorator_call_args
         assert inner_wrapper_func.__qualname__ == "dr_mcp_tool.<locals>.decorator.<locals>.wrapper"
 
-        mock_mcp_server_tool.assert_called_once_with(
+        mock_datarobot_mcp_server_tool.assert_called_once_with(
             **mock_update_mcp_tool_init_args_with_tool_category.return_value
         )
-        mock_mcp_server_tool_callable = mock_mcp_server_tool.return_value
+        mock_mcp_server_tool_callable = mock_datarobot_mcp_server_tool.return_value
         mock_mcp_server_tool_callable.assert_called_once_with(
             mock_dr_mcp_extras_decorator.return_value
         )
@@ -226,7 +226,7 @@ class TestMCPToolDecorator:
     def test_dr_mcp_tool_decorator_with_tool_type_setup(
         self,
         mock_mcp_tool_callable: Mock,
-        mock_mcp_server_tool: Mock,
+        mock_datarobot_mcp_server_tool: Mock,
         mock_update_mcp_tool_init_args_with_tool_category: Mock,
     ) -> None:
         mock_mcp_tool_callable_args = {}
@@ -238,7 +238,7 @@ class TestMCPToolDecorator:
             mock_tool_type,
             **mock_mcp_tool_callable_args,
         )
-        mock_mcp_server_tool.assert_called_once_with(
+        mock_datarobot_mcp_server_tool.assert_called_once_with(
             **mock_update_mcp_tool_init_args_with_tool_category.return_value,
         )
 

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -192,8 +192,10 @@ class TestMCPToolDecorator:
             **tool_init_args,
         )
 
-        actual_tool_category = updated_tool_init_args["meta"]["tool_category"]
-        assert expected_tool_category.name == actual_tool_category
+        original_meta_arg = tool_init_args.get("meta") or {}
+        assert updated_tool_init_args["meta"] == original_meta_arg | {
+            "tool_category": expected_tool_category.name
+        }
 
     def test_dr_mcp_tool(
         self,

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -21,9 +21,7 @@ from fastmcp.exceptions import NotFoundError
 
 from datarobot_genai.drmcp.core.enums import DataRobotMCPToolCategory
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
-from datarobot_genai.drmcp.core.mcp_instance import dr_core_mcp_tool
-from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_predictive_ai_tool
-from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_third_party_api_wrapper_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_integration_tool
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
 from datarobot_genai.drmcp.core.mcp_instance import update_mcp_tool_init_args_with_tool_category
 
@@ -244,7 +242,7 @@ class TestMCPToolDecorator:
             **mock_update_mcp_tool_init_args_with_tool_category.return_value,
         )
 
-    def test_dr_mcp_predictive_ai_tool(
+    def test_dr_mcp_integration_tool(
         self,
         mock_mcp_tool_callable: Mock,
         mock_dr_mcp_tool: Mock,
@@ -252,54 +250,11 @@ class TestMCPToolDecorator:
         expected_kwarg_key = "sadfa"
         expected_kwarg_value = "23rew"
         mock_mcp_tool_callable_args = {expected_kwarg_key: expected_kwarg_value}
-        decorator = dr_mcp_predictive_ai_tool(**mock_mcp_tool_callable_args)
+        decorator = dr_mcp_integration_tool(**mock_mcp_tool_callable_args)
         decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
 
         assert not mock_dr_mcp_tool.call_args.args
         assert mock_dr_mcp_tool.call_args.kwargs == {
-            "tool_category": DataRobotMCPToolCategory.DATAROBOT_PREDICTIVE_AI_TOOL,
+            "tool_category": DataRobotMCPToolCategory.INTEGRATION_TOOL,
             expected_kwarg_key: expected_kwarg_value,
         }
-
-    def test_dr_mcp_third_party_api_wrapper_tool(
-        self,
-        mock_mcp_tool_callable: Mock,
-        mock_dr_mcp_tool: Mock,
-    ) -> None:
-        expected_kwarg_key = "sadfa"
-        expected_kwarg_value = "23rew"
-        mock_mcp_tool_callable_args = {expected_kwarg_key: expected_kwarg_value}
-        decorator = dr_mcp_third_party_api_wrapper_tool(**mock_mcp_tool_callable_args)
-        decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
-
-        assert not mock_dr_mcp_tool.call_args.args
-        assert mock_dr_mcp_tool.call_args.kwargs == {
-            "tool_category": DataRobotMCPToolCategory.THIRD_PARTY_API_WRAPPER_TOOL,
-            expected_kwarg_key: expected_kwarg_value,
-        }
-
-    def test_dr_core_mcp_tool(
-        self,
-        mock_mcp_tool_callable: Mock,
-        mock_dr_mcp_extras: Mock,
-        mock_mcp_server_tool: Mock,
-        mock_update_mcp_tool_init_args_with_tool_category: Mock,
-    ) -> None:
-        mock_mcp_tool_callable_args = {}
-        decorator = dr_core_mcp_tool()
-        decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
-
-        mock_dr_mcp_extras.assert_called_with()
-        mock_dr_mcp_extras_decorator = mock_dr_mcp_extras.return_value
-        mock_dr_mcp_extras_decorator.assert_called_once_with(mock_mcp_tool_callable)
-        mock_update_mcp_tool_init_args_with_tool_category.assert_called_once_with(
-            DataRobotMCPToolCategory.CORE_MCP_SERVER_TOOL,
-            **mock_mcp_tool_callable_args,
-        )
-        mock_mcp_server_tool.assert_called_once_with(
-            **mock_update_mcp_tool_init_args_with_tool_category.return_value
-        )
-        mock_mcp_server_tool_callable = mock_mcp_server_tool.return_value
-        mock_mcp_server_tool_callable.assert_called_once_with(
-            mock_dr_mcp_extras_decorator.return_value
-        )

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -12,22 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
-from typing import Dict
-from typing import Iterator
+from collections.abc import Iterator
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
 from fastmcp.exceptions import NotFoundError
 
-from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
-from datarobot_genai.drmcp.core.mcp_instance import mcp
-from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
-from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_third_party_api_wrapper_tool
-from datarobot_genai.drmcp.core.mcp_instance import dr_core_mcp_tool
-from datarobot_genai.drmcp.core.mcp_instance import update_mcp_tool_init_args_with_tool_category
 from datarobot_genai.drmcp.core.enums import DataRobotMCPToolCategory
+from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
+from datarobot_genai.drmcp.core.mcp_instance import dr_core_mcp_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_third_party_api_wrapper_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
+from datarobot_genai.drmcp.core.mcp_instance import update_mcp_tool_init_args_with_tool_category
 
 
 class TestDataRobotMCPInstanceAdditional:
@@ -163,12 +160,16 @@ class TestMCPToolDecorator:
             yield mock_func
 
     @pytest.fixture
-    def mock_update_mcp_tool_init_args_with_tool_category(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.update_mcp_tool_init_args_with_tool_category") as mock_func:
+    def mock_update_mcp_tool_init_args_with_tool_category(
+        self, module_under_test: str
+    ) -> Iterator[Mock]:
+        with patch(
+            f"{module_under_test}.update_mcp_tool_init_args_with_tool_category"
+        ) as mock_func:
             yield mock_func
 
     def test_update_mcp_tool_init_args_raises_error_if_tool_category_reserved_field_is_overridden(
-        self
+        self,
     ) -> None:
         mock_tool_init_args = {"meta": {"tool_category": Mock()}}
         with pytest.raises(ValueError):
@@ -176,14 +177,16 @@ class TestMCPToolDecorator:
 
     @pytest.mark.parametrize(
         "tool_init_args",
-        [{}, {"meta": {"1ewqa": "adfa"}}]
+        [{}, {"meta": {"1ewqa": "adfa"}}, {"meta": None}],
     )
     def test_update_mcp_tool_init_args_with_tool_category(
-        self, tool_init_args: Dict[str, str],
+        self,
+        tool_init_args: dict[str, str | None],
     ) -> None:
         expected_tool_category = Mock()
         updated_tool_init_args = update_mcp_tool_init_args_with_tool_category(
-            expected_tool_category, **tool_init_args,
+            expected_tool_category,
+            **tool_init_args,
         )
 
         actual_tool_category = updated_tool_init_args["meta"]["tool_category"]
@@ -207,7 +210,7 @@ class TestMCPToolDecorator:
         mock_dr_mcp_extras.assert_called_with()
         mock_dr_mcp_extras_decorator = mock_dr_mcp_extras.return_value
         dr_mcp_extras_decorator_call_args = mock_dr_mcp_extras_decorator.call_args.args
-        inner_wrapper_func, = dr_mcp_extras_decorator_call_args
+        (inner_wrapper_func,) = dr_mcp_extras_decorator_call_args
         assert inner_wrapper_func.__qualname__ == "dr_mcp_tool.<locals>.decorator.<locals>.wrapper"
 
         mock_mcp_server_tool.assert_called_once_with(
@@ -223,7 +226,7 @@ class TestMCPToolDecorator:
     )
     def test_dr_mcp_tool_decorator_with_tool_type_setup(
         self,
-            mock_mcp_tool_callable: Mock,
+        mock_mcp_tool_callable: Mock,
         mock_mcp_server_tool: Mock,
         mock_update_mcp_tool_init_args_with_tool_category: Mock,
     ) -> None:
@@ -233,7 +236,8 @@ class TestMCPToolDecorator:
         decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
 
         mock_update_mcp_tool_init_args_with_tool_category.assert_called_once_with(
-            mock_tool_type, **mock_mcp_tool_callable_args,
+            mock_tool_type,
+            **mock_mcp_tool_callable_args,
         )
         mock_mcp_server_tool.assert_called_once_with(
             **mock_update_mcp_tool_init_args_with_tool_category.return_value,
@@ -271,7 +275,8 @@ class TestMCPToolDecorator:
         mock_dr_mcp_extras_decorator = mock_dr_mcp_extras.return_value
         mock_dr_mcp_extras_decorator.assert_called_once_with(mock_mcp_tool_callable)
         mock_update_mcp_tool_init_args_with_tool_category.assert_called_once_with(
-            DataRobotMCPToolCategory.CORE_MCP_SERVER_TOOL, **mock_mcp_tool_callable_args,
+            DataRobotMCPToolCategory.CORE_MCP_SERVER_TOOL,
+            **mock_mcp_tool_callable_args,
         )
         mock_mcp_server_tool.assert_called_once_with(
             **mock_update_mcp_tool_init_args_with_tool_category.return_value

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -13,11 +13,21 @@
 # limitations under the License.
 
 from unittest.mock import patch
+from typing import Dict
+from typing import Iterator
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 from fastmcp.exceptions import NotFoundError
 
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
+from datarobot_genai.drmcp.core.mcp_instance import mcp
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_third_party_api_wrapper_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_core_mcp_tool
+from datarobot_genai.drmcp.core.mcp_instance import update_mcp_tool_init_args_with_tool_category
+from datarobot_genai.drmcp.core.enums import DataRobotMCPToolCategory
 
 
 class TestDataRobotMCPInstanceAdditional:
@@ -130,3 +140,143 @@ class TestDataRobotMCPInstanceAdditional:
             mock_logger.debug.assert_called_with(
                 "Tool old_tool not found in registry, skipping removal"
             )
+
+
+class TestMCPToolDecorator:
+    @pytest.fixture
+    def module_under_test(self) -> str:
+        return "datarobot_genai.drmcp.core.mcp_instance"
+
+    @pytest.fixture
+    def mock_dr_mcp_tool(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.dr_mcp_tool") as mock_decorator:
+            yield mock_decorator
+
+    @pytest.fixture
+    def mock_dr_mcp_extras(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.dr_mcp_extras") as mock_decorator:
+            yield mock_decorator
+
+    @pytest.fixture
+    def mock_mcp_server_tool(self) -> Iterator[Mock]:
+        with patch.object(DataRobotMCP, "tool") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_update_mcp_tool_init_args_with_tool_category(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.update_mcp_tool_init_args_with_tool_category") as mock_func:
+            yield mock_func
+
+    def test_update_mcp_tool_init_args_raises_error_if_tool_category_reserved_field_is_overridden(
+        self
+    ) -> None:
+        mock_tool_init_args = {"meta": {"tool_category": Mock()}}
+        with pytest.raises(ValueError):
+            update_mcp_tool_init_args_with_tool_category(Mock(), **mock_tool_init_args)
+
+    @pytest.mark.parametrize(
+        "tool_init_args",
+        [{}, {"meta": {"1ewqa": "adfa"}}]
+    )
+    def test_update_mcp_tool_init_args_with_tool_category(
+        self, tool_init_args: Dict[str, str],
+    ) -> None:
+        expected_tool_category = Mock()
+        updated_tool_init_args = update_mcp_tool_init_args_with_tool_category(
+            expected_tool_category, **tool_init_args,
+        )
+
+        actual_tool_category = updated_tool_init_args["meta"]["tool_category"]
+        assert expected_tool_category == actual_tool_category
+
+    @pytest.fixture
+    def mock_mcp_tool_callable(self) -> Iterator[Mock]:
+        yield Mock(return_value=Mock())
+
+    def test_dr_mcp_tool(
+        self,
+        mock_mcp_tool_callable: Mock,
+        mock_dr_mcp_extras: Mock,
+        mock_mcp_server_tool: Mock,
+        mock_update_mcp_tool_init_args_with_tool_category: Mock,
+    ) -> None:
+        mock_mcp_tool_callable_args = {}
+        decorator = dr_mcp_tool()
+        decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
+
+        mock_dr_mcp_extras.assert_called_with()
+        mock_dr_mcp_extras_decorator = mock_dr_mcp_extras.return_value
+        dr_mcp_extras_decorator_call_args = mock_dr_mcp_extras_decorator.call_args.args
+        inner_wrapper_func, = dr_mcp_extras_decorator_call_args
+        assert inner_wrapper_func.__qualname__ == "dr_mcp_tool.<locals>.decorator.<locals>.wrapper"
+
+        mock_mcp_server_tool.assert_called_once_with(
+            **mock_update_mcp_tool_init_args_with_tool_category.return_value
+        )
+        mock_mcp_server_tool_callable = mock_mcp_server_tool.return_value
+        mock_mcp_server_tool_callable.assert_called_once_with(
+            mock_dr_mcp_extras_decorator.return_value
+        )
+
+    @pytest.mark.usefixtures(
+        "mock_dr_mcp_extras",
+    )
+    def test_dr_mcp_tool_decorator_with_tool_type_setup(
+        self,
+            mock_mcp_tool_callable: Mock,
+        mock_mcp_server_tool: Mock,
+        mock_update_mcp_tool_init_args_with_tool_category: Mock,
+    ) -> None:
+        mock_mcp_tool_callable_args = {}
+        mock_tool_type = Mock()
+        decorator = dr_mcp_tool(tool_category=mock_tool_type)
+        decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
+
+        mock_update_mcp_tool_init_args_with_tool_category.assert_called_once_with(
+            mock_tool_type, **mock_mcp_tool_callable_args,
+        )
+        mock_mcp_server_tool.assert_called_once_with(
+            **mock_update_mcp_tool_init_args_with_tool_category.return_value,
+        )
+
+    def test_dr_mcp_third_party_api_wrapper_tool(
+        self,
+        mock_mcp_tool_callable: Mock,
+        mock_dr_mcp_tool: Mock,
+    ) -> None:
+        expected_kwarg_key = "sadfa"
+        expected_kwarg_value = "23rew"
+        mock_mcp_tool_callable_args = {expected_kwarg_key: expected_kwarg_value}
+        decorator = dr_mcp_third_party_api_wrapper_tool(**mock_mcp_tool_callable_args)
+        decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
+
+        assert not mock_dr_mcp_tool.call_args.args
+        assert mock_dr_mcp_tool.call_args.kwargs == {
+            "tool_category": DataRobotMCPToolCategory.THIRD_PARTY_API_WRAPPER_TOOL,
+            expected_kwarg_key: expected_kwarg_value,
+        }
+
+    def test_dr_core_mcp_tool(
+        self,
+        mock_mcp_tool_callable: Mock,
+        mock_dr_mcp_extras: Mock,
+        mock_mcp_server_tool: Mock,
+        mock_update_mcp_tool_init_args_with_tool_category: Mock,
+    ) -> None:
+        mock_mcp_tool_callable_args = {}
+        decorator = dr_core_mcp_tool()
+        decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
+
+        mock_dr_mcp_extras.assert_called_with()
+        mock_dr_mcp_extras_decorator = mock_dr_mcp_extras.return_value
+        mock_dr_mcp_extras_decorator.assert_called_once_with(mock_mcp_tool_callable)
+        mock_update_mcp_tool_init_args_with_tool_category.assert_called_once_with(
+            DataRobotMCPToolCategory.CORE_MCP_SERVER_TOOL, **mock_mcp_tool_callable_args,
+        )
+        mock_mcp_server_tool.assert_called_once_with(
+            **mock_update_mcp_tool_init_args_with_tool_category.return_value
+        )
+        mock_mcp_server_tool_callable = mock_mcp_server_tool.return_value
+        mock_mcp_server_tool_callable.assert_called_once_with(
+            mock_dr_mcp_extras_decorator.return_value
+        )

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -22,6 +22,7 @@ from fastmcp.exceptions import NotFoundError
 from datarobot_genai.drmcp.core.enums import DataRobotMCPToolCategory
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 from datarobot_genai.drmcp.core.mcp_instance import dr_core_mcp_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_predictive_ai_tool
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_third_party_api_wrapper_tool
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
 from datarobot_genai.drmcp.core.mcp_instance import update_mcp_tool_init_args_with_tool_category
@@ -242,6 +243,23 @@ class TestMCPToolDecorator:
         mock_mcp_server_tool.assert_called_once_with(
             **mock_update_mcp_tool_init_args_with_tool_category.return_value,
         )
+
+    def test_dr_mcp_predictive_ai_tool(
+        self,
+        mock_mcp_tool_callable: Mock,
+        mock_dr_mcp_tool: Mock,
+    ) -> None:
+        expected_kwarg_key = "sadfa"
+        expected_kwarg_value = "23rew"
+        mock_mcp_tool_callable_args = {expected_kwarg_key: expected_kwarg_value}
+        decorator = dr_mcp_predictive_ai_tool(**mock_mcp_tool_callable_args)
+        decorator(mock_mcp_tool_callable)(**mock_mcp_tool_callable_args)
+
+        assert not mock_dr_mcp_tool.call_args.args
+        assert mock_dr_mcp_tool.call_args.kwargs == {
+            "tool_category": DataRobotMCPToolCategory.DATAROBOT_PREDICTIVE_AI_TOOL,
+            expected_kwarg_key: expected_kwarg_value,
+        }
 
     def test_dr_mcp_third_party_api_wrapper_tool(
         self,

--- a/tests/drmcp/unit/test_register_tools.py
+++ b/tests/drmcp/unit/test_register_tools.py
@@ -454,7 +454,7 @@ class TestRegisterTool:
             description=None,
             annotations=None,
             tags=None,
-            meta={"tool_category": DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL},
+            meta={"tool_category": DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL.name},
         )
         mock_datarobot_mcp_server.add_tool.assert_called_once_with(
             mock_tool_from_function.return_value

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
### To reviewers
I ran `drmcp-integration` and `drmcp-acceptance` testings locally. All testings passed.

# RATIONALE
### Why do we need to differentiate tools ?
We need to record the MCP server snapshot (e.g., tools packaged under it) to support MCP server lineage. At this moment, there are following tools packaged with one MCP server. We need a better way to differentiate them and record the tool category in the MCP server snapshot.
- User created tool: user created tool
- Predictive AI tool/3rd party integration tools: tool wrapping around DR public API/3rd party service API (e.g., github) to provide Predictive AI functionalities 
- Dynamic tools: Tools (custom inference model deployment) only loaded after MCP server is up.


### The general idea behind the design
- Add tool category concept (e.g., user tool, integration tool, dynamic tool) to represent tools created for different purposes.
- Record this info under Tool.meta.

### mcp tool decorators
- `def dr_mcp_tool()` decorator
This will be used to decorate user create tools (e.g., tools under app/tools).

- `def dr_mcp_integration_tool()` decorator
This will be used to decorate integration tools (e.g., Predictive AI/3rd party integration tools).

- For dynamic tools
Set tool_category=DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL of dynamic tool within `def register_tools()`.

- Replace @dr_mcp_tool with @dr_mcp_integration_tool decorator in selected modules
```
find ./src/datarobot_genai/drmcp/tools/tavily/ -type f -name '*.py' -exec sed -i 's/@dr_mcp_tool/@dr_mcp_integration_tool/g' {} +
```



## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
