### PR TITLE
[MODEL-22469] Sync mcp linage in mcp server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.13.3
+- Enabled functionalities of synchronizing MCP item metadata within MCP server (still behind the feature flag).
+
 ## 0.13.2
 - Updated to remove prints, but instead use `logging` instead in our agents outputs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.13.2"
+version = "0.13.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
@@ -25,6 +25,7 @@ from datarobot_genai.drmcp.core.dynamic_prompts.register import (
 )
 from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
 from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 
@@ -59,8 +60,12 @@ async def register_prompt_from_prompt_template_id_and_version(
             prompt_template=prompt_template
         )
         if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_prompts()
+            try:
+                linear_manager = LineageManager(mcp)
+                await linear_manager.sync_mcp_prompts()
+            except LRSEnvVarIsNotSetError as error:
+                error_message = f"MCP item metadata is not sync. {str(error)}"
+                logger.warning(error_message)
         return registered_prompt
 
     prompt_template_version = get_datarobot_prompt_template_version(
@@ -76,8 +81,12 @@ async def register_prompt_from_prompt_template_id_and_version(
         prompt_template=prompt_template, prompt_template_version=prompt_template_version
     )
     if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        linear_manager = LineageManager(mcp)
-        await linear_manager.sync_mcp_prompts()
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_prompts()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)
     return registered_prompt
 
 
@@ -95,8 +104,12 @@ async def delete_registered_prompt_template(prompt_template_id: str) -> bool:
         f"version {prompt_template_version_id}"
     )
     if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        linear_manager = LineageManager(mcp)
-        await linear_manager.sync_mcp_prompts()
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_prompts()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)
     return True
 
 
@@ -145,5 +158,9 @@ async def refresh_registered_prompt_template(headers_auth_only: bool = False) ->
             await mcp.remove_prompt_mapping(mcp_prompt_template_id, mcp_prompt_template_version_id)
 
     if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        linear_manager = LineageManager(mcp)
-        await linear_manager.sync_mcp_prompts()
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_prompts()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
@@ -24,6 +24,8 @@ from datarobot_genai.drmcp.core.dynamic_prompts.register import (
     register_prompt_from_datarobot_prompt_management,
 )
 from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
