### PR TITLE
[MODEL-22711] Enable Integration Tests in Task File

### DIFF
--- a/.taskfiles/tests.yml
+++ b/.taskfiles/tests.yml
@@ -14,7 +14,7 @@ tasks:
           uv run pytest --junitxml=test_results/test-results.xml \
             --cov=datarobot_genai --cov-branch --cov-fail-under=${COV_FAIL_UNDER} --no-cov-on-fail \
             -vv -s tests \
-            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
+            --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
     silent: true
 
   # Use when crewai extra is not installed (e.g. macOS Intel: install-no-crewai).
@@ -26,7 +26,7 @@ tasks:
           uv run pytest --junitxml=test_results/test-results.xml \
             --cov=datarobot_genai --cov-branch --no-cov-on-fail \
             -vv -s tests \
-            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration \
+            --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration \
             --ignore=tests/crewai
     silent: true
 

--- a/.taskfiles/tests.yml
+++ b/.taskfiles/tests.yml
@@ -14,7 +14,7 @@ tasks:
           uv run pytest --junitxml=test_results/test-results.xml \
             --cov=datarobot_genai --cov-branch --cov-fail-under=${COV_FAIL_UNDER} --no-cov-on-fail \
             -vv -s tests \
-            --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
+            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
     silent: true
 
   # Use when crewai extra is not installed (e.g. macOS Intel: install-no-crewai).
@@ -26,7 +26,7 @@ tasks:
           uv run pytest --junitxml=test_results/test-results.xml \
             --cov=datarobot_genai --cov-branch --no-cov-on-fail \
             -vv -s tests \
-            --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration \
+            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration \
             --ignore=tests/crewai
     silent: true
 
@@ -49,7 +49,7 @@ tasks:
           echo "pytest path: tests/{{.MODULE}}"
           uv run pytest tests/{{.MODULE}} \
             --junitxml=test_results/test-results.xml -vv -s \
-            --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
+            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
     silent: true
 
   smoke-extras-none:

--- a/.taskfiles/tests.yml
+++ b/.taskfiles/tests.yml
@@ -26,7 +26,7 @@ tasks:
           uv run pytest --junitxml=test_results/test-results.xml \
             --cov=datarobot_genai --cov-branch --no-cov-on-fail \
             -vv -s tests \
-            --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration \
+            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration \
             --ignore=tests/crewai
     silent: true
 
@@ -49,7 +49,7 @@ tasks:
           echo "pytest path: tests/{{.MODULE}}"
           uv run pytest tests/{{.MODULE}} \
             --junitxml=test_results/test-results.xml -vv -s \
-            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
+            {{if ne .MODULE "drmcp"}}--ignore=tests/drmcp/integration {{end}}--ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
     silent: true
 
   smoke-extras-none:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.5
+- Update task file to enable integration tests
+
 ## 0.6.4
 - Created prompt stubs for MCP integration tests
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.4"
+version = "0.6.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -67,6 +67,7 @@ class StubDeployment:
     ):
         self.id = deployment_id
         self.model = {"project_id": project_id, "id": model_id}
