### PR TITLE
[MODEL-22464] Update mcp item type related enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.5.12
+Update MCP item metadata related enums
+- DataRobotMCPToolCategory
+- DataRobotMCPPromptCategory
+- DataRobotMCPResourceCategory
+
 ## 0.5.11
 
 - Created DR MCP test stubs and added stub `client` attribute integrated with MCP server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.5.11"
+version = "0.5.12"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/core/enums.py
+++ b/src/datarobot_genai/drmcp/core/enums.py
@@ -17,14 +17,56 @@ from enum import auto
 
 class DataRobotMCPToolCategory(Enum):
     USER_TOOL = auto()  # tools created by users
-    INTEGRATION_TOOL = auto()  # tools as a wrapper of external service
-    DYNAMICALLY_LOADED_TOOL = auto()  # tools dynamically loaded after MCP server is up
+    BUILD_IN_TOOL = auto()  # tools as a wrapper of external service
+    USER_TOOL_DEPLOYMENT = auto()  # tools dynamically loaded after MCP server is up
+    UNKNOWN = auto()  # tools without category
+
+    @staticmethod
+    def from_string(enum_str: str) -> "DataRobotMCPToolCategory":
+        enum_str_map = {
+            "USER_TOOL": DataRobotMCPToolCategory.USER_TOOL,
+            "BUILD_IN_TOOL": DataRobotMCPToolCategory.BUILD_IN_TOOL,
+            "USER_TOOL_DEPLOYMENT": DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT,
+            "UNKNOWN": DataRobotMCPToolCategory.UNKNOWN,
+        }
+        if enum_str not in enum_str_map:
+            error_msg = f"Enum string should be one of {', '.join(enum_str_map.keys())}"
+            raise ValueError(error_msg)
+
+        return enum_str_map[enum_str]
 
 
 class DataRobotMCPPromptCategory(Enum):
     USER_PROMPT = auto()  # prompt created by users
-    DYNAMICALLY_LOADED_PROMPT = auto()  # prompts dynamically loaded after MCP server is up
+    USER_PROMPT_TEMPLATE_VERSION = auto()  # prompts dynamically loaded after MCP server is up
+    UNKNOWN = auto()  # prompts without category
+
+    @staticmethod
+    def from_string(enum_str: str) -> "DataRobotMCPPromptCategory":
+        enum_str_map = {
+            "USER_PROMPT": DataRobotMCPPromptCategory.USER_PROMPT,
+            "USER_PROMPT_TEMPLATE_VERSION": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION,
+            "UNKNOWN": DataRobotMCPPromptCategory.UNKNOWN,
+        }
+        if enum_str not in enum_str_map:
+            error_msg = f"Enum string should be one of {', '.join(enum_str_map.keys())}"
+            raise ValueError(error_msg)
+
+        return enum_str_map[enum_str]
 
 
 class DataRobotMCPResourceCategory(Enum):
     USER_RESOURCE = auto()  # resource created by users
