### PR TITLE
[BUZZOK-29457] Add hooks for retrieving and storing memories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.5.11"
+version = "0.6.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -182,7 +182,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
                 crew = self.crew()
 
-                kickoff_inputs = self.make_kickoff_inputs(str(user_prompt_content))
+                kickoff_inputs = self.make_kickoff_inputs(str(user_prompt_content), context)
                 # Chat history is opt-in: only populate it if the agent/template
                 # declares a `chat_history` kickoff input (i.e. it uses `{chat_history}`
                 # in prompts).

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -75,7 +75,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
         return Crew(agents=self.agents, tasks=self.tasks, verbose=self.verbose)
 
     @abc.abstractmethod
-    def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+    def make_kickoff_inputs(self, user_prompt_content: str, context: str) -> dict[str, Any]:
         """Build the inputs dict for ``Crew.kickoff``.
 
         Subclasses must implement this to provide the exact inputs required
@@ -153,9 +153,14 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
         usage_metrics = self._extract_usage_metrics(crew_output)
         return response_text, pipeline_interactions, usage_metrics
 
+    @abc.abstractmethod
+    def retrieve_memories_based_on_user_prompt(self, user_prompt: Any) -> str:
+        raise NotImplementedError("Not implemented")
+
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the CrewAI workflow with the provided completion parameters."""
         user_prompt_content = extract_user_prompt_content(run_agent_input)
+        context = self.retrieve_memories_based_on_user_prompt(user_prompt_content)
         # Preserve prior template startup print for CLI parity
         try:
             print("Running agent with user prompt:", user_prompt_content, flush=True)

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -126,12 +126,11 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
             # No declared variables: preserve pre-history behaviour.
             template_input = user_prompt
 
-        current_messages = self.prompt_template.invoke(template_input).to_messages()
         messages = self.retrieve_memories_based_on_user_prompt(user_prompt)
-        messages.extend(self.prompt_template.invoke(user_prompt).to_messages())
+        messages.extend(self.prompt_template.invoke(template_input).to_messages())
         command = Command(  # type: ignore[var-annotated]
             update={
-                "messages": current_messages,
+                "messages": messages,
             },
         )
         return command

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -83,7 +83,7 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
         raise NotImplementedError("Not implemented")
 
     @abc.abstractmethod
-    def store_memory(self, pipeline_interactions: MultiTurnSample) -> None:
+    def store_memory(self, pipeline_interactions: "MultiTurnSample") -> None:
         raise NotImplementedError("Not implemented")
 
     def convert_input_message(self, run_agent_input: RunAgentInput) -> Command:

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -149,7 +149,8 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
                 forwarded_headers=self.forwarded_headers,
             ) as mcp_tools:
                 self.set_mcp_tools(mcp_tools)
-                result = await self._invoke(run_agent_input)
+                input_command = self.convert_input_message(run_agent_input)
+                result = await self._invoke(input_command)
 
                 # Yield all items from the result generator
                 # The context will be closed when this generator is exhausted
@@ -173,8 +174,7 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
                 # Re-raise if it's a different RuntimeError
                 raise
 