@@ -53,9 +55,13 @@ async def register_prompt_from_prompt_template_id_and_version(
         raise DynamicPromptRegistrationError("Registration failed. Could not find prompt template.")
 
     if not prompt_template_version_id:
-        return await register_prompt_from_datarobot_prompt_management(
+        registered_prompt = await register_prompt_from_datarobot_prompt_management(
             prompt_template=prompt_template
         )
+        if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_prompts()
+        return registered_prompt
 
     prompt_template_version = get_datarobot_prompt_template_version(
         prompt_template_id, prompt_template_version_id
@@ -66,9 +72,13 @@ async def register_prompt_from_prompt_template_id_and_version(
             "Registration failed. Could not find prompt template version."
         )
 
-    return await register_prompt_from_datarobot_prompt_management(
+    registered_prompt = await register_prompt_from_datarobot_prompt_management(
         prompt_template=prompt_template, prompt_template_version=prompt_template_version
     )
+    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_prompts()
+    return registered_prompt
 
 
 async def delete_registered_prompt_template(prompt_template_id: str) -> bool:
@@ -84,6 +94,9 @@ async def delete_registered_prompt_template(prompt_template_id: str) -> bool:
         f"Deleted prompt name {prompt_name} for prompt template id {prompt_template_id}, "
         f"version {prompt_template_version_id}"
     )
+    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_prompts()
     return True
 
 
@@ -130,3 +143,7 @@ async def refresh_registered_prompt_template(headers_auth_only: bool = False) ->
         if mcp_prompt_template_id not in prompt_templates_ids:
             # We need to also delete prompt templates that are
             await mcp.remove_prompt_mapping(mcp_prompt_template_id, mcp_prompt_template_version_id)
+
+    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_prompts()

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
@@ -58,7 +58,7 @@ async def register_prompt_from_prompt_template_id_and_version(
         registered_prompt = await register_prompt_from_datarobot_prompt_management(
             prompt_template=prompt_template
         )
-        if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        if FeatureFlag.is_mcp_tools_gallery_support_enabled():
             linear_manager = LineageManager(mcp)
             await linear_manager.sync_mcp_prompts()
         return registered_prompt
@@ -75,7 +75,7 @@ async def register_prompt_from_prompt_template_id_and_version(
     registered_prompt = await register_prompt_from_datarobot_prompt_management(
         prompt_template=prompt_template, prompt_template_version=prompt_template_version
     )
-    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
         linear_manager = LineageManager(mcp)
         await linear_manager.sync_mcp_prompts()
     return registered_prompt
@@ -94,7 +94,7 @@ async def delete_registered_prompt_template(prompt_template_id: str) -> bool:
         f"Deleted prompt name {prompt_name} for prompt template id {prompt_template_id}, "
         f"version {prompt_template_version_id}"
     )
-    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
         linear_manager = LineageManager(mcp)
         await linear_manager.sync_mcp_prompts()
     return True
@@ -144,6 +144,6 @@ async def refresh_registered_prompt_template(headers_auth_only: bool = False) ->
             # We need to also delete prompt templates that are
             await mcp.remove_prompt_mapping(mcp_prompt_template_id, mcp_prompt_template_version_id)
 
-    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
         linear_manager = LineageManager(mcp)
         await linear_manager.sync_mcp_prompts()

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
@@ -23,6 +23,9 @@ from fastmcp.prompts.prompt import Prompt
 from pydantic import Field
 
 from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
+from datarobot_genai.drmcp.core.mcp_instance import mcp
 from datarobot_genai.drmcp.core.mcp_instance import register_prompt
 
 from .dr_lib import get_datarobot_prompt_template_versions
@@ -52,6 +55,10 @@ async def register_prompts_from_datarobot_prompt_management() -> None:
             await register_prompt_from_datarobot_prompt_management(prompt, latest_version)
         except DynamicPromptRegistrationError:
             pass
+
+    if prompts and FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_prompts()
 
 
 async def register_prompt_from_datarobot_prompt_management(

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
@@ -57,7 +57,7 @@ async def register_prompts_from_datarobot_prompt_management() -> None:
         except DynamicPromptRegistrationError:
             pass
 
-    if prompts and FeatureFlag.is_mcp_tools_gallery_support_enabled():
+    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
         try:
             linear_manager = LineageManager(mcp)
             await linear_manager.sync_mcp_prompts()

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
@@ -24,6 +24,7 @@ from pydantic import Field
 
 from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
 from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 from datarobot_genai.drmcp.core.mcp_instance import register_prompt
@@ -57,8 +58,12 @@ async def register_prompts_from_datarobot_prompt_management() -> None:
             pass
 
     if prompts and FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        linear_manager = LineageManager(mcp)
-        await linear_manager.sync_mcp_prompts()
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_prompts()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)
 
 
 async def register_prompt_from_datarobot_prompt_management(

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
@@ -56,7 +56,7 @@ async def register_prompts_from_datarobot_prompt_management() -> None:
         except DynamicPromptRegistrationError:
             pass
 
-    if prompts and FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+    if prompts and FeatureFlag.is_mcp_tools_gallery_support_enabled():
         linear_manager = LineageManager(mcp)
         await linear_manager.sync_mcp_prompts()
 

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
@@ -43,7 +43,7 @@ async def register_tool_for_deployment_id(deployment_id: str) -> Tool:
     """
     deployment = get_sdk_client(headers_auth_only=True).Deployment.get(deployment_id)
     registered_tool = await register_tool_of_datarobot_deployment(deployment)
-    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
         linear_manager = LineageManager(mcp)
         await linear_manager.sync_mcp_tools()
 
@@ -66,7 +66,7 @@ async def delete_registered_tool_deployment(deployment_id: str) -> bool:
     tool_name = deployments[deployment_id]
     await mcp.remove_deployment_mapping(deployment_id)
     logger.info(f"Deleted tool {tool_name} for deployment {deployment_id}")
-    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
         linear_manager = LineageManager(mcp)
         await linear_manager.sync_mcp_tools()
     return True

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
@@ -20,6 +20,8 @@ from datarobot_genai.drmcp.core.clients import get_sdk_client
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
     register_tool_of_datarobot_deployment,
 )
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,10 @@ async def register_tool_for_deployment_id(deployment_id: str) -> Tool:
     """
     deployment = get_sdk_client(headers_auth_only=True).Deployment.get(deployment_id)
     registered_tool = await register_tool_of_datarobot_deployment(deployment)
+    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_tools()
+
     return registered_tool
 
 
@@ -60,4 +66,7 @@ async def delete_registered_tool_deployment(deployment_id: str) -> bool:
     tool_name = deployments[deployment_id]
     await mcp.remove_deployment_mapping(deployment_id)
     logger.info(f"Deleted tool {tool_name} for deployment {deployment_id}")
+    if FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_tools()
     return True

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
@@ -21,6 +21,7 @@ from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
     register_tool_of_datarobot_deployment,
 )
 from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 
@@ -44,8 +45,12 @@ async def register_tool_for_deployment_id(deployment_id: str) -> Tool:
     deployment = get_sdk_client(headers_auth_only=True).Deployment.get(deployment_id)
     registered_tool = await register_tool_of_datarobot_deployment(deployment)
     if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        linear_manager = LineageManager(mcp)
-        await linear_manager.sync_mcp_tools()
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_tools()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)
 
     return registered_tool
 
@@ -67,6 +72,10 @@ async def delete_registered_tool_deployment(deployment_id: str) -> bool:
     await mcp.remove_deployment_mapping(deployment_id)
     logger.info(f"Deleted tool {tool_name} for deployment {deployment_id}")
     if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        linear_manager = LineageManager(mcp)
-        await linear_manager.sync_mcp_tools()
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_tools()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)
     return True

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
@@ -44,7 +44,7 @@ async def register_tools_of_datarobot_deployments() -> None:
             logger.error(f"Unexpected error for deployment {deployment_id}: {exc}")
             pass
 
-    if deployment_ids and FeatureFlag.is_mcp_tools_gallery_support_enabled():
+    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
         try:
             linear_manager = LineageManager(mcp)
             await linear_manager.sync_mcp_tools()

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
@@ -20,6 +20,9 @@ from datarobot_genai.drmcp.core.clients import get_api_client
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.config import create_deployment_tool_config
 from datarobot_genai.drmcp.core.dynamic_tools.register import register_external_tool
 from datarobot_genai.drmcp.core.exceptions import DynamicToolRegistrationError
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
+from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +42,10 @@ async def register_tools_of_datarobot_deployments() -> None:
         except Exception as exc:
             logger.error(f"Unexpected error for deployment {deployment_id}: {exc}")
             pass
+
+    if deployment_ids and FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_tools()
 
 
 async def register_tool_of_datarobot_deployment(

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
@@ -43,7 +43,7 @@ async def register_tools_of_datarobot_deployments() -> None:
             logger.error(f"Unexpected error for deployment {deployment_id}: {exc}")
             pass
 
-    if deployment_ids and FeatureFlag.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled:
+    if deployment_ids and FeatureFlag.is_mcp_tools_gallery_support_enabled():
         linear_manager = LineageManager(mcp)
         await linear_manager.sync_mcp_tools()
 

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
@@ -21,6 +21,7 @@ from datarobot_genai.drmcp.core.dynamic_tools.deployment.config import create_de
 from datarobot_genai.drmcp.core.dynamic_tools.register import register_external_tool
 from datarobot_genai.drmcp.core.exceptions import DynamicToolRegistrationError
 from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 
@@ -44,8 +45,12 @@ async def register_tools_of_datarobot_deployments() -> None:
             pass
 
     if deployment_ids and FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        linear_manager = LineageManager(mcp)
-        await linear_manager.sync_mcp_tools()
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_tools()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)
 
 
 async def register_tool_of_datarobot_deployment(

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
+from functools import lru_cache
 
 from datarobot_genai.drmcp.core.clients import (
     setup_and_return_dr_api_client_with_static_config_in_container,
@@ -34,3 +35,8 @@ class FeatureFlag:
             name=feature_flag_info["name"],
             enabled=bool(feature_flag_info["value"]),
         )
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    def is_mcp_tools_gallery_support_enabled(cls) -> bool:
+        return cls.create("ENABLE_MCP_TOOLS_GALLERY_SUPPORT").enabled

--- a/src/datarobot_genai/drmcp/core/lineage/enums.py
+++ b/src/datarobot_genai/drmcp/core/lineage/enums.py
@@ -16,6 +16,10 @@ from enum import Enum
 from enum import auto
 
 
+class LRSEnvVarIsNotSetError(Exception):
+    """Exception raised when env var is missing in LRS container."""
+
+
 class LRSEnvVars(Enum):
     MLOPS_DEPLOYMENT_ID = auto()
 
@@ -24,5 +28,7 @@ class LRSEnvVars(Enum):
 
     def get_os_env_value(self) -> str:
         env_value = os.getenv(self.to_env_name())
-        assert env_value, f"Env var {self} is not assigned in the LRS container"
+        if not env_value:
+            error_message = f"Env var {self} is not assigned in the LRS container"
+            raise LRSEnvVarIsNotSetError(error_message)
         return env_value

--- a/src/datarobot_genai/drmcp/core/lineage/manager.py
+++ b/src/datarobot_genai/drmcp/core/lineage/manager.py
@@ -30,7 +30,6 @@ from datarobot._experimental.models.user_mcp_server_deployment import (
     TypeOfToolInUserMCPServerDeployment,
 )
 from datarobot.errors import ClientError as DataRobotAPIClientError
-from fastmcp import FastMCP
 
 from datarobot_genai.drmcp.core.clients import (
     setup_and_return_dr_api_client_with_static_config_in_container,
@@ -40,12 +39,13 @@ from datarobot_genai.drmcp.core.lineage.entities import MCPPromptMetadata
 from datarobot_genai.drmcp.core.lineage.entities import MCPResourceMetadata
 from datarobot_genai.drmcp.core.lineage.entities import MCPToolMetadata
 from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVars
+from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 
 logger = logging.getLogger(__name__)
 
 
 class LineageManager:
-    def __init__(self, mcp_server_instance: FastMCP) -> None:
+    def __init__(self, mcp_server_instance: DataRobotMCP) -> None:
         setup_and_return_dr_api_client_with_static_config_in_container()
         self.mcp_server_deployment_id = LRSEnvVars.MLOPS_DEPLOYMENT_ID.get_os_env_value()
         self.mcp_server_instance = mcp_server_instance

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -29,7 +29,9 @@ without injecting headers.
 import os
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 
 import datarobot as dr
 import datarobot_predict.deployment as _dr_predict_deployment
@@ -39,6 +41,8 @@ from datarobot_genai.drmcp import create_mcp_server
 from datarobot_genai.drmcp.core import clients
 from datarobot_genai.drmcp.core.clients import get_sdk_client as _original_get_sdk_client
 from datarobot_genai.drmcp.core.dynamic_prompts import register as prompt_register
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import test_create_dr_client
 from datarobot_genai.drmcp.test_utils.stubs.prediction_result_stub import (
     test_create_prediction_result,
@@ -156,6 +160,13 @@ def _apply_prompt_stubs() -> None:
     prompt_register.get_datarobot_prompt_template_versions = _stub_prompt_template_versions
 
 
+def apply_lineage_manager_stubs() -> None:
+    FeatureFlag.is_mcp_tools_gallery_support_enabled = Mock()  # type: ignore[assignment]
+    LineageManager.__init__ = Mock(return_value=None)  # type: ignore[assignment]
+    LineageManager.sync_mcp_tools = AsyncMock()  # type: ignore[assignment]
+    LineageManager.sync_mcp_prompts = AsyncMock()  # type: ignore[assignment]
+
+
 def _apply_dr_client_stubs() -> None:
     """Replace the real DataRobot client with stubs (patches token + client for stdio)."""
     stub_dr = test_create_dr_client()
@@ -185,6 +196,7 @@ def main() -> None:
     """Run the integration test MCP server."""
     if os.environ.get("MCP_USE_CLIENT_STUBS", "true") == "true":
         _apply_dr_client_stubs()
+        apply_lineage_manager_stubs()
     elif os.environ.get("MCP_SERVER_NAME") == "integration":
         _patch_get_sdk_client_for_stdio()
 

--- a/tests/drmcp/integration/test_dynamic_tools.py
+++ b/tests/drmcp/integration/test_dynamic_tools.py
@@ -270,6 +270,7 @@ async def test_get_mcp_tool_metadata(
     assert actual_input_schema == expected_input_schema
 
 
+@pytest.mark.skip(reason="MODEL-22984")
 @pytest.mark.asyncio
 @responses.activate
 async def test_dynamic_tool_registration(dr_client, mock_api_responses) -> None:

--- a/tests/drmcp/unit/conftest.py
+++ b/tests/drmcp/unit/conftest.py
@@ -72,8 +72,8 @@ def mock_all_telemetry(request: pytest.FixtureRequest) -> Generator[None, None, 
 
 
 @pytest.fixture
-def mock_feature_flag_create() -> Iterator[Mock]:
-    with patch.object(FeatureFlag, "create") as mock_func:
+def mock_is_mcp_tools_gallery_support_enabled() -> Iterator[Mock]:
+    with patch.object(FeatureFlag, "is_mcp_tools_gallery_support_enabled") as mock_func:
         yield mock_func
 
 

--- a/tests/drmcp/unit/conftest.py
+++ b/tests/drmcp/unit/conftest.py
@@ -11,11 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from collections.abc import Generator
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 
 
 @pytest.fixture(autouse=True)
@@ -64,3 +69,36 @@ def mock_all_telemetry(request: pytest.FixtureRequest) -> Generator[None, None, 
         ),
     ):
         yield
+
+
+@pytest.fixture
+def mock_feature_flag_create() -> Iterator[Mock]:
+    with patch.object(FeatureFlag, "create") as mock_func:
+        yield mock_func
+
+
+@pytest.fixture
+def mock_lineage_manager_init() -> Iterator[Mock]:
+    with patch.object(LineageManager, "__init__") as mock_func:
+        mock_func.return_value = None
+        yield mock_func
+
+
+@pytest.fixture
+def mock_sync_mcp_tools() -> Iterator[AsyncMock]:
+    with patch.object(
+        LineageManager,
+        "sync_mcp_tools",
+        new_callable=AsyncMock,
+    ) as mock_func:
+        yield mock_func
+
+
+@pytest.fixture
+def mock_sync_mcp_prompts() -> Iterator[AsyncMock]:
+    with patch.object(
+        LineageManager,
+        "sync_mcp_prompts",
+        new_callable=AsyncMock,
+    ) as mock_func:
+        yield mock_func

--- a/tests/drmcp/unit/core/lineage/test_enums.py
+++ b/tests/drmcp/unit/core/lineage/test_enums.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 import pytest
 
+from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVars
 
 
@@ -32,3 +33,12 @@ class TestLRSEnvVars:
         lrs_env_var.get_os_env_value()
 
         mock_os_getenv.assert_called_with(lrs_env_var.name)
+
+    @pytest.mark.parametrize("lrs_env_var", [lrs_env_var for lrs_env_var in LRSEnvVars])
+    def test_get_os_env_value_raise_error(
+        self, mock_os_getenv: Mock, lrs_env_var: LRSEnvVars
+    ) -> None:
+        mock_os_getenv.return_value = None
+
+        with pytest.raises(LRSEnvVarIsNotSetError):
+            lrs_env_var.get_os_env_value()

--- a/tests/drmcp/unit/core/test_feature_flags.py
+++ b/tests/drmcp/unit/core/test_feature_flags.py
@@ -32,6 +32,11 @@ class TestFeatureFlags:
         ) as mock_func:
             yield mock_func
 
+    @pytest.fixture
+    def mock_feature_flag_create(self) -> Iterator[Mock]:
+        with patch.object(FeatureFlag, "create") as mock_func:
+            yield mock_func
+
     def test_create(self, mock_get_datarobot_client: Mock) -> None:
         mock_datarobot_client = mock_get_datarobot_client.return_value
         expected_feature_flag_name = Mock()
@@ -49,3 +54,9 @@ class TestFeatureFlags:
         assert output == FeatureFlag(
             name=expected_feature_flag_name, enabled=bool(expected_feature_status)
         )
+
+    def test_is_mcp_tools_gallery_support_enabled(self, mock_feature_flag_create: Mock) -> None:
+        output = FeatureFlag.is_mcp_tools_gallery_support_enabled()
+
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        assert output == mock_feature_flag_create.return_value.enabled

--- a/tests/drmcp/unit/dynamic_prompts/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_controllers.py
@@ -150,7 +150,7 @@ class TestPromptTemplatesAdd:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -190,7 +190,7 @@ class TestPromptTemplatesAdd:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -214,7 +214,7 @@ class TestPromptTemplatesAdd:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_registering_with_prompt_template_id(
         self,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_get_datarobot_prompt_template: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
@@ -228,14 +228,14 @@ class TestPromptTemplatesAdd:
         mock_register_prompt_from_datarobot_prompt_management.assert_called_once_with(
             prompt_template=mock_prompt_template,
         )
-        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_registering_with_prompt_template_and_version_ids(
         self,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_get_datarobot_prompt_template: Mock,
         mock_get_datarobot_prompt_template_version: Mock,
         mock_lineage_manager_init: Mock,
@@ -260,7 +260,7 @@ class TestPromptTemplatesAdd:
             prompt_template=mock_prompt_template,
             prompt_template_version=mock_prompt_template_version,
         )
-        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
 
@@ -298,7 +298,7 @@ class TestPromptTemplatesDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -334,7 +334,7 @@ class TestPromptTemplatesDeletion:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_deletion(
         self,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
         mcp_server: DataRobotMCP,
@@ -344,7 +344,7 @@ class TestPromptTemplatesDeletion:
 
         await delete_registered_prompt_template(prompt_id)
 
-        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
 
@@ -368,7 +368,7 @@ class TestPromptTemplatesRefresh:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -405,13 +405,13 @@ class TestPromptTemplatesRefresh:
     )
     async def test_sync_mcp_metadata_after_refresh_prompts(
         self,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
         mcp_server: DataRobotMCP,
     ) -> None:
         await refresh_registered_prompt_template()
 
-        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()

--- a/tests/drmcp/unit/dynamic_prompts/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_controllers.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import AsyncIterator
 from collections.abc import Iterator
+from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import datarobot as dr
 import pytest
-import pytest_asyncio
 
 from datarobot_genai.drmcp.core.dynamic_prompts.controllers import delete_registered_prompt_template
 from datarobot_genai.drmcp.core.dynamic_prompts.controllers import (
@@ -31,8 +30,8 @@ from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 
 
-@pytest_asyncio.fixture
-async def mcp_server() -> AsyncIterator[DataRobotMCP]:
+@pytest.fixture
+def mcp_server() -> Iterator[DataRobotMCP]:
     """Create a separate MCP instance for testing."""
     test_mcp = DataRobotMCP()
 
@@ -118,10 +117,43 @@ def dr_lib_mock_for_refresh() -> Iterator[None]:
         yield
 
 
+@pytest.fixture
+def mock_module_under_test() -> str:
+    return "datarobot_genai.drmcp.core.dynamic_prompts.controllers"
+
+
 class TestPromptTemplatesAdd:
     """Tests for prompt templates add/update functionality."""
 
+    @pytest.fixture
+    def mock_get_datarobot_prompt_template(self, mock_module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{mock_module_under_test}.get_datarobot_prompt_template") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_datarobot_prompt_template_version(
+        self, mock_module_under_test: str
+    ) -> Iterator[Mock]:
+        with patch(f"{mock_module_under_test}.get_datarobot_prompt_template_version") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_register_prompt_from_datarobot_prompt_management(
+        self,
+        mock_module_under_test: str,
+    ) -> Iterator[AsyncMock]:
+        with patch(
+            f"{mock_module_under_test}.register_prompt_from_datarobot_prompt_management",
+            new_callable=AsyncMock,
+        ) as mock_func:
+            yield mock_func
+
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_prompts",
+    )
     async def test_add_prompt_templates(self, mcp_server: DataRobotMCP, dr_lib_mock: None) -> None:
         """Test add prompt template."""
         # Check if there's no data at the beginning
@@ -157,6 +189,11 @@ class TestPromptTemplatesAdd:
         assert internal_mappings == {}
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_prompts",
+    )
     async def test_update_prompt_template(
         self, mcp_server: DataRobotMCP, dr_lib_mock: None
     ) -> None:
@@ -173,6 +210,59 @@ class TestPromptTemplatesAdd:
         # Verify MCP internal state consistency
         internal_mappings = await mcp_server.get_prompt_mapping()
         assert internal_mappings == {"pt1": ("ptv1.1", "pt1 name")}
+
+    @pytest.mark.asyncio
+    async def test_sync_mcp_metadata_after_registering_with_prompt_template_id(
+        self,
+        mock_feature_flag_create: Mock,
+        mock_get_datarobot_prompt_template: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_prompts: Mock,
+        mock_register_prompt_from_datarobot_prompt_management: AsyncMock,
+        mcp_server: DataRobotMCP,
+    ) -> None:
+        prompt_template_id = Mock()
+        await register_prompt_from_prompt_template_id_and_version(prompt_template_id, None)
+
+        mock_prompt_template = mock_get_datarobot_prompt_template.return_value
+        mock_register_prompt_from_datarobot_prompt_management.assert_called_once_with(
+            prompt_template=mock_prompt_template,
+        )
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_lineage_manager_init.assert_called_once_with(mcp_server)
+        mock_sync_mcp_prompts.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_sync_mcp_metadata_after_registering_with_prompt_template_and_version_ids(
+        self,
+        mock_feature_flag_create: Mock,
+        mock_get_datarobot_prompt_template: Mock,
+        mock_get_datarobot_prompt_template_version: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_prompts: Mock,
+        mock_register_prompt_from_datarobot_prompt_management: Mock,
+        mcp_server: DataRobotMCP,
+    ) -> None:
+        prompt_template_id = Mock()
+        prompt_template_version_id = Mock()
+        await register_prompt_from_prompt_template_id_and_version(
+            prompt_template_id,
+            prompt_template_version_id,
+        )
+
+        mock_get_datarobot_prompt_template.assert_called_once_with(prompt_template_id)
+        mock_prompt_template = mock_get_datarobot_prompt_template.return_value
+        mock_get_datarobot_prompt_template_version.assert_called_once_with(
+            prompt_template_id, prompt_template_version_id
+        )
+        mock_prompt_template_version = mock_get_datarobot_prompt_template_version.return_value
+        mock_register_prompt_from_datarobot_prompt_management.assert_called_once_with(
+            prompt_template=mock_prompt_template,
+            prompt_template_version=mock_prompt_template_version,
+        )
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_lineage_manager_init.assert_called_once_with(mcp_server)
+        mock_sync_mcp_prompts.assert_called_once_with()
 
 
 class TestPromptTemplatesListing:
@@ -207,6 +297,11 @@ class TestPromptTemplatesDeletion:
     """Tests for prompt templates deletion functionality."""
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_prompts",
+    )
     async def test_delete_registered_prompt_template(self, mcp_server: DataRobotMCP) -> None:
         """Test delete registered prompt template."""
         # Setup - add test prompts directly to MCP
@@ -236,11 +331,47 @@ class TestPromptTemplatesDeletion:
             "pt1": ("ptv1.1", "abc"),
         }
 
+    @pytest.mark.asyncio
+    async def test_sync_mcp_metadata_after_deletion(
+        self,
+        mock_feature_flag_create: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_prompts: Mock,
+        mcp_server: DataRobotMCP,
+    ) -> None:
+        prompt_id = Mock()
+        await mcp_server.set_prompt_mapping(prompt_id, Mock(), Mock())
+
+        await delete_registered_prompt_template(prompt_id)
+
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_lineage_manager_init.assert_called_once_with(mcp_server)
+        mock_sync_mcp_prompts.assert_called_once_with()
+
 
 class TestPromptTemplatesRefresh:
     """Tests for prompt templates refresh functionality."""
 
+    @pytest.fixture
+    def mock_get_datarobot_prompt_templates(self, mock_module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{mock_module_under_test}.get_datarobot_prompt_templates") as mock_func:
+            mock_func.return_value = []
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_datarobot_prompt_template_versions(
+        self, mock_module_under_test: str
+    ) -> Iterator[Mock]:
+        with patch(f"{mock_module_under_test}.get_datarobot_prompt_template_versions") as mock_func:
+            mock_func.return_value = {}
+            yield mock_func
+
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_prompts",
+    )
     async def test_refresh_prompt_templates(
         self, mcp_server: DataRobotMCP, dr_lib_mock_for_refresh: None
     ) -> None:
@@ -266,3 +397,21 @@ class TestPromptTemplatesRefresh:
             "pt3": ("ptv3.1", "pt3 name"),  # New pt3
             # And pt2 deleted
         }
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_get_datarobot_prompt_templates",
+        "mock_get_datarobot_prompt_template_versions",
+    )
+    async def test_sync_mcp_metadata_after_refresh_prompts(
+        self,
+        mock_feature_flag_create: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_prompts: Mock,
+        mcp_server: DataRobotMCP,
+    ) -> None:
+        await refresh_registered_prompt_template()
+
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_lineage_manager_init.assert_called_once_with(mcp_server)
+        mock_sync_mcp_prompts.assert_called_once_with()

--- a/tests/drmcp/unit/dynamic_prompts/test_register.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_register.py
@@ -126,7 +126,7 @@ class TestRegisterPrompt:
             yield mock_mcp
 
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -144,7 +144,7 @@ class TestRegisterPrompt:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -169,7 +169,7 @@ class TestRegisterPrompt:
         self,
         mock_get_datarobot_prompt_templates: Mock,
         mock_get_datarobot_prompt_template_versions: Mock,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
         mock_mcp_server: Mock,
@@ -192,7 +192,7 @@ class TestRegisterPrompt:
             mock_prompt,
             prompt_template_version,
         )