+    UNKNOWN = auto()  # resources without category
+
+    @staticmethod
+    def from_string(enum_str: str) -> "DataRobotMCPResourceCategory":
+        enum_str_map = {
+            "USER_RESOURCE": DataRobotMCPResourceCategory.USER_RESOURCE,
+            "UNKNOWN": DataRobotMCPResourceCategory.UNKNOWN,
+        }
+        if enum_str not in enum_str_map:
+            error_msg = f"Enum string should be one of {', '.join(enum_str_map.keys())}"
+            raise ValueError(error_msg)
+
+        return enum_str_map[enum_str]

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -428,7 +428,7 @@ def dr_mcp_integration_tool(
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         return dr_mcp_tool(
-            tool_category=DataRobotMCPToolCategory.INTEGRATION_TOOL,
+            tool_category=DataRobotMCPToolCategory.BUILD_IN_TOOL,
             **mcp_tool_init_args,
         )(func)
 
@@ -479,7 +479,7 @@ async def register_tools(
     description: str | None = None,
     tags: set[str] | None = None,
     deployment_id: str | None = None,
-    tool_category: DataRobotMCPToolCategory = DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL,
+    tool_category: DataRobotMCPToolCategory = DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT,
 ) -> Tool:
     """
     Register new tools after server has started.
@@ -544,7 +544,7 @@ async def register_prompt(
     tags: set[str] | None = None,
     meta: dict[str, Any] | None = None,
     prompt_template: tuple[str, str] | None = None,
-    prompt_category: DataRobotMCPPromptCategory = DataRobotMCPPromptCategory.DYNAMICALLY_LOADED_PROMPT,  # noqa: E501
+    prompt_category: DataRobotMCPPromptCategory = DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION,  # noqa: E501
 ) -> Prompt:
     """
     Register new prompt after server has started.

--- a/tests/drmcp/unit/core/test_enums.py
+++ b/tests/drmcp/unit/core/test_enums.py
@@ -1,0 +1,43 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from datarobot_genai.drmcp.core.enums import DataRobotMCPPromptCategory
+from datarobot_genai.drmcp.core.enums import DataRobotMCPResourceCategory
+from datarobot_genai.drmcp.core.enums import DataRobotMCPToolCategory
+
+
+class TestDataRobotMCPToolCategory:
+    @pytest.mark.parametrize(
+        "tool_category", [tool_category for tool_category in DataRobotMCPToolCategory]
+    )
+    def test_from_string(self, tool_category: DataRobotMCPToolCategory) -> None:
+        assert DataRobotMCPToolCategory.from_string(tool_category.name) == tool_category
+
+
+class TestDataRobotMCPPromptCategory:
+    @pytest.mark.parametrize(
+        "prompt_category", [prompt_category for prompt_category in DataRobotMCPPromptCategory]
+    )
+    def test_from_string(self, prompt_category: DataRobotMCPPromptCategory) -> None:
+        assert DataRobotMCPPromptCategory.from_string(prompt_category.name) == prompt_category
+
+
+class TestDataRobotMCPResourceCategory:
+    @pytest.mark.parametrize(
+        "resource_category",
+        [resource_category for resource_category in DataRobotMCPResourceCategory],
+    )
+    def test_from_string(self, resource_category: DataRobotMCPResourceCategory) -> None:
+        assert DataRobotMCPResourceCategory.from_string(resource_category.name) == resource_category

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -262,7 +262,7 @@ class TestMCPToolDecorator:
 
         assert not mock_dr_mcp_tool.call_args.args
         assert mock_dr_mcp_tool.call_args.kwargs == {
-            "tool_category": DataRobotMCPToolCategory.INTEGRATION_TOOL,
+            "tool_category": DataRobotMCPToolCategory.BUILD_IN_TOOL,
             expected_kwarg_key: expected_kwarg_value,
         }
 

--- a/tests/drmcp/unit/test_register_prompt.py
+++ b/tests/drmcp/unit/test_register_prompt.py
@@ -135,7 +135,9 @@ class TestRegisterPrompt:
             title=None,
             description=None,
             tags=None,
-            meta={"resource_category": DataRobotMCPPromptCategory.DYNAMICALLY_LOADED_PROMPT.name},
+            meta={
+                "resource_category": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION.name
+            },
         )
         mock_datarobot_mcp_server.add_prompt.assert_called_once_with(
             mock_prompt_from_function.return_value

--- a/tests/drmcp/unit/test_register_tools.py
+++ b/tests/drmcp/unit/test_register_tools.py
@@ -454,7 +454,7 @@ class TestRegisterTool:
             description=None,
             annotations=None,
             tags=None,
-            meta={"tool_category": DataRobotMCPToolCategory.DYNAMICALLY_LOADED_TOOL.name},
+            meta={"tool_category": DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT.name},
         )
         mock_datarobot_mcp_server.add_tool.assert_called_once_with(
             mock_tool_from_function.return_value

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.5.11"
+version = "0.5.12"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1195,7 +1195,6 @@ drmcp = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
     { name = "aiosignal" },
-    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "datarobot" },
     { name = "datarobot-asgi-middleware" },

--- a/uv.lock
+++ b/uv.lock
@@ -1195,6 +1195,7 @@ drmcp = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
     { name = "aiosignal" },
+    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "datarobot" },
     { name = "datarobot-asgi-middleware" },


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This PR updated the MCP item type related enums to make it align with the enum values to be saved in DB (https://github.com/datarobot/DataRobot/pull/151953/changes#diff-8a5105ad64ec53d34af5491560e82cd841b70086729caad3620cee620eaf6b42R34).

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the enum values written into `meta` during tool/prompt registration, which may affect compatibility with existing persisted data and downstream consumers relying on previous category names.
> 
> **Overview**
> Bumps package version to `0.5.12` and updates MCP item metadata enums to match the category strings expected to be persisted (tools/prompts/resources).
> 
> This renames and expands categories (e.g. `INTEGRATION_TOOL` e `BUILD_IN_TOOL`, dynamically-loaded types e deployment/template-version types), adds an explicit `UNKNOWN` category, and introduces `from_string()` helpers for converting DB strings to enums. Default categories used by `dr_mcp_integration_tool`, `register_tools`, and `register_prompt` are updated accordingly, with tests added/updated to cover the new mappings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1eb140fb956b7f50fcca3d7c80c30bd1b1417c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->