### PR TITLE
[buzzok-29867] [BUZZOK-29912] Fix NAT event streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.7
+- Rework NAT AG-UI integration
+- Do not return final response from NAT twice
+
 ## 0.8.6
 - Locked upperbound for dragent dependencies (fastapi, starlette) to avoid compatibility issues
 - Locked lowerbound for AG-UI because of a change in reasoning events validation

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -14,6 +14,7 @@
 import os
 import uuid
 
+from ag_ui.verify import validate_sequence
 import httpx
 from ag_ui.core import Event
 from ag_ui.core import EventType
@@ -66,3 +67,23 @@ def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
         if event.type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):
             parts.append(event.delta)
     return "".join(parts)
+
+
+def validate_dragent_ag_ui_sequence(events: list[Event]) -> None:
+    """Validate a sequence of DRAgent events against AG-UI protocol validators,
+    and also againts our internal assumptions about the sequence.
+    """
+    validate_sequence(events, debug=True)
+
+    # Additional rule 1: no events but custom within tool calls
+    tool_call_is_active = False
+    for event in events:
+        if event.type == EventType.CUSTOM:
+            continue # custom events are allowed within tool calls
+        if tool_call_is_active:
+            if event.type not in (EventType.TOOL_CALL_ARGS, EventType.TOOL_CALL_END):
+                raise ValueError(f"Invalid event within tool call: {event.type}")
+            if event.type == EventType.TOOL_CALL_END:
+                tool_call_is_active = False
+        elif event.type == EventType.TOOL_CALL_START:
+            tool_call_is_active = True

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -14,7 +14,6 @@
 import os
 import uuid
 
-from ag_ui.verify import validate_sequence
 import httpx
 from ag_ui.core import Event
 from ag_ui.core import EventType
@@ -67,23 +66,3 @@ def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
         if event.type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):
             parts.append(event.delta)
     return "".join(parts)
-
-
-def validate_dragent_ag_ui_sequence(events: list[Event]) -> None:
-    """Validate a sequence of DRAgent events against AG-UI protocol validators,
-    and also againts our internal assumptions about the sequence.
-    """
-    validate_sequence(events, debug=True)
-
-    # Additional rule 1: no events but custom within tool calls
-    tool_call_is_active = False
-    for event in events:
-        if event.type == EventType.CUSTOM:
-            continue # custom events are allowed within tool calls
-        if tool_call_is_active:
-            if event.type not in (EventType.TOOL_CALL_ARGS, EventType.TOOL_CALL_END):
-                raise ValueError(f"Invalid event within tool call: {event.type}")
-            if event.type == EventType.TOOL_CALL_END:
-                tool_call_is_active = False
-        elif event.type == EventType.TOOL_CALL_START:
-            tool_call_is_active = True

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -17,6 +17,7 @@ import os
 import httpx
 import pytest
 from ag_ui.core import EventType
+from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import FRAMEWORK
 from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
