### PR TITLE
[MODEL-22690] Try to get perplexity/tavily api key from 2 headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.7
+- When getting api key in perplexity/tavily try to get it from 2 different headers (as fallback)
+
 ## 0.6.6
 - Refactor drtools to use Polars for data handling, removing pandas dependency
 - Enhance acceptance tests for realtime predictions with inline CSV dataset support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.6"
+version = "0.6.7"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.5"
+version = "0.6.6"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drtools/clients/helpers.py
+++ b/src/datarobot_genai/drtools/clients/helpers.py
@@ -15,19 +15,21 @@ from fastmcp.server.dependencies import get_http_headers
 
 
 def get_api_key_from_headers(header_name: str) -> str | None:
-    if header_name.startswith("x-datarobot-"):
-        header_name = header_name[len("x-datarobot-") :]
-    if header_name.startswith("x-"):
-        header_name = header_name[len("x-") :]
-
     headers = get_http_headers()
 
-    # Try to get from x-{header}
-    if api_key := headers.get(f"x-{header_name}"):
+    # First try to get just {header}
+    if api_key := headers.get(header_name):
         return api_key
 
-    # Try to get from x-datarobot-{header}
+    # Then try to get x-datarobot-{header}
     if api_key := headers.get(f"x-datarobot-{header_name}"):
         return api_key
+
+    # If header starts with x- but not x-datarobot- we've fallback
+    if header_name.startswith("x-") and not header_name.startswith("x-datarobot-"):
+        header_name = header_name[2:]
+        # Try to get x-datarobot-{header_without_x-}
+        if api_key := headers.get(f"x-datarobot-{header_name}"):
+            return api_key
 
     return None

--- a/src/datarobot_genai/drtools/clients/helpers.py
+++ b/src/datarobot_genai/drtools/clients/helpers.py
@@ -17,19 +17,15 @@ from fastmcp.server.dependencies import get_http_headers
 def get_api_key_from_headers(header_name: str) -> str | None:
     headers = get_http_headers()
 
-    # First try to get just {header}
-    if api_key := headers.get(header_name):
-        return api_key
+    candidates = [header_name]
 
-    # Then try to get x-datarobot-{header}
-    if api_key := headers.get(f"x-datarobot-{header_name}"):
-        return api_key
-
-    # If header starts with x- but not x-datarobot- we've fallback
     if header_name.startswith("x-") and not header_name.startswith("x-datarobot-"):
-        header_name = header_name[2:]
-        # Try to get x-datarobot-{header_without_x-}
-        if api_key := headers.get(f"x-datarobot-{header_name}"):
-            return api_key
+        candidates.append(f"x-datarobot-{header_name[2:]}")
+    elif not header_name.startswith("x-datarobot-"):
+        candidates.append(f"x-datarobot-{header_name}")
+
+    for name in candidates:
+        if value := headers.get(name):
+            return value
 
     return None

--- a/src/datarobot_genai/drtools/clients/helpers.py
+++ b/src/datarobot_genai/drtools/clients/helpers.py
@@ -1,0 +1,20 @@
+from fastmcp.server.dependencies import get_http_headers
+
+
+def get_api_key_from_headers(header_name: str) -> str | None:
+    if header_name.startswith("x-datarobot-"):
+        header_name = header_name[len("x-datarobot-") :]
+    if header_name.startswith("x-"):
+        header_name = header_name[len("x-") :]
+
+    headers = get_http_headers()
+
+    # Try to get from x-{header}
+    if api_key := headers.get(f"x-{header_name}"):
+        return api_key
+
+    # Try go get from x-datarobot-{header}
+    if api_key := headers.get(f"x-datarobot-{header_name}"):
+        return api_key
+
+    return None

--- a/src/datarobot_genai/drtools/clients/helpers.py
+++ b/src/datarobot_genai/drtools/clients/helpers.py
@@ -13,7 +13,7 @@ def get_api_key_from_headers(header_name: str) -> str | None:
     if api_key := headers.get(f"x-{header_name}"):
         return api_key
 
-    # Try go get from x-datarobot-{header}
+    # Try to get from x-datarobot-{header}
     if api_key := headers.get(f"x-datarobot-{header_name}"):
         return api_key
 

--- a/src/datarobot_genai/drtools/clients/helpers.py
+++ b/src/datarobot_genai/drtools/clients/helpers.py
@@ -1,3 +1,16 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from fastmcp.server.dependencies import get_http_headers
 
 

