### PR TITLE
[FIX] Add header to token candidate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.6.13
-- Add `x-datarobot-identity-token` to `HEADER_TOKEN_CANDIDATE_NAMES`
+- Added `x-datarobot-identity-token` to `HEADER_TOKEN_CANDIDATE_NAMES`
 
 ## 0.6.12
 - Add Mem0 for storing agent memory capabilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.13
+- Add `x-datarobot-identity-token` to `HEADER_TOKEN_CANDIDATE_NAMES`
+
 ## 0.6.11
 - Fixed AG-UI event serialization
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "DataRobot, Inc." }]
 dynamic = ["optional-dependencies"]
 
+# Optional dependencies (extras) are defined in setup.py
+
 [project.urls]
 Homepage = "https://github.com/datarobot-oss/datarobot-genai"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.11"
+version = "0.6.12"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.12"
+version = "0.6.13"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "DataRobot, Inc." }]
 dynamic = ["optional-dependencies"]
 
-# Optional dependencies (extras) are defined in setup.py
-dependencies = []
-
 [project.urls]
 Homepage = "https://github.com/datarobot-oss/datarobot-genai"
 

--- a/src/datarobot_genai/drmcp/core/clients.py
+++ b/src/datarobot_genai/drmcp/core/clients.py
@@ -94,6 +94,7 @@ HEADER_TOKEN_CANDIDATE_NAMES = [
     "authorization",
     "x-datarobot-api-token",
     "x-datarobot-api-key",
+    "x-datarobot-identity-token",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.12"
+version = "0.6.13"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.11"
+version = "0.6.12"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Update Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request token extraction by accepting an additional header value, which can affect authentication behavior. Change is small and additive, but should be validated across deployments to avoid token/precedence confusion.
> 
> **Overview**
> Adds support for authenticating requests via the `x-datarobot-identity-token` header by including it in `HEADER_TOKEN_CANDIDATE_NAMES` during token resolution.
> 
> Bumps package version to `0.6.13` and updates the changelog/lockfile accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3c7030905558cfc03eeba0121e5ec8aed76e489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->