### PR TITLE
[MODEL-22707] Create Dynamic Prompt Stubs for MCP Integration Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.4
+- Created prompt stubs for MCP integration tests
+
 ## 0.6.3
 - Created model stubs for MCP integration tests
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.3"
+version = "0.6.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -39,7 +39,6 @@ from datarobot_genai.drmcp import create_mcp_server
 from datarobot_genai.drmcp.core import clients
 from datarobot_genai.drmcp.core.clients import get_sdk_client as _original_get_sdk_client
 from datarobot_genai.drmcp.core.credentials import get_credentials
-from datarobot_genai.drmcp.core.dynamic_prompts import dr_lib as _dr_lib
 from datarobot_genai.drmcp.core.dynamic_prompts import register as prompt_register
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import test_create_dr_client
 from datarobot_genai.drmcp.test_utils.stubs.prediction_result_stub import (
@@ -73,11 +72,6 @@ def _stub_prompt_template_versions(
 ) -> dict[str, list[Any]]:
     """Stub that matches dr_lib.get_datarobot_prompt_template_versions signature."""
     return get_stub_prompt_template_versions(prompt_template_ids)
-
-
-if os.environ.get("MCP_USE_CLIENT_STUBS", "true") == "true":
-    _dr_lib.get_datarobot_prompt_templates = get_stub_prompt_templates  # type: ignore[assignment]
-    _dr_lib.get_datarobot_prompt_template_versions = _stub_prompt_template_versions
 
 
 def detect_user_modules() -> Any:

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -39,10 +39,14 @@ from datarobot_genai.drmcp import create_mcp_server
 from datarobot_genai.drmcp.core import clients
 from datarobot_genai.drmcp.core.clients import get_sdk_client as _original_get_sdk_client
 from datarobot_genai.drmcp.core.credentials import get_credentials
+from datarobot_genai.drmcp.core.dynamic_prompts import dr_lib as _dr_lib
+from datarobot_genai.drmcp.core.dynamic_prompts import register as prompt_register
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import test_create_dr_client
 from datarobot_genai.drmcp.test_utils.stubs.prediction_result_stub import (
     test_create_prediction_result,
 )
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import get_stub_prompt_template_versions
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import get_stub_prompt_templates
 from datarobot_genai.drtools.clients import datarobot as tools_datarobot_client
 
 # Import elicitation test tool to register it with the MCP server
@@ -61,6 +65,19 @@ try:
 except ImportError:
     # These imports will fail when running from library without user modules
     pass
+
+
+def _stub_prompt_template_versions(
+    prompt_template_ids: list[str],
+    headers_auth_only: bool = False,
+) -> dict[str, list[Any]]:
+    """Stub that matches dr_lib.get_datarobot_prompt_template_versions signature."""
+    return get_stub_prompt_template_versions(prompt_template_ids)
+
+
+if os.environ.get("MCP_USE_CLIENT_STUBS", "true") == "true":
+    _dr_lib.get_datarobot_prompt_templates = get_stub_prompt_templates  # type: ignore[assignment]
+    _dr_lib.get_datarobot_prompt_template_versions = _stub_prompt_template_versions
 
 
 def detect_user_modules() -> Any:
@@ -139,6 +156,12 @@ def _apply_predict_stubs() -> None:
     _dr_predict_deployment.predict = test_create_prediction_result
 
 
+def _apply_prompt_stubs() -> None:
+    """Patch register module so prompt registration uses stub templates/versions in this process."""
+    prompt_register.get_datarobot_prompt_templates = get_stub_prompt_templates  # type: ignore[assignment]
+    prompt_register.get_datarobot_prompt_template_versions = _stub_prompt_template_versions
+
+
 def _apply_dr_client_stubs() -> None:
     """Replace the real DataRobot client with stubs (patches token + client for stdio)."""
     stub_dr = test_create_dr_client()
@@ -156,6 +179,7 @@ def _apply_dr_client_stubs() -> None:
     # Tools call get_datarobot_access_token() before DataRobotClient; patch for stdio (no headers).
     tools_datarobot_client.get_datarobot_access_token = _get_datarobot_access_token_stdio_fallback
     _apply_predict_stubs()
+    _apply_prompt_stubs()
 
 
 def main() -> None:

--- a/src/datarobot_genai/drmcp/test_utils/stubs/prompt_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/prompt_stubs.py
@@ -1,0 +1,100 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stub prompt templates and versions for integration tests (test_dynamic_prompts)."""
+
+from types import SimpleNamespace
+
+# Names and text used by test_dynamic_prompts; keep in sync with conftest fixture names.
+STUB_PROMPT_WITHOUT_VERSION = "drmcp-integration-test-prompt-without-version"
+STUB_PROMPT_VERSION_NO_VARS = "drmcp-integration-test-prompt-with-version-without-variables"
+STUB_PROMPT_VERSION_WITH_VARS = "drmcp-integration-test-prompt-with-variables"
+STUB_PROMPT_VERSION_NO_VARS_TEXT = "Prompt text without any variables."
+STUB_PROMPT_VERSION_WITH_VARS_TEXT = "Prompt text to greet {{name}} in max {{sentences}} sentences."
+# Same name for two templates to test duplicate-name handling (suffix in list_prompts).
+STUB_PROMPT_DUPLICATE_NAME = "drmcp-integration-test-prompt-duplicate-stub"
+
+
+def _var(name: str, description: str = "") -> SimpleNamespace:
+    return SimpleNamespace(name=name, description=description)
+
+
+def _template(tid: str, name: str, description: str = "") -> SimpleNamespace:
+    t = SimpleNamespace(id=tid, name=name, description=description or name)
+    return t
+
+
+def _version(
+    vid: str,
+    ptid: str,
+    prompt_text: str,
+    variables: list,
+    version: int = 1,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=vid,
+        prompt_template_id=ptid,
+        prompt_text=prompt_text,
+        commit_comment="",
+        version=version,
+        variables=variables,
+        creation_date="",
+        creation_user_id="",
+        user_name="",
+    )
+
+
+def get_stub_prompt_templates() -> list[SimpleNamespace]:
+    """Return stub prompt templates for register_prompts_from_datarobot_prompt_management."""
+    # Exclude STUB_PROMPT_WITHOUT_VERSION so it is not registered (test expects it not in list).
+    return [
+        _template("stub-pt-1", STUB_PROMPT_VERSION_NO_VARS),
+        _template("stub-pt-2", STUB_PROMPT_VERSION_WITH_VARS),
+        _template("stub-pt-dup-1", STUB_PROMPT_DUPLICATE_NAME),
+        _template("stub-pt-dup-2", STUB_PROMPT_DUPLICATE_NAME),
+    ]
+
+
+def get_stub_prompt_template_versions(
+    prompt_template_ids: list[str],
+) -> dict[str, list[SimpleNamespace]]:
+    """Return stub versions for each template id (for stub mode)."""
+    result: dict[str, list[SimpleNamespace]] = {}
+    if "stub-pt-1" in prompt_template_ids:
+        result["stub-pt-1"] = [
+            _version(
+                "stub-v-1",
+                "stub-pt-1",
+                STUB_PROMPT_VERSION_NO_VARS_TEXT,
+                [],
+            )
+        ]
+    if "stub-pt-2" in prompt_template_ids:
+        result["stub-pt-2"] = [
+            _version(
+                "stub-v-2",
+                "stub-pt-2",
+                STUB_PROMPT_VERSION_WITH_VARS_TEXT,
+                [_var("name"), _var("sentences")],
+            )
+        ]
+    if "stub-pt-dup-1" in prompt_template_ids:
+        result["stub-pt-dup-1"] = [
+            _version("stub-v-dup-1", "stub-pt-dup-1", "Duplicate prompt 1.", [])
+        ]
+    if "stub-pt-dup-2" in prompt_template_ids:
+        result["stub-pt-dup-2"] = [
+            _version("stub-v-dup-2", "stub-pt-dup-2", "Duplicate prompt 2.", [])
+        ]
+    return result

--- a/tests/drmcp/integration/conftest.py
+++ b/tests/drmcp/integration/conftest.py
@@ -12,20 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import uuid
-from collections.abc import Iterator
 from typing import Any
 
 import pytest
 
-from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_DUPLICATE_NAME
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_NO_VARS
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_NO_VARS_TEXT
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_WITH_VARS
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_WITH_VARS_TEXT
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_WITHOUT_VERSION
-from tests.drmcp.integration.helper import create_prompt_template
-from tests.drmcp.integration.helper import delete_prompt_template
 from tests.drmcp.integration.helper import get_or_create_prompt_template
 from tests.drmcp.integration.helper import get_or_create_prompt_template_version
 
@@ -51,12 +46,6 @@ def prompt_template_text_without_variables() -> str:
 @pytest.fixture(scope="session")
 def prompt_template_name_with_version_with_variables() -> str:
     return "drmcp-integration-test-prompt-with-variables"
-
-
-@pytest.fixture(scope="session")
-def prompt_template_name_duplicate() -> str:
-    random_suffix = str(uuid.uuid4())
-    return f"drmcp-integration-test-prompt-duplicate-{random_suffix}"
 
 
 @pytest.fixture(scope="session")
@@ -125,49 +114,3 @@ def prompt_template_with_version_with_variables(
         "version_id": prompt_template_version["id"],
         "prompt_text": prompt_template_version["prompt_text"],
     }
-
-
-@pytest.fixture(scope="session")
-def prompt_templates_with_duplicates(
-    prompt_template_name_duplicate: str,
-    prompt_template_text_without_variables: str,
-    prompt_template_text_with_2_variables: str,
-) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
-    if _use_stubs():
-        stub = {
-            "name": STUB_PROMPT_DUPLICATE_NAME,
-            "prompt_text": prompt_template_text_without_variables,
-        }
-        yield (stub, {**stub, "prompt_text": prompt_template_text_with_2_variables})
-        return
-    prompt_template_1 = create_prompt_template(prompt_template_name_duplicate)
-    prompt_template_version_1 = get_or_create_prompt_template_version(
-        prompt_template_id=prompt_template_1["id"],
-        prompt_text=prompt_template_text_without_variables,
-        variables=[],
-    )
-    prompt_template_2 = create_prompt_template(prompt_template_name_duplicate)
-    prompt_template_version_2 = get_or_create_prompt_template_version(
-        prompt_template_id=prompt_template_2["id"],
-        prompt_text=prompt_template_text_with_2_variables,
-        variables=["name", "sentences"],
-    )
-
-    yield (
-        {
-            "id": prompt_template_1["id"],
-            "name": prompt_template_name_duplicate,
-            "version_id": prompt_template_version_1["id"],
-            "prompt_text": prompt_template_version_1["prompt_text"],
-        },
-        {
-            "id": prompt_template_2["id"],
-            "name": prompt_template_name_duplicate,
-            "version_id": prompt_template_version_2["id"],
-            "prompt_text": prompt_template_version_2["prompt_text"],
-        },
-    )
-
-    # Cleanup
-    delete_prompt_template(prompt_template_1["id"])
-    delete_prompt_template(prompt_template_2["id"])

--- a/tests/drmcp/integration/conftest.py
+++ b/tests/drmcp/integration/conftest.py
@@ -11,16 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import uuid
 from collections.abc import Iterator
 from typing import Any
 
 import pytest
 
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_DUPLICATE_NAME
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_NO_VARS
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_NO_VARS_TEXT
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_WITH_VARS
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_WITH_VARS_TEXT
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_WITHOUT_VERSION
 from tests.drmcp.integration.helper import create_prompt_template
 from tests.drmcp.integration.helper import delete_prompt_template
 from tests.drmcp.integration.helper import get_or_create_prompt_template
 from tests.drmcp.integration.helper import get_or_create_prompt_template_version
+
+# Default to stub mode so session-scoped fixtures return stub data without calling the API.
+os.environ.setdefault("MCP_USE_CLIENT_STUBS", "true")
 
 
 @pytest.fixture(scope="session")
@@ -54,8 +64,14 @@ def prompt_template_text_with_2_variables() -> str:
     return "Prompt text to greet {{name}} in max {{sentences}} sentences."
 
 
+def _use_stubs() -> bool:
+    return os.environ.get("MCP_USE_CLIENT_STUBS", "true").lower() == "true"
+
+
 @pytest.fixture(scope="session")
 def prompt_template_without_versions(prompt_template_name_without_version: str) -> dict[str, Any]:
+    if _use_stubs():
+        return {"name": STUB_PROMPT_WITHOUT_VERSION}
     return get_or_create_prompt_template(prompt_template_name_without_version)
 
 
@@ -64,6 +80,11 @@ def prompt_template_with_version_without_variables(
     prompt_template_name_with_version_without_variables: str,
     prompt_template_text_without_variables: str,
 ) -> dict[str, Any]:
+    if _use_stubs():
+        return {
+            "name": STUB_PROMPT_VERSION_NO_VARS,
+            "prompt_text": STUB_PROMPT_VERSION_NO_VARS_TEXT,
+        }
     prompt_template = get_or_create_prompt_template(
         prompt_template_name_with_version_without_variables
     )
@@ -85,6 +106,11 @@ def prompt_template_with_version_with_variables(
     prompt_template_name_with_version_with_variables: str,
     prompt_template_text_with_2_variables: str,
 ) -> dict[str, Any]:
+    if _use_stubs():
+        return {
+            "name": STUB_PROMPT_VERSION_WITH_VARS,
+            "prompt_text": STUB_PROMPT_VERSION_WITH_VARS_TEXT,
+        }
     prompt_template = get_or_create_prompt_template(
         prompt_template_name_with_version_with_variables
     )
@@ -107,6 +133,13 @@ def prompt_templates_with_duplicates(
     prompt_template_text_without_variables: str,
     prompt_template_text_with_2_variables: str,
 ) -> Iterator[tuple[dict[str, Any], dict[str, Any]]]:
+    if _use_stubs():
+        stub = {
+            "name": STUB_PROMPT_DUPLICATE_NAME,
+            "prompt_text": prompt_template_text_without_variables,
+        }
+        yield (stub, {**stub, "prompt_text": prompt_template_text_with_2_variables})
+        return
     prompt_template_1 = create_prompt_template(prompt_template_name_duplicate)
     prompt_template_version_1 = get_or_create_prompt_template_version(
         prompt_template_id=prompt_template_1["id"],

--- a/tests/drmcp/integration/test_dynamic_prompts.py
+++ b/tests/drmcp/integration/test_dynamic_prompts.py
@@ -138,7 +138,7 @@ class TestMCPDRPromptManagementIntegration:
 
         Uses stub prompts (use_stub=True) so no real API duplicate resources are needed.
         """
-        async with integration_test_mcp_session(timeout=self.TIMEOUT, use_stub=True) as session:
+        async with integration_test_mcp_session(timeout=self.TIMEOUT) as session:
             prompt_template_name_1 = STUB_PROMPT_DUPLICATE_NAME
             prompt_template_name_2 = STUB_PROMPT_DUPLICATE_NAME
 

--- a/tests/drmcp/integration/test_dynamic_prompts.py
+++ b/tests/drmcp/integration/test_dynamic_prompts.py
@@ -18,6 +18,7 @@ from mcp import McpError
 
 from datarobot_genai.drmcp import integration_test_mcp_session
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
+from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_DUPLICATE_NAME
 
 
 @pytest.mark.asyncio
@@ -29,7 +30,7 @@ class TestMCPDRPromptManagementIntegration:
 
     async def test_prompt_without_version(self, prompt_template_without_versions: dict) -> None:
         """Integration test for prompt template without any versions that cannot be used in MCP."""
-        async with integration_test_mcp_session(timeout=self.TIMEOUT, use_stub=False) as session:
+        async with integration_test_mcp_session(timeout=self.TIMEOUT) as session:
             prompt_template_name = prompt_template_without_versions["name"]
 
             # Check if testing prompt
@@ -51,7 +52,7 @@ class TestMCPDRPromptManagementIntegration:
         self, prompt_template_with_version_without_variables: dict
     ) -> None:
         """Integration test for prompt template with version without any variables."""