@@ -24,7 +25,6 @@ from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
-from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("MCP_DEPLOYMENT_ID"),
@@ -58,8 +58,8 @@ def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[
     # THEN: a response is correct AG UI events
     mcp_ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # THEN: the events are a valid AG-UI sequence
-    validate_dragent_ag_ui_sequence(mcp_ag_ui_events)
+    # THEN: a response is a valid AG-UI sequence
+    validate_sequence(mcp_ag_ui_events)
 
     # THEN: the events contain tool call events (if framework supports tool calls)
     tool_types = {

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -14,16 +14,17 @@
 
 import os
 
-from ag_ui.verify import validate_sequence
 import httpx
 import pytest
 from ag_ui.core import EventType
 
-from dragent_tests.helpers import FRAMEWORK, FRAMEWORK_SUPPORTS_TOOL_CALLS
+from dragent_tests.helpers import FRAMEWORK
+from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
+from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("MCP_DEPLOYMENT_ID"),
@@ -58,7 +59,7 @@ def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[
     mcp_ag_ui_events = collect_ag_ui_events(sse_events)
 
     # THEN: the events are a valid AG-UI sequence
-    validate_sequence(mcp_ag_ui_events, debug=True)
+    validate_dragent_ag_ui_sequence(mcp_ag_ui_events)
 
     # THEN: the events contain tool call events (if framework supports tool calls)
     tool_types = {

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -14,6 +14,7 @@
 
 import os
 
+from ag_ui.verify import validate_sequence
 import httpx
 import pytest
 from ag_ui.core import EventType
@@ -55,6 +56,9 @@ def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[
 
     # THEN: a response is correct AG UI events
     mcp_ag_ui_events = collect_ag_ui_events(sse_events)
+
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(mcp_ag_ui_events, debug=True)
 
     # THEN: the events contain tool call events (if framework supports tool calls)
     tool_types = {

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -14,9 +14,6 @@
 
 from __future__ import annotations
 
-import os
-
-from ag_ui.verify import validate_sequence
 import httpx
 import pytest
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
@@ -25,6 +22,7 @@ from dragent_tests.helpers import FRAMEWORK
 from dragent_tests.helpers import GENERATE_PATH
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
+from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 
 @pytest.mark.skipif(
@@ -49,7 +47,7 @@ def test_generate_single(http_client: httpx.Client) -> None:
     assert len(response_data.events) > 0
 
     # THEN: the events are a valid AG-UI sequence
-    validate_sequence(response_data.events, debug=True)
+    validate_dragent_ag_ui_sequence(response_data.events)
 
     # THEN: there are events with text
     full_text = collect_text(response_data.events)

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from ag_ui.verify import validate_sequence
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
 from dragent_tests.helpers import FRAMEWORK
 from dragent_tests.helpers import GENERATE_PATH
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
-from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 
 @pytest.mark.skipif(
@@ -47,7 +47,7 @@ def test_generate_single(http_client: httpx.Client) -> None:
     assert len(response_data.events) > 0
 
     # THEN: the events are a valid AG-UI sequence
-    validate_dragent_ag_ui_sequence(response_data.events)
+    validate_sequence(response_data.events)
 
     # THEN: there are events with text
     full_text = collect_text(response_data.events)

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 
+from ag_ui.verify import validate_sequence
 import httpx
 import pytest
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
@@ -31,7 +32,7 @@ from dragent_tests.helpers import make_generate_payload
     reason="NAT returns single response in chat completions format, and we do not yet care to fix "
     "it."
 )
-def test_generate_single_produces_text(http_client: httpx.Client) -> None:
+def test_generate_single(http_client: httpx.Client) -> None:
     """Concatenated text deltas produce a non-empty response."""
     # GIVEN: a payload that requests "Say 'hello world' and nothing else."
     payload = make_generate_payload("Say 'hello world' and nothing else.")
@@ -46,6 +47,9 @@ def test_generate_single_produces_text(http_client: httpx.Client) -> None:
 
     # THEN: the response contains AG-UI events
     assert len(response_data.events) > 0
+
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(response_data.events, debug=True)
 
     # THEN: there are events with text
     full_text = collect_text(response_data.events)

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import httpx
+from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
@@ -23,8 +24,7 @@ from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
 
 
-# TODO: analyze that its a correct AG-UI sequence
-def test_generate_streaming_produces_text(http_client: httpx.Client) -> None:
+def test_generate_streaming(http_client: httpx.Client) -> None:
     """Concatenated text deltas produce a non-empty response."""
     # GIVEN: a payload that requests "Say 'hello world' and nothing else."
     payload = make_generate_payload("Say 'hello world' and nothing else.")
@@ -39,6 +39,9 @@ def test_generate_streaming_produces_text(http_client: httpx.Client) -> None:
 
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_responses)
+
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(ag_ui_events, debug=True)
 
     # THEN: there are events with text
     full_text = collect_text(ag_ui_events)

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -15,13 +15,13 @@
 from __future__ import annotations
 
 import httpx
+from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
-from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 
 def test_generate_streaming(http_client: httpx.Client) -> None:
@@ -41,7 +41,7 @@ def test_generate_streaming(http_client: httpx.Client) -> None:
     ag_ui_events = collect_ag_ui_events(sse_responses)
 
     # THEN: the events are a valid AG-UI sequence
-    validate_dragent_ag_ui_sequence(ag_ui_events)
+    validate_sequence(ag_ui_events)
 
     # THEN: there are events with text
     full_text = collect_text(ag_ui_events)

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -15,13 +15,13 @@
 from __future__ import annotations
 
 import httpx
-from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
+from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 
 def test_generate_streaming(http_client: httpx.Client) -> None:
@@ -41,7 +41,7 @@ def test_generate_streaming(http_client: httpx.Client) -> None:
     ag_ui_events = collect_ag_ui_events(sse_responses)
 
     # THEN: the events are a valid AG-UI sequence
-    validate_sequence(ag_ui_events, debug=True)
+    validate_dragent_ag_ui_sequence(ag_ui_events)
 
     # THEN: there are events with text
     full_text = collect_text(ag_ui_events)

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from ag_ui.verify import validate_sequence
 import httpx
 from ag_ui.core import EventType
 import pytest
@@ -51,6 +52,9 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
 
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_events)
+
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(ag_ui_events, debug=True)
 
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -14,17 +14,18 @@
 
 from __future__ import annotations
 
-from ag_ui.verify import validate_sequence
 import httpx
-from ag_ui.core import EventType
 import pytest
+from ag_ui.core import EventType
 
-from dragent_tests.helpers import FRAMEWORK, FRAMEWORK_SUPPORTS_TOOL_CALLS
+from dragent_tests.helpers import FRAMEWORK
+from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
+from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 CALCULATOR_PROMPT = (
     "You MUST use the calculator tool to compute the following expression. "
@@ -54,7 +55,7 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
     ag_ui_events = collect_ag_ui_events(sse_events)
 
     # THEN: the events are a valid AG-UI sequence
-    validate_sequence(ag_ui_events, debug=True)
+    validate_dragent_ag_ui_sequence(ag_ui_events)
 
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import httpx
 import pytest
 from ag_ui.core import EventType
+from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import FRAMEWORK
 from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
@@ -25,7 +26,6 @@ from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
-from dragent_tests.helpers import validate_dragent_ag_ui_sequence
 
 CALCULATOR_PROMPT = (
     "You MUST use the calculator tool to compute the following expression. "
@@ -59,7 +59,7 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
     ag_ui_events = collect_ag_ui_events(sse_events)
 
     # THEN: the events are a valid AG-UI sequence
-    validate_dragent_ag_ui_sequence(ag_ui_events)
+    validate_sequence(ag_ui_events)
 
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pytest-rerunfailures",
     "pytest-timeout",
     "python-dotenv",
+    "ag-ui-protocol @ git+https://github.com/cavitcakir/ag-ui@feat/python-validate-sequence#egg=ag-ui&subdirectory=sdks/python",
 ]
 
 [dependency-groups]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -841,7 +841,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.5"
+version = "0.8.6"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -28,14 +28,10 @@ wheels = [
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.13"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.14"
+source = { git = "https://github.com/cavitcakir/ag-ui?subdirectory=sdks%2Fpython&rev=feat%2Fpython-validate-sequence#2eca856589f48118323b941d06f1780c69fefdd7" }
 dependencies = [
     { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b5/fc0b65b561d00d88811c8a7d98ee735833f81554be244340950e7b65820c/ag_ui_protocol-0.1.13.tar.gz", hash = "sha256:811d7d7dcce4783dec252918f40b717ebfa559399bf6b071c4ba47c0c1e21bcb", size = 5671, upload-time = "2026-02-19T18:40:38.602Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/9f/b833c1ab1999da35ebad54841ae85d2c2764c931da9a6f52d8541b6901b2/ag_ui_protocol-0.1.13-py3-none-any.whl", hash = "sha256:1393fa894c1e8416efe184168a50689e760d05b32f4646eebb8ff423dddf8e8f", size = 8053, upload-time = "2026-02-19T18:40:37.27Z" },
 ]
 
 [[package]]
@@ -845,7 +841,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.3"
+version = "0.8.5"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1119,6 +1115,7 @@ name = "datarobot-genai-e2e-tests"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "ag-ui-protocol" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },
@@ -1149,6 +1146,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ag-ui-protocol", git = "https://github.com/cavitcakir/ag-ui?subdirectory=sdks%2Fpython&rev=feat%2Fpython-validate-sequence" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.5"
+version = "0.8.6"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.4"
+version = "0.8.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/converters.py
+++ b/src/datarobot_genai/dragent/frontends/converters.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import logging
-import uuid
 
+from ag_ui.core import CustomEvent
 from ag_ui.core import RunAgentInput
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
@@ -79,13 +79,16 @@ def convert_chat_request_to_run_agent_input(request: ChatRequest) -> RunAgentInp
 ## --- NAT chat completions -> dragent AG-UI ---
 
 
+# When NAT native agent is used it returns a string with the response in streaming mode
+# We don't need it: it is already returned from LLM events in StepAdaptor
+# So we
 def convert_str_to_dragent_event_response(
     response: str,
 ) -> DRAgentEventResponse:
     return DRAgentEventResponse(
         usage_metrics=default_usage_metrics(),
         pipeline_interactions=None,
-        events=[TextMessageChunkEvent(message_id=str(uuid.uuid4()), delta=response)],
+        events=[CustomEvent(name="DEFAULT_NAT_RESPONSE", value={"delta": response})],
     )
 
 

--- a/src/datarobot_genai/dragent/frontends/converters.py
+++ b/src/datarobot_genai/dragent/frontends/converters.py
@@ -80,8 +80,8 @@ def convert_chat_request_to_run_agent_input(request: ChatRequest) -> RunAgentInp
 
 
 # When NAT native agent is used it returns a string with the response in streaming mode
-# We don't need it: it is already returned from LLM events in StepAdaptor
-# So we
+# we don't need it: it is already returned from LLM events in StepAdaptor.
+# So we return it as a custom event just to keep the interface consistent.
 def convert_str_to_dragent_event_response(
     response: str,
 ) -> DRAgentEventResponse:

--- a/src/datarobot_genai/dragent/frontends/step_adaptor.py
+++ b/src/datarobot_genai/dragent/frontends/step_adaptor.py
@@ -181,7 +181,7 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
         events = []
         if payload.event_type == IntermediateStepType.LLM_START:
             events.append(ReasoningStartEvent(message_id=payload.UUID))
-            events.append(ReasoningMessageStartEvent(message_id=payload.UUID, role="assistant"))
+            events.append(ReasoningMessageStartEvent(message_id=payload.UUID, role="reasoning"))
             self.seen_llm_new_token = False
         elif payload.event_type == IntermediateStepType.LLM_END:
             if not self.seen_llm_new_token:
@@ -208,8 +208,10 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
         # run id and thread id are set on the API level, should not be set here
         if payload.event_type == IntermediateStepType.WORKFLOW_START:
             event = RunStartedEvent(run_id="", thread_id="")
+            event = StepStartedEvent(step_name=payload.name)
         elif payload.event_type == IntermediateStepType.WORKFLOW_END:
             event = RunFinishedEvent(run_id="", thread_id="")
+            event = StepFinishedEvent(step_name=payload.name)
         else:
             raise self._unknown_step_type(payload)
 
@@ -285,20 +287,15 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
     def _handle_function(
         self, payload: IntermediateStepPayload, ancestry: InvocationNode
     ) -> ResponseSerializable | None:
-        # NAT function -> AG-UI step
-        event = None
-        # run id and thread id are set on the API level, should not be set here
+        # Just track the function level so we can handle nested functions correctly
         if payload.event_type == IntermediateStepType.FUNCTION_START:
             self.function_level += 1
-            event = StepStartedEvent(step_name=payload.name)
         elif payload.event_type == IntermediateStepType.FUNCTION_END:
             self.function_level -= 1
-            event = StepFinishedEvent(step_name=payload.name)
         else:
             raise self._unknown_step_type(payload)
 
-        response = DRAgentEventResponse(events=[event])
-        return response
+        return None
 
     def _handle_custom(
         self, payload: IntermediateStepPayload, ancestry: InvocationNode

--- a/src/datarobot_genai/dragent/frontends/step_adaptor.py
+++ b/src/datarobot_genai/dragent/frontends/step_adaptor.py
@@ -204,18 +204,18 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
     def _handle_workflow(
         self, payload: IntermediateStepPayload, ancestry: InvocationNode
     ) -> ResponseSerializable | None:
-        event = None
+        events = []
         # run id and thread id are set on the API level, should not be set here
         if payload.event_type == IntermediateStepType.WORKFLOW_START:
-            event = RunStartedEvent(run_id="", thread_id="")
-            event = StepStartedEvent(step_name=payload.name)
+            events.append(RunStartedEvent(run_id="", thread_id=""))
+            events.append(StepStartedEvent(step_name=payload.name))
         elif payload.event_type == IntermediateStepType.WORKFLOW_END:
-            event = RunFinishedEvent(run_id="", thread_id="")
-            event = StepFinishedEvent(step_name=payload.name)
+            events.append(StepFinishedEvent(step_name=payload.name))
+            events.append(RunFinishedEvent(run_id="", thread_id=""))
         else:
             raise self._unknown_step_type(payload)
 
-        response = DRAgentEventResponse(events=[event])
+        response = DRAgentEventResponse(events=events)
         return response
 
     @staticmethod

--- a/tests/dragent/frontends/test_converters.py
+++ b/tests/dragent/frontends/test_converters.py
@@ -192,7 +192,10 @@ def test_convert_str_to_dragent_event_response() -> None:
     assert result.usage_metrics["total_tokens"] == 0
     assert result.events is not None
     assert len(result.events) == 1
-    assert result.events[0].delta == delta
+
+    # THEN event is a CustomEvent with the correct name and value
+    assert result.events[0].value["delta"] == delta
+    assert result.events[0].name == "DEFAULT_NAT_RESPONSE"
 
 
 # --- Various converters ---

--- a/tests/dragent/frontends/test_step_adaptor.py
+++ b/tests/dragent/frontends/test_step_adaptor.py
@@ -15,6 +15,7 @@
 import json
 import uuid
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 from ag_ui.core import CustomEvent
@@ -117,8 +118,13 @@ def payloads():
 @pytest.fixture
 def expected_responses(intermediate_steps_ids, payloads):
     return [
-        DRAgentEventResponse(events=[RunStartedEvent(run_id="", thread_id="")]),
-        DRAgentEventResponse(events=[StepStartedEvent(step_name="tool_calling_agent")]),
+        DRAgentEventResponse(
+            events=[
+                RunStartedEvent(run_id="", thread_id=""),
+                StepStartedEvent(step_name="tool_calling_agent"),
+            ]
+        ),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[TextMessageStartEvent(message_id=intermediate_steps_ids["agent_message_id"])],
             model="vertex_ai/claude-3-5-haiku@20241022",
@@ -150,6 +156,7 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallStartEvent(
@@ -162,6 +169,7 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ReasoningStartEvent(message_id=intermediate_steps_ids["planner_message_id"]),
@@ -187,6 +195,7 @@ def expected_responses(intermediate_steps_ids, payloads):
             ],
             model="claude-3-5-haiku@20241022",
         ),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(tool_call_id=intermediate_steps_ids["planner_tool_call_id"]),
@@ -210,6 +219,7 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ReasoningStartEvent(message_id=intermediate_steps_ids["writer_message_id"]),
@@ -235,6 +245,7 @@ def expected_responses(intermediate_steps_ids, payloads):
                 "total_tokens": 700,
             },
         ),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(tool_call_id=intermediate_steps_ids["writer_tool_call_id"]),
@@ -246,6 +257,7 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(
@@ -259,8 +271,13 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[StepFinishedEvent(step_name="tool_calling_agent")]),
-        DRAgentEventResponse(events=[RunFinishedEvent(run_id="", thread_id="")]),
+        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
+        DRAgentEventResponse(
+            events=[
+                StepFinishedEvent(step_name="tool_calling_agent"),
+                RunFinishedEvent(run_id="", thread_id=""),
+            ]
+        ),
     ]
 
 

--- a/tests/dragent/frontends/test_step_adaptor.py
+++ b/tests/dragent/frontends/test_step_adaptor.py
@@ -150,7 +150,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[StepStartedEvent(step_name="content_writer_pipeline")]),
         DRAgentEventResponse(
             events=[
                 ToolCallStartEvent(
@@ -163,7 +162,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[StepStartedEvent(step_name="planner")]),
         DRAgentEventResponse(
             events=[
                 ReasoningStartEvent(message_id=intermediate_steps_ids["planner_message_id"]),
@@ -189,7 +187,6 @@ def expected_responses(intermediate_steps_ids, payloads):
             ],
             model="claude-3-5-haiku@20241022",
         ),
-        DRAgentEventResponse(events=[StepFinishedEvent(step_name="planner")]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(tool_call_id=intermediate_steps_ids["planner_tool_call_id"]),
@@ -213,7 +210,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[StepStartedEvent(step_name="writer")]),
         DRAgentEventResponse(
             events=[
                 ReasoningStartEvent(message_id=intermediate_steps_ids["writer_message_id"]),
@@ -239,7 +235,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 "total_tokens": 700,
             },
         ),
-        DRAgentEventResponse(events=[StepFinishedEvent(step_name="writer")]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(tool_call_id=intermediate_steps_ids["writer_tool_call_id"]),
@@ -251,7 +246,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[StepFinishedEvent(step_name="content_writer_pipeline")]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.5"
+version = "0.8.6"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.4"
+version = "0.8.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

1. NAT identifies as FUNCTION every agent and every tool call. This makes it too many steps. We can only have one top level step at the RUN level.
2. NAT agent returns final response as a string object. But it is already processed in StepAdaptor. Hence this makes the string response a custom event just in case we need it.

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core NAT→AG-UI event conversion and step lifecycle emission, which can affect client-facing streaming sequences and downstream consumers. Added sequence validation in e2e tests reduces regression risk but relies on a git-pinned `ag-ui-protocol` version.
> 
> **Overview**
> Reworks NAT→AG-UI integration to produce cleaner, non-duplicative event streams: NAT’s final string response is no longer emitted as a text chunk (avoiding double-final output) and is instead wrapped as a `CustomEvent` (`DEFAULT_NAT_RESPONSE`).
> 
> Adjusts step/lifecycle event emission so only workflow boundaries generate `RunStarted`/`RunFinished` and a single top-level `StepStarted`/`StepFinished`, while NAT `FUNCTION_*` steps no longer create AG-UI step events (they’re tracked internally and surfaced as custom events in tests).
> 
> Strengthens e2e coverage by validating that streaming, tools, and MCP responses form a valid AG-UI event sequence via `validate_sequence`, and bumps the package to `0.8.7` (including e2e tests depending on a git revision of `ag-ui-protocol` that provides sequence validation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 060f33862247e0afbb4d266581ed328c14c4ad70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->