### PR TITLE
[MODEL-22677] Create Model Stubs for MCP Integration Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.3
+- Created model stubs for MCP integration tests
+
 ## 0.6.2
 - Created MCP predict test stubs and added stub predict client attribute integrated with MCP server
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.2"
+version = "0.6.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
+
+# Project id used by test_create_dr_client(); use for integration tests with stubs.
+STUB_PROJECT_ID = "test_project_123"
 
 
 class StubModel:
@@ -25,7 +29,9 @@ class StubModel:
         self.metrics = metrics
 
     def score(self, dataset_url: str) -> MagicMock:
-        """Stub scoring method."""
+        """Stub scoring method. Raises for fake URLs so integration tests can assert errors."""
+        if "example.com" in (dataset_url or ""):
+            raise Exception("404 client error: {'message': 'Not Found'}")
         return MagicMock(id=f"job_{self.id}_{hash(dataset_url) % 1000}")
 
 
@@ -91,21 +97,29 @@ class StubDRClient:
 def test_create_dr_client() -> StubDRClient:
     """Create a stub DataRobot client with test project and models."""
     client = StubDRClient()
-    # Create test project with stub models
+
+    # Metrics shape: get_best_model expects metrics[metric].get("validation")
+    def _metrics(auc: float, logloss: float) -> dict:
+        return {
+            "AUC": {"validation": auc},
+            "LogLoss": {"validation": logloss},
+        }
+
+    # Create test project with stub models (model_1 best by AUC for integration test_model)
     project = StubProject(
         "test_project_123",
         models=[
             StubModel(
                 "model_1",
                 "Keras Text Convolutional Neural Network Classifier",
-                {"AUC": 0.95, "LogLoss": 0.12},
+                _metrics(0.95, 0.12),
             ),
-            StubModel("model_2", "Random Forest", {"AUC": 0.92, "LogLoss": 0.15}),
-            StubModel("model_3", "LightGBM", {"AUC": 0.94, "LogLoss": 0.13}),
+            StubModel("model_2", "Random Forest", _metrics(0.92, 0.15)),
+            StubModel("model_3", "LightGBM", _metrics(0.94, 0.13)),
         ],
     )
     # Create standalone model
-    standalone_model = StubModel("standalone_model", "Neural Network", {"AUC": 0.88})
+    standalone_model = StubModel("standalone_model", "Neural Network", _metrics(0.88, 0.2))
 
     def get_project(project_id: str) -> StubProject | None:
         """Stub Project.get that returns appropriate project or raises exception."""
@@ -146,3 +160,8 @@ def test_create_dr_client() -> StubDRClient:
     client.Model.get = get_model
     client.Deployment.get = get_deployment
     return client
+
+
+def get_stub_classification_project() -> dict[str, Any]:
+    """Return a stub project dict for integration tests (id matches test_create_dr_client)."""
+    return {"project": SimpleNamespace(id=STUB_PROJECT_ID)}

--- a/tests/drmcp/integration/test_model.py
+++ b/tests/drmcp/integration/test_model.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-from typing import Any
 
 import pytest
 from mcp.types import CallToolResult
@@ -21,15 +20,19 @@ from mcp.types import ListToolsResult
 from mcp.types import TextContent
 
 from datarobot_genai.drmcp.test_utils.mcp_utils_integration import integration_test_mcp_session
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import get_stub_classification_project
 
 
 @pytest.mark.asyncio
 class TestMCPToolsIntegration:
     """Integration tests for MCP tools."""
 
-    async def test_model_tools(self, classification_project: dict[str, Any]) -> None:
-        """Complete integration test for ModelTools through MCP."""
-        async with integration_test_mcp_session(use_stub=False) as session:
+    async def test_model_tools(self) -> None:
+        """Complete integration test for ModelTools through MCP (uses DR client stubs)."""
+        stub_project = get_stub_classification_project()
+        project_id = stub_project["project"].id
+
+        async with integration_test_mcp_session() as session:
             # 1 Test listing available tools
             tools_result: ListToolsResult = await session.list_tools()
             tool_names = [tool.name for tool in tools_result.tools]
