### PR TITLE
[BUZZOK-29956] LLamaindex is not returning text in the tool call test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.9
+- Made build_workflow async 
+
 ## 0.8.8
 - When constructing the agent card, prefer the DATAROBOT_PUBLIC_API_ENDPOINT over DATAROBOT_API_ENDPOINT, avoiding connection issues in onprem environments.
 

--- a/e2e-tests/dragent/llamaindex/myagent.py
+++ b/e2e-tests/dragent/llamaindex/myagent.py
@@ -35,7 +35,7 @@ class MyAgent(LlamaIndexAgent):
         super().__init__(**kwargs)
         self._llm = llm
 
-    def build_workflow(self) -> AgentWorkflow:
+    async def build_workflow(self) -> AgentWorkflow:
         planner = FunctionAgent(
             name="planner",
             description="Creates short bullet-point outlines",

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import os
 import uuid
-
 import httpx
 from ag_ui.core import Event
 from ag_ui.core import EventType
@@ -65,15 +64,4 @@ def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
     for event in ag_ui_events:
         if event.type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):
             parts.append(event.delta)
-    return "".join(parts)
-
-
-def collect_tool_result_content(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
-    """Join serialized tool outputs from TOOL_CALL_RESULT events."""
-    parts: list[str] = []
-    for event in ag_ui_events:
-        if event.type == EventType.TOOL_CALL_RESULT:
-            content = getattr(event, "content", None)
-            if isinstance(content, str):
-                parts.append(content)
     return "".join(parts)

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -66,3 +66,14 @@ def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
         if event.type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):
             parts.append(event.delta)
     return "".join(parts)
+
+
+def collect_tool_result_content(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
+    """Join serialized tool outputs from TOOL_CALL_RESULT events."""
+    parts: list[str] = []
+    for event in ag_ui_events:
+        if event.type == EventType.TOOL_CALL_RESULT:
+            content = getattr(event, "content", None)
+            if isinstance(content, str):
+                parts.append(content)
+    return "".join(parts)

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import httpx
-import logging
 import pytest
 from ag_ui.core import EventType
 from ag_ui.verify import validate_sequence
@@ -27,8 +26,6 @@ from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
-
-logger = logging.getLogger(__name__)
 
 CALCULATOR_PROMPT = (
     "You MUST use the calculator tool to compute the following expression. "

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -24,6 +24,7 @@ from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
+from dragent_tests.helpers import collect_tool_result_content
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
 
@@ -82,8 +83,10 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
             f"Tool call events found when framework does not support them. Got: {event_types}"
         )
 
-    # THEN: the tool call events contain the correct result
+    # THEN: the calculator produced the correct value (assistant text and/or tool payload).
     full_text = collect_text(ag_ui_events)
-    assert EXPECTED_RESULT in full_text, (
-        f"Expected '{EXPECTED_RESULT}' in response. Got: {full_text[:500]}"
+    tool_text = collect_tool_result_content(ag_ui_events)
+    assert EXPECTED_RESULT in full_text or EXPECTED_RESULT in tool_text, (
+        f"Expected '{EXPECTED_RESULT}' in streamed text or tool results. "
+        f"Got text: {full_text[:500]!r} tool_results: {tool_text[:500]!r}"
     )

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -41,10 +41,7 @@ EXPECTED_RESULT = str((1234 * 567890) + 91011)
     FRAMEWORK == "base",
     reason="Base framework does not implement anything, skipping tool call tests",
 )
-@pytest.mark.xfail(
-    condition=FRAMEWORK == "llamaindex",
-    reason="BUZZOK-29956: Not returning text message in the end of the response"
-)
+
 def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
     """Agent uses calculator tool when asked to compute."""
     # GIVEN: a payload that requests the calculator tool to compute the expression

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import httpx
+import logging
 import pytest
 from ag_ui.core import EventType
 from ag_ui.verify import validate_sequence
@@ -24,9 +25,10 @@ from dragent_tests.helpers import FRAMEWORK_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import GENERATE_STREAM_PATH
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
-from dragent_tests.helpers import collect_tool_result_content
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
+
+logger = logging.getLogger(__name__)
 
 CALCULATOR_PROMPT = (
     "You MUST use the calculator tool to compute the following expression. "
@@ -83,10 +85,8 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
             f"Tool call events found when framework does not support them. Got: {event_types}"
         )
 
-    # THEN: the calculator produced the correct value (assistant text and/or tool payload).
+    # THEN: the tool call events contain the correct result
     full_text = collect_text(ag_ui_events)
-    tool_text = collect_tool_result_content(ag_ui_events)
-    assert EXPECTED_RESULT in full_text or EXPECTED_RESULT in tool_text, (
-        f"Expected '{EXPECTED_RESULT}' in streamed text or tool results. "
-        f"Got text: {full_text[:500]!r} tool_results: {tool_text[:500]!r}"
+    assert EXPECTED_RESULT in full_text, (
+        f"Expected '{EXPECTED_RESULT}' in response. Got: {full_text[:500]}"
     )

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.9"
+version = "0.8.11"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.10"
+version = "0.8.11"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1157,7 +1157,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.10"
+version = "0.8.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to e2e test agent behavior and test expectations plus a version bump; main risk is potential async/sync mismatch causing LlamaIndex e2e workflow startup failures.
> 
> **Overview**
> Updates the LlamaIndex e2e test agent to implement `build_workflow` as `async`, aligning it with the `LlamaIndexAgent` contract and enabling async tool loading/workflow construction.
> 
> Re-enables the calculator tool-call e2e test for the `llamaindex` framework by removing the prior `xfail`, and bumps the package version to `0.8.11` with a matching changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82b4a2099936950ebaf539c983fcfad8b8dafb4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->