--- a/src/datarobot_genai/drtools/clients/perplexity.py
+++ b/src/datarobot_genai/drtools/clients/perplexity.py
@@ -62,7 +62,7 @@ async def get_perplexity_access_token() -> str | ToolError:
         ```
     """
     try:
-        if api_key := get_api_key_from_headers("perplexity-api-key"):
+        if api_key := get_api_key_from_headers("x-perplexity-api-key"):
             return api_key
 
         logger.warning("Perplexity API key not found in headers.")

--- a/src/datarobot_genai/drtools/clients/perplexity.py
+++ b/src/datarobot_genai/drtools/clients/perplexity.py
@@ -18,7 +18,6 @@ from typing import Any
 from typing import Literal
 
 from fastmcp.exceptions import ToolError
-from fastmcp.server.dependencies import get_http_headers
 from perplexity import AsyncPerplexity
 from perplexity.types import ChatMessageInput
 from perplexity.types import StreamChunk
@@ -28,6 +27,8 @@ from perplexity.types.chat.completion_create_params import ResponseFormatRespons
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+
+from datarobot_genai.drtools.clients.helpers import get_api_key_from_headers
 
 logger = logging.getLogger(__name__)
 
@@ -61,9 +62,7 @@ async def get_perplexity_access_token() -> str | ToolError:
         ```
     """
     try:
-        headers = get_http_headers()
-
-        if api_key := headers.get("x-perplexity-api-key"):
+        if api_key := get_api_key_from_headers("perplexity-api-key"):
             return api_key
 
         logger.warning("Perplexity API key not found in headers.")
@@ -73,7 +72,7 @@ async def get_perplexity_access_token() -> str | ToolError:
         )
     except Exception as e:
         logger.error(f"Unexpected error obtaining Perplexity API key: {e}.", exc_info=e)
-        return ToolError("An unexpected error occured while obtaining Perplexity API key.")
+        return ToolError("An unexpected error occurred while obtaining Perplexity API key.")
 
 
 class PerplexityError(Exception):

--- a/src/datarobot_genai/drtools/clients/tavily.py
+++ b/src/datarobot_genai/drtools/clients/tavily.py
@@ -47,7 +47,7 @@ async def get_tavily_access_token() -> str:
     ------
         ToolError: If API key is not found in headers
     """
-    if api_key := get_api_key_from_headers("tavily-api-key"):
+    if api_key := get_api_key_from_headers("x-tavily-api-key"):
         return api_key
 
     logger.warning("Tavily API key not found in headers")

--- a/src/datarobot_genai/drtools/clients/tavily.py
+++ b/src/datarobot_genai/drtools/clients/tavily.py
@@ -19,11 +19,12 @@ from typing import Any
 from typing import Literal
 
 from fastmcp.exceptions import ToolError
-from fastmcp.server.dependencies import get_http_headers
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 from tavily import AsyncTavilyClient
+
+from datarobot_genai.drtools.clients.helpers import get_api_key_from_headers
 
 logger = logging.getLogger(__name__)
 
@@ -46,10 +47,7 @@ async def get_tavily_access_token() -> str:
     ------
         ToolError: If API key is not found in headers
     """
-    headers = get_http_headers()
-
-    api_key = headers.get("x-tavily-api-key")
-    if api_key:
+    if api_key := get_api_key_from_headers("tavily-api-key"):
         return api_key
 
     logger.warning("Tavily API key not found in headers")

--- a/tests/drmcp/unit/tool_clients/test_tavily_client.py
+++ b/tests/drmcp/unit/tool_clients/test_tavily_client.py
@@ -34,8 +34,8 @@ class TestGetTavilyAccessToken:
     async def test_returns_api_key_from_headers(self) -> None:
         """Test getting API key from HTTP headers."""
         with patch(
-            "datarobot_genai.drtools.clients.tavily.get_http_headers",
-            return_value={"x-tavily-api-key": "test-api-key-123"},
+            "datarobot_genai.drtools.clients.tavily.get_api_key_from_headers",
+            return_value="test-api-key-123",
         ):
             result = await get_tavily_access_token()
             assert result == "test-api-key-123"
@@ -44,8 +44,8 @@ class TestGetTavilyAccessToken:
     async def test_raises_error_when_missing(self) -> None:
         """Test that missing API key raises ToolError."""
         with patch(
-            "datarobot_genai.drtools.clients.tavily.get_http_headers",
-            return_value={},
+            "datarobot_genai.drtools.clients.tavily.get_api_key_from_headers",
+            return_value=None,
         ):
             with pytest.raises(ToolError, match="Tavily API key not found"):
                 await get_tavily_access_token()

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.5"
+version = "0.6.6"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
Try to get perplexity/tavily api key from 2 headers (as fallback)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small refactor of API key header lookup with a fallback header name; behavior change is limited to authentication header resolution for Perplexity/Tavily.
> 
> **Overview**
> Bumps version to `0.6.7` and documents the change in `CHANGELOG.md`.
> 
> Adds a shared `get_api_key_from_headers` helper that looks up API keys from both the original header (e.g. `x-perplexity-api-key` / `x-tavily-api-key`) and a `x-datarobot-...` prefixed fallback, and updates the Perplexity and Tavily clients to use it (including a minor typo fix in a Perplexity error message).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46f22f7e89c0251fce8c7b03329a208978283a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->