-        async with integration_test_mcp_session(timeout=self.TIMEOUT, use_stub=False) as session:
+        async with integration_test_mcp_session(timeout=self.TIMEOUT) as session:
             prompt_template_name = prompt_template_with_version_without_variables["name"]
             prompt_template_prompt_text = prompt_template_with_version_without_variables[
                 "prompt_text"
@@ -78,7 +79,7 @@ class TestMCPDRPromptManagementIntegration:
         var_2_name = "sentences"
         var_2_value = "5"
 
-        async with integration_test_mcp_session(timeout=self.TIMEOUT, use_stub=False) as session:
+        async with integration_test_mcp_session(timeout=self.TIMEOUT) as session:
             prompt_template_name = prompt_template_with_version_with_variables["name"]
             prompt_template_prompt_text = prompt_template_with_version_with_variables["prompt_text"]
 
@@ -106,7 +107,7 @@ class TestMCPDRPromptManagementIntegration:
         """Integration test for prompt template with version with variables
         when not enough variables provided.
         """
-        async with integration_test_mcp_session(timeout=self.TIMEOUT, use_stub=False) as session:
+        async with integration_test_mcp_session(timeout=self.TIMEOUT) as session:
             prompt_template_name = prompt_template_with_version_with_variables["name"]
 
             # Check if testing prompt is in list of all prompts
@@ -132,28 +133,25 @@ class TestMCPDRPromptManagementIntegration:
                     == e.value.error.message
                 )
 
