### PR TITLE
Fix CLI config bug, it ignore user opt out for predictive tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "datarobot-genai"
-version = "0.4.4"
+version = "0.4.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -403,7 +403,7 @@ def _individual_env_set_for_field(
 
 
 def _apply_mcp_cli_configs_overrides(config: MCPServerConfig) -> MCPServerConfig:
-    """Override from MCP_CLI_CONFIGS when field is at default and individual env not set."""
+    """Apply MCP_CLI_CONFIGS: listed options enabled; others disabled unless individual env set."""
     raw = (config.mcp_cli_configs or "").strip()
     if not raw:
         return config
@@ -411,8 +411,6 @@ def _apply_mcp_cli_configs_overrides(config: MCPServerConfig) -> MCPServerConfig
     root_updates: dict[str, Any] = {}
     tool_updates: dict[str, Any] = {}
     for mcp_opt, root_attr, tool_attr in MCP_CLI_OPTS:
-        if mcp_opt not in enabled:
-            continue
         attr = root_attr if root_attr is not None else tool_attr
         assert attr is not None  # each MCP_CLI_OPTS row has either root_attr or tool_attr
         model: type[MCPServerConfig] | type[MCPToolConfig] = (
@@ -420,17 +418,24 @@ def _apply_mcp_cli_configs_overrides(config: MCPServerConfig) -> MCPServerConfig
         )
         if _individual_env_set_for_field(model, attr):
             continue
-        if root_attr is not None:
-            current = getattr(config, root_attr)
-            default = MCPServerConfig.model_fields[root_attr].default
-            if current == default:
-                root_updates[root_attr] = True
+        if mcp_opt in enabled:
+            if root_attr is not None:
+                current = getattr(config, root_attr)
+                default = MCPServerConfig.model_fields[root_attr].default
+                if current == default:
+                    root_updates[root_attr] = True
+            else:
+                assert tool_attr is not None
+                current = getattr(config.tool_config, tool_attr)
+                default = MCPToolConfig.model_fields[tool_attr].default
+                if current == default:
+                    tool_updates[tool_attr] = True
+        elif root_attr is not None:
+            # Option not in MCP_CLI_CONFIGS: disable.
+            root_updates[root_attr] = False
         else:
             assert tool_attr is not None
-            current = getattr(config.tool_config, tool_attr)
-            default = MCPToolConfig.model_fields[tool_attr].default
-            if current == default:
-                tool_updates[tool_attr] = True
+            tool_updates[tool_attr] = False
     if tool_updates:
         root_updates["tool_config"] = config.tool_config.model_copy(update=tool_updates)
     if not root_updates:

--- a/src/datarobot_genai/drmcp/tools/predictive/data.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/data.py
@@ -19,7 +19,7 @@ from typing import Annotated
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.core.utils import is_valid_url
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
 from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
@@ -27,7 +27,7 @@ from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_t
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"predictive", "data", "write", "upload", "catalog"})
+@dr_mcp_integration_tool(tags={"predictive", "data", "write", "upload", "catalog"})
 async def upload_dataset_to_ai_catalog(
     *,
     file_path: Annotated[str, "The path to the dataset file to upload."] | None = None,
@@ -69,7 +69,7 @@ async def upload_dataset_to_ai_catalog(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "data", "read", "list", "catalog"})
+@dr_mcp_integration_tool(tags={"predictive", "data", "read", "list", "catalog"})
 async def list_ai_catalog_items() -> ToolResult:
     """List all AI Catalog items (datasets) for the authenticated user."""
     token = await get_datarobot_access_token()
@@ -97,7 +97,7 @@ async def list_ai_catalog_items() -> ToolResult:
 # from datarobot_genai.drmcp.core.memory_management import MemoryManager, get_memory_manager
 
 
-# @dr_mcp_tool()
+# @dr_mcp_integration_tool()
 # async def list_ai_catalog_items(
 #     ctx: Context, agent_id: str = None, storage_id: str = None
 # ) -> str:

