### PR TITLE
[BUZZOK-29842] Make per-user workflows callable via the DRUM frontserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+
+
+## 0.7.4
+- Allow running nat agents with per-user workflows with drum
+
 ## 0.7.3
 - Added `temperature` parameter support to LLM MCP clients (`BaseLLMMCPClient`, `DRLLMGatewayMCPClient`): read from config dict and forwarded to `chat.completions.create`
 - Added `LLM_TEMPERATURE` env var support in `get_openai_llm_client_config()` and `get_dr_llm_gateway_client_config()` to control LLM temperature in acceptance tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
-
 ## 0.7.4
-- Allow running nat agents with per-user workflows with drum
+- Allowed running nat agents with per-user workflows with drum
 
 ## 0.7.3
 - Added `temperature` parameter support to LLM MCP clients (`BaseLLMMCPClient`, `DRLLMGatewayMCPClient`): read from config dict and forwarded to `chat.completions.create`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.7.3"
+version = "0.7.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -211,65 +211,68 @@ class NatAgent(BaseAgent[None]):
         text_started = False
 
         async with load_workflow(self.workflow_path, headers=headers) as workflow:
-            async with workflow.run(chat_request) as runner:
-                intermediate_future = pull_intermediate_structured()
-                async for result in runner.result_stream():
-                    if isinstance(result, ChatResponse):
-                        result_text = result.choices[0].message.content
-                    else:
-                        result_text = str(result)
+            async with workflow.session(user_id=thread_id) as session:
+                async with session.run(chat_request) as runner:
+                    intermediate_future = pull_intermediate_structured()
+                    async for result in runner.result_stream():
+                        if isinstance(result, ChatResponse):
+                            result_text = result.choices[0].message.content
+                        else:
+                            result_text = str(result)
 