-    async def test_prompt_when_duplicated_names_exists(
-        self, prompt_templates_with_duplicates: tuple[dict, dict]
-    ) -> None:
-        """Integration test for prompt template when duplicated names exist."""
-        first_prompt_template, second_prompt_template = prompt_templates_with_duplicates
-        async with integration_test_mcp_session(timeout=self.TIMEOUT, use_stub=False) as session:
-            prompt_template_name_1 = first_prompt_template["name"]
-            prompt_template_name_2 = second_prompt_template["name"]
+    async def test_prompt_when_duplicated_names_exists(self) -> None:
+        """Integration test for prompt template when duplicated names exist.
 
-            # Its name from API -> it's duplicated
+        Uses stub prompts (use_stub=True) so no real API duplicate resources are needed.
+        """
+        async with integration_test_mcp_session(timeout=self.TIMEOUT, use_stub=True) as session:
+            prompt_template_name_1 = STUB_PROMPT_DUPLICATE_NAME
+            prompt_template_name_2 = STUB_PROMPT_DUPLICATE_NAME
+
             assert prompt_template_name_1 == prompt_template_name_2
 
-            # Check if both prompts are in list of all prompts
             prompts_list = await session.list_prompts()
             prompts_names = {p.name for p in prompts_list.prompts}
 
             # One prompt is without any "suffix"
             assert prompt_template_name_1 in prompts_names
 
