### PR TITLE
[BUZZOK-29772] [BUZZOK-29591] Add base agent e2e examples

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,8 @@ jobs:
               - 'src/datarobot_genai/llama_index/**'
             nat:
               - 'src/datarobot_genai/nat/**'
+            base:
+              - 'e2e-tests/dragent/base/**'
             core:
               - 'src/datarobot_genai/dragent/**'
               - 'src/datarobot_genai/core/**'
@@ -39,8 +41,8 @@ jobs:
         run: |
           frameworks='[]'
           core="${{ steps.filter.outputs.core }}"
-          declare -A changed=( [langgraph]="${{ steps.filter.outputs.langgraph }}" [llamaindex]="${{ steps.filter.outputs.llamaindex }}" [nat]="${{ steps.filter.outputs.nat }}" )
-          for fw in langgraph llamaindex nat; do
+          declare -A changed=( [langgraph]="${{ steps.filter.outputs.langgraph }}" [llamaindex]="${{ steps.filter.outputs.llamaindex }}" [nat]="${{ steps.filter.outputs.nat }}" [base]="${{ steps.filter.outputs.base }}" )
+          for fw in langgraph llamaindex nat base; do
             if [[ "${changed[$fw]}" == "true" || "$core" == "true" ]]; then
               frameworks=$(echo "$frameworks" | jq -c ". + [\"$fw\"]")
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.7.6
+- Added base agent e2e example under `e2e-tests/dragent/base/` demonstrating how to extend `BaseAgent` directly with litellm
+
 ## 0.7.5
 - Added `authenticated_a2a_client` function group to dragent, to authenticate all api calls including calls to `/.well-known/agent-card.json`.
 

--- a/e2e-tests/dragent/Taskfile.yaml
+++ b/e2e-tests/dragent/Taskfile.yaml
@@ -26,3 +26,9 @@ tasks:
     cmds:
       - echo "🔨 Running LlamaIndex agent via NAT"
       - uv run nat start dragent_fastapi --config_file workflow.yaml --port {{.AGENT_PORT | default "8080"}}
+  run-base:
+    desc: "🔨 Running base agent via NAT"
+    dir: ./base
+    cmds:
+      - echo "🔨 Running base agent via NAT"
+      - uv run nat start dragent_fastapi --config_file workflow.yaml --port {{.AGENT_PORT | default "8080"}}

--- a/e2e-tests/dragent/base/myagent.py
+++ b/e2e-tests/dragent/base/myagent.py
@@ -1,0 +1,74 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+from ag_ui.core import EventType
+from ag_ui.core import RunAgentInput
+from ag_ui.core import RunFinishedEvent
+from ag_ui.core import RunStartedEvent
+from ag_ui.core import TextMessageContentEvent
+from ag_ui.core import TextMessageEndEvent
+from ag_ui.core import TextMessageStartEvent
+from datarobot_genai.core.agents import BaseAgent
+from datarobot_genai.core.agents import InvokeReturn
+from datarobot_genai.core.agents import UsageMetrics
+from datarobot_genai.core.agents import default_usage_metrics
+
+
+class MyAgent(BaseAgent[None]):
+    """Base agent that returns a static success response for e2e testing."""
+
+    async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
+        usage_metrics: UsageMetrics = default_usage_metrics()
+        thread_id = run_agent_input.thread_id
+        run_id = run_agent_input.run_id
+        message_id = str(uuid.uuid4())
+
+        yield (
+            RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=run_id),
+            None,
+            usage_metrics,
+        )
+        yield (
+            TextMessageStartEvent(
+                type=EventType.TEXT_MESSAGE_START,
+                message_id=message_id,
+                role="assistant",
+            ),
+            None,
+            usage_metrics,
+        )
+        yield (
+            TextMessageContentEvent(
+                type=EventType.TEXT_MESSAGE_CONTENT,
+                message_id=message_id,
+                delta="Success",
+            ),
+            None,
+            usage_metrics,
+        )
+        yield (
+            TextMessageEndEvent(
+                type=EventType.TEXT_MESSAGE_END,
+                message_id=message_id,
+            ),
+            None,
+            usage_metrics,
+        )
+        yield (
+            RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id),
+            None,
+            usage_metrics,
+        )

