### PR TITLE
Update MCP integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,92 @@
+# To add a suite: add a `filters:` entry, a job output, and a job with `if:` as below.
+
+name: Integration Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  TASK_VERSION: 3.48.0
+
+jobs:
+  detect-changes:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      # Expose each paths-filter rule for downstream jobs (add one line per suite).
+      drmcp: ${{ steps.filter.outputs.drmcp }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            drmcp:
+              - 'src/datarobot_genai/drmcp/**'
+              - 'src/datarobot_genai/drtools/**'
+              - 'setup.py'
+              - 'tests/drmcp/integration/**'
+              - '.github/workflows/integration.yml'
+            # Example — add another suite:
+            # other_package:
+            #   - 'src/datarobot_genai/other/**'
+            #   - 'tests/other/integration/**'
+
+  drmcp-integration:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.drmcp == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      SESSION_SECRET_KEY: acceptance-test-secret
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: ${{ env.TASK_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Cache uv and virtualenv
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+          key: drmcp-integration-uv-${{ runner.os }}-3.12-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            drmcp-integration-uv-${{ runner.os }}-3.12-
+
+      - name: Install dependencies (drmcp)
+        run: uv sync --extra drmcp --dev
+
+      - name: Run drmcp integration tests
+        run: |
+          mkdir -p test_results
+          task drmcp-integration CLI_ARGS='tests/drmcp/integration/ --junitxml=test_results/drmcp-integration.xml'
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drmcp-integration-results-py3.12
+          path: test_results/
+          if-no-files-found: ignore

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,10 +31,6 @@ jobs:
               - 'setup.py'
               - 'tests/drmcp/integration/**'
               - '.github/workflows/integration.yml'
-            # Example — add another suite:
-            # other_package:
-            #   - 'src/datarobot_genai/other/**'
-            #   - 'tests/other/integration/**'
 
   drmcp-integration:
     needs: detect-changes
@@ -81,7 +77,7 @@ jobs:
       - name: Run drmcp integration tests
         run: |
           mkdir -p test_results
-          task drmcp-integration CLI_ARGS='tests/drmcp/integration/ --junitxml=test_results/drmcp-integration.xml'
+          task drmcp-integration CLI_ARGS='tests/drmcp/integration/ --junitxml=test_results/drmcp-integration.xml --durations=0'
 
       - name: Upload test results
         if: always()

--- a/.taskfiles/env.yml
+++ b/.taskfiles/env.yml
@@ -7,13 +7,6 @@ tasks:
       - uv sync --all-extras --dev
     silent: true
 
-  # Use on macOS Intel (x86_64) when full install fails: lancedb has no wheel for that platform (pulled in by crewai-tools).
-  update-env-no-crewai:
-    desc: "Update environment with dev + all extras except crewai (for macOS Intel)"
-    cmds:
-      - uv sync --dev --extra core --extra dragent --extra langgraph --extra llamaindex --extra nat --extra auth --extra drmcp
-    silent: true
-
   update-env-dev:
     desc: "Update environment with dev only"
     cmds:

--- a/.taskfiles/tests.yml
+++ b/.taskfiles/tests.yml
@@ -17,19 +17,6 @@ tasks:
             --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
     silent: true
 
-  # Use when crewai extra is not installed (e.g. macOS Intel: install-no-crewai).
-  test-no-crewai:
-    desc: "Run unit tests excluding crewai (when crewai extra not installed)"
-    cmds:
-      - mkdir -p test_results
-      - |
-          uv run pytest --junitxml=test_results/test-results.xml \
-            --cov=datarobot_genai --cov-branch --no-cov-on-fail \
-            -vv -s tests \
-            --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration \
-            --ignore=tests/crewai
-    silent: true
-
   test-module:
     desc: "Run repo unit tests via pytest for a specific module"
     requires:
@@ -50,5 +37,5 @@ tasks:
           {{if eq .MODULE "nat"}}uv pip install 'crewai>=1.1.0,<2.0.0' 'llama-index-llms-litellm>=0.4.1,<0.7.0'{{end}}
           uv run pytest tests/{{.MODULE}} \
             --junitxml=test_results/test-results.xml -vv -s \
-            {{if ne .MODULE "drmcp"}}--ignore=tests/drmcp/integration {{end}}--ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
+            --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
     silent: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.9
+- Added GitHub Actions workflow `integration.yml`: path-filtered **Integration Tests** job for drmcp (runs when `src/datarobot_genai/drmcp`, `src/datarobot_genai/drtools`, `setup.py`, `tests/drmcp/integration`, or the workflow file changes; aligned with the e2e workflow pattern)
+- DRMCP integration/ETE: `tests/drmcp/stub_credentials.py` plus `ete_test_server.py` default stub `DATAROBOT_*` env so `task drmcp-integration` can start the MCP server without a real API token in `.env`; shared stub token constant wired from `tests/drmcp/conftest.py`
+- `test_interactive.py`: read `DR_LLM_GATEWAY_MODEL` and optional `LLM_TEMPERATURE` into the LLM Gateway client config (consistent with ETE helpers)
+
 ## 0.8.8
 - When constructing the agent card, prefer the DATAROBOT_PUBLIC_API_ENDPOINT over DATAROBOT_API_ENDPOINT, avoiding connection issues in onprem environments.
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -42,14 +42,6 @@ tasks:
       - uv sync --all-extras --dev
     silent: true
 
-  # Use on macOS Intel (x86_64) when install fails due to lancedb (no wheel; pulled in by crewai-tools).
-  install-no-crewai:
-    desc: "🔧 Install dependencies (all extras except crewai, for macOS Intel)"
-    cmds:
-      - echo "🔧 Installing dependencies (all extras except crewai)..."
-      - uv sync --dev --extra core --extra dragent --extra langgraph --extra llamaindex --extra nat --extra auth --extra drmcp
-    silent: true
-
   build:
     desc: "Build distribution packages"
     cmds:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.8"
+version = "0.8.9"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/test_interactive.py
+++ b/src/datarobot_genai/drmcp/test_utils/test_interactive.py
@@ -51,7 +51,8 @@ async def test_mcp_interactive() -> None:
 
     # Optional DataRobot settings
     datarobot_endpoint = os.environ.get("DATAROBOT_ENDPOINT")
-    model = os.environ.get("MODEL")
+    dr_llm_gateway_model = os.environ.get("DR_LLM_GATEWAY_MODEL")
+    llm_temperature = os.environ.get("LLM_TEMPERATURE")
 
     print("🤖 Initializing LLM MCP Client...")
 
@@ -62,8 +63,15 @@ async def test_mcp_interactive() -> None:
     }
     if datarobot_endpoint:
         config["datarobot_endpoint"] = datarobot_endpoint
-    if model:
-        config["model"] = model
+    if dr_llm_gateway_model:
+        config["model"] = dr_llm_gateway_model
+    if llm_temperature is not None:
+        config["temperature"] = llm_temperature
+
+    if not config.get("model"):
+        print("❌ Error: no LLM model configured")
+        print("Set DR_LLM_GATEWAY_MODEL in your .env (same as ETE tests).")
+        return
 
     llm_client = DRLLMGatewayMCPClient(str(config))
 

--- a/tests/drmcp/acceptance/ete_test_server.py
+++ b/tests/drmcp/acceptance/ete_test_server.py
@@ -21,6 +21,11 @@ _project_root = Path(__file__).parent.parent.parent.parent
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
+# Task drmcp-integration starts this process before pytest; fixtures cannot set env here.
+from tests.drmcp.stub_credentials import apply_stub_datarobot_credentials_env  # noqa: E402
+
+apply_stub_datarobot_credentials_env()
+
 from datarobot_genai.drmcp import create_mcp_server  # noqa: E402
 
 # Import to register test tools with the MCP server

--- a/tests/drmcp/conftest.py
+++ b/tests/drmcp/conftest.py
@@ -28,13 +28,12 @@ from datarobot_genai.drmcp.core.credentials import get_credentials
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubDeployment
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubModel
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubProject
-
-_STUB_DATAROBOT_API_TOKEN = "test-token"
+from tests.drmcp.stub_credentials import STUB_DATAROBOT_API_TOKEN
 
 
 def _is_stub_token() -> bool:
     """Return True when DATAROBOT_API_TOKEN is the stub (no real API calls)."""
-    return os.environ.get("DATAROBOT_API_TOKEN") == _STUB_DATAROBOT_API_TOKEN
+    return os.environ.get("DATAROBOT_API_TOKEN") == STUB_DATAROBOT_API_TOKEN
 
 
 def _stub_project_fixture_dict(
@@ -63,7 +62,7 @@ def _make_dr_client() -> Any:
     # Otherwise the ValueError below is reachable and gives a clear message.
     if not os.environ.get("DATAROBOT_API_TOKEN"):
         if os.environ.get("MCP_USE_CLIENT_STUBS", "true").lower() == "true":
-            os.environ["DATAROBOT_API_TOKEN"] = _STUB_DATAROBOT_API_TOKEN
+            os.environ["DATAROBOT_API_TOKEN"] = STUB_DATAROBOT_API_TOKEN
             if not os.environ.get("DATAROBOT_ENDPOINT"):
                 os.environ["DATAROBOT_ENDPOINT"] = DEFAULT_DATAROBOT_ENDPOINT
             # Stub env persists for the session so all code paths see the same credentials.
@@ -75,7 +74,7 @@ def _make_dr_client() -> Any:
     # Session fixtures in this file (timeseries_regression_project, classification_project,
     # etc.) check _is_stub_token() first and yield stub data without calling dr.*, so they
     # never hit the API when no client is configured.
-    if token != _STUB_DATAROBOT_API_TOKEN:
+    if token != STUB_DATAROBOT_API_TOKEN:
         dr.Client(token=token, endpoint=creds.datarobot.endpoint)
     DRContext.use_case = None
     return dr

--- a/tests/drmcp/stub_credentials.py
+++ b/tests/drmcp/stub_credentials.py
@@ -1,0 +1,27 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stub DataRobot credentials for integration/ETE runs that use MCP client stubs (no real API)."""
+
+import os
+
+from datarobot_genai.drmcp.core.constants import DEFAULT_DATAROBOT_ENDPOINT
+
+STUB_DATAROBOT_API_TOKEN = "test-token"
+
+
+def apply_stub_datarobot_credentials_env() -> None:
+    """Set DATAROBOT_* env only when unset (does not override a developer's real token)."""
+    os.environ.setdefault("DATAROBOT_API_TOKEN", STUB_DATAROBOT_API_TOKEN)
+    os.environ.setdefault("DATAROBOT_ENDPOINT", DEFAULT_DATAROBOT_ENDPOINT)

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.8.8"
+version = "0.8.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- Added GitHub Actions workflow `integration.yml`: path-filtered **Integration Tests** job for drmcp (runs when `src/datarobot_genai/drmcp`, `src/datarobot_genai/drtools`, `setup.py`, `tests/drmcp/integration`, or the workflow file changes; aligned with the e2e workflow pattern)
- DRMCP integration/ETE: `tests/drmcp/stub_credentials.py` plus `ete_test_server.py` default stub `DATAROBOT_*` env so `task drmcp-integration` can start the MCP server without a real API token in `.env`; shared stub token constant wired from `tests/drmcp/conftest.py`
- `test_interactive.py`: read `DR_LLM_GATEWAY_MODEL` and optional `LLM_TEMPERATURE` into the LLM Gateway client config (consistent with ETE helpers)

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new CI workflow and dependency graph changes (adds `litellm` to additional extras), which can affect install/CI behavior even though runtime library code is largely unchanged.
> 
> **Overview**
> Adds a new GitHub Actions `integration.yml` workflow that path-filters changes and runs `drmcp` integration tests in CI (Python 3.12, `uv` cache, uploads JUnit artifacts).
> 
> Makes DRMCP integration/ETE runs less dependent on real credentials by introducing `tests/drmcp/stub_credentials.py` and applying it in `ete_test_server.py`, and centralizes the stub token constant used by `tests/drmcp/conftest.py`.
> 
> Tightens local/dev task configuration by removing the `*-no-crewai` install/test tasks, adjusts `test-module` ignores, updates the interactive MCP test to require `DR_LLM_GATEWAY_MODEL` (and optional `LLM_TEMPERATURE`), and bumps the package version to `0.8.10` (including `uv.lock` updates and extra dependency adjustments).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae08388d777934b658401d25fdd064b328815ef3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->