### PR TITLE
Scaffold mcp_tools/ subpackage with tool registry

### DIFF
--- a/src/datarobot_genai/mcp_tools/__init__.py
+++ b/src/datarobot_genai/mcp_tools/__init__.py
@@ -1,0 +1,8 @@
+"""MCP Tools subpackage for datarobot-genai.
+
+This package provides tool implementations that can be used either:
+- Via MCP server (registered at startup by drmcp)
+- Directly injected into agent frameworks (LangGraph, CrewAI, etc.)
+
+See BUZZOK-29612 for the decoupling rationale.
+"""

--- a/src/datarobot_genai/mcp_tools/_registry.py
+++ b/src/datarobot_genai/mcp_tools/_registry.py
@@ -1,0 +1,81 @@
+"""Tool registry with deduplication support.
+
+Tools register themselves here. The MCP server reads from this registry
+at startup. This allows tools to be used without MCP (e.g. injected
+directly into LangGraph agents) per BUZZOK-29612.
+
+Usage:
+    from datarobot_genai.mcp_tools._registry import register_tool, get_all_tools
+
+    # In a tool module:
+    register_tool(
+        name="my_tool",
+        func=my_tool_func,
+        description="Does a thing",
+        category="wren_tools",
+    )
+
+    # At server startup:
+    for name, tool_def in get_all_tools().items():
+        mcp.tool(name=name)(tool_def.func)
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Dict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ToolDefinition:
+    name: str
+    func: Callable
+    description: str
+    category: str  # "dr_tools", "wren_tools", "data_ops", etc.
+    params_schema: dict = field(default_factory=dict)
+
+
+_tool_registry: Dict[str, ToolDefinition] = {}
+
+
+def register_tool(
+    name: str,
+    func: Callable,
+    description: str,
+    category: str,
+    params_schema: dict | None = None,
+) -> None:
+    """Register a tool. If duplicate name exists, log warning and keep first."""
+    if name in _tool_registry:
+        logger.warning(
+            "Duplicate tool '%s' from category '%s' "
+            "— keeping existing from '%s'",
+            name,
+            category,
+            _tool_registry[name].category,
+        )
+        return
+    _tool_registry[name] = ToolDefinition(
+        name=name,
+        func=func,
+        description=description,
+        category=category,
+        params_schema=params_schema or {},
+    )
+
+
+def get_all_tools() -> Dict[str, ToolDefinition]:
+    """Return all registered tools."""
+    return dict(_tool_registry)
+
+
+def get_tools_by_category(category: str) -> Dict[str, ToolDefinition]:
+    """Return tools filtered by category."""
+    return {k: v for k, v in _tool_registry.items() if v.category == category}
+
+
+def clear_registry() -> None:
+    """Clear all registered tools. Used in tests."""
+    _tool_registry.clear()

--- a/src/datarobot_genai/mcp_tools/data_ops/__init__.py
+++ b/src/datarobot_genai/mcp_tools/data_ops/__init__.py
@@ -1,0 +1,1 @@
+"""Placeholder — tools will be added in follow-up PRs."""

--- a/src/datarobot_genai/mcp_tools/dr_tools/__init__.py
+++ b/src/datarobot_genai/mcp_tools/dr_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Placeholder — tools will be added in follow-up PRs."""

--- a/src/datarobot_genai/mcp_tools/wren_tools/__init__.py
+++ b/src/datarobot_genai/mcp_tools/wren_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Placeholder — tools will be added in follow-up PRs."""

--- a/tests/test_mcp_tools/test_registry.py
+++ b/tests/test_mcp_tools/test_registry.py
@@ -1,0 +1,48 @@
+"""Tests for the tool registry."""
+import pytest
+from datarobot_genai.mcp_tools._registry import (
+    register_tool,
+    get_all_tools,
+    get_tools_by_category,
+    clear_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+async def _dummy_tool(x: str) -> str:
+    return x
+
+
+def test_register_and_retrieve():
+    register_tool("my_tool", _dummy_tool, "A test tool", "test_category")
+    tools = get_all_tools()
+    assert "my_tool" in tools
+    assert tools["my_tool"].category == "test_category"
+
+
+def test_duplicate_keeps_first():
+    register_tool("dup", _dummy_tool, "First", "cat_a")
+    register_tool("dup", _dummy_tool, "Second", "cat_b")
+    tools = get_all_tools()
+    assert tools["dup"].description == "First"
+    assert tools["dup"].category == "cat_a"
+
+
+def test_get_by_category():
+    register_tool("tool_a", _dummy_tool, "A", "alpha")
+    register_tool("tool_b", _dummy_tool, "B", "beta")
+    register_tool("tool_c", _dummy_tool, "C", "alpha")
+    alpha_tools = get_tools_by_category("alpha")
+    assert len(alpha_tools) == 2
+    assert "tool_a" in alpha_tools
+    assert "tool_c" in alpha_tools
+
+
+def test_empty_registry():
+    assert get_all_tools() == {}


### PR DESCRIPTION
## Summary

- Adds `src/datarobot_genai/mcp_tools/` subpackage with a deduplicating tool registry (`_registry.py`)
- Creates empty placeholder sub-directories: `dr_tools/`, `wren_tools/`, `data_ops/`
- Adds `tests/test_mcp_tools/test_registry.py` with 4 passing tests
- **Zero changes to `drmcp/`, `pyproject.toml`, or any existing code**

This is the first PR in the panel decomposition sequence. It creates a landing pad for:
- PR 2: Migrate wren-mcp tools → `wren_tools/`
- PR 3: Generic MCP resources for datasets/deployments/models
- PR 6: Generic filter/aggregate/sort tools → `data_ops/`

Related: BUZZOK-29612 (Rabih's tool decoupling work). This PR intentionally does **not** move any existing tools — if his work lands first with a different structure, this can be discarded with zero cost.

## Test plan

- [x] `pytest tests/test_mcp_tools/` — 4 passed
- [x] No existing tests modified
- [x] No imports added to `drmcp/` or anywhere else
- [x] PR is < 200 lines of new code total

🤖 Generated with [Claude Code](https://claude.com/claude-code)