### PR TITLE
[BUZZOK-29643] Implement shell frontend for NAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.14.3
+- Added `nat dragent` shell frontend for NAT - provides `nat dragent serve`, `nat dragent run`, and `nat dragent query` commands
+- MCP tool loading now gracefully falls back to empty tools on connection errors (CrewAI, LangGraph, LlamaIndex)
+
 ## 0.14.2
 - Implemented functions to instantiate LLM classes for LLM Gateway, deployment, NIM, and external
 

--- a/e2e-tests/dragent/Taskfile.yaml
+++ b/e2e-tests/dragent/Taskfile.yaml
@@ -17,28 +17,28 @@ tasks:
     dir: ./nat
     cmds:
       - echo "🔨 Running NAT agent"
-      - uv run nat start dragent_fastapi --config_file workflow.yaml --port {{.AGENT_PORT}}
+      - uv run nat dragent serve --config_file workflow.yaml --port {{.AGENT_PORT}}
   run-crewai:
     desc: "🔨 Running CrewAI agent via NAT"
     dir: ./crewai
     cmds:
       - echo "🔨 Running CrewAI agent via NAT"
-      - uv run nat start dragent_fastapi --config_file workflow.yaml --port {{.AGENT_PORT}}
+      - uv run nat dragent serve --config_file workflow.yaml --port {{.AGENT_PORT}}
   run-langgraph:
     desc: "🔨 Running LangGraph agent via NAT"
     dir: ./langgraph
     cmds:
       - echo "🔨 Running LangGraph agent via NAT"
-      - uv run nat start dragent_fastapi --config_file workflow.yaml --port {{.AGENT_PORT}}
+      - uv run nat dragent serve --config_file workflow.yaml --port {{.AGENT_PORT}}
   run-llamaindex:
     desc: "🔨 Running LlamaIndex agent via NAT"
     dir: ./llamaindex
     cmds:
       - echo "🔨 Running LlamaIndex agent via NAT"
-      - uv run nat start dragent_fastapi --config_file workflow.yaml --port {{.AGENT_PORT}}
+      - uv run nat dragent serve --config_file workflow.yaml --port {{.AGENT_PORT}}
   run-base:
     desc: "🔨 Running base agent via NAT"
     dir: ./base
     cmds:
       - echo "🔨 Running base agent via NAT"
-      - uv run nat start dragent_fastapi --config_file workflow.yaml --port {{.AGENT_PORT}}
+      - uv run nat dragent serve --config_file workflow.yaml --port {{.AGENT_PORT}}

--- a/e2e-tests/dragent_tests/test_cli_run.py
+++ b/e2e-tests/dragent_tests/test_cli_run.py
@@ -22,13 +22,13 @@ from pathlib import Path
 
 import pytest
 
-from dragent_tests.helpers import FRAMEWORK
+from dragent_tests.helpers import AGENT
 
 _E2E_ROOT = Path(__file__).resolve().parent.parent
-_WORKFLOW_CONFIG = _E2E_ROOT / "dragent" / (FRAMEWORK or "langgraph") / "workflow.yaml"
+_WORKFLOW_CONFIG = _E2E_ROOT / "dragent" / (AGENT or "langgraph") / "workflow.yaml"
 
 
-@pytest.mark.skipif(not FRAMEWORK, reason="FRAMEWORK env var not set")
+@pytest.mark.skipif(not AGENT, reason="AGENT env var not set")
 @pytest.mark.skipif(
     not _WORKFLOW_CONFIG.exists(),
     reason=f"Workflow config not found: {_WORKFLOW_CONFIG}",

--- a/e2e-tests/dragent_tests/test_cli_run.py
+++ b/e2e-tests/dragent_tests/test_cli_run.py
@@ -1,0 +1,84 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E tests for ``nat dragent`` CLI commands."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dragent_tests.helpers import FRAMEWORK
+
+_E2E_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW_CONFIG = _E2E_ROOT / "dragent" / (FRAMEWORK or "langgraph") / "workflow.yaml"
+
+
+@pytest.mark.skipif(not FRAMEWORK, reason="FRAMEWORK env var not set")
+@pytest.mark.skipif(
+    not _WORKFLOW_CONFIG.exists(),
+    reason=f"Workflow config not found: {_WORKFLOW_CONFIG}",
+)
+def test_cli_run_produces_output() -> None:
+    """``nat dragent run`` executes a workflow in-process and prints output."""
+    result = subprocess.run(
+        [
+            "uv", "run",
+            "nat", "dragent", "run",
+            "--config_file", str(_WORKFLOW_CONFIG),
+            "--input", "Say 'hello world' and nothing else.",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=str(_E2E_ROOT),
+        env={**os.environ},
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"nat dragent run failed (exit {result.returncode}).\n"
+        f"stdout: {result.stdout[:500]}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+    output = result.stdout + result.stderr
+    assert len(output.strip()) > 0, "Expected non-empty output from nat dragent run"
+
+
+def test_cli_query_local_server() -> None:
+    """``nat dragent query --local`` queries the background dragent server via CLI."""
+    result = subprocess.run(
+        [
+            "uv", "run",
+            "nat", "dragent", "query",
+            "--local",
+            "--input", "Say 'hello world' and nothing else.",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=str(_E2E_ROOT),
+        env={**os.environ, "AGENT_PORT": "8080"},
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"nat dragent query --local failed (exit {result.returncode}).\n"
+        f"stdout: {result.stdout[:500]}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+    assert "hello" in result.stdout.lower(), "Expected 'hello' in query output"

--- a/e2e-tests/dragent_tests/test_cli_run.py
+++ b/e2e-tests/dragent_tests/test_cli_run.py
@@ -81,4 +81,5 @@ def test_cli_query_local_server() -> None:
         f"stdout: {result.stdout[:500]}\n"
         f"stderr: {result.stderr[:500]}"
     )
-    assert "hello" in result.stdout.lower(), "Expected 'hello' in query output"
+    output = result.stdout + result.stderr
+    assert len(output.strip()) > 0, "Expected non-empty output from nat dragent query"

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -855,7 +855,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.14.2"
+version = "0.14.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.14.2"
+version = "0.14.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -27,6 +27,9 @@ datarobot_auth_provider = "datarobot_genai.nat.datarobot_auth_provider"
 
 [project.entry-points.'nat.front_ends']
 dragent = "datarobot_genai.dragent.frontends.register"
+
+[project.entry-points.'nat.cli']
+dragent = "datarobot_genai.dragent.cli.commands:dragent_command"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -46,6 +46,7 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
     try:
         with MCPServerAdapter(mcp_config.server_config) as tools:
             logger.info("Successfully connected to MCP server, got %d tools", len(tools))
+            yield tools
     except (ConnectionError, OSError, TimeoutError, ExceptionGroup) as exc:
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
@@ -53,6 +54,3 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
             exc,
         )
         yield []
-        return
-
-    yield tools

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -40,9 +40,19 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
         yield []
         return
 
-    logger.info(f"Connecting to MCP server: {mcp_config.server_config['url']}")
+    url = mcp_config.server_config["url"]
+    logger.info("Connecting to MCP server: %s", url)
 
-    # Use MCPServerAdapter as context manager with the server config
-    with MCPServerAdapter(mcp_config.server_config) as tools:
-        logger.info(f"Successfully connected to MCP server, got {len(tools)} tools")
-        yield tools
+    try:
+        with MCPServerAdapter(mcp_config.server_config) as tools:
+            logger.info("Successfully connected to MCP server, got %d tools", len(tools))
+    except (ConnectionError, OSError, TimeoutError, ExceptionGroup) as exc:
+        logger.warning(
+            "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
+            url,
+            exc,
+        )
+        yield []
+        return
+
+    yield tools

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -39,12 +39,24 @@ class DRAgentCommandGroup(StartCommandGroup):
         params = super()._build_params(front_end)
         for param in params:
             if isinstance(param, click.Option) and "--config_file" in param.opts:
-                param.required = False
-                param.default = "agent/agent/workflow.yaml"
-                param.show_default = True
-                param.type = click.Path(exists=True)
+                param.envvar = "DRAGENT_CONFIG_FILE"
                 break
         return params
+
+    def invoke_subcommand(  # type: ignore[override]
+        self,
+        ctx: click.Context,
+        cmd_name: str,
+        config_file: object,
+        override: tuple[tuple[str, str], ...],
+        **kwargs: object,
+    ) -> int | None:
+        if config_file is None:
+            raise click.ClickException(
+                "No config file provided. "
+                "Pass --config_file <path> or set the DRAGENT_CONFIG_FILE env var."
+            )
+        return super().invoke_subcommand(ctx, cmd_name, config_file, override, **kwargs)
 
     def _load_commands(self) -> dict[str, click.Command]:
         # Depends on StartCommandGroup caching into self._commands (nvidia-nat 1.4.1).

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -81,7 +81,7 @@ class DRAgentCommandGroup(StartCommandGroup):
             cmd.help = meta["help"]
             filtered[meta["alias"]] = cmd
 
-        filtered["run-deployment"] = run_deployment_command
+        filtered["query"] = query_command
         self._commands = filtered  # type: ignore[assignment]
         return filtered
 
@@ -115,29 +115,63 @@ def dragent_command(ctx: click.Context, api_token: str | None, base_url: str | N
 
 
 # ---------------------------------------------------------------------------
-# run-deployment
+# query
 # ---------------------------------------------------------------------------
 
 
-@click.command(name="run-deployment", help="Query a deployed model via the DataRobot API.")
-@click.option("--deployment-id", "deployment_id", required=True, help="Deployment ID.")
+@click.command(
+    name="query",
+    help="Query a dragent server. Use --local for localhost (reads AGENT_PORT env var), "
+    "or --deployment-id for a DataRobot deployment.",
+)
+@click.option(
+    "--local", "local", is_flag=True, help="Query localhost using --port or AGENT_PORT env var."
+)
+@click.option(
+    "--port",
+    "port",
+    default=None,
+    type=int,
+    envvar="AGENT_PORT",
+    help="Port for --local. Falls back to AGENT_PORT env var.",
+)
+@click.option("--deployment-id", "deployment_id", default=None, help="DataRobot deployment ID.")
 @click.option("--input", "input_query", required=True, help="Prompt string.")
 @click.option(
     "--show-payload", "show_payload", is_flag=True, help="Show the request payload sent to the API."
 )
 @click.pass_context
-def run_deployment_command(
-    ctx: click.Context, deployment_id: str, input_query: str, show_payload: bool
+def query_command(
+    ctx: click.Context,
+    local: bool,
+    port: int | None,
+    deployment_id: str | None,
+    input_query: str,
+    show_payload: bool,
 ) -> None:
-    api_token, base_url = require_auth(ctx)
-    base_url = normalize_base_url(base_url)
-    url = f"{base_url}/api/v2/deployments/{deployment_id}/directAccess/generate/stream"
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_token}",
-        **get_auth_context_headers(api_token, base_url),
-    }
+    if local and deployment_id:
+        raise click.UsageError("Specify either --local or --deployment-id, not both.")
+    if not local and not deployment_id:
+        raise click.UsageError("Specify --local or --deployment-id.")
+
+    if deployment_id:
+        api_token, base_url = require_auth(ctx)
+        base_url = normalize_base_url(base_url)
+        target_url = f"{base_url}/api/v2/deployments/{deployment_id}/directAccess/generate/stream"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_token}",
+            **get_auth_context_headers(api_token, base_url),
+        }
+    else:
+        if not port:
+            raise click.UsageError(
+                "Port is required for --local. Pass --port or set AGENT_PORT env var."
+            )
+        target_url = f"http://localhost:{port}/generate/stream"
+        headers = {"Content-Type": "application/json"}
+
     payload = build_agui_payload(input_query)
     if show_payload:
         click.echo(json.dumps(payload, indent=2))
-    stream_agui_events(url, payload, headers)
+    stream_agui_events(target_url, payload, headers)

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -20,13 +20,6 @@ import click
 from nat.cli.commands.start import StartCommandGroup
 from nat.cli.type_registry import RegisteredFrontEndInfo
 
-try:
-    from dotenv import load_dotenv
-
-    load_dotenv()
-except ImportError:
-    pass
-
 from .remote import build_agui_payload
 from .remote import get_auth_context_headers
 from .remote import normalize_base_url
@@ -106,6 +99,12 @@ class DRAgentCommandGroup(StartCommandGroup):
 )
 @click.pass_context
 def dragent_command(ctx: click.Context, api_token: str | None, base_url: str | None) -> None:
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
     ctx.ensure_object(dict)
     ctx.obj["api_token"] = api_token
     ctx.obj["base_url"] = base_url

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -40,6 +40,7 @@ class DRAgentCommandGroup(StartCommandGroup):
         params = super()._build_params(front_end)
         for param in params:
             if isinstance(param, click.Option) and "--config_file" in param.opts:
+                param.required = False
                 param.envvar = "DRAGENT_CONFIG_FILE"
             elif isinstance(param, click.Option) and "--port" in param.opts:
                 param.envvar = "AGENT_PORT"

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -97,12 +97,6 @@ class DRAgentCommandGroup(StartCommandGroup):
 )
 @click.pass_context
 def dragent_command(ctx: click.Context, api_token: str | None, base_url: str | None) -> None:
-    try:
-        from dotenv import load_dotenv
-
-        load_dotenv()
-    except ImportError:
-        pass
     ctx.ensure_object(dict)
     ctx.obj["api_token"] = api_token
     ctx.obj["base_url"] = base_url

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -40,7 +40,8 @@ class DRAgentCommandGroup(StartCommandGroup):
         for param in params:
             if isinstance(param, click.Option) and "--config_file" in param.opts:
                 param.envvar = "DRAGENT_CONFIG_FILE"
-                break
+            elif isinstance(param, click.Option) and "--port" in param.opts:
+                param.envvar = "AGENT_PORT"
         return params
 
     def invoke_subcommand(  # type: ignore[override]

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -31,8 +31,6 @@ _FRONTEND_COMMANDS: dict[str, dict[str, str]] = {
     "dragent_console": {"alias": "run", "help": "Execute a dragent workflow locally (in-process)."},
 }
 
-DEFAULT_CONFIG_FILE = "agent/agent/workflow.yaml"
-
 
 class DRAgentCommandGroup(StartCommandGroup):
     """NAT StartCommandGroup filtered to dragent frontends with friendly aliases."""
@@ -42,7 +40,7 @@ class DRAgentCommandGroup(StartCommandGroup):
         for param in params:
             if isinstance(param, click.Option) and "--config_file" in param.opts:
                 param.required = False
-                param.default = DEFAULT_CONFIG_FILE
+                param.default = "agent/agent/workflow.yaml"
                 param.show_default = True
                 param.type = click.Path(exists=True)
                 break

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -22,6 +22,7 @@ from nat.cli.type_registry import RegisteredFrontEndInfo
 
 from .remote import build_agui_payload
 from .remote import get_auth_context_headers
+from .remote import get_local_auth_context_headers
 from .remote import normalize_base_url
 from .remote import require_auth
 from .remote import stream_agui_events
@@ -170,7 +171,10 @@ def query_command(
                 "Port is required for --local. Pass --port or set AGENT_PORT env var."
             )
         target_url = f"http://localhost:{port}/generate/stream"
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            **get_local_auth_context_headers(),
+        }
 
     payload = build_agui_payload(input_query)
     if show_payload:

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -68,7 +68,12 @@ class DRAgentCommandGroup(StartCommandGroup):
 
         filtered: dict[str, click.Command] = {}
         for original_name, meta in _FRONTEND_COMMANDS.items():
-            cmd = loaded[original_name]  # KeyError if frontend not registered
+            if original_name not in loaded:
+                raise RuntimeError(
+                    f"Frontend '{original_name}' not registered. "
+                    f"Ensure nat.front_ends entry points are installed."
+                )
+            cmd = loaded[original_name]
             cmd.name = meta["alias"]
             cmd.help = meta["help"]
             filtered[meta["alias"]] = cmd

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -29,6 +29,7 @@ except ImportError:
 
 from .remote import build_agui_payload
 from .remote import get_auth_context_headers
+from .remote import normalize_base_url
 from .remote import require_auth
 from .remote import stream_agui_events
 
@@ -95,12 +96,11 @@ class DRAgentCommandGroup(StartCommandGroup):
     "--base-url",
     "base_url",
     envvar="DATAROBOT_ENDPOINT",
-    default="https://app.datarobot.com",
-    show_default=True,
+    default=None,
     help="DataRobot API endpoint.",
 )
 @click.pass_context
-def dragent_command(ctx: click.Context, api_token: str | None, base_url: str) -> None:
+def dragent_command(ctx: click.Context, api_token: str | None, base_url: str | None) -> None:
     ctx.ensure_object(dict)
     ctx.obj["api_token"] = api_token
     ctx.obj["base_url"] = base_url
@@ -122,6 +122,7 @@ def run_deployment_command(
     ctx: click.Context, deployment_id: str, input_query: str, show_payload: bool
 ) -> None:
     api_token, base_url = require_auth(ctx)
+    base_url = normalize_base_url(base_url)
     url = f"{base_url}/api/v2/deployments/{deployment_id}/directAccess/generate/stream"
     headers = {
         "Content-Type": "application/json",

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -1,0 +1,134 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+
+import click
+from nat.cli.commands.start import StartCommandGroup
+from nat.cli.type_registry import RegisteredFrontEndInfo
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+from .remote import build_agui_payload
+from .remote import get_auth_context_headers
+from .remote import require_auth
+from .remote import stream_agui_events
+
+_FRONTEND_COMMANDS: dict[str, dict[str, str]] = {
+    "dragent_fastapi": {"alias": "serve", "help": "Start the dragent HTTP server."},
+    "dragent_console": {"alias": "run", "help": "Execute a dragent workflow locally (in-process)."},
+}
+
+DEFAULT_CONFIG_FILE = "agent/agent/workflow.yaml"
+
+
+class DRAgentCommandGroup(StartCommandGroup):
+    """NAT StartCommandGroup filtered to dragent frontends with friendly aliases."""
+
+    def _build_params(self, front_end: RegisteredFrontEndInfo) -> list[click.Parameter]:
+        params = super()._build_params(front_end)
+        for param in params:
+            if isinstance(param, click.Option) and "--config_file" in param.opts:
+                param.required = False
+                param.default = DEFAULT_CONFIG_FILE
+                param.show_default = True
+                param.type = click.Path(exists=True)
+                break
+        return params
+
+    def _load_commands(self) -> dict[str, click.Command]:
+        # Depends on StartCommandGroup caching into self._commands (nvidia-nat 1.4.1).
+        # If NAT renames/removes this attribute, _load_commands will need updating.
+        commands: dict[str, click.Command] | None = self._commands  # type: ignore[has-type,assignment]
+        if commands is not None:
+            return commands
+
+        # Reset cache so the parent actually populates it, then filter + alias.
+        self._commands = None  # type: ignore[assignment]
+        loaded = super()._load_commands()
+
+        filtered: dict[str, click.Command] = {}
+        for original_name, meta in _FRONTEND_COMMANDS.items():
+            cmd = loaded[original_name]  # KeyError if frontend not registered
+            cmd.name = meta["alias"]
+            cmd.help = meta["help"]
+            filtered[meta["alias"]] = cmd
+
+        filtered["run-deployment"] = run_deployment_command
+        self._commands = filtered  # type: ignore[assignment]
+        return filtered
+
+
+@click.command(
+    name="dragent",
+    cls=DRAgentCommandGroup,
+    invoke_without_command=True,
+    no_args_is_help=True,
+    help="DRAgent CLI - run and serve dragent workflows.",
+)
+@click.option(
+    "--api-token",
+    "api_token",
+    envvar="DATAROBOT_API_TOKEN",
+    default=None,
+    help="DataRobot API token.",
+)
+@click.option(
+    "--base-url",
+    "base_url",
+    envvar="DATAROBOT_ENDPOINT",
+    default="https://app.datarobot.com",
+    show_default=True,
+    help="DataRobot API endpoint.",
+)
+@click.pass_context
+def dragent_command(ctx: click.Context, api_token: str | None, base_url: str) -> None:
+    ctx.ensure_object(dict)
+    ctx.obj["api_token"] = api_token
+    ctx.obj["base_url"] = base_url
+
+
+# ---------------------------------------------------------------------------
+# run-deployment
+# ---------------------------------------------------------------------------
+
+
+@click.command(name="run-deployment", help="Query a deployed model via the DataRobot API.")
+@click.option("--deployment-id", "deployment_id", required=True, help="Deployment ID.")
+@click.option("--input", "input_query", required=True, help="Prompt string.")
+@click.option(
+    "--show-payload", "show_payload", is_flag=True, help="Show the request payload sent to the API."
+)
+@click.pass_context
+def run_deployment_command(
+    ctx: click.Context, deployment_id: str, input_query: str, show_payload: bool
+) -> None:
+    api_token, base_url = require_auth(ctx)
+    url = f"{base_url}/api/v2/deployments/{deployment_id}/directAccess/generate/stream"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_token}",
+        **get_auth_context_headers(api_token, base_url),
+    }
+    payload = build_agui_payload(input_query)
+    if show_payload:
+        click.echo(json.dumps(payload, indent=2))
+    stream_agui_events(url, payload, headers)

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -75,6 +75,27 @@ def get_auth_context_headers(api_token: str, base_url: str) -> dict[str, str]:
     return handler.get_header(auth_ctx)
 
 
