### PR TITLE
[BUZZOK-29868] [BUZZOK-29837] [BUZZOK-29784] Enable MCP and tool tests for all agents

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run e2e tests
         working-directory: e2e-tests
         run: |
-          uv run pytest dragent_tests -vv -s --timeout=60 --tb=short --reruns=1 --reruns-delay=5 --junitxml=test_results/results.xml
+          uv run pytest dragent_tests -vv -s --timeout=60 --tb=short --junitxml=test_results/results.xml
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run e2e tests
         working-directory: e2e-tests
         run: |
-          uv run pytest dragent_tests -vv -s --timeout=60 --tb=short --junitxml=test_results/results.xml
+          uv run pytest dragent_tests -vv -s --timeout=60 --tb=short --reruns=1 --reruns-delay=5 --junitxml=test_results/results.xml
 
       - name: Upload test results
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.1
+- Fixed issue with NAT profiler interacting with MCP tools for langgraph
+- Enabled MCP and tool tests for all agents
+- Implemented decorator `nat_tool` which allows registering a function in NAT with a single line
+
 ## 0.8.0
 - Allowed configuring step adaptor
 - Reorganized `dragent` to submodules

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -46,7 +46,7 @@ class MyAgent(CrewAIAgent):
                 "outline with 3-5 key points. No paragraphs, no explanations — just the list."
             ),
             llm=self._llm,
