### PR TITLE
[BUZZOK-29219] Update NAT MCP client for 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.5.7
+
+- Updated NAT MCP client for 1.4.1 changes
+- Update default transport for NAT MCP client to `streamable_http`
+- Log error and fall back to empty function group when NAT MCP client is misconfigured
+
 ## 0.5.6
 
 - Bump NAT libraries to 1.4.1
@@ -26,12 +32,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.5.2
 
 - Dependency groups are converted into the optional `extra` options for installation, without list of default dependencies.
-
-## 0.5.2
-
-- Updated NAT MCP client for 1.4.0 changes
-- Update default transport for NAT MCP client to `streamable_http`
-- Log error and fall back to empty function group when NAT MCP client is misconfigured
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Dependency groups are converted into the optional `extra` options for installation, without list of default dependencies.
 
+## 0.5.2
+
+- Updated NAT MCP client for 1.4.0 changes
+- Update default transport for NAT MCP client to `streamable_http`
+- Log error and fall back to empty function group when NAT MCP client is misconfigured
+
 ## 0.5.1
 
 - Added the CHANGELOG.md file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.5.6"
+version = "0.5.7"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -285,6 +285,8 @@ async def datarobot_mcp_client_function_group(
 
         logger.warning("Error in MCP client function group: %s", primary_exception)
         group.mcp_client = None
+        group.mcp_client_server_name = getattr(client, "server_name", str(config.server.url))
+        group.mcp_client_transport = getattr(client, "transport", config.server.transport)
         if not yielded:
             yield group
         else:

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -45,11 +45,11 @@ def _default_transport() -> Literal["streamable-http", "sse", "stdio"]:
     return server_config["transport"] if server_config else "streamable-http"
 
 
-def _default_url() -> HttpUrl | None:
+def _default_url() -> HttpUrl:
     from datarobot_genai.core.mcp.common import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
-    return server_config["url"] if server_config else "http://localhost:8080/mcp"
+    return server_config["url"] if server_config else HttpUrl("http://localhost:8080/mcp")
 
 
 def _default_auth_provider() -> str | AuthenticationRef | None:

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -284,7 +284,5 @@ async def datarobot_mcp_client_function_group(
             yield group
     except Exception as e:
         logger.warning(f"Error in MCP client function group: {e}")
-    # finally:
-    #     # Clean up client reference on the group to avoid stale clients
-    #     #group.mcp_client = None
-    #     yield group
+        group.mcp_client = None
+        yield group

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -59,13 +59,6 @@ def _default_auth_provider() -> str | AuthenticationRef | None:
     return "datarobot_mcp_auth" if server_config else None
 
 
-def _default_command() -> str | None:
-    from datarobot_genai.core.mcp.common import MCPConfig  # noqa: PLC0415
-
-    server_config = MCPConfig().server_config
-    return None if server_config else "docker"
-
-
 class DataRobotMCPServerConfig(MCPServerConfig):
     transport: Literal["streamable-http", "sse"] = Field(
         default_factory=_default_transport,

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -280,7 +280,7 @@ async def datarobot_mcp_client_function_group(
             yield group
     except Exception as e:
         primary_exception = e
-        if isinstance(e, ExceptionGroup):  # noqa: F821
+        if isinstance(e, ExceptionGroup):  # type: ignore[name-defined]  # noqa: F821
             primary_exception = extract_primary_exception(list(e.exceptions))
 
         logger.warning("Error in MCP client function group: %s", primary_exception)

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _default_transport() -> Literal["streamable-http", "sse", "stdio"]:
+def _default_transport() -> Literal["streamable-http", "sse"]:
     from datarobot_genai.core.mcp.common import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
@@ -145,7 +145,6 @@ async def datarobot_mcp_client_function_group(
         The function group
     """
     from nat.plugins.mcp.client.client_base import MCPSSEClient  # noqa: PLC0415
-    from nat.plugins.mcp.client.client_base import MCPStdioClient  # noqa: PLC0415
     from nat.plugins.mcp.client.client_impl import MCPFunctionGroup  # noqa: PLC0415
     from nat.plugins.mcp.client.client_impl import (
         mcp_apply_tool_alias_and_description,  # noqa: PLC0415
@@ -158,21 +157,7 @@ async def datarobot_mcp_client_function_group(
         auth_provider = await _builder.get_auth_provider(config.server.auth_provider)
 
     # Build the appropriate client
-    if config.server.transport == "stdio":
-        if not config.server.command:
-            raise ValueError("command is required for stdio transport")
-        client = MCPStdioClient(
-            config.server.command,
-            config.server.args,
-            config.server.env,
-            tool_call_timeout=config.tool_call_timeout,
-            auth_flow_timeout=config.auth_flow_timeout,
-            reconnect_enabled=config.reconnect_enabled,
-            reconnect_max_attempts=config.reconnect_max_attempts,
-            reconnect_initial_backoff=config.reconnect_initial_backoff,
-            reconnect_max_backoff=config.reconnect_max_backoff,
-        )
-    elif config.server.transport == "sse":
+    if config.server.transport == "sse":
         client = MCPSSEClient(
             str(config.server.url),
             tool_call_timeout=config.tool_call_timeout,

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -281,9 +281,10 @@ async def datarobot_mcp_client_function_group(
                     input_schema=input_schema,
                     converters=tool_fn.converters,
                 )
+            yield group
     except Exception as e:
         logger.warning(f"Error in MCP client function group: {e}")
-    finally:
-        # Clean up client reference on the group to avoid stale clients
-        group.mcp_client = None
-        yield group
+    # finally:
+    #     # Clean up client reference on the group to avoid stale clients
+    #     #group.mcp_client = None
+    #     yield group

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -15,16 +15,9 @@
 from __future__ import annotations
 
 import logging
-import sys
 from datetime import timedelta
 from typing import TYPE_CHECKING
 from typing import Literal
-
-# ExceptionGroup is a builtin from Python 3.11+; package supports 3.10 (see pyproject.toml).
-if sys.version_info >= (3, 11):
-    from builtins import ExceptionGroup
-else:
-    ExceptionGroup = ()  # type: ignore[misc]  # sentinel so isinstance(e, ExceptionGroup) is False on 3.10
 
 from nat.cli.register_workflow import register_function_group
 from nat.data_models.component_ref import AuthenticationRef
@@ -271,9 +264,10 @@ async def datarobot_mcp_client_function_group(
             yielded = True
             yield group
     except Exception as e:
-        primary_exception = e
-        if isinstance(e, ExceptionGroup):
+        if hasattr(e, "exceptions"):
             primary_exception = extract_primary_exception(list(e.exceptions))
+        else:
+            primary_exception = e
 
         logger.warning("Error in MCP client function group: %s", primary_exception)
         group.mcp_client = None

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -25,6 +25,7 @@ from nat.plugins.mcp.client.client_base import AuthAdapter
 from nat.plugins.mcp.client.client_base import MCPStreamableHTTPClient
 from nat.plugins.mcp.client.client_config import MCPServerConfig
 from nat.plugins.mcp.client.client_impl import MCPClientConfig
+from nat.plugins.mcp.exception_handler import extract_primary_exception
 from pydantic import Field
 from pydantic import HttpUrl
 
@@ -283,6 +284,10 @@ async def datarobot_mcp_client_function_group(
                 )
             yield group
     except Exception as e:
-        logger.warning(f"Error in MCP client function group: {e}")
+        primary_exception = e
+        if isinstance(e, ExceptionGroup):  # noqa: F821
+            primary_exception = extract_primary_exception(list(e.exceptions))
+
+        logger.warning(f"Error in MCP client function group: {primary_exception}")
         group.mcp_client = None
         yield group

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -15,9 +15,16 @@
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import timedelta
 from typing import TYPE_CHECKING
 from typing import Literal
+
+# ExceptionGroup is a builtin from Python 3.11+; package supports 3.10 (see pyproject.toml).
+if sys.version_info >= (3, 11):
+    from builtins import ExceptionGroup
+else:
+    ExceptionGroup = ()  # type: ignore[misc]  # sentinel so isinstance(e, ExceptionGroup) is False on 3.10
 
 from nat.cli.register_workflow import register_function_group
 from nat.data_models.component_ref import AuthenticationRef
@@ -265,7 +272,7 @@ async def datarobot_mcp_client_function_group(
             yield group
     except Exception as e:
         primary_exception = e
-        if isinstance(e, ExceptionGroup):  # type: ignore[name-defined]  # noqa: F821
+        if isinstance(e, ExceptionGroup):
             primary_exception = extract_primary_exception(list(e.exceptions))
 
         logger.warning("Error in MCP client function group: %s", primary_exception)

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -41,14 +41,14 @@ def _default_transport() -> Literal["streamable-http", "sse", "stdio"]:
     from datarobot_genai.core.mcp.common import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
-    return server_config["transport"] if server_config else "stdio"
+    return server_config["transport"] if server_config else "streamable-http"
 
 
 def _default_url() -> HttpUrl | None:
     from datarobot_genai.core.mcp.common import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
-    return server_config["url"] if server_config else None
+    return server_config["url"] if server_config else "http://localhost"
 
 
 def _default_auth_provider() -> str | AuthenticationRef | None:
@@ -66,11 +66,11 @@ def _default_command() -> str | None:
 
 
 class DataRobotMCPServerConfig(MCPServerConfig):
-    transport: Literal["streamable-http", "sse", "stdio"] = Field(
+    transport: Literal["streamable-http", "sse"] = Field(
         default_factory=_default_transport,
         description="Transport type to connect to the MCP server (sse or streamable-http)",
     )
-    url: HttpUrl | None = Field(
+    url: HttpUrl = Field(
         default_factory=_default_url,
         description="URL of the MCP server (for sse or streamable-http transport)",
     )
@@ -78,10 +78,6 @@ class DataRobotMCPServerConfig(MCPServerConfig):
     auth_provider: str | AuthenticationRef | None = Field(
         default_factory=_default_auth_provider,
         description="Reference to authentication provider",
-    )
-    command: str | None = Field(
-        default_factory=_default_command,
-        description="Command to run for stdio transport (e.g. 'python' or 'docker')",
     )
 
 

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -48,7 +48,7 @@ def _default_url() -> HttpUrl | None:
     from datarobot_genai.core.mcp.common import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
-    return server_config["url"] if server_config else "http://localhost"
+    return server_config["url"] if server_config else "http://localhost:8080/mcp"
 
 
 def _default_auth_provider() -> str | AuthenticationRef | None:

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -60,16 +60,19 @@ def load_config(config_file: StrPath, headers: dict[str, str] | None = None) -> 
 def add_headers_to_datarobot_mcp_auth(config_yaml: dict, headers: dict[str, str] | None) -> None:
     if headers:
         if authentication := config_yaml.get("authentication"):
+            keys_present = {k.lower() for k in headers.keys()}
+            extra_api_token_keys = {"x-datarobot-api-token", "x-datarobot-api-key"}
+            has_extra_api_token_header = extra_api_token_keys & keys_present
+            # Do not mutate the caller's headers; give each auth config its own copy.
+            if "Authorization" in headers and not has_extra_api_token_header:
+                token = headers["Authorization"].removeprefix("Bearer ")
+                headers_copy = {**headers, "x-datarobot-api-token": token}
+            else:
+                headers_copy = dict(headers)
             for auth_name in authentication:
                 auth_config = authentication[auth_name]
                 if auth_config.get("_type") == "datarobot_mcp_auth":
-                    keys_present = {k.lower() for k in headers.keys()}
-                    extra_api_token_keys = {"x-datarobot-api-token", "x-datarobot-api-key"}
-                    has_extra_api_token_header = extra_api_token_keys & keys_present
-                    if "Authorization" in headers and not has_extra_api_token_header:
-                        token = headers["Authorization"].removeprefix("Bearer ")
-                        headers["x-datarobot-api-token"] = token
-                    auth_config["headers"] = headers
+                    auth_config["headers"] = dict(headers_copy)
 
 
 def add_headers_to_datarobot_llm_deployment(

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -63,10 +63,6 @@ def add_headers_to_datarobot_mcp_auth(config_yaml: dict, headers: dict[str, str]
             for auth_name in authentication:
                 auth_config = authentication[auth_name]
                 if auth_config.get("_type") == "datarobot_mcp_auth":
-                    if "Authorization" in headers:
-                        token = headers["Authorization"].lstrip("Bearer ")
-                        headers["x-datarobot-api-token"] = token
-                        headers["x-datarobot-api-key"] = token
                     auth_config["headers"] = headers
 
 

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -63,6 +63,12 @@ def add_headers_to_datarobot_mcp_auth(config_yaml: dict, headers: dict[str, str]
             for auth_name in authentication:
                 auth_config = authentication[auth_name]
                 if auth_config.get("_type") == "datarobot_mcp_auth":
+                    keys_present = {k.lower() for k in headers.keys()}
+                    extra_api_token_keys = {"x-datarobot-api-token", "x-datarobot-api-key"}
+                    has_extra_api_token_header = extra_api_token_keys & keys_present
+                    if "Authorization" in headers and not has_extra_api_token_header:
+                        token = headers["Authorization"].lstrip("Bearer ")
+                        headers["x-datarobot-api-token"] = token
                     auth_config["headers"] = headers
 
 

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -67,7 +67,7 @@ def add_headers_to_datarobot_mcp_auth(config_yaml: dict, headers: dict[str, str]
                     extra_api_token_keys = {"x-datarobot-api-token", "x-datarobot-api-key"}
                     has_extra_api_token_header = extra_api_token_keys & keys_present
                     if "Authorization" in headers and not has_extra_api_token_header:
-                        token = headers["Authorization"].lstrip("Bearer ")
+                        token = headers["Authorization"].removeprefix("Bearer ")
                         headers["x-datarobot-api-token"] = token
                     auth_config["headers"] = headers
 

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -63,6 +63,10 @@ def add_headers_to_datarobot_mcp_auth(config_yaml: dict, headers: dict[str, str]
             for auth_name in authentication:
                 auth_config = authentication[auth_name]
                 if auth_config.get("_type") == "datarobot_mcp_auth":
+                    if "Authorization" in headers:
+                        token = headers["Authorization"].lstrip("Bearer ")
+                        headers["x-datarobot-api-token"] = token
+                        headers["x-datarobot-api-key"] = token
                     auth_config["headers"] = headers
 
 

--- a/tests/nat/integration/test_agent.py
+++ b/tests/nat/integration/test_agent.py
@@ -20,6 +20,7 @@ from unittest.mock import ANY
 import pytest
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 
+from datarobot_genai.core.chat import agent_chat_completion_wrapper
 from datarobot_genai.core.chat.completions import convert_chat_completion_params_to_run_agent_input
 from datarobot_genai.core.chat.responses import async_gen_to_sync_thread
 from datarobot_genai.core.chat.responses import (
@@ -72,23 +73,6 @@ def agent_with_mcp(workflow_with_mcp_path, config):
     )
 
 
-async def test_run_method(agent):
-    # Call the run method with test inputs
-    completion_create_params = {
-        "model": "test-model",
-        "messages": [{"role": "user", "content": "AI"}],
-        "environment_var": True,
-    }
-    result, pipeline_interactions, usage = await agent.invoke(completion_create_params)
-
-    assert result
-    assert isinstance(result, str)
-    assert pipeline_interactions
-    assert usage["completion_tokens"] > 0
-    assert usage["prompt_tokens"] > 0
-    assert usage["total_tokens"] > 0
-
-
 async def test_run_method_with_mcp(agent_with_mcp):
     # You probably need to comment out the disable_env_file conftest fixture to pick up
     # MCP settings from .env.
@@ -126,7 +110,8 @@ async def test_run_method_streaming(agent):
         "environment_var": True,
         "stream": True,
     }
-    streaming_response_iterator = await agent.invoke(completion_create_params)
+    run_agent_input = convert_chat_completion_params_to_run_agent_input(completion_create_params)
+    streaming_response_iterator = agent.invoke(run_agent_input)
 
     async for (
         result,
@@ -159,14 +144,10 @@ def test_custom_model_streaming_response(agent):
     event_loop = asyncio.new_event_loop()
     thread_pool_executor.submit(asyncio.set_event_loop, event_loop).result()
 
-    # Invoke the agent and check if it returns a generator or a tuple
-    # Set the authorization context in the worker thread before invoking the agent
-    def invoke_with_auth_context():  # type: ignore[no-untyped-def]
-        return event_loop.run_until_complete(
-            agent.invoke(completion_create_params=completion_create_params)
-        )
-
-    result = thread_pool_executor.submit(invoke_with_auth_context).result()
+    result = thread_pool_executor.submit(
+        event_loop.run_until_complete,
+        agent_chat_completion_wrapper(agent, completion_create_params),
+    ).result()
 
     streaming_response_iterator = async_gen_to_sync_thread(result, thread_pool_executor, event_loop)
 

--- a/tests/nat/integration/workflow_with_mcp.yaml
+++ b/tests/nat/integration/workflow_with_mcp.yaml
@@ -33,3 +33,4 @@ workflow:
   llm_name: datarobot_llm
   tool_names:
     - mcp_tools
+    - completion_tool

--- a/tests/nat/test_helpers.py
+++ b/tests/nat/test_helpers.py
@@ -47,6 +47,71 @@ from datarobot_genai.nat.helpers import load_workflow
                 }
             },
         ),
+        # Authorization Bearer is copied to x-datarobot-api-token with prefix removed
+        (
+            {"authentication": {"some_auth_name": {"_type": "datarobot_mcp_auth"}}},
+            {"Authorization": "Bearer mytoken"},
+            {
+                "authentication": {
+                    "some_auth_name": {
+                        "_type": "datarobot_mcp_auth",
+                        "headers": {
+                            "Authorization": "Bearer mytoken",
+                            "x-datarobot-api-token": "mytoken",
+                        },
+                    }
+                }
+            },
+        ),
+        # Token starting with chars in {'B','e','a','r',' '} must not be stripped
+        # (removeprefix, not lstrip)
+        (
+            {"authentication": {"some_auth_name": {"_type": "datarobot_mcp_auth"}}},
+            {"Authorization": "Bearer abcToken"},
+            {
+                "authentication": {
+                    "some_auth_name": {
+                        "_type": "datarobot_mcp_auth",
+                        "headers": {
+                            "Authorization": "Bearer abcToken",
+                            "x-datarobot-api-token": "abcToken",
+                        },
+                    }
+                }
+            },
+        ),
+        # Authorization Bearer is not copied when extra key is present
+        (
+            {"authentication": {"some_auth_name": {"_type": "datarobot_mcp_auth"}}},
+            {"Authorization": "Bearer mytoken", "x-datarobot-api-token": "othertoken"},
+            {
+                "authentication": {
+                    "some_auth_name": {
+                        "_type": "datarobot_mcp_auth",
+                        "headers": {
+                            "Authorization": "Bearer mytoken",
+                            "x-datarobot-api-token": "othertoken",
+                        },
+                    }
+                }
+            },
+        ),
+        # Authorization Bearer is not copied when extra key is present
+        (
+            {"authentication": {"some_auth_name": {"_type": "datarobot_mcp_auth"}}},
+            {"Authorization": "Bearer mytoken", "x-datarobot-api-key": "othertoken"},
+            {
+                "authentication": {
+                    "some_auth_name": {
+                        "_type": "datarobot_mcp_auth",
+                        "headers": {
+                            "Authorization": "Bearer mytoken",
+                            "x-datarobot-api-key": "othertoken",
+                        },
+                    }
+                }
+            },
+        ),
         (
             {"authentication": {"some_auth_name": {"_type": "not_datarobot_mcp_auth"}}},
             {"h1": "v1"},

--- a/tests/nat/test_helpers.py
+++ b/tests/nat/test_helpers.py
@@ -129,6 +129,33 @@ def test_add_headers_to_datarobot_mcp_auth(config, headers, expected):
     assert config == expected
 
 
+def test_add_headers_to_datarobot_mcp_auth_does_not_mutate_caller_headers():
+    """Caller's headers dict must not be mutated (no x-datarobot-api-token added in place)."""
+    headers = {"Authorization": "Bearer mytoken"}
+    config = {"authentication": {"auth1": {"_type": "datarobot_mcp_auth"}}}
+    add_headers_to_datarobot_mcp_auth(config, headers)
+    assert headers == {"Authorization": "Bearer mytoken"}
+    assert "x-datarobot-api-token" not in headers
+
+
+def test_add_headers_to_datarobot_mcp_auth_each_config_gets_own_headers_dict():
+    """Each datarobot_mcp_auth config must get its own headers dict (no shared mutable ref)."""
+    headers = {"h1": "v1"}
+    config = {
+        "authentication": {
+            "auth1": {"_type": "datarobot_mcp_auth"},
+            "auth2": {"_type": "datarobot_mcp_auth"},
+        }
+    }
+    add_headers_to_datarobot_mcp_auth(config, headers)
+    h1 = config["authentication"]["auth1"]["headers"]
+    h2 = config["authentication"]["auth2"]["headers"]
+    assert h1 == h2 == {"h1": "v1"}
+    assert h1 is not h2
+    h1["only_in_one"] = "x"
+    assert "only_in_one" not in h2
+
+
 @pytest.mark.parametrize(
     "config, headers, expected",
     [

--- a/tests/nat/test_mcp_client.py
+++ b/tests/nat/test_mcp_client.py
@@ -56,13 +56,10 @@ class _FakeMCPClient(MCPBaseClient):
         *,
         tools: dict[str, _FakeTool],
         url: str | None = None,
-        command: str | None = None,
-        args: list[str] | None = None,
     ) -> None:
-        super().__init__("stdio")
+        super().__init__("streamable-http")
         self._tools = tools
         self.url = url
-        self.command = command
 
     async def get_tool(self, name: str) -> _FakeTool:
         """Retrieve a tool by name."""
@@ -79,11 +76,9 @@ class _FakeMCPClient(MCPBaseClient):
 
 
 async def test_datarobot_mcp_client():
-    with patch("nat.plugins.mcp.client.client_base.MCPStdioClient") as mock_client:
+    with patch("nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient") as mock_client:
         fake_tools = {"a": _FakeTool("a", "da"), "b": _FakeTool("b", "db")}
-        mock_client.return_value = _FakeMCPClient(
-            tools=fake_tools, command="python", args=["server.py"]
-        )
+        mock_client.side_effect = lambda url: _FakeMCPClient(tools=fake_tools, url=url)
         server_config = DataRobotMCPServerConfig()
         config = DataRobotMCPClientConfig(server=server_config)
         async with WorkflowBuilder() as builder:

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,22 @@ overrides = [{ name = "ragas", specifier = ">=0.3.8,<0.4.0" }]
 excludes = ["uv"]
 
 [[package]]
+name = "a2a-sdk"
+version = "0.3.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", marker = "python_full_version >= '3.11'" },
+    { name = "httpx", marker = "python_full_version >= '3.11'" },
+    { name = "httpx-sse", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/76/cefa956fb2d3911cb91552a1da8ce2dbb339f1759cb475e2982f0ae2332b/a2a_sdk-0.3.24.tar.gz", hash = "sha256:3581e6e8a854cd725808f5732f90b7978e661b6d4e227a4755a8f063a3c1599d", size = 255550, upload-time = "2026-02-20T10:05:43.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/6e/cae5f0caea527b39c0abd7204d9416768764573c76649ca03cc345a372be/a2a_sdk-0.3.24-py3-none-any.whl", hash = "sha256:7b248767096bb55311f57deebf6b767349388d94c1b376c60cb8f6b715e053f6", size = 145752, upload-time = "2026-02-20T10:05:41.729Z" },
+]
+
+[[package]]
 name = "ag-ui-protocol"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1258,6 +1274,7 @@ nat = [
     { name = "datarobot-predict" },
     { name = "llama-index-llms-litellm" },
     { name = "nvidia-nat", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nat-a2a", marker = "python_full_version >= '3.11'" },
     { name = "nvidia-nat-langchain", marker = "python_full_version >= '3.11'" },
     { name = "nvidia-nat-llama-index", marker = "python_full_version >= '3.11'" },
     { name = "nvidia-nat-mcp", marker = "python_full_version >= '3.11'" },
@@ -1357,11 +1374,12 @@ requires-dist = [
     { name = "llama-index-llms-litellm", marker = "extra == 'nat'", specifier = ">=0.4.1,<0.7.0" },
     { name = "llama-index-llms-openai", marker = "extra == 'llamaindex'", specifier = ">=0.6.0,<0.7.0" },
     { name = "llama-index-tools-mcp", marker = "extra == 'llamaindex'", specifier = ">=0.1.0,<0.5.0" },
-    { name = "nvidia-nat", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.0" },
-    { name = "nvidia-nat-langchain", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.0" },
-    { name = "nvidia-nat-llama-index", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.0" },
-    { name = "nvidia-nat-mcp", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.0" },
-    { name = "nvidia-nat-opentelemetry", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.0" },
+    { name = "nvidia-nat", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.1" },
+    { name = "nvidia-nat-a2a", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.1" },
+    { name = "nvidia-nat-langchain", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.1" },
+    { name = "nvidia-nat-llama-index", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.1" },
+    { name = "nvidia-nat-mcp", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.1" },
+    { name = "nvidia-nat-opentelemetry", marker = "python_full_version >= '3.11' and extra == 'nat'", specifier = "==1.4.1" },
     { name = "openai", marker = "extra == 'core'", specifier = ">=1.76.2,<2.0.0" },
     { name = "openai", marker = "extra == 'crewai'", specifier = ">=1.76.2,<2.0.0" },
     { name = "openai", marker = "extra == 'drmcp'", specifier = ">=1.76.2,<2.0.0" },
@@ -1997,6 +2015,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth", marker = "python_full_version >= '3.11'" },
+    { name = "googleapis-common-protos", marker = "python_full_version >= '3.11'" },
+    { name = "proto-plus", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/98/586ec94553b569080caef635f98a3723db36a38eac0e3d7eb3ea9d2e4b9a/google_api_core-2.30.0.tar.gz", hash = "sha256:02edfa9fab31e17fc0befb5f161b3bf93c9096d99aed584625f38065c511ad9b", size = 176959, upload-time = "2026-02-18T20:28:11.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/27/09c33d67f7e0dcf06d7ac17d196594e66989299374bfb0d4331d1038e76b/google_api_core-2.30.0-py3-none-any.whl", hash = "sha256:80be49ee937ff9aba0fd79a6eddfde35fe658b9953ab9b79c57dd7061afa8df5", size = 173288, upload-time = "2026-02-18T20:28:10.367Z" },
 ]
 
 [[package]]
@@ -4422,7 +4456,7 @@ wheels = [
 
 [[package]]
 name = "nvidia-nat"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioboto3", marker = "python_full_version >= '3.11'" },
@@ -4460,12 +4494,24 @@ dependencies = [
     { name = "wikipedia", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/c6/21cf6bd5ce2126264912a696f229a559b6bf1483b712a22b5b8e787405ba/nvidia_nat-1.4.0-py3-none-any.whl", hash = "sha256:82356d49498597ca11be07082133112795ea2d7b3ec1f9c572e8dce23773f7dd", size = 1011876, upload-time = "2026-02-03T03:07:20.462Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/09/ecf74efddba73cc5fcc9d177e37e23c487dc606d56051ff2ad6de915bdca/nvidia_nat-1.4.1-py3-none-any.whl", hash = "sha256:763422295df9a1771d882d4f5e266622b30eb9fc89864f1d4400f149521f9e2e", size = 1011974, upload-time = "2026-02-09T18:47:04.409Z" },
+]
+
+[[package]]
+name = "nvidia-nat-a2a"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "a2a-sdk", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nat", marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/87/3131c074f5632d7575030bdee367a2cf771d2381e1b9813454d3d2b0bf12/nvidia_nat_a2a-1.4.1-py3-none-any.whl", hash = "sha256:328c46ed7b1462a0d63a2e86d82aa48818c6e2a1c7a72957d5776be524097738", size = 43954, upload-time = "2026-02-09T18:45:25.544Z" },
 ]
 
 [[package]]
 name = "nvidia-nat-langchain"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain", marker = "python_full_version >= '3.11'" },
@@ -4482,12 +4528,12 @@ dependencies = [
     { name = "nvidia-nat", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/83/9bf4ede51d0f2be7a3c5c5ec4c2bfa56f52a084ecedb8fb67cc5e8f5e776/nvidia_nat_langchain-1.4.0-py3-none-any.whl", hash = "sha256:7b7ac79d28f7a4bf21a68ee26e969fcf0b2fc84628042e162c74d4a3233cdeb6", size = 64528, upload-time = "2026-02-03T03:03:47.095Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b3/6a5c9f292a58e033c10f419fd0502ee2dfdee86b8841d9ab8206ca9fa1b5/nvidia_nat_langchain-1.4.1-py3-none-any.whl", hash = "sha256:bf72d1eea2117805b95a3a3ab472bbe9466092e2832a25442202fa37363bdeeb", size = 64529, upload-time = "2026-02-09T18:44:09.555Z" },
 ]
 
 [[package]]
 name = "nvidia-nat-llama-index"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index", marker = "python_full_version >= '3.11'" },
@@ -4504,12 +4550,12 @@ dependencies = [
     { name = "nvidia-nat", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/38/782ab0a6dc5299b3ab5a8ff684c5481c4f36af768e06c692e420de94b24b/nvidia_nat_llama_index-1.4.0-py3-none-any.whl", hash = "sha256:d785b414d3fdc2ed8304e7c602823c7264310465e8216a50ee50646944d86097", size = 53146, upload-time = "2026-02-03T03:08:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c15f17e3fec48f6d08896947ec158082a99a8587669fca14786e45be54e1/nvidia_nat_llama_index-1.4.1-py3-none-any.whl", hash = "sha256:aa08291df6029b75b316b2b8fedad856739aecf648f41c60c258da7dbe00d7b7", size = 53151, upload-time = "2026-02-09T19:02:34.606Z" },
 ]
 
 [[package]]
 name = "nvidia-nat-mcp"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiorwlock", marker = "python_full_version >= '3.11'" },
@@ -4517,12 +4563,12 @@ dependencies = [
     { name = "nvidia-nat", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/23/eb4133561aeaed2644fecad7dfce4ba7c899c2579b0476f9f2ea5d06bfee/nvidia_nat_mcp-1.4.0-py3-none-any.whl", hash = "sha256:626d036419a6ddb42b3abc5a8cb76f90abd8e0191129dfa88bde439bc993f191", size = 126169, upload-time = "2026-02-03T03:20:16.405Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7d/0ceb057fe32919737f4846970c2182ad743b36224947d2c0a2d0d85faecf/nvidia_nat_mcp-1.4.1-py3-none-any.whl", hash = "sha256:23545b44d49bf7ea7290baf52dd7f82466ea8791d810716846dafe372ff08b91", size = 126169, upload-time = "2026-02-09T19:04:05.664Z" },
 ]
 
 [[package]]
 name = "nvidia-nat-opentelemetry"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-nat", marker = "python_full_version >= '3.11'" },
@@ -4531,7 +4577,7 @@ dependencies = [
     { name = "opentelemetry-sdk", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/6f/fd6b03ef118840a2dac1328712239c5fa94ef1f748b8eaaf929a94cf07c2/nvidia_nat_opentelemetry-1.4.0-py3-none-any.whl", hash = "sha256:20430d00ace474eac2c348631fb20a5f3b48af9f7da033083bfdee69d4da5950", size = 67395, upload-time = "2026-02-03T03:08:15.838Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/60/4fc3b56ff58f64bdd7bbc223a0e5f217443d19e2fc382d5df46e36175e3a/nvidia_nat_opentelemetry-1.4.1-py3-none-any.whl", hash = "sha256:48ae3f0f2800cf990555e18110d96438f14551267fd1ad5b1c09bd77a10d91e9", size = 67397, upload-time = "2026-02-09T18:48:03.407Z" },
 ]
 
 [[package]]
@@ -5481,6 +5527,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/f0/615c30622316496d2cbbc29f5985f7777d3ada70f23370608c1d3e081c1f/propcache-0.4.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f7ee0e597f495cf415bcbd3da3caa3bd7e816b74d0d52b8145954c5e6fd3ff37", size = 44897, upload-time = "2025-10-08T19:47:48.336Z" },
     { url = "https://files.pythonhosted.org/packages/fd/ca/6002e46eccbe0e33dcd4069ef32f7f1c9e243736e07adca37ae8c4830ec3/propcache-0.4.1-cp313-cp313t-win_arm64.whl", hash = "sha256:929d7cbe1f01bb7baffb33dc14eb5691c95831450a26354cd210a8155170c93a", size = 39789, upload-time = "2025-10-08T19:47:49.876Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", size = 56929, upload-time = "2026-02-02T17:34:49.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/79/ac273cbbf744691821a9cca88957257f41afe271637794975ca090b9588b/proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc", size = 50480, upload-time = "2026-02-02T17:34:47.339Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.5.4"
+version = "0.5.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Update the `datarobot_mcp_client_function_group` for NAT 1.4.1 changes.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Set the `_default_user_id` on the MCP function group. Update the NAT integration tests for recent changes. Change the default transport for NAT MCP to `streamable_http`. Log error and carry on when the MCP config fails.
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection defaults and error-handling semantics for MCP client initialization, which could mask configuration issues or alter runtime behavior if callers relied on `stdio` or strict failures.
> 
> **Overview**
> Updates the DataRobot NAT MCP integration for NAT `1.4.1` by **dropping `stdio` transport support**, defaulting to `streamable-http`, and providing a default MCP URL when not configured.
> 
> `datarobot_mcp_client_function_group` now **initializes `_default_user_id` / `_allow_default_user_id_for_tool_calls`** (with a service-account-friendly fallback) and **catches MCP client/session errors**, logging the primary exception and yielding an *empty* function group instead of failing outright.
> 
> Header injection for `datarobot_mcp_auth` is hardened to avoid mutating caller-provided headers, optionally derive `x-datarobot-api-token` from `Authorization: Bearer ...`, and ensure each auth config gets its own headers dict; tests and the MCP workflow/integration tests are updated accordingly, along with version bumps to `0.5.7` and refreshed lockfile deps (including `nvidia-nat-*` `1.4.1` and `nvidia-nat-a2a`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25be901def7e01ed3bed8bacae5dd5525d6fe95d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->