### PR TITLE
[BUZZOK-29686] Suppress known-harmless NAT warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.9.1
-- Suppress known-harmless NAT warnings
+- Suppressed known-harmless NAT warnings
 
 ## 0.9.0
 - Removed side-effects in MCPConfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.9.1
+- Suppress known-harmless NAT warnings
+
 ## 0.9.0
 - Removed side-effects in MCPConfig
 - Renamed datarobot_genai.core.mcp.common to datarobot_genai.core.mcp.config

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -984,9 +984,9 @@ requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'langgraph'", specifier = ">=0.1.14,<0.2.0" },
     { name = "ag-ui-protocol", marker = "extra == 'llamaindex'", specifier = ">=0.1.14,<0.2.0" },
     { name = "ag-ui-protocol", marker = "extra == 'nat'", specifier = ">=0.1.14,<0.2.0" },
-    { name = "aiohttp", marker = "extra == 'auth'", specifier = ">=3.9.0,<4.0.0" },
-    { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.9.0,<4.0.0" },
-    { name = "aiohttp", marker = "extra == 'drtools'", specifier = ">=3.9.0,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'auth'", specifier = ">=3.13.3,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.13.3,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'drtools'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp-retry", marker = "extra == 'drmcp'", specifier = ">=2.8.3,<3.0.0" },
     { name = "anthropic", marker = "extra == 'crewai'", specifier = "~=0.71.0,<1.0.0" },
     { name = "anyio", marker = "extra == 'dragent'", specifier = "==4.11.0" },
@@ -995,6 +995,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'drmcp'", specifier = ">=4.12.0,<5.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drtools'", specifier = ">=4.12.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'drmcp'", specifier = ">=1.34.0,<2.0.0" },
+    { name = "boto3", marker = "extra == 'drtools'", specifier = ">=1.34.0,<2.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.1.0,<2.0.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
     { name = "datarobot", marker = "extra == 'core'", specifier = ">=3.10.0,<4.0.0" },
@@ -1006,6 +1007,8 @@ requires-dist = [
     { name = "datarobot", marker = "extra == 'llamaindex'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", marker = "extra == 'nat'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.10.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.10.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
     { name = "datarobot-early-access", marker = "extra == 'core'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'crewai'", specifier = "==3.14.0.2026.3.18.162920" },
@@ -1119,16 +1122,16 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'drmcp'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic", marker = "extra == 'drtools'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic-settings", marker = "extra == 'drmcp'", specifier = ">=2.1.0,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'core'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'crewai'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'dragent'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'drmcp'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'langgraph'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'llamaindex'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pyjwt", marker = "extra == 'nat'", specifier = ">=2.10.1,<3.0.0" },
-    { name = "pypdf", marker = "extra == 'drmcp'", specifier = ">=6.1.3,<7.0.0" },
-    { name = "pypdf", marker = "extra == 'drtools'", specifier = ">=6.1.3,<7.0.0" },
-    { name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pyjwt", marker = "extra == 'core'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'crewai'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'dragent'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'drmcp'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'langgraph'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'llamaindex'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", marker = "extra == 'nat'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pypdf", marker = "extra == 'drmcp'", specifier = ">=6.9.2,<7.0.0" },
+    { name = "pypdf", marker = "extra == 'drtools'", specifier = ">=6.9.2,<7.0.0" },
+    { name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.9.2,<7.0.0" },
     { name = "python-dateutil", marker = "extra == 'drmcp'", specifier = ">=2.9.0,<3.0.0" },
     { name = "python-dateutil", marker = "extra == 'drtools'", specifier = ">=2.9.0,<3.0.0" },
     { name = "python-dotenv", marker = "extra == 'drmcp'", specifier = ">=1.1.0,<2.0.0" },
@@ -4739,11 +4742,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.9.1"
+version = "6.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/fb/dc2e8cb006e80b0020ed20d8649106fe4274e82d8e756ad3e24ade19c0df/pypdf-6.9.1.tar.gz", hash = "sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d", size = 5311551, upload-time = "2026-03-17T10:46:07.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/f4/75543fa802b86e72f87e9395440fe1a89a6d149887e3e55745715c3352ac/pypdf-6.9.1-py3-none-any.whl", hash = "sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f", size = 333661, upload-time = "2026-03-17T10:46:06.286Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.9.0"
+version = "0.9.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import typing
 from collections.abc import AsyncGenerator
 
@@ -35,6 +36,18 @@ from .patches import patch_crewai_callback_handler
 # Patch nvidia-nat-crewai callback handler for crewai >= 1.1.0 compatibility.
 # Must run before NAT's instrument() is called. Safe no-op if crewai not installed.
 patch_crewai_callback_handler()
+
+# Suppress known-harmless NAT warnings that alarm users but can't be acted on.
+# Runs at plugin-discovery time so it takes effect regardless of entry point
+# (nat start, dragent serve, etc.).
+_NOISY_NAT_LOGGERS = [
+    "nat.data_models.step_adaptor",  # "StepAdaptor is disabled" (expected when mode=OFF)
+    "nat.front_ends.fastapi.fastapi_front_end_plugin",  # "Dask is not installed"
+    "nat.front_ends.fastapi.fastapi_front_end_plugin_worker",  # "Dask is not available"
+    "nat.experimental.decorators.experimental_warning_decorator",  # "feature is experimental"
+]
+for _logger_name in _NOISY_NAT_LOGGERS:
+    logging.getLogger(_logger_name).setLevel(logging.ERROR)
 
 
 class DRAgentA2AConfig(BaseModel):

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -14,6 +14,7 @@
 
 import logging
 import typing
+import warnings
 from collections.abc import AsyncGenerator
 
 from a2a.types import AgentSkill
@@ -37,17 +38,30 @@ from .patches import patch_crewai_callback_handler
 # Must run before NAT's instrument() is called. Safe no-op if crewai not installed.
 patch_crewai_callback_handler()
 
-# Suppress known-harmless NAT warnings that alarm users but can't be acted on.
-# Runs at plugin-discovery time so it takes effect regardless of entry point
-# (nat start, dragent serve, etc.).
-_NOISY_NAT_LOGGERS = [
-    "nat.data_models.step_adaptor",  # "StepAdaptor is disabled" (expected when mode=OFF)
-    "nat.front_ends.fastapi.fastapi_front_end_plugin",  # "Dask is not installed"
-    "nat.front_ends.fastapi.fastapi_front_end_plugin_worker",  # "Dask is not available"
-    "nat.experimental.decorators.experimental_warning_decorator",  # "feature is experimental"
+# Suppress specific non-actionable NAT warning messages by content.
+# Patch Handler.handle (inherited by all subclasses — they only override emit)
+# because root-logger filters are skipped during log propagation.
+_SUPPRESSED_NAT_MESSAGES = [
+    "StepAdaptor is disabled",
+    "Dask is not installed",
+    "Dask is not available",
+    "feature is experimental",
+    "Using provided input_schema for multi-argument function",
+    "not found in outstanding start steps",
 ]
-for _logger_name in _NOISY_NAT_LOGGERS:
-    logging.getLogger(_logger_name).setLevel(logging.ERROR)
+_orig_handler_handle = logging.Handler.handle
+
+
+def _filtered_handle(self: logging.Handler, record: logging.LogRecord) -> bool | None:
+    if any(s in record.getMessage() for s in _SUPPRESSED_NAT_MESSAGES):
+        return None
+    return _orig_handler_handle(self, record)
+
+
+logging.Handler.handle = _filtered_handle  # type: ignore[assignment]
+
+# Suppress UserWarning from langchain about non-default parameters (uses warnings.warn, not logging)
+warnings.filterwarnings("ignore", message=".*stream_options is not default parameter.*")
 
 
 class DRAgentA2AConfig(BaseModel):

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -45,14 +45,18 @@ _SUPPRESSED_NAT_MESSAGES = [
     "StepAdaptor is disabled",
     "Dask is not installed",
     "Dask is not available",
-    "feature is experimental",
+    "feature is experimental and the API may change",
     "Using provided input_schema for multi-argument function",
 ]
 _orig_handler_handle = logging.Handler.handle
 
 
 def _filtered_handle(self: logging.Handler, record: logging.LogRecord) -> bool | None:
-    if any(s in record.getMessage() for s in _SUPPRESSED_NAT_MESSAGES):
+    try:
+        msg = record.getMessage()
+    except Exception:
+        return _orig_handler_handle(self, record)
+    if any(s in msg for s in _SUPPRESSED_NAT_MESSAGES):
         return None
     return _orig_handler_handle(self, record)
 

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -47,7 +47,6 @@ _SUPPRESSED_NAT_MESSAGES = [
     "Dask is not available",
     "feature is experimental",
     "Using provided input_schema for multi-argument function",
-    "not found in outstanding start steps",
 ]
 _orig_handler_handle = logging.Handler.handle
 

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -39,7 +39,7 @@ from .patches import patch_crewai_callback_handler
 patch_crewai_callback_handler()
 
 # Suppress specific non-actionable NAT warning messages by content.
-# Patch Handler.handle (inherited by all subclasses — they only override emit)
+# Patch Handler.handle (inherited by all subclasses - they only override emit)
 # because root-logger filters are skipped during log propagation.
 _SUPPRESSED_NAT_MESSAGES = [
     "StepAdaptor is disabled",

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -49,7 +49,7 @@ def _default_url() -> HttpUrl:
     from datarobot_genai.core.mcp.config import MCPConfig  # noqa: PLC0415
 
     server_config = MCPConfig().server_config
-    return server_config["url"] if server_config else HttpUrl("http://localhost:8080/mcp")
+    return HttpUrl(server_config["url"]) if server_config else HttpUrl("http://localhost:8080/mcp")
 
 
 def _default_auth_provider() -> str | AuthenticationRef | None:
@@ -61,7 +61,7 @@ def _default_auth_provider() -> str | AuthenticationRef | None:
 
 class DataRobotMCPServerConfig(MCPServerConfig):
     transport: Literal["streamable-http", "sse"] = Field(
-        default_factory=_default_transport,
+        default_factor=_default_transport,
         description="Transport type to connect to the MCP server (sse or streamable-http)",
     )
     url: HttpUrl = Field(
@@ -253,7 +253,7 @@ async def datarobot_mcp_client_function_group(
                     input_schema = None
 
                 # Add to group
-                logger.info("Adding tool %s to group", function_name)
+                logger.debug("Adding tool %s to group", function_name)
                 group.add_function(
                     name=function_name,
                     description=description,

--- a/src/datarobot_genai/nat/datarobot_mcp_client.py
+++ b/src/datarobot_genai/nat/datarobot_mcp_client.py
@@ -61,7 +61,7 @@ def _default_auth_provider() -> str | AuthenticationRef | None:
 
 class DataRobotMCPServerConfig(MCPServerConfig):
     transport: Literal["streamable-http", "sse"] = Field(
-        default_factor=_default_transport,
+        default_factory=_default_transport,
         description="Transport type to connect to the MCP server (sse or streamable-http)",
     )
     url: HttpUrl = Field(

--- a/uv.lock
+++ b/uv.lock
@@ -1157,7 +1157,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Some of the NAT warnings were already gone. With the changes in this PR, we see:
```
[agent]  🔐 Checking authentication..
[agent]  ✅ '.env' credentials are valid.
[agent]  2026-03-31 11:51:38 - INFO     - nat.cli.commands.start:192 - Starting NAT from config file: 'agent/workflow.yaml'
[agent]  2026-03-31 11:51:38 - INFO     - nat.runtime.session:295 - Workflow is per-user (entry_function=None)
[agent]  2026-03-31 11:51:38 - INFO     - nat.runtime.session:295 - Workflow is per-user (entry_function=None)
[agent]  2026-03-31 11:51:38 - INFO     - nat.runtime.session:295 - Workflow is per-user (entry_function=None)
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:246 - Added health check endpoint at /
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:246 - Added health check endpoint at /ping
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:246 - Added health check endpoint at /ping/
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:246 - Added health check endpoint at /health
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:246 - Added health check endpoint at /health/
[agent]  2026-03-31 11:51:38 - INFO     - nat.runtime.session:295 - Workflow is per-user (entry_function=None)
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:64 - Initialized NATWorkflowAgentExecutor (message-only) for workflow: langgraph_agent
[agent]  2026-03-31 11:51:38 - INFO     - nat.plugins.a2a.server.front_end_plugin_worker:294 - Created A2A server with DefaultRequestHandler
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:197 - A2A endpoint URL: http://localhost:8842/a2a/
[agent]  2026-03-31 11:51:38 - INFO     - datarobot_genai.dragent.frontends.fastapi:198 - A2A agent card URL: http://localhost:8842/a2a/.well-known/agent-card.json
```

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [x] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it monkeypatches `logging.Handler.handle` globally, which could unintentionally suppress or alter logging behavior outside NAT and make troubleshooting harder.
> 
> **Overview**
> Bumps the package version to `0.9.1` and documents the release in `CHANGELOG.md`.
> 
> In `dragent` frontend registration, globally suppresses several known non-actionable NAT log messages by monkeypatching `logging.Handler.handle`, and ignores a specific langchain `UserWarning` via `warnings.filterwarnings`.
> 
> Tightens/updates dependency metadata in lockfiles (notably `aiohttp>=3.13.3`, `pyjwt>=2.12.0`, `pypdf>=6.9.2`, plus extra markers for `boto3`/`datarobot[auth]`), and makes the MCP client default URL handling explicitly construct `HttpUrl(...)` while downgrading a tool-registration log from `info` to `debug`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12234cfe2dc19257cc3110ac688481d14e626027. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->