--- a/e2e-tests/dragent/base/myagent.py
+++ b/e2e-tests/dragent/base/myagent.py
@@ -31,7 +31,7 @@ class MyAgent(BaseAgent[None]):
     """Base agent that returns a static success response for e2e testing."""
 
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
-        usage_metrics: UsageMetrics = default_usage_metrics()
+        empty_metrics: UsageMetrics = default_usage_metrics()
         thread_id = run_agent_input.thread_id
         run_id = run_agent_input.run_id
         message_id = str(uuid.uuid4())
@@ -39,7 +39,7 @@ class MyAgent(BaseAgent[None]):
         yield (
             RunStartedEvent(type=EventType.RUN_STARTED, thread_id=thread_id, run_id=run_id),
             None,
-            usage_metrics,
+            empty_metrics,
         )
         yield (
             TextMessageStartEvent(
@@ -48,7 +48,7 @@ class MyAgent(BaseAgent[None]):
                 role="assistant",
             ),
             None,
-            usage_metrics,
+            empty_metrics,
         )
         yield (
             TextMessageContentEvent(
@@ -57,7 +57,7 @@ class MyAgent(BaseAgent[None]):
                 delta="Success",
             ),
             None,
-            usage_metrics,
+            empty_metrics,
         )
         yield (
             TextMessageEndEvent(
@@ -65,10 +65,10 @@ class MyAgent(BaseAgent[None]):
                 message_id=message_id,
             ),
             None,
-            usage_metrics,
+            empty_metrics,
         )
         yield (
             RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id),
             None,
-            usage_metrics,
+            empty_metrics,
         )

--- a/e2e-tests/dragent/base/register.py
+++ b/e2e-tests/dragent/base/register.py
@@ -1,0 +1,51 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import AsyncGenerator
+
+from nat.builder.builder import Builder
+from nat.cli.register_workflow import register_function
+from nat.data_models.agent import AgentBaseConfig
+
+
+class BaseAgentConfig(AgentBaseConfig, name="base_agent"):
+    """NAT config for the base agent."""
+
+
+@register_function(
+    config_type=BaseAgentConfig,
+)
+async def base_agent(config: BaseAgentConfig, builder: Builder) -> AsyncGenerator:
+    from ag_ui.core import RunAgentInput  # noqa: PLC0415
+    from datarobot_genai.dragent.response import DRAgentEventResponse  # noqa: PLC0415
+    from nat.builder.function_info import FunctionInfo  # noqa: PLC0415
+
+    from dragent.base.myagent import MyAgent  # noqa: PLC0415
+
+    async def _response_fn(
+        input_message: RunAgentInput,
+    ) -> AsyncGenerator[DRAgentEventResponse, None]:
+        agent = MyAgent()
+
+        async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):
+            yield DRAgentEventResponse(
+                events=[event],
+                usage_metrics=usage_metrics,
+                pipeline_interactions=pipeline_interactions,
+            )
+
+    yield FunctionInfo.from_fn(
+        _response_fn,
+        description=config.description,
+    )

--- a/e2e-tests/dragent/base/workflow.yaml
+++ b/e2e-tests/dragent/base/workflow.yaml
@@ -1,0 +1,22 @@
+---
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+llms:
+  datarobot_llm:
+    _type: datarobot-llm-component
+
+workflow:
+  _type: base_agent
+  llm_name: datarobot_llm
+  description: Base agent example

--- a/e2e-tests/dragent/base/workflow.yaml
+++ b/e2e-tests/dragent/base/workflow.yaml
@@ -12,11 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-llms:
-  datarobot_llm:
-    _type: datarobot-llm-component
-
 workflow:
   _type: base_agent
-  llm_name: datarobot_llm
   description: Base agent example