--- a/src/datarobot_genai/drmcp/tools/predictive/deployment.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/deployment.py
@@ -18,14 +18,14 @@ from typing import Annotated
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
 from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"predictive", "deployment", "read", "management", "list"})
+@dr_mcp_integration_tool(tags={"predictive", "deployment", "read", "management", "list"})
 async def list_deployments() -> ToolResult:
     """List all DataRobot deployments for the authenticated user."""
     token = await get_datarobot_access_token()
@@ -41,7 +41,7 @@ async def list_deployments() -> ToolResult:
     )
 
 
-@dr_mcp_tool(tags={"predictive", "deployment", "read", "model", "info"})
+@dr_mcp_integration_tool(tags={"predictive", "deployment", "read", "model", "info"})
 async def get_model_info_from_deployment(
     *,
     deployment_id: Annotated[str, "The ID of the DataRobot deployment"] | None = None,
@@ -58,7 +58,7 @@ async def get_model_info_from_deployment(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "deployment", "write", "model", "create"})
+@dr_mcp_integration_tool(tags={"predictive", "deployment", "write", "model", "create"})
 async def deploy_model(
     *,
     model_id: Annotated[str, "The ID of the DataRobot model to deploy"] | None = None,

--- a/src/datarobot_genai/drmcp/tools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/deployment_info.py
@@ -27,14 +27,14 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
 from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"predictive", "deployment", "read", "info", "metadata"})
