### PR TITLE
[BUZZOK-30056] Fix changelog & add test for tool-calling in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.10.2
+- Fixed multi-turn tool-calling by preserving assistant `tool_calls` on `AssistantMessage` and retaining tool-call metadata in chat history summaries.
+
 ## 0.10.1
 - Fixed multi-turn tool-calling: preserving tool_calls on AssistantMessage and passing structured native messages to all agent frameworks when conversation history is present.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.10.1"
+version = "0.10.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/tests/core/agents/test_history.py
+++ b/tests/core/agents/test_history.py
@@ -18,7 +18,9 @@ from ag_ui.core import RunAgentInput
 from ag_ui.core import UserMessage
 
 from datarobot_genai.core.agents.history import _summarize_tool_calls
+from datarobot_genai.core.agents.history import build_history_summary_from_messages
 from datarobot_genai.core.agents.history import extract_history_messages
+from datarobot_genai.core.chat.completions import convert_chat_completion_params_to_run_agent_input
 
 
 def _make_run_agent_input(messages: list) -> RunAgentInput:
@@ -251,3 +253,47 @@ class TestExtractHistoryMessagesSingleUserMessage:
     def test_empty_messages_returns_empty_history(self) -> None:
         rai = _make_run_agent_input([])
         assert extract_history_messages(rai, max_history=20) == []
+
+
+class TestBuildHistorySummaryFromChatCompletions:
+    def test_preserves_tool_call_only_assistant_turns_in_history_summary(self) -> None:
+        # GIVEN a multi-turn chat completion payload with an assistant tool-call-only turn
+        params = {
+            "messages": [
+                {"role": "user", "content": "Choose a location and check the weather"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"location": "Boston, MA"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_abc123",
+                    "content": '{"temperature": 72, "condition": "sunny"}',
+                },
+                {
+                    "role": "user",
+                    "content": "What was the temperature? And what location was I asking about?",
+                },
+            ]
+        }
+
+        # WHEN converting to RunAgentInput and building the history summary
+        run_agent_input = convert_chat_completion_params_to_run_agent_input(params)
+        summary = build_history_summary_from_messages(run_agent_input, max_history=20)
+
+        # THEN the summary retains the tool-call metadata and tool result
+        assert summary == (
+            "user: Choose a location and check the weather\n"
+            'assistant: [tool_calls] get_weather({"location": "Boston, MA"})\n'
+            'tool: {"temperature": 72, "condition": "sunny"}'
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1157,7 +1157,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version/changelog bump plus a new regression test; no production logic changes are included in this diff.
> 
> **Overview**
> Bumps `datarobot-genai` to `0.10.2` and updates `CHANGELOG.md` to document a fix for multi-turn tool-calling history preservation.
> 
> Adds a unit test that exercises OpenAI-style chat completions conversion and asserts `build_history_summary_from_messages` retains assistant *tool-call-only* turns (including tool-call metadata) along with subsequent tool outputs when summarizing history.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0205236763da03ba7629b1d13e25f51108a8d099. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->