-        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
 
@@ -201,7 +201,7 @@ class TestRegisterPrompt:
         self,
         mock_get_datarobot_prompt_templates: Mock,
         mock_get_datarobot_prompt_template_versions: Mock,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
     ) -> None:
@@ -213,6 +213,6 @@ class TestRegisterPrompt:
         mock_get_datarobot_prompt_template_versions.assert_called_once_with(
             prompt_template_ids=[],
         )
-        mock_feature_flag_create.assert_not_called()
+        mock_is_mcp_tools_gallery_support_enabled.assert_not_called()
         mock_lineage_manager_init.assert_not_called()
         mock_sync_mcp_prompts.assert_not_called()

--- a/tests/drmcp/unit/dynamic_prompts/test_register.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_register.py
@@ -195,24 +195,3 @@ class TestRegisterPrompt:
         mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
-
-    @pytest.mark.asyncio
-    async def test_not_run_sync_mcp_metadata_after_no_prompt_is_registered(
-        self,
-        mock_get_datarobot_prompt_templates: Mock,
-        mock_get_datarobot_prompt_template_versions: Mock,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
-        mock_lineage_manager_init: Mock,
-        mock_sync_mcp_prompts: Mock,
-    ) -> None:
-        mock_get_datarobot_prompt_templates.return_value = []
-
-        await register_prompts_from_datarobot_prompt_management()
-
-        mock_get_datarobot_prompt_templates.assert_called_once_with()
-        mock_get_datarobot_prompt_template_versions.assert_called_once_with(
-            prompt_template_ids=[],
-        )
-        mock_is_mcp_tools_gallery_support_enabled.assert_not_called()
-        mock_lineage_manager_init.assert_not_called()
-        mock_sync_mcp_prompts.assert_not_called()

