### PR TITLE
[MODEL-22689] Make model required for MCP clients acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.8
+- Make model required for MCP clients acceptance tests
+
 ## 0.6.7
 - When getting api key in perplexity/tavily try to get it from 2 different headers (as fallback)
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1014,13 +1014,15 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-threading", marker = "extra == 'nat'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-threading", marker = "extra == 'pydanticai'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'drmcp'", specifier = ">=1.22.0,<2.0.0" },
-    { name = "pandas", marker = "extra == 'drmcp'", specifier = ">=2.2.3,<3.0.0" },
-    { name = "pandas", marker = "extra == 'drtools'", specifier = ">=2.2.3,<3.0.0" },
     { name = "perplexityai", marker = "extra == 'drmcp'", specifier = ">=0.27,<1.0" },
     { name = "perplexityai", marker = "extra == 'drtools'", specifier = ">=0.27,<1.0" },
+    { name = "polars", marker = "extra == 'drmcp'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "polars", marker = "extra == 'drtools'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pyarrow", marker = "extra == 'core'", specifier = "==21.0.0" },
     { name = "pyarrow", marker = "extra == 'crewai'", specifier = "==21.0.0" },
     { name = "pyarrow", marker = "extra == 'dragent'", specifier = "==21.0.0" },
+    { name = "pyarrow", marker = "extra == 'drmcp'", specifier = ">=21.0.0,<22.0.0" },
+    { name = "pyarrow", marker = "extra == 'drtools'", specifier = ">=21.0.0,<22.0.0" },
     { name = "pyarrow", marker = "extra == 'langgraph'", specifier = "==21.0.0" },
     { name = "pyarrow", marker = "extra == 'llamaindex'", specifier = "==21.0.0" },
     { name = "pyarrow", marker = "extra == 'nat'", specifier = "==21.0.0" },
@@ -1042,6 +1044,8 @@ requires-dist = [
     { name = "pypdf", marker = "extra == 'drmcp'", specifier = ">=6.1.3,<7.0.0" },
     { name = "pypdf", marker = "extra == 'drtools'", specifier = ">=6.1.3,<7.0.0" },
     { name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.0.0,<7.0.0" },
+    { name = "python-dateutil", marker = "extra == 'drmcp'", specifier = ">=2.9.0,<3.0.0" },
+    { name = "python-dateutil", marker = "extra == 'drtools'", specifier = ">=2.9.0,<3.0.0" },
     { name = "python-dotenv", marker = "extra == 'drmcp'", specifier = ">=1.1.0,<2.0.0" },
     { name = "ragas", marker = "extra == 'core'", specifier = ">=0.3.8,<0.4.0" },
     { name = "ragas", marker = "extra == 'crewai'", specifier = ">=0.3.8,<0.4.0" },

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.5"
+version = "0.6.7"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.7"
+version = "0.6.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/clients/anthropic.py
+++ b/src/datarobot_genai/drmcp/test_utils/clients/anthropic.py
@@ -50,15 +50,15 @@ class AnthropicMCPClient(BaseLLMMCPClient):
         Args:
             config: Configuration string or dict with:
                 - anthropic_api_key: Anthropic API key
-                - model: Model name (default: "claude-3-5-sonnet-20241022")
+                - model: Model name (**required**)
                 - save_llm_responses: Whether to save responses (default: True)
         """
         super().__init__(config)
 
-    def _create_llm_client(self, config_dict: dict) -> tuple[openai.OpenAI, str]:
+    def _create_llm_client(self, config_dict: dict) -> tuple[openai.OpenAI, str | None]:
         """Create the LLM client for Anthropic (OpenAI-compatible endpoint)."""
         anthropic_api_key = config_dict.get("anthropic_api_key")
-        model = config_dict.get("model", "claude-3-5-sonnet-20241022")
+        model = config_dict.get("model")
 
         # Anthropic provides an OpenAI-compatible endpoint
         client = openai.OpenAI(

--- a/src/datarobot_genai/drmcp/test_utils/clients/base.py
+++ b/src/datarobot_genai/drmcp/test_utils/clients/base.py
@@ -67,7 +67,12 @@ class BaseLLMMCPClient(ABC):
             config: Configuration string or dict with provider-specific keys.
         """
         config_dict = self._parse_config(config)
-        self.openai_client, self.model = self._create_llm_client(config_dict)
+        self.openai_client, model = self._create_llm_client(config_dict)
+        if not model:
+            raise ValueError(
+                "'model' is required in the client configuration. Please specify a model name."
+            )
+        self.model: str = model
         self.save_llm_responses = config_dict.get("save_llm_responses", True)
         self.available_tools: list[dict[str, Any]] = []
         self.available_prompts: list[dict[str, Any]] = []
@@ -88,7 +93,7 @@ class BaseLLMMCPClient(ABC):
     @abstractmethod
     def _create_llm_client(
         self, config_dict: dict
-    ) -> tuple[openai.OpenAI | openai.AzureOpenAI, str]:
+    ) -> tuple[openai.OpenAI | openai.AzureOpenAI, str | None]:
         """
         Create the LLM client.
 

--- a/src/datarobot_genai/drmcp/test_utils/clients/dr_gateway.py
+++ b/src/datarobot_genai/drmcp/test_utils/clients/dr_gateway.py
@@ -38,18 +38,18 @@ class DRLLMGatewayMCPClient(BaseLLMMCPClient):
             config: Configuration string or dict with:
                 - datarobot_api_token: DataRobot API token
                 - datarobot_endpoint: DataRobot endpoint URL (default: "https://app.datarobot.com/api/v2")
-                - model: Model name (default: "gpt-4o-mini")
+                - model: Model name (**required**)
                 - save_llm_responses: Whether to save responses (default: True)
         """
         super().__init__(config)
 
-    def _create_llm_client(self, config_dict: dict) -> tuple[openai.OpenAI, str]:
+    def _create_llm_client(self, config_dict: dict) -> tuple[openai.OpenAI, str | None]:
         """Create the LLM client for DataRobot LLM Gateway."""
         datarobot_api_token = config_dict.get("datarobot_api_token")
         datarobot_endpoint = config_dict.get(
             "datarobot_endpoint", "https://app.datarobot.com/api/v2"
         )
-        model = config_dict.get("model", "gpt-4o-mini")
+        model = config_dict.get("model")
 
         # Build gateway URL: {endpoint}/genai/llmgw
         gateway_url = datarobot_endpoint.rstrip("/") + "/genai/llmgw"

--- a/src/datarobot_genai/drmcp/test_utils/clients/openai.py
+++ b/src/datarobot_genai/drmcp/test_utils/clients/openai.py
@@ -60,7 +60,7 @@ class OpenAILLMMCPClient(BaseLLMMCPClient):
             client = openai.AzureOpenAI(
                 api_key=openai_api_key,
                 azure_endpoint=openai_api_base,
-                api_version=config_dict.get("openai_api_version", "2024-02-15-preview"),
+                api_version=config_dict.get("openai_api_version"),
             )
             return client, openai_api_deployment_id
         else:

--- a/src/datarobot_genai/drmcp/test_utils/clients/openai.py
+++ b/src/datarobot_genai/drmcp/test_utils/clients/openai.py
@@ -40,19 +40,20 @@ class OpenAILLMMCPClient(BaseLLMMCPClient):
                 - openai_api_base: Optional Azure OpenAI endpoint
                 - openai_api_deployment_id: Optional Azure deployment ID
                 - openai_api_version: Optional Azure API version
-                - model: Model name (default: "gpt-3.5-turbo")
+                - model: Model name (**required** for non-Azure; not needed for Azure
+                    when deployment ID is set)
                 - save_llm_responses: Whether to save responses (default: True)
         """
         super().__init__(config)
 
     def _create_llm_client(
         self, config_dict: dict
-    ) -> tuple[openai.OpenAI | openai.AzureOpenAI, str]:
+    ) -> tuple[openai.OpenAI | openai.AzureOpenAI, str | None]:
         """Create the LLM client for OpenAI or Azure OpenAI."""
         openai_api_key = config_dict.get("openai_api_key")
         openai_api_base = config_dict.get("openai_api_base")
         openai_api_deployment_id = config_dict.get("openai_api_deployment_id")
-        model = config_dict.get("model", "gpt-3.5-turbo")
+        model = config_dict.get("model")
 
         if openai_api_base and openai_api_deployment_id:
             # Azure OpenAI

--- a/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
@@ -53,10 +53,16 @@ def get_openai_llm_client_config() -> dict[str, str]:
     ):  # For Azure OpenAI, we need additional variables
         raise ValueError("Missing required environment variable: OPENAI_API_DEPLOYMENT_ID")
 
+    openai_model = os.environ.get("OPENAI_MODEL")
+    if not openai_model:
+        raise ValueError("Missing required environment variable: OPENAI_MODEL")
+
     config: dict[str, str] = {
         "openai_api_key": openai_api_key,
     }
 
+    if openai_model:
+        config["model"] = openai_model
     if openai_api_base:
         config["openai_api_base"] = openai_api_base
     if openai_api_deployment_id:
@@ -77,11 +83,17 @@ def get_dr_llm_gateway_client_config() -> dict[str, str]:
     if not datarobot_api_token:
         raise ValueError("Missing required environment variable: DATAROBOT_API_TOKEN")
 
+    dr_llm_gateway_model = os.environ.get("DR_LLM_GATEWAY_MODEL")
+    if not dr_llm_gateway_model:
+        raise ValueError("Missing required environment variable: DR_LLM_GATEWAY_MODEL")
+
     config: dict[str, str] = {
         "datarobot_api_token": datarobot_api_token,
         "save_llm_responses": str(save_llm_responses),
     }
 
+    if dr_llm_gateway_model:
+        config["model"] = dr_llm_gateway_model
     if datarobot_endpoint:
         config["datarobot_endpoint"] = datarobot_endpoint
 

--- a/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/mcp_utils_ete.py
@@ -54,7 +54,7 @@ def get_openai_llm_client_config() -> dict[str, str]:
         raise ValueError("Missing required environment variable: OPENAI_API_DEPLOYMENT_ID")
 
     openai_model = os.environ.get("OPENAI_MODEL")
-    if not openai_model:
+    if not openai_api_deployment_id and not openai_model:
         raise ValueError("Missing required environment variable: OPENAI_MODEL")
 
     config: dict[str, str] = {
@@ -92,8 +92,7 @@ def get_dr_llm_gateway_client_config() -> dict[str, str]:
         "save_llm_responses": str(save_llm_responses),
     }
 
-    if dr_llm_gateway_model:
-        config["model"] = dr_llm_gateway_model
+    config["model"] = dr_llm_gateway_model
     if datarobot_endpoint:
         config["datarobot_endpoint"] = datarobot_endpoint
 

--- a/tests/drmcp/unit/test_test_interactive.py
+++ b/tests/drmcp/unit/test_test_interactive.py
@@ -31,6 +31,7 @@ from openai.types.chat.chat_completion_message_tool_call import (
     Function as ChatCompletionMessageToolCallFunction,
 )
 
+from datarobot_genai.drmcp.test_utils.clients.anthropic import AnthropicMCPClient
 from datarobot_genai.drmcp.test_utils.clients.base import LLMResponse
 from datarobot_genai.drmcp.test_utils.clients.base import ToolCall
 from datarobot_genai.drmcp.test_utils.clients.dr_gateway import DRLLMGatewayMCPClient
@@ -115,7 +116,7 @@ def mock_azure_openai_patch():
 @pytest.fixture
 def basic_client_config() -> dict:
     """Return basic client configuration."""
-    return {"openai_api_key": "test-key"}
+    return {"openai_api_key": "test-key", "model": "gpt-4"}
 
 
 @pytest.fixture
@@ -212,12 +213,19 @@ class TestLLMMCPClient:
 
     def test_init_with_defaults(self, mock_openai_patch) -> None:
         """Test OpenAILLMMCPClient initialization with default values."""
-        config = {"openai_api_key": "test-key"}
+        config = {"openai_api_key": "test-key", "model": "gpt-4"}
 
         client = OpenAILLMMCPClient(str(config))
 
-        assert client.model == "gpt-3.5-turbo"
+        assert client.model == "gpt-4"
         assert client.save_llm_responses is True
+
+    def test_init_without_model_raises_value_error(self, mock_openai_patch) -> None:
+        """Test that OpenAILLMMCPClient raises ValueError when model is not provided."""
+        config = {"openai_api_key": "test-key"}
+
+        with pytest.raises(ValueError, match="'model' is required"):
+            OpenAILLMMCPClient(str(config))
 
     @pytest.mark.asyncio
     async def test_add_mcp_tool_to_available_tools(self, llm_client, mock_session) -> None:
@@ -365,7 +373,7 @@ class TestLLMMCPClient:
         self, mock_save_file, mock_openai_patch, mock_session, mock_openai_client_instance
     ) -> None:
         """Test process_prompt_with_mcp_support with single LLM response (no tool calls)."""
-        config = {"openai_api_key": "test-key", "save_llm_responses": True}
+        config = {"openai_api_key": "test-key", "model": "gpt-4", "save_llm_responses": True}
         client = OpenAILLMMCPClient(str(config))
 
         mock_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
@@ -388,7 +396,7 @@ class TestLLMMCPClient:
         mock_openai_client_instance,
     ) -> None:
         """Test process_prompt_with_mcp_support with tool calls."""
-        config = {"openai_api_key": "test-key", "save_llm_responses": True}
+        config = {"openai_api_key": "test-key", "model": "gpt-4", "save_llm_responses": True}
         client = OpenAILLMMCPClient(str(config))
 
         mock_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
@@ -417,7 +425,7 @@ class TestLLMMCPClient:
         self, mock_openai_patch, mock_session, mock_openai_client_instance
     ) -> None:
         """Test that process_prompt_with_mcp_support cleans content (removes * and lowercases)."""
-        config = {"openai_api_key": "test-key", "save_llm_responses": False}
+        config = {"openai_api_key": "test-key", "model": "gpt-4", "save_llm_responses": False}
         client = OpenAILLMMCPClient(str(config))
 
         mock_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
@@ -435,7 +443,7 @@ class TestLLMMCPClient:
         self, mock_openai_patch, mock_session, mock_openai_client_instance
     ) -> None:
         """Test process_prompt_with_mcp_support without saving responses."""
-        config = {"openai_api_key": "test-key", "save_llm_responses": False}
+        config = {"openai_api_key": "test-key", "model": "gpt-4", "save_llm_responses": False}
         client = OpenAILLMMCPClient(str(config))
 
         mock_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
@@ -474,7 +482,7 @@ class TestDRLLMGatewayMCPClient:
 
     def test_init_with_defaults(self, mock_openai_patch) -> None:
         """Test DRLLMGatewayMCPClient initialization with default values."""
-        config = {"datarobot_api_token": "test-token"}
+        config = {"datarobot_api_token": "test-token", "model": "gpt-4o-mini"}
 
         client = DRLLMGatewayMCPClient(str(config))
 
@@ -532,3 +540,40 @@ class TestDRLLMGatewayMCPClient:
             api_key="test-token",
             base_url="https://app.datarobot.com/api/v2/genai/llmgw",
         )
+
+    def test_init_without_model_raises_value_error(self, mock_openai_patch) -> None:
+        """Test that DRLLMGatewayMCPClient raises ValueError when model is not provided."""
+        config = {
+            "datarobot_api_token": "test-token",
+            "datarobot_endpoint": "https://app.datarobot.com/api/v2",
+        }
+
+        with pytest.raises(ValueError, match="'model' is required"):
+            DRLLMGatewayMCPClient(str(config))
+
+
+class TestAnthropicMCPClient:
+    """Test cases for AnthropicMCPClient class."""
+
+    def test_init_with_anthropic_config(self, mock_openai_patch) -> None:
+        """Test AnthropicMCPClient initialization."""
+        config = {
+            "anthropic_api_key": "sk-ant-test",
+            "model": "claude-3-5-sonnet-20241022",
+        }
+
+        client = AnthropicMCPClient(str(config))
+
+        assert client.model == "claude-3-5-sonnet-20241022"
+        assert client.save_llm_responses is True
+        mock_openai_patch.assert_called_once_with(
+            api_key="sk-ant-test",
+            base_url="https://api.anthropic.com/v1",
+        )
+
+    def test_init_without_model_raises_value_error(self, mock_openai_patch) -> None:
+        """Test that AnthropicMCPClient raises ValueError when model is not provided."""
+        config = {"anthropic_api_key": "sk-ant-test"}
+
+        with pytest.raises(ValueError, match="'model' is required"):
+            AnthropicMCPClient(str(config))

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
The MCP clients previously had hardcoded default models which could silently misconfigure requests if a user forgot to specify one, leading to unexpected costs or runtime errors. Making model required forces explicit configuration and fails fast with a clear error instead of falling back to a potentially wrong or outdated default.

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a behavior-breaking change for MCP test clients/configuration: `model` is no longer defaulted and missing values now raise immediately, which may fail existing test setups and CI env configs. Scope is limited to `drmcp` test utilities and lock/version bumps, with minimal production impact.
> 
> **Overview**
> **MCP acceptance-test LLM clients now require an explicit `model`.** `BaseLLMMCPClient` validates `model` and raises a clear `ValueError` instead of silently falling back to provider-specific defaults, and provider clients (OpenAI, DR LLM Gateway, Anthropic) stop supplying default model names.
> 
> E2E test config helpers now require `OPENAI_MODEL` (when not using Azure deployment IDs) and `DR_LLM_GATEWAY_MODEL`, and unit tests are updated to always pass a model plus new coverage for the failure case (and for `AnthropicMCPClient`). The release is bumped to `0.6.8` with corresponding changelog and lockfile updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d1f4b94fd614974a0bf852d2a8f251a75c2ccf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->