### PR TITLE
[MODEL-22552] Add customized mcp prompt resource decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.5.4
+
+- Added dr_mcp_prompt as prompt function decorator
+- Added dr_mcp_resource as resource function decorator
 
 ## 0.5.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.5.3"
+version = "0.5.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/core/enums.py
+++ b/src/datarobot_genai/drmcp/core/enums.py
@@ -19,3 +19,12 @@ class DataRobotMCPToolCategory(Enum):
     USER_TOOL = auto()  # tools created by users
     INTEGRATION_TOOL = auto()  # tools as a wrapper of external service
     DYNAMICALLY_LOADED_TOOL = auto()  # tools dynamically loaded after MCP server is up
+
+
+class DataRobotMCPPromptCategory(Enum):
+    USER_PROMPT = auto()  # prompt created by users
+    DYNAMICALLY_LOADED_PROMPT_TEMPLATE = auto()  # prompts dynamically loaded after MCP server is up
+
+
+class DataRobotMCPResourceCategory(Enum):
+    USER_RESOURCE = auto()  # resource created by users

--- a/src/datarobot_genai/drmcp/core/enums.py
+++ b/src/datarobot_genai/drmcp/core/enums.py
@@ -23,7 +23,7 @@ class DataRobotMCPToolCategory(Enum):
 
 class DataRobotMCPPromptCategory(Enum):
     USER_PROMPT = auto()  # prompt created by users
