### PR TITLE
[BUZZOK-29403] Allow per_user NAT workflows to expose A2A endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.18
+- Enable A2A endpoints for per-user workflows with configurable skills via `DRAgentA2AConfig`
+- **Breaking**: `DRAgentFastApiFrontEndConfig.a2a` type changed from `A2AFrontEndConfig` to `DRAgentA2AConfig`; update `workflow.yaml` by nesting the existing A2A fields under `server:`
+
 ## 0.6.17
 - Fixed CVE-2026-25580: removed unused `pydantic-ai-slim` dependency and `pydanticai` install extra
 - Added e2e tests for dragent server covering streaming, tool use, and MCP integration
@@ -15,7 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.6.15
 - Added Agent2Agent (A2A) server endpoints to `DRAgentFastApiFrontEndPluginWorker`, mounted at `/a2a`.
 - Extended DRAgentFastApiFrontEndConfig with configuration options for the A2A server.
-- A2A endpoints can be enabled by the `expose_a2a_server_endpoints` setting in the workflow.yaml file.
 - Added per_user_tool_calling_agent workflow type
 - Fixed `ToolCallArgsEvent.delta` encoding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.6.18
+## 0.6.19
 - Enable A2A endpoints for per-user workflows with configurable skills via `DRAgentA2AConfig`
 - **Breaking**: `DRAgentFastApiFrontEndConfig.a2a` type changed from `A2AFrontEndConfig` to `DRAgentA2AConfig`; update `workflow.yaml` by nesting the existing A2A fields under `server:`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.18"
+version = "0.6.19"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/dragent/converters.py
+++ b/src/datarobot_genai/dragent/converters.py
@@ -17,6 +17,7 @@ import uuid
 
 from ag_ui.core import RunAgentInput
 from ag_ui.core import TextMessageChunkEvent
+from ag_ui.core import TextMessageContentEvent
 from langchain_core.messages import ToolMessage
 from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatRequestOrMessage
@@ -92,3 +93,18 @@ def convert_str_to_dragent_event_response(
 
 def convert_tool_message_to_str(message: ToolMessage) -> str:
     return message.content
+
+
+def aggregate_dragent_event_responses(
+    responses: list[DRAgentEventResponse],
+) -> DRAgentEventResponse:
+    all_events = [event for response in responses for event in response.events]
+    return DRAgentEventResponse(events=all_events)
+
+
+def convert_dragent_event_response_to_str(response: DRAgentEventResponse) -> str:
+    return "".join(
+        event.delta
+        for event in response.events
+        if isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent))
+    )

--- a/src/datarobot_genai/dragent/frontserver.py
+++ b/src/datarobot_genai/dragent/frontserver.py
@@ -103,6 +103,18 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             security_schemes, security = await self._a2a_worker._generate_security_schemes(
                 frontend_config.server_auth
             )
+        if self.front_end_config.a2a.skills:
+            skills = self.front_end_config.a2a.skills
+        else:
+            skills = [
+                AgentSkill(
+                    id="call",
+                    name=frontend_config.name,
+                    description=frontend_config.description,
+                    tags=[],
+                    examples=[],
+                )
+            ]
         agent_card = AgentCard(
             name=frontend_config.name,
             description=frontend_config.description,
@@ -114,16 +126,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
                 streaming=frontend_config.capabilities.streaming,
                 push_notifications=frontend_config.capabilities.push_notifications,
             ),
-            skills=list(self.front_end_config.a2a.skills)
-            or [
-                AgentSkill(
-                    id="call",
-                    name=frontend_config.name,
-                    description=frontend_config.description,
-                    tags=[],
-                    examples=[],
-                )
-            ],
+            skills=skills,
             security_schemes=security_schemes,
             security=security,
         )

--- a/src/datarobot_genai/dragent/frontserver.py
+++ b/src/datarobot_genai/dragent/frontserver.py
@@ -22,6 +22,9 @@ from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugi
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
+from a2a.server.agent_execution import RequestContext
+from a2a.server.events import EventQueue
+from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
 from nat.runtime.loader import WorkflowBuilder
 from pydantic import BaseModel
@@ -33,6 +36,39 @@ from datarobot_genai.dragent.step_adaptor import DRAgentNestedReasoningStepAdapt
 DATAROBOT_EXPECTED_HEALTH_ROUTES = ["/", "/ping", "/ping/", "/health", "/health/"]
 
 logger = logging.getLogger(__name__)
+
+
+class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
+    """Subclass of NATWorkflowAgentExecutor that supports per-user workflows.
+
+    Two problems with the parent class for per-user workflows:
+
+    1. ``__init__`` accesses ``session_manager.workflow`` which raises ``ValueError``
+       for per-user workflows.  We bypass it and log via ``config.workflow.type`` instead.
+
+    2. ``execute`` calls ``self.session_manager.session()`` with no ``user_id``, which
+       raises ``ValueError`` for per-user workflows.  We override it to pass the A2A
+       ``context_id`` as the ``user_id``, giving each conversation its own isolated
+       per-user workflow instance.
+    """
+
+    def __init__(self, session_manager: SessionManager) -> None:
+        # Bypass parent __init__ to avoid session_manager.workflow access,
+        # which raises ValueError for per-user workflows. Log via config instead.
+        self.session_manager = session_manager
+        logger.info(
+            "Initialized NATWorkflowAgentExecutor (message-only) for workflow: %s",
+            session_manager.config.workflow.type,
+        )
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:  # type: ignore[override]
+        # Inject the A2A context_id as user_id before delegating to the parent execute.
+        # The parent calls self.session_manager.session() with no user_id, which raises
+        # ValueError for per-user workflows.  Setting the context var here means the
+        # SessionManager's _get_user_id_from_context() will find it automatically.
+        if context.context_id:
+            self.session_manager._context_state.user_id.set(context.context_id)
+        await super().execute(context, event_queue)
 
 
 class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