+        self.status = "active"
 
     def get_features(self) -> list:
         """

--- a/tests/drmcp/conftest.py
+++ b/tests/drmcp/conftest.py
@@ -72,6 +72,9 @@ def _make_dr_client() -> Any:
     if not token:
         raise ValueError("Integration tests need DATAROBOT_API_TOKEN environment variable set.")
     # Skip real API init when using stub token (CI/stub mode); dr.Client() would 401.
+    # Session fixtures in this file (timeseries_regression_project, classification_project,
+    # etc.) check _is_stub_token() first and yield stub data without calling dr.*, so they
+    # never hit the API when no client is configured.
     if token != _STUB_DATAROBOT_API_TOKEN:
         dr.Client(token=token, endpoint=creds.datarobot.endpoint)
     DRContext.use_case = None
@@ -240,6 +243,7 @@ def multiseries_regression_project(
         yield _stub_project_fixture_dict(
             "stub_multiseries_project",
             "stub_multiseries_deployment",
+            target="sales",
         )
         return
 

--- a/tests/drmcp/conftest.py
+++ b/tests/drmcp/conftest.py
@@ -35,7 +35,9 @@ def _make_dr_client() -> Any:
     token = creds.datarobot.application_api_token
     if not token:
         raise ValueError("Integration tests need DATAROBOT_API_TOKEN environment variable set.")
-    dr.Client(token=token, endpoint=creds.datarobot.endpoint)
+    # Skip real API init when using stub token (CI/stub mode); dr.Client() would 401.
+    if token != _STUB_DATAROBOT_API_TOKEN:
+        dr.Client(token=token, endpoint=creds.datarobot.endpoint)
     DRContext.use_case = None
     return dr
 

--- a/tests/drmcp/conftest.py
+++ b/tests/drmcp/conftest.py
@@ -15,6 +15,7 @@ import os
 from collections.abc import Generator
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -22,15 +23,50 @@ import datarobot as dr
 import pytest
 from datarobot.context import Context as DRContext
 
+from datarobot_genai.drmcp.core.constants import DEFAULT_DATAROBOT_ENDPOINT
 from datarobot_genai.drmcp.core.credentials import get_credentials
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubDeployment
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubModel
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubProject
 
 _STUB_DATAROBOT_API_TOKEN = "test-token"
 
 
+def _is_stub_token() -> bool:
+    """Return True when DATAROBOT_API_TOKEN is the stub (no real API calls)."""
+    return os.environ.get("DATAROBOT_API_TOKEN") == _STUB_DATAROBOT_API_TOKEN
+
+
+def _stub_project_fixture_dict(
+    project_id: str,
+    deployment_id: str,
+    source_dataset_id: str = "stub_dataset_id",
+    *,
+    target: str = "sentiment",
+) -> dict[str, Any]:
+    """Minimal stub dict for project fixtures when using stub token."""
+    project = StubProject(project_id)
+    project.catalog_id = source_dataset_id  # type: ignore[attr-defined]
+    project.target = target  # type: ignore[attr-defined]
+    return {
+        "project": project,
+        "model": StubModel("stub_model_1", "StubModel", {}),
+        "deployment": StubDeployment(deployment_id, project_id=project_id),
+        "deployment_id": deployment_id,
+        "source_dataset_id": source_dataset_id,
+    }
+
+
 def _make_dr_client() -> Any:
     """Build DataRobot client from credentials (env). No HTTP context in pytest."""
+    # Only set stub credentials when token is missing and stub mode is enabled (e.g. CI).
+    # Otherwise the ValueError below is reachable and gives a clear message.
     if not os.environ.get("DATAROBOT_API_TOKEN"):
-        os.environ["DATAROBOT_API_TOKEN"] = _STUB_DATAROBOT_API_TOKEN
+        if os.environ.get("MCP_USE_CLIENT_STUBS", "true").lower() == "true":
+            os.environ["DATAROBOT_API_TOKEN"] = _STUB_DATAROBOT_API_TOKEN
+            if not os.environ.get("DATAROBOT_ENDPOINT"):
+                os.environ["DATAROBOT_ENDPOINT"] = DEFAULT_DATAROBOT_ENDPOINT
+            # Stub env persists for the session so all code paths see the same credentials.
     creds = get_credentials()
     token = creds.datarobot.application_api_token
     if not token:
@@ -76,6 +112,14 @@ def timeseries_regression_project(
     timeseries_regression_project_name: str,
 ) -> Generator[dict[str, Any], None, None]:
     """Create a time series regression project and return the best model deployment."""
+    if _is_stub_token():
+        yield _stub_project_fixture_dict(
+            "stub_ts_project",
+            "stub_ts_deployment",
+            target="sales",
+        )
+        return
+
     deployment_label = "MCP Test TS Regression Deployment"
 
     # First, check if deployment already exists
@@ -192,6 +236,13 @@ def multiseries_regression_project(
     multiseries_regression_project_name: str,
 ) -> Generator[dict[str, Any], None, None]:
     """Create a multiseries time series regression project and return the best model deployment."""
+    if _is_stub_token():
+        yield _stub_project_fixture_dict(
+            "stub_multiseries_project",
+            "stub_multiseries_deployment",
+        )
+        return
+
     deployment_label = "MCP Test Multiseries TS Regression Deployment"
 
     # First, check if deployment already exists
@@ -309,6 +360,13 @@ def classification_project(
     classification_project_name: str,
 ) -> Generator[dict[str, Any], None, None]:
     """Create a text classification project and return the best model deployment."""
+    if _is_stub_token():
+        yield _stub_project_fixture_dict(
+            "stub_classification_project",
+            "stub_classification_deployment",
+        )
+        return
+
     deployment_label = "MCP Test Text Classification Deployment"
 
     # First, check if deployment already exists
@@ -427,6 +485,14 @@ def classification_predict_dataset(
     classification_predict_file_path: Path,
 ) -> Generator[dict[str, Any], None, None]:
     """Upload text classification prediction dataset to AI Catalog."""
+    if _is_stub_token():
+        yield {
+            "dataset": SimpleNamespace(id="stub_predict_dataset_id"),
+            "dataset_id": "stub_predict_dataset_id",
+            "file_path": str(classification_predict_file_path),
+        }
+        return
+
     # Check if dataset already exists in AI Catalog
     try:
         datasets = dr.Dataset.list()

--- a/tests/drmcp/conftest.py
+++ b/tests/drmcp/conftest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from collections.abc import Generator
 from collections.abc import Iterator
 from pathlib import Path
@@ -23,9 +24,13 @@ from datarobot.context import Context as DRContext
 
 from datarobot_genai.drmcp.core.credentials import get_credentials
 
+_STUB_DATAROBOT_API_TOKEN = "test-token"
+
 
 def _make_dr_client() -> Any:
     """Build DataRobot client from credentials (env). No HTTP context in pytest."""
+    if not os.environ.get("DATAROBOT_API_TOKEN"):
+        os.environ["DATAROBOT_API_TOKEN"] = _STUB_DATAROBOT_API_TOKEN
     creds = get_credentials()
     token = creds.datarobot.application_api_token
     if not token:

--- a/tests/drmcp/integration/test_predict_realtime.py
+++ b/tests/drmcp/integration/test_predict_realtime.py
@@ -373,7 +373,7 @@ class TestMCPRealtimePredictToolsIntegration:
         self, timeseries_regression_project: dict[str, Any], test_data_dir: Any
     ) -> None:
         """Integration test for predict_realtime with comprehensive explanation parameters."""
-        async with integration_test_mcp_session(use_stub=False) as session:
+        async with integration_test_mcp_session() as session:
             deployment_id = timeseries_regression_project["deployment_id"]
             predict_file = test_data_dir / "timeseries_regression_predict.csv"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Enable integration tests in task file by removing `--ignore=tests/drmcp/integration`

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly test/task configuration changes plus more robust stubbed integration-test setup; low production risk, with the main potential impact being longer or different local/CI test execution behavior.
> 
> **Overview**
> Enables `drmcp` integration tests to run via Task targets by no longer ignoring `tests/drmcp/integration` in `test-no-crewai` and by conditionally including them in `test-module` when `MODULE=drmcp`.
> 
> Updates `tests/drmcp` integration fixtures to support a *stubbed* DataRobot mode (auto-populating a stub token/endpoint, skipping `dr.Client()` init, and yielding stub project/deployment/dataset objects), and adjusts an integration test to use the default stubbed MCP session.
> 
> Bumps the package version to `0.6.5` and records the change in `CHANGELOG.md` (plus lockfile updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bba2d3572c4b2132da46aac2cd32ec3d6b151dfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->