-    async def _invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
-        input_command = self.convert_input_message(run_agent_input)
+    async def _invoke(self, input_command: Command) -> InvokeReturn:
         logger.info(
             f"Running a langgraph agent with a command: {input_command}",
         )

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -211,8 +211,8 @@ async def test_invoke_overwrites_blank_chat_history_placeholder(
             return super().kickoff(inputs=inputs)
 
     class AgentWithPlaceholder(TestAgent):
-        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
-            return {"topic": user_prompt_content, "chat_history": ""}
+        def make_kickoff_inputs(self, user_prompt_content: str, context: str) -> dict[str, Any]:
+            return {"topic": user_prompt_content, "chat_history": "", "context": context}
 
     out = CrewOutput(raw="agent result")
     agent = AgentWithPlaceholder(out, api_base="https://x/", api_key="k", verbose=False)
@@ -241,8 +241,12 @@ async def test_invoke_does_not_overwrite_non_empty_chat_history_override(
             return super().kickoff(inputs=inputs)
 
     class AgentWithOverride(TestAgent):
-        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
-            return {"topic": user_prompt_content, "chat_history": "CUSTOM OVERRIDE"}
+        def make_kickoff_inputs(self, user_prompt_content: str, context: str) -> dict[str, Any]:
+            return {
+                "topic": user_prompt_content,
+                "chat_history": "CUSTOM OVERRIDE",
+                "context": context,
+            }
 
     out = CrewOutput(raw="agent result")
     agent = AgentWithOverride(out, api_base="https://x/", api_key="k", verbose=False)

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -74,11 +74,14 @@ class TestAgent(CrewAIAgent):
     def tasks(self) -> list[Any]:
         return [object()]
 
-    def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
-        return {"topic": user_prompt_content}
+    def make_kickoff_inputs(self, user_prompt_content: str, context: str) -> dict[str, Any]:
+        return {"topic": user_prompt_content, "context": context}
 
     def crew(self) -> Any:
         return TestCrew(self.crew_output)
+
+    def retrieve_memories_based_on_user_prompt(self, user_prompt: Any) -> str:
+        return ""
 
 
 # --- Tests for create_pipeline_interactions_from_messages ---

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -35,6 +35,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langgraph.graph.message import MessagesState
 from langgraph.graph.state import Command
 from langgraph.graph.state import StateGraph
+from ragas import MultiTurnSample
 
 from datarobot_genai.langgraph.agent import LangGraphAgent
 
@@ -185,10 +186,18 @@ class SimpleLangGraphAgent(LangGraphAgent):
     def retrieve_memories_based_on_user_prompt(self, user_prompt: Any) -> list[BaseMessage]:
         return []
 
+    def store_memory(self, pipeline_interactions: MultiTurnSample) -> None:
+        pass
+
 
 class LangGraphAgentWithMemories(SimpleLangGraphAgent):
+    stored_memories = []
+
     def retrieve_memories_based_on_user_prompt(self, user_prompt: Any) -> list[BaseMessage]:
         return [SystemMessage(content="Retrieved memories here")]
+
+    def store_memory(self, pipeline_interactions: MultiTurnSample) -> None:
+        self.stored_memories.append(pipeline_interactions)
 
 
 class HistoryAwareLangGraphAgent(LangGraphAgent):
@@ -518,7 +527,7 @@ def test_create_pipeline_interactions_from_events_filters_tool_messages() -> Non
     assert len(msgs) == 2
 
 
-async def test_langgraph_retrieves_memories(run_agent_input):
+async def test_langgraph_with_memories(run_agent_input):
     # GIVEN a simple langgraph agent implementation
     agent = LangGraphAgentWithMemories()
 
@@ -526,21 +535,31 @@ async def test_langgraph_retrieves_memories(run_agent_input):
     streaming_response_iterator = agent.invoke(run_agent_input)
 
     # THEN the streaming response iterator returns the expected first response including memory
-    async for _ in streaming_response_iterator:
-        expected_command = Command(
-            update={
-                "messages": [
-                    SystemMessage(content="Retrieved memories here"),
-                    SystemMessage(content="You are a helpful assistant. Tell user about AI."),
-                    HumanMessage(content="Hi, tell me about AI."),
-                ]
-            }
-        )
-        agent.workflow.compile().astream.assert_called_once_with(
-            input=expected_command,
-            config={},
-            debug=True,
-            stream_mode=["updates", "messages"],
-            subgraphs=True,
-        )
-        break
+    # and stores a memory.
+    first_item_consumed = False
+    async for (
+        _,
+        pipeline_interactions,
+        _,
+    ) in streaming_response_iterator:
+        if not first_item_consumed:
+            expected_command = Command(
+                update={
+                    "messages": [
+                        SystemMessage(content="Retrieved memories here"),
+                        SystemMessage(content="You are a helpful assistant. Tell user about AI."),
+                        HumanMessage(content="Hi, tell me about AI."),
+                    ]
+                }
+            )
+            agent.workflow.compile().astream.assert_called_once_with(
+                input=expected_command,
+                config={},
+                debug=True,
+                stream_mode=["updates", "messages"],
+                subgraphs=True,
+            )
+            first_item_consumed = True
+
+        if pipeline_interactions:
+            assert agent.stored_memories == [pipeline_interactions]

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -228,6 +228,12 @@ class HistoryAwareLangGraphAgent(LangGraphAgent):
     def langgraph_config(self) -> dict[str, Any]:
         return {}
 
+    def retrieve_memories_based_on_user_prompt(self, user_prompt: Any) -> list[BaseMessage]:
+        return []
+
+    def store_memory(self, pipeline_interactions: MultiTurnSample) -> None:
+        pass
+
 
 def test_convert_input_message_includes_history() -> None:
     """convert_input_message should include history when template uses {chat_history}."""

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -27,6 +27,7 @@ from ag_ui.core import SystemMessage as AgSystemMessage
 from ag_ui.core import UserMessage
 from langchain_core.messages import AIMessage
 from langchain_core.messages import AIMessageChunk
+from langchain_core.messages import BaseMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import SystemMessage
 from langchain_core.messages import ToolMessage
@@ -180,6 +181,9 @@ class SimpleLangGraphAgent(LangGraphAgent):
     @property
     def langgraph_config(self) -> dict[str, Any]:
         return {}
+
+    def retrieve_memories_based_on_user_prompt(self, user_prompt: Any) -> list[BaseMessage]:
+        return []
 
 
 class HistoryAwareLangGraphAgent(LangGraphAgent):

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.5.11"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
We want to support agent memory when the user opts in.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Add a method to retrieve memories based on the user prompt and include with the context sent to the agent. Add a method to store memories based on the extracted events at the end of the agent execution.
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an API-breaking change for all subclasses of `CrewAIAgent`/`LangGraphAgent` due to new required abstract methods and a changed `make_kickoff_inputs` signature, and it alters runtime message construction and streaming side effects (memory storage).
> 
> **Overview**
> Adds opt-in agent memory hooks across both frameworks. `CrewAIAgent` now requires `retrieve_memories_based_on_user_prompt()` and passes its returned `context` into `make_kickoff_inputs(...)`, changing that abstract method signature to include the new context value.
> 
> `LangGraphAgent` now requires `retrieve_memories_based_on_user_prompt()` and `store_memory()`: retrieved messages are prepended to the prompt-generated messages when building the `Command`, and any emitted `pipeline_interactions` are persisted via `store_memory()` during streaming. Tests were updated/added to cover memory injection and persistence, and the package version was bumped to `0.6.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04f792dbf13b486c4860c8c0efb5a98896badaca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->