### PR TITLE
Fix dynamic tools and cli config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.14
+- Fix loading JSON schemas from the package directory in DRUM adapter to work from wheel or source
+- Fix dynamic tool deployment registration to filter deployments with `tool` tag name and value using strict AND logic
+- Fix configuration parsing to correctly disable predictive tools when `MCP_CLI_CONFIGS` is empty
+
 ## 0.6.13
 - Added `x-datarobot-identity-token` to `HEADER_TOKEN_CANDIDATE_NAMES`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.13"
+version = "0.6.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -30,7 +30,10 @@ dragent = "datarobot_genai.dragent.register"
 where = ["src"]
 
 [tool.setuptools.package-data]
-datarobot_genai = ["py.typed"]
+datarobot_genai = [
+    "py.typed",
+    "drmcp/core/dynamic_tools/deployment/schemas/*.json",
+]
 
 [tool.uv]
 package = true

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -337,15 +337,16 @@ class MCPServerConfig(BaseSettings):
         ),
         description="Enable/disable memory management",
     )
-    mcp_cli_configs: str = Field(
-        default="",
+    mcp_cli_configs: str | None = Field(
+        default=None,
         validation_alias=AliasChoices(
             RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "MCP_CLI_CONFIGS",
             "MCP_CLI_CONFIGS",
         ),
         description="Comma-separated list of features to enable: dynamic_tools, dynamic_prompts, "
         "predictive, gdrive, microsoft_graph, jira, confluence, perplexity, tavily. "
-        "Individual env vars (e.g. ENABLE_PREDICTIVE_TOOLS) take precedence when set.",
+        "When unset (None), defaults apply. When set to empty string, all listed features are "
+        "disabled. Individual env vars (e.g. ENABLE_PREDICTIVE_TOOLS) take precedence when set.",
     )
 
     tool_config: MCPToolConfig = Field(
@@ -413,11 +414,17 @@ def _individual_env_set_for_field(
 
 
 def _apply_mcp_cli_configs_overrides(config: MCPServerConfig) -> MCPServerConfig:
-    """Apply MCP_CLI_CONFIGS: listed options enabled; others disabled unless individual env set."""
-    raw = (config.mcp_cli_configs or "").strip()
-    if not raw:
+    """Apply MCP_CLI_CONFIGS from config: listed options enabled; others disabled
+    unless individual env set.
+
+    - If mcp_cli_configs is None (unset), do not apply overrides (defaults apply).
+    - If mcp_cli_configs is set but empty string, treat as disable all (enabled set is empty).
+    - If mcp_cli_configs is set and non-empty, parse comma list and apply as before.
+    """
+    if config.mcp_cli_configs is None:
         return config
-    enabled = {s.strip().lower() for s in raw.split(",") if s.strip()}
+    raw = (config.mcp_cli_configs or "").strip()
+    enabled = {s.strip().lower() for s in raw.split(",") if s.strip()} if raw else set()
     root_updates: dict[str, Any] = {}
     tool_updates: dict[str, Any] = {}
     for mcp_opt, root_attr, tool_attr in MCP_CLI_OPTS:

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/adapters/drum.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/adapters/drum.py
@@ -53,7 +53,7 @@ class DrumTargetType(str, Enum):
 
 def _load_schema_json(name: str) -> dict[str, Any]:
     """Load a JSON schema from the package schemas directory (works from wheel or source)."""
-    ref = importlib.resources.files(_DEPLOYMENT_PKG).joinpath("schemas", name)
+    ref = importlib.resources.files(_DEPLOYMENT_PKG).joinpath("schemas").joinpath(name)
     return json.loads(ref.read_text())
 
 

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/adapters/drum.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/adapters/drum.py
@@ -11,17 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import importlib.resources
 import json
 from enum import Enum
 from functools import lru_cache
-from pathlib import Path
 from typing import Any
 from typing import Literal
 
 from .base import MetadataBase
 
-# Path to the schemas directory
-SCHEMAS_DIR = Path(__file__).parent.parent / "schemas"
+_DEPLOYMENT_PKG = "datarobot_genai.drmcp.core.dynamic_tools.deployment"
 
 
 class DrumTargetType(str, Enum):
@@ -51,22 +51,22 @@ class DrumTargetType(str, Enum):
         }
 
 
+def _load_schema_json(name: str) -> dict[str, Any]:
+    """Load a JSON schema from the package schemas directory (works from wheel or source)."""
+    ref = importlib.resources.files(_DEPLOYMENT_PKG).joinpath("schemas", name)
+    return json.loads(ref.read_text())
+
+
 @lru_cache(maxsize=1)
 def _get_prediction_fallback_schema() -> dict[str, Any]:
     """Get the default prediction input schema for DRUM deployments."""
-    schema_path = SCHEMAS_DIR / "drum_prediction_fallback_schema.json"
-    with open(schema_path) as f:
-        schema: dict[str, Any] = json.load(f)
-        return schema
+    return _load_schema_json("drum_prediction_fallback_schema.json")
 
 
 @lru_cache(maxsize=1)
 def _get_agentic_fallback_schema() -> dict[str, Any]:
     """Get the default agentic workflow input schema for DRUM deployments."""
-    schema_path = SCHEMAS_DIR / "drum_agentic_fallback_schema.json"
-    with open(schema_path) as f:
-        schema: dict[str, Any] = json.load(f)
-        return schema
+    return _load_schema_json("drum_agentic_fallback_schema.json")
 
 
 def get_default_schema(target_type: str) -> dict[str, Any]:

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
@@ -84,4 +84,12 @@ def get_datarobot_tool_deployments() -> list[str]:
         client=get_api_client(),
     )
 
-    return [deployment["id"] for deployment in deployments_data]
+    # The API filters with OR logic for tags, so we need to filter for AND logic
+    valid_deployment_ids = []
+    for deployment in deployments_data:
+        for tag in deployment.get("tags", []):
+            if tag.get("name") == "tool" and tag.get("value") == "tool":
+                valid_deployment_ids.append(deployment["id"])
+                break
+
+    return valid_deployment_ids

--- a/tests/drmcp/unit/dynamic_tools/test_adapters.py
+++ b/tests/drmcp/unit/dynamic_tools/test_adapters.py
@@ -169,6 +169,18 @@ class TestDrumMetadataAdapter:
         assert "type" in drum_adapter.input_schema
         assert "properties" in drum_adapter.input_schema
 
+    def test_drum_adapter_agentic_workflow_fallback_schema(self, drum_metadata_unstructured):
+        """Test fallback schema for agentic_workflow target type."""
+        drum_metadata_unstructured["target_type"] = "agenticworkflow"
+        del drum_metadata_unstructured["model_metadata"]["input_schema"]
+
+        adapter = DrumMetadataAdapter.from_deployment_metadata(drum_metadata_unstructured)
+        schema = adapter.input_schema
+        assert schema is not None
+        assert "type" in schema
+        assert schema["type"] == "object"
+        assert "properties" in schema
+
     def test_drum_adapter_headers_are_empty(self, drum_adapter):
         """Test that DRUM deployments have Content-Type header."""
         assert drum_adapter.headers == {}

--- a/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
+++ b/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
@@ -1,0 +1,69 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
+    get_datarobot_tool_deployments,
+)
+
+
+@patch("datarobot_genai.drmcp.core.dynamic_tools.deployment.register.get_api_client")
+@patch("datarobot_genai.drmcp.core.dynamic_tools.deployment.register.dr")
+def test_get_datarobot_tool_deployments_filters_tags_correctly(mock_dr, mock_get_api_client):
+    """Test get_datarobot_tool_deployments accurately filters tags with AND logic."""
+    mock_deployments_data = [
+        # Should be included (has name="tool" and value="tool")
+        {
+            "id": "deployment_1",
+            "tags": [{"name": "tool", "value": "tool"}, {"name": "other", "value": "other"}],
+        },
+        # Should be excluded (has name="tool", but value="MCP")
+        {
+            "id": "deployment_2",
+            "tags": [{"name": "tool", "value": "MCP"}],
+        },
+        # Should be excluded (no tags)
+        {
+            "id": "deployment_3",
+            "tags": [],
+        },
+        # Should be excluded (no 'tags' key)
+        {
+            "id": "deployment_4",
+        },
+        # Should be included (has name="tool" and value="tool" in a different position)
+        {
+            "id": "deployment_5",
+            "tags": [{"name": "something", "value": "else"}, {"name": "tool", "value": "tool"}],
+        },
+        # Should be excluded (name="other", value="tool")
+        {
+            "id": "deployment_6",
+            "tags": [{"name": "other", "value": "tool"}],
+        },
+    ]
+
+    mock_dr.utils.pagination.unpaginate.return_value = mock_deployments_data
+
+    result = get_datarobot_tool_deployments()
+
+    # It calls dr.utils.pagination.unpaginate with exactly these parameters
+    mock_dr.utils.pagination.unpaginate.assert_called_once_with(
+        initial_url="deployments/",
+        initial_params={"tag_values": "tool", "tag_keys": "tool"},
+        client=mock_get_api_client(),
+    )
+
+    assert result == ["deployment_1", "deployment_5"]

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -263,7 +263,7 @@ class TestMCPCLIConfigs:
         with patch.dict(os.environ, {}, clear=True):
             self._reset_config()
             config = get_config()
