### PR TITLE
[buzzok-30013] Isolating PyPi secrets 

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment:
+      name: Release
+      deployment: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,6 +61,6 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.DATAROBOT_GENAI_PYPI_TOKEN }}
           packages-dir: dist
           skip-existing: false

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -22,6 +22,9 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    environment:
+      name: Release
+      deployment: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
       issues: write
     environment:
-      name: Release
+      name: Build
       deployment: false
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.8.14
-- Isolate publish secrets to an environment
+- Isolated publish secrets to an environment
 
 ## 0.8.13
 - Added base agent for retrieving and storing memory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.8.14
+- Isolate publish secrets to an environment
+
 ## 0.8.13
 - Added base agent for retrieving and storing memory
 
@@ -16,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated helpers.py to use FastMCP's get_http_headers with safe import handling
 
 ## 0.8.11
-- Made build_workflow async 
+- Made build_workflow async
 
 ## 0.8.10
 - Added GitHub Actions workflow `integration.yml`: path-filtered **Integration Tests** job for drmcp (runs when `src/datarobot_genai/drmcp`, `src/datarobot_genai/drtools`, `setup.py`, `tests/drmcp/integration`, or the workflow file changes; aligned with the e2e workflow pattern)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.8.12"
+version = "0.8.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/build GitHub Actions configuration and the secret name used for PyPI publishing, which can break publishing if environment/secrets are misconfigured.
> 
> **Overview**
> **Isolates package publishing credentials behind GitHub Environments.** The PyPI and TestPyPI publish workflows now run under explicit `Release` and `Build` environments, respectively, to scope access to secrets.
> 
> **Updates release publishing configuration.** The PyPI publish step switches to using `secrets.DATAROBOT_GENAI_PYPI_TOKEN` instead of the previous token, and the project version is bumped to `0.8.14` with a matching changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d548585f01498fd1dcdb440e016ca236380bca5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->