### PR TITLE
[-] Add httpx and sseclient dependencies for nat dragent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.14
+- Added `sseclient-py` and `httpx` as a dependency for NAT mode
+
 ## 0.6.13
 - Added `x-datarobot-identity-token` to `HEADER_TOKEN_CANDIDATE_NAMES`
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -781,8 +781,8 @@ wheels = [
 ]
 
 [[package]]
-version = "0.6.11"
 name = "datarobot-genai"
+version = "0.6.14"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -872,6 +872,7 @@ nat = [
     { name = "crewai" },
     { name = "datarobot" },
     { name = "datarobot-predict" },
+    { name = "httpx" },
     { name = "llama-index-llms-litellm" },
     { name = "nvidia-nat" },
     { name = "nvidia-nat-a2a" },
@@ -940,6 +941,7 @@ requires-dist = [
     { name = "fastmcp", marker = "extra == 'drtools'", specifier = ">=2.13.0.2,<3.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
+    { name = "httpx", marker = "extra == 'nat'", specifier = ">=0.27.0,<1.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },
     { name = "langgraph-prebuilt", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -893,6 +893,7 @@ nat = [
     { name = "pyjwt" },
     { name = "ragas" },
     { name = "requests" },
+    { name = "sseclient-py" },
 ]
 
 [package.metadata]
@@ -1066,6 +1067,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'nat'", specifier = ">=2.32.4,<3.0.0" },
     { name = "requests", marker = "extra == 'pydanticai'", specifier = ">=2.32.4,<3.0.0" },
     { name = "rich", marker = "extra == 'drmcp'", specifier = ">=13.0.0,<16.0.0" },
+    { name = "sseclient-py", marker = "extra == 'nat'", specifier = ">=1.8.0,<2.0.0" },
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]
@@ -4909,6 +4911,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
+]
+
+[[package]]
+name = "sseclient-py"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/2e/59920f7d66b7f9932a3d83dd0ec53fab001be1e058bf582606fe414a5198/sseclient_py-1.9.0-py3-none-any.whl", hash = "sha256:340062b1587fc2880892811e2ab5b176d98ef3eee98b3672ff3a3ba1e8ed0f6f", size = 8351, upload-time = "2026-01-02T23:39:30.995Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.13"
+version = "0.6.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ nat = core + [
     "opentelemetry-instrumentation-langchain>=0.40.5,<1.0.0",
     "anyio==4.11.0",
     "httpx>=0.27.0,<1.0.0",
+    "sseclient-py>=1.8.0,<2.0.0",
 ]
 
 pydanticai = core + [

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ nat = core + [
     "opentelemetry-instrumentation-llamaindex>=0.40.5,<1.0.0",
     "opentelemetry-instrumentation-langchain>=0.40.5,<1.0.0",
     "anyio==4.11.0",
+    "httpx>=0.27.0,<1.0.0",
 ]
 
 pydanticai = core + [

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.13"
+version = "0.6.14"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1313,6 +1313,7 @@ nat = [
     { name = "crewai", marker = "python_full_version >= '3.11'" },
     { name = "datarobot" },
     { name = "datarobot-predict" },
+    { name = "httpx" },
     { name = "llama-index-llms-litellm" },
     { name = "nvidia-nat", marker = "python_full_version >= '3.11'" },
     { name = "nvidia-nat-a2a", marker = "python_full_version >= '3.11'" },
@@ -1411,6 +1412,7 @@ requires-dist = [
     { name = "fastmcp", marker = "extra == 'drtools'", specifier = ">=2.13.0.2,<3.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
+    { name = "httpx", marker = "extra == 'nat'", specifier = ">=0.27.0,<1.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },
     { name = "langgraph-prebuilt", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1334,6 +1334,7 @@ nat = [
     { name = "pyjwt" },
     { name = "ragas" },
     { name = "requests" },
+    { name = "sseclient-py" },
 ]
 pydanticai = [
     { name = "ag-ui-protocol" },
@@ -1537,6 +1538,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'nat'", specifier = ">=2.32.4,<3.0.0" },
     { name = "requests", marker = "extra == 'pydanticai'", specifier = ">=2.32.4,<3.0.0" },
     { name = "rich", marker = "extra == 'drmcp'", specifier = ">=13.0.0,<16.0.0" },
+    { name = "sseclient-py", marker = "extra == 'nat'", specifier = ">=1.8.0,<2.0.0" },
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]
@@ -7348,6 +7350,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
+]
+
+[[package]]
+name = "sseclient-py"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/2e/59920f7d66b7f9932a3d83dd0ec53fab001be1e058bf582606fe414a5198/sseclient_py-1.9.0-py3-none-any.whl", hash = "sha256:340062b1587fc2880892811e2ab5b176d98ef3eee98b3672ff3a3ba1e8ed0f6f", size = 8351, upload-time = "2026-01-02T23:39:30.995Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Update Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk packaging-only change: bumps version and adds dependencies for the `nat` extra, primarily impacting installation/lockfile resolution rather than runtime logic.
> 
> **Overview**
> Bumps `datarobot-genai` to **0.6.14** and documents the release in `CHANGELOG.md`.
> 
> Updates the `nat` optional dependency set to include `httpx` and `sseclient-py`, and refreshes both `uv.lock` and `e2e-tests/uv.lock` to reflect the new extras and pinned artifacts (including adding `sseclient-py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbdfa30c9b25070fc5c63d038e3595a589d639e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->