-            # Second prompt has suffix
-            # We cannot mock uuid here as it's separate process running MCP server
-            pattern = re.compile(rf"{prompt_template_name_1} \([A-Za-z0-9]{{4}}\)")
+            # Second prompt has suffix (e.g. "name (Ab12)")
+            pattern = re.compile(rf"{re.escape(prompt_template_name_1)} \([A-Za-z0-9]{{4}}\)")
             matches = [s for s in prompts_names if pattern.search(s)]
 
             assert len(matches) == 1

--- a/tests/drmcp/integration/test_elicitation_capabilities.py
+++ b/tests/drmcp/integration/test_elicitation_capabilities.py
@@ -64,9 +64,7 @@ async def test_elicitation_capability_negotiation(
 
     callback = elicitation_handler if has_elicitation_callback else None
 
-    async with integration_test_mcp_session(
-        elicitation_callback=callback, use_stub=False
-    ) as session:
+    async with integration_test_mcp_session(elicitation_callback=callback) as session:
         # Get the init result stored by integration_test_mcp_session
         init_result = session._init_result  # type: ignore[attr-defined]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Created prompt stubs for MCP integration tests.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test utilities and integration tests, mainly swapping real Prompt Management API calls for in-process stubs. Main risk is reduced coverage of real API integration if stub mode is unintentionally used in environments expecting live resources.
> 
> **Overview**
> Adds in-process stub prompt templates/versions for MCP dynamic prompt integration tests and wires them into the integration MCP server by patching prompt registration functions when `MCP_USE_CLIENT_STUBS=true`.
> 
> Integration tests now default to stub mode (via `MCP_USE_CLIENT_STUBS`) and remove runtime creation/cleanup of real prompt templates, including updating the duplicate-name test to rely on stubbed duplicates and tightening the suffix-match regex.
> 
> Bumps package version to `0.6.4` and updates lockfiles/changelog accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7296d0d2ab5c871dd654aac070e98fd765bdf20f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->