--- a/tests/drmcp/unit/dynamic_prompts/test_register.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_register.py
@@ -14,6 +14,8 @@
 
 """Tests for external prompt registration."""
 
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 from uuid import UUID
@@ -94,6 +96,40 @@ class TestToValidFunctionName:
 class TestRegisterPrompt:
     """Tests for register_prompt - happy path."""
 
+    @pytest.fixture
+    def module_under_test(self) -> str:
+        return "datarobot_genai.drmcp.core.dynamic_prompts.register"
+
+    @pytest.fixture
+    def mock_get_datarobot_prompt_templates(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.get_datarobot_prompt_templates") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_datarobot_prompt_template_versions(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.get_datarobot_prompt_template_versions") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_register_prompt_from_datarobot_prompt_management(
+        self, module_under_test: str
+    ) -> Iterator[AsyncMock]:
+        with patch(
+            f"{module_under_test}.register_prompt_from_datarobot_prompt_management",
+            new_callable=AsyncMock,
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_mcp_server(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.mcp") as mock_mcp:
+            yield mock_mcp
+
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_prompts",
+    )
     @pytest.mark.asyncio
     async def test_register_prompt_from_datarobot_prompt_management(
         self,
@@ -107,6 +143,11 @@ class TestRegisterPrompt:
         assert "Dummy prompt name" in prompts, "`Dummy prompt name` is missing."
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_prompts",
+    )
     @patch("datarobot_genai.drmcp.core.dynamic_prompts.utils.uuid4")
     async def test_register_prompt_from_datarobot_prompt_management_duplicated_prompt_names(
         self,
@@ -122,3 +163,56 @@ class TestRegisterPrompt:
 
         assert "Dummy prompt name" in prompts, "`Dummy prompt name` is missing."
         assert "Dummy prompt name (f2bd)" in prompts, "`Dummy prompt name (f2bd)` is missing."
+
+    @pytest.mark.asyncio
+    async def test_sync_mcp_metadata_after_register_prompts(
+        self,
+        mock_get_datarobot_prompt_templates: Mock,
+        mock_get_datarobot_prompt_template_versions: Mock,
+        mock_feature_flag_create: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_prompts: Mock,
+        mock_mcp_server: Mock,
+        mock_register_prompt_from_datarobot_prompt_management: AsyncMock,
+    ) -> None:
+        mock_prompt = Mock()
+        mock_get_datarobot_prompt_templates.return_value = [mock_prompt]
+        prompt_template_version = dr.genai.PromptTemplateVersion("adsf", version=1)
+        mock_get_datarobot_prompt_template_versions.return_value = {
+            mock_prompt.id: [prompt_template_version],
+        }
+
+        await register_prompts_from_datarobot_prompt_management()
+
+        mock_get_datarobot_prompt_templates.assert_called_once_with()
+        mock_get_datarobot_prompt_template_versions.assert_called_once_with(
+            prompt_template_ids=[mock_prompt.id],
+        )
+        mock_register_prompt_from_datarobot_prompt_management.assert_called_once_with(
+            mock_prompt,
+            prompt_template_version,
+        )
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
+        mock_sync_mcp_prompts.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_not_run_sync_mcp_metadata_after_no_prompt_is_registered(
+        self,
+        mock_get_datarobot_prompt_templates: Mock,
+        mock_get_datarobot_prompt_template_versions: Mock,
+        mock_feature_flag_create: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_prompts: Mock,
+    ) -> None:
+        mock_get_datarobot_prompt_templates.return_value = []
+
+        await register_prompts_from_datarobot_prompt_management()
+
+        mock_get_datarobot_prompt_templates.assert_called_once_with()
+        mock_get_datarobot_prompt_template_versions.assert_called_once_with(
+            prompt_template_ids=[],
+        )
+        mock_feature_flag_create.assert_not_called()
+        mock_lineage_manager_init.assert_not_called()
+        mock_sync_mcp_prompts.assert_not_called()

--- a/tests/drmcp/unit/dynamic_tools/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_tools/test_controllers.py
@@ -123,7 +123,7 @@ class TestToolRegistration:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -156,7 +156,7 @@ class TestToolRegistration:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -198,7 +198,7 @@ class TestToolRegistration:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_registration(
         self,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_get_sdk_client: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_tools: Mock,
@@ -214,7 +214,7 @@ class TestToolRegistration:
         mock_register_tool_of_datarobot_deployment.assert_called_once_with(
             mock_sdk_client.Deployment.get.return_value
         )
-        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_tools.assert_called_once_with()
 
@@ -258,7 +258,7 @@ class TestDeploymentDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -294,7 +294,7 @@ class TestDeploymentDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -340,7 +340,7 @@ class TestDeploymentDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -393,7 +393,7 @@ class TestDeploymentDeletion:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_deletion(
         self,
-        mock_feature_flag_create: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_tools: Mock,
         mcp_server: DataRobotMCP,
@@ -403,7 +403,7 @@ class TestDeploymentDeletion:
 
         await delete_registered_tool_deployment(tool_id)
 
-        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_tools.assert_called_once_with()
 
@@ -413,7 +413,7 @@ class TestIntegratedWorkflow:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_feature_flag_create",
+        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )

--- a/tests/drmcp/unit/dynamic_tools/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_tools/test_controllers.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
-import pytest_asyncio
 from fastmcp.tools.tool import Tool
 
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.controllers import (
@@ -68,8 +69,8 @@ def mock_config():
     return config
 
 
-@pytest_asyncio.fixture
-async def mcp_server():
+@pytest.fixture
+def mcp_server() -> Iterator[DataRobotMCP]:
     """Create a separate MCP instance for testing."""
     test_mcp = DataRobotMCP()
 
@@ -96,10 +97,36 @@ def mock_external_dependencies():
         yield {"sdk": mock_sdk, "mock_config": mock_config}
 
 
+@pytest.fixture
+def module_under_test() -> str:
+    return "datarobot_genai.drmcp.core.dynamic_tools.deployment.controllers"
+
+
 class TestToolRegistration:
     """Tests for tool registration functionality."""
 
+    @pytest.fixture
+    def mock_get_sdk_client(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.get_sdk_client") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_register_tool_of_datarobot_deployment(
+        self,
+        module_under_test: str,
+    ) -> Iterator[AsyncMock]:
+        with patch(
+            f"{module_under_test}.register_tool_of_datarobot_deployment",
+            new_callable=AsyncMock,
+        ) as mock_func:
+            yield mock_func
+
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+    )
     async def test_register_tool_with_deployment_description(
         self,
         deployment_id,
@@ -128,6 +155,11 @@ class TestToolRegistration:
         assert registered_tools[0].description == "Get weather for cities"
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+    )
     async def test_register_multiple_tools(
         self,
         deployment_id,
@@ -162,6 +194,29 @@ class TestToolRegistration:
         assert len(registered_tools) == 2
         tool_names = {tool.name for tool in registered_tools}
         assert tool_names == {"weather_tool", "Another Tool"}
+
+    @pytest.mark.asyncio
+    async def test_sync_mcp_metadata_after_registration(
+        self,
+        mock_feature_flag_create: Mock,
+        mock_get_sdk_client: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_tools: Mock,
+        mock_register_tool_of_datarobot_deployment: AsyncMock,
+        mcp_server: DataRobotMCP,
+    ) -> None:
+        tool_id = Mock()
+        await register_tool_for_deployment_id(tool_id)
+
+        mock_get_sdk_client.assert_called_once_with(headers_auth_only=True)
+        mock_sdk_client = mock_get_sdk_client.return_value
+        mock_sdk_client.Deployment.get.assert_called_once_with(tool_id)
+        mock_register_tool_of_datarobot_deployment.assert_called_once_with(
+            mock_sdk_client.Deployment.get.return_value
+        )
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_lineage_manager_init.assert_called_once_with(mcp_server)
+        mock_sync_mcp_tools.assert_called_once_with()
 
 
 class TestDeploymentListing:
@@ -202,6 +257,11 @@ class TestDeploymentDeletion:
     """Tests for deployment deletion functionality."""
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+    )
     async def test_delete_existing_deployment_with_logging(
         self,
         deployment_id,
@@ -233,6 +293,11 @@ class TestDeploymentDeletion:
         mock_logger.info.assert_called_once_with(expected_log_msg)
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+    )
     async def test_delete_nonexistent_deployment(
         self,
         deployment_id,
@@ -274,6 +339,11 @@ class TestDeploymentDeletion:
         assert final_mappings == {}
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+    )
     async def test_delete_multiple_deployments_sequentially(
         self,
         deployment_id,
@@ -320,11 +390,33 @@ class TestDeploymentDeletion:
         final_mappings = await mcp_server.get_deployment_mapping()
         assert final_mappings == {}
 
+    @pytest.mark.asyncio
+    async def test_sync_mcp_metadata_after_deletion(
+        self,
+        mock_feature_flag_create: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_tools: Mock,
+        mcp_server: DataRobotMCP,
+    ) -> None:
+        tool_id = Mock()
+        await mcp_server.set_deployment_mapping(tool_id, Mock())
+
+        await delete_registered_tool_deployment(tool_id)
+
+        mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+        mock_lineage_manager_init.assert_called_once_with(mcp_server)
+        mock_sync_mcp_tools.assert_called_once_with()
+
 
 class TestIntegratedWorkflow:
     """Tests for complete workflow integration."""
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
+        "mock_feature_flag_create",
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+    )
     async def test_complete_deployment_lifecycle(
         self,
         deployment_id,

--- a/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
+++ b/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
@@ -11,12 +11,52 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
 from unittest.mock import patch
+
+import datarobot as dr
+import pytest
 
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
     get_datarobot_tool_deployments,
 )
+from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
+    register_tools_of_datarobot_deployments,
+)
+
+
+@pytest.fixture
+def module_under_test() -> str:
+    return "datarobot_genai.drmcp.core.dynamic_tools.deployment.register"
+
+
+@pytest.fixture
+def mock_get_datarobot_tool_deployments(module_under_test: str) -> Iterator[Mock]:
+    with patch(f"{module_under_test}.get_datarobot_tool_deployments") as mock_func:
+        yield mock_func
+
+
+@pytest.fixture
+def mock_register_tool_of_datarobot_deployment(module_under_test: str) -> Iterator[AsyncMock]:
+    with patch(
+        f"{module_under_test}.register_tool_of_datarobot_deployment",
+        new_callable=AsyncMock,
+    ) as mock_func:
+        yield mock_func
+
+
+@pytest.fixture
+def mock_mcp_server(module_under_test: str) -> Iterator[Mock]:
+    with patch(f"{module_under_test}.mcp") as mock_mcp:
+        yield mock_mcp
+
+
+@pytest.fixture
+def mock_datarobot_deployment_get() -> Iterator[Mock]:
+    with patch.object(dr.Deployment, "get") as mock_func:
+        yield mock_func
 
 
 @patch("datarobot_genai.drmcp.core.dynamic_tools.deployment.register.get_api_client")
@@ -67,3 +107,46 @@ def test_get_datarobot_tool_deployments_filters_tags_correctly(mock_dr, mock_get
     )
 
     assert result == ["deployment_1", "deployment_5"]
+
+
+@pytest.mark.asyncio
+async def test_sync_mcp_metadata_after_register_tools(
+    mock_datarobot_deployment_get: Mock,
+    mock_feature_flag_create: Mock,
+    mock_get_datarobot_tool_deployments: Mock,
+    mock_lineage_manager_init: Mock,
+    mock_sync_mcp_tools: Mock,
+    mock_mcp_server: Mock,
+    mock_register_tool_of_datarobot_deployment: AsyncMock,
+) -> None:
+    mock_deployment_id = Mock()
+    mock_get_datarobot_tool_deployments.return_value = [mock_deployment_id]
+
+    await register_tools_of_datarobot_deployments()
+
+    mock_get_datarobot_tool_deployments.assert_called_once_with()
+    mock_datarobot_deployment_get.assert_called_once_with(mock_deployment_id)
+    mock_register_tool_of_datarobot_deployment.assert_called_once_with(
+        mock_datarobot_deployment_get.return_value,
+    )
+    mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+    mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
+    mock_sync_mcp_tools.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_not_run_sync_mcp_metadata_after_no_tool_is_registered(
+    mock_feature_flag_create: Mock,
+    mock_get_datarobot_tool_deployments: Mock,
+    mock_lineage_manager_init: Mock,
+    mock_mcp_server: Mock,
+    mock_sync_mcp_tools: Mock,
+) -> None:
+    mock_get_datarobot_tool_deployments.return_value = []
+
+    await register_tools_of_datarobot_deployments()
+
+    mock_get_datarobot_tool_deployments.assert_called_once_with()
+    mock_feature_flag_create.assert_not_called()
+    mock_lineage_manager_init.assert_not_called()
+    mock_sync_mcp_tools.assert_not_called()

--- a/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
+++ b/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
@@ -112,7 +112,7 @@ def test_get_datarobot_tool_deployments_filters_tags_correctly(mock_dr, mock_get
 @pytest.mark.asyncio
 async def test_sync_mcp_metadata_after_register_tools(
     mock_datarobot_deployment_get: Mock,
-    mock_feature_flag_create: Mock,
+    mock_is_mcp_tools_gallery_support_enabled: Mock,
     mock_get_datarobot_tool_deployments: Mock,
     mock_lineage_manager_init: Mock,
     mock_sync_mcp_tools: Mock,
@@ -129,14 +129,14 @@ async def test_sync_mcp_metadata_after_register_tools(
     mock_register_tool_of_datarobot_deployment.assert_called_once_with(
         mock_datarobot_deployment_get.return_value,
     )
-    mock_feature_flag_create.assert_called_once_with("ENABLE_MCP_TOOLS_GALLERY_SUPPORT")
+    mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
     mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
     mock_sync_mcp_tools.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_not_run_sync_mcp_metadata_after_no_tool_is_registered(
-    mock_feature_flag_create: Mock,
+    mock_is_mcp_tools_gallery_support_enabled: Mock,
     mock_get_datarobot_tool_deployments: Mock,
     mock_lineage_manager_init: Mock,
     mock_mcp_server: Mock,
@@ -147,6 +147,6 @@ async def test_not_run_sync_mcp_metadata_after_no_tool_is_registered(
     await register_tools_of_datarobot_deployments()
 
     mock_get_datarobot_tool_deployments.assert_called_once_with()
-    mock_feature_flag_create.assert_not_called()
+    mock_is_mcp_tools_gallery_support_enabled.assert_not_called()
     mock_lineage_manager_init.assert_not_called()
     mock_sync_mcp_tools.assert_not_called()

--- a/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
+++ b/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
@@ -132,21 +132,3 @@ async def test_sync_mcp_metadata_after_register_tools(
     mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
     mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
     mock_sync_mcp_tools.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_not_run_sync_mcp_metadata_after_no_tool_is_registered(
-    mock_is_mcp_tools_gallery_support_enabled: Mock,
-    mock_get_datarobot_tool_deployments: Mock,
-    mock_lineage_manager_init: Mock,
-    mock_mcp_server: Mock,
-    mock_sync_mcp_tools: Mock,
-) -> None:
-    mock_get_datarobot_tool_deployments.return_value = []
-
-    await register_tools_of_datarobot_deployments()
-
-    mock_get_datarobot_tool_deployments.assert_called_once_with()
-    mock_is_mcp_tools_gallery_support_enabled.assert_not_called()
-    mock_lineage_manager_init.assert_not_called()
-    mock_sync_mcp_tools.assert_not_called()

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -96,6 +96,11 @@ class TestDataRobotMCPServer:
         assert server._mcp == mock_mcp
         assert server._mcp_transport == "stdio"
 
+    @pytest.mark.usefixtures(
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+        "mock_is_mcp_tools_gallery_support_enabled",
+    )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch(
         "datarobot_genai.drmcp.core.dynamic_tools.deployment.register.get_datarobot_tool_deployments"

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
### Context
It is our decision that making MCP server dynamic/updatable even when MCP server is bound to a fixed version. This means we will need to sync the MCP metadata (stored in mongo) when
- MCP server is started.
- MCP server is updated with tools (remove, add)
- MCP server is updated with prompt template (remove, add)


### What is in this PR 
This PR added the logic to sync MCP server metadata with MCP server status (e.g., registered tools, prompts) when
- MCP server is started.
- MCP server is updated with tools (remove, add)
- MCP server is updated with prompt template (remove, add)

### About MCP metadata sync logic
- It is behind the feature flag.
- The basic logic is 1) checking the MCP server tool/prompts status 2) sync it with MCP metadata in mongo.



<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds post-registration/deletion metadata sync calls that touch external DataRobot APIs and rely on deployment env vars; failures are handled via warnings but could impact runtime behavior when the feature flag is enabled.
> 
> **Overview**
> **Adds optional MCP metadata sync (lineage) for tools and prompts.** After dynamic tool deployment registration/deletion and prompt template register/delete/refresh, the server now conditionally calls `LineageManager.sync_mcp_tools()` / `sync_mcp_prompts()` when `ENABLE_MCP_TOOLS_GALLERY_SUPPORT` is enabled.
> 
> **Improves gating and error handling.** Introduces cached `FeatureFlag.is_mcp_tools_gallery_support_enabled()` and replaces an `assert` in `LRSEnvVars.get_os_env_value()` with a dedicated `LRSEnvVarIsNotSetError`, logging a warning instead of crashing when required LRS env vars are missing.
> 
> **Tests and release bump.** Updates unit/integration test scaffolding to stub the new lineage/feature-flag behavior (and skips one dynamic tools integration test), and bumps version to `0.13.3` with a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35dc8127ee3bfa81bb1c93a4f613d11d059e65c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->