### PR TITLE
[BUZZOK-30008] [BUZZOK-30007] [BUZZOK-30029] Big decomposition of MCP context and agent

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           frameworks='[]'
           core="${{ steps.filter.outputs.core }}"
-          declare -A changed=( [langgraph]="${{ steps.filter.outputs.langgraph }}" [llamaindex]="${{ steps.filter.outputs.llamaindex }}" [nat]="${{ steps.filter.outputs.nat }}" [base]="${{ steps.filter.outputs.base }}" )
-          for fw in langgraph llamaindex nat base; do
+          declare -A changed=( [langgraph]="${{ steps.filter.outputs.langgraph }}" [llamaindex]="${{ steps.filter.outputs.llamaindex }}" [nat]="${{ steps.filter.outputs.nat }}" [base]="${{ steps.filter.outputs.base }}" [crewai]="${{ steps.filter.outputs.crewai }}" )
+          for fw in langgraph llamaindex nat base crewai; do
             if [[ "${changed[$fw]}" == "true" || "$core" == "true" ]]; then
               frameworks=$(echo "$frameworks" | jq -c ". + [\"$fw\"]")
             fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,8 @@ jobs:
               - 'src/datarobot_genai/langgraph/**'
             llamaindex:
               - 'src/datarobot_genai/llama_index/**'
+            crewai:
+              - 'src/datarobot_genai/crewai/**'
             nat:
               - 'src/datarobot_genai/nat/**'
             base:

--- a/.github/workflows/workflow-pr-automation.yaml
+++ b/.github/workflows/workflow-pr-automation.yaml
@@ -15,7 +15,7 @@ jobs:
   # knows it has passed code review and is ready for the next step.
   mark-reviewed:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.3
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.5
     with:
       pr_number: ${{ github.event.pull_request.number }}
 
@@ -24,7 +24,7 @@ jobs:
   # so reviewers are alerted that the PR is ready for their attention.
   notify-ready-for-review:
     if: github.event_name == 'pull_request' && contains(github.event.label.name, 'ready for review')
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.3
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.5
     with:
       pr_number: ${{ github.event.pull_request.number }}
       pr_url: ${{ github.event.pull_request.html_url }}
@@ -41,7 +41,7 @@ jobs:
   # to the corresponding Jira issue in the PR description or as a comment.
   add-jira-link:
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'edited')
-    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.3
+    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.5
     with:
       pr_title: ${{ github.event.pull_request.title }}
       pr_number: ${{ github.event.pull_request.number }}
@@ -54,6 +54,6 @@ jobs:
   # that are still open and may need attention.
   notify-slack-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.3
+    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.5
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.taskfiles/tests.yml
+++ b/.taskfiles/tests.yml
@@ -39,3 +39,15 @@ tasks:
             --junitxml=test_results/test-results.xml -vv -s \
             --ignore=tests/drmcp/integration --ignore=tests/drmcp/acceptance --ignore=tests/nat/integration
     silent: true
+
+  test-nat-integration:
+    desc: "Run NAT integration tests"
+    cmds:
+      - mkdir -p test_results
+      - |
+          set -e
+          COV_FAIL_UNDER=80
+          uv run pytest --junitxml=test_results/test-results.xml \
+            --cov=datarobot_genai --cov-branch --cov-fail-under=${COV_FAIL_UNDER} --no-cov-on-fail \
+            -vv -s tests/nat/integration
+    silent: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.10.0
+- **Breaking**: Decoupled agents and MCP tools. Now mcp_tools_context has to be called explicitly outside of an agent invoke.
+- Reworked `mcp_tools_context`arguments to use `MCPConfig` explicitly.
+- Fixed issue with `RuntimeError: generator didn't stop after athrow()` in MCP context.
+
 ## 0.9.0
 - Removed side-effects in MCPConfig
 - Renamed datarobot_genai.core.mcp.common to datarobot_genai.core.mcp.config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Breaking**: Decoupled agents and MCP tools. Now mcp_tools_context has to be called explicitly outside of an agent invoke.
 - Reworked `mcp_tools_context`arguments to use `MCPConfig` explicitly.
 - Fixed issue with `RuntimeError: generator didn't stop after athrow()` in MCP context.
+- Fix CrewAI streaming steps and reasoning: enable CrewAI streaming by default
+- Unify logging for CrewAI
 
 ## 0.9.2
 - Added AG-UI Events for CrewAI

--- a/e2e-tests/Taskfile.yaml
+++ b/e2e-tests/Taskfile.yaml
@@ -43,3 +43,8 @@ tasks:
     cmds:
       - echo "🧪 Running tests for drmcp"
       - uv run pytest drmcp_tests -vv -s
+  test-target:
+    desc: "🧪 Run tests for a specific target"
+    cmds:
+      - echo "🧪 Running tests for {{.TARGET}}"
+      - uv run pytest {{.CLI_ARGS}} -vv -s

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -20,9 +20,10 @@ from crewai import Task
 from crewai.tools import tool
 from datarobot_genai.core.agents import make_system_prompt
 from datarobot_genai.crewai.agent import CrewAIAgent
-from datarobot_genai.drtools.calculator import calculator
 
-calculator_tool = tool(calculator)
+from dragent.tool import generate_objectid
+
+generate_objectid_tool = tool(generate_objectid)
 
 
 class MyAgent(CrewAIAgent):
@@ -43,10 +44,12 @@ class MyAgent(CrewAIAgent):
             goal="Create a short bullet-point outline with 3-5 key points about: {topic}.",
             backstory=make_system_prompt(
                 "You are a content planner. Given a topic, produce a short bullet-point "
-                "outline with 3-5 key points. No paragraphs, no explanations — just the list."
+                "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
+                "Use the generate_objectid tool when asked to generate an object ID for a "
+                "deployment."
             ),
             llm=self._llm,
-            tools=[calculator_tool] + self.tools,
+            tools=[generate_objectid_tool] + self.tools,
             verbose=self.verbose,
         )
         writer = Agent(
@@ -54,10 +57,11 @@ class MyAgent(CrewAIAgent):
             goal="Write a 2-3 sentence response based on the planner's outline about: {topic}.",
             backstory=make_system_prompt(
                 "You are a concise writer. Using the planner's outline, write a short response "
-                "in 2-3 sentences. Use the calculator tool when asked to compute math."
+                "in 2-3 sentences. Use the generate_objectid tool when asked to "
+                "generate an object ID for a deployment."
             ),
             llm=self._llm,
-            tools=[calculator_tool] + self.tools,
+            tools=[generate_objectid_tool] + self.tools,
             verbose=self.verbose,
         )
         return [planner, writer]

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -20,10 +20,12 @@ from crewai import Task
 from crewai.tools import tool
 from datarobot_genai.core.agents import make_system_prompt
 from datarobot_genai.crewai.agent import CrewAIAgent
+from datarobot_genai.drtools.calculator import calculator
 
 from dragent.tool import generate_objectid
 
 generate_objectid_tool = tool(generate_objectid)
+calculator_tool = tool(calculator)
 
 
 class MyAgent(CrewAIAgent):
@@ -46,10 +48,12 @@ class MyAgent(CrewAIAgent):
                 "You are a content planner. Given a topic, produce a short bullet-point "
                 "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
                 "Use the generate_objectid tool when asked to generate an object ID for a "
-                "deployment."
+                "deployment. Use the calculator tool when asked to compute a mathematical "
+                "expression."
             ),
             llm=self._llm,
-            tools=[generate_objectid_tool] + self.tools,
+            function_calling_llm=self._llm,
+            tools=[generate_objectid_tool, calculator_tool] + self.tools,
             verbose=self.verbose,
         )
         writer = Agent(
@@ -58,10 +62,12 @@ class MyAgent(CrewAIAgent):
             backstory=make_system_prompt(
                 "You are a concise writer. Using the planner's outline, write a short response "
                 "in 2-3 sentences. Use the generate_objectid tool when asked to "
-                "generate an object ID for a deployment."
+                "generate an object ID for a deployment. Use the calculator tool when asked to "
+                "compute a mathematical expression."
             ),
             llm=self._llm,
-            tools=[generate_objectid_tool] + self.tools,
+            function_calling_llm=self._llm,
+            tools=[generate_objectid_tool, calculator_tool] + self.tools,
             verbose=self.verbose,
         )
         return [planner, writer]
@@ -80,17 +86,21 @@ class MyAgent(CrewAIAgent):
             Task(
                 description=(
                     "Create a short outline about: {topic}. "
-                    "Prior conversation context (may be empty): {chat_history}"
+                    "Prior conversation context (may be empty): {chat_history}. "
+                    "Execute tool calls if requested instead of this task."
                 ),
-                expected_output="A bullet-point outline with 3-5 key points.",
+                expected_output=(
+                    "A bullet-point outline with 3-5 key points. Or the result of a tool call."
+                ),
                 agent=planner,
             ),
             Task(
                 description=(
                     "Using the planner's outline, write a short response about: {topic}. "
-                    "Prior conversation context (may be empty): {chat_history}"
+                    "Prior conversation context (may be empty): {chat_history}. "
+                    "Execute tool calls if requested instead of this task."
                 ),
-                expected_output="A concise 2-3 sentence response.",
+                expected_output="A concise 2-3 sentence response. Or the result of a tool call.",
                 agent=writer,
             ),
         ]

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -46,7 +46,7 @@ class MyAgent(CrewAIAgent):
                 "outline with 3-5 key points. No paragraphs, no explanations — just the list."
             ),
             llm=self._llm,
-            tools=[calculator_tool] + self.mcp_tools,
+            tools=[calculator_tool] + self.tools,
             verbose=self.verbose,
         )
         writer = Agent(
@@ -57,7 +57,7 @@ class MyAgent(CrewAIAgent):
                 "in 2-3 sentences. Use the calculator tool when asked to compute math."
             ),
             llm=self._llm,
-            tools=[calculator_tool] + self.mcp_tools,
+            tools=[calculator_tool] + self.tools,
             verbose=self.verbose,
         )
         return [planner, writer]

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from crewai import Agent
-from crewai import Crew
 from crewai import Task
 from crewai.tools import tool
 from datarobot_genai.core.agents import make_system_prompt
@@ -75,10 +74,6 @@ class MyAgent(CrewAIAgent):
     @property
     def tasks(self) -> list[Any]:
         return self._tasks_for(self.agents)
-
-    def crew(self) -> Crew:
-        agents = self.agents
-        return Crew(agents=agents, tasks=self._tasks_for(agents), verbose=self.verbose)
 
     def _tasks_for(self, agents: list[Any]) -> list[Any]:
         planner, writer = agents

--- a/e2e-tests/dragent/crewai/register.py
+++ b/e2e-tests/dragent/crewai/register.py
@@ -16,13 +16,9 @@ from collections.abc import AsyncGenerator
 from typing import Annotated
 
 from ag_ui.core.types import RunAgentInput
-from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
-from datarobot_genai.nat.helpers import extract_authorization_from_context
-from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
-from nat.builder.function_info import Streaming
 from nat.cli.register_workflow import register_per_user_function
 from nat.data_models.agent import AgentBaseConfig
 
@@ -42,9 +38,15 @@ class CrewaiAgentConfig(AgentBaseConfig, name="crewai_agent"):
     framework_wrappers=[LLMFrameworkEnum.CREWAI],
 )
 async def crewai_agent(config: CrewaiAgentConfig, builder: Builder) -> AsyncGenerator:
-    from nat.builder.function_info import FunctionInfo  # noqa: PLC0415
+    from datarobot_genai.core.mcp import MCPConfig
+    from datarobot_genai.crewai.mcp import mcp_tools_context
+    from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
+    from datarobot_genai.nat.helpers import extract_authorization_from_context
+    from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
+    from nat.builder.function_info import FunctionInfo
+    from nat.builder.function_info import Streaming
 