--- a/e2e-tests/dragent/base/workflow.yaml
+++ b/e2e-tests/dragent/base/workflow.yaml
@@ -12,6 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+llms:
+  datarobot_llm:
+    _type: datarobot-llm-component
+
 workflow:
   _type: base_agent
+  llm_name: datarobot_llm
   description: Base agent example

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -26,6 +26,10 @@ dragent-crewai = [
 dragent-llamaindex = [
     "datarobot-genai[dragent,llamaindex]"
 ]
+dragent-base = [
+    "datarobot-genai[dragent]",
+    "litellm>=1.74.9,<2.0.0",
+]
 lint = [
     "mypy>=1.19.1",
     "ruff>=0.15.2",
@@ -35,6 +39,7 @@ lint = [
 langgraph_agent = "dragent.langgraph.register"
 crewai_agent = "dragent.crewai.register"
 llamaindex_agent = "dragent.llamaindex.register"
+base_agent = "dragent.base.register"
 
 [tool.uv]
 package = true

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -28,7 +28,6 @@ dragent-llamaindex = [
 ]
 dragent-base = [
     "datarobot-genai[dragent]",
-    "litellm>=1.74.9,<2.0.0",
 ]
 lint = [
     "mypy>=1.19.1",

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1129,7 +1129,6 @@ dependencies = [
 [package.dev-dependencies]
 dragent-base = [
     { name = "datarobot-genai", extra = ["dragent"] },
-    { name = "litellm" },
 ]
 dragent-crewai = [
     { name = "datarobot-genai", extra = ["crewai", "dragent"] },
@@ -1158,10 +1157,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dragent-base = [
-    { name = "datarobot-genai", extras = ["dragent"], editable = "../" },
-    { name = "litellm", specifier = ">=1.74.9,<2.0.0" },
-]
+dragent-base = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]
 dragent-crewai = [{ name = "datarobot-genai", extras = ["dragent", "crewai"], editable = "../" }]
 dragent-langgraph = [{ name = "datarobot-genai", extras = ["dragent", "langgraph"], editable = "../" }]
 dragent-llamaindex = [{ name = "datarobot-genai", extras = ["dragent", "llamaindex"], editable = "../" }]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -845,7 +845,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.7.4"
+version = "0.7.6"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1127,6 +1127,10 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dragent-base = [
+    { name = "datarobot-genai", extra = ["dragent"] },
+    { name = "litellm" },
+]
 dragent-crewai = [
     { name = "datarobot-genai", extra = ["crewai", "dragent"] },
 ]
@@ -1154,6 +1158,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dragent-base = [
+    { name = "datarobot-genai", extras = ["dragent"], editable = "../" },
+    { name = "litellm", specifier = ">=1.74.9,<2.0.0" },
+]
 dragent-crewai = [{ name = "datarobot-genai", extras = ["dragent", "crewai"], editable = "../" }]
 dragent-langgraph = [{ name = "datarobot-genai", extras = ["dragent", "langgraph"], editable = "../" }]
 dragent-llamaindex = [{ name = "datarobot-genai", extras = ["dragent", "llamaindex"], editable = "../" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.7.5"
+version = "0.7.6"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.7.4"
+version = "0.7.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a new E2E example and CI wiring plus a version bump; low risk since it doesn’t change runtime library behavior, but may affect CI runtime/matrix selection.
> 
> **Overview**
> Adds a new **"base" dragent E2E example** (`e2e-tests/dragent/base/`) that demonstrates extending `BaseAgent` directly and registering it as a NAT workflow plugin, emitting minimal AG-UI streaming events.
> 
> Updates the E2E Taskfile and GitHub Actions matrix/path filters to run this new framework group, and adds a `dragent-base` dependency group + NAT plugin entry in `e2e-tests/pyproject.toml`.
> 
> Bumps package version to `0.7.6` and records the change in `CHANGELOG.md` (lockfiles updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c31afb91fb311599c6977db840094c9237ede3ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->