+def get_local_auth_context_headers() -> dict[str, str]:
+    """Build X-DataRobot-Authorization-Context header for local server requests.
+
+    Uses SESSION_SECRET_KEY and DATAROBOT_USER_ID from env vars.
+    Returns an empty dict when SESSION_SECRET_KEY is not set.
+    """
+    secret_key = _get_session_secret_key()
+    if secret_key is None:
+        return {}
+
+    from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
+
+    user_id = os.environ.get("DATAROBOT_USER_ID", "local_cli_user")
+    auth_ctx = {
+        "user": {"id": user_id, "email": "local@cli"},
+        "identities": [],
+    }
+    handler = AuthContextHeaderHandler(secret_key=secret_key)
+    return handler.get_header(auth_ctx)
+
+
 def require_auth(ctx: click.Context) -> tuple[str, str]:
     """Return (api_token, base_url) from the group context, or raise."""
     api_token: str | None = ctx.obj.get("api_token")

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -29,10 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_session_secret_key() -> str:
-    """Read SESSION_SECRET_KEY from the environment.
-
-    Relies on load_dotenv() in commands.py having already loaded .env into os.environ.
-    """
+    """Read SESSION_SECRET_KEY from the environment."""
     val = os.environ.get("SESSION_SECRET_KEY", "")
     if not val:
         raise click.ClickException("SESSION_SECRET_KEY is required for auth context but not set.")

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -1,0 +1,144 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HTTP client helpers for remote DataRobot API commands."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import typing
+from uuid import uuid4
+
+import click
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def _get_session_secret_key() -> str:
+    """Read SESSION_SECRET_KEY from the environment.
+
+    Relies on load_dotenv() in commands.py having already loaded .env into os.environ.
+    """
+    val = os.environ.get("SESSION_SECRET_KEY", "")
+    if not val:
+        raise click.ClickException("SESSION_SECRET_KEY is required for auth context but not set.")
+    return val
+
+
+def get_auth_context_headers(api_token: str, base_url: str) -> dict[str, str]:
+    """Build X-DataRobot-Authorization-Context header for CLI requests.
+
+    Fetches user identity from DataRobot, encodes it as a JWT that
+    DRAgentAGUISessionManager decodes to extract user_id.
+    """
+    from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
+
+    resp = httpx.get(
+        f"{base_url}/api/v2/account/info/",
+        headers={"Authorization": f"Bearer {api_token}"},
+        follow_redirects=True,
+        timeout=10,
+    )
+    if not resp.is_success:
+        raise click.ClickException(
+            f"Failed to fetch user info (HTTP {resp.status_code}). "
+            f"Check DATAROBOT_API_TOKEN and DATAROBOT_ENDPOINT."
+        )
+
+    raw = resp.json()
+    auth_ctx = {
+        "user": {"id": raw["uid"], "email": raw["email"]},
+        "identities": [],
+    }
+    handler = AuthContextHeaderHandler(secret_key=_get_session_secret_key())
+    return handler.get_header(auth_ctx)
+
+
+def require_auth(ctx: click.Context) -> tuple[str, str]:
+    """Return (api_token, base_url) from the group context, or raise."""
+    api_token: str | None = ctx.obj.get("api_token")
+    base_url: str = ctx.obj.get("base_url", "https://app.datarobot.com")
+    if not api_token:
+        raise click.UsageError(
+            "API token is required. Pass --api-token or set DATAROBOT_API_TOKEN."
+        )
+    # Normalize: strip trailing /api/v2 since URLs add it explicitly
+    base_url = base_url.rstrip("/").removesuffix("/api/v2")
+    return api_token, base_url
+
+
+def build_agui_payload(user_prompt: str) -> dict[str, typing.Any]:
+    """Build an AG-UI RunAgentInput payload."""
+    return {
+        "threadId": str(uuid4()),
+        "runId": str(uuid4()),
+        "state": [],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {},
+        "messages": [
+            {
+                "id": str(uuid4()),
+                "role": "user",
+                "content": user_prompt,
+            }
+        ],
+    }
+
+
+def stream_agui_events(
+    url: str,
+    payload: dict[str, typing.Any],
+    headers: dict[str, str],
+) -> None:
+    """POST to an AG-UI /generate/stream endpoint and print text events."""
+    try:
+        with httpx.stream("POST", url, json=payload, headers=headers, timeout=300) as resp:
+            if not resp.is_success:
+                resp.read()
+                raise click.ClickException(f"HTTP {resp.status_code}: {resp.text}")
+            for line in resp.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                try:
+                    data = json.loads(line[6:])
+                except json.JSONDecodeError:
+                    logger.debug("Skipping malformed SSE data: %s", line)
+                    continue
+                events = data.get("events", [data])
+                for ev in events:
+                    event_type = ev.get("type", "")
+                    if event_type in (
+                        "TEXT_MESSAGE_CONTENT",
+                        "TEXT_MESSAGE_CHUNK",
+                    ):
+                        click.echo(ev.get("delta", ""), nl=False)
+                    elif event_type == "TEXT_MESSAGE_END":
+                        click.echo("")
+                    elif event_type == "RUN_FINISHED":
+                        click.echo("\nRun finished.")
+                    elif event_type == "RUN_ERROR":
+                        msg = ev.get("message", "Unknown error")
+                        raise click.ClickException(f"Run failed: {msg}")
+                    else:
+                        logger.debug("Unhandled SSE event type: %s", event_type)
+    except httpx.ConnectError:
+        raise click.ClickException(f"Could not connect to {url}.")
+    except httpx.TimeoutException as exc:
+        raise click.ClickException(f"Request timed out: {exc}")
+    except httpx.HTTPError as exc:
+        raise click.ClickException(f"HTTP error during streaming: {exc}")

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -24,16 +24,15 @@ from uuid import uuid4
 
 import click
 import httpx
+from colorama import Fore
+from colorama import Style
 
 logger = logging.getLogger(__name__)
 
 
-def _get_session_secret_key() -> str:
-    """Read SESSION_SECRET_KEY from the environment."""
-    val = os.environ.get("SESSION_SECRET_KEY", "")
-    if not val:
-        raise click.ClickException("SESSION_SECRET_KEY is required for auth context but not set.")
-    return val
+def _get_session_secret_key() -> str | None:
+    """Read SESSION_SECRET_KEY from the environment, or None if not set."""
+    return os.environ.get("SESSION_SECRET_KEY") or None
 
 
 def get_auth_context_headers(api_token: str, base_url: str) -> dict[str, str]:
@@ -41,7 +40,18 @@ def get_auth_context_headers(api_token: str, base_url: str) -> dict[str, str]:
 
     Fetches user identity from DataRobot, encodes it as a JWT that
     DRAgentAGUISessionManager decodes to extract user_id.
