### PR TITLE
[BUZZOK-29971] When constructing the agent card prefer DATAROBOT_PUBLIC_API_ENDPOINT over DATAROBOT_API_ENDPOINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.8
+- When constructing the agent card, prefer the DATAROBOT_PUBLIC_API_ENDPOINT over DATAROBOT_API_ENDPOINT, avoiding connection issues in onprem environments.
+
 ## 0.8.7
 - Rework NAT AG-UI integration
 - Do not return final response from NAT twice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.7"
+version = "0.8.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -145,9 +145,17 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         """
         mlops_deployment_id = os.getenv("MLOPS_DEPLOYMENT_ID", "")
         if mlops_deployment_id:
-            datarobot_endpoint = os.getenv("DATAROBOT_ENDPOINT", "")
+            # Prefer DATAROBOT_PUBLIC_API_ENDPOINT over DATAROBOT_ENDPOINT because on-prem
+            # deployments often set DATAROBOT_ENDPOINT to an internal k8s URL, while
+            # DATAROBOT_PUBLIC_API_ENDPOINT holds the externally reachable URL needed here
+            # to construct a publicly accessible agent-card URL.
+            datarobot_endpoint = os.getenv("DATAROBOT_PUBLIC_API_ENDPOINT") or os.getenv(
+                "DATAROBOT_ENDPOINT", ""
+            )
             if not datarobot_endpoint:
-                raise ValueError("DATAROBOT_ENDPOINT must be set when MLOPS_DEPLOYMENT_ID is set")
+                raise ValueError(
+                    "DATAROBOT_PUBLIC_API_ENDPOINT must be set when MLOPS_DEPLOYMENT_ID is set"
+                )
             base = datarobot_endpoint.rstrip("/")
             return f"{base}/deployments/{mlops_deployment_id}/directAccess/{A2A_MOUNT_PATH}/"
         return f"http://{frontend_config.host}:{frontend_config.port}/{A2A_MOUNT_PATH}/"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -154,7 +154,8 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             )
             if not datarobot_endpoint:
                 raise ValueError(
-                    "DATAROBOT_PUBLIC_API_ENDPOINT must be set when MLOPS_DEPLOYMENT_ID is set"
+                    "DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set "
+                    "when MLOPS_DEPLOYMENT_ID is set"
                 )
             base = datarobot_endpoint.rstrip("/")
             return f"{base}/deployments/{mlops_deployment_id}/directAccess/{A2A_MOUNT_PATH}/"

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -184,7 +184,9 @@ class TestDRAgentFastApiFrontEndPluginWorker:
     def test_get_a2a_endpoint_url_deployment_missing_endpoint_raises(self, worker):
         cfg = A2AFrontEndConfig(host="localhost", port=8000)
         with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "abc123"}, clear=True):
-            with pytest.raises(ValueError, match="DATAROBOT_PUBLIC_API_ENDPOINT must be set"):
+            with pytest.raises(
+                ValueError, match="DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set"
+            ):
                 worker._get_a2a_endpoint_url(cfg)
 
     async def test_add_routes_inherits_host_port_from_fastapi_config(

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -146,7 +146,7 @@ class TestDRAgentFastApiFrontEndPluginWorker:
             "MLOPS_DEPLOYMENT_ID": "abc123",
             "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
         }
-        with patch.dict(os.environ, env):
+        with patch.dict(os.environ, env, clear=True):
             url = worker._get_a2a_endpoint_url(cfg)
         assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
 
@@ -156,15 +156,35 @@ class TestDRAgentFastApiFrontEndPluginWorker:
             "MLOPS_DEPLOYMENT_ID": "abc123",
             "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2/",
         }
-        with patch.dict(os.environ, env):
+        with patch.dict(os.environ, env, clear=True):
+            url = worker._get_a2a_endpoint_url(cfg)
+        assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
+
+    def test_get_a2a_endpoint_url_deployment_prefers_public_api_endpoint(self, worker):
+        cfg = A2AFrontEndConfig(host="localhost", port=8000)
+        env = {
+            "MLOPS_DEPLOYMENT_ID": "abc123",
+            "DATAROBOT_PUBLIC_API_ENDPOINT": "https://public.datarobot.com/api/v2",
+            "DATAROBOT_ENDPOINT": "https://internal.k8s.local/api/v2",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            url = worker._get_a2a_endpoint_url(cfg)
+        assert url == "https://public.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
+
+    def test_get_a2a_endpoint_url_deployment_falls_back_to_endpoint(self, worker):
+        cfg = A2AFrontEndConfig(host="localhost", port=8000)
+        env = {
+            "MLOPS_DEPLOYMENT_ID": "abc123",
+            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+        }
+        with patch.dict(os.environ, env, clear=True):
             url = worker._get_a2a_endpoint_url(cfg)
         assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
 
     def test_get_a2a_endpoint_url_deployment_missing_endpoint_raises(self, worker):
         cfg = A2AFrontEndConfig(host="localhost", port=8000)
-        with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "abc123"}, clear=False):
-            os.environ.pop("DATAROBOT_ENDPOINT", None)
-            with pytest.raises(ValueError, match="DATAROBOT_ENDPOINT must be set"):
+        with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "abc123"}, clear=True):
+            with pytest.raises(ValueError, match="DATAROBOT_PUBLIC_API_ENDPOINT must be set"):
                 worker._get_a2a_endpoint_url(cfg)
 
     async def test_add_routes_inherits_host_port_from_fastapi_config(

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.7"
+version = "0.8.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
In most of the onprem environments DATAROBOT_API_ENDPOINT points to an k8s internal URL, causing errors when connecting a local agent to a DR hosted agent.

Related PR: https://github.com/datarobot/DataRobot/pull/152718
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to A2A URL construction based on env var precedence, with expanded unit tests to cover new behavior and error messaging.
> 
> **Overview**
> When constructing the A2A agent-card URL in `DRAgentFastApiFrontEndPluginWorker._get_a2a_endpoint_url`, the code now **prefers** `DATAROBOT_PUBLIC_API_ENDPOINT` (falling back to `DATAROBOT_ENDPOINT`) for `MLOPS_DEPLOYMENT_ID` deployments, and updates the missing-config error message accordingly.
> 
> Adds/updates unit tests to validate the new env-var precedence and uses `patch.dict(..., clear=True)` for isolation. Bumps package version to `0.8.8` and records the change in `CHANGELOG.md` (with lockfile version update).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9904d60aa58216853381005e883c99f010bf73cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->