### PR TITLE
[BUZZOK-29929] Fix anyio cancel scope, by keeping builder enter/exit in one task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.7
+- Fixed RuntimeError during per-user MCP builder cleanup
+
 ## 0.8.6
 - Locked upperbound for dragent dependencies (fastapi, starlette) to avoid compatibility issues
 - Locked lowerbound for AG-UI because of a change in reasoning events validation

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -857,29 +857,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pandas" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "strenum" },
-    { name = "trafaret" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/63/1ea3461a165c51f255ccdcb96411e82671cf8d0b3791718c2042aa5f0bfc/datarobot_early_access-3.14.0.2026.3.18.162920.tar.gz", hash = "sha256:94eacf05010a01131679017b2742b6bca6800d23e2c48210e1968af6e40e6e35", size = 837031, upload-time = "2026-03-18T16:29:24.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/7b/b1a34fb997290d22159db756a41a047c47335f656598d52f4bb014a6a0f1/datarobot_early_access-3.14.0.2026.3.18.162920-py3-none-any.whl", hash = "sha256:7625a2cd3c1670b5d6b927b48e464750f68dff4463db11079f6e81fab257305e", size = 909539, upload-time = "2026-03-18T16:29:22.525Z" },
-]
-
-[[package]]
-name = "datarobot-early-access"
-version = "3.14.0.2026.3.18.162920"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pandas" },
     { name = "python-dateutil" },
     { name = "pytz" },

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -857,6 +857,29 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pandas" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "strenum" },
+    { name = "trafaret" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/63/1ea3461a165c51f255ccdcb96411e82671cf8d0b3791718c2042aa5f0bfc/datarobot_early_access-3.14.0.2026.3.18.162920.tar.gz", hash = "sha256:94eacf05010a01131679017b2742b6bca6800d23e2c48210e1968af6e40e6e35", size = 837031, upload-time = "2026-03-18T16:29:24.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/7b/b1a34fb997290d22159db756a41a047c47335f656598d52f4bb014a6a0f1/datarobot_early_access-3.14.0.2026.3.18.162920-py3-none-any.whl", hash = "sha256:7625a2cd3c1670b5d6b927b48e464750f68dff4463db11079f6e81fab257305e", size = 909539, upload-time = "2026-03-18T16:29:22.525Z" },
+]
+
+[[package]]
+name = "datarobot-early-access"
+version = "3.14.0.2026.3.18.162920"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pandas" },
     { name = "python-dateutil" },
     { name = "pytz" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.6"
+version = "0.8.7"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+import asyncio
 import logging
+import typing
+from contextlib import nullcontext
+from datetime import datetime
 
 from fastapi import Request
+from nat.runtime.session import PerUserBuilderInfo
 from nat.runtime.session import SessionManager
 from pydantic import BaseModel
 
@@ -23,12 +30,34 @@ from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
 from .request import DRAgentRunAgentInput
 from .response import DRAgentEventResponse
 
+if typing.TYPE_CHECKING:
+    from nat.builder.per_user_workflow_builder import PerUserWorkflowBuilder
+    from nat.builder.workflow import Workflow
+
 logger = logging.getLogger(__name__)
 
 _auth_context_handler = AuthContextHeaderHandler()
 
+# Default timeout (seconds) for waiting on a lifecycle task to finish teardown.
+_LIFECYCLE_TASK_TIMEOUT = 30.0
+
 
 class DRAgentAGUISessionManager(SessionManager):
+    """Session manager with cross-task-safe per-user builder lifecycle management.
+
+    The upstream :class:`SessionManager` calls ``builder.__aenter__()`` in an HTTP
+    request task but ``builder.__aexit__()`` in a periodic background cleanup task.
+    The MCP streamable-HTTP client uses *anyio* cancel scopes internally, and *anyio*
+    forbids exiting a cancel scope from a task different to the one that entered it,
+    causing a ``RuntimeError`` during idle-session cleanup.
+
+    This subclass fixes the problem by running each per-user builder's full lifecycle
+    (``__aenter__`` → populate → build → … → ``__aexit__``) inside a **dedicated
+    asyncio task**, and replacing the builder's ``__aexit__`` on the instance so that
+    the upstream ``_cleanup_inactive_per_user_builders`` and ``shutdown`` transparently
+    signal the lifecycle task instead of calling ``__aexit__`` cross-task.
+    """
+
     def get_workflow_input_schema(self) -> type[BaseModel]:
         """Get workflow input schema for OpenAPI documentation."""
         return DRAgentRunAgentInput
@@ -36,6 +65,142 @@ class DRAgentAGUISessionManager(SessionManager):
     def get_workflow_streaming_output_schema(self) -> type[BaseModel]:
         """Get workflow streaming output schema for OpenAPI documentation."""
         return DRAgentEventResponse
+
+    # ------------------------------------------------------------------
+    # Per-user builder lifecycle — runs enter/exit in one dedicated task
+    # ------------------------------------------------------------------
+
+    async def _get_or_create_per_user_builder(
+        self, user_id: str
+    ) -> tuple[PerUserWorkflowBuilder, Workflow]:
+        """Create or return the cached per-user builder for *user_id*.
+
+        Overrides the base implementation so that ``builder.__aenter__()`` and
+        all resource setup happen inside a **dedicated asyncio task**.  That task
+        lives until cleanup or shutdown calls the builder's ``__aexit__``
+        (replaced on the instance to signal the task) — so the real
+        ``__aexit__`` always runs in the *same* task as ``__aenter__``,
+        avoiding the cross-task cancel-scope error from anyio.
+        """
+        from nat.builder.per_user_workflow_builder import PerUserWorkflowBuilder  # noqa: PLC0415
+
+        async with self._per_user_builders_lock:
+            if user_id in self._per_user_builders:
+                builder_info = self._per_user_builders[user_id]
+                builder_info.last_activity = datetime.now()
+                return builder_info.builder, builder_info.workflow
+
+            logger.info(
+                "Creating per-user builder for user=%s, entry_function=%s",
+                user_id,
+                self._entry_function,
+            )
+
+            builder = PerUserWorkflowBuilder(user_id=user_id, shared_builder=self._shared_builder)
+
+            # Coordination primitives shared with the lifecycle task.
+            ready_event = asyncio.Event()
+            shutdown_event = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            result_future: asyncio.Future[Workflow] = loop.create_future()
+
+            async def _builder_lifecycle() -> None:
+                """Run the full builder lifecycle in a single task.
+
+                This ensures ``__aenter__`` and ``__aexit__`` share the same
+                asyncio task so that anyio cancel scopes remain valid.
+                """
+                try:
+                    await builder.__aenter__()
+                    try:
+                        await builder.populate_builder(self._config)
+                        workflow = await builder.build(entry_function=self._entry_function)
+                        result_future.set_result(workflow)
+                    except BaseException as exc:
+                        if not result_future.done():
+                            result_future.set_exception(exc)
+                        raise
+                    finally:
+                        ready_event.set()
+
+                    # Keep the task alive until cleanup/shutdown signals.
+                    await shutdown_event.wait()
+
+                except BaseException:
+                    if not ready_event.is_set():
+                        ready_event.set()
+                finally:
+                    try:
+                        # Call the *real* class-level __aexit__ (not our
+                        # instance replacement below) — in this same task.
+                        await type(builder).__aexit__(builder, None, None, None)
+                    except Exception:
+                        logger.exception(
+                            "Error during builder teardown for user %s",
+                            user_id,
+                        )
+
+            task = asyncio.create_task(_builder_lifecycle(), name=f"builder-lifecycle-{user_id}")
+
+            # Wait for the lifecycle task to finish setup.
+            await ready_event.wait()
+
+            try:
+                workflow = result_future.result()
+            except BaseException:
+                # Wait for the lifecycle task to finish its own cleanup.
+                try:
+                    await asyncio.wait_for(task, timeout=_LIFECYCLE_TASK_TIMEOUT)
+                except Exception:
+                    pass
+                raise
+
+            # Replace __aexit__ on the *instance* so that the upstream
+            # _cleanup_inactive_per_user_builders() and shutdown() — which
+            # call ``builder_info.builder.__aexit__(…)`` — transparently
+            # signal the lifecycle task instead of calling __aexit__
+            # cross-task.
+            async def _signal_shutdown(*_exc_details: object) -> None:
+                shutdown_event.set()
+                try:
+                    await asyncio.wait_for(task, timeout=_LIFECYCLE_TASK_TIMEOUT)
+                except TimeoutError:
+                    logger.warning(
+                        "Lifecycle task for user %s did not finish in time; cancelling",
+                        user_id,
+                    )
+                    task.cancel()
+
+            builder.__aexit__ = _signal_shutdown  # type: ignore[method-assign]
+
+            # Create per-user semaphore for concurrency control.
+            if self._max_concurrency > 0:
+                per_user_semaphore: asyncio.Semaphore | nullcontext = asyncio.Semaphore(
+                    self._max_concurrency
+                )
+            else:
+                per_user_semaphore = nullcontext()
+
+            builder_info = PerUserBuilderInfo(
+                builder=builder,
+                workflow=workflow,
+                semaphore=per_user_semaphore,
+                last_activity=datetime.now(),
+                ref_count=0,
+                lock=asyncio.Lock(),
+            )
+            self._per_user_builders[user_id] = builder_info
+
+            logger.info(
+                "Created per-user builder for user=%s (total users: %d)",
+                user_id,
+                len(self._per_user_builders),
+            )
+            return builder_info.builder, builder_info.workflow
+
+    # ------------------------------------------------------------------
+    # HTTP metadata extraction
+    # ------------------------------------------------------------------
 
     def set_metadata_from_http_request(self, request: Request) -> None:
         """Extend base metadata extraction to also set user_id from DataRobot auth context.

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+from datetime import datetime
+from datetime import timedelta
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -23,6 +26,43 @@ from nat.runtime.session import SessionManager
 from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.session import DRAgentAGUISessionManager
+
+_BUILDER_PATCH = "nat.builder.per_user_workflow_builder.PerUserWorkflowBuilder"
+
+
+class FakeBuilder:
+    """Async-context-manager stand-in for ``PerUserWorkflowBuilder``.
+
+    Records which asyncio task called ``__aenter__`` / ``__aexit__`` and
+    exposes an :attr:`exited` event so tests can synchronise on teardown.
+    """
+
+    def __init__(self, workflow=None, *, populate_error=None):
+        self.workflow = workflow or MagicMock()
+        self.populate_error = populate_error
+        self.enter_task_id: int | None = None
+        self.exit_task_id: int | None = None
+        self.exited = asyncio.Event()
+
+    async def __aenter__(self):
+        self.enter_task_id = id(asyncio.current_task())
+        return self
+
+    async def __aexit__(self, *exc):
+        self.exit_task_id = id(asyncio.current_task())
+        self.exited.set()
+
+    async def populate_builder(self, config):
+        if self.populate_error:
+            raise self.populate_error
+
+    async def build(self, entry_function=None):
+        return self.workflow
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -45,6 +85,28 @@ def session_manager():
         yield manager
 
 
+@pytest.fixture
+def per_user_session_manager():
+    """DRAgentAGUISessionManager configured for per-user workflows."""
+    mock_reg = MagicMock(
+        is_per_user=True,
+        per_user_function_input_schema=MagicMock(),
+        per_user_function_single_output_schema=MagicMock(),
+        per_user_function_streaming_output_schema=MagicMock(),
+    )
+    with patch("nat.cli.type_registry.GlobalTypeRegistry.get") as g:
+        g.return_value.get_function.return_value = mock_reg
+        yield DRAgentAGUISessionManager(
+            config=Config(general=GeneralConfig()),
+            shared_builder=MagicMock(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Schema override tests
+# ---------------------------------------------------------------------------
+
+
 class TestDRAgentAGUISessionManager:
     def test_is_session_manager_subclass(self):
         assert issubclass(DRAgentAGUISessionManager, SessionManager)
@@ -58,3 +120,89 @@ class TestDRAgentAGUISessionManager:
     ):
         schema = session_manager.get_workflow_streaming_output_schema()
         assert schema is DRAgentEventResponse
+
+
+# ---------------------------------------------------------------------------
+# Cross-task-safe per-user builder lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestPerUserBuilderLifecycle:
+    """Verify that __aenter__ and __aexit__ always run in the same task."""
+
+    @staticmethod
+    async def _create(mgr, user_id, **builder_kw):
+        """Patch ``PerUserWorkflowBuilder`` and create a per-user builder.
+
+        Returns ``(builder, workflow, fake)`` where *fake* is the
+        :class:`FakeBuilder` instance used inside the lifecycle task.
+        """
+        fake = FakeBuilder(**builder_kw)
+        with patch(_BUILDER_PATCH, return_value=fake):
+            builder, workflow = await mgr._get_or_create_per_user_builder(user_id)
+        return builder, workflow, fake
+
+    async def test_aenter_and_aexit_run_in_same_task(self, per_user_session_manager):
+        builder, _, fake = await self._create(per_user_session_manager, "u1")
+
+        # Trigger the replaced __aexit__ (same path upstream cleanup uses).
+        await builder.__aexit__(None, None, None)
+
+        assert fake.enter_task_id is not None
+        assert fake.enter_task_id == fake.exit_task_id
+
+    async def test_returns_cached_builder(self, per_user_session_manager):
+        b1, w1, _ = await self._create(per_user_session_manager, "u2")
+        # Second call hits the cache — no patch needed.
+        b2, w2 = await per_user_session_manager._get_or_create_per_user_builder("u2")
+
+        assert (b1, w1) == (b2, w2)
+        await per_user_session_manager.shutdown()
+
+    async def test_upstream_cleanup_triggers_aexit(self, per_user_session_manager):
+        _, _, fake = await self._create(per_user_session_manager, "u3")
+
+        # Mark the builder as expired.
+        info = per_user_session_manager._per_user_builders["u3"]
+        info.last_activity = datetime.now() - timedelta(hours=2)
+
+        cleaned = await per_user_session_manager._cleanup_inactive_per_user_builders()
+
+        assert cleaned == 1
+        assert "u3" not in per_user_session_manager._per_user_builders
+        await asyncio.wait_for(fake.exited.wait(), timeout=5.0)
+
+    async def test_cleanup_skips_active_builders(self, per_user_session_manager):
+        _, _, _ = await self._create(per_user_session_manager, "u4")
+
+        info = per_user_session_manager._per_user_builders["u4"]
+        info.ref_count = 1
+        info.last_activity = datetime.now() - timedelta(hours=2)
+
+        cleaned = await per_user_session_manager._cleanup_inactive_per_user_builders()
+        assert cleaned == 0
+        assert "u4" in per_user_session_manager._per_user_builders
+
+        info.ref_count = 0
+        await per_user_session_manager.shutdown()
+
+    async def test_shutdown_exits_all_builders(self, per_user_session_manager):
+        fakes = {}
+        for uid in ("ua", "ub"):
+            _, _, fake = await self._create(per_user_session_manager, uid)
+            fakes[uid] = fake
+
+        await per_user_session_manager.shutdown()
+
+        assert all(f.exited.is_set() for f in fakes.values())
+        assert not per_user_session_manager._per_user_builders
+
+    async def test_creation_failure_propagates(self, per_user_session_manager):
+        with pytest.raises(RuntimeError, match="populate failed"):
+            await self._create(
+                per_user_session_manager,
+                "uf",
+                populate_error=RuntimeError("populate failed"),
+            )
+
+        assert "uf" not in per_user_session_manager._per_user_builders


### PR DESCRIPTION
# Root cause
The upstream `SessionManager` creates a per-user builder inside an HTTP request task — calling __aenter__() on it, which opens an MCP streamable-HTTP client and enters an anyio cancel scope bound to that task. When the session times out, a periodic background cleanup task calls __aexit__() on the same builder, but anyio forbids exiting a cancel scope from a different task than the one that entered it, raising a RuntimeError. 

# Fix
The fix overrides `_get_or_create_per_user_builder` in `DRAgentAGUISessionManager` to spin up a small dedicated asyncio task per user that owns the builder's full lifecycle: it calls __aenter__(), runs setup, then parks waiting for a shutdown signal. The builder's __aexit__ is replaced on the instance with a lightweight coroutine that sets that shutdown signal and awaits the task — so when the upstream cleanup or shutdown code calls builder.__aexit__(), the real teardown executes inside the same task that entered the context, satisfying anyio's cancel-scope constraint without touching any upstream cleanup or shutdown logic.

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches per-user session lifecycle and teardown concurrency, which can affect resource cleanup and request handling if incorrect. Added tests reduce risk but async task signaling/timeouts could still surface edge cases under load.
> 
> **Overview**
> Fixes a per-user session cleanup/shutdown `RuntimeError` caused by anyio cancel scopes being exited from a different task than they were entered.
> 
> `DRAgentAGUISessionManager` now overrides `_get_or_create_per_user_builder` to run each per-user builder’s full lifecycle in a dedicated asyncio task and replaces the builder instance’s `__aexit__` to signal/await that task, making upstream cleanup/shutdown cross-task-safe. Adds async unit tests covering lifecycle behavior (cached builders, cleanup vs active refcounts, shutdown, and creation failures) and bumps version to `0.8.11` with a changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0981335beb37d0eb9d19920c0ce43ede20b917d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->