### PR TITLE
[MODEL-22732] Align MCP telemetry with OTel semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.16
+- Align MCP OpenTelemetry spans with OTel semantic conventions.
+
 ## 0.6.15
 - Added Agent2Agent (A2A) server endpoints to `DRAgentFastApiFrontEndPluginWorker`, mounted at `/a2a`.
 - Extended DRAgentFastApiFrontEndConfig with configuration options for the A2A server.
 - A2A endpoints can be enabled by the `expose_a2a_server_endpoints` setting in the workflow.yaml file.
 - Added per_user_tool_calling_agent workflow type
 - Fixed `ToolCallArgsEvent.delta` encoding
-- Align MCP OpenTelemetry spans with OTel semantic conventions.
 
 ## 0.6.14
 - Fix loading JSON schemas from the package directory in DRUM adapter to work from wheel or source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - A2A endpoints can be enabled by the `expose_a2a_server_endpoints` setting in the workflow.yaml file.
 - Added per_user_tool_calling_agent workflow type
 - Fixed `ToolCallArgsEvent.delta` encoding
-
+- Align MCP OpenTelemetry spans with OTel semantic conventions.
 
 ## 0.6.14
 - Fix loading JSON schemas from the package directory in DRUM adapter to work from wheel or source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.15"
+version = "0.6.16"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/drmcp/core/telemetry.py
+++ b/src/datarobot_genai/drmcp/core/telemetry.py
@@ -64,7 +64,7 @@ def _serialize_tool_arguments(value: Any) -> str:
     """Serialize tool call arguments as JSON per OTel convention."""
     if isinstance(value, Mapping) and not isinstance(value, str):
         return json.dumps(dict(value))
-    if isinstance(value, (dict, list)):
+    if isinstance(value, list):
         return json.dumps(value)
     return str(value)
 
@@ -93,7 +93,7 @@ class OpenTelemetryMiddleware(Middleware):
     async def on_request(self, context: MiddlewareContext, call_next: CallNext[Any, Any]) -> Any:
         with tracer.start_as_current_span(
             f"mcp.request.{context.method}",
-            kind=SpanKind.CLIENT,
+            kind=SpanKind.SERVER,
         ) as span:
             span.set_attribute("mcp.method.name", context.method or "")
             try:
@@ -113,7 +113,7 @@ class OpenTelemetryMiddleware(Middleware):
 
         with self.tracer.start_as_current_span(
             f"tool.{tool_name}",
-            kind=SpanKind.CLIENT,
+            kind=SpanKind.SERVER,
         ) as span:
             span.set_attributes(
                 {

--- a/src/datarobot_genai/drmcp/core/telemetry.py
+++ b/src/datarobot_genai/drmcp/core/telemetry.py
@@ -59,6 +59,16 @@ from starlette.responses import Response
 from .config import get_config
 from .credentials import get_credentials
 
+
+def _serialize_tool_arguments(value: Any) -> str:
+    """Serialize tool call arguments as JSON per OTel convention."""
+    if isinstance(value, Mapping) and not isinstance(value, str):
+        return json.dumps(dict(value))
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return str(value)
+
+
 root_logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
@@ -108,7 +118,9 @@ class OpenTelemetryMiddleware(Middleware):
             span.set_attributes(
                 {
                     "gen_ai.tool.name": tool_name,
-                    "gen_ai.tool.call.arguments": str(context.message.arguments),
+                    "gen_ai.tool.call.arguments": _serialize_tool_arguments(
+                        context.message.arguments
+                    ),
                     "gen_ai.operation.name": "execute_tool",
                     "mcp.method.name": "tools/call",
                 }
@@ -295,7 +307,11 @@ def initialize_telemetry(mcp: FastMCP) -> None:
 
 
 def _add_parameters_to_span(
-    span: Span, func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
+    span: Span,
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    trace_type: str = "tool",
 ) -> None:
     """Add function parameters as span attributes.
 
@@ -325,7 +341,7 @@ def _add_parameters_to_span(
             span.set_attribute(f"tool.param.{name}", value)
             arguments[name] = value
 
-    if arguments:
+    if arguments and trace_type == "tool":
         span.set_attribute("gen_ai.tool.call.arguments", json.dumps(arguments))
 
 
@@ -387,15 +403,16 @@ def trace_execution(trace_name: str | None = None, trace_type: str = "tool") -> 
             tracer = trace.get_tracer(__name__)
             span = tracer.start_span(f"{trace_type}.{span_name}")
 
-            # Add standard attributes
-            span.set_attribute("gen_ai.tool.name", span_name)
+            # Add standard attributes: tool-specific only when trace_type is "tool"
             if trace_type == "tool":
+                span.set_attribute("gen_ai.tool.name", span_name)
                 span.set_attribute("gen_ai.operation.name", "execute_tool")
             else:
                 span.set_attribute("gen_ai.operation.name", trace_type)
+                span.set_attribute(f"{trace_type}.name", span_name)
 
             # Add tool parameters as span attributes
-            _add_parameters_to_span(span, func, args, kwargs)
+            _add_parameters_to_span(span, func, args, kwargs, trace_type)
 
             # Add configured attributes from config
             config = get_config()

--- a/src/datarobot_genai/drmcp/core/telemetry.py
+++ b/src/datarobot_genai/drmcp/core/telemetry.py
@@ -14,6 +14,7 @@
 
 import functools
 import inspect
+import json
 import logging
 import os
 from collections.abc import Callable
@@ -46,6 +47,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import Span
 from opentelemetry.trace import SpanContext
+from opentelemetry.trace import SpanKind
 from opentelemetry.trace import Status
 from opentelemetry.trace import StatusCode
 from opentelemetry.trace import format_trace_id
@@ -79,14 +81,16 @@ class OpenTelemetryMiddleware(Middleware):
         self.tracer = trace.get_tracer(tracer_name)
 
     async def on_request(self, context: MiddlewareContext, call_next: CallNext[Any, Any]) -> Any:
-        with tracer.start_as_current_span(f"mcp.request.{context.method}") as span:
-            span.set_attribute("mcp.source", context.source)
-            span.set_attribute("mcp.type", context.type)
-            span.set_attribute("mcp.method", context.method or "")
+        with tracer.start_as_current_span(
+            f"mcp.request.{context.method}",
+            kind=SpanKind.CLIENT,
+        ) as span:
+            span.set_attribute("mcp.method.name", context.method or "")
             try:
                 result = await call_next(context)
                 span.set_status(Status(StatusCode.OK))
             except Exception as e:
+                span.set_attribute("error.type", type(e).__name__)
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 span.record_exception(e)
                 raise
@@ -97,25 +101,25 @@ class OpenTelemetryMiddleware(Middleware):
     ) -> ToolResult:
         tool_name = context.message.name
 
-        with self.tracer.start_as_current_span(f"tool.{tool_name}") as span:
+        with self.tracer.start_as_current_span(
+            f"tool.{tool_name}",
+            kind=SpanKind.CLIENT,
+        ) as span:
             span.set_attributes(
                 {
-                    "mcp.tool.name": tool_name,
-                    "mcp.tool.arguments": str(context.message.arguments),
+                    "gen_ai.tool.name": tool_name,
+                    "gen_ai.tool.call.arguments": str(context.message.arguments),
+                    "gen_ai.operation.name": "execute_tool",
+                    "mcp.method.name": "tools/call",
                 }
             )
             try:
                 result = await call_next(context)
-                span.set_attribute("mcp.tool.success", True)
-                if hasattr(result, "content"):
-                    span.set_attribute("mcp.tool.content_length", len(str(result.content)))
-
                 span.set_status(Status(StatusCode.OK))
                 return result
 
             except Exception as e:
-                span.set_attribute("mcp.tool.success", False)
-                span.set_attribute("mcp.tool.error", str(e))
+                span.set_attribute("error.type", type(e).__name__)
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 span.record_exception(e)
                 raise
@@ -307,15 +311,22 @@ def _add_parameters_to_span(
     param_names = param_names[start_idx:]
     args = args[start_idx:]
 
+    arguments: dict[str, Any] = {}
+
     # Add positional arguments
     for name, value in zip(param_names, args):
         if isinstance(value, (str, int, float, bool)):
             span.set_attribute(f"tool.param.{name}", value)
+            arguments[name] = value
 
     # Add keyword arguments
     for name, value in kwargs.items():
         if isinstance(value, (str, int, float, bool)):
             span.set_attribute(f"tool.param.{name}", value)
+            arguments[name] = value
+
+    if arguments:
+        span.set_attribute("gen_ai.tool.call.arguments", json.dumps(arguments))
 
 
 def get_trace_id() -> str | None:
@@ -377,8 +388,11 @@ def trace_execution(trace_name: str | None = None, trace_type: str = "tool") -> 
             span = tracer.start_span(f"{trace_type}.{span_name}")
 
             # Add standard attributes
-            span.set_attribute("mcp.type", trace_type)
-            span.set_attribute(f"{trace_type}.name", span_name)
+            span.set_attribute("gen_ai.tool.name", span_name)
+            if trace_type == "tool":
+                span.set_attribute("gen_ai.operation.name", "execute_tool")
+            else:
+                span.set_attribute("gen_ai.operation.name", trace_type)
 
             # Add tool parameters as span attributes
             _add_parameters_to_span(span, func, args, kwargs)
@@ -395,10 +409,11 @@ def trace_execution(trace_name: str | None = None, trace_type: str = "tool") -> 
             span = _create_span_for_tool(trace_name, trace_type, args, kwargs)
             try:
                 result = await func(*args, **kwargs)
-                span.set_attribute(f"{trace_type}.success", True)
+                span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:
-                span.set_attribute(f"{trace_type}.success", False)
+                span.set_attribute("error.type", type(e).__name__)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
                 span.record_exception(e)
                 raise e
             finally:
@@ -409,10 +424,11 @@ def trace_execution(trace_name: str | None = None, trace_type: str = "tool") -> 
             span = _create_span_for_tool(trace_name, trace_type, args, kwargs)
             try:
                 result = func(*args, **kwargs)
-                span.set_attribute(f"{trace_type}.success", True)
+                span.set_status(Status(StatusCode.OK))
                 return result
             except Exception as e:
-                span.set_attribute(f"{trace_type}.success", False)
+                span.set_attribute("error.type", type(e).__name__)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
                 span.record_exception(e)
                 raise e
             finally:

--- a/tests/drmcp/unit/test_telemetry.py
+++ b/tests/drmcp/unit/test_telemetry.py
@@ -123,9 +123,7 @@ def test_trace_execution_sync() -> None:
         mock_span.set_attribute.assert_any_call("gen_ai.operation.name", "execute_tool")
         mock_span.set_attribute.assert_any_call("tool.param.param1", "test")
         mock_span.set_attributes.assert_any_call({"custom.attr": "test-value"})
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.tool.call.arguments", '{"param1": "test"}'
-        )
+        mock_span.set_attribute.assert_any_call("gen_ai.tool.call.arguments", '{"param1": "test"}')
         mock_span.set_status.assert_called()
 
 

--- a/tests/drmcp/unit/test_telemetry.py
+++ b/tests/drmcp/unit/test_telemetry.py
@@ -88,12 +88,15 @@ async def test_trace_execution_async() -> None:
         result = await test_async_function("test", 123)
 
         assert result == "test-123"
-        mock_span.set_attribute.assert_any_call("mcp.type", "tool")
-        mock_span.set_attribute.assert_any_call("tool.name", "test_tool")
+        mock_span.set_attribute.assert_any_call("gen_ai.tool.name", "test_tool")
+        mock_span.set_attribute.assert_any_call("gen_ai.operation.name", "execute_tool")
         mock_span.set_attribute.assert_any_call("tool.param.param1", "test")
         mock_span.set_attributes.assert_any_call({"custom.attr": "test-value"})
         mock_span.set_attribute.assert_any_call("tool.param.param2", 123)
-        mock_span.set_attribute.assert_any_call("tool.success", True)
+        mock_span.set_attribute.assert_any_call(
+            "gen_ai.tool.call.arguments", '{"param1": "test", "param2": 123}'
+        )
+        mock_span.set_status.assert_called()
 
 
 def test_trace_execution_sync() -> None:
@@ -116,11 +119,14 @@ def test_trace_execution_sync() -> None:
         result = test_sync_function("test")
 
         assert result == "result-test"
-        mock_span.set_attribute.assert_any_call("mcp.type", "tool")
-        mock_span.set_attribute.assert_any_call("tool.name", "test_sync_function")
+        mock_span.set_attribute.assert_any_call("gen_ai.tool.name", "test_sync_function")
+        mock_span.set_attribute.assert_any_call("gen_ai.operation.name", "execute_tool")
         mock_span.set_attribute.assert_any_call("tool.param.param1", "test")
         mock_span.set_attributes.assert_any_call({"custom.attr": "test-value"})
-        mock_span.set_attribute.assert_any_call("tool.success", True)
+        mock_span.set_attribute.assert_any_call(
+            "gen_ai.tool.call.arguments", '{"param1": "test"}'
+        )
+        mock_span.set_status.assert_called()
 
 
 def test_get_trace_id() -> None:
@@ -253,7 +259,7 @@ class TestOpenTelemetryMiddleware:
             await middleware.on_request(mock_context, mock_call_next)
 
         mock_tracer.start_as_current_span.assert_called_once()
-        mock_span.set_attribute.assert_called()
+        mock_span.set_attribute.assert_any_call("error.type", "Exception")
         mock_span.record_exception.assert_called_once()
         mock_span.set_status.assert_called_once()
 
@@ -285,7 +291,6 @@ class TestOpenTelemetryMiddleware:
         assert result == mock_response
         middleware.tracer.start_as_current_span.assert_called_once()
         mock_span.set_attributes.assert_called_once()
-        mock_span.set_attribute.assert_called()
         mock_span.set_status.assert_called_once()
 
     @pytest.mark.asyncio
@@ -344,6 +349,6 @@ class TestOpenTelemetryMiddleware:
 
         middleware.tracer.start_as_current_span.assert_called_once()
         mock_span.set_attributes.assert_called_once()
-        mock_span.set_attribute.assert_called()
+        mock_span.set_attribute.assert_any_call("error.type", "Exception")
         mock_span.record_exception.assert_called_once()
         mock_span.set_status.assert_called_once()


### PR DESCRIPTION
Use OpenTelemetry MCP/GenAI semantic convention attributes for tool spans.

**on_request**
- `mcp.method` → `mcp.method.name`
- Remove `mcp.source`, `mcp.type` (redundant with span kind / method name)
- Set span kind to SERVER (this is server-side middleware handling incoming requests); set `error.type` on failure

**on_call_tool**
- `mcp.tool.name` → `gen_ai.tool.name`
- `mcp.tool.arguments` → `gen_ai.tool.call.arguments`
- Add `gen_ai.operation.name` = execute_tool, `mcp.method.name` = tools/call
- Remove `mcp.tool.success`, `mcp.tool.content_length`, `mcp.tool.error` (use span status and `error.type`)
- Set span kind to SERVER (server-side middleware processing incoming tool calls)

**trace_execution decorator**
- `mcp.type` / `tool.name` → `gen_ai.operation.name`, `gen_ai.tool.name`
- `tool.success` → `span.set_status(StatusCode.OK/ERROR)`
- Add `gen_ai.tool.call.arguments` (JSON) alongside `tool.param.*`

Ref: https://datarobot.atlassian.net/browse/MODEL-22732
OTel spec: https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/