+@dr_mcp_integration_tool(tags={"predictive", "deployment", "read", "info", "metadata"})
 async def get_deployment_info(
     *,
     deployment_id: Annotated[str, "The ID of the DataRobot deployment"] | None = None,
@@ -101,7 +101,7 @@ async def get_deployment_info(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "deployment", "read", "template", "data"})
+@dr_mcp_integration_tool(tags={"predictive", "deployment", "read", "template", "data"})
 async def generate_prediction_data_template(
     *,
     deployment_id: Annotated[str, "The ID of the DataRobot deployment"] | None = None,
@@ -198,7 +198,7 @@ async def generate_prediction_data_template(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "deployment", "read", "validation", "data"})
+@dr_mcp_integration_tool(tags={"predictive", "deployment", "read", "validation", "data"})
 async def validate_prediction_data(
     *,
     deployment_id: Annotated[str, "The ID of the DataRobot deployment"] | None = None,
@@ -331,7 +331,7 @@ async def validate_prediction_data(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "deployment", "read", "features", "info"})
+@dr_mcp_integration_tool(tags={"predictive", "deployment", "read", "features", "info"})
 async def get_deployment_features(
     *,
     deployment_id: Annotated[str, "The ID of the DataRobot deployment"] | None = None,

--- a/src/datarobot_genai/drmcp/tools/predictive/model.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/model.py
@@ -21,7 +21,7 @@ from datarobot.models.model import Model
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
 from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
@@ -54,7 +54,7 @@ class ModelEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
-@dr_mcp_tool(tags={"predictive", "model", "read", "management", "info"})
+@dr_mcp_integration_tool(tags={"predictive", "model", "read", "management", "info"})
 async def get_best_model(
     *,
     project_id: Annotated[str, "The DataRobot project ID"] | None = None,
@@ -113,7 +113,7 @@ async def get_best_model(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "model", "read", "scoring", "dataset"})
+@dr_mcp_integration_tool(tags={"predictive", "model", "read", "scoring", "dataset"})
 async def score_dataset_with_model(
     *,
     project_id: Annotated[str, "The DataRobot project ID"] | None = None,
@@ -144,7 +144,7 @@ async def score_dataset_with_model(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "model", "read", "management", "list"})
+@dr_mcp_integration_tool(tags={"predictive", "model", "read", "management", "list"})
 async def list_models(
     *,
     project_id: Annotated[str, "The DataRobot project ID"] | None = None,

--- a/src/datarobot_genai/drmcp/tools/predictive/predict.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/predict.py
@@ -24,7 +24,7 @@ from fastmcp.resources import HttpResource
 from fastmcp.resources import ResourceManager
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.core.clients import get_credentials
 from datarobot_genai.drmcp.core.utils import generate_presigned_url
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
@@ -105,7 +105,7 @@ def wait_for_preds_and_cache_results(
     return _handle_prediction_resource(job, bucket, key, deployment_id, input_desc)
 
 
-@dr_mcp_tool(tags={"predictive", "prediction", "read", "scoring", "batch"})
+@dr_mcp_integration_tool(tags={"predictive", "prediction", "read", "scoring", "batch"})
 async def predict_by_file_path(
     deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"]
     | None = None,
@@ -136,7 +136,7 @@ async def predict_by_file_path(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "prediction", "read", "scoring", "batch"})
+@dr_mcp_integration_tool(tags={"predictive", "prediction", "read", "scoring", "batch"})
 async def predict_by_ai_catalog(
     deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"]
     | None = None,
@@ -171,7 +171,7 @@ async def predict_by_ai_catalog(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "prediction", "read", "scoring", "batch"})
+@dr_mcp_integration_tool(tags={"predictive", "prediction", "read", "scoring", "batch"})
 async def predict_from_project_data(
     deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"]
     | None = None,
@@ -222,7 +222,7 @@ async def predict_from_project_data(
 
 
 # FIXME
-# @dr_mcp_tool(tags={"prediction", "explanations", "shap"})
+# @dr_mcp_integration_tool(tags={"prediction", "explanations", "shap"})
 async def get_prediction_explanations(
     project_id: str,
     model_id: str,

--- a/src/datarobot_genai/drmcp/tools/predictive/predict_realtime.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/predict_realtime.py
@@ -26,7 +26,7 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 from pydantic import BaseModel
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.core.utils import predictions_result_response
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
 from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
@@ -46,7 +46,7 @@ def make_output_settings() -> BucketInfo:
     return BucketInfo(bucket=bucket_info["bucket"], key=s3_key)
 
 
-@dr_mcp_tool(tags={"predictive", "prediction", "realtime", "read", "scoring"})
+@dr_mcp_integration_tool(tags={"predictive", "prediction", "realtime", "read", "scoring"})
 async def predict_by_ai_catalog_rt(
     deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"]
     | None = None,
@@ -114,7 +114,7 @@ async def predict_by_ai_catalog_rt(
     return ToolResult(structured_content=content)
 
 
-@dr_mcp_tool(tags={"predictive", "prediction", "realtime", "read", "scoring"})
+@dr_mcp_integration_tool(tags={"predictive", "prediction", "realtime", "read", "scoring"})
 async def predict_realtime(
     deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"]
     | None = None,

--- a/src/datarobot_genai/drmcp/tools/predictive/project.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/project.py
@@ -18,14 +18,14 @@ from typing import Annotated
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
 from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
 logger = logging.getLogger(__name__)
 
 
-@dr_mcp_tool(tags={"predictive", "project", "read", "management", "list"})
+@dr_mcp_integration_tool(tags={"predictive", "project", "read", "management", "list"})
 async def list_projects() -> ToolResult:
     """List all DataRobot projects for the authenticated user."""
     token = await get_datarobot_access_token()
@@ -38,7 +38,7 @@ async def list_projects() -> ToolResult:
     )
 
 
-@dr_mcp_tool(tags={"predictive", "project", "read", "data", "info"})
+@dr_mcp_integration_tool(tags={"predictive", "project", "read", "data", "info"})
 async def get_project_dataset_by_name(
     *,
     project_id: Annotated[str, "The ID of the DataRobot project."] | None = None,

--- a/src/datarobot_genai/drmcp/tools/predictive/training.py
+++ b/src/datarobot_genai/drmcp/tools/predictive/training.py
@@ -24,7 +24,7 @@ import pandas as pd
 from fastmcp.exceptions import ToolError
 from fastmcp.tools.tool import ToolResult
 
-from datarobot_genai.drmcp import dr_mcp_tool
+from datarobot_genai.drmcp import dr_mcp_integration_tool
 from datarobot_genai.drmcp.tools.clients.datarobot import DataRobotClient
 from datarobot_genai.drmcp.tools.clients.datarobot import get_datarobot_access_token
 
@@ -87,7 +87,7 @@ def _get_dataset_or_raise(client: Any, dataset_id: str) -> tuple[Any, pd.DataFra
         raise ToolError(f"Failed to retrieve dataset '{dataset_id}': {error_str}")
 
 
-@dr_mcp_tool(tags={"predictive", "training", "read", "analysis", "dataset"})
+@dr_mcp_integration_tool(tags={"predictive", "training", "read", "analysis", "dataset"})
 async def analyze_dataset(
     *,
     dataset_id: Annotated[str, "The ID of the DataRobot dataset to analyze"] | None = None,
@@ -139,7 +139,7 @@ async def analyze_dataset(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "training", "read", "analysis", "usecase"})
+@dr_mcp_integration_tool(tags={"predictive", "training", "read", "analysis", "usecase"})
 async def suggest_use_cases(
     *,
     dataset_id: Annotated[str, "The ID of the DataRobot dataset to analyze"] | None = None,
@@ -169,7 +169,7 @@ async def suggest_use_cases(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "training", "read", "analysis", "eda"})
+@dr_mcp_integration_tool(tags={"predictive", "training", "read", "analysis", "eda"})
 async def get_exploratory_insights(
     *,
     dataset_id: Annotated[str, "The ID of the DataRobot dataset to analyze"] | None = None,
@@ -468,7 +468,7 @@ def _analyze_target_for_use_cases(df: pd.DataFrame, target_col: str) -> list[Use
     return suggestions
 
 
-@dr_mcp_tool(tags={"predictive", "training", "write", "autopilot", "model"})
+@dr_mcp_integration_tool(tags={"predictive", "training", "write", "autopilot", "model"})
 async def start_autopilot(
     *,
     target: Annotated[str, "Name of the target column for modeling"] | None = None,
@@ -548,7 +548,7 @@ async def start_autopilot(
         raise ToolError(f"Failed to start Autopilot: {str(e)}")
 
 
-@dr_mcp_tool(tags={"prediction", "training", "read", "model", "evaluation"})
+@dr_mcp_integration_tool(tags={"prediction", "training", "read", "model", "evaluation"})
 async def get_model_roc_curve(
     *,
     project_id: Annotated[str, "The ID of the DataRobot project"] | None = None,
@@ -608,7 +608,7 @@ async def get_model_roc_curve(
         raise ToolError(f"Failed to get ROC curve: {str(e)}")
 
 
-@dr_mcp_tool(tags={"predictive", "training", "read", "model", "evaluation"})
+@dr_mcp_integration_tool(tags={"predictive", "training", "read", "model", "evaluation"})
 async def get_model_feature_impact(
     *,
     project_id: Annotated[str, "The ID of the DataRobot project"] | None = None,
@@ -633,7 +633,7 @@ async def get_model_feature_impact(
     )
 
 
-@dr_mcp_tool(tags={"predictive", "training", "read", "model", "evaluation"})
+@dr_mcp_integration_tool(tags={"predictive", "training", "read", "model", "evaluation"})
 async def get_model_lift_chart(
     *,
     project_id: Annotated[str, "The ID of the DataRobot project"] | None = None,

--- a/tests/drmcp/acceptance/test_tools.py
+++ b/tests/drmcp/acceptance/test_tools.py
@@ -19,10 +19,10 @@ These tools are loaded by the MCP server and are available for testing purposes.
 """
 
 from datarobot_genai.drmcp.core.auth import must_get_auth_context
-from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_integration_tool
 
 
-@dr_mcp_tool()
+@dr_mcp_integration_tool()
 async def get_auth_context_user_info() -> str:
     """
     Tool that retrieves and returns user info like ID, name, and email from the auth context.

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
# RATIONALE

- Fix CLI config bug, it ignore user opt out for predictive tools.
- We recently added a new decorator but we missed to change it for the predictive tools.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
