### PR TITLE
[MODEL-22464] Add DataRobotMCPServer API to wrap around fastmcp APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.5.10
+- Add DataRobotMCPServer APIs to retrieve registered tools/prompts/resources.
+
 ## 0.5.9
 - Add MCP tool `deploy_custom_model` for deploying custom inference models (e.g. `.pkl`, `.joblib`) to DataRobot MLOps
 - Custom model deployment: validation for prediction servers (consistent with `deploy_model`), optional execution environment, model file discovery in folder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.5.9"
+version = "0.5.10"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -21,6 +21,9 @@ from collections.abc import Callable
 from typing import Any
 
 from fastmcp import FastMCP
+from fastmcp.prompts import Prompt
+from fastmcp.resources import Resource
+from fastmcp.tools import Tool
 from starlette.middleware import Middleware
 
 from .auth import initialize_oauth_middleware
@@ -303,6 +306,15 @@ class DataRobotMCPServer:
         except Exception as e:
             self._logger.error(f"Server error: {e}")
             raise
+
+    async def get_tools(self) -> dict[str, Tool]:
+        return await self._mcp.get_tools()
+
+    async def get_prompts(self) -> dict[str, Prompt]:
+        return await self._mcp.get_prompts()
+
+    async def get_resources(self) -> dict[str, Resource]:
+        return await self._mcp.get_resources()
 
 
 def create_mcp_server(

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -32,6 +32,9 @@ def mock_mcp() -> MagicMock:
     mock._list_tools_mcp = AsyncMock(
         return_value=[MagicMock(name="tool1"), MagicMock(name="tool2")]
     )
+    mock.get_tools = AsyncMock(return_value=[])
+    mock.get_prompts = AsyncMock(return_value=[])
+    mock.get_resources = AsyncMock(return_value=[])
     # Mock low-level server for _configure_mcp_capabilities()
     mock._mcp_server = MagicMock()
     mock._mcp_server.notification_options = MagicMock()
@@ -311,6 +314,33 @@ class TestDataRobotMCPServer:
         mock_mcp._list_tools_mcp.assert_called_once()
         # Should be called twice: once for run_server, once for pre_server_shutdown
         assert mock_loop.run_until_complete.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_tools(self, mock_mcp: MagicMock) -> None:
+        dr_mcp_server = DataRobotMCPServer(mock_mcp)
+
+        actual_outputs = await dr_mcp_server.get_tools()
+
+        mock_mcp.get_tools.assert_called_once_with()
+        assert actual_outputs == mock_mcp.get_tools.return_value
+
+    @pytest.mark.asyncio
+    async def test_get_prompts(self, mock_mcp: MagicMock) -> None:
+        dr_mcp_server = DataRobotMCPServer(mock_mcp)
+
+        actual_outputs = await dr_mcp_server.get_prompts()
+
+        mock_mcp.get_prompts.assert_called_once_with()
+        assert actual_outputs == mock_mcp.get_prompts.return_value
+
+    @pytest.mark.asyncio
+    async def test_get_resources(self, mock_mcp: MagicMock) -> None:
+        dr_mcp_server = DataRobotMCPServer(mock_mcp)
+
+        actual_outputs = await dr_mcp_server.get_resources()
+
+        mock_mcp.get_resources.assert_called_once_with()
+        assert actual_outputs == mock_mcp.get_resources.return_value
 
 
 def test_mcp_server_capabilities():

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+from collections.abc import Iterator
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -26,15 +27,34 @@ from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 
 @pytest.fixture
-def mock_mcp() -> MagicMock:
+def mock_fastmcp_get_tools() -> Iterator[AsyncMock]:
+    yield AsyncMock(return_value={})
+
+
+@pytest.fixture
+def mock_fastmcp_get_prompts() -> Iterator[AsyncMock]:
+    yield AsyncMock(return_value={})
+
+
+@pytest.fixture
+def mock_fastmcp_get_resources() -> Iterator[AsyncMock]:
+    yield AsyncMock(return_value={})
+
+
+@pytest.fixture
+def mock_mcp(
+    mock_fastmcp_get_prompts: AsyncMock,
+    mock_fastmcp_get_resources: AsyncMock,
+    mock_fastmcp_get_tools: AsyncMock,
+) -> MagicMock:
     """Create a mock FastMCP instance."""
     mock = MagicMock(spec=FastMCP)
     mock._list_tools_mcp = AsyncMock(
         return_value=[MagicMock(name="tool1"), MagicMock(name="tool2")]
     )
-    mock.get_tools = AsyncMock(return_value=[])
-    mock.get_prompts = AsyncMock(return_value=[])
-    mock.get_resources = AsyncMock(return_value=[])
+    mock.get_tools = mock_fastmcp_get_tools
+    mock.get_prompts = mock_fastmcp_get_prompts
+    mock.get_resources = mock_fastmcp_get_resources
     # Mock low-level server for _configure_mcp_capabilities()
     mock._mcp_server = MagicMock()
     mock._mcp_server.notification_options = MagicMock()
@@ -316,31 +336,43 @@ class TestDataRobotMCPServer:
         assert mock_loop.run_until_complete.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_get_tools(self, mock_mcp: MagicMock) -> None:
+    async def test_get_tools(
+        self,
+        mock_fastmcp_get_tools: AsyncMock,
+        mock_mcp: MagicMock,
+    ) -> None:
         dr_mcp_server = DataRobotMCPServer(mock_mcp)
 
         actual_outputs = await dr_mcp_server.get_tools()
 
-        mock_mcp.get_tools.assert_called_once_with()
-        assert actual_outputs == mock_mcp.get_tools.return_value
+        mock_fastmcp_get_tools.assert_called_once_with()
+        assert actual_outputs == mock_fastmcp_get_tools.return_value
 
     @pytest.mark.asyncio
-    async def test_get_prompts(self, mock_mcp: MagicMock) -> None:
+    async def test_get_prompts(
+        self,
+        mock_fastmcp_get_prompts: AsyncMock,
+        mock_mcp: MagicMock,
+    ) -> None:
         dr_mcp_server = DataRobotMCPServer(mock_mcp)
 
         actual_outputs = await dr_mcp_server.get_prompts()
 
-        mock_mcp.get_prompts.assert_called_once_with()
-        assert actual_outputs == mock_mcp.get_prompts.return_value
+        mock_fastmcp_get_prompts.assert_called_once_with()
+        assert actual_outputs == mock_fastmcp_get_prompts.return_value
 
     @pytest.mark.asyncio
-    async def test_get_resources(self, mock_mcp: MagicMock) -> None:
+    async def test_get_resources(
+        self,
+        mock_fastmcp_get_resources: AsyncMock,
+        mock_mcp: MagicMock,
+    ) -> None:
         dr_mcp_server = DataRobotMCPServer(mock_mcp)
 
         actual_outputs = await dr_mcp_server.get_resources()
 
-        mock_mcp.get_resources.assert_called_once_with()
-        assert actual_outputs == mock_mcp.get_resources.return_value
+        mock_fastmcp_get_resources.assert_called_once_with()
+        assert actual_outputs == mock_fastmcp_get_resources.return_value
 
 
 def test_mcp_server_capabilities():

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.5.9"
+version = "0.5.10"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
This PRs add three DataRobotMCPServer APIs to wrap the following fastmcp instance native APIs
- def get_tools()
- def get_prompts()
- def get_resources()

Why not directly referring `DataRobotMCPServer._mcp.get_tools | get_prompts | get_resources` ?
- We treated the FastMCP instance as the private attribute of `class DataRobotMCPServer` (e.g., DataRobotMCPServer._mcp) to achieve some level of encapsulation. Directly referring it breaks the encapsulation.
- I will need to retrieve MCP tools/prompts/resources through DataRobotMCPServer object. Directly creating DataRobotMCPServer APIs will make testing easier (e.g., I can direly mock these DataRobotMCPServer APIs instead of mock the native fastmcp) 

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API surface and test updates with no changes to server startup/shutdown or auth/data-handling logic.
> 
> **Overview**
> `DataRobotMCPServer` now exposes async wrapper methods (`get_tools`, `get_prompts`, `get_resources`) that delegate to the underlying `FastMCP` instance, providing a public API without reaching into `_mcp`.
> 
> Unit tests were updated to mock and assert these new accessors, and the release metadata was bumped to `0.5.10` (with a matching changelog entry and lockfile update).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d7833a04e6921b293f65ed08e9e6516b30a319f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->