-            tools=self.mcp_tools,
+            tools=[calculator_tool] + self.mcp_tools,
             verbose=self.verbose,
         )
         writer = Agent(

--- a/e2e-tests/dragent/langgraph/myagent.py
+++ b/e2e-tests/dragent/langgraph/myagent.py
@@ -63,7 +63,7 @@ class MyAgent(LangGraphAgent):
     def agent_planner(self) -> Any:
         return create_agent(
             self._llm,
-            tools=self.mcp_tools,
+            tools=[calculator_tool] + self.mcp_tools,
             system_prompt=make_system_prompt(
                 "You are a content planner. Given a topic, produce a short bullet-point "
                 "outline with 3-5 key points. No paragraphs, no explanations — just the list."

--- a/e2e-tests/dragent/llamaindex/myagent.py
+++ b/e2e-tests/dragent/llamaindex/myagent.py
@@ -45,7 +45,7 @@ class MyAgent(LlamaIndexAgent):
                 "When done, hand off to the writer agent."
             ),
             llm=self._llm,
-            tools=self.mcp_tools,
+            tools=[calculator] + self.mcp_tools,
             can_handoff_to=["writer"],
         )
         writer = FunctionAgent(

--- a/e2e-tests/dragent/nat/register.py
+++ b/e2e-tests/dragent/nat/register.py
@@ -1,0 +1,18 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datarobot_genai.drtools.calculator import calculator
+from datarobot_genai.nat.tool import nat_tool
+
+nat_tool(calculator, "calculator")

--- a/e2e-tests/dragent/nat/workflow.yaml
+++ b/e2e-tests/dragent/nat/workflow.yaml
@@ -27,6 +27,9 @@ functions:
       You are a concise writer. Using the planner's outline, write a short
       response in 2-3 sentences.
     description: A tool that writes the content for the requested topic.
+  calculator:
+    _type: calculator
+    description: A tool that calculates the result of a mathematical expression.
 
 llms:
   datarobot_llm:
@@ -47,6 +50,7 @@ workflow:
     - planner
     - writer
     - mcp_tools
+    - calculator
   return_direct:
     - writer
   system_prompt: |

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import uuid
 
 import httpx
@@ -20,6 +21,8 @@ from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
 GENERATE_STREAM_PATH = "/generate/stream"
 GENERATE_PATH = "/generate"
+FRAMEWORK = os.environ.get("FRAMEWORK")
+FRAMEWORK_SUPPORTS_TOOL_CALLS = FRAMEWORK in ["langgraph", "nat"]
 
 
 def make_generate_payload(content: str) -> dict:  # type: ignore[type-arg]

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -18,6 +18,7 @@ import httpx
 import pytest
 from ag_ui.core import EventType
 
+from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import make_generate_payload
@@ -28,16 +29,16 @@ pytestmark = pytest.mark.skipif(
     reason="MCP_DEPLOYMENT_ID not set; skipping MCP tests",
 )
 
-pytest.skip(
-    reason="MCP tests are not implemented yet. TODO: BUZZOK-29837",
-    allow_module_level=True
-)
-
 MCP_TOOL_PROMPT = (
     "You MUST use the search_datarobot_agentic_docs tool to search for 'MCP server'. "
     "Call it with query='MCP server' and max_results=1. "
     "Report only the title of the first result."
 )
+
+EXPECTED_TOOL_CALL_NAMES = {
+    "search_datarobot_agentic_docs",
+    "mcp_tools__search_datarobot_agentic_docs"
+}
 
 
 def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
@@ -52,21 +53,26 @@ def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[
     # THEN: a response is correct AG UI events
     mcp_ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # THEN: the events contain tool call events
-    event_types = {e.type for e in mcp_ag_ui_events}
+    # THEN: the events contain tool call events (if framework supports tool calls)
     tool_types = {
         EventType.TOOL_CALL_START,
         EventType.TOOL_CALL_END,
         EventType.TOOL_CALL_ARGS,
         EventType.TOOL_CALL_RESULT,
     }
-    assert event_types & tool_types, f"No tool call events found. Got: {event_types}"
+    event_types = {e.type for e in mcp_ag_ui_events}
+    if FRAMEWORK_SUPPORTS_TOOL_CALLS:
+        assert event_types & tool_types, f"No tool call events found. Got: {event_types}"
 
-    # THEN: the tool call events contain mcp_tools__search_datarobot_agentic_docs
-    tool_call_names = {
-        e.tool_call_name for e in mcp_ag_ui_events if e.type == EventType.TOOL_CALL_START
-    }
-    assert "mcp_tools__search_datarobot_agentic_docs" in tool_call_names, (
-        "No tool call event found for mcp_tools__search_datarobot_agentic_docs. "
-        f"Got: {tool_call_names}"
-    )
+        # THEN: the tool call events contain mcp_tools__search_datarobot_agentic_docs
+        tool_call_names = {
+            e.tool_call_name for e in mcp_ag_ui_events if e.type == EventType.TOOL_CALL_START
+        }
+        assert EXPECTED_TOOL_CALL_NAMES & tool_call_names, (
+            "No tool call event found for mcp_tools__search_datarobot_agentic_docs. "
+            f"Got: {tool_call_names}"
+        )
+    else:
+        assert not event_types & tool_types, (
+            f"Tool call events found when framework does not support them. Got: {event_types}"
+        )

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -18,7 +18,7 @@ import httpx
 import pytest
 from ag_ui.core import EventType
 
-from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
+from dragent_tests.helpers import FRAMEWORK, FRAMEWORK_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import make_generate_payload
@@ -40,7 +40,10 @@ EXPECTED_TOOL_CALL_NAMES = {
     "mcp_tools__search_datarobot_agentic_docs"
 }
 
-
+@pytest.mark.skipif(
+    FRAMEWORK == "base",
+    reason="Base framework does not implement anything, skipping MCP tool call tests",
+)
 def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
     """Agent invokes an MCP tool (search_datarobot_agentic_docs)."""
     # GIVEN: a prompt that invokes the search_datarobot_agentic_docs tool

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -20,11 +20,11 @@ import httpx
 import pytest
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
+from dragent_tests.helpers import FRAMEWORK
 from dragent_tests.helpers import GENERATE_PATH
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 
-FRAMEWORK = os.environ.get("FRAMEWORK")
 
 @pytest.mark.skipif(
     FRAMEWORK == "nat",

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -15,10 +15,11 @@
 from __future__ import annotations
 
 import httpx
-import pytest
 from ag_ui.core import EventType
+import pytest
 
-from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS, GENERATE_STREAM_PATH
+from dragent_tests.helpers import FRAMEWORK, FRAMEWORK_SUPPORTS_TOOL_CALLS
+from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
@@ -34,7 +35,10 @@ CALCULATOR_PROMPT = (
 
 EXPECTED_RESULT = str((1234 * 567890) + 91011)
 
-
+@pytest.mark.skipif(
+    FRAMEWORK == "base",
+    reason="Base framework does not implement anything, skipping tool call tests",
+)
 def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
     """Agent uses calculator tool when asked to compute."""
     # GIVEN: a payload that requests the calculator tool to compute the expression

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -18,16 +18,11 @@ import httpx
 import pytest
 from ag_ui.core import EventType
 
-from dragent_tests.helpers import GENERATE_STREAM_PATH
+from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS, GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
-
-pytest.skip(
-    reason="Not all frameworks emit TOOL_CALL AG-UI events yet. TODO: BUZZOK-29784",
-    allow_module_level=True
-)
 
 CALCULATOR_PROMPT = (
     "You MUST use the calculator tool to compute the following expression. "
@@ -38,7 +33,6 @@ CALCULATOR_PROMPT = (
 )
 
 EXPECTED_RESULT = str((1234 * 567890) + 91011)
-
 
 
 def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
@@ -62,16 +56,21 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
         EventType.TOOL_CALL_ARGS,
         EventType.TOOL_CALL_RESULT,
     }
-    assert event_types & tool_types, f"No tool call events found. Got: {event_types}"
+    if FRAMEWORK_SUPPORTS_TOOL_CALLS:
+        assert event_types & tool_types, f"No tool call events found. Got: {event_types}"
 
-    # THEN: the tool call events contain the calculator tool
-    tool_call_names = {
-        e.tool_call_name for e in ag_ui_events if e.type == EventType.TOOL_CALL_START
-    }
-    assert "calculator" in tool_call_names, (
-        "No tool call event found for calculator. "
-        f"Got: {tool_call_names}"
-    )
+        # THEN: the tool call events contain the calculator tool
+        tool_call_names = {
+            e.tool_call_name for e in ag_ui_events if e.type == EventType.TOOL_CALL_START
+        }
+        assert "calculator" in tool_call_names, (
+            "No tool call event found for calculator. "
+            f"Got: {tool_call_names}"
+        )
+    else:
+        assert not event_types & tool_types, (
+            f"Tool call events found when framework does not support them. Got: {event_types}"
+        )
 
     # THEN: the tool call events contain the correct result
     full_text = collect_text(ag_ui_events)

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -35,6 +35,7 @@ lint = [
 ]
 
 [project.entry-points.'nat.plugins']
+nat_agent = "dragent.nat.register"
 langgraph_agent = "dragent.langgraph.register"
 crewai_agent = "dragent.crewai.register"
 llamaindex_agent = "dragent.llamaindex.register"

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -845,7 +845,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.0"
+version = "0.8.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -17,12 +17,57 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from langchain.tools import BaseTool
+from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.sessions import SSEConnection
 from langchain_mcp_adapters.sessions import StreamableHttpConnection
 from langchain_mcp_adapters.sessions import create_session
 from langchain_mcp_adapters.tools import load_mcp_tools
+from pydantic import PrivateAttr
 
 from datarobot_genai.core.mcp.common import MCPConfig
+
+
+def _wrap_mcp_tool_for_langgraph(inner: BaseTool) -> BaseTool:
+    """Wrap an MCP tool so LangGraph-injected 'runtime' is filtered from callback inputs.
+
+    MCP tools from langchain_mcp_adapters use args_schema=tool.inputSchema (a dict).
+    LangChain's _filter_injected_args only filters keys declared on Pydantic args_schema,
+    so it never filters 'runtime'. That leaves ToolRuntime (with config/callbacks) in the
+    inputs passed to profiler callbacks, which then fail on copy.deepcopy (e.g. coroutines).
+
+    This wrapper declares 'runtime' as an injected arg so it is filtered before callbacks
+    see the inputs, while delegating execution to the inner tool unchanged.
+    """
+
+    async def _invoke_inner(**kwargs: Any) -> Any:
+        # Call the inner tool's coroutine so we return (content, artifact), not the
+        # formatted output that ainvoke() would return.
+        if getattr(inner, "coroutine", None) is not None:
+            return await inner.coroutine(**kwargs)
+        return await inner.ainvoke(kwargs)
+
+    class _MCPToolWrapper(StructuredTool):
+        """Thin wrapper that adds 'runtime' to injected args for callback filtering."""
+
+        _inner: BaseTool = PrivateAttr()
+
+        def __init__(self, inner_tool: BaseTool, coro: Any) -> None:
+            super().__init__(
+                name=inner_tool.name,
+                description=inner_tool.description or "",
+                args_schema=inner_tool.args_schema,
+                coroutine=coro,
+                response_format=getattr(inner_tool, "response_format", "content_and_artifact"),
+                metadata=getattr(inner_tool, "metadata", None),
+            )
+            self._inner = inner_tool
+
+        @property
+        def _injected_args_keys(self) -> frozenset[str]:
+            base: frozenset[str] = getattr(self._inner, "_injected_args_keys", frozenset())
+            return base | frozenset(["runtime"])
+
+    return _MCPToolWrapper(inner, _invoke_inner)
 
 
 @asynccontextmanager
@@ -68,6 +113,9 @@ async def mcp_tools_context(
 
     async with create_session(connection=connection) as session:
         # Use the connection to load available MCP tools
-        tools = await load_mcp_tools(session=session)
+        raw_tools = await load_mcp_tools(session=session)
+        # Wrap so LangGraph-injected 'runtime' is filtered from callback inputs (avoids
+        # copy.deepcopy of non-serializable ToolRuntime in NAT profiler).
+        tools = [_wrap_mcp_tool_for_langgraph(t) for t in raw_tools]
         print(f"Successfully loaded {len(tools)} MCP tools", flush=True)
         yield tools

--- a/src/datarobot_genai/nat/tool.py
+++ b/src/datarobot_genai/nat/tool.py
@@ -1,0 +1,58 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import inspect
+from collections.abc import AsyncGenerator
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from nat.builder.builder import Builder
+from nat.builder.function import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.function import FunctionBaseConfig
+
+
+def _sync_to_async(fn: Callable) -> Callable:
+    """Wrap a sync function in an async one."""
+
+    @wraps(fn)
+    async def async_wrapper(*args: object, **kwargs: object) -> Any:  # noqa: ANN401
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    return async_wrapper
+
+
+def nat_tool(fn: Callable, name: str, description: str | None = None) -> Callable:
+    """Decorate a function as a NAT tool."""
+
+    class NatToolConfig(FunctionBaseConfig, name=name):  # type: ignore[call-arg]
+        pass
+
+    @register_function(
+        config_type=NatToolConfig,
+    )
+    async def wrapper(config: NatToolConfig, builder: Builder) -> AsyncGenerator:
+        # NAT expects a coroutine function, so we wrap sync functions in an async one.
+        if not inspect.iscoroutinefunction(fn):
+            fn_for_nat = _sync_to_async(fn)
+        else:
+            fn_for_nat = fn
+        yield FunctionInfo.from_fn(
+            fn=fn_for_nat,
+            description=description,
+        )
+
+    return fn

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -14,7 +14,6 @@
 
 import os
 from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
@@ -41,7 +40,45 @@ def mock_load_mcp_tools():
 
 @pytest.fixture
 def mock_tools():
-    return [MagicMock(), MagicMock()]
+    from langchain_core.tools import StructuredTool
+    from pydantic import BaseModel
+    from pydantic import Field
+
+    # Dummy argument schema for a test tool
+    class DummyToolInput(BaseModel):
+        foo: str = Field(..., description="A foo string argument")
+        bar: int = Field(42, description="A bar integer argument")
+
+    async def dummy_tool_func(foo: str, bar: int = 42, runtime=None):
+        """Do something."""
+        # Runtime arg to mimic MCP runtime-injected parameter
+        return ({"content": f"foo={foo}; bar={bar}", "artifact": None}, [])
+
+    # Dummy 1: tool using args_schema and coroutine
+    dummy_tool_1 = StructuredTool(
+        name="dummy-tool-1",
+        description="A dummy MCP-like tool for testing.",
+        args_schema=DummyToolInput,
+        coroutine=dummy_tool_func,
+        response_format="content_and_artifact",
+        metadata={"_meta": {"example": 1}},
+    )
+
+    # Dummy 2: Minimal version, no response_format or metadata
+    class Tool2Input(BaseModel):
+        val: int = Field(...)
+
+    async def tool2_func(val: int, runtime=None):
+        return ({"content": str(val * 10), "artifact": None}, [])
+
+    dummy_tool_2 = StructuredTool(
+        name="tool-2",
+        description="A second dummy MCP tool.",
+        args_schema=Tool2Input,
+        coroutine=tool2_func,
+    )
+
+    return [dummy_tool_1, dummy_tool_2]
 
 
 @pytest.fixture
@@ -50,6 +87,20 @@ def mock_session_instance():
     session_instance.__aenter__.return_value = session_instance
     session_instance.__aexit__.return_value = None
     return session_instance
+
+
+@pytest.fixture
+def assert_mock_tools_expected(mock_tools):
+    tool_names = [t.name for t in mock_tools]
+    tool_descriptions = [t.description for t in mock_tools]
+    tool_args_schemas = [t.args_schema for t in mock_tools]
+
+    def assert_mock_tools_expected(tools):
+        assert [t.name for t in tools] == tool_names
+        assert [t.description for t in tools] == tool_descriptions
+        assert [t.args_schema for t in tools] == tool_args_schemas
+
+    return assert_mock_tools_expected
 
 
 @pytest.fixture
@@ -70,7 +121,9 @@ class TestMCPToolsContext:
             async with mcp_tools_context() as tools:
                 assert tools == []
 
-    async def test_mcp_tools_context_with_external_url(self, setup_session_and_tools):
+    async def test_mcp_tools_context_with_external_url(
+        self, setup_session_and_tools, assert_mock_tools_expected
+    ):
         test_headers = '{"X-API-Key": "test-key", "Content-Type": "application/json"}'
         test_transport = "sse"
         external_url = "https://mcp-server.example.com/mcp"
@@ -85,7 +138,7 @@ class TestMCPToolsContext:
             clear=True,
         ):
             async with mcp_tools_context() as tools:
-                assert tools == setup_session_and_tools["tools"]
+                assert_mock_tools_expected(tools)
 
                 # Verify create_session was called with correct connection config
                 setup_session_and_tools["session"].assert_called_once()
@@ -103,13 +156,13 @@ class TestMCPToolsContext:
                 )
 
     async def test_mcp_tools_context_with_external_url_default_transport(
-        self, setup_session_and_tools
+        self, setup_session_and_tools, assert_mock_tools_expected
     ):
         external_url = "https://mcp-server.example.com/mcp"
 
         with patch.dict(os.environ, {"EXTERNAL_MCP_URL": external_url}, clear=True):
             async with mcp_tools_context() as tools:
-                assert tools == setup_session_and_tools["tools"]
+                assert_mock_tools_expected(tools)
 
                 # Verify create_session was called with correct connection config
                 # (default transport)
@@ -126,7 +179,7 @@ class TestMCPToolsContext:
                 )
 
     async def test_mcp_tools_context_with_datarobot_deployment(
-        self, setup_session_and_tools, agent_auth_context_data
+        self, setup_session_and_tools, agent_auth_context_data, assert_mock_tools_expected
     ):
         deployment_id = "abc123def456789012345678"
         api_base = "https://app.datarobot.com/api/v2"
@@ -146,7 +199,7 @@ class TestMCPToolsContext:
             clear=True,
         ):
             async with mcp_tools_context() as tools:
-                assert tools == setup_session_and_tools["tools"]
+                assert_mock_tools_expected(tools)
                 # Check that create_session was called with correct connection config
                 setup_session_and_tools["session"].assert_called_once()
                 call_args = setup_session_and_tools["session"].call_args
@@ -159,7 +212,7 @@ class TestMCPToolsContext:
                 )
 
     async def test_mcp_tools_context_with_parameters(
-        self, setup_session_and_tools, agent_auth_context_data
+        self, setup_session_and_tools, agent_auth_context_data, assert_mock_tools_expected
     ):
         deployment_id = "abc123def456789012345678"
         custom_api_base = "https://custom.datarobot.com/api/v2"
@@ -179,7 +232,7 @@ class TestMCPToolsContext:
             clear=True,
         ):
             async with mcp_tools_context() as tools:
