### PR TITLE
[BUZZOK-29634] Improve dragent's event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.5.15
+## 0.5.16
 - Improve `dragent`'s event handling
 
 ## 0.5.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.5.15
+- Improve `dragent`'s event handling
+
+## 0.5.15
 - Restructure the tools and move them to drtools instead of drmcp.tools
 
 ## 0.5.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.5.15"
+version = "0.5.16"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ core = [
     "opentelemetry-instrumentation-httpx>=0.43b0,<1.0.0",
     "opentelemetry-instrumentation-openai>=0.40.5,<1.0.0",
     "opentelemetry-instrumentation-threading>=0.43b0,<1.0.0",
-    "ag-ui-protocol>=0.1.9,<0.2.0",
+    # Kepp the ag-ui-protocol version in sync with the version used in the fastapi_server
+    "ag-ui-protocol==0.1.13",
     "pyarrow==21.0.0",
 ]
 

--- a/src/datarobot_genai/dragent/converters.py
+++ b/src/datarobot_genai/dragent/converters.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import logging
+import uuid
 
 from ag_ui.core import RunAgentInput
-from ag_ui.core import TextMessageChunkEvent
+from ag_ui.core import TextMessageContentEvent
+from ag_ui.core import TextMessageEndEvent
+from ag_ui.core import TextMessageStartEvent
 from langchain_core.messages import ToolMessage
 from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatRequestOrMessage
@@ -79,11 +82,16 @@ def convert_chat_request_to_run_agent_input(request: ChatRequest) -> RunAgentInp
 def convert_str_to_dragent_event_response(
     response: str,
 ) -> DRAgentEventResponse:
+    message_id = str(uuid.uuid4())
     return DRAgentEventResponse(
         delta=response,
         usage_metrics=default_usage_metrics(),
         pipeline_interactions=None,
-        events=[TextMessageChunkEvent(delta=response)],
+        events=[
+            TextMessageStartEvent(message_id=message_id),
+            TextMessageContentEvent(message_id=message_id, delta=response),
+            TextMessageEndEvent(message_id=message_id),
+        ],
     )
 
 

--- a/src/datarobot_genai/dragent/converters.py
+++ b/src/datarobot_genai/dragent/converters.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 import logging
-import uuid
 
 from ag_ui.core import RunAgentInput
-from ag_ui.core import TextMessageContentEvent
-from ag_ui.core import TextMessageEndEvent
-from ag_ui.core import TextMessageStartEvent
+from ag_ui.core import TextMessageChunkEvent
 from langchain_core.messages import ToolMessage
 from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatRequestOrMessage
@@ -82,16 +79,11 @@ def convert_chat_request_to_run_agent_input(request: ChatRequest) -> RunAgentInp
 def convert_str_to_dragent_event_response(
     response: str,
 ) -> DRAgentEventResponse:
-    message_id = str(uuid.uuid4())
     return DRAgentEventResponse(
         delta=response,
         usage_metrics=default_usage_metrics(),
         pipeline_interactions=None,
-        events=[
-            TextMessageStartEvent(message_id=message_id),
-            TextMessageContentEvent(message_id=message_id, delta=response),
-            TextMessageEndEvent(message_id=message_id),
-        ],
+        events=[TextMessageChunkEvent(delta=response)],
     )
 
 

--- a/src/datarobot_genai/dragent/register.py
+++ b/src/datarobot_genai/dragent/register.py
@@ -25,6 +25,7 @@ from datarobot_genai.dragent.converters import convert_dragent_run_agent_input_t
 from datarobot_genai.dragent.converters import (
     convert_dragent_run_agent_input_to_chat_request_or_message,
 )
+from datarobot_genai.dragent.converters import convert_str_to_dragent_event_response
 from datarobot_genai.dragent.converters import convert_tool_message_to_str
 
 
