### PR TITLE
[BUZZOK-29835] Fix NAT config serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.6.20
-- Fixed an issue where the API token loaded via an environment variable was not properly serialized in NAT.
+- Fixed an issue where the API token loaded via an environment variable was not properly serialized in NAT
 
 ## 0.6.19
 - Enable A2A endpoints for per-user workflows with configurable skills via `DRAgentA2AConfig`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.20
+- Fixed an issue where the API token loaded via an environment variable was not properly serialized in NAT.
+
 ## 0.6.19
 - Enable A2A endpoints for per-user workflows with configurable skills via `DRAgentA2AConfig`
 - **Breaking**: `DRAgentFastApiFrontEndConfig.a2a` type changed from `A2AFrontEndConfig` to `DRAgentA2AConfig`; update `workflow.yaml` by nesting the existing A2A fields under `server:`

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.18"
+version = "0.6.20"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.6.19"
+version = "0.6.20"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"

--- a/src/datarobot_genai/nat/datarobot_auth_provider.py
+++ b/src/datarobot_genai/nat/datarobot_auth_provider.py
@@ -25,6 +25,7 @@ from nat.data_models.authentication import AuthResult
 from nat.data_models.authentication import HeaderCred
 from nat.data_models.common import SerializableSecretStr
 from pydantic import Field
+from pydantic import SecretStr
 
 from datarobot_genai.core.mcp.common import MCPConfig
 
@@ -39,7 +40,11 @@ class Config(DataRobotAppFrameworkBaseSettings):
     datarobot_api_token: str | None = None
 
 
-config = Config()
+def _get_default_api_token() -> SecretStr | None:
+    """Get the default API token from environment, wrapped in SecretStr for proper serialization."""
+    if datarobot_api_token := Config().datarobot_api_token:
+        return SecretStr(datarobot_api_token)
+    return None
 
 
 class DataRobotAPIKeyAuthProviderConfig(APIKeyAuthProviderConfig, name="datarobot_api_key"):  # type: ignore[call-arg]
@@ -48,7 +53,7 @@ class DataRobotAPIKeyAuthProviderConfig(APIKeyAuthProviderConfig, name="datarobo
             "Raw API token or credential to be injected into the request parameter. "
             "Used for 'bearer','x-api-key','custom', and other schemes. "
         ),
-        default=config.datarobot_api_token,
+        default_factory=_get_default_api_token,
     )
     default_user_id: str | None = Field(default="default-user", description="Default user ID")
     allow_default_user_id_for_tool_calls: bool = Field(
@@ -63,13 +68,17 @@ async def datarobot_api_key_client(
     yield APIKeyAuthProvider(config=config)
 
 
-mcp_config = MCPConfig().server_config
+def _get_default_headers() -> None | dict[str, str]:
+    """Get the default headers dict from environment."""
+    if mcp_config := MCPConfig().server_config:
+        return mcp_config["headers"]
+    return None
 
 
 class DataRobotMCPAuthProviderConfig(AuthProviderBaseConfig, name="datarobot_mcp_auth"):  # type: ignore[call-arg]
     headers: dict[str, str] | None = Field(
         description=("Headers to be used for authentication. "),
-        default=mcp_config["headers"] if mcp_config else None,
+        default_factory=_get_default_headers,
     )
     default_user_id: str | None = Field(default="default-user", description="Default user ID")
     allow_default_user_id_for_tool_calls: bool = Field(

--- a/tests/nat/test_auth_provider.py
+++ b/tests/nat/test_auth_provider.py
@@ -10,9 +10,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+from unittest.mock import patch
 
 from nat.authentication.api_key.api_key_auth_provider import APIKeyAuthProvider
 from nat.builder.workflow_builder import WorkflowBuilder
+from pydantic import SecretStr
 
 from datarobot_genai.nat.datarobot_auth_provider import DataRobotAPIKeyAuthProviderConfig
 from datarobot_genai.nat.datarobot_auth_provider import DataRobotMCPAuthProvider
@@ -25,6 +28,46 @@ async def test_datarobot_auth_provider():
         await builder.add_auth_provider("datarobot_api_key", config)
         auth_provider = await builder.get_auth_provider("datarobot_api_key")
         assert isinstance(auth_provider, APIKeyAuthProvider)
+
+
+def test_datarobot_auth_provider_config_serialization():
+    """Test that config serializes properly when raw_key is provided directly."""
+    config = DataRobotAPIKeyAuthProviderConfig(raw_key="test_token_abc")
+
+    # Verify raw_key is a SecretStr, not a plain string
+    assert isinstance(config.raw_key, SecretStr), (
+        f"raw_key should be SecretStr, got {type(config.raw_key)}"
+    )
+
+    # Serialize to dict - this is how NAT uses the config
+    dumped = config.model_dump()
+    assert "raw_key" in dumped
+    assert dumped["raw_key"] == "test_token_abc"
+
+    # Serialize to JSON
+    json_str = config.model_dump_json()
+    assert "test_token_abc" in json_str
+
+
+def test_datarobot_auth_provider_config_serialization_from_env():
+    """Test config serializes properly when raw_key comes from environment."""
+    with patch.dict(os.environ, {"DATAROBOT_API_TOKEN": "test_token_123"}):
+        config = DataRobotAPIKeyAuthProviderConfig()
+
+    # Verify raw_key is a SecretStr, not a plain string
+    assert isinstance(config.raw_key, SecretStr), (
+        f"raw_key should be SecretStr when loaded from env, got {type(config.raw_key)}"
+    )
+
+    # Serialize to dict - this is how NAT uses the config
+    # This would fail if raw_key is a plain string
+    dumped = config.model_dump()
+    assert "raw_key" in dumped
+    assert dumped["raw_key"] == "test_token_123"
+
+    # Serialize to JSON - another common NAT operation
+    json_str = config.model_dump_json()
+    assert "test_token_123" in json_str
 
 
 async def test_datarobot_mcp_auth_provider():

--- a/uv.lock
+++ b/uv.lock
@@ -1126,7 +1126,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.6.19"
+version = "0.6.20"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Fixes the issue with a config, which crashes during serialization when `DATAROBOT_API_TOKEN` is loaded from env.

Example error during runtime:
```
Error: Error calling function get_secret_value: AttributeError: 'str' object has no attribute 'get_secret_value'
```

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->


## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Update Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NAT authentication config defaults/serialization for API tokens and headers; while the change is small, mistakes could break auth configuration loading in deployments that rely on env-provided secrets.
> 
> **Overview**
> Fixes a NAT config serialization crash when `DATAROBOT_API_TOKEN` is sourced from the environment by switching auth config defaults to `default_factory` functions that return properly typed secrets (`SecretStr`) instead of raw strings.
> 
> Adds unit coverage for `DataRobotAPIKeyAuthProviderConfig` serialization (direct value and env-derived), and bumps the package version to `0.6.20` with corresponding changelog and lockfile updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46e601e0c3477eb81534993354172cce41ed0e9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->