### PR TITLE
[MODEL-22869] -- rename MCP tool/prompt category related enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.7.8
+- Updated enum values under DataRobotMCPPromptCategory and DataRobotMCPToolCategory to make them align with accepted enums of DataRobot public API.
+- Removed UNKNOWN enum value from DataRobotMCPPromptCategory, DataRobotMCPToolCategory, and DataRobotMCPResourceCategory.
+
 ## 0.7.7
 - Forwarded `x-untrusted-*` headers alongside `x-datarobot-*` headers in NAT `extract_datarobot_headers_from_context()`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.7.7"
+version = "0.7.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/enums.py
+++ b/src/datarobot_genai/drmcp/core/enums.py
@@ -17,17 +17,15 @@ from enum import auto
 
 class DataRobotMCPToolCategory(Enum):
     USER_TOOL = auto()  # tools created by users
-    BUILD_IN_TOOL = auto()  # tools as a wrapper of external service
+    BUILT_IN_TOOL = auto()  # tools as a wrapper of external service
     USER_TOOL_DEPLOYMENT = auto()  # tools dynamically loaded after MCP server is up
-    UNKNOWN = auto()  # tools without category
 
     @staticmethod
     def from_string(enum_str: str) -> "DataRobotMCPToolCategory":
         enum_str_map = {
             "USER_TOOL": DataRobotMCPToolCategory.USER_TOOL,
-            "BUILD_IN_TOOL": DataRobotMCPToolCategory.BUILD_IN_TOOL,
+            "BUILT_IN_TOOL": DataRobotMCPToolCategory.BUILT_IN_TOOL,
             "USER_TOOL_DEPLOYMENT": DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT,
-            "UNKNOWN": DataRobotMCPToolCategory.UNKNOWN,
         }
         if enum_str not in enum_str_map:
             error_msg = f"Enum string should be one of {', '.join(enum_str_map.keys())}"
@@ -37,16 +35,14 @@ class DataRobotMCPToolCategory(Enum):
 
 
 class DataRobotMCPPromptCategory(Enum):
-    USER_PROMPT = auto()  # prompt created by users
+    USER_PROMPT_TEMPLATE = auto()  # prompt created by users
     USER_PROMPT_TEMPLATE_VERSION = auto()  # prompts dynamically loaded after MCP server is up
-    UNKNOWN = auto()  # prompts without category
 
     @staticmethod
     def from_string(enum_str: str) -> "DataRobotMCPPromptCategory":
         enum_str_map = {
-            "USER_PROMPT": DataRobotMCPPromptCategory.USER_PROMPT,
+            "USER_PROMPT_TEMPLATE": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE,
             "USER_PROMPT_TEMPLATE_VERSION": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION,
-            "UNKNOWN": DataRobotMCPPromptCategory.UNKNOWN,
         }
         if enum_str not in enum_str_map:
             error_msg = f"Enum string should be one of {', '.join(enum_str_map.keys())}"
@@ -57,13 +53,11 @@ class DataRobotMCPPromptCategory(Enum):
 
 class DataRobotMCPResourceCategory(Enum):
     USER_RESOURCE = auto()  # resource created by users
-    UNKNOWN = auto()  # resources without category
 
     @staticmethod
     def from_string(enum_str: str) -> "DataRobotMCPResourceCategory":
         enum_str_map = {
             "USER_RESOURCE": DataRobotMCPResourceCategory.USER_RESOURCE,
-            "UNKNOWN": DataRobotMCPResourceCategory.UNKNOWN,
         }
         if enum_str not in enum_str_map:
             error_msg = f"Enum string should be one of {', '.join(enum_str_map.keys())}"

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -428,7 +428,7 @@ def dr_mcp_integration_tool(
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         return dr_mcp_tool(
-            tool_category=DataRobotMCPToolCategory.BUILD_IN_TOOL,
+            tool_category=DataRobotMCPToolCategory.BUILT_IN_TOOL,
             **mcp_tool_init_args,
         )(func)
 
@@ -598,7 +598,7 @@ async def register_prompt(
 
 
 def dr_mcp_prompt(
-    prompt_category: DataRobotMCPPromptCategory = DataRobotMCPPromptCategory.USER_PROMPT,
+    prompt_category: DataRobotMCPPromptCategory = DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE,
     prompt_init_args: PromptInitArguments = PromptInitArguments(),
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     def prompt_decorator(func: Callable[P, T]) -> Callable[P, T]:

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -262,7 +262,7 @@ class TestMCPToolDecorator:
 
         assert not mock_dr_mcp_tool.call_args.args
         assert mock_dr_mcp_tool.call_args.kwargs == {
-            "tool_category": DataRobotMCPToolCategory.BUILD_IN_TOOL,
+            "tool_category": DataRobotMCPToolCategory.BUILT_IN_TOOL,
             expected_kwarg_key: expected_kwarg_value,
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This PR renames the MCP tool/prompt category related enums.

- Context
These MCP tool/prompt categories are used when the tool/prompt function is decorated. This info will be recorded in DB through pulumi/terraform and public API. 

- What and why to sync
MCP tool/prompt categorie enum were also used in public API client and public API controller in a sense that only legit enum values are accepted. So this PR tried to sync MCP tool/prompt category enums in datarobot-gentai with the ones in public API client/public API. Here are just some examples:

https://github.com/datarobot/public_api_client/blob/de8d48181f44d6caee4cfbd01e6510cfdc34ad94/datarobot/_experimental/models/user_mcp_server_deployment.py#L28
https://github.com/datarobot/public_api_client/blob/de8d48181f44d6caee4cfbd01e6510cfdc34ad94/datarobot/_experimental/models/user_mcp_server_version.py#L29


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames and removes enum values used in tool/prompt/resource metadata, which can break callers that rely on previous names (e.g., `BUILD_IN_TOOL`, `USER_PROMPT`, or `UNKNOWN`) or accept unknown categories.
> 
> **Overview**
> Bumps package version to `0.7.8` and documents the release in `CHANGELOG.md`.
> 
> Aligns MCP category enums with DataRobot public API by renaming `DataRobotMCPToolCategory.BUILD_IN_TOOL` to `BUILT_IN_TOOL`, renaming the prompt category `USER_PROMPT` to `USER_PROMPT_TEMPLATE`, and removing the `UNKNOWN` value from tool/prompt/resource category enums (and their `from_string` mappings).
> 
> Updates decorator defaults/usages (`dr_mcp_integration_tool`, `dr_mcp_prompt`) and the corresponding unit test expectations to use the new enum names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 686a0c7e3133371c900a0754336ffd471b4848f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->