@@ -47,3 +48,4 @@ GlobalTypeConverter.register_converter(convert_dragent_run_agent_input_to_chat_r
 GlobalTypeConverter.register_converter(convert_chat_request_to_run_agent_input)
 GlobalTypeConverter.register_converter(convert_dragent_run_agent_input_to_chat_request_or_message)
 GlobalTypeConverter.register_converter(convert_tool_message_to_str)
+GlobalTypeConverter.register_converter(convert_str_to_dragent_event_response)

--- a/src/datarobot_genai/dragent/step_adaptor.py
+++ b/src/datarobot_genai/dragent/step_adaptor.py
@@ -135,7 +135,7 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
         # Text might be sent in both LLM_END and LLM_NEW_TOKEN steps
         # we need to send content only once
         elif payload.event_type == IntermediateStepType.LLM_END:
-            if not self.seen_llm_new_token:
+            if not self.seen_llm_new_token and payload.data.payload.text:
                 events.append(
                     TextMessageContentEvent(
                         message_id=payload.UUID, delta=payload.data.payload.text
@@ -145,9 +145,10 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
             events.append(TextMessageEndEvent(message_id=payload.UUID))
         elif payload.event_type == IntermediateStepType.LLM_NEW_TOKEN:
             self.seen_llm_new_token = True
-            events.append(
-                TextMessageContentEvent(message_id=payload.UUID, delta=payload.data.chunk)
-            )
+            if payload.data.chunk:
+                events.append(
+                    TextMessageContentEvent(message_id=payload.UUID, delta=payload.data.chunk)
+                )
         else:
             raise self._unknown_step_type(payload)
 

--- a/src/datarobot_genai/dragent/step_adaptor.py
+++ b/src/datarobot_genai/dragent/step_adaptor.py
@@ -136,12 +136,13 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
         # Text might be sent in both LLM_END and LLM_NEW_TOKEN steps
         # we need to send content only once
         elif payload.event_type == IntermediateStepType.LLM_END:
-            if not self.seen_llm_new_token and payload.data.payload.text:
+            payload_text = getattr(getattr(payload.data, "payload", None), "text", None)
+            if not self.seen_llm_new_token and payload_text:
                 # LLM produced text without streaming — emit start + content + end together
                 events.append(TextMessageStartEvent(message_id=payload.UUID))
                 events.append(
                     TextMessageContentEvent(
-                        message_id=payload.UUID, delta=payload.data.payload.text
+                        message_id=payload.UUID, delta=payload_text
                     )
                 )
                 events.append(TextMessageEndEvent(message_id=payload.UUID))

--- a/src/datarobot_genai/dragent/step_adaptor.py
+++ b/src/datarobot_genai/dragent/step_adaptor.py
@@ -113,9 +113,10 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
     ) -> ResponseSerializable | None:
         # Find the start in the history with matching run_id
 
-        # Always treat LLM events as primary text so tokens stream to the frontend
-        # in real time, regardless of nesting depth.
-        events = self._handle_llm_primary_function(payload)
+        if self.function_level == 1:
+            events = self._handle_llm_primary_function(payload)
+        else:
+            events = self._handle_llm_nested_function(payload)
 
         response = DRAgentEventResponse(
             events=events,

--- a/src/datarobot_genai/dragent/step_adaptor.py
+++ b/src/datarobot_genai/dragent/step_adaptor.py
@@ -140,11 +140,7 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
             if not self.seen_llm_new_token and payload_text:
                 # LLM produced text without streaming — emit start + content + end together
                 events.append(TextMessageStartEvent(message_id=payload.UUID))
-                events.append(
-                    TextMessageContentEvent(
-                        message_id=payload.UUID, delta=payload_text
-                    )
-                )
+                events.append(TextMessageContentEvent(message_id=payload.UUID, delta=payload_text))
                 events.append(TextMessageEndEvent(message_id=payload.UUID))
             elif self.seen_llm_new_token:
                 # Do not emit payload.text here to avoid duplicating already streamed chunks.

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.5.15"
+version = "0.5.16"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This improves `dragent's` event handling in cases like empty LLM messages. 

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `dragent`’s AG-UI event sequencing for LLM steps, which can affect downstream consumers expecting previous start/content/end patterns. Also pins `ag-ui-protocol` to an exact version, which may impact dependency compatibility.
> 
> **Overview**
> Improves `dragent`’s LLM-to-AG-UI translation to avoid emitting `TextMessageStartEvent`/content for empty or tool-only LLM turns, and to emit `TextMessageStartEvent` only when the first non-empty streamed token arrives.
> 
> Updates tests to cover empty `LLM_END`, empty streamed chunks, streaming lifecycle ordering, and state reset between turns, and bumps package version to `0.5.16` (including pinning `ag-ui-protocol==0.1.13` and registering `convert_str_to_dragent_event_response`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1240dc8398dd00cec726d1142fe9d26d901f8be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->