### PR TITLE
[BUZZOK-29990] Pin LiteLLM to below exploited versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.9
+- Pin LiteLLM to safe version to prevent exploit (see https://github.com/BerriAI/litellm/issues/24518)
+
 ## 0.8.8
 - When constructing the agent card, prefer the DATAROBOT_PUBLIC_API_ENDPOINT over DATAROBOT_API_ENDPOINT, avoiding connection issues in onprem environments.
 

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -46,6 +46,7 @@ base_agent = "dragent.base.register"
 package = true
 override-dependencies = [
     "crewai[litellm]>=1.1.0,<2.0.0",
+    "litellm>=1.72.1,<2.0.0,!=1.82.7,!=1.82.8",
 ]
 
 [tool.uv.sources]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -8,7 +8,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "crewai", extras = ["litellm"], specifier = ">=1.1.0,<2.0.0" }]
+overrides = [
+    { name = "crewai", extras = ["litellm"], specifier = ">=1.1.0,<2.0.0" },
+    { name = "litellm", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
+]
 
 [[package]]
 name = "a2a-sdk"
@@ -871,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.7"
+version = "0.8.9"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -884,6 +887,7 @@ crewai = [
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
+    { name = "litellm" },
     { name = "nvidia-nat-crewai" },
     { name = "openai" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
@@ -905,6 +909,7 @@ dragent = [
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
     { name = "fastapi" },
+    { name = "litellm" },
     { name = "nvidia-nat" },
     { name = "nvidia-nat-a2a" },
     { name = "nvidia-nat-langchain" },
@@ -930,6 +935,7 @@ langgraph = [
     { name = "langchain-mcp-adapters" },
     { name = "langgraph" },
     { name = "langgraph-prebuilt" },
+    { name = "litellm" },
     { name = "nvidia-nat-langchain" },
     { name = "openai" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
@@ -948,6 +954,7 @@ llamaindex = [
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
+    { name = "litellm" },
     { name = "llama-index" },
     { name = "llama-index-core" },
     { name = "llama-index-llms-langchain" },
@@ -1024,6 +1031,11 @@ requires-dist = [
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },
     { name = "langgraph-prebuilt", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },
+    { name = "litellm", marker = "extra == 'crewai'", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
+    { name = "litellm", marker = "extra == 'dragent'", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
+    { name = "litellm", marker = "extra == 'langgraph'", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
+    { name = "litellm", marker = "extra == 'llamaindex'", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
+    { name = "litellm", marker = "extra == 'nat'", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
     { name = "llama-index", marker = "extra == 'llamaindex'", specifier = ">=0.14.0,<0.15.0" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.14.0,<0.15.0" },
     { name = "llama-index-llms-langchain", marker = "extra == 'llamaindex'", specifier = ">=0.6.1,<0.8.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.8"
+version = "0.8.9"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ datarobot_genai = [
 package = true
 override-dependencies = [
   "crewai[litellm]>=1.1.0,<2.0.0",
+  "litellm>=1.72.1,<2.0.0,!=1.82.7,!=1.82.8",
   "ragas>=0.3.8,<0.4.0",
   "onnxruntime==1.23.1; python_version == '3.10'",
 ]

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ langgraph = core + [
     "langchain-mcp-adapters>=0.1.12,<0.2.0",
     "langgraph>=1.0.0,<1.1.0",
     "langgraph-prebuilt>=1.0.0,<1.1.0",
+    "litellm>=1.72.1,<2.0.0,!=1.82.7,!=1.82.8",
     "nvidia-nat-langchain==1.4.1",
     "opentelemetry-instrumentation-langchain>=0.40.5,<1.0.0",
 ]
@@ -75,6 +76,7 @@ llamaindex = core + [
 ]
 
 nat = core + [
+    "litellm>=1.72.1,<2.0.0,!=1.82.7,!=1.82.8",
     "nvidia-nat==1.4.1",
     "nvidia-nat-a2a==1.4.1",
     "nvidia-nat-opentelemetry==1.4.1",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ crewai = core + [
     "anthropic~=0.71.0,<1.0.0",  # Needed for integration with anthropic endpoints
     "azure-ai-inference>=1.0.0b9,<2.0.0",  # Needed for integration with azure endpoints
     "crewai[litellm]>=1.1.0,<2.0.0",
+    "litellm>=1.72.1,<2.0.0,!=1.82.7,!=1.82.8",
     "crewai-tools[mcp]>=0.69.0,<0.77.0",
     "nvidia-nat-crewai==1.4.1",
     "opentelemetry-instrumentation-crewai>=0.40.5,<1.0.0",
@@ -65,6 +66,7 @@ llamaindex = core + [
     "llama-index-core>=0.14.0,<0.15.0",
     "llama-index-llms-langchain>=0.6.1,<0.8.0",
     "llama-index-llms-litellm>=0.4.1,<0.7.0",  # Sync nat dependency if possible too
+    "litellm>=1.72.1,<2.0.0,!=1.82.7,!=1.82.8",
     "llama-index-llms-openai>=0.6.0,<0.7.0",
     "llama-index-tools-mcp>=0.1.0,<0.5.0",
     "nvidia-nat-llama-index==1.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "crewai", extras = ["litellm"], specifier = ">=1.1.0,<2.0.0" },
+    { name = "litellm", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
     { name = "onnxruntime", marker = "python_full_version == '3.10.*'", specifier = "==1.23.1" },
     { name = "ragas", specifier = ">=0.3.8,<0.4.0" },
 ]
@@ -1197,6 +1198,7 @@ crewai = [
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
+    { name = "litellm" },
     { name = "nvidia-nat-crewai" },
     { name = "openai" },
     { name = "opentelemetry-instrumentation-aiohttp-client", version = "0.55b1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
@@ -1337,6 +1339,7 @@ llamaindex = [
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
+    { name = "litellm" },
     { name = "llama-index" },
     { name = "llama-index-core" },
     { name = "llama-index-llms-langchain" },
@@ -1464,6 +1467,8 @@ requires-dist = [
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },
     { name = "langgraph-prebuilt", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<1.1.0" },
+    { name = "litellm", marker = "extra == 'crewai'", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
+    { name = "litellm", marker = "extra == 'llamaindex'", specifier = ">=1.72.1,!=1.82.7,!=1.82.8,<2.0.0" },
     { name = "llama-index", marker = "extra == 'llamaindex'", specifier = ">=0.14.0,<0.15.0" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.14.0,<0.15.0" },
     { name = "llama-index-llms-langchain", marker = "extra == 'llamaindex'", specifier = ">=0.6.1,<0.8.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.8"
+version = "0.8.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

## Summary
Big attack on LiteLLM. Pin the repo.

https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/

## Active Security Issue
https://github.com/BerriAI/litellm/issues/24518

## Changes
- Pin lite llm to `litellm>=1.72.1,<2.0.0,!=1.82.7,!=1.82.8`

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily dependency pinning, but it affects multiple optional extras and lockfiles, which can change runtime behavior and compatibility across agent frameworks.
> 
> **Overview**
> Bumps the package version to **0.8.9** and records the release in `CHANGELOG.md`.
> 
> Pins `litellm` across the main project and e2e tests (including relevant extras) to `>=1.72.1,<2.0.0` while explicitly excluding `1.82.7` and `1.82.8`, and updates both `uv.lock` files accordingly to ensure the resolved dependency set reflects the security constraint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 594d70d52cf81c76959ce721296899705bdbab1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->