-                assert tools == setup_session_and_tools["tools"]
+                assert_mock_tools_expected(tools)
                 # Check that create_session was called with custom parameters
                 setup_session_and_tools["session"].assert_called_once()
                 call_args = setup_session_and_tools["session"].call_args
@@ -188,7 +241,9 @@ class TestMCPToolsContext:
                 assert connection_config["url"] == expected_url
                 assert connection_config["headers"]["Authorization"] == f"Bearer {custom_api_key}"
 
-    async def test_mcp_tools_context_with_sse_transport(self, setup_session_and_tools):
+    async def test_mcp_tools_context_with_sse_transport(
+        self, setup_session_and_tools, assert_mock_tools_expected
+    ):
         external_url = "https://mcp-server.example.com/mcp"
 
         with patch.dict(
@@ -197,7 +252,7 @@ class TestMCPToolsContext:
             clear=True,
         ):
             async with mcp_tools_context() as tools:
-                assert tools == setup_session_and_tools["tools"]
+                assert_mock_tools_expected(tools)
                 # Verify create_session was called with SSE transport
                 setup_session_and_tools["session"].assert_called_once()
                 call_args = setup_session_and_tools["session"].call_args

--- a/tests/nat/test_tool.py
+++ b/tests/nat/test_tool.py
@@ -1,0 +1,180 @@
+# Copyright 2025 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import inspect
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.nat.tool import _sync_to_async
+from datarobot_genai.nat.tool import nat_tool
+
+
+class TestSyncToAsync:
+    """Tests for _sync_to_async."""
+
+    def test_returns_coroutine_function(self):
+        def sync_fn(x: int) -> int:
+            return x + 1
+
+        wrapped = _sync_to_async(sync_fn)
+        assert inspect.iscoroutinefunction(wrapped)
+
+    def test_preserves_annotations(self):
+        def sync_fn(x: int) -> str:
+            return str(x)
+
+        wrapped = _sync_to_async(sync_fn)
+        assert wrapped.__annotations__["x"] is int
+        assert wrapped.__annotations__["return"] is str
+
+    def test_preserves_name_and_doc(self):
+        def sync_fn(x: int) -> int:
+            """Double the input."""
+            return x * 2
+
+        wrapped = _sync_to_async(sync_fn)
+        assert wrapped.__name__ == "sync_fn"
+        assert wrapped.__doc__ == "Double the input."
+
+    @pytest.mark.asyncio
+    async def test_wrapper_returns_same_result(self):
+        def sync_fn(x: int, y: int) -> int:
+            return x + y
+
+        wrapped = _sync_to_async(sync_fn)
+        result = await wrapped(2, 3)
+        assert result == 5
+
+    @pytest.mark.asyncio
+    async def test_wrapper_accepts_kwargs(self):
+        def sync_fn(a: int, b: int) -> int:
+            return a - b
+
+        wrapped = _sync_to_async(sync_fn)
+        result = await wrapped(a=10, b=3)
+        assert result == 7
+
+
+class TestNatTool:
+    """Tests for nat_tool decorator."""
+
+    def test_returns_original_function(self):
+        def my_sync_tool(x: int) -> int:
+            return x
+
+        result = nat_tool(my_sync_tool, "my_tool", description="Does nothing")
+        assert result is my_sync_tool
+
+    def test_async_function_returned_as_is(self):
+        async def my_async_tool(x: int) -> int:
+            return x
+
+        result = nat_tool(my_async_tool, "my_async_tool")
+        assert result is my_async_tool
+
+    @patch("datarobot_genai.nat.tool.FunctionInfo")
+    @patch("datarobot_genai.nat.tool._sync_to_async")
+    @patch("datarobot_genai.nat.tool.register_function")
+    def test_sync_function_causes_sync_to_async_call(
+        self,
+        mock_register: MagicMock,
+        mock_sync_to_async: MagicMock,
+        mock_function_info: MagicMock,
+    ):
+        async def fake_async(x: str) -> str:
+            return x
+
+        mock_sync_to_async.return_value = fake_async
+
+        def sync_tool(msg: str) -> str:
+            return msg
+
+        nat_tool(sync_tool, "echo", description="Echoes")
+
+        # Wrapper is only run when NAT invokes it; run it here to trigger from_fn
+        wrapper = mock_register.return_value.call_args[0][0]
+        config = MagicMock()
+        builder = MagicMock()
+
+        async def run_wrapper():
+            gen = wrapper(config, builder)
+            return await gen.__anext__()
+
+        asyncio.run(run_wrapper())
+
+        mock_sync_to_async.assert_called_once_with(sync_tool)
+        mock_function_info.from_fn.assert_called_once()
+        call_kw = mock_function_info.from_fn.call_args.kwargs
+        assert call_kw["fn"] is fake_async
+        assert call_kw["description"] == "Echoes"
+
+    @patch("datarobot_genai.nat.tool.FunctionInfo")
+    @patch("datarobot_genai.nat.tool._sync_to_async")
+    @patch("datarobot_genai.nat.tool.register_function")
+    def test_async_function_does_not_call_sync_to_async(
+        self,
+        mock_register: MagicMock,
+        mock_sync_to_async: MagicMock,
+        mock_function_info: MagicMock,
+    ):
+        async def async_tool(msg: str) -> str:
+            return msg
+
+        nat_tool(async_tool, "async_echo", description="Async echo")
+
+        # Run the registered wrapper so from_fn is invoked
+        wrapper = mock_register.return_value.call_args[0][0]
+        asyncio.run(wrapper(MagicMock(), MagicMock()).__anext__())
+
+        mock_sync_to_async.assert_not_called()
+        mock_function_info.from_fn.assert_called_once_with(
+            fn=async_tool,
+            description="Async echo",
+        )
+
+    @patch("datarobot_genai.nat.tool.FunctionInfo")
+    @patch("datarobot_genai.nat.tool.register_function")
+    def test_description_none_passed_through(
+        self, mock_register: MagicMock, mock_function_info: MagicMock
+    ):
+        async def async_tool(x: int) -> int:
+            return x
+
+        nat_tool(async_tool, "no_desc")
+
+        # Run the registered wrapper so from_fn is invoked
+        wrapper = mock_register.return_value.call_args[0][0]
+        asyncio.run(wrapper(MagicMock(), MagicMock()).__anext__())
+
+        mock_function_info.from_fn.assert_called_once()
+        assert mock_function_info.from_fn.call_args.kwargs["description"] is None
+
+    @patch("datarobot_genai.nat.tool.FunctionInfo")
+    @patch("datarobot_genai.nat.tool.register_function")
+    def test_register_function_called_with_config_type(
+        self, mock_register: MagicMock, mock_function_info: MagicMock
+    ):
+        from nat.data_models.function import FunctionBaseConfig
+
+        async def async_tool(x: int) -> int:
+            return x
+
+        nat_tool(async_tool, "my_tool_name")
+
+        call_args = mock_register.call_args
+        config_type = call_args.kwargs["config_type"]
+        assert issubclass(config_type, FunctionBaseConfig)

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