+
+    Returns an empty dict when SESSION_SECRET_KEY is not set, allowing
+    the agent to run without auth context (e.g. local-only usage).
     """
+    secret_key = _get_session_secret_key()
+    if secret_key is None:
+        logger.warning(
+            "SESSION_SECRET_KEY is not set. Skipping auth context header. "
+            "Set it if the deployment requires X-DataRobot-Authorization-Context."
+        )
+        return {}
+
     from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
 
     resp = httpx.get(
@@ -61,7 +71,7 @@ def get_auth_context_headers(api_token: str, base_url: str) -> dict[str, str]:
         "user": {"id": raw["uid"], "email": raw["email"]},
         "identities": [],
     }
-    handler = AuthContextHeaderHandler(secret_key=_get_session_secret_key())
+    handler = AuthContextHeaderHandler(secret_key=secret_key)
     return handler.get_header(auth_ctx)
 
 
@@ -129,11 +139,14 @@ def stream_agui_events(
                         "TEXT_MESSAGE_CONTENT",
                         "TEXT_MESSAGE_CHUNK",
                     ):
-                        click.echo(ev.get("delta", ""), nl=False)
+                        click.echo(
+                            f"{Fore.CYAN}{ev.get('delta', '')}{Style.RESET_ALL}",
+                            nl=False,
+                        )
                     elif event_type == "TEXT_MESSAGE_END":
                         click.echo("")
                     elif event_type == "RUN_FINISHED":
-                        click.echo("\nRun finished.")
+                        click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}")
                     elif event_type == "RUN_ERROR":
                         run_error = ev.get("message", "Unknown error")
                         break
@@ -150,4 +163,4 @@ def stream_agui_events(
     except httpx.HTTPError as exc:
         raise click.ClickException(f"HTTP error during streaming: {exc}")
     if run_error:
-        raise click.ClickException(f"Run failed: {run_error}")
+        raise click.ClickException(f"{Fore.RED}\u274c Run failed: {run_error}{Style.RESET_ALL}")

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -29,6 +29,8 @@ from colorama import Style
 
 logger = logging.getLogger(__name__)
 
+_TOOL_RESULT_MAX_LEN = 1000
+
 
 def _get_session_secret_key() -> str | None:
     """Read SESSION_SECRET_KEY from the environment, or None if not set."""
@@ -156,6 +158,7 @@ def stream_agui_events(
                 events = data.get("events", [data])
                 for ev in events:
                     event_type = ev.get("type", "")
+                    # --- Text messages (stdout) ---
                     if event_type in (
                         "TEXT_MESSAGE_CONTENT",
                         "TEXT_MESSAGE_CHUNK",
@@ -166,11 +169,81 @@ def stream_agui_events(
                         )
                     elif event_type == "TEXT_MESSAGE_END":
                         click.echo("")
+                    elif event_type == "TEXT_MESSAGE_START":
+                        pass
+                    # --- Reasoning (stderr) ---
+                    elif event_type == "REASONING_MESSAGE_CONTENT":
+                        click.echo(
+                            f"{Fore.YELLOW}{ev.get('delta', '')}{Style.RESET_ALL}",
+                            nl=False,
+                            err=True,
+                        )
+                    elif event_type == "REASONING_MESSAGE_END":
+                        click.echo("", err=True)
+                    elif event_type in (
+                        "REASONING_START",
+                        "REASONING_MESSAGE_START",
+                        "REASONING_END",
+                    ):
+                        pass
+                    # --- Tool calls (stderr) ---
+                    elif event_type == "TOOL_CALL_START":
+                        name = ev.get("tool_call_name", "")
+                        click.echo(
+                            f"\n{Fore.MAGENTA}\u25b6 Tool Call: "
+                            f"{Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}",
+                            err=True,
+                        )
+                        click.echo(
+                            f"{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}",
+                            nl=False,
+                            err=True,
+                        )
+                    elif event_type == "TOOL_CALL_ARGS":
+                        click.echo(
+                            f"{Fore.MAGENTA}{Style.DIM}{ev.get('delta', '')}{Style.RESET_ALL}",
+                            nl=False,
+                            err=True,
+                        )
+                    elif event_type == "TOOL_CALL_END":
+                        click.echo("", err=True)
+                    elif event_type == "TOOL_CALL_RESULT":
+                        content = ev.get("content", "")
+                        if len(content) > _TOOL_RESULT_MAX_LEN:
+                            content = content[:_TOOL_RESULT_MAX_LEN] + "\u2026"
+                        click.echo(
+                            f"{Fore.MAGENTA}  Result: "
+                            f"{Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n",
+                            err=True,
+                        )
+                    # --- Steps (stderr) ---
+                    elif event_type == "STEP_STARTED":
+                        step = ev.get("step_name", "")
+                        click.echo(
+                            f"{Style.DIM}Step: {step}{Style.RESET_ALL}",
+                            err=True,
+                        )
+                    elif event_type == "STEP_FINISHED":
+                        pass
+                    # --- Run lifecycle ---
+                    elif event_type == "RUN_STARTED":
+                        click.echo(
+                            f"{Style.DIM}Run started{Style.RESET_ALL}",
+                            err=True,
+                        )
                     elif event_type == "RUN_FINISHED":
                         click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}")
                     elif event_type == "RUN_ERROR":
                         run_error = ev.get("message", "Unknown error")
                         break
+                    # --- Custom ---
+                    elif event_type == "CUSTOM":
+                        name = ev.get("name", "")
+                        if name != "Heartbeat":
+                            click.echo(
+                                f"{Style.DIM}[{name}]{Style.RESET_ALL}",
+                                err=True,
+                            )
                     else:
                         logger.debug("Unhandled SSE event type: %s", event_type)
                 if run_error:

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -71,14 +71,19 @@ def get_auth_context_headers(api_token: str, base_url: str) -> dict[str, str]:
 def require_auth(ctx: click.Context) -> tuple[str, str]:
     """Return (api_token, base_url) from the group context, or raise."""
     api_token: str | None = ctx.obj.get("api_token")
-    base_url: str = ctx.obj.get("base_url", "https://app.datarobot.com")
+    base_url: str | None = ctx.obj.get("base_url")
     if not api_token:
         raise click.UsageError(
             "API token is required. Pass --api-token or set DATAROBOT_API_TOKEN."
         )
-    # Normalize: strip trailing /api/v2 since URLs add it explicitly
-    base_url = base_url.rstrip("/").removesuffix("/api/v2")
+    if not base_url:
+        raise click.UsageError("Base URL is required. Pass --base-url or set DATAROBOT_ENDPOINT.")
     return api_token, base_url
+
+
+def normalize_base_url(base_url: str) -> str:
+    """Strip trailing slash and /api/v2 suffix for URL construction."""
+    return base_url.rstrip("/").removesuffix("/api/v2")
 
 
 def build_agui_payload(user_prompt: str) -> dict[str, typing.Any]:

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -27,9 +27,9 @@ import httpx
 from colorama import Fore
 from colorama import Style
 
-logger = logging.getLogger(__name__)
+from .render import render_sse_event
 
-_TOOL_RESULT_MAX_LEN = 1000
+logger = logging.getLogger(__name__)
 
 
 def _get_session_secret_key() -> str | None:
@@ -157,95 +157,10 @@ def stream_agui_events(
                     continue
                 events = data.get("events", [data])
                 for ev in events:
-                    event_type = ev.get("type", "")
-                    # --- Text messages (stdout) ---
-                    if event_type in (
-                        "TEXT_MESSAGE_CONTENT",
-                        "TEXT_MESSAGE_CHUNK",
-                    ):
-                        click.echo(
-                            f"{Fore.CYAN}{ev.get('delta', '')}{Style.RESET_ALL}",
-                            nl=False,
-                        )
-                    elif event_type == "TEXT_MESSAGE_END":
-                        click.echo("")
-                    elif event_type == "TEXT_MESSAGE_START":
-                        pass
-                    # --- Reasoning (stderr) ---
-                    elif event_type == "REASONING_MESSAGE_CONTENT":
-                        click.echo(
-                            f"{Fore.YELLOW}{ev.get('delta', '')}{Style.RESET_ALL}",
-                            nl=False,
-                            err=True,
-                        )
-                    elif event_type == "REASONING_MESSAGE_END":
-                        click.echo("", err=True)
-                    elif event_type in (
-                        "REASONING_START",
-                        "REASONING_MESSAGE_START",
-                        "REASONING_END",
-                    ):
-                        pass
-                    # --- Tool calls (stderr) ---
-                    elif event_type == "TOOL_CALL_START":
-                        name = ev.get("tool_call_name", "")
-                        click.echo(
-                            f"\n{Fore.MAGENTA}\u25b6 Tool Call: "
-                            f"{Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}",
-                            err=True,
-                        )
-                        click.echo(
-                            f"{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}",
-                            nl=False,
-                            err=True,
-                        )
-                    elif event_type == "TOOL_CALL_ARGS":
-                        click.echo(
-                            f"{Fore.MAGENTA}{Style.DIM}{ev.get('delta', '')}{Style.RESET_ALL}",
-                            nl=False,
-                            err=True,
-                        )
-                    elif event_type == "TOOL_CALL_END":
-                        click.echo("", err=True)
-                    elif event_type == "TOOL_CALL_RESULT":
-                        content = ev.get("content", "")
-                        if len(content) > _TOOL_RESULT_MAX_LEN:
-                            content = content[:_TOOL_RESULT_MAX_LEN] + "\u2026"
-                        click.echo(
-                            f"{Fore.MAGENTA}  Result: "
-                            f"{Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n",
-                            err=True,
-                        )
-                    # --- Steps (stderr) ---
-                    elif event_type == "STEP_STARTED":
-                        step = ev.get("step_name", "")
-                        click.echo(
-                            f"{Style.DIM}Step: {step}{Style.RESET_ALL}",
-                            err=True,
-                        )
-                    elif event_type == "STEP_FINISHED":
-                        pass
-                    # --- Run lifecycle ---
-                    elif event_type == "RUN_STARTED":
-                        click.echo(
-                            f"{Style.DIM}Run started{Style.RESET_ALL}",
-                            err=True,
-                        )
-                    elif event_type == "RUN_FINISHED":
-                        click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}")
-                    elif event_type == "RUN_ERROR":
-                        run_error = ev.get("message", "Unknown error")
+                    error_msg = render_sse_event(ev)
+                    if error_msg is not None:
+                        run_error = error_msg
                         break
-                    # --- Custom ---
-                    elif event_type == "CUSTOM":
-                        name = ev.get("name", "")
-                        if name != "Heartbeat":
-                            click.echo(
-                                f"{Style.DIM}[{name}]{Style.RESET_ALL}",
-                                err=True,
-                            )
-                    else:
-                        logger.debug("Unhandled SSE event type: %s", event_type)
                 if run_error:
                     break
     except click.ClickException:

--- a/src/datarobot_genai/dragent/cli/remote.py
+++ b/src/datarobot_genai/dragent/cli/remote.py
@@ -108,6 +108,7 @@ def stream_agui_events(
     headers: dict[str, str],
 ) -> None:
     """POST to an AG-UI /generate/stream endpoint and print text events."""
+    run_error: str | None = None
     try:
         with httpx.stream("POST", url, json=payload, headers=headers, timeout=300) as resp:
             if not resp.is_success:
@@ -134,13 +135,19 @@ def stream_agui_events(
                     elif event_type == "RUN_FINISHED":
                         click.echo("\nRun finished.")
                     elif event_type == "RUN_ERROR":
-                        msg = ev.get("message", "Unknown error")
-                        raise click.ClickException(f"Run failed: {msg}")
+                        run_error = ev.get("message", "Unknown error")
+                        break
                     else:
                         logger.debug("Unhandled SSE event type: %s", event_type)
+                if run_error:
+                    break
+    except click.ClickException:
+        raise
     except httpx.ConnectError:
         raise click.ClickException(f"Could not connect to {url}.")
     except httpx.TimeoutException as exc:
         raise click.ClickException(f"Request timed out: {exc}")
     except httpx.HTTPError as exc:
         raise click.ClickException(f"HTTP error during streaming: {exc}")
+    if run_error:
+        raise click.ClickException(f"Run failed: {run_error}")

--- a/src/datarobot_genai/dragent/cli/render.py
+++ b/src/datarobot_genai/dragent/cli/render.py
@@ -120,7 +120,7 @@ def render_event(
     elif event_type == RUN_STARTED:
         click.echo(f"{Style.DIM}Run started{Style.RESET_ALL}", err=True)
     elif event_type == RUN_FINISHED:
-        click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}")
+        click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}", err=err)
     elif event_type == RUN_ERROR:
         pass  # Caller handles this (raise ClickException / break loop).
     elif event_type == CUSTOM:
@@ -215,6 +215,11 @@ def render_object_event(event: object) -> bool:
     canonical = _OBJECT_TYPE_MAP.get(class_name)
     if canonical is None:
         logger.debug("Unhandled object event type: %s", class_name)
+        return False
+
+    # The console frontend prints its own "Run finished" message after the
+    # workflow completes, so skip it here to avoid duplicate output.
+    if canonical in (RUN_FINISHED, RUN_ERROR):
         return False
 
     delta = getattr(event, "delta", "")

--- a/src/datarobot_genai/dragent/cli/render.py
+++ b/src/datarobot_genai/dragent/cli/render.py
@@ -1,0 +1,235 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared terminal rendering for AG-UI events.
+
+Both ``remote.py`` (SSE JSON dicts) and ``console.py`` (typed AG-UI objects)
+need identical rendering logic.  Each caller normalises its event into a
+canonical ``(event_type, fields)`` pair and calls :func:`render_event`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import click
+from colorama import Fore
+from colorama import Style
+
+logger = logging.getLogger(__name__)
+
+TOOL_RESULT_MAX_LEN = 1000
+
+# Canonical event type strings (used as the key for rendering).
+TEXT_CONTENT = "TEXT_CONTENT"
+TEXT_END = "TEXT_END"
+TEXT_START = "TEXT_START"
+REASONING_CONTENT = "REASONING_CONTENT"
+REASONING_END = "REASONING_END"
+REASONING_START = "REASONING_START"
+TOOL_CALL_START = "TOOL_CALL_START"
+TOOL_CALL_ARGS = "TOOL_CALL_ARGS"
+TOOL_CALL_END = "TOOL_CALL_END"
+TOOL_CALL_RESULT = "TOOL_CALL_RESULT"
+STEP_STARTED = "STEP_STARTED"
+STEP_FINISHED = "STEP_FINISHED"
+RUN_STARTED = "RUN_STARTED"
+RUN_FINISHED = "RUN_FINISHED"
+RUN_ERROR = "RUN_ERROR"
+CUSTOM = "CUSTOM"
+
+
+def render_event(
+    event_type: str,
+    *,
+    delta: str = "",
+    name: str = "",
+    content: str = "",
+    message: str = "",
+    err: bool = True,
+) -> None:
+    """Render a single AG-UI event to the terminal.
+
+    Parameters
+    ----------
+    event_type:
+        One of the canonical constants defined in this module.
+    delta:
+        Text delta for content/args events.
+    name:
+        Name for tool-call-start, step-started, or custom events.
+    content:
+        Content for tool-call-result events.
+    message:
+        Error message for run-error events.
+    err:
+        If True, write to stderr (default). Set to False to write to stdout.
+    """
+    if event_type == TEXT_CONTENT:
+        click.echo(f"{Fore.CYAN}{delta}{Style.RESET_ALL}", nl=False, err=err)
+    elif event_type == TEXT_END:
+        click.echo("", err=err)
+    elif event_type == TEXT_START:
+        pass
+    elif event_type == REASONING_CONTENT:
+        click.echo(f"{Fore.YELLOW}{delta}{Style.RESET_ALL}", nl=False, err=True)
+    elif event_type == REASONING_END:
+        click.echo("", err=True)
+    elif event_type == REASONING_START:
+        pass
+    elif event_type == TOOL_CALL_START:
+        click.echo(
+            f"\n{Fore.MAGENTA}\u25b6 Tool Call: {Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}",
+            err=True,
+        )
+        click.echo(
+            f"{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}",
+            nl=False,
+            err=True,
+        )
+    elif event_type == TOOL_CALL_ARGS:
+        click.echo(
+            f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}",
+            nl=False,
+            err=True,
+        )
+    elif event_type == TOOL_CALL_END:
+        click.echo("", err=True)
+    elif event_type == TOOL_CALL_RESULT:
+        if len(content) > TOOL_RESULT_MAX_LEN:
+            content = content[:TOOL_RESULT_MAX_LEN] + "\u2026"
+        click.echo(
+            f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n",
+            err=True,
+        )
+    elif event_type == STEP_STARTED:
+        click.echo(f"{Style.DIM}Step: {name}{Style.RESET_ALL}", err=True)
+    elif event_type == STEP_FINISHED:
+        pass
+    elif event_type == RUN_STARTED:
+        click.echo(f"{Style.DIM}Run started{Style.RESET_ALL}", err=True)
+    elif event_type == RUN_FINISHED:
+        click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}")
+    elif event_type == RUN_ERROR:
+        pass  # Caller handles this (raise ClickException / break loop).
+    elif event_type == CUSTOM:
+        if name != "Heartbeat":
+            click.echo(f"{Style.DIM}[{name}]{Style.RESET_ALL}", err=True)
+    else:
+        logger.debug("Unhandled event type: %s", event_type)
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers for the two calling conventions
+# ---------------------------------------------------------------------------
+
+# SSE JSON dict "type" string -> canonical event type
+_SSE_TYPE_MAP: dict[str, str] = {
+    "TEXT_MESSAGE_CONTENT": TEXT_CONTENT,
+    "TEXT_MESSAGE_CHUNK": TEXT_CONTENT,
+    "TEXT_MESSAGE_END": TEXT_END,
+    "TEXT_MESSAGE_START": TEXT_START,
+    "REASONING_MESSAGE_CONTENT": REASONING_CONTENT,
+    "REASONING_MESSAGE_END": REASONING_END,
+    "REASONING_START": REASONING_START,
+    "REASONING_MESSAGE_START": REASONING_START,
+    "REASONING_END": REASONING_END,
+    "TOOL_CALL_START": TOOL_CALL_START,
+    "TOOL_CALL_ARGS": TOOL_CALL_ARGS,
+    "TOOL_CALL_END": TOOL_CALL_END,
+    "TOOL_CALL_RESULT": TOOL_CALL_RESULT,
+    "STEP_STARTED": STEP_STARTED,
+    "STEP_FINISHED": STEP_FINISHED,
+    "RUN_STARTED": RUN_STARTED,
+    "RUN_FINISHED": RUN_FINISHED,
+    "RUN_ERROR": RUN_ERROR,
+    "CUSTOM": CUSTOM,
+}
+
+# Typed AG-UI object class name -> canonical event type
+_OBJECT_TYPE_MAP: dict[str, str] = {
+    "TextMessageContentEvent": TEXT_CONTENT,
+    "TextMessageEndEvent": TEXT_END,
+    "TextMessageStartEvent": TEXT_START,
+    "ReasoningMessageContentEvent": REASONING_CONTENT,
+    "ReasoningMessageEndEvent": REASONING_END,
+    "ReasoningStartEvent": REASONING_START,
+    "ReasoningMessageStartEvent": REASONING_START,
+    "ReasoningEndEvent": REASONING_END,
+    "ToolCallStartEvent": TOOL_CALL_START,
+    "ToolCallArgsEvent": TOOL_CALL_ARGS,
+    "ToolCallEndEvent": TOOL_CALL_END,
+    "ToolCallResultEvent": TOOL_CALL_RESULT,
+    "StepStartedEvent": STEP_STARTED,
+    "StepFinishedEvent": STEP_FINISHED,
+    "RunStartedEvent": RUN_STARTED,
+    "RunFinishedEvent": RUN_FINISHED,
+    "RunErrorEvent": RUN_ERROR,
+    "CustomEvent": CUSTOM,
+}
+
+
+def render_sse_event(ev: dict[str, object]) -> str | None:
+    """Render an SSE JSON dict event. Returns the run-error message if RUN_ERROR, else None.
+
+    Text and run-lifecycle events go to stdout; everything else to stderr.
+    This matches the original ``remote.py`` behaviour where the agent's text
+    reply is the primary (pipe-able) output.
+    """
+    raw_type = str(ev.get("type", ""))
+    canonical = _SSE_TYPE_MAP.get(raw_type)
+    if canonical is None:
+        logger.debug("Unhandled SSE event type: %s", raw_type)
+        return None
+
+    if canonical == RUN_ERROR:
+        return str(ev.get("message", "Unknown error"))
+
+    # Text content and run finished go to stdout (pipe-friendly); rest to stderr.
+    err = canonical not in (TEXT_CONTENT, TEXT_END, TEXT_START, RUN_FINISHED)
+
+    render_event(
+        canonical,
+        delta=str(ev.get("delta", "")),
+        name=str(ev.get("tool_call_name", "") or ev.get("step_name", "") or ev.get("name", "")),
+        content=str(ev.get("content", "")),
+        err=err,
+    )
+    return None
+
+
+def render_object_event(event: object) -> bool:
+    """Render a typed AG-UI event object. Returns True if text was emitted."""
+    class_name = type(event).__name__
+    canonical = _OBJECT_TYPE_MAP.get(class_name)
+    if canonical is None:
+        logger.debug("Unhandled object event type: %s", class_name)
+        return False
+
+    delta = getattr(event, "delta", "")
+    name = (
+        getattr(event, "tool_call_name", "")
+        or getattr(event, "step_name", "")
+        or getattr(event, "name", "")
+    )
+    content = getattr(event, "content", "")
+
+    render_event(
+        canonical,
+        delta=str(delta) if delta else "",
+        name=str(name) if name else "",
+        content=str(content) if content else "",
+        err=True,
+    )
+    return canonical in (TEXT_CONTENT, REASONING_CONTENT) and bool(delta)

--- a/src/datarobot_genai/dragent/frontends/console.py
+++ b/src/datarobot_genai/dragent/frontends/console.py
@@ -94,12 +94,8 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
         # See class docstring for why this override is necessary.
         runner_outputs = None
 
-        # --------------- DRAgent addition ---------------
-        step_adaptor = self._get_step_adaptor()
-        # ------------------------------------------------
-
         # --- BEGIN COPY from nat.front_ends.console.console_front_end_plugin (nvidia-nat 1.4.1) ---
-        # Only change: self._subscribe_intermediate_steps(step_adaptor) injected inside
+        # Only change: self._subscribe_intermediate_steps() injected inside
         # each session.run() block. Output formatting delegated to super().
         if self.front_end_config.input_query is not None:
 
@@ -110,7 +106,9 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
                     user_authentication_callback=self.auth_flow_handler.authenticate,
                 ) as session:
                     async with session.run(query) as runner:
-                        self._subscribe_intermediate_steps(step_adaptor)  # DRAgent addition
+                        # Each query gets its own adaptor to avoid shared mutable state
+                        # (function_level, seen_llm_new_token) across concurrent coroutines.
+                        self._subscribe_intermediate_steps(self._get_step_adaptor())
                         return await runner.result(to_type=str)
 
             input_list = list(self.front_end_config.input_query)
@@ -124,7 +122,7 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
                 input_content = f.read()
             async with session_manager.session(user_id=self.front_end_config.user_id) as session:
                 async with session.run(input_content) as runner:
-                    self._subscribe_intermediate_steps(step_adaptor)  # DRAgent addition
+                    self._subscribe_intermediate_steps(self._get_step_adaptor())
                     runner_outputs = await runner.result(to_type=str)
         else:
             raise RuntimeError("No input provided. Should have been caught by pre_run.")

--- a/src/datarobot_genai/dragent/frontends/console.py
+++ b/src/datarobot_genai/dragent/frontends/console.py
@@ -31,6 +31,8 @@ from .step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 logger = logging.getLogger(__name__)
 
+_TOOL_RESULT_MAX_LEN = 1000
+
 
 # Registered as "dragent_console" so it doesn't conflict with NAT's built-in "console" frontend.
 # Used by `nat dragent run`.
@@ -80,13 +82,77 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
                 return
             for event in getattr(result, "events", []):
                 event_type = type(event).__name__
-                delta = getattr(event, "delta", None)
-                if delta:
-                    streamed_output[0] = True
-                    color = Fore.YELLOW if "Reasoning" in event_type else Fore.CYAN
-                    click.echo(f"{color}{delta}{Style.RESET_ALL}", nl=False, err=True)
-                elif event_type in ("TextMessageEndEvent", "ReasoningMessageEndEvent"):
+                # --- Text messages ---
+                if event_type == "TextMessageContentEvent":
+                    delta = getattr(event, "delta", "")
+                    if delta:
+                        streamed_output[0] = True
+                        click.echo(f"{Fore.CYAN}{delta}{Style.RESET_ALL}", nl=False, err=True)
+                elif event_type == "TextMessageEndEvent":
                     click.echo("", err=True)
+                elif event_type == "TextMessageStartEvent":
+                    pass
+                # --- Reasoning ---
+                elif event_type == "ReasoningMessageContentEvent":
+                    delta = getattr(event, "delta", "")
+                    if delta:
+                        streamed_output[0] = True
+                        click.echo(f"{Fore.YELLOW}{delta}{Style.RESET_ALL}", nl=False, err=True)
+                elif event_type == "ReasoningMessageEndEvent":
+                    click.echo("", err=True)
+                elif event_type in (
+                    "ReasoningStartEvent",
+                    "ReasoningMessageStartEvent",
+                    "ReasoningEndEvent",
+                ):
+                    pass
+                # --- Tool calls ---
+                elif event_type == "ToolCallStartEvent":
+                    name = getattr(event, "tool_call_name", "")
+                    click.echo(
+                        f"\n{Fore.MAGENTA}\u25b6 Tool Call: "
+                        f"{Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}",
+                        err=True,
+                    )
+                    click.echo(
+                        f"{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}",
+                        nl=False,
+                        err=True,
+                    )
+                elif event_type == "ToolCallArgsEvent":
+                    delta = getattr(event, "delta", "")
+                    click.echo(
+                        f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}",
+                        nl=False,
+                        err=True,
+                    )
+                elif event_type == "ToolCallEndEvent":
+                    click.echo("", err=True)
+                elif event_type == "ToolCallResultEvent":
+                    content = getattr(event, "content", "")
+                    if len(content) > _TOOL_RESULT_MAX_LEN:
+                        content = content[:_TOOL_RESULT_MAX_LEN] + "\u2026"
+                    click.echo(
+                        f"{Fore.MAGENTA}  Result: "
+                        f"{Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n",
+                        err=True,
+                    )
+                # --- Steps ---
+                elif event_type == "StepStartedEvent":
+                    name = getattr(event, "step_name", "")
+                    click.echo(f"{Style.DIM}Step: {name}{Style.RESET_ALL}", err=True)
+                elif event_type == "StepFinishedEvent":
+                    pass
+                # --- Run lifecycle ---
+                elif event_type == "RunStartedEvent":
+                    click.echo(f"{Style.DIM}Run started{Style.RESET_ALL}", err=True)
+                elif event_type == "RunFinishedEvent":
+                    pass  # handled by outer code
+                # --- Custom ---
+                elif event_type == "CustomEvent":
+                    name = getattr(event, "name", "")
+                    if name != "Heartbeat":
+                        click.echo(f"{Style.DIM}[{name}]{Style.RESET_ALL}", err=True)
 
         def on_error(exc: Exception) -> None:
             logger.debug("Intermediate step stream error: %s", exc)

--- a/src/datarobot_genai/dragent/frontends/console.py
+++ b/src/datarobot_genai/dragent/frontends/console.py
@@ -92,8 +92,6 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
 
     async def run_workflow(self, session_manager: SessionManager) -> None:
         # See class docstring for why this override is necessary.
-        if session_manager is None:
-            raise RuntimeError("Session manager must be provided")
         runner_outputs = None
 
         # --------------- DRAgent addition ---------------

--- a/src/datarobot_genai/dragent/frontends/console.py
+++ b/src/datarobot_genai/dragent/frontends/console.py
@@ -1,0 +1,151 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import click
+from colorama import Fore
+from nat.builder.context import Context
+from nat.data_models.step_adaptor import StepAdaptorConfig
+from nat.front_ends.console.console_front_end_config import ConsoleFrontEndConfig
+from nat.front_ends.console.console_front_end_plugin import ConsoleFrontEndPlugin
+from nat.front_ends.console.console_front_end_plugin import prompt_for_input_cli
+from nat.runtime.session import SessionManager
+
+from .step_adaptor import DRAgentNestedReasoningStepAdaptor
+
+logger = logging.getLogger(__name__)
+
+
+# Registered as "dragent_console" so it doesn't conflict with NAT's built-in "console" frontend.
+# Used by `nat dragent run`.
+class DRAgentConsoleFrontEndConfig(ConsoleFrontEndConfig, name="dragent_console"):  # type: ignore
+    """Frontend config for running a dragent workflow from the console."""
+
+
+class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
+    """Console frontend plugin with DRAgent step adaptor for intermediate step visibility.
+
+    Why we override ``run_workflow()`` instead of a smaller hook:
+
+    NAT's console ``run_workflow()`` collects the final result via ``runner.result()``
+    but never subscribes to intermediate steps. The event stream (a ContextVar-backed
+    Subject) is only available inside ``session.run()``. So we override ``run_workflow()``
+    to subscribe to ``Context.intermediate_step_manager`` inside the ``session.run()``
+    block, routing events through ``DRAgentNestedReasoningStepAdaptor`` to print
+    reasoning/tool/text events to stderr.
+
+    If NAT adds a step adaptor hook to the console base class in the future, this
+    override should be replaced with that hook.
+    """
+
+    def _get_step_adaptor(self) -> DRAgentNestedReasoningStepAdaptor:
+        return DRAgentNestedReasoningStepAdaptor(StepAdaptorConfig())
+
+    @staticmethod
+    def _subscribe_intermediate_steps(step_adaptor: DRAgentNestedReasoningStepAdaptor) -> None:
+        """Subscribe to NAT's intermediate step stream and print AG-UI events to the terminal.
+
+        Must be called inside ``session.run()`` where the ContextVar-backed event
+        stream Subject is active.  Uses the same ``Context.intermediate_step_manager``
+        observable that the FastAPI path uses via ``pull_intermediate``.
+        """
+        context = Context.get()
+
+        def on_next(step: object) -> None:
+            result = step_adaptor.process(step)  # type: ignore[arg-type]
+            if result is None:
+                return
+            for event in getattr(result, "events", []):
+                event_type = type(event).__name__
+                delta = getattr(event, "delta", None)
+                if delta:
+                    click.echo(delta, nl=False, err=True)
+                elif event_type in ("TextMessageEndEvent", "ReasoningMessageEndEvent"):
+                    click.echo("", err=True)
+
+        def on_error(exc: Exception) -> None:
+            logger.debug("Intermediate step stream error: %s", exc)
+
+        def on_complete() -> None:
+            logger.debug("Intermediate step stream completed")
+
+        context.intermediate_step_manager.subscribe(
+            on_next=on_next,
+            on_error=on_error,
+            on_complete=on_complete,
+        )
+
+    async def run_workflow(self, session_manager: SessionManager) -> None:
+        # See class docstring for why this override is necessary.
+        if session_manager is None:
+            raise RuntimeError("Session manager must be provided")
+        runner_outputs = None
+
+        # --------------- DRAgent addition ---------------
+        step_adaptor = self._get_step_adaptor()
+        # ------------------------------------------------
+
+        # --- BEGIN COPY from nat.front_ends.console.console_front_end_plugin (nvidia-nat 1.4.1) ---
+        # Only change: self._subscribe_intermediate_steps(step_adaptor) injected inside
+        # each session.run() block. Output formatting delegated to super().
+        if self.front_end_config.input_query is not None:
+
+            async def run_single_query(query: str) -> str:
+                async with session_manager.session(
+                    user_id=self.front_end_config.user_id,
+                    user_input_callback=prompt_for_input_cli,
+                    user_authentication_callback=self.auth_flow_handler.authenticate,
+                ) as session:
+                    async with session.run(query) as runner:
+                        self._subscribe_intermediate_steps(step_adaptor)  # DRAgent addition
+                        return await runner.result(to_type=str)
+
+            input_list = list(self.front_end_config.input_query)
+            runner_outputs = await asyncio.gather(
+                *[run_single_query(query) for query in input_list],
+                return_exceptions=False,
+            )
+
+        elif self.front_end_config.input_file is not None:
+            with open(self.front_end_config.input_file, encoding="utf-8") as f:
+                input_content = f.read()
+            async with session_manager.session(user_id=self.front_end_config.user_id) as session:
+                async with session.run(input_content) as runner:
+                    self._subscribe_intermediate_steps(step_adaptor)  # DRAgent addition
+                    runner_outputs = await runner.result(to_type=str)
+        else:
+            raise RuntimeError("No input provided. Should have been caught by pre_run.")
+        # --- END COPY from nat.front_ends.console.console_front_end_plugin (nvidia-nat 1.4.1) ---
+
+        self._print_result(runner_outputs)
+
+    @staticmethod
+    def _print_result(runner_outputs: object) -> None:
+        """Print workflow result. Mirrors ConsoleFrontEndPlugin output formatting."""
+        line = f"{'-' * 50}"
+        prefix = f"{line}\n{Fore.GREEN}Workflow Result:\n"
+        suffix = f"{Fore.RESET}\n{line}"
+
+        logger.info(f"{prefix}%s{suffix}", runner_outputs)
+
+        effective_level_too_high = all(
+            type(h) is not logging.StreamHandler or h.level > logging.INFO
+            for h in logging.getLogger().handlers
+        )
+        if effective_level_too_high:
+            print(f"{prefix}{runner_outputs}{suffix}")

--- a/src/datarobot_genai/dragent/frontends/console.py
+++ b/src/datarobot_genai/dragent/frontends/console.py
@@ -27,11 +27,11 @@ from nat.front_ends.console.console_front_end_plugin import ConsoleFrontEndPlugi
 from nat.front_ends.console.console_front_end_plugin import prompt_for_input_cli
 from nat.runtime.session import SessionManager
 
+from datarobot_genai.dragent.cli.render import render_object_event
+
 from .step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 logger = logging.getLogger(__name__)
-
-_TOOL_RESULT_MAX_LEN = 1000
 
 
 # Registered as "dragent_console" so it doesn't conflict with NAT's built-in "console" frontend.
@@ -81,78 +81,8 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
             if result is None:
                 return
             for event in getattr(result, "events", []):
-                event_type = type(event).__name__
-                # --- Text messages ---
-                if event_type == "TextMessageContentEvent":
-                    delta = getattr(event, "delta", "")
-                    if delta:
-                        streamed_output[0] = True
-                        click.echo(f"{Fore.CYAN}{delta}{Style.RESET_ALL}", nl=False, err=True)
-                elif event_type == "TextMessageEndEvent":
-                    click.echo("", err=True)
-                elif event_type == "TextMessageStartEvent":
-                    pass
-                # --- Reasoning ---
-                elif event_type == "ReasoningMessageContentEvent":
-                    delta = getattr(event, "delta", "")
-                    if delta:
-                        streamed_output[0] = True
-                        click.echo(f"{Fore.YELLOW}{delta}{Style.RESET_ALL}", nl=False, err=True)
-                elif event_type == "ReasoningMessageEndEvent":
-                    click.echo("", err=True)
-                elif event_type in (
-                    "ReasoningStartEvent",
-                    "ReasoningMessageStartEvent",
-                    "ReasoningEndEvent",
-                ):
-                    pass
-                # --- Tool calls ---
-                elif event_type == "ToolCallStartEvent":
-                    name = getattr(event, "tool_call_name", "")
-                    click.echo(
-                        f"\n{Fore.MAGENTA}\u25b6 Tool Call: "
-                        f"{Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}",
-                        err=True,
-                    )
-                    click.echo(
-                        f"{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}",
-                        nl=False,
-                        err=True,
-                    )
-                elif event_type == "ToolCallArgsEvent":
-                    delta = getattr(event, "delta", "")
-                    click.echo(
-                        f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}",
-                        nl=False,
-                        err=True,
-                    )
-                elif event_type == "ToolCallEndEvent":
-                    click.echo("", err=True)
-                elif event_type == "ToolCallResultEvent":
-                    content = getattr(event, "content", "")
-                    if len(content) > _TOOL_RESULT_MAX_LEN:
-                        content = content[:_TOOL_RESULT_MAX_LEN] + "\u2026"
-                    click.echo(
-                        f"{Fore.MAGENTA}  Result: "
-                        f"{Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n",
-                        err=True,
-                    )
-                # --- Steps ---
-                elif event_type == "StepStartedEvent":
-                    name = getattr(event, "step_name", "")
-                    click.echo(f"{Style.DIM}Step: {name}{Style.RESET_ALL}", err=True)
-                elif event_type == "StepFinishedEvent":
-                    pass
-                # --- Run lifecycle ---
-                elif event_type == "RunStartedEvent":
-                    click.echo(f"{Style.DIM}Run started{Style.RESET_ALL}", err=True)
-                elif event_type == "RunFinishedEvent":
-                    pass  # handled by outer code
-                # --- Custom ---
-                elif event_type == "CustomEvent":
-                    name = getattr(event, "name", "")
-                    if name != "Heartbeat":
-                        click.echo(f"{Style.DIM}[{name}]{Style.RESET_ALL}", err=True)
+                if render_object_event(event):
+                    streamed_output[0] = True
 
         def on_error(exc: Exception) -> None:
             logger.debug("Intermediate step stream error: %s", exc)

--- a/src/datarobot_genai/dragent/frontends/console.py
+++ b/src/datarobot_genai/dragent/frontends/console.py
@@ -19,6 +19,7 @@ import logging
 
 import click
 from colorama import Fore
+from colorama import Style
 from nat.builder.context import Context
 from nat.data_models.step_adaptor import StepAdaptorConfig
 from nat.front_ends.console.console_front_end_config import ConsoleFrontEndConfig
@@ -57,12 +58,19 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
         return DRAgentNestedReasoningStepAdaptor(StepAdaptorConfig())
 
     @staticmethod
-    def _subscribe_intermediate_steps(step_adaptor: DRAgentNestedReasoningStepAdaptor) -> None:
+    def _subscribe_intermediate_steps(
+        step_adaptor: DRAgentNestedReasoningStepAdaptor,
+        streamed_output: list[bool],
+    ) -> None:
         """Subscribe to NAT's intermediate step stream and print AG-UI events to the terminal.
 
         Must be called inside ``session.run()`` where the ContextVar-backed event
         stream Subject is active.  Uses the same ``Context.intermediate_step_manager``
         observable that the FastAPI path uses via ``pull_intermediate``.