-    DYNAMICALLY_LOADED_PROMPT_TEMPLATE = auto()  # prompts dynamically loaded after MCP server is up
+    DYNAMICALLY_LOADED_PROMPT = auto()  # prompts dynamically loaded after MCP server is up
 
 
 class DataRobotMCPResourceCategory(Enum):

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -461,6 +461,17 @@ async def check_tool_registration_status_after_it_finishes(
     logger.info(f"Registered tools: {len(tools)}")
 
 
+async def check_prompt_registration_status_after_it_finishes(
+    mcp_server: DataRobotMCP,
+    prompt_name_no_duplicate: str,
+) -> None:
+    # Verify prompt is registered
+    prompts = await mcp_server.get_prompts()
+    if not any(prompt.name == prompt_name_no_duplicate for prompt in prompts.values()):
+        raise RuntimeError(f"Prompt {prompt_name_no_duplicate} was not registered successfully")
+    logger.info(f"Registered prompts: {len(prompts)}")
+
+
 async def register_tools(
     fn: AnyFunction,
     name: str | None = None,
@@ -468,6 +479,7 @@ async def register_tools(
     description: str | None = None,
     tags: set[str] | None = None,
     deployment_id: str | None = None,
+    tool_category: DataRobotMCPToolCategory = DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL,
 ) -> Tool:
     """
     Register new tools after server has started.
@@ -479,6 +491,7 @@ async def register_tools(
         description: Optional description of what the tool does
         tags: Optional set of tags to apply to the tool
         deployment_id: Optional deployment ID associated with the tool
+        tool_category: Category of the tool. Its value is from DataRobotMCPToolCategory
 
     Returns
     -------
@@ -508,7 +521,7 @@ async def register_tools(
         description=description,
         annotations=annotations,
         tags=tags,
-        meta={"tool_category": DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL.name},
+        meta={"tool_category": tool_category.name},
     )
 
     # Register the tool
@@ -531,6 +544,7 @@ async def register_prompt(
     tags: set[str] | None = None,
     meta: dict[str, Any] | None = None,
     prompt_template: tuple[str, str] | None = None,
+    prompt_category: DataRobotMCPPromptCategory = DataRobotMCPPromptCategory.DYNAMICALLY_LOADED_PROMPT,  # noqa: E501
 ) -> Prompt:
     """
     Register new prompt after server has started.
@@ -543,6 +557,7 @@ async def register_prompt(
         tags: Optional set of tags to apply to the prompt
         meta: Optional dict of metadata to apply to the prompt
         prompt_template: Optional (id, version id) of the prompt template
+        prompt_category: Category of prompt. Its value is from DataRobotMCPPromptCategory
 
     Returns
     -------
@@ -554,6 +569,8 @@ async def register_prompt(
 
     prompt_name_no_duplicate = await get_prompt_name_no_duplicate(mcp, prompt_name)
 
+    meta = meta or {}
+    meta["resource_category"] = prompt_category.name
     prompt = Prompt.from_function(
         fn=wrapped_fn,
         name=prompt_name_no_duplicate,
@@ -572,11 +589,7 @@ async def register_prompt(
 
     registered_prompt = mcp.add_prompt(prompt)
 
-    # Verify prompt is registered
-    prompts = await mcp.get_prompts()
-    if not any(prompt.name == prompt_name_no_duplicate for prompt in prompts.values()):
-        raise RuntimeError(f"Prompt {prompt_name_no_duplicate} was not registered successfully")
-    logger.info(f"Registered prompts: {len(prompts)}")
+    await check_prompt_registration_status_after_it_finishes(mcp, prompt_name_no_duplicate)
 
     # Notify clients that the prompt list has changed
     await mcp.notify_prompts_changed()

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -14,9 +14,13 @@
 
 import logging
 from collections.abc import Callable
+from dataclasses import asdict
+from dataclasses import dataclass
 from functools import wraps
 from typing import Any
+from typing import ParamSpec
 from typing import TypedDict
+from typing import TypeVar
 
 from fastmcp import Context
 from fastmcp import FastMCP
@@ -24,18 +28,25 @@ from fastmcp.exceptions import NotFoundError
 from fastmcp.prompts.prompt import Prompt
 from fastmcp.server.dependencies import get_context
 from fastmcp.tools import Tool
+from mcp.types import Annotations as MCPAnnotationsType
 from mcp.types import AnyFunction
+from mcp.types import Icon as MCPIconType
 from mcp.types import ToolAnnotations
 from typing_extensions import Unpack
 
 from .config import MCPServerConfig
 from .config import get_config
 from .dynamic_prompts.utils import get_prompt_name_no_duplicate
+from .enums import DataRobotMCPPromptCategory
+from .enums import DataRobotMCPResourceCategory
 from .enums import DataRobotMCPToolCategory
 from .logging import log_execution
 from .memory_management.manager import MemoryManager
 from .memory_management.manager import get_memory_manager
 from .telemetry import trace_execution
+
+P = ParamSpec("P")
+T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +274,65 @@ class ToolKwargs(TypedDict, total=False):
     exclude_args: list[str] | None
     meta: dict[str, Any] | None
     enabled: bool | None
+
+
+@dataclass
+class PromptInitArguments:
+    name: str | None = None
+    title: str | None = None
+    description: str | None = None
+    icons: list[MCPIconType] | None = None
+    tags: set[str] | None = None
+    enabled: bool | None = None
+    meta: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        meta = self.meta or {}
+        if meta.get("prompt_category"):
+            raise ValueError(
+                "prompt_category is a reserved field under meta. Please don't override it."
+            )
+
+    def to_dict(
+        self,
+    ) -> dict[str, str | bool | set[str] | list[MCPIconType] | dict[str, Any] | None]:
+        return asdict(self)
+
+    def set_prompt_category(self, prompt_category: DataRobotMCPPromptCategory) -> None:
+        self.meta = self.meta or {}
+        self.meta["prompt_category"] = prompt_category.name
+
+
+@dataclass
+class ResourceInitArguments:
+    uri: str
+    name: str | None = None
+    title: str | None = None
+    description: str | None = None
+    icons: list[MCPIconType] | None = None
+    mime_type: str | None = None
+    tags: set[str] | None = None
+    enabled: bool | None = None
+    annotations: MCPAnnotationsType | dict[str, Any] | None = None
+    meta: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        meta = self.meta or {}
+        if meta.get("resource_category"):
+            raise ValueError(
+                "resource_category is a reserved field under meta. Please don't override it."
+            )
+
+    def to_dict(
+        self,
+    ) -> dict[
+        str, str | bool | set[str] | list[MCPIconType] | dict[str, Any] | MCPAnnotationsType | None
+    ]:
+        return asdict(self)
+
+    def set_resource_category(self, resource_category: DataRobotMCPResourceCategory) -> None:
+        self.meta = self.meta or {}
+        self.meta["resource_category"] = resource_category.name
 
 
 def dr_core_mcp_tool(
@@ -512,3 +582,33 @@ async def register_prompt(
     await mcp.notify_prompts_changed()
 
     return registered_prompt
+
+
+def dr_mcp_prompt(
+    prompt_category: DataRobotMCPPromptCategory = DataRobotMCPPromptCategory.USER_PROMPT,
+    prompt_init_args: PromptInitArguments = PromptInitArguments(),
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    def prompt_decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @wraps(func)
+        def _inner_decorator(*args: P.args, **kwargs: P.kwargs) -> T:
+            return func(*args, **kwargs)
+
+        prompt_init_args.set_prompt_category(prompt_category)
+        return mcp.prompt(**prompt_init_args.to_dict())(_inner_decorator)
+
+    return prompt_decorator
+
+
+def dr_mcp_resource(
+    resource_init_args: ResourceInitArguments,
+    resource_category: DataRobotMCPResourceCategory = DataRobotMCPResourceCategory.USER_RESOURCE,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    def resource_decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @wraps(func)
+        def _inner_decorator(*args: P.args, **kwargs: P.kwargs) -> T:
+            return func(*args, **kwargs)
+
+        resource_init_args.set_resource_category(resource_category)
+        return mcp.resource(**resource_init_args.to_dict())(_inner_decorator)
+
+    return resource_decorator

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -21,9 +21,18 @@ from fastmcp.exceptions import NotFoundError
 
 from datarobot_genai.drmcp.core.enums import DataRobotMCPToolCategory
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
+from datarobot_genai.drmcp.core.mcp_instance import PromptInitArguments
+from datarobot_genai.drmcp.core.mcp_instance import ResourceInitArguments
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_integration_tool
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_prompt
+from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_resource
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
 from datarobot_genai.drmcp.core.mcp_instance import update_mcp_tool_init_args_with_tool_category
+
+
+@pytest.fixture
+def module_under_test() -> str:
+    return "datarobot_genai.drmcp.core.mcp_instance"
 
 
 class TestDataRobotMCPInstanceAdditional:
@@ -139,10 +148,6 @@ class TestDataRobotMCPInstanceAdditional:
 
 
 class TestMCPToolDecorator:
-    @pytest.fixture
-    def module_under_test(self) -> str:
-        return "datarobot_genai.drmcp.core.mcp_instance"
-
     @pytest.fixture
     def mock_dr_mcp_tool(self, module_under_test: str) -> Iterator[Mock]:
         with patch(f"{module_under_test}.dr_mcp_tool") as mock_decorator:
@@ -260,3 +265,145 @@ class TestMCPToolDecorator:
             "tool_category": DataRobotMCPToolCategory.INTEGRATION_TOOL,
             expected_kwarg_key: expected_kwarg_value,
         }
+
+
+class TestPromptInitArguments:
+    def test_prompt_init_arguments_fail_when_setting_reserved_prompt_category(self) -> None:
+        with pytest.raises(ValueError):
+            PromptInitArguments(meta={"prompt_category": Mock()})
+
+    def test_to_dict(self) -> None:
+        prompt_init_args = PromptInitArguments()
+        assert prompt_init_args.to_dict() == {
+            "name": None,
+            "title": None,
+            "description": None,
+            "icons": None,
+            "tags": None,
+            "enabled": None,
+            "meta": None,
+        }
+
+    @pytest.mark.parametrize(
+        "meta_arg",
+        [{}, None, {"1ewqa": "adfa"}],
+    )
+    def test_set_prompt_category(self, meta_arg: dict[str, str | None] | None):
+        prompt_init_args = PromptInitArguments(meta=meta_arg)
+
+        expected_prompt_category = Mock()
+        prompt_init_args.set_prompt_category(expected_prompt_category)
+
+        original_meta_arg = meta_arg or {}
+        expected_meta_arg = original_meta_arg | {"prompt_category": expected_prompt_category.name}
+        assert prompt_init_args.meta == expected_meta_arg
+
+
+class TestResourceInitArguments:
+    def test_resource_init_arguments_fail_when_setting_reserved_resource_category(self) -> None:
+        with pytest.raises(ValueError):
+            ResourceInitArguments(uri="dsafds", meta={"resource_category": Mock()})
+
+    def test_to_dict(self) -> None:
+        expected_uri = "sdafsd"
+        resource_init_args = ResourceInitArguments(uri=expected_uri)
+        assert resource_init_args.to_dict() == {
+            "uri": expected_uri,
+            "name": None,
+            "title": None,
+            "description": None,
+            "icons": None,
+            "mime_type": None,
+            "tags": None,
+            "enabled": None,
+            "annotations": None,
+            "meta": None,
+        }
+
+    @pytest.mark.parametrize(
+        "meta_arg",
+        [{}, None, {"1ewqa": "adfa"}],
+    )
+    def test_set_resource_category(self, meta_arg: dict[str, str | None] | None):
+        resource_init_args = ResourceInitArguments(uri="dafds", meta=meta_arg)
+
+        expected_resource_category = Mock()
+        resource_init_args.set_resource_category(expected_resource_category)
+
+        original_meta_arg = meta_arg or {}
+        expected_meta_arg = original_meta_arg | {
+            "resource_category": expected_resource_category.name
+        }
+        assert resource_init_args.meta == expected_meta_arg
+
+
+class TestMCPPromptDecorator:
+    @pytest.fixture
+    def mock_mcp_prompt_callable(self) -> Iterator[Mock]:
+        yield Mock(return_value=Mock())
+
+    @pytest.fixture
+    def mock_datarobot_mcp_server_prompt(self) -> Iterator[Mock]:
+        with patch.object(DataRobotMCP, "prompt") as mock_func:
+            yield mock_func
+
+    def test_dr_mcp_prompt(
+        self,
+        mock_mcp_prompt_callable: Mock,
+        mock_datarobot_mcp_server_prompt: Mock,
+    ) -> None:
+        mock_mcp_prompt_callable_args = {}
+        mock_prompt_category = Mock()
+        mock_prompt_init_args = Mock()
+        mock_prompt_init_args.to_dict.return_value = {}
+        decorator = dr_mcp_prompt(mock_prompt_category, mock_prompt_init_args)
+        decorator(mock_mcp_prompt_callable)(**mock_mcp_prompt_callable_args)
+
+        mock_prompt_init_args.set_prompt_category.assert_called_once_with(mock_prompt_category)
+        mock_datarobot_mcp_server_prompt.assert_called_once_with(
+            **mock_prompt_init_args.to_dict.return_value,
+        )
+        mock_datarobot_mcp_server_prompt_func = mock_datarobot_mcp_server_prompt.return_value
+        call_args = mock_datarobot_mcp_server_prompt_func.call_args.args
+        (inner_wrapper_func,) = call_args
+        assert (
+            inner_wrapper_func.__qualname__
+            == "dr_mcp_prompt.<locals>.prompt_decorator.<locals>._inner_decorator"
+        )
+
+
+class TestMCPResourceDecorator:
+    @pytest.fixture
+    def mock_mcp_resource_callable(self) -> Iterator[Mock]:
+        yield Mock(return_value=Mock())
+
+    @pytest.fixture
+    def mock_datarobot_mcp_server_resource(self) -> Iterator[Mock]:
+        with patch.object(DataRobotMCP, "resource") as mock_func:
+            yield mock_func
+
+    def test_dr_mcp_prompt(
+        self,
+        mock_mcp_resource_callable: Mock,
+        mock_datarobot_mcp_server_resource: Mock,
+    ) -> None:
+        mock_mcp_resource_callable_args = {}
+        mock_resource_category = Mock()
+        mock_resource_init_args = Mock()
+        mock_resource_init_args.to_dict.return_value = {}
+        decorator = dr_mcp_resource(mock_resource_init_args, mock_resource_category)
+        decorator(mock_mcp_resource_callable)(**mock_mcp_resource_callable_args)
+
+        mock_resource_init_args.set_resource_category.assert_called_once_with(
+            mock_resource_category
+        )
+        mock_datarobot_mcp_server_resource.assert_called_once_with(
+            **mock_resource_init_args.to_dict.return_value,
+        )
+        mock_datarobot_mcp_server_resource_func = mock_datarobot_mcp_server_resource.return_value
+        call_args = mock_datarobot_mcp_server_resource_func.call_args.args
+        (inner_wrapper_func,) = call_args
+        assert (
+            inner_wrapper_func.__qualname__
+            == "dr_mcp_resource.<locals>.resource_decorator.<locals>._inner_decorator"
+        )

--- a/tests/drmcp/unit/test_register_prompt.py
+++ b/tests/drmcp/unit/test_register_prompt.py
@@ -1,0 +1,148 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+from fastmcp.prompts import Prompt
+
+from datarobot_genai.drmcp.core.enums import DataRobotMCPPromptCategory
+from datarobot_genai.drmcp.core.mcp_instance import (
+    check_prompt_registration_status_after_it_finishes,
+)
+from datarobot_genai.drmcp.core.mcp_instance import register_prompt
+
+
+class TestRegisterPrompt:
+    @pytest.fixture
+    def module_under_test(self) -> str:
+        return "datarobot_genai.drmcp.core.mcp_instance"
+
+    @pytest.fixture
+    def mock_mcp_tool_callable(self) -> Iterator[Mock]:
+        yield Mock(return_value=Mock())
+
+    @pytest.fixture
+    def mock_dr_mcp_extras(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.dr_mcp_extras") as mock_decorator:
+            yield mock_decorator
+
+    @pytest.fixture
+    def mock_datarobot_mcp_server(
+        self,
+        module_under_test: str,
+    ) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.mcp") as mock_instance:
+            mock_instance.notify_prompts_changed = AsyncMock()
+            mock_instance.get_prompts = AsyncMock()
+            yield mock_instance
+
+    @pytest.fixture
+    def mock_get_prompt_name_no_duplicate(
+        self,
+        module_under_test: str,
+    ) -> Iterator[AsyncMock]:
+        with patch(
+            f"{module_under_test}.get_prompt_name_no_duplicate",
+            new_callable=AsyncMock,
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_prompt_from_function(self) -> Iterator[Mock]:
+        with patch.object(Prompt, "from_function") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_check_prompt_registration_status_after_it_finishes(
+        self,
+        module_under_test: str,
+    ) -> Iterator[AsyncMock]:
+        with patch(
+            f"{module_under_test}.check_prompt_registration_status_after_it_finishes",
+            new_callable=AsyncMock,
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.mark.asyncio
+    async def test_check_prompt_registration_status_after_it_finishes_succeeds(
+        self,
+        mock_datarobot_mcp_server: Mock,
+    ) -> None:
+        mock_function_name = "sadfads"
+        mock_registered_prompt = Mock()
+        mock_registered_prompt.name = mock_function_name
+        mock_datarobot_mcp_server.get_prompts.return_value = {"adsfdas": mock_registered_prompt}
+
+        await check_prompt_registration_status_after_it_finishes(
+            mock_datarobot_mcp_server,
+            mock_function_name,
+        )
+
+        mock_datarobot_mcp_server.get_prompts.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_prompt_registration_status_after_it_finishes_fails(
+        self,
+        mock_datarobot_mcp_server: Mock,
+    ) -> None:
+        mock_datarobot_mcp_server.get_prompts.return_value = {"adsfdas": Mock()}
+
+        with pytest.raises(RuntimeError):
+            await check_prompt_registration_status_after_it_finishes(
+                mock_datarobot_mcp_server,
+                Mock(),
+            )
+            mock_datarobot_mcp_server.get_prompts.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_register_prompt_with_proper_tool_category(
+        self,
+        mock_check_prompt_registration_status_after_it_finishes: Mock,
+        mock_datarobot_mcp_server: Mock,
+        mock_dr_mcp_extras: Mock,
+        mock_get_prompt_name_no_duplicate: AsyncMock,
+        mock_mcp_tool_callable: Mock,
+        mock_prompt_from_function: Mock,
+    ) -> None:
+        prompt_func_name = Mock()
+        actual_output = await register_prompt(fn=mock_mcp_tool_callable, name=prompt_func_name)
+
+        mock_dr_mcp_extras.assert_called_once_with(type="prompt")
+        mock_dr_mcp_extras_decorator = mock_dr_mcp_extras.return_value
+        mock_dr_mcp_extras_decorator.assert_called_once_with(mock_mcp_tool_callable)
+        mock_get_prompt_name_no_duplicate.assert_called_once_with(
+            mock_datarobot_mcp_server,
+            prompt_func_name,
+        )
+        mock_wrapper_func = mock_dr_mcp_extras_decorator.return_value
+        mock_prompt_from_function.assert_called_once_with(
+            fn=mock_wrapper_func,
+            name=mock_get_prompt_name_no_duplicate.return_value,
+            title=None,
+            description=None,
+            tags=None,
+            meta={"resource_category": DataRobotMCPPromptCategory.DYNAMICALLY_LOADED_PROMPT.name},
+        )
+        mock_datarobot_mcp_server.add_prompt.assert_called_once_with(
+            mock_prompt_from_function.return_value
+        )
+        mock_check_prompt_registration_status_after_it_finishes.assert_called_once_with(
+            mock_datarobot_mcp_server,
+            mock_get_prompt_name_no_duplicate.return_value,
+        )
+        mock_datarobot_mcp_server.notify_prompts_changed.assert_called_once_with()
+        assert actual_output == mock_datarobot_mcp_server.add_prompt.return_value

--- a/uv.lock
+++ b/uv.lock
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
#### Why do we need to add category info for MCP prompts and resource ?
We need to record the MCP server snapshot (e.g., prompts/resource packaged under it) to support MCP server lineage. At this moment, there are following prompts/resource packaged with one MCP server. We need a better way to differentiate them and record the its category in the MCP server snapshot.

- User created prompt
A prompt function created by users within MCP server.
- Dynamic prompt
Prompts created outside MCP server and only loaded after MCP server is up.
- User created resource
A resource function created by users within MCP server.

#### The general idea behind the design
- Add tool category concept to represent prompts/resources created for different purposes.
- Record this info under Prompt.meta and Resource.meta.


#### Testings
I have run `task drmcp-integration` and `task drmcp-acceptance` testings locally. Testings passed.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