@@ -76,13 +112,11 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             logger.info("A2A server endpoints are disabled")
             return
 
-        workflow = await builder.build()
-
         # A2AFrontEndPluginWorker reads config.general.front_end to get its front_end_config.
         # We must pass it a full Config with the A2AFrontEndConfig substituted in.
         # We also inherit host/port from the FastAPI config so the agent card URL is gets mounted
         # under the correct endpoint.
-        a2a_config = self.front_end_config.a2a.model_copy(
+        a2a_config = self.front_end_config.a2a.server.model_copy(
             update={"host": self.front_end_config.host, "port": self.front_end_config.port}
         )
         nat_config = self._config.model_copy(
@@ -90,12 +124,61 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         )
         self._a2a_worker = A2AFrontEndPluginWorker(nat_config)
 
-        agent_card = await self._a2a_worker.create_agent_card(workflow)
+        from a2a.types import AgentCapabilities
+        from a2a.types import AgentCard
+        from a2a.types import AgentSkill
+
+        cfg = self._a2a_worker.front_end_config
+        security_schemes = None
+        security = None
+        if cfg.server_auth:
+            security_schemes, security = await self._a2a_worker._generate_security_schemes(
+                cfg.server_auth
+            )
+        agent_card = AgentCard(
+            name=cfg.name,
+            description=cfg.description,
+            url=f"http://{cfg.host}:{cfg.port}/",
+            version=cfg.version,
+            default_input_modes=cfg.default_input_modes,
+            default_output_modes=cfg.default_output_modes,
+            capabilities=AgentCapabilities(
+                streaming=cfg.capabilities.streaming,
+                push_notifications=cfg.capabilities.push_notifications,
+            ),
+            skills=[
+                AgentSkill(
+                    id=s.id,
+                    name=s.name,
+                    description=s.description,
+                    tags=s.tags,
+                    examples=s.examples,
+                )
+                for s in self.front_end_config.a2a.skills
+            ]
+            or [
+                AgentSkill(
+                    id="call",
+                    name=cfg.name,
+                    description=cfg.description,
+                    tags=[],
+                    examples=[],
+                )
+            ],
+            security_schemes=security_schemes,
+            security=security,
+        )
+        session_manager = await SessionManager.create(
+            config=self._config,
+            shared_builder=builder,
+            max_concurrency=self._a2a_worker.max_concurrency,
+        )
+        agent_executor = _PerUserCompatibleAgentExecutor(session_manager)
+
         # TODO: A newer NAT version adds `public_base_url` to `A2AFrontEndConfig`, which would
         # let us set the public URL directly in the config instead of replacing it here.
         # Once we upgrade NAT, replace _get_a2a_endpoint_url with public_base_url.
         agent_card.url = self._get_a2a_endpoint_url(agent_card.url)
-        agent_executor = self._a2a_worker.create_agent_executor(workflow, builder)
         a2a_server = self._a2a_worker.create_a2a_server(agent_card, agent_executor)
 
         a2a_app = a2a_server.build()

--- a/src/datarobot_genai/dragent/frontserver.py
+++ b/src/datarobot_genai/dragent/frontserver.py
@@ -17,14 +17,18 @@ import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+from a2a.server.agent_execution import RequestContext
+from a2a.server.events import EventQueue
+from a2a.types import AgentCapabilities
+from a2a.types import AgentCard
+from a2a.types import AgentSkill
 from fastapi import FastAPI
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
-from a2a.server.agent_execution import RequestContext
-from a2a.server.events import EventQueue
 from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
+from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
 from nat.runtime.loader import WorkflowBuilder
 from pydantic import BaseModel
@@ -34,6 +38,7 @@ from datarobot_genai.dragent.session import DRAgentAGUISessionManager
 from datarobot_genai.dragent.step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 DATAROBOT_EXPECTED_HEALTH_ROUTES = ["/", "/ping", "/ping/", "/health", "/health/"]
+A2A_MOUNT_PATH = "a2a"
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +95,41 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         return sm
 
-    def _get_a2a_endpoint_url(self, default_url: str) -> str:
+    async def _create_agent_card(self, frontend_config: A2AFrontEndConfig) -> AgentCard:
+        assert self._a2a_worker is not None
+        security_schemes = None
+        security = None
+        if frontend_config.server_auth:
+            security_schemes, security = await self._a2a_worker._generate_security_schemes(
+                frontend_config.server_auth
+            )
+        agent_card = AgentCard(
+            name=frontend_config.name,
+            description=frontend_config.description,
+            url=self._get_a2a_endpoint_url(frontend_config),
+            version=frontend_config.version,
+            default_input_modes=frontend_config.default_input_modes,
+            default_output_modes=frontend_config.default_output_modes,
+            capabilities=AgentCapabilities(
+                streaming=frontend_config.capabilities.streaming,
+                push_notifications=frontend_config.capabilities.push_notifications,
+            ),
+            skills=list(self.front_end_config.a2a.skills)
+            or [
+                AgentSkill(
+                    id="call",
+                    name=frontend_config.name,
+                    description=frontend_config.description,
+                    tags=[],
+                    examples=[],
+                )
+            ],
+            security_schemes=security_schemes,
+            security=security,
+        )
+        return agent_card
+
+    def _get_a2a_endpoint_url(self, frontend_config: A2AFrontEndConfig) -> str:
         """Construct the A2A endpoint URL.
 
         In a DataRobot deployment, uses the deployment's direct access URL.
@@ -102,8 +141,8 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             if not datarobot_endpoint:
                 raise ValueError("DATAROBOT_ENDPOINT must be set when MLOPS_DEPLOYMENT_ID is set")
             base = datarobot_endpoint.rstrip("/")
-            return f"{base}/deployments/{mlops_deployment_id}/directAccess/a2a/"
-        return default_url.rstrip("/") + "/a2a/"
+            return f"{base}/deployments/{mlops_deployment_id}/directAccess/{A2A_MOUNT_PATH}/"
+        return f"http://{frontend_config.host}:{frontend_config.port}/{A2A_MOUNT_PATH}/"
 
     async def add_routes(self, app: FastAPI, builder: WorkflowBuilder) -> None:
         await super().add_routes(app, builder)
@@ -124,50 +163,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         )
         self._a2a_worker = A2AFrontEndPluginWorker(nat_config)
 
-        from a2a.types import AgentCapabilities
-        from a2a.types import AgentCard
-        from a2a.types import AgentSkill
-
-        cfg = self._a2a_worker.front_end_config
-        security_schemes = None
-        security = None
-        if cfg.server_auth:
-            security_schemes, security = await self._a2a_worker._generate_security_schemes(
-                cfg.server_auth
-            )
-        agent_card = AgentCard(
-            name=cfg.name,
-            description=cfg.description,
-            url=f"http://{cfg.host}:{cfg.port}/",
-            version=cfg.version,
-            default_input_modes=cfg.default_input_modes,
-            default_output_modes=cfg.default_output_modes,
-            capabilities=AgentCapabilities(
-                streaming=cfg.capabilities.streaming,
-                push_notifications=cfg.capabilities.push_notifications,
-            ),
-            skills=[
-                AgentSkill(
-                    id=s.id,
-                    name=s.name,
-                    description=s.description,
-                    tags=s.tags,
-                    examples=s.examples,
-                )
-                for s in self.front_end_config.a2a.skills
-            ]
-            or [
-                AgentSkill(
-                    id="call",
-                    name=cfg.name,
-                    description=cfg.description,
-                    tags=[],
-                    examples=[],
-                )
-            ],
-            security_schemes=security_schemes,
-            security=security,
-        )
+        agent_card = await self._create_agent_card(self._a2a_worker.front_end_config)
         session_manager = await SessionManager.create(
             config=self._config,
             shared_builder=builder,
@@ -175,14 +171,10 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         )
         agent_executor = _PerUserCompatibleAgentExecutor(session_manager)
 
-        # TODO: A newer NAT version adds `public_base_url` to `A2AFrontEndConfig`, which would
-        # let us set the public URL directly in the config instead of replacing it here.
-        # Once we upgrade NAT, replace _get_a2a_endpoint_url with public_base_url.
-        agent_card.url = self._get_a2a_endpoint_url(agent_card.url)
         a2a_server = self._a2a_worker.create_a2a_server(agent_card, agent_executor)
-
         a2a_app = a2a_server.build()
-        app.mount("/a2a", a2a_app)
+
+        app.mount(f"/{A2A_MOUNT_PATH}", a2a_app)
 
         logger.info(f"A2A endpoint URL: {agent_card.url}")
         logger.info(f"A2A agent card URL: {agent_card.url}.well-known/agent-card.json")

--- a/src/datarobot_genai/dragent/frontserver.py
+++ b/src/datarobot_genai/dragent/frontserver.py
@@ -172,6 +172,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             shared_builder=builder,
             max_concurrency=self._a2a_worker.max_concurrency,
         )
+        self._session_managers.append(session_manager)
         agent_executor = _PerUserCompatibleAgentExecutor(session_manager)
 
         a2a_server = self._a2a_worker.create_a2a_server(agent_card, agent_executor)

--- a/src/datarobot_genai/dragent/frontserver.py
+++ b/src/datarobot_genai/dragent/frontserver.py
@@ -71,9 +71,14 @@ class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
         # The parent calls self.session_manager.session() with no user_id, which raises
         # ValueError for per-user workflows.  Setting the context var here means the
         # SessionManager's _get_user_id_from_context() will find it automatically.
+        token = None
         if context.context_id:
-            self.session_manager._context_state.user_id.set(context.context_id)
-        await super().execute(context, event_queue)
+            token = self.session_manager._context_state.user_id.set(context.context_id)
+        try:
+            await super().execute(context, event_queue)
+        finally:
+            if token is not None:
+                self.session_manager._context_state.user_id.reset(token)
 
 
 class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
@@ -167,7 +172,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         self._a2a_worker = A2AFrontEndPluginWorker(nat_config)
 
         agent_card = await self._create_agent_card(self._a2a_worker.front_end_config)
-        session_manager = await SessionManager.create(
+        session_manager = await DRAgentAGUISessionManager.create(
             config=self._config,
             shared_builder=builder,
             max_concurrency=self._a2a_worker.max_concurrency,

--- a/src/datarobot_genai/dragent/register.py
+++ b/src/datarobot_genai/dragent/register.py
@@ -15,6 +15,7 @@
 import typing
 from collections.abc import AsyncGenerator
 
+from a2a.types import AgentSkill
 from nat.cli.register_workflow import register_front_end
 from nat.data_models.api_server import GlobalTypeConverter
 from nat.data_models.config import Config
@@ -33,21 +34,11 @@ from datarobot_genai.dragent.converters import convert_str_to_dragent_event_resp
 from datarobot_genai.dragent.converters import convert_tool_message_to_str
 
 
-class DRAgentSkillConfig(BaseModel):
-    """DR-owned skill definition, isolated from NAT's A2AFrontEndConfig."""
-
-    id: str = Field(description="Unique identifier for the skill.")
-    name: str = Field(description="Human-readable name for the skill.")
-    description: str = Field(description="Description of what the skill does.")
-    tags: list[str] = Field(default=[], description="Keywords describing the skill.")
-    examples: list[str] = Field(default=[], description="Example prompts for the skill.")
-
-
 class DRAgentA2AConfig(BaseModel):
     """DR-owned wrapper around NAT's A2AFrontEndConfig with optional skill definitions."""
 
     server: A2AFrontEndConfig = Field(description="NAT A2A server configuration.")
-    skills: list[DRAgentSkillConfig] = Field(
+    skills: list[AgentSkill] = Field(
         default=[],
         description="Skills to advertise in the A2A agent card. "
         "If empty, a single default skill is generated from the agent name and description.",

--- a/src/datarobot_genai/dragent/register.py
+++ b/src/datarobot_genai/dragent/register.py
@@ -20,6 +20,7 @@ from nat.data_models.api_server import GlobalTypeConverter
 from nat.data_models.config import Config
 from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
+from pydantic import BaseModel
 from pydantic import Field
 
 import datarobot_genai.dragent.per_user_tool_calling_agent  # noqa: F401 — registers per_user_tool_calling_agent
@@ -32,9 +33,30 @@ from datarobot_genai.dragent.converters import convert_str_to_dragent_event_resp
 from datarobot_genai.dragent.converters import convert_tool_message_to_str
 
 
+class DRAgentSkillConfig(BaseModel):
+    """DR-owned skill definition, isolated from NAT's A2AFrontEndConfig."""
+
+    id: str = Field(description="Unique identifier for the skill.")
+    name: str = Field(description="Human-readable name for the skill.")
+    description: str = Field(description="Description of what the skill does.")
+    tags: list[str] = Field(default=[], description="Keywords describing the skill.")
+    examples: list[str] = Field(default=[], description="Example prompts for the skill.")
+
+
+class DRAgentA2AConfig(BaseModel):
+    """DR-owned wrapper around NAT's A2AFrontEndConfig with optional skill definitions."""
+
+    server: A2AFrontEndConfig = Field(description="NAT A2A server configuration.")
+    skills: list[DRAgentSkillConfig] = Field(
+        default=[],
+        description="Skills to advertise in the A2A agent card. "
+        "If empty, a single default skill is generated from the agent name and description.",
+    )
+
+
 # Register frontend
 class DRAgentFastApiFrontEndConfig(FastApiFrontEndConfig, name="dragent_fastapi"):  # type: ignore
-    a2a: A2AFrontEndConfig | None = Field(
+    a2a: DRAgentA2AConfig | None = Field(
         default=None,
         description="Expose this agent via the Agent2Agent protocol. "
         "A2A server endpoints are mounted under /a2a/.",

--- a/src/datarobot_genai/dragent/register.py
+++ b/src/datarobot_genai/dragent/register.py
@@ -26,6 +26,7 @@ from pydantic import Field
 
 import datarobot_genai.dragent.per_user_tool_calling_agent  # noqa: F401 — registers per_user_tool_calling_agent
 from datarobot_genai.dragent.converters import convert_chat_request_to_run_agent_input
+from datarobot_genai.dragent.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.converters import convert_dragent_run_agent_input_to_chat_request
 from datarobot_genai.dragent.converters import (
     convert_dragent_run_agent_input_to_chat_request_or_message,
@@ -69,3 +70,4 @@ GlobalTypeConverter.register_converter(convert_chat_request_to_run_agent_input)
 GlobalTypeConverter.register_converter(convert_dragent_run_agent_input_to_chat_request_or_message)
 GlobalTypeConverter.register_converter(convert_tool_message_to_str)
 GlobalTypeConverter.register_converter(convert_str_to_dragent_event_response)
+GlobalTypeConverter.register_converter(convert_dragent_event_response_to_str)

--- a/tests/dragent/test_converters.py
+++ b/tests/dragent/test_converters.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import Tool
 from ag_ui.core import UserMessage
 from langchain_core.messages import ToolMessage as LangchainToolMessage
@@ -19,7 +20,9 @@ from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.api_server import Message
 
+from datarobot_genai.dragent.converters import aggregate_dragent_event_responses
 from datarobot_genai.dragent.converters import convert_chat_request_to_run_agent_input
+from datarobot_genai.dragent.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.converters import convert_dragent_run_agent_input_to_chat_request
 from datarobot_genai.dragent.converters import (
     convert_dragent_run_agent_input_to_chat_request_or_message,
@@ -202,3 +205,80 @@ def test_convert_tool_message_to_str() -> None:
 
     # THEN result is the message content
     assert result == "tool result"
+
+
+# --- aggregate_dragent_event_responses ---
+
+
+def test_aggregate_dragent_event_responses_combines_events() -> None:
+    # GIVEN two responses with events
+    r1 = DRAgentEventResponse(events=[TextMessageContentEvent(message_id="m1", delta="Hello ")])
+    r2 = DRAgentEventResponse(events=[TextMessageContentEvent(message_id="m1", delta="world")])
+
+    # WHEN aggregating
+    result = aggregate_dragent_event_responses([r1, r2])
+
+    # THEN all events are combined in order
+    assert isinstance(result, DRAgentEventResponse)
+    assert len(result.events) == 2
+    assert result.events[0].delta == "Hello "
+    assert result.events[1].delta == "world"
+
+
+def test_aggregate_dragent_event_responses_empty() -> None:
+    # GIVEN an empty list
+    result = aggregate_dragent_event_responses([])
+
+    # THEN result has no events
+    assert result.events == []
+
+
+# --- convert_dragent_event_response_to_str ---
+
+
+def test_convert_dragent_event_response_to_str_joins_text_deltas() -> None:
+    # GIVEN a response with multiple TextMessageContentEvents
+    response = DRAgentEventResponse(
+        events=[
+            TextMessageContentEvent(message_id="m1", delta="Hello "),
+            TextMessageContentEvent(message_id="m1", delta="world"),
+        ]
+    )
+
+    # WHEN converting to str
+    result = convert_dragent_event_response_to_str(response)
+
+    # THEN result is the concatenated text
+    assert result == "Hello world"
+
+
+def test_convert_dragent_event_response_to_str_ignores_non_text_events() -> None:
+    # GIVEN a response mixing text events with non-text-bearing events
+    from ag_ui.core import StepStartedEvent
+    from ag_ui.core import TextMessageChunkEvent
+
+    response = DRAgentEventResponse(
+        events=[
+            TextMessageContentEvent(message_id="m1", delta="Hi"),
+            TextMessageChunkEvent(message_id="m1", delta=" there"),
+            StepStartedEvent(step_name="some_step"),
+        ]
+    )
+
+    # WHEN converting to str
+    result = convert_dragent_event_response_to_str(response)
+
+    # THEN TextMessageContentEvent and TextMessageChunkEvent deltas are included;
+    # non-text events (e.g. StepStartedEvent) are ignored.
+    assert result == "Hi there"
+
+
+def test_convert_dragent_event_response_to_str_empty_events() -> None:
+    # GIVEN a response with no events
+    response = DRAgentEventResponse(events=[])
+
+    # WHEN converting to str
+    result = convert_dragent_event_response_to_str(response)
+
+    # THEN result is empty string
+    assert result == ""

--- a/tests/dragent/test_frontserver.py
+++ b/tests/dragent/test_frontserver.py
@@ -228,6 +228,26 @@ class TestDRAgentFastApiFrontEndPluginWorker:
 
         mock_a2a_worker.create_a2a_server.assert_called_once()
 
+    async def test_add_routes_appends_session_manager(
+        self, dragent_worker, mock_builder, mock_a2a_worker, patch_super_add_routes
+    ):
+        app = FastAPI()
+        mock_session_manager = MagicMock()
+        with (
+            patch(
+                "datarobot_genai.dragent.frontserver.A2AFrontEndPluginWorker",
+                return_value=mock_a2a_worker,
+            ),
+            patch(
+                "datarobot_genai.dragent.frontserver.SessionManager.create",
+                new_callable=AsyncMock,
+                return_value=mock_session_manager,
+            ),
+        ):
+            await dragent_worker.add_routes(app, mock_builder)
+
+        assert mock_session_manager in dragent_worker._session_managers
+
     async def test_add_routes_disabled(self, mock_builder, patch_super_add_routes):
         """When a2a is None (default), A2A routes are not mounted."""
         config = Config(general=GeneralConfig(front_end=DRAgentFastApiFrontEndConfig()))

--- a/tests/dragent/test_frontserver.py
+++ b/tests/dragent/test_frontserver.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from a2a.types import AgentSkill
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nat.builder.workflow_builder import WorkflowBuilder
@@ -29,6 +30,7 @@ from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 
 from datarobot_genai.dragent.frontserver import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontserver import DRAgentFastApiFrontEndPluginWorker
+from datarobot_genai.dragent.frontserver import _PerUserCompatibleAgentExecutor
 from datarobot_genai.dragent.register import DRAgentA2AConfig
 from datarobot_genai.dragent.register import DRAgentFastApiFrontEndConfig
 from datarobot_genai.dragent.step_adaptor import DRAgentNestedReasoningStepAdaptor
@@ -57,6 +59,17 @@ def dragent_worker():
     )
     with patch.dict(os.environ, {"NAT_CONFIG_FILE": "unused"}):
         return DRAgentFastApiFrontEndPluginWorker(config)
+
+
+@pytest.fixture
+def dragent_worker_with_a2a(dragent_worker, mock_a2a_worker):
+    dragent_worker._a2a_worker = mock_a2a_worker
+    return dragent_worker
+
+
+@pytest.fixture
+def a2a_frontend_config():
+    return A2AFrontEndConfig(name="My Agent", description="Does things", host="localhost", port=8000)
 
 
 @pytest.fixture
@@ -224,6 +237,112 @@ class TestDRAgentFastApiFrontEndPluginWorker:
         ) as mock_a2a_worker_cls:
             await disabled_worker.add_routes(app, mock_builder)
             mock_a2a_worker_cls.assert_not_called()
+
+
+class TestPerUserCompatibleAgentExecutor:
+    @pytest.fixture
+    def session_manager(self):
+        sm = MagicMock()
+        sm.config.workflow.type = "test_workflow"
+        return sm
+
+    @pytest.fixture
+    def executor(self, session_manager):
+        return _PerUserCompatibleAgentExecutor(session_manager)
+
+    @pytest.fixture
+    def patch_super_execute(self):
+        with patch.object(
+            _PerUserCompatibleAgentExecutor.__bases__[0],
+            "execute",
+            new_callable=AsyncMock,
+        ) as mock:
+            yield mock
+
+    def test_init_sets_session_manager(self, executor, session_manager):
+        assert executor.session_manager is session_manager
+
+    async def test_execute_injects_context_id_as_user_id(
+        self, executor, session_manager, patch_super_execute
+    ):
+        context = MagicMock()
+        context.context_id = "user-123"
+        event_queue = MagicMock()
+
+        await executor.execute(context, event_queue)
+
+        session_manager._context_state.user_id.set.assert_called_once_with("user-123")
+        patch_super_execute.assert_awaited_once_with(context, event_queue)
+
+    async def test_execute_skips_user_id_injection_when_no_context_id(
+        self, executor, session_manager, patch_super_execute
+    ):
+        context = MagicMock()
+        context.context_id = None
+        event_queue = MagicMock()
+
+        await executor.execute(context, event_queue)
+
+        session_manager._context_state.user_id.set.assert_not_called()
+
+
+class TestCreateAgentCard:
+    async def test_default_skill_when_skills_empty(
+        self, dragent_worker_with_a2a, a2a_frontend_config
+    ):
+        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        assert len(card.skills) == 1
+        assert card.skills[0].id == "call"
+        assert card.skills[0].name == "My Agent"
+        assert card.skills[0].description == "Does things"
+
+    async def test_configured_skills_used_when_present(
+        self, dragent_worker_with_a2a, a2a_frontend_config
+    ):
+        skill = AgentSkill(id="summarize", name="Summarize", description="Summarizes text", tags=[])
+        dragent_worker_with_a2a.front_end_config.a2a.skills = [skill]
+        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        assert len(card.skills) == 1
+        assert card.skills[0].id == "summarize"
+
+    async def test_agent_card_fields_from_frontend_config(self, dragent_worker_with_a2a):
+        cfg = A2AFrontEndConfig(
+            name="My Agent",
+            description="Does things",
+            version="2.0.0",
+            host="localhost",
+            port=9000,
+        )
+        card = await dragent_worker_with_a2a._create_agent_card(cfg)
+        assert card.name == "My Agent"
+        assert card.description == "Does things"
+        assert card.version == "2.0.0"
+        assert card.url == "http://localhost:9000/a2a/"
+
+    async def test_security_schemes_set_when_server_auth_present(
+        self, dragent_worker_with_a2a, mock_a2a_worker, a2a_frontend_config
+    ):
+        mock_schemes = MagicMock()
+        mock_security = MagicMock()
+        mock_a2a_worker._generate_security_schemes = AsyncMock(
+            return_value=(mock_schemes, mock_security)
+        )
+        a2a_frontend_config.server_auth = MagicMock()
+        with patch("datarobot_genai.dragent.frontserver.AgentCard") as mock_agent_card_cls:
+            await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        mock_a2a_worker._generate_security_schemes.assert_awaited_once_with(
+            a2a_frontend_config.server_auth
+        )
+        _, kwargs = mock_agent_card_cls.call_args
+        assert kwargs["security_schemes"] is mock_schemes
+        assert kwargs["security"] is mock_security
+
+    async def test_no_security_when_server_auth_absent(
+        self, dragent_worker_with_a2a, a2a_frontend_config
+    ):
+        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        assert card.security_schemes is None
+        assert card.security is None
 
 
 class TestDRAgentFastApiFrontEndConfig:

--- a/tests/dragent/test_frontserver.py
+++ b/tests/dragent/test_frontserver.py
@@ -122,36 +122,35 @@ class TestDRAgentFastApiFrontEndPluginWorker:
         assert isinstance(worker.get_step_adaptor(), DRAgentNestedReasoningStepAdaptor)
 
     def test_get_a2a_endpoint_url_default(self, worker):
-        url = worker._get_a2a_endpoint_url("http://localhost:8000/")
-        assert url == "http://localhost:8000/a2a/"
-
-    def test_get_a2a_endpoint_url_strips_trailing_slash(self, worker):
-        url = worker._get_a2a_endpoint_url("http://localhost:8000")
-        assert url == "http://localhost:8000/a2a/"
+        cfg = A2AFrontEndConfig(host="localhost", port=8000)
+        assert worker._get_a2a_endpoint_url(cfg) == "http://localhost:8000/a2a/"
 
     def test_get_a2a_endpoint_url_deployment(self, worker):
+        cfg = A2AFrontEndConfig(host="localhost", port=8000)
         env = {
             "MLOPS_DEPLOYMENT_ID": "abc123",
             "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
         }
         with patch.dict(os.environ, env):
-            url = worker._get_a2a_endpoint_url("http://localhost:8000/")
+            url = worker._get_a2a_endpoint_url(cfg)
         assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
 
     def test_get_a2a_endpoint_url_deployment_strips_trailing_slash(self, worker):
+        cfg = A2AFrontEndConfig(host="localhost", port=8000)
         env = {
             "MLOPS_DEPLOYMENT_ID": "abc123",
             "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2/",
         }
         with patch.dict(os.environ, env):
-            url = worker._get_a2a_endpoint_url("http://localhost:8000/")
+            url = worker._get_a2a_endpoint_url(cfg)
         assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
 
     def test_get_a2a_endpoint_url_deployment_missing_endpoint_raises(self, worker):
+        cfg = A2AFrontEndConfig(host="localhost", port=8000)
         with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "abc123"}, clear=False):
             os.environ.pop("DATAROBOT_ENDPOINT", None)
             with pytest.raises(ValueError, match="DATAROBOT_ENDPOINT must be set"):
-                worker._get_a2a_endpoint_url("http://localhost:8000/")
+                worker._get_a2a_endpoint_url(cfg)
 
     async def test_add_routes_inherits_host_port_from_fastapi_config(
         self, dragent_worker, mock_builder, mock_a2a_worker, patch_super_add_routes

--- a/tests/dragent/test_frontserver.py
+++ b/tests/dragent/test_frontserver.py
@@ -69,7 +69,9 @@ def dragent_worker_with_a2a(dragent_worker, mock_a2a_worker):
 
 @pytest.fixture
 def a2a_frontend_config():
-    return A2AFrontEndConfig(name="My Agent", description="Does things", host="localhost", port=8000)
+    return A2AFrontEndConfig(
+        name="My Agent", description="Does things", host="localhost", port=8000
+    )
 
 
 @pytest.fixture

--- a/tests/dragent/test_frontserver.py
+++ b/tests/dragent/test_frontserver.py
@@ -29,6 +29,7 @@ from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 
 from datarobot_genai.dragent.frontserver import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontserver import DRAgentFastApiFrontEndPluginWorker
+from datarobot_genai.dragent.register import DRAgentA2AConfig
 from datarobot_genai.dragent.register import DRAgentFastApiFrontEndConfig
 from datarobot_genai.dragent.step_adaptor import DRAgentNestedReasoningStepAdaptor
 
@@ -45,9 +46,11 @@ def dragent_worker():
     config = Config(
         general=GeneralConfig(
             front_end=DRAgentFastApiFrontEndConfig(
-                a2a=A2AFrontEndConfig(
-                    name="Test Agent",
-                    description="A test agent",
+                a2a=DRAgentA2AConfig(
+                    server=A2AFrontEndConfig(
+                        name="Test Agent",
+                        description="A test agent",
+                    )
                 ),
             )
         )
@@ -85,8 +88,10 @@ def mock_builder():
 @pytest.fixture
 def mock_a2a_worker():
     worker = MagicMock()
-    worker.create_agent_card = AsyncMock(return_value=MagicMock(url="http://localhost:8000/"))
-    worker.create_agent_executor = MagicMock(return_value=MagicMock())
+    worker.front_end_config = A2AFrontEndConfig(
+        name="Test Agent", description="A test agent", host="localhost", port=8000
+    )
+    worker._generate_security_schemes = AsyncMock(return_value=(None, None))
     worker.create_a2a_server = MagicMock(
         return_value=MagicMock(build=MagicMock(return_value=FastAPI()))
     )
@@ -152,10 +157,17 @@ class TestDRAgentFastApiFrontEndPluginWorker:
         self, dragent_worker, mock_builder, mock_a2a_worker, patch_super_add_routes
     ):
         app = FastAPI()
-        with patch(
-            "datarobot_genai.dragent.frontserver.A2AFrontEndPluginWorker",
-            return_value=mock_a2a_worker,
-        ) as mock_a2a_worker_cls:
+        with (
+            patch(
+                "datarobot_genai.dragent.frontserver.A2AFrontEndPluginWorker",
+                return_value=mock_a2a_worker,
+            ) as mock_a2a_worker_cls,
+            patch(
+                "datarobot_genai.dragent.frontserver.SessionManager.create",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
             await dragent_worker.add_routes(app, mock_builder)
 
         a2a_config_used = mock_a2a_worker_cls.call_args[0][0].general.front_end
@@ -167,27 +179,39 @@ class TestDRAgentFastApiFrontEndPluginWorker:
         self, dragent_worker, mock_builder, mock_a2a_worker, patch_super_add_routes
     ):
         app = FastAPI()
-        mock_a2a_worker.create_agent_card.return_value = MagicMock(url="http://localhost:8000/")
-        with patch(
-            "datarobot_genai.dragent.frontserver.A2AFrontEndPluginWorker",
-            return_value=mock_a2a_worker,
+        with (
+            patch(
+                "datarobot_genai.dragent.frontserver.A2AFrontEndPluginWorker",
+                return_value=mock_a2a_worker,
+            ),
+            patch(
+                "datarobot_genai.dragent.frontserver.SessionManager.create",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
         ):
             await dragent_worker.add_routes(app, mock_builder)
-        assert mock_a2a_worker.create_agent_card.return_value.url == "http://localhost:8000/a2a/"
+        agent_card = mock_a2a_worker.create_a2a_server.call_args[0][0]
+        assert agent_card.url == "http://localhost:8000/a2a/"
 
     @pytest.mark.asyncio
     async def test_add_routes_mounts_a2a(
         self, dragent_worker, mock_builder, mock_a2a_worker, patch_super_add_routes
     ):
         app = FastAPI()
-        with patch(
-            "datarobot_genai.dragent.frontserver.A2AFrontEndPluginWorker",
-            return_value=mock_a2a_worker,
+        with (
+            patch(
+                "datarobot_genai.dragent.frontserver.A2AFrontEndPluginWorker",
+                return_value=mock_a2a_worker,
+            ),
+            patch(
+                "datarobot_genai.dragent.frontserver.SessionManager.create",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
         ):
             await dragent_worker.add_routes(app, mock_builder)
 
-        mock_a2a_worker.create_agent_card.assert_awaited_once()
-        mock_a2a_worker.create_agent_executor.assert_called_once()
         mock_a2a_worker.create_a2a_server.assert_called_once()
 
     async def test_add_routes_disabled(self, mock_builder, patch_super_add_routes):
@@ -213,22 +237,24 @@ class TestDRAgentFastApiFrontEndConfig:
 
     def test_custom_a2a_fields(self):
         config = DRAgentFastApiFrontEndConfig(
-            a2a=A2AFrontEndConfig(
-                name="My Agent",
-                description="Does things",
-                version="2.0.0",
+            a2a=DRAgentA2AConfig(
+                server=A2AFrontEndConfig(
+                    name="My Agent",
+                    description="Does things",
+                    version="2.0.0",
+                )
             )
         )
-        assert config.a2a.name == "My Agent"
-        assert config.a2a.description == "Does things"
-        assert config.a2a.version == "2.0.0"
+        assert config.a2a.server.name == "My Agent"
+        assert config.a2a.server.description == "Does things"
+        assert config.a2a.server.version == "2.0.0"
 
     def test_is_not_a2a_front_end_config(self):
         config = DRAgentFastApiFrontEndConfig()
         assert not isinstance(config, A2AFrontEndConfig)
 
     def test_a2a_enables_endpoints(self):
-        config = DRAgentFastApiFrontEndConfig(a2a=A2AFrontEndConfig())
+        config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=A2AFrontEndConfig()))
         assert config.a2a is not None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1126,7 +1126,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.18"
+version = "0.6.19"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
The previous way of adding A2A endpoints to the fastapi app was equivalent to the NAT A2A server implementation implementation. It inherited the limitation that per_user workflows can not be exposed via it, causing agents not being able to be A2A server and using A2A clients at the same time. This PR works around the following issues:
  1. Agent card without a workflow instance — built the card directly from config metadata instead of introspecting a live workflow, with a configurable skills list and a sensible default fallback.
  2. Skill configuration — introduced DRAgentA2AConfig (a DR-owned wrapper around NAT's A2AFrontEndConfig) with a skills field, letting users declare skills in workflow.yaml without touching NAT-owned config.
  3. Per-user executor — _PerUserCompatibleAgentExecutor works around two limitations of NATWorkflowAgentExecutor: it bypasses the __init__ access to session_manager.workflow (which raises for per-user), and injects context_id as user_id so each conversation gets its own isolated workflow instance.
 
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Update Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking config shape change for A2A (`a2a` now wraps `server`/`skills`) and alters A2A request execution by injecting `context_id` into session user scoping, which could impact routing/concurrency behavior if misconfigured.
> 
> **Overview**
> Enables `dragent` FastAPI front-end to expose Agent2Agent (A2A) endpoints for *per-user* NAT workflows by swapping the A2A executor to `_PerUserCompatibleAgentExecutor`, which maps each A2A `context_id` to a per-user workflow instance.
> 
> Adds `DRAgentA2AConfig` (wrapping NAT’s `A2AFrontEndConfig`) to support configurable advertised `skills` in the agent card, with a default fallback skill when none are provided, and updates A2A mounting/URL construction to be driven by `host`/`port` + deployment env vars.
> 
> Adds new converters to aggregate/serialize `DRAgentEventResponse` to text, updates tests accordingly, and bumps version to `0.6.19` (with changelog noting the **breaking** config change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f01e0527f08da8f3ac2744c2b4b1fae5a7e7ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->