This was intended to fix langgraph, but the issue with langraph was essentially the MCP. So I also enabled MCP tests for all agents, and tool tests for all agents, and implemented an simple way to register functions in NAT to be used as tools.

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LangGraph MCP tool invocation by wrapping tools to filter injected `runtime`, which could subtly affect tool execution/callback behavior, and expands e2e coverage across frameworks. Core changes are localized but interact with third-party LangChain/NAT tooling.
> 
> **Overview**
> Bumps version to `0.8.1` and documents the release in `CHANGELOG.md`.
> 
> Fixes a LangGraph+MCP edge case by wrapping loaded MCP tools in `mcp_tools_context` so the LangGraph-injected `runtime` argument is treated as injected and filtered before callbacks/profilers run (avoids deepcopy/serialization failures).
> 
> Enables and broadens e2e tool/MCP coverage across agents: adds calculator tool wiring to CrewAI/LangGraph/LlamaIndex examples, introduces a NAT e2e plugin (`dragent/nat/register.py`) plus workflow updates to expose `calculator`, and updates e2e assertions/skip logic to be framework-aware.
> 
> Adds a new `nat_tool` helper (`src/datarobot_genai/nat/tool.py`) to register NAT tools from a function in one line (including sync-to-async wrapping), with new unit tests for both the LangGraph MCP wrapping behavior and `nat_tool`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a1bcaafa6759db4a78d98f40fd4934ec6d879c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->