### PR TITLE
[BUZZOK-29432] Fix github usernames for bugbot

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -34,7 +34,7 @@ This document outlines common guidelines which should be applied when making cha
 | PRODUCT | @dr-nate-daly-pm | |
 | TECHLEAD | @tsdaemon | |
 | DOC | @smagee-robot @jendavies | |
-| APPS-Customer Engineering | @carsongee @Luke Shulman @zingbretsen | |
+| APPS-Customer Engineering | @carsongee | |
 
 ## A. Critical areas
 

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -31,10 +31,10 @@ This document outlines common guidelines which should be applied when making cha
 
 | Stakeholder | Person | Approval |
 |---|---|---|
-| PRODUCT | @Nate Daly | |
-| TECHLEAD | @Anatolii Stehnii | |
-| DOC | @Shawn Magee @Jen Davies | |
-| APPS-Customer Engineering | @Carson Gee @Luke Shulman @Zach Ingbretsen | |
+| PRODUCT | @dr-nate-daly-pm | |
+| TECHLEAD | @tsdaemon | |
+| DOC | @smagee-robot @jendavies | |
+| APPS-Customer Engineering | @carsongee @Luke Shulman @zingbretsen | |
 
 ## A. Critical areas
 
@@ -52,14 +52,14 @@ See Backward compatibility of agentic application templates for more context.
 
 ### A10. Changes to dr start
 
-Requires: PRODUCT and @Carson Gee sign-off, DOC ticket
+Requires: PRODUCT and @carsongee sign-off, DOC ticket
 
-dr start is the key part of UX of agentic starter application, and any changes to it have to be reviewed by PRODUCT ( @Nate Daly ). This includes direct changes to task start, and indirect changes:
+dr start is the key part of UX of agentic starter application, and any changes to it have to be reviewed by PRODUCT ( @dr-nate-daly-pm ). This includes direct changes to task start, and indirect changes:
 
 - new configuration options in agent or mcp (see Message from Anatolii Stehnii in #agentic-flow-dev for example)
 - Change to dr start logic in CLI itself
 
-Tired waiting review from @Carson Gee ? Try splitting your PR, and deliver critical changes separately!
+Tired waiting review from @carsongee ? Try splitting your PR, and deliver critical changes separately!
 
 We SHOULD BE mindful about the number of questions we are asking from users in components configuration, and try reducing them as much as possible. Related initiatives:
 
@@ -68,7 +68,7 @@ We SHOULD BE mindful about the number of questions we are asking from users in c
 
 ### A11. Adding or removing tasks in all components
 
-Requires: @Carson Gee sign-off, DOC review
+Requires: @carsongee sign-off, DOC review
 
 task is essentially our TUI, and we should be mindful adding or removing them as this may be just as disruptive as adding or removing GUI elements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.10
+- Updated cursorbot review instructions with correct names
+
 ## 0.6.9
 - Added cursorbot review instructions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.9"
+version = "0.6.10"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"


### PR DESCRIPTION
## Summary
- Replace display names with GitHub handles in BUGBOT.md stakeholder table and all @-mentions throughout the document

## Test plan
- [x] Verified all @-mentions are replaced with correct GitHub handles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates plus a patch version bump; no runtime code paths or dependencies are affected.
> 
> **Overview**
> Updates `.cursor/BUGBOT.md` to replace stakeholder display names with correct GitHub handles (including all related `@`-mentions).
> 
> Bumps the project version to `0.6.10` and adds a matching `CHANGELOG.md` entry describing the BugBot instruction update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7a9ee7b2e3c8cdc029b36ca1f604aec9683992d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->