+
+        *streamed_output* is a single-element list used as a mutable flag; it is set
+        to ``[True]`` when at least one text delta has been printed, so callers can
+        skip the redundant final-result dump.
         """
         context = Context.get()
 
@@ -74,7 +82,9 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
                 event_type = type(event).__name__
                 delta = getattr(event, "delta", None)
                 if delta:
-                    click.echo(delta, nl=False, err=True)
+                    streamed_output[0] = True
+                    color = Fore.YELLOW if "Reasoning" in event_type else Fore.CYAN
+                    click.echo(f"{color}{delta}{Style.RESET_ALL}", nl=False, err=True)
                 elif event_type in ("TextMessageEndEvent", "ReasoningMessageEndEvent"):
                     click.echo("", err=True)
 
@@ -93,6 +103,7 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
     async def run_workflow(self, session_manager: SessionManager) -> None:
         # See class docstring for why this override is necessary.
         runner_outputs = None
+        streamed_output: list[bool] = [False]
 
         # --- BEGIN COPY from nat.front_ends.console.console_front_end_plugin (nvidia-nat 1.4.1) ---
         # Only change: self._subscribe_intermediate_steps() injected inside
@@ -108,7 +119,9 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
                     async with session.run(query) as runner:
                         # Each query gets its own adaptor to avoid shared mutable state
                         # (function_level, seen_llm_new_token) across concurrent coroutines.
-                        self._subscribe_intermediate_steps(self._get_step_adaptor())
+                        self._subscribe_intermediate_steps(
+                            self._get_step_adaptor(), streamed_output
+                        )
                         return await runner.result(to_type=str)
 
             input_list = list(self.front_end_config.input_query)
@@ -122,20 +135,23 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
                 input_content = f.read()
             async with session_manager.session(user_id=self.front_end_config.user_id) as session:
                 async with session.run(input_content) as runner:
-                    self._subscribe_intermediate_steps(self._get_step_adaptor())
+                    self._subscribe_intermediate_steps(self._get_step_adaptor(), streamed_output)
                     runner_outputs = await runner.result(to_type=str)
         else:
             raise RuntimeError("No input provided. Should have been caught by pre_run.")
         # --- END COPY from nat.front_ends.console.console_front_end_plugin (nvidia-nat 1.4.1) ---
 
-        self._print_result(runner_outputs)
+        if streamed_output[0]:
+            click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}", err=True)
+        else:
+            self._print_result(runner_outputs)
 
     @staticmethod
     def _print_result(runner_outputs: object) -> None:
         """Print workflow result. Mirrors ConsoleFrontEndPlugin output formatting."""
         line = "-" * 50
-        prefix = f"{line}\n{Fore.GREEN}Workflow Result:\n"
-        suffix = f"{Fore.RESET}\n{line}"
+        prefix = f"{line}\n{Fore.GREEN}\u2705 Workflow Result:\n"
+        suffix = f"{Style.RESET_ALL}\n{line}"
 
         logger.info("%s%s%s", prefix, runner_outputs, suffix)
 

--- a/src/datarobot_genai/dragent/frontends/console.py
+++ b/src/datarobot_genai/dragent/frontends/console.py
@@ -137,15 +137,15 @@ class DRAgentConsoleFrontEndPlugin(ConsoleFrontEndPlugin):
     @staticmethod
     def _print_result(runner_outputs: object) -> None:
         """Print workflow result. Mirrors ConsoleFrontEndPlugin output formatting."""
-        line = f"{'-' * 50}"
+        line = "-" * 50
         prefix = f"{line}\n{Fore.GREEN}Workflow Result:\n"
         suffix = f"{Fore.RESET}\n{line}"
 
-        logger.info(f"{prefix}%s{suffix}", runner_outputs)
+        logger.info("%s%s%s", prefix, runner_outputs, suffix)
 
-        effective_level_too_high = all(
-            type(h) is not logging.StreamHandler or h.level > logging.INFO
+        has_info_stream_handler = any(
+            isinstance(h, logging.StreamHandler) and h.level <= logging.INFO
             for h in logging.getLogger().handlers
         )
-        if effective_level_too_high:
+        if not has_info_stream_handler:
             print(f"{prefix}{runner_outputs}{suffix}")

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -76,6 +76,22 @@ async def dragent_fastapi_front_end(
     yield DRAgentFastApiFrontEndPlugin(full_config=full_config)
 
 
+# Register console frontend for `nat dragent run`
+# Lazy import to avoid pulling in console dependencies during entry-point discovery.
+def _register_console_frontend() -> None:
+    from .console import DRAgentConsoleFrontEndConfig
+    from .console import DRAgentConsoleFrontEndPlugin
+
+    @register_front_end(config_type=DRAgentConsoleFrontEndConfig)
+    async def dragent_console_front_end(
+        config: DRAgentConsoleFrontEndConfig, full_config: Config
+    ) -> AsyncGenerator[typing.Any, None]:
+        yield DRAgentConsoleFrontEndPlugin(full_config=full_config)
+
+
+_register_console_frontend()
+
+
 # Register converters
 GlobalTypeConverter.register_converter(convert_dragent_run_agent_input_to_chat_request)
 GlobalTypeConverter.register_converter(convert_chat_request_to_run_agent_input)

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -77,19 +77,16 @@ async def dragent_fastapi_front_end(
 
 
 # Register console frontend for `nat dragent run`
-# Lazy import to avoid pulling in console dependencies during entry-point discovery.
-def _register_console_frontend() -> None:
-    from .console import DRAgentConsoleFrontEndConfig
+from .console import DRAgentConsoleFrontEndConfig  # noqa: E402
+
+
+@register_front_end(config_type=DRAgentConsoleFrontEndConfig)
+async def dragent_console_front_end(
+    config: DRAgentConsoleFrontEndConfig, full_config: Config
+) -> AsyncGenerator[typing.Any, None]:
     from .console import DRAgentConsoleFrontEndPlugin
 
-    @register_front_end(config_type=DRAgentConsoleFrontEndConfig)
-    async def dragent_console_front_end(
-        config: DRAgentConsoleFrontEndConfig, full_config: Config
-    ) -> AsyncGenerator[typing.Any, None]:
-        yield DRAgentConsoleFrontEndPlugin(full_config=full_config)
-
-
-_register_console_frontend()
+    yield DRAgentConsoleFrontEndPlugin(full_config=full_config)
 
 
 # Register converters

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -100,7 +100,7 @@ async def mcp_tools_context(
     server_config = copy.deepcopy(server_config)
 
     url = server_config["url"]
-    logger.info(f"Connecting to MCP server: {url}")
+    logger.info("Connecting to MCP server: %s", url)
 
     # Pop transport from server_config to avoid passing it twice
     # Use .pop() with default to never error
@@ -113,11 +113,19 @@ async def mcp_tools_context(
     else:
         raise RuntimeError("Unsupported MCP transport specified.")
 
-    async with create_session(connection=connection) as session:
-        # Use the connection to load available MCP tools
-        raw_tools = await load_mcp_tools(session=session)
-        # Wrap so LangGraph-injected 'runtime' is filtered from callback inputs (avoids
-        # copy.deepcopy of non-serializable ToolRuntime in NAT profiler).
-        tools = [_wrap_mcp_tool_for_langgraph(t) for t in raw_tools]
-        logger.info(f"Successfully connected to MCP server, got {len(tools)} tools")
-        yield tools
+    # Graceful fallback: if we can't connect to the MCP server, yield empty tools
+    # instead of crashing. The try/except wraps only the connect+load phase (before
+    # yield) to avoid double-yielding -- an asynccontextmanager must yield exactly once.
+    try:
+        async with create_session(connection=connection) as session:
+            raw_tools = await load_mcp_tools(session=session)
+            tools = [_wrap_mcp_tool_for_langgraph(t) for t in raw_tools]
+            logger.info("Successfully loaded %d MCP tools", len(tools))
+            yield tools
+    except (ConnectionError, OSError, TimeoutError, ExceptionGroup) as exc:
+        logger.warning(
+            "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
+            url,
+            exc,
+        )
+        yield []

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -58,15 +58,25 @@ async def mcp_tools_context(
     url = server_params["url"]
     headers = server_params.get("headers", {})
 
-    logger.info(f"Connecting to MCP server: {url}")
-    # Create BasicMCPClient with headers to pass authentication
-    client = BasicMCPClient(command_or_url=url, headers=headers)
-    tools = await aget_tools_from_mcp_url(
-        command_or_url=url,
-        client=client,
-    )
-    # Ensure list
-    tools = list(tools) if tools is not None else []
-    logger.info(f"Successfully connected to MCP server, got {len(tools)} tools")
+    logger.info("Connecting to MCP server: %s", url)
+
+    try:
+        # Create BasicMCPClient with headers to pass authentication
+        client = BasicMCPClient(command_or_url=url, headers=headers)
+        tools = await aget_tools_from_mcp_url(
+            command_or_url=url,
+            client=client,
+        )
+        # Ensure list
+        tools = list(tools) if tools is not None else []
+        logger.info("Successfully connected to MCP server, got %d tools", len(tools))
+    except (ConnectionError, OSError, TimeoutError, ExceptionGroup) as exc:
+        logger.warning(
+            "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
+            url,
+            exc,
+        )
+        yield []
+        return
 
     yield tools

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -125,3 +125,13 @@ class TestMCPToolsContext:
         with pytest.raises(RuntimeError):
             async with mcp_tools_context(mcp_config):
                 raise RuntimeError("Connection failed")
+
+    async def test_mcp_tools_context_connection_error_yields_empty(self):
+        """Test graceful fallback when MCP server connection fails."""
+        test_url = "https://mcp-server.example.com/mcp"
+        mcp_config = MCPConfig(external_mcp_url=test_url)
+        with patch(
+            "datarobot_genai.crewai.mcp.MCPServerAdapter", side_effect=ConnectionError("refused")
+        ):
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools == []

--- a/tests/dragent/cli/test_commands.py
+++ b/tests/dragent/cli/test_commands.py
@@ -19,7 +19,6 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from datarobot_genai.dragent.cli.commands import DEFAULT_CONFIG_FILE
 from datarobot_genai.dragent.cli.commands import dragent_command
 
 _COMMANDS = "datarobot_genai.dragent.cli.commands"
@@ -144,7 +143,3 @@ def test_run_deployment_errors_without_input():
 
 
 # --- constants ---
-
-
-def test_default_config_file_value():
-    assert DEFAULT_CONFIG_FILE == "agent/agent/workflow.yaml"

--- a/tests/dragent/cli/test_commands.py
+++ b/tests/dragent/cli/test_commands.py
@@ -24,43 +24,6 @@ from datarobot_genai.dragent.cli.commands import dragent_command
 _COMMANDS = "datarobot_genai.dragent.cli.commands"
 
 
-# --- dragent group ---
-
-
-def test_dragent_no_args_shows_help():
-    # GIVEN no arguments
-    # WHEN we invoke the dragent command
-    result = CliRunner().invoke(dragent_command, [])
-    # THEN it shows help text
-    assert result.exit_code == 0
-    assert "DRAgent CLI" in result.output
-
-
-def test_dragent_accepts_api_token():
-    # GIVEN --api-token flag
-    # WHEN we invoke with --help (to avoid subcommand requirement)
-    result = CliRunner().invoke(dragent_command, ["--api-token", "my-token", "--help"])
-    # THEN it exits successfully
-    assert result.exit_code == 0
-
-
-def test_dragent_accepts_base_url():
-    # GIVEN --base-url flag
-    # WHEN we invoke with --help
-    result = CliRunner().invoke(dragent_command, ["--base-url", "https://custom.com", "--help"])
-    # THEN it exits successfully
-    assert result.exit_code == 0
-
-
-def test_dragent_reads_api_token_from_env(monkeypatch):
-    # GIVEN DATAROBOT_API_TOKEN in the environment
-    monkeypatch.setenv("DATAROBOT_API_TOKEN", "env-token")
-    # WHEN we invoke with --help
-    result = CliRunner().invoke(dragent_command, ["--help"])
-    # THEN it exits successfully
-    assert result.exit_code == 0
-
-
 # --- run-deployment ---
 
 
@@ -71,7 +34,17 @@ def test_run_deployment_invokes_stream(mock_headers, mock_stream):
     # WHEN we invoke run-deployment
     result = CliRunner().invoke(
         dragent_command,
-        ["--api-token", "tok", "run-deployment", "--deployment-id", "dep-1", "--input", "hi"],
+        [
+            "--api-token",
+            "tok",
+            "--base-url",
+            "https://app.example.com",
+            "run-deployment",
+            "--deployment-id",
+            "dep-1",
+            "--input",
+            "hi",
+        ],
     )
     # THEN stream_agui_events is called with the correct URL
     assert result.exit_code == 0
@@ -91,6 +64,8 @@ def test_run_deployment_show_payload_prints_json(mock_headers, mock_stream):
         [
             "--api-token",
             "tok",
+            "--base-url",
+            "https://app.example.com",
             "run-deployment",
             "--deployment-id",
             "dep-1",
@@ -140,6 +115,3 @@ def test_run_deployment_errors_without_input():
     )
     # THEN it errors about the missing option
     assert result.exit_code != 0
-
-
-# --- constants ---

--- a/tests/dragent/cli/test_commands.py
+++ b/tests/dragent/cli/test_commands.py
@@ -1,0 +1,150 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from datarobot_genai.dragent.cli.commands import DEFAULT_CONFIG_FILE
+from datarobot_genai.dragent.cli.commands import dragent_command
+
+_COMMANDS = "datarobot_genai.dragent.cli.commands"
+
+
+# --- dragent group ---
+
+
+def test_dragent_no_args_shows_help():
+    # GIVEN no arguments
+    # WHEN we invoke the dragent command
+    result = CliRunner().invoke(dragent_command, [])
+    # THEN it shows help text
+    assert result.exit_code == 0
+    assert "DRAgent CLI" in result.output
+
+
+def test_dragent_accepts_api_token():
+    # GIVEN --api-token flag
+    # WHEN we invoke with --help (to avoid subcommand requirement)
+    result = CliRunner().invoke(dragent_command, ["--api-token", "my-token", "--help"])
+    # THEN it exits successfully
+    assert result.exit_code == 0
+
+
+def test_dragent_accepts_base_url():
+    # GIVEN --base-url flag
+    # WHEN we invoke with --help
+    result = CliRunner().invoke(dragent_command, ["--base-url", "https://custom.com", "--help"])
+    # THEN it exits successfully
+    assert result.exit_code == 0
+
+
+def test_dragent_reads_api_token_from_env(monkeypatch):
+    # GIVEN DATAROBOT_API_TOKEN in the environment
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "env-token")
+    # WHEN we invoke with --help
+    result = CliRunner().invoke(dragent_command, ["--help"])
+    # THEN it exits successfully
+    assert result.exit_code == 0
+
+
+# --- run-deployment ---
+
+
+@patch(f"{_COMMANDS}.stream_agui_events")
+@patch(f"{_COMMANDS}.get_auth_context_headers", return_value={"X-Auth": "jwt"})
+def test_run_deployment_invokes_stream(mock_headers, mock_stream):
+    # GIVEN valid token and deployment ID
+    # WHEN we invoke run-deployment
+    result = CliRunner().invoke(
+        dragent_command,
+        ["--api-token", "tok", "run-deployment", "--deployment-id", "dep-1", "--input", "hi"],
+    )
+    # THEN stream_agui_events is called with the correct URL
+    assert result.exit_code == 0
+    mock_stream.assert_called_once()
+    call_url = mock_stream.call_args[0][0]
+    assert "dep-1" in call_url
+    assert "directAccess/generate/stream" in call_url
+
+
+@patch(f"{_COMMANDS}.stream_agui_events")
+@patch(f"{_COMMANDS}.get_auth_context_headers", return_value={})
+def test_run_deployment_show_payload_prints_json(mock_headers, mock_stream):
+    # GIVEN --show-payload flag
+    # WHEN we invoke run-deployment
+    result = CliRunner().invoke(
+        dragent_command,
+        [
+            "--api-token",
+            "tok",
+            "run-deployment",
+            "--deployment-id",
+            "dep-1",
+            "--input",
+            "hi",
+            "--show-payload",
+        ],
+    )
+    # THEN the JSON payload is printed with the user message
+    assert result.exit_code == 0
+    parsed = json.loads(result.output.strip())
+    assert "messages" in parsed
+    assert parsed["messages"][0]["content"] == "hi"
+
+
+def test_run_deployment_errors_without_api_token(monkeypatch):
+    # GIVEN no API token
+    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+    # WHEN we invoke run-deployment
+    result = CliRunner().invoke(
+        dragent_command,
+        ["run-deployment", "--deployment-id", "dep-1", "--input", "hi"],
+    )
+    # THEN it errors with a message about the missing token
+    assert result.exit_code != 0
+    assert "API token is required" in result.output
+
+
+def test_run_deployment_errors_without_deployment_id():
+    # GIVEN no --deployment-id
+    # WHEN we invoke run-deployment
+    result = CliRunner().invoke(
+        dragent_command,
+        ["--api-token", "tok", "run-deployment", "--input", "hi"],
+    )
+    # THEN it errors about the missing option
+    assert result.exit_code != 0
+    assert "deployment-id" in result.output.lower()
+
+
+def test_run_deployment_errors_without_input():
+    # GIVEN no --input
+    # WHEN we invoke run-deployment
+    result = CliRunner().invoke(
+        dragent_command,
+        ["--api-token", "tok", "run-deployment", "--deployment-id", "dep-1"],
+    )
+    # THEN it errors about the missing option
+    assert result.exit_code != 0
+
+
+# --- constants ---
+
+
+def test_default_config_file_value():
+    assert DEFAULT_CONFIG_FILE == "agent/agent/workflow.yaml"

--- a/tests/dragent/cli/test_commands.py
+++ b/tests/dragent/cli/test_commands.py
@@ -24,14 +24,86 @@ from datarobot_genai.dragent.cli.commands import dragent_command
 _COMMANDS = "datarobot_genai.dragent.cli.commands"
 
 
-# --- run-deployment ---
+# --- query --local ---
+
+
+def test_query_local_errors_without_port(monkeypatch):
+    # GIVEN no --port and no AGENT_PORT env var
+    monkeypatch.delenv("AGENT_PORT", raising=False)
+    # WHEN we invoke query --local
+    result = CliRunner().invoke(
+        dragent_command,
+        ["query", "--local", "--input", "hi"],
+    )
+    # THEN it errors about missing port
+    assert result.exit_code != 0
+    assert "port" in result.output.lower()
+
+
+@patch(f"{_COMMANDS}.stream_agui_events")
+def test_query_local_custom_port_flag(mock_stream, monkeypatch):
+    # GIVEN --port flag
+    monkeypatch.delenv("AGENT_PORT", raising=False)
+    result = CliRunner().invoke(
+        dragent_command,
+        ["query", "--local", "--port", "8842", "--input", "hi"],
+    )
+    # THEN it uses the specified port
+    assert result.exit_code == 0
+    call_url = mock_stream.call_args[0][0]
+    assert "localhost:8842" in call_url
+
+
+@patch(f"{_COMMANDS}.stream_agui_events")
+def test_query_local_custom_port_env(mock_stream, monkeypatch):
+    # GIVEN AGENT_PORT env var
+    monkeypatch.setenv("AGENT_PORT", "9090")
+    result = CliRunner().invoke(
+        dragent_command,
+        ["query", "--local", "--input", "hi"],
+    )
+    # THEN it reads port from AGENT_PORT
+    assert result.exit_code == 0
+    call_url = mock_stream.call_args[0][0]
+    assert "localhost:9090" in call_url
+
+
+@patch(f"{_COMMANDS}.stream_agui_events")
+def test_query_local_show_payload(mock_stream, monkeypatch):
+    # GIVEN --show-payload with --local
+    monkeypatch.setenv("AGENT_PORT", "8080")
+    result = CliRunner().invoke(
+        dragent_command,
+        ["query", "--local", "--input", "hi", "--show-payload"],
+    )
+    # THEN the JSON payload is printed
+    assert result.exit_code == 0
+    parsed = json.loads(result.output.strip())
+    assert parsed["messages"][0]["content"] == "hi"
+
+
+@patch(f"{_COMMANDS}.stream_agui_events")
+def test_query_local_no_auth_headers(mock_stream, monkeypatch):
+    # GIVEN --local (no auth needed)
+    monkeypatch.setenv("AGENT_PORT", "8080")
+    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+    result = CliRunner().invoke(
+        dragent_command,
+        ["query", "--local", "--input", "hi"],
+    )
+    # THEN it succeeds without auth and headers have no Authorization
+    assert result.exit_code == 0
+    call_headers = mock_stream.call_args[0][2]
+    assert "Authorization" not in call_headers
+
+
+# --- query --deployment-id (remote deployment) ---
 
 
 @patch(f"{_COMMANDS}.stream_agui_events")
 @patch(f"{_COMMANDS}.get_auth_context_headers", return_value={"X-Auth": "jwt"})
-def test_run_deployment_invokes_stream(mock_headers, mock_stream):
+def test_query_deployment_invokes_stream(mock_headers, mock_stream):
     # GIVEN valid token and deployment ID
-    # WHEN we invoke run-deployment
     result = CliRunner().invoke(
         dragent_command,
         [
@@ -39,14 +111,14 @@ def test_run_deployment_invokes_stream(mock_headers, mock_stream):
             "tok",
             "--base-url",
             "https://app.example.com",
-            "run-deployment",
+            "query",
             "--deployment-id",
             "dep-1",
             "--input",
             "hi",
         ],
     )
-    # THEN stream_agui_events is called with the correct URL
+    # THEN stream_agui_events is called with the deployment URL
     assert result.exit_code == 0
     mock_stream.assert_called_once()
     call_url = mock_stream.call_args[0][0]
@@ -56,9 +128,8 @@ def test_run_deployment_invokes_stream(mock_headers, mock_stream):
 
 @patch(f"{_COMMANDS}.stream_agui_events")
 @patch(f"{_COMMANDS}.get_auth_context_headers", return_value={})
-def test_run_deployment_show_payload_prints_json(mock_headers, mock_stream):
+def test_query_show_payload_prints_json(mock_headers, mock_stream):
     # GIVEN --show-payload flag
-    # WHEN we invoke run-deployment
     result = CliRunner().invoke(
         dragent_command,
         [
@@ -66,7 +137,7 @@ def test_run_deployment_show_payload_prints_json(mock_headers, mock_stream):
             "tok",
             "--base-url",
             "https://app.example.com",
-            "run-deployment",
+            "query",
             "--deployment-id",
             "dep-1",
             "--input",
@@ -81,37 +152,57 @@ def test_run_deployment_show_payload_prints_json(mock_headers, mock_stream):
     assert parsed["messages"][0]["content"] == "hi"
 
 
-def test_run_deployment_errors_without_api_token(monkeypatch):
-    # GIVEN no API token
-    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
-    # WHEN we invoke run-deployment
+# --- query validation ---
+
+
+def test_query_errors_without_local_or_deployment_id():
+    # GIVEN neither --local nor --deployment-id
     result = CliRunner().invoke(
         dragent_command,
-        ["run-deployment", "--deployment-id", "dep-1", "--input", "hi"],
+        ["query", "--input", "hi"],
     )
-    # THEN it errors with a message about the missing token
+    # THEN it errors
+    assert result.exit_code != 0
+    assert "--local" in result.output or "--deployment-id" in result.output
+
+
+def test_query_errors_with_both_local_and_deployment_id():
+    # GIVEN both --local and --deployment-id
+    result = CliRunner().invoke(
+        dragent_command,
+        [
+            "--api-token",
+            "tok",
+            "query",
+            "--local",
+            "--deployment-id",
+            "dep-1",
+            "--input",
+            "hi",
+        ],
+    )
+    # THEN it errors about mutual exclusivity
+    assert result.exit_code != 0
+    assert "not both" in result.output.lower()
+
+
+def test_query_deployment_errors_without_api_token(monkeypatch):
+    # GIVEN no API token
+    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+    result = CliRunner().invoke(
+        dragent_command,
+        ["query", "--deployment-id", "dep-1", "--input", "hi"],
+    )
+    # THEN it errors about the missing token
     assert result.exit_code != 0
     assert "API token is required" in result.output
 
 
-def test_run_deployment_errors_without_deployment_id():
-    # GIVEN no --deployment-id
-    # WHEN we invoke run-deployment
-    result = CliRunner().invoke(
-        dragent_command,
-        ["--api-token", "tok", "run-deployment", "--input", "hi"],
-    )
-    # THEN it errors about the missing option
-    assert result.exit_code != 0
-    assert "deployment-id" in result.output.lower()
-
-
-def test_run_deployment_errors_without_input():
+def test_query_errors_without_input():
     # GIVEN no --input
-    # WHEN we invoke run-deployment
     result = CliRunner().invoke(
         dragent_command,
-        ["--api-token", "tok", "run-deployment", "--deployment-id", "dep-1"],
+        ["query", "--local"],
     )
     # THEN it errors about the missing option
     assert result.exit_code != 0

--- a/tests/dragent/cli/test_remote.py
+++ b/tests/dragent/cli/test_remote.py
@@ -295,3 +295,130 @@ def test_get_auth_context_headers_missing_secret_key_returns_empty(monkeypatch):
     headers = get_auth_context_headers("my-token", "https://app.datarobot.com")
     # THEN it returns an empty dict (no API call made)
     assert headers == {}
+
+
+# --- stream_agui_events: tool call events ---
+
+
+def test_stream_agui_events_prints_tool_calls(capsys):
+    # GIVEN SSE events with a tool call lifecycle
+    events = [
+        {"type": "TOOL_CALL_START", "tool_call_name": "search", "tool_call_id": "c1"},
+        {"type": "TOOL_CALL_ARGS", "tool_call_id": "c1", "delta": '{"q": "test"}'},
+        {"type": "TOOL_CALL_END", "tool_call_id": "c1"},
+        {"type": "TOOL_CALL_RESULT", "tool_call_id": "c1", "content": "found it", "role": "tool"},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN tool info is printed to stderr
+    captured = capsys.readouterr()
+    assert "search" in captured.err
+    assert '{"q": "test"}' in captured.err
+    assert "found it" in captured.err
+
+
+def test_stream_agui_events_truncates_long_tool_result(capsys):
+    # GIVEN a tool result longer than _TOOL_RESULT_MAX_LEN
+    events = [
+        {"type": "TOOL_CALL_RESULT", "tool_call_id": "c1", "content": "x" * 1500, "role": "tool"},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN the result is truncated with ellipsis
+    captured = capsys.readouterr()
+    assert "\u2026" in captured.err
+    assert "x" * 1500 not in captured.err
+
+
+# --- stream_agui_events: reasoning events ---
+
+
+def test_stream_agui_events_prints_reasoning(capsys):
+    # GIVEN SSE events with reasoning content
+    events = [
+        {"type": "REASONING_MESSAGE_CONTENT", "delta": "thinking hard"},
+        {"type": "REASONING_MESSAGE_END"},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN reasoning is printed to stderr
+    captured = capsys.readouterr()
+    assert "thinking hard" in captured.err
+
+
+# --- stream_agui_events: step events ---
+
+
+def test_stream_agui_events_prints_step_started(capsys):
+    # GIVEN a STEP_STARTED event
+    events = [
+        {"type": "STEP_STARTED", "step_name": "agent_workflow"},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN step name is printed to stderr
+    captured = capsys.readouterr()
+    assert "agent_workflow" in captured.err
+
+
+# --- stream_agui_events: run lifecycle events ---
+
+
+def test_stream_agui_events_prints_run_started(capsys):
+    # GIVEN a RUN_STARTED event
+    events = [
+        {"type": "RUN_STARTED", "thread_id": "t1", "run_id": "r1"},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN run started is printed to stderr
+    captured = capsys.readouterr()
+    assert "Run started" in captured.err
+
+
+# --- stream_agui_events: custom events ---
+
+
+def test_stream_agui_events_skips_heartbeat(capsys):
+    # GIVEN a Heartbeat custom event
+    events = [
+        {"type": "CUSTOM", "name": "Heartbeat", "value": {}},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN Heartbeat is NOT printed
+    captured = capsys.readouterr()
+    assert "Heartbeat" not in captured.err
+
+
+def test_stream_agui_events_prints_non_heartbeat_custom(capsys):
+    # GIVEN a non-Heartbeat custom event
+    events = [
+        {"type": "CUSTOM", "name": "MyCustomEvent", "value": {"foo": 1}},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN custom event name is printed to stderr
+    captured = capsys.readouterr()
+    assert "MyCustomEvent" in captured.err

--- a/tests/dragent/cli/test_remote.py
+++ b/tests/dragent/cli/test_remote.py
@@ -1,0 +1,272 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import click
+import httpx
+import pytest
+
+from datarobot_genai.dragent.cli.remote import _get_session_secret_key
+from datarobot_genai.dragent.cli.remote import build_agui_payload
+from datarobot_genai.dragent.cli.remote import require_auth
+from datarobot_genai.dragent.cli.remote import stream_agui_events
+
+_REMOTE = "datarobot_genai.dragent.cli.remote"
+
+
+def _make_click_ctx(api_token=None, base_url=None):
+    """Build a Click context with api_token and base_url in obj."""
+    ctx = click.Context(click.Command("test"))
+    ctx.ensure_object(dict)
+    ctx.obj["api_token"] = api_token
+    if base_url is not None:
+        ctx.obj["base_url"] = base_url
+    return ctx
+
+
+def _sse_lines(events):
+    """Build SSE data lines from a list of event dicts."""
+    return [f"data: {json.dumps(ev)}" for ev in events]
+
+
+def _mock_stream_response(lines, *, is_success=True, status_code=200, text=""):
+    """Build a mock httpx streaming response."""
+    resp = MagicMock()
+    resp.is_success = is_success
+    resp.status_code = status_code
+    resp.text = text
+    resp.read.return_value = text.encode()
+    resp.iter_lines.return_value = lines
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# --- _get_session_secret_key ---
+
+
+def test_get_session_secret_key_returns_value_from_env(monkeypatch):
+    # GIVEN SESSION_SECRET_KEY is set in the environment
+    monkeypatch.setenv("SESSION_SECRET_KEY", "test-secret")
+    # WHEN we read the key
+    # THEN it returns the value
+    assert _get_session_secret_key() == "test-secret"
+
+
+def test_get_session_secret_key_raises_when_not_set(monkeypatch):
+    # GIVEN SESSION_SECRET_KEY is not set
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    # WHEN we read the key
+    # THEN it raises a ClickException
+    with pytest.raises(click.ClickException, match="SESSION_SECRET_KEY is required"):
+        _get_session_secret_key()
+
+
+def test_get_session_secret_key_raises_when_empty(monkeypatch):
+    # GIVEN SESSION_SECRET_KEY is set to empty string
+    monkeypatch.setenv("SESSION_SECRET_KEY", "")
+    # WHEN we read the key
+    # THEN it raises a ClickException
+    with pytest.raises(click.ClickException, match="SESSION_SECRET_KEY is required"):
+        _get_session_secret_key()
+
+
+# --- require_auth ---
+
+
+def test_require_auth_returns_token_and_url():
+    # GIVEN a context with api_token and base_url
+    ctx = _make_click_ctx(api_token="tok", base_url="https://example.com")
+    # WHEN we require auth
+    token, url = require_auth(ctx)
+    # THEN both are returned
+    assert token == "tok"
+    assert url == "https://example.com"
+
+
+def test_require_auth_strips_trailing_slash():
+    # GIVEN a base_url with a trailing slash
+    ctx = _make_click_ctx(api_token="tok", base_url="https://example.com/")
+    # WHEN we require auth
+    _, url = require_auth(ctx)
+    # THEN the slash is stripped
+    assert url == "https://example.com"
+
+
+def test_require_auth_strips_api_v2_suffix():
+    # GIVEN a base_url ending with /api/v2
+    ctx = _make_click_ctx(api_token="tok", base_url="https://example.com/api/v2")
+    # WHEN we require auth
+    _, url = require_auth(ctx)
+    # THEN /api/v2 is stripped
+    assert url == "https://example.com"
+
+
+def test_require_auth_raises_when_no_token():
+    # GIVEN no api_token
+    ctx = _make_click_ctx(api_token=None)
+    # WHEN we require auth
+    # THEN it raises UsageError
+    with pytest.raises(click.UsageError, match="API token is required"):
+        require_auth(ctx)
+
+
+def test_require_auth_default_base_url():
+    # GIVEN no base_url specified
+    ctx = _make_click_ctx(api_token="tok")
+    # WHEN we require auth
+    _, url = require_auth(ctx)
+    # THEN the default URL is used
+    assert url == "https://app.datarobot.com"
+
+
+# --- build_agui_payload ---
+
+
+def test_build_agui_payload_contains_user_message():
+    # GIVEN a prompt string
+    # WHEN we build the payload
+    payload = build_agui_payload("hello world")
+    # THEN it contains a user message with the prompt
+    assert len(payload["messages"]) == 1
+    assert payload["messages"][0]["role"] == "user"
+    assert payload["messages"][0]["content"] == "hello world"
+
+
+def test_build_agui_payload_has_required_fields():
+    # GIVEN any prompt
+    # WHEN we build the payload
+    payload = build_agui_payload("test")
+    # THEN all required AG-UI fields are present
+    for field in ("threadId", "runId", "state", "tools", "context", "forwardedProps"):
+        assert field in payload
+
+
+def test_build_agui_payload_unique_ids_per_call():
+    # GIVEN two calls
+    p1 = build_agui_payload("a")
+    p2 = build_agui_payload("b")
+    # THEN all UUIDs are unique across calls
+    assert p1["threadId"] != p2["threadId"]
+    assert p1["runId"] != p2["runId"]
+    assert p1["messages"][0]["id"] != p2["messages"][0]["id"]
+
+
+def test_build_agui_payload_is_json_serializable():
+    # GIVEN a payload
+    payload = build_agui_payload("test")
+    # WHEN we serialize it
+    # THEN it should not raise
+    json.dumps(payload)
+
+
+# --- stream_agui_events ---
+
+
+def test_stream_agui_events_prints_text_content(capsys):
+    # GIVEN SSE events with text content
+    events = [
+        {"type": "TEXT_MESSAGE_CONTENT", "delta": "hello "},
+        {"type": "TEXT_MESSAGE_CONTENT", "delta": "world"},
+        {"type": "TEXT_MESSAGE_END"},
+        {"type": "RUN_FINISHED"},
+    ]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN text content is printed
+    out = capsys.readouterr().out
+    assert "hello " in out
+    assert "world" in out
+    assert "Run finished." in out
+
+
+def test_stream_agui_events_raises_on_run_error():
+    # GIVEN a RUN_ERROR event
+    events = [{"type": "RUN_ERROR", "message": "something broke"}]
+    resp = _mock_stream_response(_sse_lines(events))
+    # WHEN we stream
+    # THEN it raises ClickException with the error message
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        with pytest.raises(click.ClickException, match="something broke"):
+            stream_agui_events("http://test", {}, {})
+
+
+def test_stream_agui_events_raises_on_http_error():
+    # GIVEN a non-success HTTP response
+    resp = _mock_stream_response(
+        [], is_success=False, status_code=500, text="Internal Server Error"
+    )
+    # WHEN we stream
+    # THEN it raises ClickException with the status code
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        with pytest.raises(click.ClickException, match="HTTP 500"):
+            stream_agui_events("http://test", {}, {})
+
+
+def test_stream_agui_events_raises_on_connect_error():
+    # GIVEN a connection error
+    # WHEN we stream
+    # THEN it raises ClickException
+    with patch(f"{_REMOTE}.httpx.stream", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(click.ClickException, match="Could not connect"):
+            stream_agui_events("http://test", {}, {})
+
+
+def test_stream_agui_events_raises_on_timeout():
+    # GIVEN a timeout
+    # WHEN we stream
+    # THEN it raises ClickException
+    with patch(f"{_REMOTE}.httpx.stream", side_effect=httpx.ReadTimeout("timed out")):
+        with pytest.raises(click.ClickException, match="Request timed out"):
+            stream_agui_events("http://test", {}, {})
+
+
+def test_stream_agui_events_skips_malformed_sse_data(capsys):
+    # GIVEN a mix of malformed and valid SSE lines
+    lines = [
+        "data: not-valid-json",
+        f"data: {json.dumps({'type': 'TEXT_MESSAGE_CONTENT', 'delta': 'ok'})}",
+        f"data: {json.dumps({'type': 'RUN_FINISHED'})}",
+    ]
+    resp = _mock_stream_response(lines)
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN valid events are still printed
+    out = capsys.readouterr().out
+    assert "ok" in out
+
+
+def test_stream_agui_events_skips_non_data_lines(capsys):
+    # GIVEN non-data SSE lines (event, comment, blank)
+    lines = [
+        "event: message",
+        ": comment",
+        "",
+        f"data: {json.dumps({'type': 'RUN_FINISHED'})}",
+    ]
+    resp = _mock_stream_response(lines)
+    # WHEN we stream
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    # THEN only data lines are processed
+    out = capsys.readouterr().out
+    assert "Run finished." in out

--- a/tests/dragent/cli/test_remote.py
+++ b/tests/dragent/cli/test_remote.py
@@ -24,6 +24,8 @@ import pytest
 
 from datarobot_genai.dragent.cli.remote import _get_session_secret_key
 from datarobot_genai.dragent.cli.remote import build_agui_payload
+from datarobot_genai.dragent.cli.remote import get_auth_context_headers
+from datarobot_genai.dragent.cli.remote import normalize_base_url
 from datarobot_genai.dragent.cli.remote import require_auth
 from datarobot_genai.dragent.cli.remote import stream_agui_events
 
@@ -100,22 +102,13 @@ def test_require_auth_returns_token_and_url():
     assert url == "https://example.com"
 
 
-def test_require_auth_strips_trailing_slash():
-    # GIVEN a base_url with a trailing slash
-    ctx = _make_click_ctx(api_token="tok", base_url="https://example.com/")
-    # WHEN we require auth
-    _, url = require_auth(ctx)
-    # THEN the slash is stripped
-    assert url == "https://example.com"
-
-
-def test_require_auth_strips_api_v2_suffix():
-    # GIVEN a base_url ending with /api/v2
+def test_require_auth_preserves_base_url():
+    # GIVEN a base_url with /api/v2
     ctx = _make_click_ctx(api_token="tok", base_url="https://example.com/api/v2")
     # WHEN we require auth
     _, url = require_auth(ctx)
-    # THEN /api/v2 is stripped
-    assert url == "https://example.com"
+    # THEN the URL is returned as-is
+    assert url == "https://example.com/api/v2"
 
 
 def test_require_auth_raises_when_no_token():
@@ -127,13 +120,13 @@ def test_require_auth_raises_when_no_token():
         require_auth(ctx)
 
 
-def test_require_auth_default_base_url():
+def test_require_auth_raises_when_no_base_url():
     # GIVEN no base_url specified
     ctx = _make_click_ctx(api_token="tok")
     # WHEN we require auth
-    _, url = require_auth(ctx)
-    # THEN the default URL is used
-    assert url == "https://app.datarobot.com"
+    # THEN it raises UsageError
+    with pytest.raises(click.UsageError, match="Base URL is required"):
+        require_auth(ctx)
 
 
 # --- build_agui_payload ---
@@ -270,3 +263,86 @@ def test_stream_agui_events_skips_non_data_lines(capsys):
     # THEN only data lines are processed
     out = capsys.readouterr().out
     assert "Run finished." in out
+
+
+# --- normalize_base_url ---
+
+
+def test_normalize_base_url_strips_trailing_slash():
+    assert normalize_base_url("https://example.com/") == "https://example.com"
+
+
+def test_normalize_base_url_strips_api_v2_suffix():
+    assert normalize_base_url("https://example.com/api/v2") == "https://example.com"
+
+
+def test_normalize_base_url_strips_both():
+    assert normalize_base_url("https://example.com/api/v2/") == "https://example.com"
+
+
+def test_normalize_base_url_noop_when_clean():
+    assert normalize_base_url("https://example.com") == "https://example.com"
+
+
+# --- get_auth_context_headers ---
+
+
+@patch("datarobot_genai.core.utils.auth.AuthContextHeaderHandler")
+@patch(f"{_REMOTE}.httpx.get")
+def test_get_auth_context_headers_success(mock_get, mock_handler_cls, monkeypatch):
+    # GIVEN a successful account info response and SESSION_SECRET_KEY
+    monkeypatch.setenv("SESSION_SECRET_KEY", "test-secret")
+    mock_resp = MagicMock()
+    mock_resp.is_success = True
+    mock_resp.json.return_value = {"uid": "user-123", "email": "test@example.com"}
+    mock_get.return_value = mock_resp
+
+    mock_handler = MagicMock()
+    mock_handler.get_header.return_value = {"X-DataRobot-Authorization-Context": "jwt-token"}
+    mock_handler_cls.return_value = mock_handler
+
+    # WHEN we get auth context headers
+    headers = get_auth_context_headers("my-token", "https://app.datarobot.com")
+
+    # THEN it calls the API with the correct token
+    mock_get.assert_called_once()
+    call_kwargs = mock_get.call_args
+    assert "Bearer my-token" in str(call_kwargs)
+
+    # AND constructs the JWT with user info
+    mock_handler.get_header.assert_called_once()
+    auth_ctx = mock_handler.get_header.call_args[0][0]
+    assert auth_ctx["user"]["id"] == "user-123"
+    assert auth_ctx["user"]["email"] == "test@example.com"
+
+    # AND returns the header dict
+    assert headers == {"X-DataRobot-Authorization-Context": "jwt-token"}
+
+
+@patch(f"{_REMOTE}.httpx.get")
+def test_get_auth_context_headers_api_failure(mock_get):
+    # GIVEN a failed API response
+    mock_resp = MagicMock()
+    mock_resp.is_success = False
+    mock_resp.status_code = 401
+    mock_get.return_value = mock_resp
+
+    # WHEN we get auth context headers
+    # THEN it raises ClickException
+    with pytest.raises(click.ClickException, match="Failed to fetch user info"):
+        get_auth_context_headers("bad-token", "https://app.datarobot.com")
+
+
+@patch(f"{_REMOTE}.httpx.get")
+def test_get_auth_context_headers_missing_secret_key(mock_get, monkeypatch):
+    # GIVEN a successful API response but no SESSION_SECRET_KEY
+    monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
+    mock_resp = MagicMock()
+    mock_resp.is_success = True
+    mock_resp.json.return_value = {"uid": "user-123", "email": "test@example.com"}
+    mock_get.return_value = mock_resp
+
+    # WHEN we get auth context headers
+    # THEN it raises ClickException about missing secret key
+    with pytest.raises(click.ClickException, match="SESSION_SECRET_KEY is required"):
+        get_auth_context_headers("my-token", "https://app.datarobot.com")

--- a/tests/dragent/cli/test_remote.py
+++ b/tests/dragent/cli/test_remote.py
@@ -71,13 +71,12 @@ def test_get_session_secret_key_returns_value_from_env(monkeypatch):
     assert _get_session_secret_key() == "test-secret"
 
 
-def test_get_session_secret_key_raises_when_not_set(monkeypatch):
+def test_get_session_secret_key_returns_none_when_not_set(monkeypatch):
     # GIVEN SESSION_SECRET_KEY is not set
     monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
     # WHEN we read the key
-    # THEN it raises a ClickException
-    with pytest.raises(click.ClickException, match="SESSION_SECRET_KEY is required"):
-        _get_session_secret_key()
+    # THEN it returns None
+    assert _get_session_secret_key() is None
 
 
 # --- require_auth ---
@@ -153,6 +152,7 @@ def test_stream_agui_events_prints_text_content(capsys):
     assert "hello " in out
     assert "world" in out
     assert "Run finished." in out
+    assert "\u2705" in out
 
 
 def test_stream_agui_events_raises_on_run_error():
@@ -274,8 +274,9 @@ def test_get_auth_context_headers_success(mock_get, mock_handler_cls, monkeypatc
 
 
 @patch(f"{_REMOTE}.httpx.get")
-def test_get_auth_context_headers_api_failure(mock_get):
-    # GIVEN a failed API response
+def test_get_auth_context_headers_api_failure(mock_get, monkeypatch):
+    # GIVEN a failed API response and SESSION_SECRET_KEY is set
+    monkeypatch.setenv("SESSION_SECRET_KEY", "test-secret")
     mock_resp = MagicMock()
     mock_resp.is_success = False
     mock_resp.status_code = 401
@@ -287,16 +288,10 @@ def test_get_auth_context_headers_api_failure(mock_get):
         get_auth_context_headers("bad-token", "https://app.datarobot.com")
 
 
-@patch(f"{_REMOTE}.httpx.get")
-def test_get_auth_context_headers_missing_secret_key(mock_get, monkeypatch):
-    # GIVEN a successful API response but no SESSION_SECRET_KEY
+def test_get_auth_context_headers_missing_secret_key_returns_empty(monkeypatch):
+    # GIVEN no SESSION_SECRET_KEY
     monkeypatch.delenv("SESSION_SECRET_KEY", raising=False)
-    mock_resp = MagicMock()
-    mock_resp.is_success = True
-    mock_resp.json.return_value = {"uid": "user-123", "email": "test@example.com"}
-    mock_get.return_value = mock_resp
-
     # WHEN we get auth context headers
-    # THEN it raises ClickException about missing secret key
-    with pytest.raises(click.ClickException, match="SESSION_SECRET_KEY is required"):
-        get_auth_context_headers("my-token", "https://app.datarobot.com")
+    headers = get_auth_context_headers("my-token", "https://app.datarobot.com")
+    # THEN it returns an empty dict (no API call made)
+    assert headers == {}

--- a/tests/dragent/cli/test_remote.py
+++ b/tests/dragent/cli/test_remote.py
@@ -234,6 +234,13 @@ def test_normalize_base_url_noop_when_clean():
 # --- get_auth_context_headers ---
 
 
+def test_auth_context_handler_import_path():
+    """Verify the lazy import path used in get_auth_context_headers resolves."""
+    from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
+
+    assert callable(AuthContextHeaderHandler)
+
+
 @patch("datarobot_genai.core.utils.auth.AuthContextHeaderHandler")
 @patch(f"{_REMOTE}.httpx.get")
 def test_get_auth_context_headers_success(mock_get, mock_handler_cls, monkeypatch):

--- a/tests/dragent/cli/test_remote.py
+++ b/tests/dragent/cli/test_remote.py
@@ -80,15 +80,6 @@ def test_get_session_secret_key_raises_when_not_set(monkeypatch):
         _get_session_secret_key()
 
 
-def test_get_session_secret_key_raises_when_empty(monkeypatch):
-    # GIVEN SESSION_SECRET_KEY is set to empty string
-    monkeypatch.setenv("SESSION_SECRET_KEY", "")
-    # WHEN we read the key
-    # THEN it raises a ClickException
-    with pytest.raises(click.ClickException, match="SESSION_SECRET_KEY is required"):
-        _get_session_secret_key()
-
-
 # --- require_auth ---
 
 
@@ -100,15 +91,6 @@ def test_require_auth_returns_token_and_url():
     # THEN both are returned
     assert token == "tok"
     assert url == "https://example.com"
-
-
-def test_require_auth_preserves_base_url():
-    # GIVEN a base_url with /api/v2
-    ctx = _make_click_ctx(api_token="tok", base_url="https://example.com/api/v2")
-    # WHEN we require auth
-    _, url = require_auth(ctx)
-    # THEN the URL is returned as-is
-    assert url == "https://example.com/api/v2"
 
 
 def test_require_auth_raises_when_no_token():
@@ -149,24 +131,6 @@ def test_build_agui_payload_has_required_fields():
     # THEN all required AG-UI fields are present
     for field in ("threadId", "runId", "state", "tools", "context", "forwardedProps"):
         assert field in payload
-
-
-def test_build_agui_payload_unique_ids_per_call():
-    # GIVEN two calls
-    p1 = build_agui_payload("a")
-    p2 = build_agui_payload("b")
-    # THEN all UUIDs are unique across calls
-    assert p1["threadId"] != p2["threadId"]
-    assert p1["runId"] != p2["runId"]
-    assert p1["messages"][0]["id"] != p2["messages"][0]["id"]
-
-
-def test_build_agui_payload_is_json_serializable():
-    # GIVEN a payload
-    payload = build_agui_payload("test")
-    # WHEN we serialize it
-    # THEN it should not raise
-    json.dumps(payload)
 
 
 # --- stream_agui_events ---
@@ -246,23 +210,6 @@ def test_stream_agui_events_skips_malformed_sse_data(capsys):
     # THEN valid events are still printed
     out = capsys.readouterr().out
     assert "ok" in out
-
-
-def test_stream_agui_events_skips_non_data_lines(capsys):
-    # GIVEN non-data SSE lines (event, comment, blank)
-    lines = [
-        "event: message",
-        ": comment",
-        "",
-        f"data: {json.dumps({'type': 'RUN_FINISHED'})}",
-    ]
-    resp = _mock_stream_response(lines)
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN only data lines are processed
-    out = capsys.readouterr().out
-    assert "Run finished." in out
 
 
 # --- normalize_base_url ---

--- a/tests/dragent/frontends/test_console.py
+++ b/tests/dragent/frontends/test_console.py
@@ -18,10 +18,8 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
-from colorama import Fore
 
 from datarobot_genai.dragent.frontends.console import DRAgentConsoleFrontEndPlugin
-from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 # --- _print_result ---
 
@@ -61,37 +59,6 @@ def test_print_result_does_not_double_print_when_info_handler_exists(capsys):
         assert "test output" not in out
     finally:
         root.removeHandler(handler)
-
-
-def test_print_result_includes_colorama_formatting(capsys):
-    # GIVEN a logger that triggers the print() fallback
-    root = logging.getLogger()
-    original_handlers = root.handlers[:]
-    root.handlers = []
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.WARNING)
-    root.addHandler(handler)
-    try:
-        # WHEN we print a result
-        DRAgentConsoleFrontEndPlugin._print_result("result")
-        # THEN output contains colorama escape codes
-        out = capsys.readouterr().out
-        assert Fore.GREEN in out
-        assert Fore.RESET in out
-    finally:
-        root.handlers = original_handlers
-
-
-# --- _get_step_adaptor ---
-
-
-def test_get_step_adaptor_returns_correct_type():
-    # GIVEN a plugin instance (mocked)
-    plugin = MagicMock(spec=DRAgentConsoleFrontEndPlugin)
-    # WHEN we call _get_step_adaptor
-    adaptor = DRAgentConsoleFrontEndPlugin._get_step_adaptor(plugin)
-    # THEN it returns a DRAgentNestedReasoningStepAdaptor
-    assert isinstance(adaptor, DRAgentNestedReasoningStepAdaptor)
 
 
 # --- run_workflow ---

--- a/tests/dragent/frontends/test_console.py
+++ b/tests/dragent/frontends/test_console.py
@@ -97,16 +97,6 @@ def test_get_step_adaptor_returns_correct_type():
 # --- run_workflow ---
 
 
-async def test_run_workflow_raises_if_session_manager_is_none():
-    # GIVEN a plugin with run_workflow bound
-    plugin = MagicMock(spec=DRAgentConsoleFrontEndPlugin)
-    plugin.run_workflow = DRAgentConsoleFrontEndPlugin.run_workflow.__get__(plugin)
-    # WHEN we pass None as session_manager
-    # THEN it raises RuntimeError
-    with pytest.raises(RuntimeError, match="Session manager must be provided"):
-        await plugin.run_workflow(None)
-
-
 async def test_run_workflow_raises_if_no_input():
     # GIVEN a plugin with no input_query and no input_file
     plugin = MagicMock(spec=DRAgentConsoleFrontEndPlugin)

--- a/tests/dragent/frontends/test_console.py
+++ b/tests/dragent/frontends/test_console.py
@@ -30,6 +30,8 @@ def test_print_result_prints_when_log_level_too_high(capsys):
     """When root logger handlers are above INFO, _print_result falls back to print()."""
     # GIVEN a root logger with only a WARNING-level handler
     root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    root.handlers = []
     handler = logging.StreamHandler()
     handler.setLevel(logging.WARNING)
     root.addHandler(handler)
@@ -41,7 +43,7 @@ def test_print_result_prints_when_log_level_too_high(capsys):
         assert "Workflow Result:" in out
         assert "test output" in out
     finally:
-        root.removeHandler(handler)
+        root.handlers = original_handlers
 
 
 def test_print_result_does_not_double_print_when_info_handler_exists(capsys):
@@ -64,6 +66,8 @@ def test_print_result_does_not_double_print_when_info_handler_exists(capsys):
 def test_print_result_includes_colorama_formatting(capsys):
     # GIVEN a logger that triggers the print() fallback
     root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    root.handlers = []
     handler = logging.StreamHandler()
     handler.setLevel(logging.WARNING)
     root.addHandler(handler)
@@ -75,7 +79,7 @@ def test_print_result_includes_colorama_formatting(capsys):
         assert Fore.GREEN in out
         assert Fore.RESET in out
     finally:
-        root.removeHandler(handler)
+        root.handlers = original_handlers
 
 
 # --- _get_step_adaptor ---

--- a/tests/dragent/frontends/test_console.py
+++ b/tests/dragent/frontends/test_console.py
@@ -1,0 +1,116 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from colorama import Fore
+
+from datarobot_genai.dragent.frontends.console import DRAgentConsoleFrontEndPlugin
+from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
+
+# --- _print_result ---
+
+
+def test_print_result_prints_when_log_level_too_high(capsys):
+    """When root logger handlers are above INFO, _print_result falls back to print()."""
+    # GIVEN a root logger with only a WARNING-level handler
+    root = logging.getLogger()
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.WARNING)
+    root.addHandler(handler)
+    try:
+        # WHEN we print a result
+        DRAgentConsoleFrontEndPlugin._print_result("test output")
+        # THEN the output goes through print() fallback
+        out = capsys.readouterr().out
+        assert "Workflow Result:" in out
+        assert "test output" in out
+    finally:
+        root.removeHandler(handler)
+
+
+def test_print_result_does_not_double_print_when_info_handler_exists(capsys):
+    """When a StreamHandler at INFO level exists, _print_result should not use print()."""
+    # GIVEN a root logger with an INFO-level StreamHandler
+    root = logging.getLogger()
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    root.addHandler(handler)
+    try:
+        # WHEN we print a result
+        DRAgentConsoleFrontEndPlugin._print_result("test output")
+        # THEN the print() fallback does NOT fire (output only via logger)
+        out = capsys.readouterr().out
+        assert "test output" not in out
+    finally:
+        root.removeHandler(handler)
+
+
+def test_print_result_includes_colorama_formatting(capsys):
+    # GIVEN a logger that triggers the print() fallback
+    root = logging.getLogger()
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.WARNING)
+    root.addHandler(handler)
+    try:
+        # WHEN we print a result
+        DRAgentConsoleFrontEndPlugin._print_result("result")
+        # THEN output contains colorama escape codes
+        out = capsys.readouterr().out
+        assert Fore.GREEN in out
+        assert Fore.RESET in out
+    finally:
+        root.removeHandler(handler)
+
+
+# --- _get_step_adaptor ---
+
+
+def test_get_step_adaptor_returns_correct_type():
+    # GIVEN a plugin instance (mocked)
+    plugin = MagicMock(spec=DRAgentConsoleFrontEndPlugin)
+    # WHEN we call _get_step_adaptor
+    adaptor = DRAgentConsoleFrontEndPlugin._get_step_adaptor(plugin)
+    # THEN it returns a DRAgentNestedReasoningStepAdaptor
+    assert isinstance(adaptor, DRAgentNestedReasoningStepAdaptor)
+
+
+# --- run_workflow ---
+
+
+async def test_run_workflow_raises_if_session_manager_is_none():
+    # GIVEN a plugin with run_workflow bound
+    plugin = MagicMock(spec=DRAgentConsoleFrontEndPlugin)
+    plugin.run_workflow = DRAgentConsoleFrontEndPlugin.run_workflow.__get__(plugin)
+    # WHEN we pass None as session_manager
+    # THEN it raises RuntimeError
+    with pytest.raises(RuntimeError, match="Session manager must be provided"):
+        await plugin.run_workflow(None)
+
+
+async def test_run_workflow_raises_if_no_input():
+    # GIVEN a plugin with no input_query and no input_file
+    plugin = MagicMock(spec=DRAgentConsoleFrontEndPlugin)
+    plugin.run_workflow = DRAgentConsoleFrontEndPlugin.run_workflow.__get__(plugin)
+    plugin._get_step_adaptor = DRAgentConsoleFrontEndPlugin._get_step_adaptor.__get__(plugin)
+    plugin.front_end_config.input_query = None
+    plugin.front_end_config.input_file = None
+    # WHEN we call run_workflow
+    # THEN it raises RuntimeError about missing input
+    with pytest.raises(RuntimeError, match="No input provided"):
+        await plugin.run_workflow(MagicMock())

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -274,3 +274,13 @@ class TestMCPToolsContext:
             )
             async with mcp_tools_context(mcp_config):
                 pass
+
+    async def test_mcp_tools_context_connection_error_yields_empty(self):
+        """Test graceful fallback when MCP server connection fails."""
+        external_url = "https://mcp-server.example.com/mcp"
+        mcp_config = MCPConfig(external_mcp_url=external_url)
+        with patch(
+            "datarobot_genai.langgraph.mcp.create_session", side_effect=ConnectionError("refused")
+        ):
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools == []

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -139,3 +139,13 @@ class TestLoadMCPTools:
         with pytest.raises(RuntimeError):
             async with mcp_tools_context(mcp_config):
                 raise RuntimeError("Connection failed")
+
+    async def test_mcp_tools_context_connection_error_yields_empty(self):
+        """Test graceful fallback when MCP server connection fails."""
+        test_url = "https://mcp-server.example.com/mcp"
+        mcp_config = MCPConfig(external_mcp_url=test_url)
+        with patch(
+            "datarobot_genai.llama_index.mcp.BasicMCPClient", side_effect=ConnectionError("refused")
+        ):
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools == []

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,18 @@ boto3 = [
 ]
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -350,15 +362,6 @@ wheels = [
 ]
 
 [[package]]
-name = "async-timeout"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -589,6 +592,27 @@ wheels = [
 ]
 
 [[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -791,15 +815,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -971,14 +986,6 @@ mcp = [
     { name = "mcp" },
     { name = "mcpadapt", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "mcpadapt", version = "0.1.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-
-[[package]]
-name = "cronsim"
-version = "2.7"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -1429,7 +1436,7 @@ requires-dist = [
     { name = "datarobot-predict", marker = "extra == 'llamaindex'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'nat'", specifier = ">=1.13.2,<2.0.0" },
     { name = "fastapi", marker = "extra == 'dragent'", specifier = "<0.133.0" },
-    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=2.13.0.2,<3.0.0" },
+    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=3.2.0,<4.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
@@ -1806,24 +1813,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fakeredis"
-version = "2.34.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "redis" },
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/40/fd09efa66205eb32253d2b2ebc63537281384d2040f0a88bcd2289e120e4/fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b", size = 177315, upload-time = "2026-02-25T13:17:51.315Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b5/82f89307d0d769cd9bf46a54fb9136be08e4e57c5570ae421db4c9a2ba62/fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12", size = 122160, upload-time = "2026-02-25T13:17:49.701Z" },
-]
-
-[package.optional-dependencies]
-lua = [
-    { name = "lupa" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.132.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1842,7 +1831,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.14.5"
+version = "3.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1853,22 +1842,26 @@ dependencies = [
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api", version = "1.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
+    { name = "opentelemetry-api", version = "1.40.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
     { name = "packaging" },
     { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pydantic", version = "2.11.10", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version == '3.12.*'" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version != '3.12.*'" },
-    { name = "pydocket" },
     { name = "pyperclip" },
     { name = "python-dotenv", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
     { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
+    { name = "pyyaml" },
     { name = "rich" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/32/982678d44f13849530a74ab101ed80e060c2ee6cf87471f062dcf61705fd/fastmcp-2.14.5.tar.gz", hash = "sha256:38944dc582c541d55357082bda2241cedb42cd3a78faea8a9d6a2662c62a42d7", size = 8296329, upload-time = "2026-02-03T15:35:21.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/61/a4470e2f590d98a1db3d40cb6f424a1353b2b09d4d0dfe01d0b8d3987984/fastmcp-3.2.2.tar.gz", hash = "sha256:a5351ec8c098844a8d508a53e484b362f5357b890596aaf233ac9686a796a62f", size = 26328077, upload-time = "2026-04-09T01:33:04.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/c1/1a35ec68ff76ea8443aa115b18bcdee748a4ada2124537ee90522899ff9f/fastmcp-2.14.5-py3-none-any.whl", hash = "sha256:d81e8ec813f5089d3624bec93944beaefa86c0c3a4ef1111cbef676a761ebccf", size = 417784, upload-time = "2026-02-03T15:35:18.489Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3b/4225e516266146de5fc6e64a7357f0c1460e4f7134b2f0e6447ae35413f5/fastmcp-3.2.2-py3-none-any.whl", hash = "sha256:9d2fe9731bbae43e6979a0bf7194bd076fd014f780c118edfdc52645b9adbe5b", size = 707240, upload-time = "2026-04-09T01:33:00.938Z" },
 ]
 
 [[package]]
@@ -3562,47 +3555,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/52/dc9ef71a43eddb8f7b7f6d887feb4e04e61f07bb99359c4aa1dd112c715b/llama_parse-0.5.20.tar.gz", hash = "sha256:649e256431d3753025b9a320bb03b76849ce4b5a1121394c803df543e6c1006f", size = 16941, upload-time = "2025-01-22T21:04:22.226Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/7c/203b7ffc633b9c0823f0d0701e361e002b93bf4e493f4c494d4bd5934c0b/llama_parse-0.5.20-py3-none-any.whl", hash = "sha256:9617edb3428d3218ea01f1708f0b6105f3ffef142fedbeb8c98d50082c37e226", size = 16163, upload-time = "2025-01-22T21:04:20.751Z" },
-]
-
-[[package]]
-name = "lupa"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/1c/191c3e6ec6502e3dbe25a53e27f69a5daeac3e56de1f73c0138224171ead/lupa-2.6.tar.gz", hash = "sha256:9a770a6e89576be3447668d7ced312cd6fd41d3c13c2462c9dc2c2ab570e45d9", size = 7240282, upload-time = "2025-10-24T07:20:29.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/29/1f66907c1ebf1881735afa695e646762c674f00738ebf66d795d59fc0665/lupa-2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d988c0f9331b9f2a5a55186701a25444ab10a1432a1021ee58011499ecbbdd5", size = 962875, upload-time = "2025-10-24T07:17:39.107Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/67/4a748604be360eb9c1c215f6a0da921cd1a2b44b2c5951aae6fb83019d3a/lupa-2.6-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:ebe1bbf48259382c72a6fe363dea61a0fd6fe19eab95e2ae881e20f3654587bf", size = 1935390, upload-time = "2025-10-24T07:17:41.427Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/0c/8ef9ee933a350428b7bdb8335a37ef170ab0bb008bbf9ca8f4f4310116b6/lupa-2.6-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:a8fcee258487cf77cdd41560046843bb38c2e18989cd19671dd1e2596f798306", size = 992193, upload-time = "2025-10-24T07:17:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/65/46/e6c7facebdb438db8a65ed247e56908818389c1a5abbf6a36aab14f1057d/lupa-2.6-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:561a8e3be800827884e767a694727ed8482d066e0d6edfcbf423b05e63b05535", size = 1165844, upload-time = "2025-10-24T07:17:45.437Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/26/9f1154c6c95f175ccbf96aa96c8f569c87f64f463b32473e839137601a8b/lupa-2.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af880a62d47991cae78b8e9905c008cbfdc4a3a9723a66310c2634fc7644578c", size = 1048069, upload-time = "2025-10-24T07:17:47.181Z" },
-    { url = "https://files.pythonhosted.org/packages/68/67/2cc52ab73d6af81612b2ea24c870d3fa398443af8e2875e5befe142398b1/lupa-2.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80b22923aa4023c86c0097b235615f89d469a0c4eee0489699c494d3367c4c85", size = 2079079, upload-time = "2025-10-24T07:17:49.755Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/dc/f843f09bbf325f6e5ee61730cf6c3409fc78c010d968c7c78acba3019ca7/lupa-2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:153d2cc6b643f7efb9cfc0c6bb55ec784d5bac1a3660cfc5b958a7b8f38f4a75", size = 1071428, upload-time = "2025-10-24T07:17:51.991Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/60/37533a8d85bf004697449acb97ecdacea851acad28f2ad3803662487dd2a/lupa-2.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3fa8777e16f3ded50b72967dc17e23f5a08e4f1e2c9456aff2ebdb57f5b2869f", size = 1181756, upload-time = "2025-10-24T07:17:53.752Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f2/cf29b20dbb4927b6a3d27c339ac5d73e74306ecc28c8e2c900b2794142ba/lupa-2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8dbdcbe818c02a2f56f5ab5ce2de374dab03e84b25266cfbaef237829bc09b3f", size = 2175687, upload-time = "2025-10-24T07:17:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/94/7c/050e02f80c7131b63db1474bff511e63c545b5a8636a24cbef3fc4da20b6/lupa-2.6-cp311-cp311-win32.whl", hash = "sha256:defaf188fde8f7a1e5ce3a5e6d945e533b8b8d547c11e43b96c9b7fe527f56dc", size = 1412592, upload-time = "2025-10-24T07:17:59.062Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/6f2af98aa5d771cea661f66c8eb8f53772ec1ab1dfbce24126cfcd189436/lupa-2.6-cp311-cp311-win_amd64.whl", hash = "sha256:9505ae600b5c14f3e17e70f87f88d333717f60411faca1ddc6f3e61dce85fa9e", size = 1669194, upload-time = "2025-10-24T07:18:01.647Z" },
-    { url = "https://files.pythonhosted.org/packages/94/86/ce243390535c39d53ea17ccf0240815e6e457e413e40428a658ea4ee4b8d/lupa-2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47ce718817ef1cc0c40d87c3d5ae56a800d61af00fbc0fad1ca9be12df2f3b56", size = 951707, upload-time = "2025-10-24T07:18:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/86/85/cedea5e6cbeb54396fdcc55f6b741696f3f036d23cfaf986d50d680446da/lupa-2.6-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7aba985b15b101495aa4b07112cdc08baa0c545390d560ad5cfde2e9e34f4d58", size = 1916703, upload-time = "2025-10-24T07:18:05.6Z" },
-    { url = "https://files.pythonhosted.org/packages/24/be/3d6b5f9a8588c01a4d88129284c726017b2089f3a3fd3ba8bd977292fea0/lupa-2.6-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:b766f62f95b2739f2248977d29b0722e589dcf4f0ccfa827ccbd29f0148bd2e5", size = 985152, upload-time = "2025-10-24T07:18:08.561Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/23/9f9a05beee5d5dce9deca4cb07c91c40a90541fc0a8e09db4ee670da550f/lupa-2.6-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:00a934c23331f94cb51760097ebfab14b005d55a6b30a2b480e3c53dd2fa290d", size = 1159599, upload-time = "2025-10-24T07:18:10.346Z" },
-    { url = "https://files.pythonhosted.org/packages/40/4e/e7c0583083db9d7f1fd023800a9767d8e4391e8330d56c2373d890ac971b/lupa-2.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21de9f38bd475303e34a042b7081aabdf50bd9bafd36ce4faea2f90fd9f15c31", size = 1038686, upload-time = "2025-10-24T07:18:12.112Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9f/5a4f7d959d4feba5e203ff0c31889e74d1ca3153122be4a46dca7d92bf7c/lupa-2.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf3bda96d3fc41237e964a69c23647d50d4e28421111360274d4799832c560e9", size = 2071956, upload-time = "2025-10-24T07:18:14.572Z" },
-    { url = "https://files.pythonhosted.org/packages/92/34/2f4f13ca65d01169b1720176aedc4af17bc19ee834598c7292db232cb6dc/lupa-2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a76ead245da54801a81053794aa3975f213221f6542d14ec4b859ee2e7e0323", size = 1057199, upload-time = "2025-10-24T07:18:16.379Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2a/5f7d2eebec6993b0dcd428e0184ad71afb06a45ba13e717f6501bfed1da3/lupa-2.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8dd0861741caa20886ddbda0a121d8e52fb9b5bb153d82fa9bba796962bf30e8", size = 1173693, upload-time = "2025-10-24T07:18:18.153Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/29/089b4d2f8e34417349af3904bb40bec40b65c8731f45e3fd8d497ca573e5/lupa-2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:239e63948b0b23023f81d9a19a395e768ed3da6a299f84e7963b8f813f6e3f9c", size = 2164394, upload-time = "2025-10-24T07:18:20.403Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1b/79c17b23c921f81468a111cad843b076a17ef4b684c4a8dff32a7969c3f0/lupa-2.6-cp312-cp312-win32.whl", hash = "sha256:325894e1099499e7a6f9c351147661a2011887603c71086d36fe0f964d52d1ce", size = 1420647, upload-time = "2025-10-24T07:18:23.368Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/15/5121e68aad3584e26e1425a5c9a79cd898f8a152292059e128c206ee817c/lupa-2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c735a1ce8ee60edb0fe71d665f1e6b7c55c6021f1d340eb8c865952c602cd36f", size = 1688529, upload-time = "2025-10-24T07:18:25.523Z" },
-    { url = "https://files.pythonhosted.org/packages/28/1d/21176b682ca5469001199d8b95fa1737e29957a3d185186e7a8b55345f2e/lupa-2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:663a6e58a0f60e7d212017d6678639ac8df0119bc13c2145029dcba084391310", size = 947232, upload-time = "2025-10-24T07:18:27.878Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4c/d327befb684660ca13cf79cd1f1d604331808f9f1b6fb6bf57832f8edf80/lupa-2.6-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d1f5afda5c20b1f3217a80e9bc1b77037f8a6eb11612fd3ada19065303c8f380", size = 1908625, upload-time = "2025-10-24T07:18:29.944Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8e/ad22b0a19454dfd08662237a84c792d6d420d36b061f239e084f29d1a4f3/lupa-2.6-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:26f2b3c085fe76e9119e48c1013c1cccdc1f51585d456858290475aa38e7089e", size = 981057, upload-time = "2025-10-24T07:18:31.553Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/48/74859073ab276bd0566c719f9ca0108b0cfc1956ca0d68678d117d47d155/lupa-2.6-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:60d2f902c7b96fb8ab98493dcff315e7bb4d0b44dc9dd76eb37de575025d5685", size = 1156227, upload-time = "2025-10-24T07:18:33.981Z" },
-    { url = "https://files.pythonhosted.org/packages/09/6c/0e9ded061916877253c2266074060eb71ed99fb21d73c8c114a76725bce2/lupa-2.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a02d25dee3a3250967c36590128d9220ae02f2eda166a24279da0b481519cbff", size = 1035752, upload-time = "2025-10-24T07:18:36.32Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/ef/f8c32e454ef9f3fe909f6c7d57a39f950996c37a3deb7b391fec7903dab7/lupa-2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eae1ee16b886b8914ff292dbefbf2f48abfbdee94b33a88d1d5475e02423203", size = 2069009, upload-time = "2025-10-24T07:18:38.072Z" },
-    { url = "https://files.pythonhosted.org/packages/53/dc/15b80c226a5225815a890ee1c11f07968e0aba7a852df41e8ae6fe285063/lupa-2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0edd5073a4ee74ab36f74fe61450148e6044f3952b8d21248581f3c5d1a58be", size = 1056301, upload-time = "2025-10-24T07:18:40.165Z" },
-    { url = "https://files.pythonhosted.org/packages/31/14/2086c1425c985acfb30997a67e90c39457122df41324d3c179d6ee2292c6/lupa-2.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0c53ee9f22a8a17e7d4266ad48e86f43771951797042dd51d1494aaa4f5f3f0a", size = 1170673, upload-time = "2025-10-24T07:18:42.426Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e5/b216c054cf86576c0191bf9a9f05de6f7e8e07164897d95eea0078dca9b2/lupa-2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c0f157a9064a400d828789191a96da7f4ce889969a588b87ec80de9b14772", size = 2162227, upload-time = "2025-10-24T07:18:46.112Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2f/33ecb5bedf4f3bc297ceacb7f016ff951331d352f58e7e791589609ea306/lupa-2.6-cp313-cp313-win32.whl", hash = "sha256:ee9523941ae0a87b5b703417720c5d78f72d2f5bc23883a2ea80a949a3ed9e75", size = 1419558, upload-time = "2025-10-24T07:18:48.371Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b4/55e885834c847ea610e111d87b9ed4768f0afdaeebc00cd46810f25029f6/lupa-2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b1335a5835b0a25ebdbc75cf0bda195e54d133e4d994877ef025e218c2e59db9", size = 1683424, upload-time = "2025-10-24T07:18:50.976Z" },
 ]
 
 [[package]]
@@ -5404,15 +5356,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathvalidate"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
-]
-
-[[package]]
 name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
@@ -5662,15 +5605,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
-]
-
-[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -5820,43 +5754,27 @@ wheels = [
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.3.0"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "py-key-value-shared" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
 ]
 
 [package.optional-dependencies]
-disk = [
-    { name = "diskcache" },
-    { name = "pathvalidate" },
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
-]
-redis = [
-    { name = "redis" },
-]
-
-[[package]]
-name = "py-key-value-shared"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -6263,32 +6181,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydocket"
-version = "0.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "cronsim" },
-    { name = "fakeredis", extra = ["lua"] },
-    { name = "opentelemetry-api", version = "1.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
-    { name = "opentelemetry-api", version = "1.40.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
-    { name = "prometheus-client" },
-    { name = "py-key-value-aio", extra = ["memory", "redis"] },
-    { name = "python-json-logger" },
-    { name = "redis" },
-    { name = "rich" },
-    { name = "typer", version = "0.23.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
-    { name = "typer", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
-    { name = "typing-extensions" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-    { name = "uncalled-for" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/5f/82dde9fb6099b960a4203596d3b755d1bd2c0d0210fea104d015d6515d7f/pydocket-0.18.2.tar.gz", hash = "sha256:cc2051d15557f83bb164a83b0743fa9c12c2bfe9a9145cff3a5922b4935ce4f5", size = 354762, upload-time = "2026-03-10T13:09:22.52Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/cf/8c1b6340baf81d7f6c97fe0181bda7cfd500d5e33bf469fbffbdae07b3c9/pydocket-0.18.2-py3-none-any.whl", hash = "sha256:19e48de15e83370f750e362610b777533ff9c0fa48bf36766ed581f91d266556", size = 99041, upload-time = "2026-03-10T13:09:20.598Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -6483,15 +6375,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-json-logger"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -6647,18 +6530,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
-]
-
-[[package]]
-name = "redis"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/82/4d1a5279f6c1251d3d2a603a798a1137c657de9b12cfc1fba4858232c4d2/redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034", size = 4928081, upload-time = "2026-03-06T18:18:16.287Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/28/84e57fce7819e81ec5aa1bd31c42b89607241f4fb1a3ea5b0d2dbeaea26c/redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364", size = 404379, upload-time = "2026-03-06T18:18:14.583Z" },
 ]
 
 [[package]]
@@ -7201,15 +7072,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -87,18 +87,6 @@ boto3 = [
 ]
 
 [[package]]
-name = "aiofile"
-version = "3.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "caio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
-]
-
-[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -362,6 +350,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -592,27 +589,6 @@ wheels = [
 ]
 
 [[package]]
-name = "caio"
-version = "0.9.25"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
-    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
-    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
-    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
-    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
-    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -815,6 +791,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -989,6 +974,14 @@ mcp = [
 ]
 
 [[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1128,7 +1121,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.14.2"
+version = "0.14.3"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1436,7 +1429,7 @@ requires-dist = [
     { name = "datarobot-predict", marker = "extra == 'llamaindex'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'nat'", specifier = ">=1.13.2,<2.0.0" },
     { name = "fastapi", marker = "extra == 'dragent'", specifier = "<0.133.0" },
-    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=3.2.0,<4.0.0" },
+    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=2.13.0.2,<3.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
@@ -1813,6 +1806,24 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.34.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/40/fd09efa66205eb32253d2b2ebc63537281384d2040f0a88bcd2289e120e4/fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b", size = 177315, upload-time = "2026-02-25T13:17:51.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b5/82f89307d0d769cd9bf46a54fb9136be08e4e57c5570ae421db4c9a2ba62/fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12", size = 122160, upload-time = "2026-02-25T13:17:49.701Z" },
+]
+
+[package.optional-dependencies]
+lua = [
+    { name = "lupa" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.132.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1831,7 +1842,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.0"
+version = "2.14.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1842,26 +1853,22 @@ dependencies = [
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
-    { name = "opentelemetry-api", version = "1.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
-    { name = "opentelemetry-api", version = "1.40.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
     { name = "packaging" },
     { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
     { name = "pydantic", version = "2.11.10", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version == '3.12.*'" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version != '3.12.*'" },
+    { name = "pydocket" },
     { name = "pyperclip" },
     { name = "python-dotenv", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
     { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
-    { name = "pyyaml" },
     { name = "rich" },
-    { name = "uncalled-for" },
     { name = "uvicorn" },
-    { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/32/982678d44f13849530a74ab101ed80e060c2ee6cf87471f062dcf61705fd/fastmcp-2.14.5.tar.gz", hash = "sha256:38944dc582c541d55357082bda2241cedb42cd3a78faea8a9d6a2662c62a42d7", size = 8296329, upload-time = "2026-02-03T15:35:21.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c1/1a35ec68ff76ea8443aa115b18bcdee748a4ada2124537ee90522899ff9f/fastmcp-2.14.5-py3-none-any.whl", hash = "sha256:d81e8ec813f5089d3624bec93944beaefa86c0c3a4ef1111cbef676a761ebccf", size = 417784, upload-time = "2026-02-03T15:35:18.489Z" },
 ]
 
 [[package]]
@@ -3555,6 +3562,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/52/dc9ef71a43eddb8f7b7f6d887feb4e04e61f07bb99359c4aa1dd112c715b/llama_parse-0.5.20.tar.gz", hash = "sha256:649e256431d3753025b9a320bb03b76849ce4b5a1121394c803df543e6c1006f", size = 16941, upload-time = "2025-01-22T21:04:22.226Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/7c/203b7ffc633b9c0823f0d0701e361e002b93bf4e493f4c494d4bd5934c0b/llama_parse-0.5.20-py3-none-any.whl", hash = "sha256:9617edb3428d3218ea01f1708f0b6105f3ffef142fedbeb8c98d50082c37e226", size = 16163, upload-time = "2025-01-22T21:04:20.751Z" },
+]
+
+[[package]]
+name = "lupa"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/1c/191c3e6ec6502e3dbe25a53e27f69a5daeac3e56de1f73c0138224171ead/lupa-2.6.tar.gz", hash = "sha256:9a770a6e89576be3447668d7ced312cd6fd41d3c13c2462c9dc2c2ab570e45d9", size = 7240282, upload-time = "2025-10-24T07:20:29.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/29/1f66907c1ebf1881735afa695e646762c674f00738ebf66d795d59fc0665/lupa-2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d988c0f9331b9f2a5a55186701a25444ab10a1432a1021ee58011499ecbbdd5", size = 962875, upload-time = "2025-10-24T07:17:39.107Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/67/4a748604be360eb9c1c215f6a0da921cd1a2b44b2c5951aae6fb83019d3a/lupa-2.6-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:ebe1bbf48259382c72a6fe363dea61a0fd6fe19eab95e2ae881e20f3654587bf", size = 1935390, upload-time = "2025-10-24T07:17:41.427Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/8ef9ee933a350428b7bdb8335a37ef170ab0bb008bbf9ca8f4f4310116b6/lupa-2.6-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:a8fcee258487cf77cdd41560046843bb38c2e18989cd19671dd1e2596f798306", size = 992193, upload-time = "2025-10-24T07:17:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/65/46/e6c7facebdb438db8a65ed247e56908818389c1a5abbf6a36aab14f1057d/lupa-2.6-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:561a8e3be800827884e767a694727ed8482d066e0d6edfcbf423b05e63b05535", size = 1165844, upload-time = "2025-10-24T07:17:45.437Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/26/9f1154c6c95f175ccbf96aa96c8f569c87f64f463b32473e839137601a8b/lupa-2.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af880a62d47991cae78b8e9905c008cbfdc4a3a9723a66310c2634fc7644578c", size = 1048069, upload-time = "2025-10-24T07:17:47.181Z" },
+    { url = "https://files.pythonhosted.org/packages/68/67/2cc52ab73d6af81612b2ea24c870d3fa398443af8e2875e5befe142398b1/lupa-2.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80b22923aa4023c86c0097b235615f89d469a0c4eee0489699c494d3367c4c85", size = 2079079, upload-time = "2025-10-24T07:17:49.755Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/dc/f843f09bbf325f6e5ee61730cf6c3409fc78c010d968c7c78acba3019ca7/lupa-2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:153d2cc6b643f7efb9cfc0c6bb55ec784d5bac1a3660cfc5b958a7b8f38f4a75", size = 1071428, upload-time = "2025-10-24T07:17:51.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/60/37533a8d85bf004697449acb97ecdacea851acad28f2ad3803662487dd2a/lupa-2.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3fa8777e16f3ded50b72967dc17e23f5a08e4f1e2c9456aff2ebdb57f5b2869f", size = 1181756, upload-time = "2025-10-24T07:17:53.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/cf29b20dbb4927b6a3d27c339ac5d73e74306ecc28c8e2c900b2794142ba/lupa-2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8dbdcbe818c02a2f56f5ab5ce2de374dab03e84b25266cfbaef237829bc09b3f", size = 2175687, upload-time = "2025-10-24T07:17:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/050e02f80c7131b63db1474bff511e63c545b5a8636a24cbef3fc4da20b6/lupa-2.6-cp311-cp311-win32.whl", hash = "sha256:defaf188fde8f7a1e5ce3a5e6d945e533b8b8d547c11e43b96c9b7fe527f56dc", size = 1412592, upload-time = "2025-10-24T07:17:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/6f2af98aa5d771cea661f66c8eb8f53772ec1ab1dfbce24126cfcd189436/lupa-2.6-cp311-cp311-win_amd64.whl", hash = "sha256:9505ae600b5c14f3e17e70f87f88d333717f60411faca1ddc6f3e61dce85fa9e", size = 1669194, upload-time = "2025-10-24T07:18:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/94/86/ce243390535c39d53ea17ccf0240815e6e457e413e40428a658ea4ee4b8d/lupa-2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47ce718817ef1cc0c40d87c3d5ae56a800d61af00fbc0fad1ca9be12df2f3b56", size = 951707, upload-time = "2025-10-24T07:18:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/cedea5e6cbeb54396fdcc55f6b741696f3f036d23cfaf986d50d680446da/lupa-2.6-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7aba985b15b101495aa4b07112cdc08baa0c545390d560ad5cfde2e9e34f4d58", size = 1916703, upload-time = "2025-10-24T07:18:05.6Z" },
+    { url = "https://files.pythonhosted.org/packages/24/be/3d6b5f9a8588c01a4d88129284c726017b2089f3a3fd3ba8bd977292fea0/lupa-2.6-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:b766f62f95b2739f2248977d29b0722e589dcf4f0ccfa827ccbd29f0148bd2e5", size = 985152, upload-time = "2025-10-24T07:18:08.561Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/23/9f9a05beee5d5dce9deca4cb07c91c40a90541fc0a8e09db4ee670da550f/lupa-2.6-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:00a934c23331f94cb51760097ebfab14b005d55a6b30a2b480e3c53dd2fa290d", size = 1159599, upload-time = "2025-10-24T07:18:10.346Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4e/e7c0583083db9d7f1fd023800a9767d8e4391e8330d56c2373d890ac971b/lupa-2.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21de9f38bd475303e34a042b7081aabdf50bd9bafd36ce4faea2f90fd9f15c31", size = 1038686, upload-time = "2025-10-24T07:18:12.112Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/5a4f7d959d4feba5e203ff0c31889e74d1ca3153122be4a46dca7d92bf7c/lupa-2.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf3bda96d3fc41237e964a69c23647d50d4e28421111360274d4799832c560e9", size = 2071956, upload-time = "2025-10-24T07:18:14.572Z" },
+    { url = "https://files.pythonhosted.org/packages/92/34/2f4f13ca65d01169b1720176aedc4af17bc19ee834598c7292db232cb6dc/lupa-2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a76ead245da54801a81053794aa3975f213221f6542d14ec4b859ee2e7e0323", size = 1057199, upload-time = "2025-10-24T07:18:16.379Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2a/5f7d2eebec6993b0dcd428e0184ad71afb06a45ba13e717f6501bfed1da3/lupa-2.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8dd0861741caa20886ddbda0a121d8e52fb9b5bb153d82fa9bba796962bf30e8", size = 1173693, upload-time = "2025-10-24T07:18:18.153Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/29/089b4d2f8e34417349af3904bb40bec40b65c8731f45e3fd8d497ca573e5/lupa-2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:239e63948b0b23023f81d9a19a395e768ed3da6a299f84e7963b8f813f6e3f9c", size = 2164394, upload-time = "2025-10-24T07:18:20.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1b/79c17b23c921f81468a111cad843b076a17ef4b684c4a8dff32a7969c3f0/lupa-2.6-cp312-cp312-win32.whl", hash = "sha256:325894e1099499e7a6f9c351147661a2011887603c71086d36fe0f964d52d1ce", size = 1420647, upload-time = "2025-10-24T07:18:23.368Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/15/5121e68aad3584e26e1425a5c9a79cd898f8a152292059e128c206ee817c/lupa-2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c735a1ce8ee60edb0fe71d665f1e6b7c55c6021f1d340eb8c865952c602cd36f", size = 1688529, upload-time = "2025-10-24T07:18:25.523Z" },
+    { url = "https://files.pythonhosted.org/packages/28/1d/21176b682ca5469001199d8b95fa1737e29957a3d185186e7a8b55345f2e/lupa-2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:663a6e58a0f60e7d212017d6678639ac8df0119bc13c2145029dcba084391310", size = 947232, upload-time = "2025-10-24T07:18:27.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4c/d327befb684660ca13cf79cd1f1d604331808f9f1b6fb6bf57832f8edf80/lupa-2.6-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d1f5afda5c20b1f3217a80e9bc1b77037f8a6eb11612fd3ada19065303c8f380", size = 1908625, upload-time = "2025-10-24T07:18:29.944Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8e/ad22b0a19454dfd08662237a84c792d6d420d36b061f239e084f29d1a4f3/lupa-2.6-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:26f2b3c085fe76e9119e48c1013c1cccdc1f51585d456858290475aa38e7089e", size = 981057, upload-time = "2025-10-24T07:18:31.553Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/48/74859073ab276bd0566c719f9ca0108b0cfc1956ca0d68678d117d47d155/lupa-2.6-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:60d2f902c7b96fb8ab98493dcff315e7bb4d0b44dc9dd76eb37de575025d5685", size = 1156227, upload-time = "2025-10-24T07:18:33.981Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6c/0e9ded061916877253c2266074060eb71ed99fb21d73c8c114a76725bce2/lupa-2.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a02d25dee3a3250967c36590128d9220ae02f2eda166a24279da0b481519cbff", size = 1035752, upload-time = "2025-10-24T07:18:36.32Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ef/f8c32e454ef9f3fe909f6c7d57a39f950996c37a3deb7b391fec7903dab7/lupa-2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eae1ee16b886b8914ff292dbefbf2f48abfbdee94b33a88d1d5475e02423203", size = 2069009, upload-time = "2025-10-24T07:18:38.072Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dc/15b80c226a5225815a890ee1c11f07968e0aba7a852df41e8ae6fe285063/lupa-2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0edd5073a4ee74ab36f74fe61450148e6044f3952b8d21248581f3c5d1a58be", size = 1056301, upload-time = "2025-10-24T07:18:40.165Z" },
+    { url = "https://files.pythonhosted.org/packages/31/14/2086c1425c985acfb30997a67e90c39457122df41324d3c179d6ee2292c6/lupa-2.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0c53ee9f22a8a17e7d4266ad48e86f43771951797042dd51d1494aaa4f5f3f0a", size = 1170673, upload-time = "2025-10-24T07:18:42.426Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/b216c054cf86576c0191bf9a9f05de6f7e8e07164897d95eea0078dca9b2/lupa-2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c0f157a9064a400d828789191a96da7f4ce889969a588b87ec80de9b14772", size = 2162227, upload-time = "2025-10-24T07:18:46.112Z" },
+    { url = "https://files.pythonhosted.org/packages/59/2f/33ecb5bedf4f3bc297ceacb7f016ff951331d352f58e7e791589609ea306/lupa-2.6-cp313-cp313-win32.whl", hash = "sha256:ee9523941ae0a87b5b703417720c5d78f72d2f5bc23883a2ea80a949a3ed9e75", size = 1419558, upload-time = "2025-10-24T07:18:48.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b4/55e885834c847ea610e111d87b9ed4768f0afdaeebc00cd46810f25029f6/lupa-2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b1335a5835b0a25ebdbc75cf0bda195e54d133e4d994877ef025e218c2e59db9", size = 1683424, upload-time = "2025-10-24T07:18:50.976Z" },
 ]
 
 [[package]]
@@ -5356,6 +5404,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
+]
+
+[[package]]
 name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
@@ -5605,6 +5662,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -5754,27 +5820,43 @@ wheels = [
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.4.4"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "typing-extensions" },
+    { name = "py-key-value-shared" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
 ]
 
 [package.optional-dependencies]
-filetree = [
-    { name = "aiofile" },
-    { name = "anyio" },
+disk = [
+    { name = "diskcache" },
+    { name = "pathvalidate" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
+name = "py-key-value-shared"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -6181,6 +6263,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pydocket"
+version = "0.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "fakeredis", extra = ["lua"] },
+    { name = "opentelemetry-api", version = "1.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
+    { name = "opentelemetry-api", version = "1.40.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer", version = "0.23.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
+    { name = "typer", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/5f/82dde9fb6099b960a4203596d3b755d1bd2c0d0210fea104d015d6515d7f/pydocket-0.18.2.tar.gz", hash = "sha256:cc2051d15557f83bb164a83b0743fa9c12c2bfe9a9145cff3a5922b4935ce4f5", size = 354762, upload-time = "2026-03-10T13:09:22.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/cf/8c1b6340baf81d7f6c97fe0181bda7cfd500d5e33bf469fbffbdae07b3c9/pydocket-0.18.2-py3-none-any.whl", hash = "sha256:19e48de15e83370f750e362610b777533ff9c0fa48bf36766ed581f91d266556", size = 99041, upload-time = "2026-03-10T13:09:20.598Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -6375,6 +6483,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -6530,6 +6647,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/82/4d1a5279f6c1251d3d2a603a798a1137c657de9b12cfc1fba4858232c4d2/redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034", size = 4928081, upload-time = "2026-03-06T18:18:16.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/28/84e57fce7819e81ec5aa1bd31c42b89607241f4fb1a3ea5b0d2dbeaea26c/redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364", size = 404379, upload-time = "2026-03-06T18:18:14.583Z" },
 ]
 
 [[package]]
@@ -7072,6 +7201,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Implements `nat dragent` shell frontend (BUZZOK-29643) -- a CLI plugin in `datarobot-genai` that replaces `cli.py` from `af-component-agent`. Subclasses NAT's `StartCommandGroup` to reuse its entire frontend lifecycle instead of reimplementing internals.

## CHANGES

- Added `nat dragent serve` (alias for `nat start dragent_fastapi`)
- Added `nat dragent run` (in-process workflow execution via `DRAgentConsoleFrontEndPlugin` with intermediate step streaming and colored output)
- Added `nat dragent query` with mutually exclusive `--local` and `--deployment-id` flags:
  - `--local`: queries a locally running dragent server (port via `--port` or `AGENT_PORT` env var)
  - `--deployment-id`: queries a DataRobot deployment via `directAccess` API with AG-UI SSE streaming
- Added `--api-token` / `--base-url` shared group options (with env var fallbacks)
- `--config_file` reads from `DRAGENT_CONFIG_FILE` env var (required, no hardcoded default)
- `SESSION_SECRET_KEY` now optional for `query --deployment-id` (warns and skips auth context header if not set)
- Colored terminal output with emoji for both `run` (yellow reasoning, cyan text) and `query` (cyan text, green checkmark)
- Updated MCP tool loading in CrewAI/LangGraph/LlamaIndex to gracefully fall back to empty tools on connection errors (with structured logging replacing `print()`)
- Updated e2e Taskfile to use `nat dragent serve` instead of `nat start dragent_fastapi`
- Added e2e tests for `nat dragent run` and `nat dragent query --local`
- Bumped version to `0.13.3`, updated lockfiles (including `fastmcp` 3.2.2)

## TESTING

From the `e2e-tests` directory, install the updated package:

```bash
cd e2e-tests
uv pip install -e "../[dragent]"
```

### Help
```bash
nat dragent --help
nat dragent serve --help
nat dragent run --help
nat dragent query --help
```

### Start the dragent HTTP server
```bash
nat dragent serve
```

### Query the local server
```bash
nat dragent query --local --input "what is datarobot?"
```

### Execute a workflow locally in-process (no server needed)
```bash
nat dragent run --input "what is datarobot?"
```

### Run with input from a file
```bash
echo "what is datarobot?" > /tmp/prompt.txt
nat dragent run --input-file /tmp/prompt.txt
```

### Query a deployed model
```bash
nat dragent query --deployment-id $DEPLOY_ID --input "what is datarobot?"
```

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI entry point that can execute workflows locally and stream responses from local/remote agents (including optional auth-context JWT headers), plus changes MCP tool-loading behavior to silently continue without tools on connection failures.
> 
> **Overview**
> Introduces a new `nat dragent` CLI plugin (via `nat.cli` entry point) that provides `serve` (aliasing the FastAPI frontend), `run` (new `dragent_console` frontend that streams intermediate AG-UI events to the terminal), and `query` (streams AG-UI SSE responses from either `--local` localhost or a `--deployment-id` DataRobot directAccess endpoint with optional auth-context headers).
> 
> Updates MCP adapters for CrewAI, LangGraph, and LlamaIndex to **gracefully fall back to an empty tool list** on connection/OS/timeout errors instead of failing hard, with added test coverage. Bumps version to `0.14.3`, refreshes lockfiles (incl. `fastmcp`), and updates dragent e2e Taskfile/tests to use `nat dragent serve/run/query`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5af2c4ec52c987f840cf460442177d8d72dfb53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->