-            assert config.mcp_cli_configs == ""
+            assert config.mcp_cli_configs is None
             assert config.mcp_server_register_dynamic_tools_on_startup is False
             assert config.mcp_server_register_dynamic_prompts_on_startup is False
             assert config.tool_config.enable_predictive_tools is True
@@ -276,12 +276,12 @@ class TestMCPCLIConfigs:
             self._reset_config()
 
     def test_no_mcp_cli_configs_empty(self) -> None:
-        """When MCP_CLI_CONFIGS is empty string, no overrides."""
+        """When MCP_CLI_CONFIGS is empty string, all listed features are disabled."""
         with patch.dict(os.environ, {"MCP_CLI_CONFIGS": ""}, clear=True):
             self._reset_config()
             config = get_config()
             assert config.mcp_server_register_dynamic_tools_on_startup is False
-            assert config.tool_config.enable_predictive_tools is True
+            assert config.tool_config.enable_predictive_tools is False
             assert config.tool_config.enable_gdrive_tools is False
             assert config.tool_config.enable_jira_tools is False
             assert config.tool_config.enable_confluence_tools is False

--- a/uv.lock
+++ b/uv.lock
@@ -1154,7 +1154,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.13"
+version = "0.6.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Fix loading JSON schemas from the package directory in DRUM adapter to work from wheel or source
- Fix dynamic tool deployment registration to filter deployments with `tool` tag name and value using strict AND logic
- Fix configuration parsing to correctly disable predictive tools when `MCP_CLI_CONFIGS` is empty

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Update Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in config parsing and deployment selection can alter which tools/features enable at runtime, potentially impacting startup behavior in existing environments.
> 
> **Overview**
> Bumps version to `0.6.14` and ensures DRUM fallback JSON schemas are loadable from installed wheels by packaging `schemas/*.json` and switching schema reads to `importlib.resources`.
> 
> Adjusts `MCP_CLI_CONFIGS` handling so **unset (`None`) means no overrides**, while an **explicit empty string disables all listed features** (including predictive tools), and updates tests accordingly.
> 
> Fixes dynamic tool auto-discovery to filter deployments using strict AND logic on tags (must include `name="tool"` and `value="tool"`), with a new unit test covering tag-filter behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5d09e2504f13ba5da410f0c42aaf3bb98fc4ebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->