-                    if result_text:
-                        if not text_started:
+                        if result_text:
+                            if not text_started:
+                                yield (
+                                    TextMessageStartEvent(
+                                        type=EventType.TEXT_MESSAGE_START, message_id=message_id
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                text_started = True
                             yield (
-                                TextMessageStartEvent(
-                                    type=EventType.TEXT_MESSAGE_START, message_id=message_id
+                                TextMessageContentEvent(
+                                    type=EventType.TEXT_MESSAGE_CONTENT,
+                                    message_id=message_id,
+                                    delta=result_text,
                                 ),
                                 None,
                                 zero_metrics,
                             )
-                            text_started = True
+
+                    if text_started:
                         yield (
-                            TextMessageContentEvent(
-                                type=EventType.TEXT_MESSAGE_CONTENT,
-                                message_id=message_id,
-                                delta=result_text,
+                            TextMessageEndEvent(
+                                type=EventType.TEXT_MESSAGE_END, message_id=message_id
                             ),
                             None,
                             zero_metrics,
                         )
 
-                if text_started:
+                    steps = await intermediate_future
+                    llm_end_steps = [
+                        step for step in steps if step.event_type == IntermediateStepType.LLM_END
+                    ]
+                    usage_metrics: UsageMetrics = {
+                        "completion_tokens": 0,
+                        "prompt_tokens": 0,
+                        "total_tokens": 0,
+                    }
+                    for step in llm_end_steps:
+                        if step.usage_info:
+                            token_usage = step.usage_info.token_usage
+                            usage_metrics["total_tokens"] += token_usage.total_tokens
+                            usage_metrics["prompt_tokens"] += token_usage.prompt_tokens
+                            usage_metrics["completion_tokens"] += token_usage.completion_tokens
+
+                    pipeline_interactions = self.create_pipeline_interactions_from_steps(steps)
                     yield (
-                        TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),
-                        None,
-                        zero_metrics,
+                        RunFinishedEvent(
+                            type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id
+                        ),
+                        pipeline_interactions,
+                        usage_metrics,
                     )
-
-                steps = await intermediate_future
-                llm_end_steps = [
-                    step for step in steps if step.event_type == IntermediateStepType.LLM_END
-                ]
-                usage_metrics: UsageMetrics = {
-                    "completion_tokens": 0,
-                    "prompt_tokens": 0,
-                    "total_tokens": 0,
-                }
-                for step in llm_end_steps:
-                    if step.usage_info:
-                        token_usage = step.usage_info.token_usage
-                        usage_metrics["total_tokens"] += token_usage.total_tokens
-                        usage_metrics["prompt_tokens"] += token_usage.prompt_tokens
-                        usage_metrics["completion_tokens"] += token_usage.completion_tokens
-
-                pipeline_interactions = self.create_pipeline_interactions_from_steps(steps)
-                yield (
-                    RunFinishedEvent(
-                        type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id
-                    ),
-                    pipeline_interactions,
-                    usage_metrics,
-                )
 
     async def run_nat_workflow(
         self, workflow_path: StrPath, chat_request: ChatRequest, headers: dict[str, str] | None
@@ -286,10 +289,11 @@ class NatAgent(BaseAgent[None]):
             list[IntermediateStep]: The list of intermediate steps
         """
         async with load_workflow(workflow_path, headers=headers) as workflow:
-            async with workflow.run(chat_request) as runner:
-                intermediate_future = pull_intermediate_structured()
-                runner_outputs = await runner.result()
-                steps = await intermediate_future
+            async with workflow.session(user_id=str(uuid.uuid4())) as session:
+                async with session.run(chat_request) as runner:
+                    intermediate_future = pull_intermediate_structured()
+                    runner_outputs = await runner.result()
+                    steps = await intermediate_future
 
         line = f"{'-' * 50}"
         prefix = f"{line}\nWorkflow Result:\n"

--- a/tests/nat/test_agent.py
+++ b/tests/nat/test_agent.py
@@ -130,10 +130,12 @@ def mock_load_workflow():
 
     mock_run = MagicMock()
     mock_run.return_value.__aenter__.return_value = AsyncMock(result_stream=mock_result_stream)
+    mock_session = MagicMock()
+    mock_session.return_value.__aenter__.return_value = AsyncMock(run=mock_run)
     with patch(
         "datarobot_genai.nat.agent.load_workflow", new_callable=MagicMock
     ) as mock_load_workflow:
-        mock_load_workflow.return_value.__aenter__.return_value = AsyncMock(run=mock_run)
+        mock_load_workflow.return_value.__aenter__.return_value = AsyncMock(session=mock_session)
         yield mock_load_workflow
 
 
@@ -265,6 +267,16 @@ async def test_invoke_mcp_headers(agent, run_agent_input):
         "prompt_tokens": 2,
         "total_tokens": 4,
     }
+
+
+@pytest.mark.usefixtures("mock_intermediate_structured")
+async def test_invoke_uses_thread_id_as_session_user_id(agent, run_agent_input, mock_load_workflow):
+    # GIVEN: an agent and run agent input with a known thread_id
+    _ = [event async for event in agent.invoke(run_agent_input)]
+
+    # THEN: workflow.session() is called with user_id equal to the thread_id
+    mock_workflow = mock_load_workflow.return_value.__aenter__.return_value
+    mock_workflow.session.assert_called_once_with(user_id=run_agent_input.thread_id)
 
 
 @pytest.mark.usefixtures("mock_intermediate_structured", "patch_environment_variables")

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Currently, the updated NAT agent with configured per-user workflow fails with DRUM. We have to pass the user_id when calling the nat agent.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NAT agent execution to run within a `workflow.session(user_id=...)`, which can affect workflow state isolation and session scoping across requests; covered by updated unit tests but touches the main invoke path.
> 
> **Overview**
> Enables NAT agents to run *per-user workflows* when invoked via DRUM by switching execution from `workflow.run(...)` to `workflow.session(user_id=...)`.
> 
> `NatAgent.invoke()` now uses the AG-UI `thread_id` as the session `user_id`, and `run_nat_workflow()` runs under a generated session as well; tests were updated to mock `session()` and assert the `user_id` wiring. Package version is bumped to `0.7.4` with a matching changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 441c19f85ff6323ac6c6976ce06de36e20426994. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->