@@ -41,7 +44,7 @@ class TestMCPToolsIntegration:
             result: CallToolResult = await session.call_tool(
                 "get_best_model",
                 {
-                    "project_id": classification_project["project"].id,
+                    "project_id": project_id,
                     "metric": "AUC",
                 },
             )
@@ -56,7 +59,7 @@ class TestMCPToolsIntegration:
                 else str(result.content[0])
             )
             data = json.loads(result_text)
-            assert data["project_id"] == classification_project["project"].id
+            assert data["project_id"] == project_id
             assert (
                 "Keras Text Convolutional Neural Network Classifier"
                 in data["best_model"]["model_type"]
@@ -67,9 +70,7 @@ class TestMCPToolsIntegration:
             # 3 Test getting best model without specifying metric
             result = await session.call_tool(
                 "get_best_model",
-                {
-                    "project_id": classification_project["project"].id,
-                },
+                {"project_id": project_id},
             )
 
             assert not result.isError
@@ -96,17 +97,14 @@ class TestMCPToolsIntegration:
                 if hasattr(result.content[0], "text")
                 else str(result.content[0])
             )
-            assert (
-                "Error in get_best_model: ClientError: 404 client error: {'message': 'Not Found'}"
-            ) in result_text, f"Result text: {result_text}"
+            # Stub returns "not found"; real API returns ClientError 404
+            assert "Error in get_best_model" in result_text
+            assert "nonexistent_project" in result_text or "Not Found" in result_text
 
             # 5 Test metric-based sorting of models
             result = await session.call_tool(
                 "get_best_model",
-                {
-                    "project_id": classification_project["project"].id,
-                    "metric": "LogLoss",
-                },
+                {"project_id": project_id, "metric": "LogLoss"},
             )
 
             result_text = (
@@ -122,11 +120,12 @@ class TestMCPToolsIntegration:
             )
             assert "LogLoss" in data["best_model"]["metrics"]
 
-            # 6 Test scoring dataset with specified model none existent model or dataset
+            # 6 Test scoring dataset with specified model /
+            # nonexistent dataset (stub raises for example.com URL)
             result = await session.call_tool(
                 "score_dataset_with_model",
                 {
-                    "project_id": classification_project["project"].id,
+                    "project_id": project_id,
                     "model_id": "standalone_model",
                     "dataset_url": "https://example.com/dataset.csv",
                 },
@@ -138,8 +137,5 @@ class TestMCPToolsIntegration:
                 if hasattr(result.content[0], "text")
                 else str(result.content[0])
             )
-            assert (
-                "Error in "
-                "score_dataset_with_model: ClientError: 404 client error: "
-                "{'message': 'Not Found'}" in result_text
-            ), f"Result text: {result_text}"
+            assert "Error in score_dataset_with_model" in result_text
+            assert "Not Found" in result_text or "404" in result_text

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Created model stubs for MCP integration tests.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Created model stubs metrics 
- `StubModel.score()` raises for URL error
-  Created `get_stub_classification_project()` and `STUB_PROJECT_ID`

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test stubs/integration tests and a version bump, with no production runtime behavior impacted.
> 
> **Overview**
> Bumps package version to `0.6.3` and records the release note in `CHANGELOG.md` (plus lockfile updates).
> 
> Enhances DataRobot MCP integration testing by expanding DR client stubs: model metrics now match the shape expected by `get_best_model`, scoring can intentionally raise a 404-like error for fake dataset URLs, and a helper `get_stub_classification_project()` provides a consistent stub project id.
> 
> Updates `tests/drmcp/integration/test_model.py` to run entirely against the stubbed MCP session (no fixture/real API), and relaxes error assertions to accommodate stub-vs-real error message differences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5af03cca400fed1fd7e4aca5c57ab88230af1401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->