-    from dragent.crewai.myagent import MyAgent  # noqa: PLC0415
+    from dragent.crewai.myagent import MyAgent
 
     async def _response_fn(
         input_message: RunAgentInput,
@@ -60,18 +62,22 @@ async def crewai_agent(config: CrewaiAgentConfig, builder: Builder) -> AsyncGene
         # Agent contains user-specific headers and authorization context
         forwarded_headers = extract_datarobot_headers_from_context()
         authorization_context = extract_authorization_from_context()
-        agent = MyAgent(
-            llm=llm,
-            forwarded_headers=forwarded_headers,
-            authorization_context=authorization_context,
+        mcp_config = MCPConfig(
+            forwarded_headers=forwarded_headers, authorization_context=authorization_context
         )
-
-        async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):
-            yield DRAgentEventResponse(
-                events=[event],
-                usage_metrics=usage_metrics,
-                pipeline_interactions=pipeline_interactions,
+        async with mcp_tools_context(mcp_config) as tools:
+            agent = MyAgent(
+                llm=llm,
+                forwarded_headers=forwarded_headers,
+                tools=tools,
             )
+
+            async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):
+                yield DRAgentEventResponse(
+                    events=[event],
+                    usage_metrics=usage_metrics,
+                    pipeline_interactions=pipeline_interactions,
+                )
 
     yield FunctionInfo.from_fn(
         _response_fn,

--- a/e2e-tests/dragent/langgraph/myagent.py
+++ b/e2e-tests/dragent/langgraph/myagent.py
@@ -63,7 +63,7 @@ class MyAgent(LangGraphAgent):
     def agent_planner(self) -> Any:
         return create_agent(
             self._llm,
-            tools=[calculator_tool] + self.mcp_tools,
+            tools=[calculator_tool] + self.tools,
             system_prompt=make_system_prompt(
                 "You are a content planner. Given a topic, produce a short bullet-point "
                 "outline with 3-5 key points. No paragraphs, no explanations — just the list."
@@ -75,7 +75,7 @@ class MyAgent(LangGraphAgent):
     def agent_writer(self) -> Any:
         return create_agent(
             self._llm,
-            tools=[calculator_tool] + self.mcp_tools,
+            tools=[calculator_tool] + self.tools,
             system_prompt=make_system_prompt(
                 "You are a concise writer. Using the planner's outline, write a short response "
                 "in 2-3 sentences. Use the calculator tool when asked to compute math."

--- a/e2e-tests/dragent/langgraph/myagent.py
+++ b/e2e-tests/dragent/langgraph/myagent.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from datarobot_genai.core.agents import make_system_prompt
-from datarobot_genai.drtools.calculator import calculator
 from datarobot_genai.langgraph.agent import LangGraphAgent
 from langchain.agents import create_agent
 from langchain_core.language_models import BaseChatModel
@@ -26,7 +25,9 @@ from langgraph.graph import START
 from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph
 
-calculator_tool = tool(calculator)
+from dragent.tool import generate_objectid
+
+generate_objectid_tool = tool(generate_objectid)
 
 
 class MyAgent(LangGraphAgent):
@@ -63,10 +64,12 @@ class MyAgent(LangGraphAgent):
     def agent_planner(self) -> Any:
         return create_agent(
             self._llm,
-            tools=[calculator_tool] + self.tools,
+            tools=[generate_objectid_tool] + self.tools,
             system_prompt=make_system_prompt(
                 "You are a content planner. Given a topic, produce a short bullet-point "
-                "outline with 3-5 key points. No paragraphs, no explanations — just the list."
+                "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
+                "Use the generate_objectid tool when asked to generate an object ID for a "
+                "deployment."
             ),
             name="planner",
         )
@@ -75,10 +78,11 @@ class MyAgent(LangGraphAgent):
     def agent_writer(self) -> Any:
         return create_agent(
             self._llm,
-            tools=[calculator_tool] + self.tools,
+            tools=[generate_objectid_tool] + self.tools,
             system_prompt=make_system_prompt(
                 "You are a concise writer. Using the planner's outline, write a short response "
-                "in 2-3 sentences. Use the calculator tool when asked to compute math."
+                "in 2-3 sentences. Use the generate_objectid tool when asked to "
+                "generate an object ID for a deployment."
             ),
             name="writer",
         )

--- a/e2e-tests/dragent/langgraph/register.py
+++ b/e2e-tests/dragent/langgraph/register.py
@@ -16,15 +16,11 @@ from collections.abc import AsyncGenerator
 from typing import Annotated
 
 from ag_ui.core import RunAgentInput
-from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
-from datarobot_genai.nat.helpers import extract_authorization_from_context
-from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_per_user_function
 from nat.data_models.agent import AgentBaseConfig
-from nat.data_models.streaming import Streaming
 
 
 class LanggraphAgentConfig(AgentBaseConfig, name="langgraph_agent"):
@@ -43,9 +39,15 @@ class LanggraphAgentConfig(AgentBaseConfig, name="langgraph_agent"):
     framework_wrappers=[LLMFrameworkEnum.LANGCHAIN],
 )
 async def langgraph_agent(config: LanggraphAgentConfig, builder: Builder) -> AsyncGenerator:
-    from nat.builder.function_info import FunctionInfo  # noqa: PLC0415
+    from datarobot_genai.core.mcp import MCPConfig
+    from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
+    from datarobot_genai.langgraph.mcp import mcp_tools_context
+    from datarobot_genai.nat.helpers import extract_authorization_from_context
+    from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
+    from nat.builder.function_info import FunctionInfo
+    from nat.data_models.streaming import Streaming
 
-    from dragent.langgraph.myagent import MyAgent  # noqa: PLC0415
+    from dragent.langgraph.myagent import MyAgent
 
     async def _response_fn(
         input_message: RunAgentInput,
@@ -61,18 +63,22 @@ async def langgraph_agent(config: LanggraphAgentConfig, builder: Builder) -> Asy
         # Agent contains user-specific headers and authorization context
         forwarded_headers = extract_datarobot_headers_from_context()
         authorization_context = extract_authorization_from_context()
-        agent = MyAgent(
-            llm=llm,
-            forwarded_headers=forwarded_headers,
-            authorization_context=authorization_context,
+        mcp_config = MCPConfig(
+            forwarded_headers=forwarded_headers, authorization_context=authorization_context
         )
-
-        async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):
-            yield DRAgentEventResponse(
-                events=[event],
-                usage_metrics=usage_metrics,
-                pipeline_interactions=pipeline_interactions,
+        async with mcp_tools_context(mcp_config) as tools:
+            agent = MyAgent(
+                llm=llm,
+                forwarded_headers=forwarded_headers,
+                tools=tools,
             )
+
+            async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):
+                yield DRAgentEventResponse(
+                    events=[event],
+                    usage_metrics=usage_metrics,
+                    pipeline_interactions=pipeline_interactions,
+                )
 
     yield FunctionInfo.from_fn(
         _response_fn,

--- a/e2e-tests/dragent/llamaindex/myagent.py
+++ b/e2e-tests/dragent/llamaindex/myagent.py
@@ -15,13 +15,14 @@
 from typing import Any
 
 from datarobot_genai.core.agents import make_system_prompt
-from datarobot_genai.drtools.calculator import calculator as _calculator_fn
 from datarobot_genai.llama_index.agent import LlamaIndexAgent
 from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.core.tools import FunctionTool
 
-calculator = FunctionTool.from_defaults(fn=_calculator_fn, name="calculator")
+from dragent.tool import generate_objectid
+
+generate_objectid_tool = FunctionTool.from_defaults(fn=generate_objectid, name="generate_objectid")
 
 
 class MyAgent(LlamaIndexAgent):
@@ -42,10 +43,11 @@ class MyAgent(LlamaIndexAgent):
             system_prompt=make_system_prompt(
                 "You are a content planner. Given a topic, produce a short bullet-point "
                 "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
-                "When done, hand off to the writer agent."
+                "Use the generate_objectid tool when asked to generate an object ID for a "
+                "deployment."
             ),
             llm=self._llm,
-            tools=[calculator] + self.tools,
+            tools=[generate_objectid_tool] + self.tools,
             can_handoff_to=["writer"],
         )
         writer = FunctionAgent(
@@ -53,10 +55,11 @@ class MyAgent(LlamaIndexAgent):
             description="Writes concise responses based on outlines",
             system_prompt=make_system_prompt(
                 "You are a concise writer. Using the planner's outline, write a short response "
-                "in 2-3 sentences. Use the calculator tool when asked to compute math."
+                "in 2-3 sentences. Use the generate_objectid tool when asked to "
+                "generate an object ID for a deployment."
             ),
             llm=self._llm,
-            tools=[calculator] + self.tools,
+            tools=[generate_objectid_tool] + self.tools,
         )
         return AgentWorkflow(agents=[planner, writer], root_agent="planner")
 

--- a/e2e-tests/dragent/llamaindex/myagent.py
+++ b/e2e-tests/dragent/llamaindex/myagent.py
@@ -45,7 +45,7 @@ class MyAgent(LlamaIndexAgent):
                 "When done, hand off to the writer agent."
             ),
             llm=self._llm,
-            tools=[calculator] + self.mcp_tools,
+            tools=[calculator] + self.tools,
             can_handoff_to=["writer"],
         )
         writer = FunctionAgent(
@@ -56,7 +56,7 @@ class MyAgent(LlamaIndexAgent):
                 "in 2-3 sentences. Use the calculator tool when asked to compute math."
             ),
             llm=self._llm,
-            tools=[calculator] + self.mcp_tools,
+            tools=[calculator] + self.tools,
         )
         return AgentWorkflow(agents=[planner, writer], root_agent="planner")
 

--- a/e2e-tests/dragent/llamaindex/register.py
+++ b/e2e-tests/dragent/llamaindex/register.py
@@ -16,10 +16,7 @@ from collections.abc import AsyncGenerator
 from typing import Annotated
 
 from ag_ui.core import RunAgentInput
-from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
-from datarobot_genai.nat.helpers import extract_authorization_from_context
-from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import Streaming
@@ -42,9 +39,14 @@ class LlamaindexAgentConfig(AgentBaseConfig, name="llamaindex_agent"):
     framework_wrappers=[LLMFrameworkEnum.LLAMA_INDEX],
 )
 async def llamaindex_agent(config: LlamaindexAgentConfig, builder: Builder) -> AsyncGenerator:
-    from nat.builder.function_info import FunctionInfo  # noqa: PLC0415
+    from datarobot_genai.core.mcp import MCPConfig
+    from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
+    from datarobot_genai.llama_index.mcp import mcp_tools_context
+    from datarobot_genai.nat.helpers import extract_authorization_from_context
+    from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
+    from nat.builder.function_info import FunctionInfo
 
-    from dragent.llamaindex.myagent import MyAgent  # noqa: PLC0415
+    from dragent.llamaindex.myagent import MyAgent
 
     async def _response_fn(
         input_message: RunAgentInput,
@@ -60,18 +62,22 @@ async def llamaindex_agent(config: LlamaindexAgentConfig, builder: Builder) -> A
         # Agent contains user-specific headers and authorization context
         forwarded_headers = extract_datarobot_headers_from_context()
         authorization_context = extract_authorization_from_context()
-        agent = MyAgent(
-            llm=llm,
-            forwarded_headers=forwarded_headers,
-            authorization_context=authorization_context,
+        mcp_config = MCPConfig(
+            forwarded_headers=forwarded_headers, authorization_context=authorization_context
         )
-
-        async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):
-            yield DRAgentEventResponse(
-                events=[event],
-                usage_metrics=usage_metrics,
-                pipeline_interactions=pipeline_interactions,
+        async with mcp_tools_context(mcp_config) as tools:
+            agent = MyAgent(
+                llm=llm,
+                forwarded_headers=forwarded_headers,
+                tools=tools,
             )
+
+            async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):
+                yield DRAgentEventResponse(
+                    events=[event],
+                    usage_metrics=usage_metrics,
+                    pipeline_interactions=pipeline_interactions,
+                )
 
     yield FunctionInfo.from_fn(
         _response_fn,

--- a/e2e-tests/dragent/nat/register.py
+++ b/e2e-tests/dragent/nat/register.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datarobot_genai.drtools.calculator import calculator
 from datarobot_genai.nat.tool import nat_tool
 
-nat_tool(calculator, "calculator")
+from dragent.tool import generate_objectid
+
+nat_tool(generate_objectid, "generate_objectid")

--- a/e2e-tests/dragent/nat/workflow.yaml
+++ b/e2e-tests/dragent/nat/workflow.yaml
@@ -27,9 +27,9 @@ functions:
       You are a concise writer. Using the planner's outline, write a short
       response in 2-3 sentences.
     description: A tool that writes the content for the requested topic.
-  calculator:
-    _type: calculator
-    description: A tool that calculates the result of a mathematical expression.
+  generate_objectid:
+    _type: generate_objectid
+    description: A tool that generates an object ID for a deployment.
 
 llms:
   datarobot_llm:
@@ -50,7 +50,7 @@ workflow:
     - planner
     - writer
     - mcp_tools
-    - calculator
+    - generate_objectid
   return_direct:
     - writer
   system_prompt: |

--- a/e2e-tests/dragent/tool.py
+++ b/e2e-tests/dragent/tool.py
@@ -1,0 +1,32 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+
+# This is a dummy tool we use to test that agents does not hallucinate tool calls. It only accepts
+# one value for the type argument, and it only returns a fixed value we can check in a test
+
+
+def generate_objectid(
+    type: Annotated[
+        str,
+        """The type of object to generate an ID for. Should be only 'deployment',
+        all other values will cause an error""",
+    ],
+) -> str:
+    """Generate a unique object ID for a deployment."""
+    if type != "deployment":
+        raise ValueError("Invalid type. Should be only 'deployment'")
+
+    return "69cbb73789723b6936c6c9e1"

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -22,7 +22,7 @@ from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 GENERATE_STREAM_PATH = "/generate/stream"
 GENERATE_PATH = "/generate"
 FRAMEWORK = os.environ.get("FRAMEWORK")
-FRAMEWORK_SUPPORTS_TOOL_CALLS = FRAMEWORK in ["crewai", "langgraph", "nat", "llamaindex"]
+FRAMEWORK_SUPPORTS_TOOL_CALLS = FRAMEWORK in ["langgraph", "nat", "llamaindex"]
 
 
 def make_generate_payload(content: str) -> dict:  # type: ignore[type-arg]

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import uuid
+
 import httpx
 from ag_ui.core import Event
 from ag_ui.core import EventType

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -27,20 +27,21 @@ from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
 
+pytestmark = pytest.mark.skipif(
+    FRAMEWORK == "base",
+    reason="Base framework does not implement anything, skipping tool call tests",
+)
+
 GENERATE_OBJECTID_PROMPT = (
     "You MUST use the generate_objectid tool to generate an object ID for a deployment. "
     "Do NOT generate it yourself. Call the generate_objectid tool with this exact input: "
     "deployment. "
-    "Report only the exact object ID from the tool, no explanation, "
-    "no formatting, no other text. Always return the final answer to the user"
+    "You MUST return the exact object ID from the tool, no explanation, "
+    "no formatting, no other text. Do not write anything else. Always return the "
+    "final answer to the user"
 )
 
-EXPECTED_RESULT = "69cbb73789723b6936c6c9e1"
-
-@pytest.mark.skipif(
-    FRAMEWORK == "base",
-    reason="Base framework does not implement anything, skipping tool call tests",
-)
+EXPECTED_GENERATE_OBJECTID_RESULT = "69cbb73789723b6936c6c9e1"
 
 def test_generate_objectid_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
     """Agent uses calculator tool when asked to compute."""
@@ -85,6 +86,69 @@ def test_generate_objectid_tool_is_called(http_client: httpx.Client) -> None:  #
 
     # THEN: the tool call events contain the correct result
     full_text = collect_text(ag_ui_events)
-    assert EXPECTED_RESULT in full_text, (
-        f"Expected '{EXPECTED_RESULT}' in response. Got: {full_text[:500]}"
+    assert EXPECTED_GENERATE_OBJECTID_RESULT in full_text, (
+        f"Expected '{EXPECTED_GENERATE_OBJECTID_RESULT}' in response. Got: {full_text[:500]}"
+    )
+
+
+CALCULATOR_PROMPT = (
+    "You MUST use the calculator tool to compute the following expression. "
+    "Do NOT compute it yourself. Call the calculator tool with this exact input: "
+    "(1234 * 567890) + 91011. "
+    "You MUST return the exact numeric result from the tool, no explanation, "
+    "no formatting, no other text. Do not write anything else. Always return the "
+    "final answer to the user"
+)
+
+EXPECTED_CALCULATOR_RESULT = str((1234 * 567890) + 91011)
+
+@pytest.mark.skip(
+    "Obsolete test: I kept it here only to because it used to be a problem for crewai, "
+    "but now it is fixed. We really don't want to run 2 tests on every run. "
+)
+def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
+    """Agent uses calculator tool when asked to compute."""
+    # GIVEN: a payload that requests the generate_objectid tool to generate an object ID for a
+    # deployment
+    payload = make_generate_payload(CALCULATOR_PROMPT)
+    # WHEN: the payload is streamed to the generate endpoint
+    with http_client.stream("POST", GENERATE_STREAM_PATH, json=payload) as response:
+        assert response.status_code == 200
+        # THEN: the response is a valid AG-UI response
+        sse_events = parse_sse_responses(response)
+
+    # THEN: the response contains AG-UI events
+    ag_ui_events = collect_ag_ui_events(sse_events)
+
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(ag_ui_events)
+
+    # THEN: there are events with tool call
+    event_types = {e.type for e in ag_ui_events}
+    tool_types = {
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_RESULT,
+    }
+    if FRAMEWORK_SUPPORTS_TOOL_CALLS:
+        assert event_types & tool_types, f"No tool call events found. Got: {event_types}"
+
+        # THEN: the tool call events contain the generate_objectid tool
+        tool_call_names = {
+            e.tool_call_name for e in ag_ui_events if e.type == EventType.TOOL_CALL_START
+        }
+        assert "calculator" in tool_call_names, (
+            "No tool call event found for calculator. "
+            f"Got: {tool_call_names}"
+        )
+    else:
+        assert not event_types & tool_types, (
+            f"Tool call events found when framework does not support them. Got: {event_types}"
+        )
+
+    # THEN: the tool call events contain the correct result
+    full_text = collect_text(ag_ui_events)
+    assert EXPECTED_CALCULATOR_RESULT in full_text, (
+        f"Expected '{EXPECTED_CALCULATOR_RESULT}' in response. Got: {full_text[:500]}"
     )

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -27,25 +27,26 @@ from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import parse_sse_responses
 
-CALCULATOR_PROMPT = (
-    "You MUST use the calculator tool to compute the following expression. "
-    "Do NOT compute it yourself. Call the calculator tool with this exact input: "
-    "(1234 * 567890) + 91011. "
-    "Report only the exact numeric result from the tool, no explanation, "
+GENERATE_OBJECTID_PROMPT = (
+    "You MUST use the generate_objectid tool to generate an object ID for a deployment. "
+    "Do NOT generate it yourself. Call the generate_objectid tool with this exact input: "
+    "deployment. "
+    "Report only the exact object ID from the tool, no explanation, "
     "no formatting, no other text. Always return the final answer to the user"
 )
 
-EXPECTED_RESULT = str((1234 * 567890) + 91011)
+EXPECTED_RESULT = "69cbb73789723b6936c6c9e1"
 
 @pytest.mark.skipif(
     FRAMEWORK == "base",
     reason="Base framework does not implement anything, skipping tool call tests",
 )
 
-def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
+def test_generate_objectid_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[type-arg]
     """Agent uses calculator tool when asked to compute."""
-    # GIVEN: a payload that requests the calculator tool to compute the expression
-    payload = make_generate_payload(CALCULATOR_PROMPT)
+    # GIVEN: a payload that requests the generate_objectid tool to generate an object ID for a
+    # deployment
+    payload = make_generate_payload(GENERATE_OBJECTID_PROMPT)
     # WHEN: the payload is streamed to the generate endpoint
     with http_client.stream("POST", GENERATE_STREAM_PATH, json=payload) as response:
         assert response.status_code == 200
@@ -69,12 +70,12 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
     if FRAMEWORK_SUPPORTS_TOOL_CALLS:
         assert event_types & tool_types, f"No tool call events found. Got: {event_types}"
 
-        # THEN: the tool call events contain the calculator tool
+        # THEN: the tool call events contain the generate_objectid tool
         tool_call_names = {
             e.tool_call_name for e in ag_ui_events if e.type == EventType.TOOL_CALL_START
         }
-        assert "calculator" in tool_call_names, (
-            "No tool call event found for calculator. "
+        assert "generate_objectid" in tool_call_names, (
+            "No tool call event found for generate_objectid. "
             f"Got: {tool_call_names}"
         )
     else:

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -59,7 +59,6 @@ def test_generate_objectid_tool_is_called(http_client: httpx.Client) -> None:  #
 
     # THEN: the events are a valid AG-UI sequence
     validate_sequence(ag_ui_events)
-
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}
     tool_types = {

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -32,7 +32,7 @@ CALCULATOR_PROMPT = (
     "Do NOT compute it yourself. Call the calculator tool with this exact input: "
     "(1234 * 567890) + 91011. "
     "Report only the exact numeric result from the tool, no explanation, "
-    "no formatting, no other text. Always return a final answer to the user"
+    "no formatting, no other text. Always return the final answer to the user"
 )
 
 EXPECTED_RESULT = str((1234 * 567890) + 91011)

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -92,6 +92,8 @@ extend-ignore = [
     "PLR0915",
     # Too many branches
     "PLR0912",
+    # inline imports
+    "PLC0415",
 ]
 fixable = [
     "I",    # isort

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "pytest-timeout",
     "python-dotenv",
     "ag-ui-protocol @ git+https://github.com/cavitcakir/ag-ui@feat/python-validate-sequence#egg=ag-ui&subdirectory=sdks/python",
-    "ipdb>=0.13.13",
 ]
 
 [dependency-groups]

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pytest-timeout",
     "python-dotenv",
     "ag-ui-protocol @ git+https://github.com/cavitcakir/ag-ui@feat/python-validate-sequence#egg=ag-ui&subdirectory=sdks/python",
+    "ipdb>=0.13.13",
 ]
 
 [dependency-groups]
@@ -33,6 +34,9 @@ dragent-base = [
 lint = [
     "mypy>=1.19.1",
     "ruff>=0.15.2",
+]
+dev = [
+    "ipdb>=0.13.13",
 ]
 
 [project.entry-points.'nat.plugins']

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -984,9 +984,9 @@ requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'langgraph'", specifier = ">=0.1.14,<0.2.0" },
     { name = "ag-ui-protocol", marker = "extra == 'llamaindex'", specifier = ">=0.1.14,<0.2.0" },
     { name = "ag-ui-protocol", marker = "extra == 'nat'", specifier = ">=0.1.14,<0.2.0" },
-    { name = "aiohttp", marker = "extra == 'auth'", specifier = ">=3.9.0,<4.0.0" },
-    { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.9.0,<4.0.0" },
-    { name = "aiohttp", marker = "extra == 'drtools'", specifier = ">=3.9.0,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'auth'", specifier = ">=3.13.3,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.13.3,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'drtools'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp-retry", marker = "extra == 'drmcp'", specifier = ">=2.8.3,<3.0.0" },
     { name = "anthropic", marker = "extra == 'crewai'", specifier = "~=0.71.0,<1.0.0" },
     { name = "anyio", marker = "extra == 'dragent'", specifier = "==4.11.0" },
@@ -995,6 +995,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'drmcp'", specifier = ">=4.12.0,<5.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drtools'", specifier = ">=4.12.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'drmcp'", specifier = ">=1.34.0,<2.0.0" },
+    { name = "boto3", marker = "extra == 'drtools'", specifier = ">=1.34.0,<2.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.1.0,<2.0.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
     { name = "datarobot", marker = "extra == 'core'", specifier = ">=3.10.0,<4.0.0" },
@@ -1006,6 +1007,8 @@ requires-dist = [
     { name = "datarobot", marker = "extra == 'llamaindex'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", marker = "extra == 'nat'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.10.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.10.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
     { name = "datarobot-early-access", marker = "extra == 'core'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'crewai'", specifier = "==3.14.0.2026.3.18.162920" },
@@ -1119,16 +1122,16 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'drmcp'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic", marker = "extra == 'drtools'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic-settings", marker = "extra == 'drmcp'", specifier = ">=2.1.0,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'core'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'crewai'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'dragent'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'drmcp'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'langgraph'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'llamaindex'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'nat'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pypdf", marker = "extra == 'drmcp'", specifier = ">=6.1.3,<7.0.0" },
-    { name = "pypdf", marker = "extra == 'drtools'", specifier = ">=6.1.3,<7.0.0" },
-    { name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pyjwt", marker = "extra == 'core'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'crewai'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'dragent'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'drmcp'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'langgraph'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'llamaindex'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'nat'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pypdf", marker = "extra == 'drmcp'", specifier = ">=6.9.2,<7.0.0" },
+    { name = "pypdf", marker = "extra == 'drtools'", specifier = ">=6.9.2,<7.0.0" },
+    { name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.9.2,<7.0.0" },
     { name = "python-dateutil", marker = "extra == 'drmcp'", specifier = ">=2.9.0,<3.0.0" },
     { name = "python-dateutil", marker = "extra == 'drtools'", specifier = ">=2.9.0,<3.0.0" },
     { name = "python-dotenv", marker = "extra == 'drmcp'", specifier = ">=1.1.0,<2.0.0" },
@@ -4739,11 +4742,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.9.1"
+version = "6.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/fb/dc2e8cb006e80b0020ed20d8649106fe4274e82d8e756ad3e24ade19c0df/pypdf-6.9.1.tar.gz", hash = "sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d", size = 5311551, upload-time = "2026-03-17T10:46:07.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/f4/75543fa802b86e72f87e9395440fe1a89a6d149887e3e55745715c3352ac/pypdf-6.9.1-py3-none-any.whl", hash = "sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f", size = 333661, upload-time = "2026-03-17T10:46:06.286Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
 ]
 
 [[package]]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1186,7 +1186,6 @@ source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },
     { name = "httpx" },
-    { name = "ipdb" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
@@ -1221,7 +1220,6 @@ lint = [
 requires-dist = [
     { name = "ag-ui-protocol", git = "https://github.com/cavitcakir/ag-ui?subdirectory=sdks%2Fpython&rev=feat%2Fpython-validate-sequence" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
-    { name = "ipdb", specifier = ">=0.13.13" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -286,6 +286,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1177,6 +1186,7 @@ source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },
     { name = "httpx" },
+    { name = "ipdb" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
@@ -1184,6 +1194,9 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "ipdb" },
+]
 dragent-base = [
     { name = "datarobot-genai", extra = ["dragent"] },
 ]
@@ -1208,6 +1221,7 @@ lint = [
 requires-dist = [
     { name = "ag-ui-protocol", git = "https://github.com/cavitcakir/ag-ui?subdirectory=sdks%2Fpython&rev=feat%2Fpython-validate-sequence" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
+    { name = "ipdb", specifier = ">=0.13.13" },
     { name = "pytest" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
@@ -1215,6 +1229,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dev = [{ name = "ipdb", specifier = ">=0.13.13" }]
 dragent-base = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]
 dragent-crewai = [{ name = "datarobot-genai", extras = ["dragent", "crewai"], editable = "../" }]
 dragent-langgraph = [{ name = "datarobot-genai", extras = ["dragent", "langgraph"], editable = "../" }]
@@ -1266,6 +1281,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/74/0c5f29109e02c4c33e8634e31d5cd7d90ecc3ed7c95e1b377ece08354068/datasets-4.8.3.tar.gz", hash = "sha256:882fb1bb514772bec17fbcad2e32985893954d0a0ecf42266e5091386be1f3b7", size = 604294, upload-time = "2026-03-19T17:43:59.32Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/c6/b8298394a8926f8af21c059f4ec794b61f9cf64ade561184027b94110639/datasets-4.8.3-py3-none-any.whl", hash = "sha256:a66cb506097bfce8461b076fb9e86ea216e00fd622387ba19909d9c1689ff8f9", size = 526834, upload-time = "2026-03-19T17:43:57.337Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
 ]
 
 [[package]]
@@ -1385,6 +1409,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -1906,12 +1939,100 @@ wheels = [
 ]
 
 [[package]]
+name = "ipdb"
+version = "0.13.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/1b/7e07e7b752017f7693a0f4d41c13e5ca29ce8cbcfdcc1fd6c4ad8c0a27a0/ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726", size = 17042, upload-time = "2023-03-09T15:40:57.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4c/b075da0092003d9a55cf2ecc1cae9384a1ca4f650d51b00fc59875fe76f6/ipdb-0.13.13-py3-none-any.whl", hash = "sha256:45529994741c4ab6d2388bfa5d7b725c2cf7fe9deffabdb8a6113aa5ed449ed4", size = 12130, upload-time = "2023-03-09T15:40:55.021Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.10.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
+    { name = "jedi", marker = "python_full_version < '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
+    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "stack-data", marker = "python_full_version < '3.12'" },
+    { name = "traitlets", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/09/ba70f8d662d5671687da55ad2cc0064cf795b15e1eea70907532202e7c97/ipython-9.10.1-py3-none-any.whl", hash = "sha256:82d18ae9fb9164ded080c71ef92a182ee35ee7db2395f67616034bebb020a232", size = 622827, upload-time = "2026-03-27T09:53:24.566Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.12.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
+    { name = "jedi", marker = "python_full_version >= '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
+    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "stack-data", marker = "python_full_version >= '3.12'" },
+    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/22/906c8108974c673ebef6356c506cebb6870d48cedea3c41e949e2dd556bb/ipython-9.12.0-py3-none-any.whl", hash = "sha256:0f2701e8ee86e117e37f50563205d36feaa259d2e08d4a6bc6b6d74b18ce128d", size = 625661, upload-time = "2026-03-27T09:42:42.831Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
 ]
 
 [[package]]
@@ -2993,6 +3114,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
 ]
 
 [[package]]
@@ -4130,6 +4263,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4163,6 +4305,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
@@ -4330,6 +4484,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4422,6 +4588,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/d7/48cbf6b0c3c39761e47a99cb483405f0fde2be22cf00d71ef316ce52b458/protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6", size = 320284, upload-time = "2026-02-04T22:54:31.782Z" },
     { url = "https://files.pythonhosted.org/packages/e3/dd/cadd6ec43069247d91f6345fa7a0d2858bef6af366dbd7ba8f05d2c77d3b/protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9", size = 320478, upload-time = "2026-02-04T22:54:32.909Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cb/e3065b447186cb70aa65acc70c86baf482d82bf75625bf5a2c4f6919c6a3/protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86", size = 173126, upload-time = "2026-02-04T22:54:39.462Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -5466,6 +5650,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "stagehand"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5675,6 +5873,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/ed/aac034e566f8846aee6472dcc90da6011a0b1829e3ffc768407df519a3b0/trafaret-2.1.1.tar.gz", hash = "sha256:d9d00800318fbd343fdfb3353e947b2ebb5557159c844696c5ac24846f76d41c", size = 26249, upload-time = "2022-04-01T17:36:25.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/32/17b47745df926eff2e5b89d79838337de88258f65a936f70416a15190142/trafaret-2.1.1-py3-none-any.whl", hash = "sha256:1966f432586797aed663edd54cbc201fd7ba59eed1638f1a7a33f17977b3a569", size = 28399, upload-time = "2022-04-01T17:36:29.066Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -5957,6 +6164,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.9.0"
+version = "0.10.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -53,11 +53,35 @@ class BaseAgent(Generic[TTool], abc.ABC):
       - model: Preferred model name
       - timeout: Request timeout
       - verbose: Verbosity flag
-      - authorization_context: Authorization context for downstream agents/tools
+      - forwarded_headers: Forwarded headers for the agent
       - max_history_messages: Maximum number of prior messages to include in chat history
+      - memory_client: Memory client for the agent
     """
 
-    _max_history_messages: int | None = None
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        model: str | None = None,
+        tools: list[TTool] | None = None,
+        verbose: bool = True,
+        timeout: int | None = 90,
+        forwarded_headers: dict[str, str] | None = None,
+        max_history_messages: int | None = None,
+        memory_client: BaseMemoryClient | None = None,
+    ) -> None:
+        self.api_key = api_key or os.environ.get("DATAROBOT_API_TOKEN")
+        self.api_base = (
+            api_base or os.environ.get("DATAROBOT_ENDPOINT") or "https://app.datarobot.com"
+        )
+        self.model = model
+        self.timeout = timeout if timeout is not None else 90
+        self.verbose = verbose
+        self._tools: list[TTool] = tools or []
+        self._forwarded_headers: dict[str, str] = forwarded_headers or {}
+        self._identity_header: dict[str, str] = prepare_identity_header(self._forwarded_headers)
+        self._max_history_messages = max_history_messages
+        self._memory_client: BaseMemoryClient | None = memory_client
 
     @property
     def max_history_messages(self) -> int:
@@ -71,55 +95,16 @@ class BaseAgent(Generic[TTool], abc.ABC):
             return self._max_history_messages
         return get_max_history_messages_default()
 
-    def __init__(
-        self,
-        *,
-        api_key: str | None = None,
-        api_base: str | None = None,
-        model: str | None = None,
-        verbose: bool | str | None = True,
-        timeout: int | None = 90,
-        authorization_context: dict[str, Any] | None = None,
-        forwarded_headers: dict[str, str] | None = None,
-        max_history_messages: int | None = None,
-        memory_client: BaseMemoryClient | None = None,
-        **_: Any,
-    ) -> None:
-        self._max_history_messages = max_history_messages
-        self.api_key = api_key or os.environ.get("DATAROBOT_API_TOKEN")
-        self.api_base = (
-            api_base or os.environ.get("DATAROBOT_ENDPOINT") or "https://app.datarobot.com"
-        )
-        self.model = model
-        self.timeout = timeout if timeout is not None else 90
-        if isinstance(verbose, str):
-            self.verbose = verbose.lower() == "true"
-        elif verbose is None:
-            self.verbose = True
-        else:
-            self.verbose = bool(verbose)
-        self._mcp_tools: list[TTool] = []
-        self._authorization_context = authorization_context or {}
-        self._forwarded_headers: dict[str, str] = forwarded_headers or {}
-        self._identity_header: dict[str, str] = prepare_identity_header(self._forwarded_headers)
-        self._memory_client: BaseMemoryClient | None = memory_client
-
-    def set_mcp_tools(self, tools: list[TTool]) -> None:
-        self._mcp_tools = tools
+    def set_tools(self, tools: list[TTool]) -> None:
+        self._tools = tools
 
     @property
-    def mcp_tools(self) -> list[TTool]:
-        """Return the list of MCP tools available to this agent.
+    def tools(self) -> list[TTool]:
+        """Return the list of tools available to this agent.
 
-        Subclasses can use this to wire tools into CrewAI agents/tasks during
-        workflow construction inside ``crew``.
+        Subclasses can use this to wire tools into the agent.
         """
-        return self._mcp_tools
-
-    @property
-    def authorization_context(self) -> dict[str, Any]:
-        """Return the authorization context for this agent."""
-        return self._authorization_context
+        return self._tools
 
     @property
     def forwarded_headers(self) -> dict[str, str]:

--- a/src/datarobot_genai/core/mcp/__init__.py
+++ b/src/datarobot_genai/core/mcp/__init__.py
@@ -1,0 +1,3 @@
+from .config import MCPConfig
+
+__all__ = ["MCPConfig"]

--- a/src/datarobot_genai/core/utils/logging.py
+++ b/src/datarobot_genai/core/utils/logging.py
@@ -1,0 +1,30 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging() -> None:
+    """Setup uniform logging for the application."""  # noqa: D401
+    current_log_level = logging.getLogger().getEffectiveLevel()
+    logger.info(f"Setting up logging, log level: {logging._levelToName[current_log_level]}")
+
+    for name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"):
+        lg = logging.getLogger(name)
+        if lg:
+            logger.debug(f"Resetting logger {name}")
+            lg.handlers.clear()
+            lg.propagate = True

--- a/src/datarobot_genai/crewai/__init__.py
+++ b/src/datarobot_genai/crewai/__init__.py
@@ -4,8 +4,6 @@ Public API:
 - mcp_tools_context: Context manager returning available MCP tools for CrewAI.
 """
 
-from datarobot_genai.core.mcp.config import MCPConfig
-
 from .agent import CrewAIAgent
 from .events import CrewAIRagasEventListener
 from .mcp import mcp_tools_context
@@ -14,5 +12,4 @@ __all__ = [
     "mcp_tools_context",
     "CrewAIAgent",
     "CrewAIRagasEventListener",
-    "MCPConfig",
 ]

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -319,6 +319,23 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                         None,
                         usage_metrics,
                     )
+                if reasoning_started:
+                    yield (
+                        ReasoningMessageEndEvent(
+                            type=EventType.REASONING_MESSAGE_END,
+                            message_id=message_id,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
+                    yield (
+                        ReasoningEndEvent(
+                            type=EventType.REASONING_END,
+                            message_id=message_id,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
             else:
                 response_text = str(crew_output.raw)
                 pipeline_interactions = self.create_pipeline_interactions_from_messages(

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -207,9 +207,9 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                     kickoff_inputs["chat_history"] = f"\n\nPrior conversation:\n{history_summary}"
             message_id = str(uuid.uuid4())
             crew_output = await crew.kickoff_async(inputs=kickoff_inputs)
+            current_agent_role = ""
 
             if isinstance(crew_output, CrewStreamingOutput):
-                current_agent_role = ""
                 reasoning_started = False
                 text_started = False
                 async for chunk in crew_output:

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -45,8 +45,6 @@ from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 from datarobot_genai.crewai.events import CrewAIRagasEventListener
 
-from .mcp import mcp_tools_context
-
 if TYPE_CHECKING:
     from ragas import MultiTurnSample
     from ragas.messages import AIMessage
@@ -172,56 +170,44 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
         pipeline_interactions: MultiTurnSample | None = None
         usage_metrics = default_usage_metrics()
 
-        # Use MCP context manager to handle connection lifecycle
-        with mcp_tools_context(
-            authorization_context=self.authorization_context,
-            forwarded_headers=self.forwarded_headers,
-        ) as mcp_tools:
-            # Set MCP tools for all agents if MCP is not configured this is effectively a no-op
-            self.set_mcp_tools(mcp_tools)
+        with crewai_event_bus.scoped_handlers():
+            ragas_event_listener = CrewAIRagasEventListener()
+            ragas_event_listener.setup_listeners(crewai_event_bus)
 
-            with crewai_event_bus.scoped_handlers():
-                ragas_event_listener = CrewAIRagasEventListener()
-                ragas_event_listener.setup_listeners(crewai_event_bus)
+            crew = self.crew()
 
-                crew = self.crew()
+            kickoff_inputs = self.make_kickoff_inputs(str(user_prompt_content))
+            # Chat history is opt-in: only populate it if the agent/template
+            # declares a `chat_history` kickoff input (i.e. it uses `{chat_history}`
+            # in prompts).
+            if "chat_history" in kickoff_inputs:
+                history_summary = self.build_history_summary(run_agent_input)
+                existing_history_text = str(kickoff_inputs.get("chat_history") or "")
 
-                kickoff_inputs = self.make_kickoff_inputs(str(user_prompt_content))
-                # Chat history is opt-in: only populate it if the agent/template
-                # declares a `chat_history` kickoff input (i.e. it uses `{chat_history}`
-                # in prompts).
-                if "chat_history" in kickoff_inputs:
-                    history_summary = self.build_history_summary(run_agent_input)
-                    existing_history_text = str(kickoff_inputs.get("chat_history") or "")
+                if history_summary and not existing_history_text.strip():
+                    kickoff_inputs["chat_history"] = f"\n\nPrior conversation:\n{history_summary}"
 
-                    if history_summary and not existing_history_text.strip():
-                        kickoff_inputs["chat_history"] = (
-                            f"\n\nPrior conversation:\n{history_summary}"
-                        )
+            crew_output = await asyncio.to_thread(crew.kickoff, inputs=kickoff_inputs)
 
-                crew_output = await asyncio.to_thread(crew.kickoff, inputs=kickoff_inputs)
+            response_text = str(crew_output.raw)
+            pipeline_interactions = self.create_pipeline_interactions_from_messages(
+                ragas_event_listener.messages
+            )
+            usage_metrics = self._extract_usage_metrics(crew_output)
 
-                response_text = str(crew_output.raw)
-                pipeline_interactions = self.create_pipeline_interactions_from_messages(
-                    ragas_event_listener.messages
-                )
-                usage_metrics = self._extract_usage_metrics(crew_output)
-
-                if response_text:
-                    yield (
-                        TextMessageChunkEvent(
-                            type=EventType.TEXT_MESSAGE_CHUNK,
-                            message_id=str(uuid.uuid4()),
-                            delta=response_text,
-                        ),
-                        None,
-                        usage_metrics,
-                    )
-
+            if response_text:
                 yield (
-                    RunFinishedEvent(
-                        type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id
+                    TextMessageChunkEvent(
+                        type=EventType.TEXT_MESSAGE_CHUNK,
+                        message_id=str(uuid.uuid4()),
+                        delta=response_text,
                     ),
-                    pipeline_interactions,
+                    None,
                     usage_metrics,
                 )
+
+            yield (
+                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id),
+                pipeline_interactions,
+                usage_metrics,
+            )

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -24,6 +24,7 @@ default. Subclasses may implement message capture if they need interactions.
 from __future__ import annotations
 
 import abc
+import logging
 import uuid
 from typing import TYPE_CHECKING
 from typing import Any
@@ -31,6 +32,8 @@ from typing import Any
 from ag_ui.core import EventType
 from ag_ui.core import ReasoningEndEvent
 from ag_ui.core import ReasoningMessageContentEvent
+from ag_ui.core import ReasoningMessageEndEvent
+from ag_ui.core import ReasoningMessageStartEvent
 from ag_ui.core import ReasoningStartEvent
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
@@ -61,6 +64,8 @@ if TYPE_CHECKING:
     from ragas.messages import HumanMessage
     from ragas.messages import ToolMessage
 
+logger = logging.getLogger(__name__)
+
 
 class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
     """Abstract base agent for CrewAI workflows.
@@ -85,7 +90,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
         Default implementation constructs a Crew with provided agents and tasks.
         Subclasses can override to customize Crew options.
         """
-        return Crew(agents=self.agents, tasks=self.tasks, verbose=self.verbose)
+        return Crew(agents=self.agents, tasks=self.tasks, verbose=self.verbose, stream=True)
 
     @abc.abstractmethod
     def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
@@ -160,12 +165,9 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the CrewAI workflow with the provided completion parameters."""
         user_prompt_content = extract_user_prompt_content(run_agent_input)
-        # Preserve prior template startup print for CLI parity
-        try:
-            print("Running agent with user prompt:", user_prompt_content, flush=True)
-        except Exception:
-            # Printing is best-effort; proceed regardless
-            pass
+        logger.info(
+            f"Running agent with user prompt: {user_prompt_content}",
+        )
 
         thread_id = run_agent_input.thread_id
         run_id = run_agent_input.run_id
@@ -207,16 +209,32 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
             crew_output = await crew.kickoff_async(inputs=kickoff_inputs)
 
             if isinstance(crew_output, CrewStreamingOutput):
-                current_task = ""
+                current_agent_role = ""
                 reasoning_started = False
-                step_started = False
                 text_started = False
                 async for chunk in crew_output:
                     # Show task transitions
-                    if chunk.task_name != current_task:
-                        current_task = chunk.task_name
-                        print(f"\n[{chunk.agent_role}] Working on: {chunk.task_name}")
-                        print("-" * 60)
+                    logger.debug(f"CrewAI chunk: {chunk.model_dump_json()}")
+                    if chunk.agent_role != current_agent_role:
+                        logger.info(f"[{chunk.agent_role}] Working on task: {chunk.task_name}")
+                        if current_agent_role:
+                            yield (
+                                StepFinishedEvent(
+                                    type=EventType.STEP_FINISHED,
+                                    step_name=current_agent_role,
+                                ),
+                                None,
+                                zero_metrics,
+                            )
+                        yield (
+                            StepStartedEvent(
+                                type=EventType.STEP_STARTED,
+                                step_name=chunk.agent_role,
+                            ),
+                            None,
+                            zero_metrics,
+                        )
+                        current_agent_role = chunk.agent_role
 
                     if streaming_event_listener.reasoning_event:
                         if not reasoning_started:
@@ -228,8 +246,24 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                                 None,
                                 zero_metrics,
                             )
+                            yield (
+                                ReasoningMessageStartEvent(
+                                    type=EventType.REASONING_MESSAGE_START,
+                                    message_id=message_id,
+                                ),
+                                None,
+                                zero_metrics,
+                            )
                             reasoning_started = True
                     elif reasoning_started:
+                        yield (
+                            ReasoningMessageEndEvent(
+                                type=EventType.REASONING_MESSAGE_END,
+                                message_id=message_id,
+                            ),
+                            None,
+                            zero_metrics,
+                        )
                         yield (
                             ReasoningEndEvent(
                                 type=EventType.REASONING_END,
@@ -239,28 +273,6 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                             zero_metrics,
                         )
                         reasoning_started = False
-
-                    if streaming_event_listener.step_event:
-                        if not step_started:
-                            yield (
-                                StepStartedEvent(
-                                    type=EventType.STEP_STARTED,
-                                    step_name=current_task,
-                                ),
-                                None,
-                                zero_metrics,
-                            )
-                            step_started = True
-                    elif step_started:
-                        yield (
-                            StepFinishedEvent(
-                                type=EventType.STEP_FINISHED,
-                                step_name=current_task,
-                            ),
-                            None,
-                            zero_metrics,
-                        )
-                        step_started = False
 
                     # Display text chunks
                     if chunk.chunk_type == StreamChunkType.TEXT:
@@ -296,7 +308,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                             )
                     # Display tool calls
                     elif chunk.chunk_type == StreamChunkType.TOOL_CALL and chunk.tool_call:
-                        print(f"\nUsing tool: {chunk.tool_call.tool_name}")
+                        logger.info(f"Using tool: {chunk.tool_call.tool_name}")
                 pipeline_interactions = self.create_pipeline_interactions_from_messages(
                     ragas_event_listener.messages
                 )
@@ -304,15 +316,6 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                 if text_started:
                     yield (
                         TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),
-                        None,
-                        usage_metrics,
-                    )
-                if step_started:
-                    yield (
-                        StepFinishedEvent(
-                            type=EventType.STEP_FINISHED,
-                            step_name=current_task,
-                        ),
                         None,
                         usage_metrics,
                     )
@@ -334,6 +337,15 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                         usage_metrics,
                     )
 
+            if current_agent_role:
+                yield (
+                    StepFinishedEvent(
+                        type=EventType.STEP_FINISHED,
+                        step_name=current_agent_role,
+                    ),
+                    None,
+                    usage_metrics,
+                )
             yield (
                 RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id),
                 pipeline_interactions,

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -202,9 +202,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                 existing_history_text = str(kickoff_inputs.get("chat_history") or "")
 
                 if history_summary and not existing_history_text.strip():
-                    kickoff_inputs["chat_history"] = (
-                        f"\n\nPrior conversation:\n{history_summary}"
-                    )
+                    kickoff_inputs["chat_history"] = f"\n\nPrior conversation:\n{history_summary}"
             message_id = str(uuid.uuid4())
             crew_output = await crew.kickoff_async(inputs=kickoff_inputs)
 
@@ -305,9 +303,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                 usage_metrics = self._extract_usage_metrics(crew_output.result)
                 if text_started:
                     yield (
-                        TextMessageEndEvent(
-                            type=EventType.TEXT_MESSAGE_END, message_id=message_id
-                        ),
+                        TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),
                         None,
                         usage_metrics,
                     )
@@ -339,9 +335,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                     )
 
             yield (
-                RunFinishedEvent(
-                    type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id
-                ),
+                RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id),
                 pipeline_interactions,
                 usage_metrics,
             )

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -40,14 +40,9 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
     print(f"Connecting to MCP server: {mcp_config.server_config['url']}", flush=True)
 
     # Use MCPServerAdapter as context manager with the server config
-    try:
-        with MCPServerAdapter(mcp_config.server_config) as tools:
-            print(
-                f"Successfully connected to MCP server, got {len(tools)} tools",
-                flush=True,
-            )
-            yield tools
-    except Exception as exc:
-        # Gracefully degrade when connection fails or adapter initialization raises
-        print(f"Failed to connect to MCP server: {exc}", flush=True)
-        yield []
+    with MCPServerAdapter(mcp_config.server_config) as tools:
+        print(
+            f"Successfully connected to MCP server, got {len(tools)} tools",
+            flush=True,
+        )
+        yield tools

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -24,7 +24,7 @@ from contextlib import asynccontextmanager
 from crewai.tools import BaseTool
 from crewai_tools import MCPServerAdapter
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 
 
 # here it is async to conform with other MCP adapters

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -18,36 +18,30 @@ MCP integration for CrewAI using MCPServerAdapter.
 This module provides MCP server connection management for CrewAI agents.
 """
 
-from collections.abc import Generator
-from contextlib import contextmanager
-from typing import Any
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
+from crewai.tools import BaseTool
 from crewai_tools import MCPServerAdapter
 
 from datarobot_genai.core.mcp.config import MCPConfig
 
 
-@contextmanager
-def mcp_tools_context(
-    authorization_context: dict[str, Any] | None = None,
-    forwarded_headers: dict[str, str] | None = None,
-) -> Generator[list[Any], None, None]:
+# here it is async to conform with other MCP adapters
+@asynccontextmanager
+async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTool], None]:
     """Context manager for MCP tools that handles connection lifecycle."""
-    config = MCPConfig(
-        authorization_context=authorization_context,
-        forwarded_headers=forwarded_headers,
-    )
     # If no MCP server configured, return empty tools list
-    if not config.server_config:
+    if not mcp_config.server_config:
         print("No MCP server configured, using empty tools list", flush=True)
         yield []
         return
 
-    print(f"Connecting to MCP server: {config.server_config['url']}", flush=True)
+    print(f"Connecting to MCP server: {mcp_config.server_config['url']}", flush=True)
 
     # Use MCPServerAdapter as context manager with the server config
     try:
-        with MCPServerAdapter(config.server_config) as tools:
+        with MCPServerAdapter(mcp_config.server_config) as tools:
             print(
                 f"Successfully connected to MCP server, got {len(tools)} tools",
                 flush=True,

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -18,6 +18,7 @@ MCP integration for CrewAI using MCPServerAdapter.
 This module provides MCP server connection management for CrewAI agents.
 """
 
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -26,6 +27,8 @@ from crewai_tools import MCPServerAdapter
 
 from datarobot_genai.core.mcp import MCPConfig
 
+logger = logging.getLogger(__name__)
+
 
 # here it is async to conform with other MCP adapters
 @asynccontextmanager
@@ -33,16 +36,13 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
     """Context manager for MCP tools that handles connection lifecycle."""
     # If no MCP server configured, return empty tools list
     if not mcp_config.server_config:
-        print("No MCP server configured, using empty tools list", flush=True)
+        logger.info("No MCP server configured, using empty tools list")
         yield []
         return
 
-    print(f"Connecting to MCP server: {mcp_config.server_config['url']}", flush=True)
+    logger.info(f"Connecting to MCP server: {mcp_config.server_config['url']}")
 
     # Use MCPServerAdapter as context manager with the server config
     with MCPServerAdapter(mcp_config.server_config) as tools:
-        print(
-            f"Successfully connected to MCP server, got {len(tools)} tools",
-            flush=True,
-        )
+        logger.info(f"Successfully connected to MCP server, got {len(tools)} tools")
         yield tools

--- a/src/datarobot_genai/crewai/ragas_events.py
+++ b/src/datarobot_genai/crewai/ragas_events.py
@@ -79,9 +79,7 @@ class CrewAIRagasEventListener:
 
         @crewai_event_bus.on(TaskCompletedEvent)
         def on_agent_task_completed(_: Any, event: Any) -> None:
-            self.messages.append(
-                AIMessage(content=f"Task output: '{json.dumps(event.output)}'", tool_calls=[])
-            )
+            self.messages.append(AIMessage(content=f"Task output: '{event.output}'", tool_calls=[]))
 
         @crewai_event_bus.on(TaskFailedEvent)
         def on_agent_task_failed(_: Any, event: Any) -> None:

--- a/src/datarobot_genai/crewai/streaming_events.py
+++ b/src/datarobot_genai/crewai/streaming_events.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from crewai.events.event_bus import CrewAIEventsBus
@@ -22,6 +23,8 @@ from crewai.events.event_types import AgentReasoningStartedEvent
 from crewai.events.event_types import TaskCompletedEvent
 from crewai.events.event_types import TaskFailedEvent
 from crewai.events.event_types import TaskStartedEvent
+
+logger = logging.getLogger(__name__)
 
 
 class CrewAIStreamingEventListener:
@@ -35,24 +38,30 @@ class CrewAIStreamingEventListener:
 
         @crewai_event_bus.on(AgentReasoningStartedEvent)
         def on_agent_reasoning_started(_: Any, event: Any) -> None:
+            logger.debug("Reasoning started")
             self.reasoning_event = True
 
         @crewai_event_bus.on(AgentReasoningCompletedEvent)
         def on_agent_reasoning_completed(_: Any, event: Any) -> None:
+            logger.debug("Reasoning completed")
             self.reasoning_event = False
 
         @crewai_event_bus.on(AgentReasoningFailedEvent)
         def on_agent_reasoning_failed(_: Any, event: Any) -> None:
+            logger.debug("Reasoning failed")
             self.reasoning_event = False
 
         @crewai_event_bus.on(TaskCompletedEvent)
         def on_agent_task_completed(_: Any, event: Any) -> None:
+            logger.debug("Task completed")
             self.step_event = False
 
         @crewai_event_bus.on(TaskFailedEvent)
         def on_agent_task_failed(_: Any, event: Any) -> None:
+            logger.debug("Task failed")
             self.step_event = False
 
         @crewai_event_bus.on(TaskStartedEvent)
         def on_agent_task_started(_: Any, event: Any) -> None:
+            logger.debug("Task started")
             self.step_event = True

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -34,6 +34,8 @@ from nat.runtime.loader import WorkflowBuilder
 from pydantic import BaseModel
 from pydantic import Field
 
+from datarobot_genai.core.utils.logging import setup_logging
+
 from .session import DRAgentAGUISessionManager
 from .step_adaptor import DRAgentNestedReasoningStepAdaptor
 
@@ -215,6 +217,8 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
                 logger.info("A2A worker resources cleaned up")
 
         app.router.lifespan_context = lifespan
+
+        setup_logging()
         return app
 
     async def add_health_route(self, app: FastAPI) -> None:

--- a/src/datarobot_genai/dragent/frontends/patches.py
+++ b/src/datarobot_genai/dragent/frontends/patches.py
@@ -19,6 +19,11 @@ nvidia-nat-crewai 1.4.1 expects crewai < 1.0.0 response format where
 ``message`` is a proper attribute on the choice object. This module patches
 the callback handler to support both formats.
 
+When ``stream=True``, LiteLLM returns a stream object (e.g. ``CustomStreamWrapper``)
+without ``.choices``. NAT's ``wrapped_llm_call`` only handles non-streaming
+``ModelResponse`` objects, so streaming calls must bypass that wrapper and call
+``litellm.completion`` directly.
+
 TODO(BUZZOK-29844): Remove once nvidia-nat-crewai ships a fix upstream.
 Upstream issue: https://github.com/NVIDIA/NeMo-Agent-Toolkit/issues/1802
 """
@@ -44,12 +49,15 @@ def patch_crewai_callback_handler() -> None:
 
     def _patched_llm_call_monkey_patch(self: Any) -> Callable[..., Any]:
         """Wrap the original monkey patch to inject message into model_extra before it runs."""
-        original_func = self._original_llm_call
+        original_litellm = self._original_llm_call
 
         def fixed_wrapped(*args: Any, **kwargs: Any) -> Any:
             def compat_completion(*a: Any, **kw: Any) -> Any:
-                output = original_func(*a, **kw)
-                for choice in output.choices:
+                output = original_litellm(*a, **kw)
+                choices = getattr(output, "choices", None)
+                if not choices:
+                    return output
+                for choice in choices:
                     if (
                         choice.model_extra is not None
                         and "message" not in choice.model_extra
@@ -62,9 +70,16 @@ def patch_crewai_callback_handler() -> None:
             self._original_llm_call = compat_completion
             try:
                 patched_wrapped = _original_method(self)
-                return patched_wrapped(*args, **kwargs)
+
+                def dispatch(*a: Any, **kw: Any) -> Any:
+                    # NAT's wrapped_llm_call reads output.choices; streaming returns an iterator.
+                    if kw.get("stream"):
+                        return original_litellm(*a, **kw)
+                    return patched_wrapped(*a, **kw)
+
+                return dispatch(*args, **kwargs)
             finally:
-                self._original_llm_call = original_func
+                self._original_llm_call = original_litellm
 
         return fixed_wrapped
 

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -43,7 +43,6 @@ from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
-from datarobot_genai.langgraph.mcp import mcp_tools_context
 
 if TYPE_CHECKING:
     from ragas import MultiTurnSample
@@ -139,18 +138,13 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
             pipeline_interactions, usage_metrics).
         """
         try:
-            async with mcp_tools_context(
-                authorization_context=self._authorization_context,
-                forwarded_headers=self.forwarded_headers,
-            ) as mcp_tools:
-                self.set_mcp_tools(mcp_tools)
-                result = await self._invoke(run_agent_input)
+            result = await self._invoke(run_agent_input)
 
-                # Yield all items from the result generator
-                # The context will be closed when this generator is exhausted
-                # Cast to async generator since we know stream=True means it's a generator
-                async for item in result:
-                    yield item
+            # Yield all items from the result generator
+            # The context will be closed when this generator is exhausted
+            # Cast to async generator since we know stream=True means it's a generator
+            async for item in result:
+                yield item
         except RuntimeError as e:
             error_message = str(e).lower()
             if "different task" in error_message and "cancel scope" in error_message:

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -91,6 +92,9 @@ async def mcp_tools_context(
         print("No MCP server configured, using empty tools list", flush=True)
         yield []
         return
+
+    # Prevent mutation of the original server_config
+    server_config = copy.deepcopy(server_config)
 
     url = server_config["url"]
     print(f"Connecting to MCP server: {url}", flush=True)

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -24,7 +24,7 @@ from langchain_mcp_adapters.sessions import create_session
 from langchain_mcp_adapters.tools import load_mcp_tools
 from pydantic import PrivateAttr
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 
 
 def _wrap_mcp_tool_for_langgraph(inner: BaseTool) -> BaseTool:

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -72,8 +72,7 @@ def _wrap_mcp_tool_for_langgraph(inner: BaseTool) -> BaseTool:
 
 @asynccontextmanager
 async def mcp_tools_context(
-    authorization_context: dict[str, Any] | None = None,
-    forwarded_headers: dict[str, str] | None = None,
+    mcp_config: MCPConfig,
 ) -> AsyncGenerator[list[BaseTool], None]:
     """Yield a list of LangChain BaseTool instances loaded via MCP.
 
@@ -86,10 +85,6 @@ async def mcp_tools_context(
     forwarded_headers : dict[str, str] | None
         Forwarded headers, e.g. x-datarobot-api-key to use for MCP authentication
     """
-    mcp_config = MCPConfig(
-        authorization_context=authorization_context,
-        forwarded_headers=forwarded_headers,
-    )
     server_config = mcp_config.server_config
 
     if not server_config:

--- a/src/datarobot_genai/llama_index/__init__.py
+++ b/src/datarobot_genai/llama_index/__init__.py
@@ -4,11 +4,11 @@ from datarobot_genai.core.mcp.config import MCPConfig
 
 from .agent import DataRobotLiteLLM
 from .agent import LlamaIndexAgent
-from .mcp import load_mcp_tools
+from .mcp import mcp_tools_context
 
 __all__ = [
     "DataRobotLiteLLM",
     "LlamaIndexAgent",
-    "load_mcp_tools",
+    "mcp_tools_context",
     "MCPConfig",
 ]

--- a/src/datarobot_genai/llama_index/__init__.py
+++ b/src/datarobot_genai/llama_index/__init__.py
@@ -1,7 +1,5 @@
 """LlamaIndex utilities and helpers."""
 
-from datarobot_genai.core.mcp.config import MCPConfig
-
 from .agent import DataRobotLiteLLM
 from .agent import LlamaIndexAgent
 from .mcp import mcp_tools_context
@@ -10,5 +8,4 @@ __all__ = [
     "DataRobotLiteLLM",
     "LlamaIndexAgent",
     "mcp_tools_context",
-    "MCPConfig",
 ]

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -67,23 +67,6 @@ class DataRobotLiteLLM(LiteLLM):
 class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
     """Abstract base agent for LlamaIndex workflows."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._mcp_tools: list[Any] = []
-
-    def set_mcp_tools(self, tools: list[Any]) -> None:
-        """Set MCP tools for this agent."""
-        self._mcp_tools = tools
-
-    @property
-    def mcp_tools(self) -> list[Any]:
-        """Return the list of MCP tools available to this agent.
-
-        Subclasses can use this to wire tools into LlamaIndex agents during
-        workflow construction inside ``build_workflow``.
-        """
-        return self._mcp_tools
-
     @abc.abstractmethod
     async def build_workflow(self) -> Any:
         """Return an AgentWorkflow instance ready to run."""

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -45,8 +45,6 @@ from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 
-from .mcp import load_mcp_tools
-
 if TYPE_CHECKING:
     from ragas import MultiTurnSample
 
@@ -112,13 +110,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 f"\n\nPrior conversation:\n{history_summary}" if history_summary else ""
             )
             input_message = input_message.replace("{chat_history}", formatted_history)
-
-        # Load MCP tools (if configured) asynchronously before building workflow
-        mcp_tools = await load_mcp_tools(
-            authorization_context=self.authorization_context,
-            forwarded_headers=self.forwarded_headers,
-        )
-        self.set_mcp_tools(mcp_tools)
 
         # Preserve prior template startup print for CLI parity
         try:

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -55,25 +55,18 @@ async def mcp_tools_context(
     url = server_params["url"]
     headers = server_params.get("headers", {})
 
-    tools = []
-    try:
-        print(f"Connecting to MCP server: {url}", flush=True)
-        # Create BasicMCPClient with headers to pass authentication
-        client = BasicMCPClient(command_or_url=url, headers=headers)
-        tools = await aget_tools_from_mcp_url(
-            command_or_url=url,
-            client=client,
-        )
-        # Ensure list
-        tools = list(tools) if tools is not None else []
-        print(
-            f"Successfully connected to MCP server, got {len(tools)} tools",
-            flush=True,
-        )
-    except Exception as e:
-        print(
-            f"Warning: Failed to connect to MCP server {url}: {e}",
-            flush=True,
-        )
+    print(f"Connecting to MCP server: {url}", flush=True)
+    # Create BasicMCPClient with headers to pass authentication
+    client = BasicMCPClient(command_or_url=url, headers=headers)
+    tools = await aget_tools_from_mcp_url(
+        command_or_url=url,
+        client=client,
+    )
+    # Ensure list
+    tools = list(tools) if tools is not None else []
+    print(
+        f"Successfully connected to MCP server, got {len(tools)} tools",
+        flush=True,
+    )
 
     yield tools

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -27,7 +27,7 @@ from llama_index.core.tools import BaseTool
 from llama_index.tools.mcp import BasicMCPClient
 from llama_index.tools.mcp import aget_tools_from_mcp_url
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 
 
 @asynccontextmanager

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -20,18 +20,20 @@ Unlike CrewAI which uses a context manager, LlamaIndex uses async calls to
 fetch tools from MCP servers.
 """
 
-from typing import Any
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
+from llama_index.core.tools import BaseTool
 from llama_index.tools.mcp import BasicMCPClient
 from llama_index.tools.mcp import aget_tools_from_mcp_url
 
 from datarobot_genai.core.mcp.config import MCPConfig
 
 
-async def load_mcp_tools(
-    authorization_context: dict[str, Any] | None = None,
-    forwarded_headers: dict[str, str] | None = None,
-) -> list[Any]:
+@asynccontextmanager
+async def mcp_tools_context(
+    mcp_config: MCPConfig,
+) -> AsyncGenerator[list[BaseTool], None]:
     """
     Asynchronously load MCP tools for LlamaIndex.
 
@@ -43,15 +45,12 @@ async def load_mcp_tools(
     -------
         List of MCP tools, or empty list if no MCP configuration is present.
     """
-    config = MCPConfig(
-        authorization_context=authorization_context,
-        forwarded_headers=forwarded_headers,
-    )
-    server_params = config.server_config
+    server_params = mcp_config.server_config
 
     if not server_params:
         print("No MCP server configured, using empty tools list", flush=True)
-        return []
+        yield []
+        return
 
     url = server_params["url"]
     headers = server_params.get("headers", {})
@@ -70,10 +69,10 @@ async def load_mcp_tools(
             f"Successfully connected to MCP server, got {len(tools_list)} tools",
             flush=True,
         )
-        return tools_list
+        yield tools_list
     except Exception as e:
         print(
             f"Warning: Failed to connect to MCP server {url}: {e}",
             flush=True,
         )
-        return []
+        yield []

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -55,6 +55,7 @@ async def mcp_tools_context(
     url = server_params["url"]
     headers = server_params.get("headers", {})
 
+    tools = []
     try:
         print(f"Connecting to MCP server: {url}", flush=True)
         # Create BasicMCPClient with headers to pass authentication
@@ -64,15 +65,15 @@ async def mcp_tools_context(
             client=client,
         )
         # Ensure list
-        tools_list = list(tools) if tools is not None else []
+        tools = list(tools) if tools is not None else []
         print(
-            f"Successfully connected to MCP server, got {len(tools_list)} tools",
+            f"Successfully connected to MCP server, got {len(tools)} tools",
             flush=True,
         )
-        yield tools_list
     except Exception as e:
         print(
             f"Warning: Failed to connect to MCP server {url}: {e}",
             flush=True,
         )
-        yield []
+
+    yield tools

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -37,7 +37,6 @@ from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
-from datarobot_genai.core.mcp.config import MCPConfig
 from datarobot_genai.nat.helpers import load_workflow
 
 if TYPE_CHECKING:
@@ -122,16 +121,13 @@ def pull_intermediate_structured() -> asyncio.Future[list[IntermediateStep]]:
 class NatAgent(BaseAgent[None]):
     def __init__(
         self,
-        *,
         workflow_path: StrPath,
         api_key: str | None = None,
         api_base: str | None = None,
         model: str | None = None,
-        verbose: bool | str | None = True,
+        verbose: bool = True,
         timeout: int | None = 90,
-        authorization_context: dict[str, Any] | None = None,
         forwarded_headers: dict[str, str] | None = None,
-        **kwargs: Any,
     ) -> None:
         super().__init__(
             api_key=api_key,
@@ -139,9 +135,7 @@ class NatAgent(BaseAgent[None]):
             model=model,
             verbose=verbose,
             timeout=timeout,
-            authorization_context=authorization_context,
             forwarded_headers=forwarded_headers,
-            **kwargs,
         )
         self.workflow_path = workflow_path
 
@@ -185,13 +179,6 @@ class NatAgent(BaseAgent[None]):
         # Print commands may need flush=True to ensure they are displayed in real-time.
         print("Running agent with user prompt:", chat_request.messages[0].content, flush=True)
 
-        mcp_config = MCPConfig(
-            authorization_context=self.authorization_context,
-            forwarded_headers=self.forwarded_headers,
-        )
-        server_config = mcp_config.server_config
-        headers = server_config["headers"] if server_config else None
-
         thread_id = run_agent_input.thread_id
         run_id = run_agent_input.run_id
         zero_metrics: UsageMetrics = {
@@ -210,7 +197,7 @@ class NatAgent(BaseAgent[None]):
         message_id = str(uuid.uuid4())
         text_started = False
 
-        async with load_workflow(self.workflow_path, headers=headers) as workflow:
+        async with load_workflow(self.workflow_path, headers=self.forwarded_headers) as workflow:
             async with workflow.session(user_id=thread_id) as session:
                 async with session.run(chat_request) as runner:
                     intermediate_future = pull_intermediate_structured()

--- a/src/datarobot_genai/nat/datarobot_auth_provider.py
+++ b/src/datarobot_genai/nat/datarobot_auth_provider.py
@@ -27,7 +27,7 @@ from nat.data_models.common import SerializableSecretStr
 from pydantic import Field
 from pydantic import SecretStr
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.nat.helpers import extract_authorization_from_context
 from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
 

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -39,21 +39,21 @@ logger = logging.getLogger(__name__)
 
 
 def _default_transport() -> Literal["streamable-http", "sse"]:
-    from datarobot_genai.core.mcp.config import MCPConfig  # noqa: PLC0415
+    from datarobot_genai.core.mcp import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
     return server_config["transport"] if server_config else "streamable-http"
 
 
 def _default_url() -> HttpUrl:
-    from datarobot_genai.core.mcp.config import MCPConfig  # noqa: PLC0415
+    from datarobot_genai.core.mcp import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
     return server_config["url"] if server_config else HttpUrl("http://localhost:8080/mcp")
 
 
 def _default_auth_provider() -> str | AuthenticationRef | None:
-    from datarobot_genai.core.mcp.config import MCPConfig  # noqa: PLC0415
+    from datarobot_genai.core.mcp import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
     return "datarobot_mcp_auth" if server_config else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import pytest
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 
 
 def make_run_agent_input_with_history() -> Any:

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -104,7 +104,7 @@ def test_base_agent_env_defaults_and_verbose(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("DATAROBOT_API_TOKEN", "env-token")
     monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2")
 
-    agent = SimpleAgent(verbose="false")
+    agent = SimpleAgent(verbose=False)
 
     assert agent.api_key == "env-token"
     # Stored as provided; normalization happens in litellm_api_base

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 import pytest
 from datarobot.models.genai.agent.auth import set_authorization_context
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 
 
 class TestMCPConfig:

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -104,13 +104,6 @@ def test_create_pipeline_interactions_from_messages_returns_sample() -> None:
 
 
 @pytest.fixture
-def patch_mcp_tools_context() -> None:
-    with patch("datarobot_genai.crewai.agent.mcp_tools_context") as mock_mcp_tools_context:
-        mock_mcp_tools_context.return_value.__enter__.return_value = ["tool1"]
-        yield mock_mcp_tools_context
-
-
-@pytest.fixture
 def run_agent_input() -> RunAgentInput:
     return RunAgentInput(
         messages=[UserMessage(content="{}", id="message_id")],
@@ -123,21 +116,19 @@ def run_agent_input() -> RunAgentInput:
     )
 
 
-async def test_invoke(run_agent_input, patch_mcp_tools_context, mock_ragas_event_listener) -> None:
+async def test_invoke(run_agent_input, mock_ragas_event_listener) -> None:
     # GIVEN agent with predefined crew output and forwarded headers
     out = CrewOutput(
         raw="agent result",
         token_usage=UsageMetrics(completion_tokens=1, prompt_tokens=2, total_tokens=3),
     )
     forwarded_headers = {"header-name": "header-value"}
-    authorization_context = {"x-datarobot-api-key": "scoped-token-123"}
     agent = AgentForTest(
         out,
         api_base="https://x/",
         api_key="k",
         verbose=True,
         forwarded_headers=forwarded_headers,
-        authorization_context=authorization_context,
     )
 
     # WHEN invoke agent is called
@@ -146,15 +137,6 @@ async def test_invoke(run_agent_input, patch_mcp_tools_context, mock_ragas_event
     # THEN response is an async generator
     assert isinstance(gen, AsyncGenerator)
     events = [event async for event in gen]
-
-    # THEN MCP context was called with forwarded headers and authorization context
-    patch_mcp_tools_context.assert_called_once_with(
-        authorization_context=authorization_context,
-        forwarded_headers=forwarded_headers,
-    )
-
-    # THEN MCP tools are set
-    assert agent.mcp_tools == ["tool1"]
 
     # THEN ragas event listener was setup
     assert mock_ragas_event_listener.called_setup
@@ -189,7 +171,7 @@ async def test_invoke(run_agent_input, patch_mcp_tools_context, mock_ragas_event
 
 
 async def test_invoke_does_not_include_chat_history_by_default(
-    patch_mcp_tools_context, mock_ragas_event_listener, run_agent_input_with_history
+    mock_ragas_event_listener, run_agent_input_with_history
 ) -> None:
     captured_inputs: dict[str, Any] = {}
 
@@ -209,7 +191,7 @@ async def test_invoke_does_not_include_chat_history_by_default(
 
 
 async def test_invoke_overwrites_blank_chat_history_placeholder(
-    patch_mcp_tools_context, mock_ragas_event_listener, run_agent_input_with_history
+    mock_ragas_event_listener, run_agent_input_with_history
 ) -> None:
     captured_inputs: dict[str, Any] = {}
 
@@ -239,7 +221,7 @@ async def test_invoke_overwrites_blank_chat_history_placeholder(
 
 
 async def test_invoke_does_not_overwrite_non_empty_chat_history_override(
-    patch_mcp_tools_context, mock_ragas_event_listener, run_agent_input_with_history
+    mock_ragas_event_listener, run_agent_input_with_history
 ) -> None:
     captured_inputs: dict[str, Any] = {}
 

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -23,10 +23,25 @@ from datarobot_genai.crewai.mcp import mcp_tools_context
 
 
 @pytest.fixture
-def mock_adapter():
+def mock_tools():
+    return [MagicMock(), MagicMock()]
+
+
+@pytest.fixture
+def mock_adapter(mock_tools):
     """Fixture for mocking MCPServerAdapter."""
     with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:
+        mock_adapter_instance = MagicMock()
+        mock_adapter_instance.__enter__.return_value = mock_tools
+        mock_adapter_instance.__exit__.return_value = None
+        mock.return_value = mock_adapter_instance
         yield mock
+
+
+@pytest.fixture(autouse=True)
+def clear_environment_variables():
+    with patch.dict(os.environ, {}, clear=True):
+        yield
 
 
 class TestMCPToolsContext:
@@ -39,97 +54,74 @@ class TestMCPToolsContext:
             async with mcp_tools_context(mcp_config) as tools:
                 assert tools == []
 
-    async def test_mcp_tools_context_with_external_url(self, mock_adapter):
+    async def test_mcp_tools_context_with_external_url(self, mock_adapter, mock_tools):
         """Test context manager with external MCP URL."""
-        mock_tools = [MagicMock(), MagicMock()]
-        mock_adapter_instance = MagicMock()
-        mock_adapter_instance.__enter__.return_value = mock_tools
-        mock_adapter_instance.__exit__.return_value = None
-        mock_adapter.return_value = mock_adapter_instance
-
         test_url = "https://mcp-server.example.com/mcp"
-        with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            mcp_config = MCPConfig()
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools == mock_tools
-                mock_adapter.assert_called_once()
-                # Check that the server config was passed correctly
-                call_args = mock_adapter.call_args[0][0]
-                assert call_args["url"] == test_url
-                assert call_args["transport"] == "streamable-http"
+        mcp_config = MCPConfig(external_mcp_url=test_url)
+        async with mcp_tools_context(mcp_config) as tools:
+            assert tools == mock_tools
+            mock_adapter.assert_called_once()
+            # Check that the server config was passed correctly
+            call_args = mock_adapter.call_args[0][0]
+            assert call_args["url"] == test_url
+            assert call_args["transport"] == "streamable-http"
 
     async def test_mcp_tools_context_with_datarobot_deployment(
-        self, mock_adapter, agent_auth_context_data
+        self, mock_adapter, agent_auth_context_data, mock_tools
     ):
         """Test context manager with DataRobot deployment ID."""
-        mock_tools = [MagicMock()]
-        mock_adapter_instance = MagicMock()
-        mock_adapter_instance.__enter__.return_value = mock_tools
-        mock_adapter_instance.__exit__.return_value = None
-        mock_adapter.return_value = mock_adapter_instance
-
         deployment_id = "abc123def456789012345678"
         api_base = "https://app.datarobot.com/api/v2"
         api_key = "test-api-key"
-        secret_key = "my-secret-key"
 
-        with patch.dict(
-            os.environ,
-            {
-                "MCP_DEPLOYMENT_ID": deployment_id,
-                "DATAROBOT_ENDPOINT": api_base,
-                "DATAROBOT_API_TOKEN": api_key,
-                "SESSION_SECRET_KEY": secret_key,
-            },
-            clear=True,
-        ):
-            mcp_config = MCPConfig(authorization_context=agent_auth_context_data)
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools == mock_tools
-                mock_adapter.assert_called_once()
-                # Check that the server config was passed correctly
-                call_args = mock_adapter.call_args[0][0]
-                expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
-                assert call_args["url"] == expected_url
-                assert call_args["transport"] == "streamable-http"
-                assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
-                assert call_args["headers"]["X-DataRobot-Authorization-Context"] is not None
+        mcp_config = MCPConfig(
+            mcp_deployment_id=deployment_id,
+            datarobot_endpoint=api_base,
+            datarobot_api_token=api_key,
+            authorization_context=agent_auth_context_data,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert tools == mock_tools
+            mock_adapter.assert_called_once()
+            # Check that the server config was passed correctly
+            call_args = mock_adapter.call_args[0][0]
+            expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
+            assert call_args["url"] == expected_url
+            assert call_args["transport"] == "streamable-http"
+            assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
+            assert call_args["headers"]["X-DataRobot-Authorization-Context"] is not None
 
     async def test_mcp_tools_context_with_forwarded_headers(
-        self, mock_adapter, agent_auth_context_data
+        self, mock_adapter, agent_auth_context_data, mock_tools
     ):
         """Test context manager with forwarded headers including scoped token."""
-        mock_tools = [MagicMock()]
-        mock_adapter_instance = MagicMock()
-        mock_adapter_instance.__enter__.return_value = mock_tools
-        mock_adapter_instance.__exit__.return_value = None
-        mock_adapter.return_value = mock_adapter_instance
-
         deployment_id = "abc123def456789012345678"
         api_base = "https://app.datarobot.com/api/v2"
         api_key = "test-api-key"
-        secret_key = "my-secret-key"
         forwarded_headers = {
             "x-datarobot-api-key": "scoped-token-123",
         }
 
-        with patch.dict(
-            os.environ,
-            {
-                "MCP_DEPLOYMENT_ID": deployment_id,
-                "DATAROBOT_ENDPOINT": api_base,
-                "DATAROBOT_API_TOKEN": api_key,
-                "SESSION_SECRET_KEY": secret_key,
-            },
-            clear=True,
-        ):
-            mcp_config = MCPConfig(
-                authorization_context=agent_auth_context_data, forwarded_headers=forwarded_headers
-            )
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools == mock_tools
-                mock_adapter.assert_called_once()
-                # Check that forwarded headers are included in the server config
-                call_args = mock_adapter.call_args[0][0]
-                assert call_args["headers"]["x-datarobot-api-key"] == "scoped-token-123"
-                assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
+        mcp_config = MCPConfig(
+            mcp_deployment_id=deployment_id,
+            datarobot_endpoint=api_base,
+            datarobot_api_token=api_key,
+            authorization_context=agent_auth_context_data,
+            forwarded_headers=forwarded_headers,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert tools == mock_tools
+            mock_adapter.assert_called_once()
+            # Check that forwarded headers are included in the server config
+            call_args = mock_adapter.call_args[0][0]
+            assert call_args["headers"]["x-datarobot-api-key"] == "scoped-token-123"
+            assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
+
+    @pytest.mark.usefixtures("mock_adapter")
+    async def test_mcp_tools_context_propagates_exceptions(self):
+        """Test context manager propagates exceptions."""
+        test_url = "https://mcp-server.example.com/mcp"
+        mcp_config = MCPConfig(external_mcp_url=test_url)
+        with pytest.raises(RuntimeError):
+            async with mcp_tools_context(mcp_config):
+                raise RuntimeError("Connection failed")

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 
 import pytest
 
+from datarobot_genai.core.mcp.config import MCPConfig
 from datarobot_genai.crewai.mcp import mcp_tools_context
 
 
@@ -31,13 +32,14 @@ def mock_adapter():
 class TestMCPToolsContext:
     """Test MCP tools context manager."""
 
-    def test_mcp_tools_context_no_configuration(self):
+    async def test_mcp_tools_context_no_configuration(self):
         """Test context manager when no MCP server is configured."""
         with patch.dict(os.environ, {}, clear=True):
-            with mcp_tools_context() as tools:
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
                 assert tools == []
 
-    def test_mcp_tools_context_with_external_url(self, mock_adapter):
+    async def test_mcp_tools_context_with_external_url(self, mock_adapter):
         """Test context manager with external MCP URL."""
         mock_tools = [MagicMock(), MagicMock()]
         mock_adapter_instance = MagicMock()
@@ -47,7 +49,8 @@ class TestMCPToolsContext:
 
         test_url = "https://mcp-server.example.com/mcp"
         with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            with mcp_tools_context() as tools:
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
                 assert tools == mock_tools
                 mock_adapter.assert_called_once()
                 # Check that the server config was passed correctly
@@ -55,7 +58,7 @@ class TestMCPToolsContext:
                 assert call_args["url"] == test_url
                 assert call_args["transport"] == "streamable-http"
 
-    def test_mcp_tools_context_with_datarobot_deployment(
+    async def test_mcp_tools_context_with_datarobot_deployment(
         self, mock_adapter, agent_auth_context_data
     ):
         """Test context manager with DataRobot deployment ID."""
@@ -80,7 +83,8 @@ class TestMCPToolsContext:
             },
             clear=True,
         ):
-            with mcp_tools_context(authorization_context=agent_auth_context_data) as tools:
+            mcp_config = MCPConfig(authorization_context=agent_auth_context_data)
+            async with mcp_tools_context(mcp_config) as tools:
                 assert tools == mock_tools
                 mock_adapter.assert_called_once()
                 # Check that the server config was passed correctly
@@ -91,7 +95,9 @@ class TestMCPToolsContext:
                 assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
                 assert call_args["headers"]["X-DataRobot-Authorization-Context"] is not None
 
-    def test_mcp_tools_context_with_forwarded_headers(self, mock_adapter, agent_auth_context_data):
+    async def test_mcp_tools_context_with_forwarded_headers(
+        self, mock_adapter, agent_auth_context_data
+    ):
         """Test context manager with forwarded headers including scoped token."""
         mock_tools = [MagicMock()]
         mock_adapter_instance = MagicMock()
@@ -117,9 +123,10 @@ class TestMCPToolsContext:
             },
             clear=True,
         ):
-            with mcp_tools_context(
+            mcp_config = MCPConfig(
                 authorization_context=agent_auth_context_data, forwarded_headers=forwarded_headers
-            ) as tools:
+            )
+            async with mcp_tools_context(mcp_config) as tools:
                 assert tools == mock_tools
                 mock_adapter.assert_called_once()
                 # Check that forwarded headers are included in the server config

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 import pytest
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.crewai.mcp import mcp_tools_context
 
 

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 from functools import cached_property
 from typing import Any
-from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
 from unittest.mock import Mock
-from unittest.mock import patch
 
 import pytest
 from ag_ui.core import AssistantMessage
@@ -433,58 +430,6 @@ async def test_langgraph_non_streaming(run_agent_input):
     assert usage_metrics["total_tokens"] == 200
     assert usage_metrics["prompt_tokens"] == 100
     assert usage_metrics["completion_tokens"] == 100
-
-
-async def test_invoke_calls_mcp_tools_context_and_sets_tools_and_cleans_up(
-    authorization_context, run_agent_input
-):
-    """Test that invoke method calls mcp_tools_context and sets tools correctly."""
-    # GIVEN a simple langgraph agent with forwarded headers
-    forwarded_headers = {
-        "x-datarobot-api-key": "scoped-token-123",
-    }
-    agent = SimpleLangGraphAgent(
-        authorization_context=authorization_context, forwarded_headers=forwarded_headers
-    )
-
-    # Mock the mcp_tools_context to return mock tools
-    mock_tools = [MagicMock(name="tool1"), MagicMock(name="tool2")]
-
-    with patch("datarobot_genai.langgraph.agent.mcp_tools_context") as mock_mcp_context:
-        # Configure the mock context manager
-        mock_context_manager = AsyncMock()
-        mock_context_manager.__aenter__.return_value = mock_tools
-        mock_context_manager.__aexit__.return_value = None
-        mock_mcp_context.return_value = mock_context_manager
-
-        with patch.object(agent, "set_mcp_tools") as mock_set_mcp_tools:
-            # WHEN invoking the agent
-            streaming_response_iterator = agent.invoke(run_agent_input)
-
-            # THEN context is not entered yet (it's entered inside the generator)
-            mock_context_manager.__aenter__.assert_not_called()
-            mock_mcp_context.assert_not_called()
-
-            # WHEN consuming the streaming generator
-            items_consumed = 0
-            async for _ in streaming_response_iterator:
-                items_consumed += 1
-                # THEN mcp_tools_context is called and context is entered when generator starts
-                if items_consumed == 1:
-                    # Verify mcp_tools_context is called with correct parameters
-                    mock_mcp_context.assert_called_once_with(
-                        authorization_context=authorization_context,
-                        forwarded_headers=forwarded_headers,
-                    )
-                    # Verify context is entered and tools are set
-                    mock_context_manager.__aenter__.assert_called_once()
-                    mock_set_mcp_tools.assert_called_once_with(mock_tools)
-                    # Context should still be open during streaming
-                    mock_context_manager.__aexit__.assert_not_called()
-
-            # THEN context is properly exited after generator is exhausted
-            # Verify __aexit__ was called with None, None, None (no exception)
-            mock_context_manager.__aexit__.assert_called_once_with(None, None, None)
 
 
 def test_create_pipeline_interactions_from_events_filters_tool_messages() -> None:

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -20,7 +20,7 @@ import pytest
 from datarobot.models.genai.agent.auth import set_authorization_context
 from pydantic import ValidationError
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.langgraph.mcp import mcp_tools_context
 
 

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -255,6 +255,15 @@ class TestMCPToolsContext:
                 session=setup_session_and_tools["session_instance"]
             )
 
+    @pytest.mark.usefixtures("setup_session_and_tools")
+    async def test_mcp_tools_context_exception_is_propagated(self):
+        external_url = "https://mcp-server.example.com/mcp"
+
+        mcp_config = MCPConfig(external_mcp_url=external_url, external_mcp_transport="sse")
+        with pytest.raises(RuntimeError):
+            async with mcp_tools_context(mcp_config):
+                raise RuntimeError("Connection failed")
+
     async def test_mcp_tools_context_unsupported_transport(self):
         external_url = "https://mcp-server.example.com/mcp"
 

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -20,6 +20,7 @@ import pytest
 from datarobot.models.genai.agent.auth import set_authorization_context
 from pydantic import ValidationError
 
+from datarobot_genai.core.mcp.config import MCPConfig
 from datarobot_genai.langgraph.mcp import mcp_tools_context
 
 
@@ -115,10 +116,17 @@ def setup_session_and_tools(mock_session, mock_load_mcp_tools, mock_session_inst
     }
 
 
+@pytest.fixture(autouse=True)
+def clear_environment_variables():
+    with patch.dict(os.environ, {}, clear=True):
+        yield
+
+
 class TestMCPToolsContext:
     async def test_mcp_tools_context_no_configuration(self):
         with patch.dict(os.environ, {}, clear=True):
-            async with mcp_tools_context() as tools:
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
                 assert tools == []
 
     async def test_mcp_tools_context_with_external_url(
@@ -128,55 +136,51 @@ class TestMCPToolsContext:
         test_transport = "sse"
         external_url = "https://mcp-server.example.com/mcp"
 
-        with patch.dict(
-            os.environ,
-            {
-                "EXTERNAL_MCP_URL": external_url,
-                "EXTERNAL_MCP_HEADERS": test_headers,
-                "EXTERNAL_MCP_TRANSPORT": test_transport,
-            },
-            clear=True,
-        ):
-            async with mcp_tools_context() as tools:
-                assert_mock_tools_expected(tools)
+        mcp_config = MCPConfig(
+            external_mcp_url=external_url,
+            external_mcp_headers=test_headers,
+            external_mcp_transport=test_transport,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert_mock_tools_expected(tools)
 
-                # Verify create_session was called with correct connection config
-                setup_session_and_tools["session"].assert_called_once()
-                call_args = setup_session_and_tools["session"].call_args
-                connection_config = call_args[1]["connection"]
-                assert connection_config["url"] == external_url.rstrip("/")
-                expected_headers = {"X-API-Key": "test-key", "Content-Type": "application/json"}
-                assert connection_config["headers"] == expected_headers
-                # SSEConnection uses transport="sse"
-                assert connection_config["transport"] == "sse"
+            # Verify create_session was called with correct connection config
+            setup_session_and_tools["session"].assert_called_once()
+            call_args = setup_session_and_tools["session"].call_args
+            connection_config = call_args[1]["connection"]
+            assert connection_config["url"] == external_url.rstrip("/")
+            expected_headers = {"X-API-Key": "test-key", "Content-Type": "application/json"}
+            assert connection_config["headers"] == expected_headers
+            # SSEConnection uses transport="sse"
+            assert connection_config["transport"] == "sse"
 
-                # Verify tools were loaded
-                setup_session_and_tools["load_tools"].assert_called_once_with(
-                    session=setup_session_and_tools["session_instance"]
-                )
+            # Verify tools were loaded
+            setup_session_and_tools["load_tools"].assert_called_once_with(
+                session=setup_session_and_tools["session_instance"]
+            )
 
     async def test_mcp_tools_context_with_external_url_default_transport(
         self, setup_session_and_tools, assert_mock_tools_expected
     ):
         external_url = "https://mcp-server.example.com/mcp"
 
-        with patch.dict(os.environ, {"EXTERNAL_MCP_URL": external_url}, clear=True):
-            async with mcp_tools_context() as tools:
-                assert_mock_tools_expected(tools)
+        mcp_config = MCPConfig(external_mcp_url=external_url)
+        async with mcp_tools_context(mcp_config) as tools:
+            assert_mock_tools_expected(tools)
 
-                # Verify create_session was called with correct connection config
-                # (default transport)
-                setup_session_and_tools["session"].assert_called_once()
-                call_args = setup_session_and_tools["session"].call_args
-                connection_config = call_args[1]["connection"]
-                assert connection_config["url"] == external_url.rstrip("/")
-                assert connection_config["headers"] == {}  # No custom headers
-                # StreamableHttpConnection uses transport="streamable_http" (underscore)
-                assert connection_config["transport"] == "streamable_http"
+            # Verify create_session was called with correct connection config
+            # (default transport)
+            setup_session_and_tools["session"].assert_called_once()
+            call_args = setup_session_and_tools["session"].call_args
+            connection_config = call_args[1]["connection"]
+            assert connection_config["url"] == external_url.rstrip("/")
+            assert connection_config["headers"] == {}  # No custom headers
+            # StreamableHttpConnection uses transport="streamable_http" (underscore)
+            assert connection_config["transport"] == "streamable_http"
 
-                setup_session_and_tools["load_tools"].assert_called_once_with(
-                    session=setup_session_and_tools["session_instance"]
-                )
+            setup_session_and_tools["load_tools"].assert_called_once_with(
+                session=setup_session_and_tools["session_instance"]
+            )
 
     async def test_mcp_tools_context_with_datarobot_deployment(
         self, setup_session_and_tools, agent_auth_context_data, assert_mock_tools_expected
@@ -189,27 +193,23 @@ class TestMCPToolsContext:
         # process, so subsequent tools and MCP calls receive it via a dedicated header.
         set_authorization_context(agent_auth_context_data)
 
-        with patch.dict(
-            os.environ,
-            {
-                "MCP_DEPLOYMENT_ID": deployment_id,
-                "DATAROBOT_ENDPOINT": api_base,
-                "DATAROBOT_API_TOKEN": api_key,
-            },
-            clear=True,
-        ):
-            async with mcp_tools_context() as tools:
-                assert_mock_tools_expected(tools)
-                # Check that create_session was called with correct connection config
-                setup_session_and_tools["session"].assert_called_once()
-                call_args = setup_session_and_tools["session"].call_args
-                connection_config = call_args[1]["connection"]
-                expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
-                assert connection_config["url"] == expected_url
-                assert connection_config["headers"]["Authorization"] == f"Bearer {api_key}"
-                setup_session_and_tools["load_tools"].assert_called_once_with(
-                    session=setup_session_and_tools["session_instance"]
-                )
+        mcp_config = MCPConfig(
+            mcp_deployment_id=deployment_id,
+            datarobot_endpoint=api_base,
+            datarobot_api_token=api_key,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert_mock_tools_expected(tools)
+            # Check that create_session was called with correct connection config
+            setup_session_and_tools["session"].assert_called_once()
+            call_args = setup_session_and_tools["session"].call_args
+            connection_config = call_args[1]["connection"]
+            expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
+            assert connection_config["url"] == expected_url
+            assert connection_config["headers"]["Authorization"] == f"Bearer {api_key}"
+            setup_session_and_tools["load_tools"].assert_called_once_with(
+                session=setup_session_and_tools["session_instance"]
+            )
 
     async def test_mcp_tools_context_with_parameters(
         self, setup_session_and_tools, agent_auth_context_data, assert_mock_tools_expected
@@ -222,56 +222,46 @@ class TestMCPToolsContext:
         # process, so subsequent tools and MCP calls receive it via a dedicated header.
         set_authorization_context(agent_auth_context_data)
 
-        with patch.dict(
-            os.environ,
-            {
-                "MCP_DEPLOYMENT_ID": deployment_id,
-                "DATAROBOT_API_TOKEN": custom_api_key,
-                "DATAROBOT_ENDPOINT": custom_api_base,
-            },
-            clear=True,
-        ):
-            async with mcp_tools_context() as tools:
-                assert_mock_tools_expected(tools)
-                # Check that create_session was called with custom parameters
-                setup_session_and_tools["session"].assert_called_once()
-                call_args = setup_session_and_tools["session"].call_args
-                connection_config = call_args[1]["connection"]
-                expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
-                assert connection_config["url"] == expected_url
-                assert connection_config["headers"]["Authorization"] == f"Bearer {custom_api_key}"
+        mcp_config = MCPConfig(
+            mcp_deployment_id=deployment_id,
+            datarobot_endpoint=custom_api_base,
+            datarobot_api_token=custom_api_key,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert_mock_tools_expected(tools)
+            # Check that create_session was called with custom parameters
+            setup_session_and_tools["session"].assert_called_once()
+            call_args = setup_session_and_tools["session"].call_args
+            connection_config = call_args[1]["connection"]
+            expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
+            assert connection_config["url"] == expected_url
+            assert connection_config["headers"]["Authorization"] == f"Bearer {custom_api_key}"
 
     async def test_mcp_tools_context_with_sse_transport(
         self, setup_session_and_tools, assert_mock_tools_expected
     ):
         external_url = "https://mcp-server.example.com/mcp"
 
-        with patch.dict(
-            os.environ,
-            {"EXTERNAL_MCP_URL": external_url, "EXTERNAL_MCP_TRANSPORT": "sse"},
-            clear=True,
-        ):
-            async with mcp_tools_context() as tools:
-                assert_mock_tools_expected(tools)
-                # Verify create_session was called with SSE transport
-                setup_session_and_tools["session"].assert_called_once()
-                call_args = setup_session_and_tools["session"].call_args
-                connection_config = call_args[1]["connection"]
-                # SSEConnection uses transport="sse"
-                assert connection_config["transport"] == "sse"
-                setup_session_and_tools["load_tools"].assert_called_once_with(
-                    session=setup_session_and_tools["session_instance"]
-                )
+        mcp_config = MCPConfig(external_mcp_url=external_url, external_mcp_transport="sse")
+        async with mcp_tools_context(mcp_config) as tools:
+            assert_mock_tools_expected(tools)
+            # Verify create_session was called with SSE transport
+            setup_session_and_tools["session"].assert_called_once()
+            call_args = setup_session_and_tools["session"].call_args
+            connection_config = call_args[1]["connection"]
+            # SSEConnection uses transport="sse"
+            assert connection_config["transport"] == "sse"
+            setup_session_and_tools["load_tools"].assert_called_once_with(
+                session=setup_session_and_tools["session_instance"]
+            )
 
     async def test_mcp_tools_context_unsupported_transport(self):
         external_url = "https://mcp-server.example.com/mcp"
 
-        with patch.dict(
-            os.environ,
-            {"EXTERNAL_MCP_URL": external_url, "EXTERNAL_MCP_TRANSPORT": "invalid-transport"},
-            clear=True,
-        ):
-            # mcp_tools_context will raise ValidationError for unsupported transport
-            with pytest.raises(ValidationError):
-                async with mcp_tools_context():
-                    pass
+        # mcp_tools_context will raise ValidationError for unsupported transport
+        with pytest.raises(ValidationError):
+            mcp_config = MCPConfig(
+                external_mcp_url=external_url, external_mcp_transport="invalid-transport"
+            )
+            async with mcp_tools_context(mcp_config):
+                pass

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -14,7 +14,6 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 from ag_ui.core import AssistantMessage
@@ -40,11 +39,8 @@ from llama_index.core.tools import ToolOutput
 from llama_index.core.tools import ToolSelection
 from ragas import MultiTurnSample
 
-from datarobot_genai.llama_index import agent as agent_mod
 from datarobot_genai.llama_index.agent import DataRobotLiteLLM
 from datarobot_genai.llama_index.agent import LlamaIndexAgent
-
-# --- Test helpers ---
 
 
 class Handler:
@@ -187,15 +183,6 @@ def agent(workflow: Workflow) -> MyLlamaAgent:
     return MyLlamaAgent(workflow, forwarded_headers=forwarded_headers)
 
 
-@pytest.fixture
-def mock_load_mcp_tools(monkeypatch: Any) -> None:
-    async def fake_load_mcp_tools(*args: Any, **kwargs: Any) -> list[Any]:  # noqa: ARG001, ANN401
-        return []
-
-    monkeypatch.setattr(agent_mod, "load_mcp_tools", fake_load_mcp_tools, raising=True)
-
-
-@pytest.mark.usefixtures("mock_load_mcp_tools")
 async def test_llama_index_agent_invoke(
     agent: MyLlamaAgent, run_agent_input: RunAgentInput
 ) -> None:
@@ -231,36 +218,6 @@ async def test_llama_index_agent_invoke(
     assert usage[-1] == {"completion_tokens": 0, "prompt_tokens": 0, "total_tokens": 0}
 
 
-async def test_llama_index_agent_invoke_with_mcp_tools(
-    monkeypatch: Any, agent: MyLlamaAgent, run_agent_input: RunAgentInput
-) -> None:
-    """Test that MCP tools are loaded and available via mcp_tools property."""
-    # GIVEN: fake mcp tools
-    mock_tools = [MagicMock(), MagicMock()]
-
-    mcp_calls = []
-
-    async def fake_load_mcp_tools(*args: Any, **kwargs: Any) -> list[Any]:  # noqa: ARG001, ANN401
-        mcp_calls.append(kwargs)
-        return mock_tools
-
-    monkeypatch.setattr(agent_mod, "load_mcp_tools", fake_load_mcp_tools, raising=True)
-
-    # WHEN: invoke the agent with a run agent input and get the events
-    gen = agent.invoke(run_agent_input)
-    [event async for event in gen]
-
-    # THEN: MCP tools were loaded and are accessible
-    assert agent.mcp_tools == mock_tools
-    assert len(agent.mcp_tools) == 2
-
-    # THEN: load_mcp_tools was called with forwarded headers
-    assert len(mcp_calls) == 1
-    assert mcp_calls[0]["forwarded_headers"] == {
-        "x-datarobot-api-key": "scoped-token-123",
-    }
-
-
 def test_make_input_message_includes_history_summary(run_agent_input_with_history) -> None:
     """By default, LlamaIndexAgent.make_input_message should NOT include history."""
     workflow = Workflow(events=[], state="S")
@@ -282,7 +239,6 @@ def test_make_input_message_zero_history_disables_summary(
     assert text == "Follow-up"
 
 
-@pytest.mark.usefixtures("mock_load_mcp_tools")
 async def test_invoke_agent_output_with_dict_tool_calls(
     run_agent_input: RunAgentInput,
 ) -> None:
@@ -314,7 +270,6 @@ async def test_invoke_agent_output_with_dict_tool_calls(
     assert pipeline[-1] is not None
 
 
-@pytest.mark.usefixtures("mock_load_mcp_tools")
 async def test_invoke_agent_stream_multiple_agents(
     run_agent_input: RunAgentInput,
 ) -> None:
@@ -347,7 +302,6 @@ async def test_invoke_agent_stream_multiple_agents(
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 
-@pytest.mark.usefixtures("mock_load_mcp_tools")
 async def test_invoke_replaces_chat_history_placeholder() -> None:
     """invoke() replaces {chat_history} placeholder with actual history."""
     captured_msgs: list[str] = []

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -71,16 +71,6 @@ class TestLoadMCPTools:
             assert call_args[1]["command_or_url"] == expected_url
             assert call_args[1]["client"].headers["Authorization"] == f"Bearer {api_key}"
 
-    async def test_mcp_tools_context_connection_error(self, mock_aget):
-        """Test loading tools handles connection errors gracefully."""
-        mock_aget.side_effect = Exception("Connection failed")
-
-        test_url = "https://mcp-server.example.com/mcp"
-        mcp_config = MCPConfig(external_mcp_url=test_url)
-        async with mcp_tools_context(mcp_config) as tools:
-            assert isinstance(tools, list)
-            assert len(tools) == 0
-
     async def test_load_mcp_tools_returns_none(self, mock_aget):
         """Test loading tools when aget_tools_from_mcp_url returns None."""
         mock_aget.return_value = None

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -19,7 +19,8 @@ from unittest.mock import patch
 
 import pytest
 
-from datarobot_genai.llama_index.mcp import load_mcp_tools
+from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.llama_index.mcp import mcp_tools_context
 
 
 class TestLoadMCPTools:
@@ -29,26 +30,10 @@ class TestLoadMCPTools:
     async def test_load_mcp_tools_no_configuration(self):
         """Test loading tools when no MCP server is configured."""
         with patch.dict(os.environ, {}, clear=True):
-            tools = await load_mcp_tools()
-            assert isinstance(tools, list)
-            assert len(tools) == 0
-
-    @pytest.mark.asyncio
-    @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
-    async def test_load_mcp_tools_with_external_url(self, mock_aget):
-        """Test loading tools with external MCP URL."""
-        mock_tools = [MagicMock(), MagicMock()]
-        mock_aget.return_value = mock_tools
-
-        test_url = "https://mcp-server.example.com/mcp"
-        with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            tools = await load_mcp_tools()
-            assert tools == mock_tools
-            mock_aget.assert_awaited_once()
-            # Check that the function was called with correct parameters
-            call_args = mock_aget.await_args
-            assert call_args[1]["command_or_url"] == test_url.rstrip("/")
-            assert call_args[1]["client"].headers == {}
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
+                assert isinstance(tools, list)
+                assert len(tools) == 0
 
     @pytest.mark.asyncio
     @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
@@ -70,14 +55,15 @@ class TestLoadMCPTools:
             },
             clear=True,
         ):
-            tools = await load_mcp_tools()
-            assert tools == mock_tools
-            mock_aget.assert_awaited_once()
-            # Check that the function was called with correct parameters
-            call_args = mock_aget.await_args
-            expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
-            assert call_args[1]["command_or_url"] == expected_url
-            assert call_args[1]["client"].headers["Authorization"] == f"Bearer {api_key}"
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools == mock_tools
+                mock_aget.assert_awaited_once()
+                # Check that the function was called with correct parameters
+                call_args = mock_aget.await_args
+                expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
+                assert call_args[1]["command_or_url"] == expected_url
+                assert call_args[1]["client"].headers["Authorization"] == f"Bearer {api_key}"
 
     @pytest.mark.asyncio
     @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
@@ -87,9 +73,10 @@ class TestLoadMCPTools:
 
         test_url = "https://mcp-server.example.com/mcp"
         with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            tools = await load_mcp_tools()
-            assert isinstance(tools, list)
-            assert len(tools) == 0
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
+                assert isinstance(tools, list)
+                assert len(tools) == 0
 
     @pytest.mark.asyncio
     @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
@@ -99,9 +86,10 @@ class TestLoadMCPTools:
 
         test_url = "https://mcp-server.example.com/mcp"
         with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            tools = await load_mcp_tools()
-            assert isinstance(tools, list)
-            assert len(tools) == 0
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
+                assert isinstance(tools, list)
+                assert len(tools) == 0
 
     @pytest.mark.asyncio
     @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
@@ -123,14 +111,15 @@ class TestLoadMCPTools:
             },
             clear=True,
         ):
-            tools = await load_mcp_tools()
-            assert tools == mock_tools
-            mock_aget.assert_awaited_once()
-            # Check that the function was called with custom parameters
-            call_args = mock_aget.await_args
-            expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
-            assert call_args[1]["command_or_url"] == expected_url
-            assert call_args[1]["client"].headers["Authorization"] == f"Bearer {custom_api_key}"
+            mcp_config = MCPConfig()
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools == mock_tools
+                mock_aget.assert_awaited_once()
+                # Check that the function was called with custom parameters
+                call_args = mock_aget.await_args
+                expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
+                assert call_args[1]["command_or_url"] == expected_url
+                assert call_args[1]["client"].headers["Authorization"] == f"Bearer {custom_api_key}"
 
     @pytest.mark.asyncio
     @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
@@ -155,11 +144,12 @@ class TestLoadMCPTools:
             },
             clear=True,
         ):
-            tools = await load_mcp_tools(forwarded_headers=forwarded_headers)
-            assert tools == mock_tools
-            mock_aget.assert_awaited_once()
-            # Check that forwarded headers are included in client headers
-            call_args = mock_aget.await_args
-            client_headers = call_args[1]["client"].headers
-            assert client_headers["x-datarobot-api-key"] == "scoped-token-123"
-            assert client_headers["Authorization"] == f"Bearer {api_key}"
+            mcp_config = MCPConfig(forwarded_headers=forwarded_headers)
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools == mock_tools
+                mock_aget.assert_awaited_once()
+                # Check that forwarded headers are included in client headers
+                call_args = mock_aget.await_args
+                client_headers = call_args[1]["client"].headers
+                assert client_headers["x-datarobot-api-key"] == "scoped-token-123"
+                assert client_headers["Authorization"] == f"Bearer {api_key}"

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -23,11 +23,24 @@ from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.llama_index.mcp import mcp_tools_context
 
 
+@pytest.fixture(autouse=True)
+def empty_agent_auth_context():
+    with patch.dict(os.environ, {}, clear=True):
+        yield
+
+
+@pytest.fixture
+def mock_aget():
+    with patch(
+        "datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock
+    ) as mock:
+        yield mock
+
+
 class TestLoadMCPTools:
     """Test async MCP tools loading."""
 
-    @pytest.mark.asyncio
-    async def test_load_mcp_tools_no_configuration(self):
+    async def test_mcp_tools_context_no_configuration(self):
         """Test loading tools when no MCP server is configured."""
         with patch.dict(os.environ, {}, clear=True):
             mcp_config = MCPConfig()
@@ -35,9 +48,7 @@ class TestLoadMCPTools:
                 assert isinstance(tools, list)
                 assert len(tools) == 0
 
-    @pytest.mark.asyncio
-    @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
-    async def test_load_mcp_tools_with_datarobot_deployment(self, mock_aget):
+    async def test_mcp_tools_context_with_datarobot_deployment(self, mock_aget):
         """Test loading tools with DataRobot deployment ID."""
         mock_tools = [MagicMock()]
         mock_aget.return_value = mock_tools
@@ -46,54 +57,41 @@ class TestLoadMCPTools:
         api_base = "https://app.datarobot.com/api/v2"
         api_key = "test-api-key"
 
-        with patch.dict(
-            os.environ,
-            {
-                "MCP_DEPLOYMENT_ID": deployment_id,
-                "DATAROBOT_ENDPOINT": api_base,
-                "DATAROBOT_API_TOKEN": api_key,
-            },
-            clear=True,
-        ):
-            mcp_config = MCPConfig()
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools == mock_tools
-                mock_aget.assert_awaited_once()
-                # Check that the function was called with correct parameters
-                call_args = mock_aget.await_args
-                expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
-                assert call_args[1]["command_or_url"] == expected_url
-                assert call_args[1]["client"].headers["Authorization"] == f"Bearer {api_key}"
+        mcp_config = MCPConfig(
+            mcp_deployment_id=deployment_id,
+            datarobot_endpoint=api_base,
+            datarobot_api_token=api_key,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert tools == mock_tools
+            mock_aget.assert_awaited_once()
+            # Check that the function was called with correct parameters
+            call_args = mock_aget.await_args
+            expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
+            assert call_args[1]["command_or_url"] == expected_url
+            assert call_args[1]["client"].headers["Authorization"] == f"Bearer {api_key}"
 
-    @pytest.mark.asyncio
-    @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
-    async def test_load_mcp_tools_connection_error(self, mock_aget):
+    async def test_mcp_tools_context_connection_error(self, mock_aget):
         """Test loading tools handles connection errors gracefully."""
         mock_aget.side_effect = Exception("Connection failed")
 
         test_url = "https://mcp-server.example.com/mcp"
-        with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            mcp_config = MCPConfig()
-            async with mcp_tools_context(mcp_config) as tools:
-                assert isinstance(tools, list)
-                assert len(tools) == 0
+        mcp_config = MCPConfig(external_mcp_url=test_url)
+        async with mcp_tools_context(mcp_config) as tools:
+            assert isinstance(tools, list)
+            assert len(tools) == 0
 
-    @pytest.mark.asyncio
-    @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
     async def test_load_mcp_tools_returns_none(self, mock_aget):
         """Test loading tools when aget_tools_from_mcp_url returns None."""
         mock_aget.return_value = None
 
         test_url = "https://mcp-server.example.com/mcp"
-        with patch.dict(os.environ, {"EXTERNAL_MCP_URL": test_url}, clear=True):
-            mcp_config = MCPConfig()
-            async with mcp_tools_context(mcp_config) as tools:
-                assert isinstance(tools, list)
-                assert len(tools) == 0
+        mcp_config = MCPConfig(external_mcp_url=test_url)
+        async with mcp_tools_context(mcp_config) as tools:
+            assert isinstance(tools, list)
+            assert len(tools) == 0
 
-    @pytest.mark.asyncio
-    @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
-    async def test_load_mcp_tools_with_parameters(self, mock_aget):
+    async def test_mcp_tools_context_with_parameters(self, mock_aget):
         """Test loading tools with explicit api_base and api_key parameters."""
         mock_tools = [MagicMock()]
         mock_aget.return_value = mock_tools
@@ -102,28 +100,21 @@ class TestLoadMCPTools:
         custom_api_base = "https://custom.datarobot.com/api/v2"
         custom_api_key = "custom-key"
 
-        with patch.dict(
-            os.environ,
-            {
-                "MCP_DEPLOYMENT_ID": deployment_id,
-                "DATAROBOT_API_TOKEN": custom_api_key,
-                "DATAROBOT_ENDPOINT": custom_api_base,
-            },
-            clear=True,
-        ):
-            mcp_config = MCPConfig()
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools == mock_tools
-                mock_aget.assert_awaited_once()
-                # Check that the function was called with custom parameters
-                call_args = mock_aget.await_args
-                expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
-                assert call_args[1]["command_or_url"] == expected_url
-                assert call_args[1]["client"].headers["Authorization"] == f"Bearer {custom_api_key}"
+        mcp_config = MCPConfig(
+            mcp_deployment_id=deployment_id,
+            datarobot_endpoint=custom_api_base,
+            datarobot_api_token=custom_api_key,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert tools == mock_tools
+            mock_aget.assert_awaited_once()
+            # Check that the function was called with custom parameters
+            call_args = mock_aget.await_args
+            expected_url = f"{custom_api_base}/deployments/{deployment_id}/directAccess/mcp"
+            assert call_args[1]["command_or_url"] == expected_url
+            assert call_args[1]["client"].headers["Authorization"] == f"Bearer {custom_api_key}"
 
-    @pytest.mark.asyncio
-    @patch("datarobot_genai.llama_index.mcp.aget_tools_from_mcp_url", new_callable=AsyncMock)
-    async def test_load_mcp_tools_with_forwarded_headers(self, mock_aget):
+    async def test_mcp_tools_context_with_forwarded_headers(self, mock_aget):
         """Test loading tools with forwarded headers including scoped token."""
         mock_tools = [MagicMock()]
         mock_aget.return_value = mock_tools
@@ -135,21 +126,26 @@ class TestLoadMCPTools:
             "x-datarobot-api-key": "scoped-token-123",
         }
 
-        with patch.dict(
-            os.environ,
-            {
-                "MCP_DEPLOYMENT_ID": deployment_id,
-                "DATAROBOT_ENDPOINT": api_base,
-                "DATAROBOT_API_TOKEN": api_key,
-            },
-            clear=True,
-        ):
-            mcp_config = MCPConfig(forwarded_headers=forwarded_headers)
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools == mock_tools
-                mock_aget.assert_awaited_once()
-                # Check that forwarded headers are included in client headers
-                call_args = mock_aget.await_args
-                client_headers = call_args[1]["client"].headers
-                assert client_headers["x-datarobot-api-key"] == "scoped-token-123"
-                assert client_headers["Authorization"] == f"Bearer {api_key}"
+        mcp_config = MCPConfig(
+            mcp_deployment_id=deployment_id,
+            datarobot_endpoint=api_base,
+            datarobot_api_token=api_key,
+            forwarded_headers=forwarded_headers,
+        )
+        async with mcp_tools_context(mcp_config) as tools:
+            assert tools == mock_tools
+            mock_aget.assert_awaited_once()
+            # Check that forwarded headers are included in client headers
+            call_args = mock_aget.await_args
+            client_headers = call_args[1]["client"].headers
+            assert client_headers["x-datarobot-api-key"] == "scoped-token-123"
+            assert client_headers["Authorization"] == f"Bearer {api_key}"
+
+    @pytest.mark.usefixtures("mock_aget")
+    async def test_mcp_tools_context_exception_is_propagated(self):
+        """Test that exceptions are propagated from aget_tools_from_mcp_url."""
+        test_url = "https://mcp-server.example.com/mcp"
+        mcp_config = MCPConfig(external_mcp_url=test_url)
+        with pytest.raises(RuntimeError):
+            async with mcp_tools_context(mcp_config):
+                raise RuntimeError("Connection failed")

--- a/tests/llamaindex/test_mcp.py
+++ b/tests/llamaindex/test_mcp.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
-from datarobot_genai.core.mcp.config import MCPConfig
+from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.llama_index.mcp import mcp_tools_context
 
 

--- a/tests/nat/integration/.env.sample
+++ b/tests/nat/integration/.env.sample
@@ -1,0 +1,7 @@
+LLM_DEFAULT_MODEL="datarobot/vertex_ai/claude-3-5-haiku@20241022"
+DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+# Values for buzok-ci-agents@datarobot.com on US prod
+# https://start.1password.com/open/i?a=SNW6QKQ365EQTAV726YE6K4S24&v=jreitiqnr2da7l2itgt5lflm2e&i=qxlkoduit6bi7u3s23n7jik2s4&h=datarobot.1password.com
+DATAROBOT_API_TOKEN=
+SESSION_SECRET_KEY=
+MCP_DEPLOYMENT_ID=

--- a/tests/nat/integration/README.md
+++ b/tests/nat/integration/README.md
@@ -1,0 +1,5 @@
+This tests NAT E2E the old-style (the way it works with drum).
+
+To run tests in this folder:
+1. Add to your root env file values from `.env.sample`
+2. `task test-nat-integration`

--- a/tests/nat/integration/test_agent.py
+++ b/tests/nat/integration/test_agent.py
@@ -27,6 +27,7 @@ from datarobot_genai.core.chat.responses import async_gen_to_sync_thread
 from datarobot_genai.core.chat.responses import (
     streaming_iterator_to_custom_model_streaming_response,
 )
+from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.nat.agent import NatAgent
 
 
@@ -67,10 +68,14 @@ def workflow_with_mcp_path():
 
 @pytest.fixture
 def agent_with_mcp(workflow_with_mcp_path, config):
+    mcp_config = MCPConfig()
+    server_config = mcp_config.server_config
+    headers = server_config["headers"] if server_config else None
     return NatAgent(
         workflow_path=workflow_with_mcp_path,
         api_key=config.datarobot_api_token,
         api_base=config.datarobot_endpoint,
+        forwarded_headers=headers,
     )
 
 

--- a/tests/nat/integration/workflow_with_mcp.yaml
+++ b/tests/nat/integration/workflow_with_mcp.yaml
@@ -17,19 +17,23 @@ functions:
     llm_name: datarobot_llm
     system_prompt: |
       You are a helpful assistant.
+
 function_groups:
   mcp_tools:
     _type: datarobot_mcp_client
+
 authentication:
   datarobot_mcp_auth:
     _type: datarobot_mcp_auth
+
 llms:
   datarobot_llm:
     _type: datarobot-llm-gateway
     model_name: azure/gpt-4o-2024-11-20
     temperature: 0.0
+
 workflow:
-  _type: react_agent
+  _type: per_user_react_agent
   llm_name: datarobot_llm
   tool_names:
     - mcp_tools

--- a/tests/nat/test_agent.py
+++ b/tests/nat/test_agent.py
@@ -59,8 +59,10 @@ def agent(workflow_path):
 def agent_with_headers(workflow_path):
     return NatAgent(
         workflow_path=workflow_path,
-        forwarded_headers={"h1": "v1"},
-        authorization_context={"c1": "v2"},
+        forwarded_headers={
+            "h1": "v1",
+            "Authorization": "Bearer test-api-key",
+        },
     )
 
 
@@ -168,20 +170,6 @@ def patch_environment_variables():
         clear=True,
     ):
         yield
-
-
-@patch.dict(os.environ, {}, clear=True)
-def test_init_with_additional_kwargs(workflow_path):
-    """Test initialization with additional keyword arguments."""
-    # Setup
-    additional_kwargs = {"extra_param1": "value1", "extra_param2": 42}
-
-    # Execute
-    agent = NatAgent(workflow_path=workflow_path, **additional_kwargs)
-
-    # Verify that the extra parameters don't create attributes
-    with pytest.raises(AttributeError):
-        _ = agent.extra_param1
 
 
 @pytest.mark.usefixtures("mock_intermediate_structured", "mock_load_workflow")
@@ -300,10 +288,6 @@ async def test_streaming_mcp_headers(
     expected_headers = {
         "h1": "v1",
         "Authorization": "Bearer test-api-key",
-        "X-DataRobot-Authorization-Context": (
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjMSI6InYyIn0"
-            ".5Elh7RxbEZV1JdUZi9duxJwXUkFRdzKhtyXyfTIj4Ms"
-        ),
     }
     mock_load_workflow.assert_called_once_with(
         workflow_path,

--- a/uv.lock
+++ b/uv.lock
@@ -1157,7 +1157,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
- [x] Resolve merge conflicts with main branch (v0.9.1)
  - CHANGELOG.md: kept 0.10.0 section, added 0.9.1 from main below it
  - pyproject.toml: kept version 0.10.0
  - uv.lock / e2e-tests/uv.lock: kept version 0.10.0
  - src/datarobot_genai/dragent/frontends/register.py: auto-merged (NAT warning suppression from main)
  - src/datarobot_genai/nat/datarobot_mcp_client.py: auto-merged (HttpUrl fix + debug log from main)
- [x] Address reviewer comment about complex str-to-bool verbose parsing (already done in earlier commits)
- [x] Resolve merge conflicts with main branch (v0.9.2 AG-UI streaming for CrewAI)
  - CHANGELOG.md: kept 0.10.0 section, added 0.9.2 entry from main
  - pyproject.toml: kept version 0.10.0
  - uv.lock: kept version 0.10.0
  - src/datarobot_genai/crewai/__init__.py: added CrewAIStreamingEventListener and MCPConfig exports from main
  - src/datarobot_genai/crewai/agent.py: incorporated AG-UI streaming (kickoff_async, streaming events) from main while keeping our MCP decomposition (no mcp_tools_context in invoke)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how MCP tools are created/injected across CrewAI/LangGraph/LlamaIndex/NAT and changes streaming/logging behavior; regressions could impact tool availability and event sequencing in agent runs.
> 
> **Overview**
> **Decouples MCP tool lifecycle from agent invocation and standardizes tool injection.** `BaseAgent` now carries a generic `tools` list (replacing `mcp_tools`/`authorization_context` plumbing), and MCP adapters (`crewai`, `langgraph`, `llama_index`) switch to `async` `mcp_tools_context(mcp_config: MCPConfig)` so callers explicitly manage tool contexts.
> 
> **Updates agent implementations and tests to match the new contract.** E2E register functions now build an `MCPConfig` from forwarded headers/authorization context, open `mcp_tools_context`, and pass the resulting tools into agents; LlamaIndex removes implicit MCP loading, LangGraph no longer wraps invocation in an MCP context, and CrewAI enables streaming by default while emitting richer AG-UI reasoning/step events and using unified logging.
> 
> **Build/CI and test harness changes.** Adds CrewAI change detection to the E2E matrix, adds a NAT integration test task and sample env, introduces a dummy `generate_objectid` tool for E2E tool-call verification, bumps project version to `0.10.0`, and updates PR automation workflow versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15e19ed2cbedf8914d9368c81e386a882ba6708a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->