### PR TITLE
[BUZZOK-30087] Upgrade to fastmcp >=3.2.0 to fix cves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.11.1
+## 0.12.0
 - Upgraded fastmcp from 2.x to 3.2.0+ (CVE-2026-32871, CVE-2026-27124, CVE-2025-64340)
 - Replaced `on_duplicate_tools`/`on_duplicate_prompts` with unified `on_duplicate` (fastmcp 3.x API)
 - Replaced `enabled` parameter with `mcp.disable()` for tool/prompt/resource registration (fastmcp 3.x API)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.10.3
+- Upgraded fastmcp from 2.x to 3.2.0+ (CVE-2026-32871, CVE-2026-27124, CVE-2025-64340)
+- Replaced `on_duplicate_tools`/`on_duplicate_prompts` with unified `on_duplicate` (fastmcp 3.x API)
+- Replaced `enabled` parameter with `mcp.disable()` for tool/prompt/resource registration (fastmcp 3.x API)
+- Made `Context.set_state`/`get_state` calls async (fastmcp 3.x API)
+
 ## 0.10.2
 - Fixed multi-turn tool-calling by preserving assistant `tool_calls` on `AssistantMessage` and retaining tool-call metadata in chat history summaries.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.11.1"
+version = "0.12.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.10.2"
+version = "0.10.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ drtools = auth + [
 
 # drmcp is standalone set of dependencies for MCP Server only (no core), only depends on drtools.
 drmcp = drtools + [
-    "fastmcp>=2.13.0.2,<3.0.0",
+    "fastmcp>=3.2.0,<4.0.0",
     "requests>=2.32.4,<3.0.0",
     "openai>=1.76.2,<2.0.0",
     "pyjwt>=2.12.0,<3.0.0",

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -245,9 +245,9 @@ class DataRobotMCPServer:
             asyncio.run(self._lifecycle.pre_server_start(self._mcp))
 
             # List registered tools, prompts, and resources before starting server
-            tools = asyncio.run(self._mcp._list_tools_mcp())
-            prompts = asyncio.run(self._mcp._list_prompts_mcp())
-            resources = asyncio.run(self._mcp._list_resources_mcp())
+            tools = asyncio.run(self._mcp.list_tools())
+            prompts = asyncio.run(self._mcp.list_prompts())
+            resources = asyncio.run(self._mcp.list_resources())
 
             tools_count = len(tools)
             prompts_count = len(prompts)

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -328,13 +328,13 @@ class DataRobotMCPServer:
             raise
 
     async def get_tools(self) -> dict[str, Tool]:
-        return await self._mcp.get_tools()
+        return {t.name: t for t in await self._mcp.list_tools()}
 
     async def get_prompts(self) -> dict[str, Prompt]:
-        return await self._mcp.get_prompts()
+        return {p.name: p for p in await self._mcp.list_prompts()}
 
     async def get_resources(self) -> dict[str, Resource]:
-        return await self._mcp.get_resources()
+        return {r.name: r for r in await self._mcp.list_resources()}
 
 
 def create_mcp_server(

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/utils.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/utils.py
@@ -29,7 +29,7 @@ async def get_prompt_name_no_duplicate(mcp: FastMCP, prompt_name: str) -> str:
     except NotFoundError:
         return prompt_name
 
-    if prompt is None:
+    if prompt is None:  # fastmcp 3.x returns None instead of raising NotFoundError
         return prompt_name
 
     prompt_name_suffix = str(uuid4())[:_SUFFIX_LENGTH]

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/utils.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/utils.py
@@ -29,5 +29,8 @@ async def get_prompt_name_no_duplicate(mcp: FastMCP, prompt_name: str) -> str:
     except NotFoundError:
         return prompt_name
 
+    if prompt is None:
+        return prompt_name
+
     prompt_name_suffix = str(uuid4())[:_SUFFIX_LENGTH]
     return f"{prompt.name} ({prompt_name_suffix})"

--- a/src/datarobot_genai/drmcp/core/lineage/manager.py
+++ b/src/datarobot_genai/drmcp/core/lineage/manager.py
@@ -113,15 +113,15 @@ class LineageManager:
         ]
 
     async def get_mcp_tools_in_mcp_server(self) -> list[MCPToolMetadata]:
-        mcp_tools = await self.mcp_server_instance._list_tools_mcp()
+        mcp_tools = await self.mcp_server_instance.list_tools()
         return [MCPToolMetadata.from_fastmcp_item(mcp_tool) for mcp_tool in mcp_tools]
 
     async def get_mcp_prompts_in_mcp_server(self) -> list[MCPPromptMetadata]:
-        mcp_prompts = await self.mcp_server_instance._list_prompts_mcp()
+        mcp_prompts = await self.mcp_server_instance.list_prompts()
         return [MCPPromptMetadata.from_fastmcp_item(mcp_prompt) for mcp_prompt in mcp_prompts]
 
     async def get_mcp_resources_in_mcp_server(self) -> list[MCPResourceMetadata]:
-        mcp_resources = await self.mcp_server_instance._list_resources_mcp()
+        mcp_resources = await self.mcp_server_instance.list_resources()
         return [
             MCPResourceMetadata.from_fastmcp_item(mcp_resource) for mcp_resource in mcp_resources
         ]

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -31,6 +31,12 @@ from fastmcp.tools import Tool
 from mcp.types import Annotations as MCPAnnotationsType
 from mcp.types import AnyFunction
 from mcp.types import Icon as MCPIconType
+from mcp.types import ListPromptsRequest
+from mcp.types import ListResourcesRequest
+from mcp.types import ListToolsRequest
+from mcp.types import Prompt as MCPPrompt
+from mcp.types import Resource as MCPResource
+from mcp.types import Tool as MCPTool
 from mcp.types import ToolAnnotations
 from typing_extensions import Unpack
 
@@ -96,6 +102,41 @@ class DataRobotMCP(FastMCP):
         super().__init__(*args, **kwargs)
         self._deployments_map: dict[str, str] = {}
         self._prompts_map: dict[str, tuple[str, str]] = {}
+
+    async def get_tools(self) -> dict[str, Tool]:
+        """Compat wrapper: fastmcp 3.x renamed get_tools→list_tools and returns a list."""
+        return {t.name: t for t in await self.list_tools()}
+
+    async def get_prompts(self) -> dict[str, Prompt]:
+        """Compat wrapper: fastmcp 3.x renamed get_prompts→list_prompts and returns a list."""
+        return {p.name: p for p in await self.list_prompts()}
+
+    async def get_resources(self) -> dict[str, Any]:
+        """Compat wrapper: fastmcp 3.x renamed get_resources→list_resources and returns a list."""
+        return {r.name: r for r in await self.list_resources()}
+
+    async def _list_tools_mcp(self, request: ListToolsRequest | None = None) -> list[MCPTool]:
+        """Compat wrapper: fastmcp 3.x requires a request arg and returns a Result object."""
+        result = await super()._list_tools_mcp(request or ListToolsRequest(method="tools/list"))
+        return list(result.tools)
+
+    async def _list_prompts_mcp(
+        self, request: ListPromptsRequest | None = None
+    ) -> list[MCPPrompt]:
+        """Compat wrapper: fastmcp 3.x requires a request arg and returns a Result object."""
+        result = await super()._list_prompts_mcp(
+            request or ListPromptsRequest(method="prompts/list")
+        )
+        return list(result.prompts)
+
+    async def _list_resources_mcp(
+        self, request: ListResourcesRequest | None = None
+    ) -> list[MCPResource]:
+        """Compat wrapper: fastmcp 3.x requires a request arg and returns a Result object."""
+        result = await super()._list_resources_mcp(
+            request or ListResourcesRequest(method="resources/list")
+        )
+        return list(result.resources)
 
     async def notify_prompts_changed(self) -> None:
         """
@@ -250,10 +291,21 @@ class DataRobotMCP(FastMCP):
 # Create the DataRobot MCP instance
 mcp_server_configs: MCPServerConfig = get_config()
 
+if (
+    mcp_server_configs.tool_registration_duplicate_behavior
+    != mcp_server_configs.prompt_registration_duplicate_behavior
+):
+    logger.warning(
+        "FastMCP 3.x uses a single on_duplicate setting for all component types. "
+        "tool_registration_duplicate_behavior=%s will be used; "
+        "prompt_registration_duplicate_behavior=%s will be ignored for FastMCP.",
+        mcp_server_configs.tool_registration_duplicate_behavior,
+        mcp_server_configs.prompt_registration_duplicate_behavior,
+    )
+
 mcp = DataRobotMCP(
     name=mcp_server_configs.mcp_server_name,
-    on_duplicate_tools=mcp_server_configs.tool_registration_duplicate_behavior,
-    on_duplicate_prompts=mcp_server_configs.prompt_registration_duplicate_behavior,
+    on_duplicate=mcp_server_configs.tool_registration_duplicate_behavior,
 )
 
 
@@ -273,7 +325,6 @@ class ToolKwargs(TypedDict, total=False):
     annotations: Any | None
     exclude_args: list[str] | None
     meta: dict[str, Any] | None
-    enabled: bool | None
 
 
 @dataclass
@@ -296,7 +347,9 @@ class PromptInitArguments:
     def to_dict(
         self,
     ) -> dict[str, str | bool | set[str] | list[MCPIconType] | dict[str, Any] | None]:
-        return asdict(self)
+        d = asdict(self)
+        d.pop("enabled", None)  # fastmcp 3.x removed 'enabled' from prompt()
+        return d
 
     def set_prompt_category(self, prompt_category: DataRobotMCPPromptCategory) -> None:
         self.meta = self.meta or {}
@@ -328,7 +381,9 @@ class ResourceInitArguments:
     ) -> dict[
         str, str | bool | set[str] | list[MCPIconType] | dict[str, Any] | MCPAnnotationsType | None
     ]:
-        return asdict(self)
+        d = asdict(self)
+        d.pop("enabled", None)  # fastmcp 3.x removed 'enabled' from resource()
+        return d
 
     def set_resource_category(self, resource_category: DataRobotMCPResourceCategory) -> None:
         self.meta = self.meta or {}
@@ -411,9 +466,14 @@ def dr_mcp_tool(
         updated_kwargs = update_mcp_tool_init_args_with_tool_category(
             tool_category, **mcp_tool_init_args
         )
+        # fastmcp 3.x removed 'enabled' from tool(); handle it separately
+        enabled = updated_kwargs.pop("enabled", None)
         # Apply the MCP decorators
         instrumented = dr_mcp_extras()(wrapper)
         mcp.tool(**updated_kwargs)(instrumented)
+        if enabled is False:
+            tool_name = updated_kwargs.get("name") or func.__name__
+            mcp.disable(names={tool_name}, components={"tool"})
         return instrumented
 
     return decorator

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -120,9 +120,7 @@ class DataRobotMCP(FastMCP):
         result = await super()._list_tools_mcp(request or ListToolsRequest(method="tools/list"))
         return list(result.tools)
 
-    async def _list_prompts_mcp(
-        self, request: ListPromptsRequest | None = None
-    ) -> list[MCPPrompt]:
+    async def _list_prompts_mcp(self, request: ListPromptsRequest | None = None) -> list[MCPPrompt]:
         """Compat wrapper: fastmcp 3.x requires a request arg and returns a Result object."""
         result = await super()._list_prompts_mcp(
             request or ListPromptsRequest(method="prompts/list")

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -465,7 +465,7 @@ def dr_mcp_tool(
             tool_category, **mcp_tool_init_args
         )
         # fastmcp 3.x removed 'enabled' from tool(); handle it separately
-        enabled = updated_kwargs.pop("enabled", None)
+        enabled = updated_kwargs.pop("enabled", None)  # type: ignore[typeddict-item]
         # Apply the MCP decorators
         instrumented = dr_mcp_extras()(wrapper)
         mcp.tool(**updated_kwargs)(instrumented)

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -31,12 +31,6 @@ from fastmcp.tools import Tool
 from mcp.types import Annotations as MCPAnnotationsType
 from mcp.types import AnyFunction
 from mcp.types import Icon as MCPIconType
-from mcp.types import ListPromptsRequest
-from mcp.types import ListResourcesRequest
-from mcp.types import ListToolsRequest
-from mcp.types import Prompt as MCPPrompt
-from mcp.types import Resource as MCPResource
-from mcp.types import Tool as MCPTool
 from mcp.types import ToolAnnotations
 from typing_extensions import Unpack
 
@@ -114,27 +108,6 @@ class DataRobotMCP(FastMCP):
     async def get_resources(self) -> dict[str, Any]:
         """Compat wrapper: fastmcp 3.x renamed get_resources→list_resources and returns a list."""
         return {r.name: r for r in await self.list_resources()}
-
-    async def _list_tools_mcp(self, request: ListToolsRequest | None = None) -> list[MCPTool]:
-        """Compat wrapper: fastmcp 3.x requires a request arg and returns a Result object."""
-        result = await super()._list_tools_mcp(request or ListToolsRequest(method="tools/list"))
-        return list(result.tools)
-
-    async def _list_prompts_mcp(self, request: ListPromptsRequest | None = None) -> list[MCPPrompt]:
-        """Compat wrapper: fastmcp 3.x requires a request arg and returns a Result object."""
-        result = await super()._list_prompts_mcp(
-            request or ListPromptsRequest(method="prompts/list")
-        )
-        return list(result.prompts)
-
-    async def _list_resources_mcp(
-        self, request: ListResourcesRequest | None = None
-    ) -> list[MCPResource]:
-        """Compat wrapper: fastmcp 3.x requires a request arg and returns a Result object."""
-        result = await super()._list_resources_mcp(
-            request or ListResourcesRequest(method="resources/list")
-        )
-        return list(result.resources)
 
     async def notify_prompts_changed(self) -> None:
         """
@@ -513,7 +486,7 @@ async def check_tool_registration_status_after_it_finishes(
     name_of_tool_to_register: str,
 ) -> None:
     # Verify tool is registered
-    tools = await mcp_server._list_tools_mcp()
+    tools = await mcp_server.list_tools()
     if not any(tool.name == name_of_tool_to_register for tool in tools):
         raise RuntimeError(f"Tool {name_of_tool_to_register} was not registered successfully")
     logger.info(f"Registered tools: {len(tools)}")
@@ -665,7 +638,10 @@ def dr_mcp_prompt(
             return func(*args, **kwargs)
 
         prompt_init_args.set_prompt_category(prompt_category)
-        return mcp.prompt(**prompt_init_args.to_dict())(_inner_decorator)
+        registered = mcp.prompt(**prompt_init_args.to_dict())(_inner_decorator)
+        if prompt_init_args.enabled is False:
+            mcp.disable(names={prompt_init_args.name or func.__name__}, components={"prompt"})
+        return registered
 
     return prompt_decorator
 
@@ -680,6 +656,9 @@ def dr_mcp_resource(
             return func(*args, **kwargs)
 
         resource_init_args.set_resource_category(resource_category)
-        return mcp.resource(**resource_init_args.to_dict())(_inner_decorator)
+        registered = mcp.resource(**resource_init_args.to_dict())(_inner_decorator)
+        if resource_init_args.enabled is False:
+            mcp.disable(names={resource_init_args.name or func.__name__}, components={"resource"})
+        return registered
 
     return resource_decorator

--- a/src/datarobot_genai/drmcp/core/routes.py
+++ b/src/datarobot_genai/drmcp/core/routes.py
@@ -57,7 +57,7 @@ def register_routes(mcp: DataRobotMCP) -> None:
         """Get metadata about tools, prompts, resources, and system configuration."""
         try:
             # Get tools with tags
-            tools = await mcp._list_tools_mcp()
+            tools = await mcp.list_tools()
             tools_metadata = [
                 {
                     "name": tool.name,
@@ -67,7 +67,7 @@ def register_routes(mcp: DataRobotMCP) -> None:
             ]
 
             # Get prompts with tags
-            prompts = await mcp._list_prompts_mcp()
+            prompts = await mcp.list_prompts()
             prompts_metadata = [
                 {
                     "name": prompt.name,
@@ -77,7 +77,7 @@ def register_routes(mcp: DataRobotMCP) -> None:
             ]
 
             # Get resources with tags
-            resources = await mcp._list_resources_mcp()
+            resources = await mcp.list_resources()
             resources_metadata = [
                 {
                     "name": resource.name,

--- a/src/datarobot_genai/drmcp/core/utils.py
+++ b/src/datarobot_genai/drmcp/core/utils.py
@@ -64,11 +64,11 @@ def get_prompt_tags(prompt: MCPPrompt) -> set[str]:
     -------
         Set of tag strings, empty set if no tags found
     """
-    # MCPPrompt has tags in meta._fastmcp.tags (as a list)
+    # MCPPrompt has tags in meta.fastmcp.tags (fastmcp 3.x)
     if not (prompt.meta and isinstance(prompt.meta, dict)):
         return set()
 
-    fastmcp_meta = prompt.meta.get("_fastmcp")
+    fastmcp_meta = prompt.meta.get("fastmcp")
     if not (fastmcp_meta and isinstance(fastmcp_meta, dict)):
         return set()
 
@@ -87,11 +87,11 @@ def get_resource_tags(resource: MCPResource) -> set[str]:
     -------
         Set of tag strings, empty set if no tags found
     """
-    # MCPResource has tags in meta._fastmcp.tags (as a list)
+    # MCPResource has tags in meta.fastmcp.tags (fastmcp 3.x)
     if not (resource.meta and isinstance(resource.meta, dict)):
         return set()
 
-    fastmcp_meta = resource.meta.get("_fastmcp")
+    fastmcp_meta = resource.meta.get("fastmcp")
     if not (fastmcp_meta and isinstance(fastmcp_meta, dict)):
         return set()
 
@@ -114,11 +114,11 @@ def get_tool_tags(tool: Tool | MCPTool) -> set[str]:
         # FastMCP Tool has tags directly as a set
         return getattr(tool, "tags", None) or set()
 
-    # MCPTool has tags in meta._fastmcp.tags (as a list)
+    # MCPTool has tags in meta.fastmcp.tags (fastmcp 3.x)
     if not (tool.meta and isinstance(tool.meta, dict)):
         return set()
 
-    fastmcp_meta = tool.meta.get("_fastmcp")
+    fastmcp_meta = tool.meta.get("fastmcp")
     if not (fastmcp_meta and isinstance(fastmcp_meta, dict)):
         return set()
 

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -97,7 +97,7 @@ class OAuthMiddleWare(Middleware):
             logger.debug("No valid authorization context extracted from request headers.")
 
         if context.fastmcp_context is not None:
-            context.fastmcp_context.set_state(AUTH_CTX_KEY, auth_context)
+            await context.fastmcp_context.set_state(AUTH_CTX_KEY, auth_context)
             logger.debug("Authorization context attached to state.")
 
         return await call_next(context)
@@ -136,7 +136,7 @@ async def must_get_auth_context() -> AuthCtx:
     """
     context = _get_context()
 
-    auth_ctx = context.get_state(AUTH_CTX_KEY)
+    auth_ctx = await context.get_state(AUTH_CTX_KEY)
     if not auth_ctx:
         raise RuntimeError("Could not retrieve authorization context from FastMCP context state.")
 

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -34,7 +34,9 @@ try:
     from fastmcp.server.dependencies import get_http_headers
     from fastmcp.server.middleware import Middleware
 
-    _get_http_headers = get_http_headers
+    def _get_http_headers(**kwargs: Any) -> dict[str, str]:
+        # fastmcp 3.x strips authorization headers by default; include them for auth
+        return get_http_headers(include_all=True, **kwargs)
     _get_context = get_context
 except ImportError:
     # FastMCP not available - create a stub that returns empty dict

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -41,11 +41,7 @@ try:
     _get_context = get_context
 except ImportError:
     # FastMCP not available - create a stub that returns empty dict
-    def _get_http_headers(include_all: bool = False) -> dict[str, str]:
-        """
-        Stub implementation when FastMCP is not available.
-        Returns empty dict to match FastMCP behavior when no request context exists.
-        """
+    def _get_http_headers(**kwargs: Any) -> dict[str, str]:
         return {}
 
     def _get_context() -> Any:

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -37,6 +37,7 @@ try:
     def _get_http_headers(**kwargs: Any) -> dict[str, str]:
         # fastmcp 3.x strips authorization headers by default; include them for auth
         return get_http_headers(include_all=True, **kwargs)
+
     _get_context = get_context
 except ImportError:
     # FastMCP not available - create a stub that returns empty dict

--- a/tests/drmcp/integration/test_auth.py
+++ b/tests/drmcp/integration/test_auth.py
@@ -73,6 +73,8 @@ def mock_middleware_context() -> MiddlewareContext:
     """Create a mocked MiddlewareContext for testing."""
     mock_message = MagicMock()
     mock_fastmcp_context = MagicMock()
+    mock_fastmcp_context.set_state = AsyncMock()
+    mock_fastmcp_context.get_state = AsyncMock()
     return MiddlewareContext(message=mock_message, fastmcp_context=mock_fastmcp_context)
 
 

--- a/tests/drmcp/integration/test_core_utils.py
+++ b/tests/drmcp/integration/test_core_utils.py
@@ -47,7 +47,7 @@ class TestCoreUtilsIntegration:
 
                 # If tool has meta with _fastmcp.tags, verify extraction
                 if tool.meta and isinstance(tool.meta, dict):
-                    fastmcp_meta = tool.meta.get("_fastmcp")
+                    fastmcp_meta = tool.meta.get("fastmcp")
                     if fastmcp_meta and isinstance(fastmcp_meta, dict):
                         meta_tags = fastmcp_meta.get("tags")
                         if meta_tags:
@@ -81,7 +81,7 @@ class TestCoreUtilsIntegration:
 
                 # Verify tags match what's in meta if present
                 if tool.meta and isinstance(tool.meta, dict):
-                    fastmcp_meta = tool.meta.get("_fastmcp")
+                    fastmcp_meta = tool.meta.get("fastmcp")
                     if fastmcp_meta and isinstance(fastmcp_meta, dict):
                         meta_tags = fastmcp_meta.get("tags")
                         if meta_tags:

--- a/tests/drmcp/integration/test_core_utils.py
+++ b/tests/drmcp/integration/test_core_utils.py
@@ -45,7 +45,7 @@ class TestCoreUtilsIntegration:
                 # Tags should be a set (empty or with values)
                 assert isinstance(tags, set)
 
-                # If tool has meta with _fastmcp.tags, verify extraction
+                # If tool has meta with fastmcp.tags, verify extraction
                 if tool.meta and isinstance(tool.meta, dict):
                     fastmcp_meta = tool.meta.get("fastmcp")
                     if fastmcp_meta and isinstance(fastmcp_meta, dict):
@@ -57,7 +57,7 @@ class TestCoreUtilsIntegration:
                             # No tags in meta, should return empty set
                             assert tags == set()
                     else:
-                        # No _fastmcp in meta, should return empty set
+                        # No fastmcp in meta, should return empty set
                         assert tags == set()
                 else:
                     # No meta or meta is not dict, should return empty set

--- a/tests/drmcp/integration/test_dynamic_prompts.py
+++ b/tests/drmcp/integration/test_dynamic_prompts.py
@@ -45,7 +45,7 @@ class TestMCPDRPromptManagementIntegration:
             # Check if it tells that prompt does not exist
             assert (
                 e.value.error.message
-                == "Unknown prompt: drmcp-integration-test-prompt-without-version"
+                == "Unknown prompt: 'drmcp-integration-test-prompt-without-version'"
             )
 
     async def test_prompt_with_version_without_variables(

--- a/tests/drmcp/integration/test_dynamic_tools.py
+++ b/tests/drmcp/integration/test_dynamic_tools.py
@@ -275,7 +275,7 @@ async def test_get_mcp_tool_metadata(
 async def test_dynamic_tool_registration(dr_client, mock_api_responses) -> None:
     await register_tools_of_datarobot_deployments()
 
-    tool_names = {tool.name for tool in await mcp._list_tools_mcp()}
+    tool_names = {tool.name for tool in await mcp.list_tools()}
 
     assert "dynamic_tool_ok" in tool_names, "`dynamic_tool_ok` is missing."
     assert "dynamic_tool_error" not in tool_names, "`dynamic_tool_error` should not be registered."

--- a/tests/drmcp/integration/test_register_tools.py
+++ b/tests/drmcp/integration/test_register_tools.py
@@ -43,7 +43,7 @@ class TestMCPRegisterToolsIntegration:
         async def test_tool() -> dict[str, int]:
             return tool_output
 
-        initial_tools = await mcp._list_tools_mcp()
+        initial_tools = await mcp.list_tools()
         assert all(tool.name != "test_tool" for tool in initial_tools)
 
         # Register the tool
@@ -69,7 +69,7 @@ class TestMCPRegisterToolsIntegration:
         async def tagged_tool(ctx: Context[ServerSession, dict[str, Any]]) -> str:
             return "tagged_response"
 
-        initial_tools = await mcp._list_tools_mcp()
+        initial_tools = await mcp.list_tools()
         assert all(tool.name != "tagged_tool" for tool in initial_tools)
 
         test_tags = {"test", "integration"}
@@ -81,17 +81,12 @@ class TestMCPRegisterToolsIntegration:
         )
 
         # Verify tool is registered with correct tags
-        tools = await mcp._list_tools_mcp()
+        tools = await mcp.list_tools()
         assert any(tool.name == "tagged_tool" for tool in tools)
 
-        # Verify tool tags
+        # Verify tool tags (list_tools returns fastmcp Tool objects with tags directly)
         registered_tool = next(tool for tool in tools if tool.name == "tagged_tool")
-        # Tags are stored in meta.fastmcp.tags by FastMCP 3.x
-        assert registered_tool.meta is not None
-        fastmcp_meta = registered_tool.meta.get("fastmcp", {})
-        meta_tags = fastmcp_meta.get("tags", [])
-        # Convert to set for comparison since order may differ
-        assert set(meta_tags) == test_tags
+        assert registered_tool.tags == test_tags
 
     async def test_dr_mcp_tool_with_enabled_false(self) -> None:
         """Test that dr_mcp_tool with enabled=False excludes tool from registration."""
@@ -102,7 +97,7 @@ class TestMCPRegisterToolsIntegration:
             return "should_not_be_callable"
 
         # Verify tool is NOT registered (enabled=False should exclude it)
-        tools = await mcp._list_tools_mcp()
+        tools = await mcp.list_tools()
         assert all(tool.name != "disabled_tool" for tool in tools)
 
     async def test_dr_mcp_tool_with_custom_meta(self) -> None:
@@ -114,7 +109,7 @@ class TestMCPRegisterToolsIntegration:
             return "meta_response"
 
         # Verify tool is registered with custom meta
-        tools = await mcp._list_tools_mcp()
+        tools = await mcp.list_tools()
         registered_tool = next((t for t in tools if t.name == "tool_with_meta"), None)
         assert registered_tool is not None
         assert registered_tool.meta is not None

--- a/tests/drmcp/integration/test_register_tools.py
+++ b/tests/drmcp/integration/test_register_tools.py
@@ -86,9 +86,9 @@ class TestMCPRegisterToolsIntegration:
 
         # Verify tool tags
         registered_tool = next(tool for tool in tools if tool.name == "tagged_tool")
-        # Tags are stored in meta._fastmcp.tags by FastMCP
+        # Tags are stored in meta.fastmcp.tags by FastMCP 3.x
         assert registered_tool.meta is not None
-        fastmcp_meta = registered_tool.meta.get("_fastmcp", {})
+        fastmcp_meta = registered_tool.meta.get("fastmcp", {})
         meta_tags = fastmcp_meta.get("tags", [])
         # Convert to set for comparison since order may differ
         assert set(meta_tags) == test_tags

--- a/tests/drmcp/unit/core/lineage/test_manager.py
+++ b/tests/drmcp/unit/core/lineage/test_manager.py
@@ -408,7 +408,7 @@ class TestLineageManager:
     ) -> None:
         mock_mcp_server = Mock()
         mock_fastmcp_tool = Mock()
-        mock_mcp_server._list_tools_mcp = AsyncMock(return_value=[mock_fastmcp_tool])
+        mock_mcp_server.list_tools = AsyncMock(return_value=[mock_fastmcp_tool])
 
         manager = LineageManager(mock_mcp_server)
         mcp_tools = await manager.get_mcp_tools_in_mcp_server()
@@ -427,7 +427,7 @@ class TestLineageManager:
     ) -> None:
         mock_mcp_server = Mock()
         mock_fastmcp_prompt = Mock()
-        mock_mcp_server._list_prompts_mcp = AsyncMock(return_value=[mock_fastmcp_prompt])
+        mock_mcp_server.list_prompts = AsyncMock(return_value=[mock_fastmcp_prompt])
 
         manager = LineageManager(mock_mcp_server)
         mcp_tools = await manager.get_mcp_prompts_in_mcp_server()
@@ -446,7 +446,7 @@ class TestLineageManager:
     ) -> None:
         mock_mcp_server = Mock()
         mock_fastmcp_resource = Mock()
-        mock_mcp_server._list_resources_mcp = AsyncMock(return_value=[mock_fastmcp_resource])
+        mock_mcp_server.list_resources = AsyncMock(return_value=[mock_fastmcp_resource])
 
         manager = LineageManager(mock_mcp_server)
         mcp_tools = await manager.get_mcp_resources_in_mcp_server()

--- a/tests/drmcp/unit/dynamic_tools/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_tools/test_controllers.py
@@ -122,7 +122,7 @@ class TestToolRegistration:
         assert deployment_mappings == {deployment_id: "weather_tool"}
 
         # Verify tool registration in MCP
-        registered_tools = await mcp_server._list_tools_mcp()
+        registered_tools = await mcp_server.list_tools()
         assert len(registered_tools) == 1
         assert registered_tools[0].name == "weather_tool"
         assert registered_tools[0].description == "Get weather for cities"
@@ -158,7 +158,7 @@ class TestToolRegistration:
         assert deployment_mappings["deployment-456"] == "Another Tool"
 
         # Verify both tools are registered in MCP
-        registered_tools = await mcp_server._list_tools_mcp()
+        registered_tools = await mcp_server.list_tools()
         assert len(registered_tools) == 2
         tool_names = {tool.name for tool in registered_tools}
         assert tool_names == {"weather_tool", "Another Tool"}

--- a/tests/drmcp/unit/test_auth.py
+++ b/tests/drmcp/unit/test_auth.py
@@ -99,6 +99,54 @@ def call_next() -> AsyncMock:
     return mock_next
 
 
+class TestGetHttpHeadersWrapper:
+    """Test that _get_http_headers includes authorization headers.
+
+    fastmcp 3.x changed get_http_headers() to strip 'authorization' by default.
+    Our wrapper must pass include_all=True so auth middleware can read tokens.
+    """
+
+    def test_fastmcp_strips_auth_headers_by_default(self) -> None:
+        """Confirm fastmcp 3.x strips authorization without include_all."""
+        from fastmcp.server.dependencies import get_http_headers
+        from fastmcp.server.dependencies import get_http_request
+
+        fake_request = MagicMock()
+        fake_request.headers = MagicMock()
+        fake_request.headers.items.return_value = [
+            ("authorization", "Bearer token123"),
+            ("x-datarobot-api-token", "dr-token-456"),
+            ("x-custom", "keep-me"),
+        ]
+
+        with patch(
+            "fastmcp.server.dependencies.get_http_request", return_value=fake_request
+        ):
+            default_headers = get_http_headers()
+            all_headers = get_http_headers(include_all=True)
+
+        # Default: authorization is stripped
+        assert "authorization" not in default_headers
+        assert "x-custom" in default_headers
+
+        # include_all: authorization is kept
+        assert "authorization" in all_headers
+        assert all_headers["authorization"] == "Bearer token123"
+
+    def test_wrapper_passes_include_all(self) -> None:
+        """Verify our _get_http_headers wrapper passes include_all=True."""
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_http_headers"
+        ) as mock_get_headers:
+            mock_get_headers.return_value = {"authorization": "Bearer token123"}
+            from datarobot_genai.drtools.core.auth import _get_http_headers
+
+            result = _get_http_headers()
+
+            mock_get_headers.assert_called_once_with(include_all=True)
+            assert result == {"authorization": "Bearer token123"}
+
+
 class TestOAuthMiddleware:
     """Tests for OAuthMiddleware class."""
 

--- a/tests/drmcp/unit/test_auth.py
+++ b/tests/drmcp/unit/test_auth.py
@@ -119,9 +119,7 @@ class TestGetHttpHeadersWrapper:
             ("x-custom", "keep-me"),
         ]
 
-        with patch(
-            "fastmcp.server.dependencies.get_http_request", return_value=fake_request
-        ):
+        with patch("fastmcp.server.dependencies.get_http_request", return_value=fake_request):
             default_headers = get_http_headers()
             all_headers = get_http_headers(include_all=True)
 
@@ -135,9 +133,7 @@ class TestGetHttpHeadersWrapper:
 
     def test_wrapper_passes_include_all(self) -> None:
         """Verify our _get_http_headers wrapper passes include_all=True."""
-        with patch(
-            "datarobot_genai.drtools.core.auth.get_http_headers"
-        ) as mock_get_headers:
+        with patch("datarobot_genai.drtools.core.auth.get_http_headers") as mock_get_headers:
             mock_get_headers.return_value = {"authorization": "Bearer token123"}
             from datarobot_genai.drtools.core.auth import _get_http_headers
 

--- a/tests/drmcp/unit/test_auth.py
+++ b/tests/drmcp/unit/test_auth.py
@@ -22,7 +22,6 @@ import pytest
 from datarobot.auth.identity import Identity
 from datarobot.auth.session import AuthCtx
 from datarobot.auth.users import User
-
 from fastmcp.server.middleware import MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 
@@ -398,11 +397,21 @@ class TestOAuthMiddleware:
 
 
 def _make_mock_context() -> MagicMock:
-    """Create a mock Context with async dict-based state (Context requires a session in fastmcp 3.x)."""
+    """Create a mock Context with async dict-based state.
+
+    Context requires a session in fastmcp 3.x, so we mock it.
+    """
     state: dict[str, Any] = {}
+
+    async def set_state(key: str, value: Any) -> None:
+        state[key] = value
+
+    async def get_state(key: str) -> Any:
+        return state.get(key)
+
     ctx = MagicMock()
-    ctx.set_state = AsyncMock(side_effect=lambda k, v: state.__setitem__(k, v))
-    ctx.get_state = AsyncMock(side_effect=lambda k: state.get(k))
+    ctx.set_state = set_state
+    ctx.get_state = get_state
     return ctx
 
 

--- a/tests/drmcp/unit/test_auth.py
+++ b/tests/drmcp/unit/test_auth.py
@@ -22,7 +22,7 @@ import pytest
 from datarobot.auth.identity import Identity
 from datarobot.auth.session import AuthCtx
 from datarobot.auth.users import User
-from fastmcp.server.context import Context
+
 from fastmcp.server.middleware import MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 
@@ -76,13 +76,13 @@ def middleware_context() -> MiddlewareContext:
     """Create a mock middleware context with fastmcp_context."""
     context = MagicMock(spec=MiddlewareContext)
 
-    # Create a dict to store state
-    state_storage = {}
+    # Create a dict to store state (set_state/get_state are async in fastmcp 3.x)
+    state_storage: dict[str, Any] = {}
 
-    def set_state(key: str, value: Any) -> None:
+    async def set_state(key: str, value: Any) -> None:
         state_storage[key] = value
 
-    def get_state(key: str) -> Any:
+    async def get_state(key: str) -> Any:
         return state_storage.get(key)
 
     context.fastmcp_context = MagicMock()
@@ -123,7 +123,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was attached to fastmcp_context
-            auth_context = middleware_context.fastmcp_context.get_state("authorization_context")
+            auth_context = await middleware_context.fastmcp_context.get_state("authorization_context")
             assert auth_context is not None
             assert isinstance(auth_context, AuthCtx)
             assert auth_context.user.id == "user123"
@@ -148,7 +148,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None
-            assert middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
 
     async def test_on_call_tool_with_invalid_auth_header(
         self,
@@ -169,7 +169,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to invalid token
-            assert middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
 
     async def test_on_call_tool_with_multiple_headers(
         self,
@@ -193,9 +193,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was properly extracted
-            assert middleware_context.fastmcp_context.get_state("authorization_context") is not None
+            assert await middleware_context.fastmcp_context.get_state("authorization_context") is not None
             assert isinstance(
-                middleware_context.fastmcp_context.get_state("authorization_context"), AuthCtx
+                await middleware_context.fastmcp_context.get_state("authorization_context"), AuthCtx
             )
 
     async def test_on_call_tool_exception_handling(
@@ -218,7 +218,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
 
     async def test_on_call_tool_propagates_tool_result(
         self,
@@ -276,7 +276,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was attached despite lowercase header name
-            auth_context = middleware_context.fastmcp_context.get_state("authorization_context")
+            auth_context = await middleware_context.fastmcp_context.get_state("authorization_context")
             assert auth_context is not None
             assert isinstance(auth_context, AuthCtx)
             assert auth_context.user.id == "user123"
@@ -298,7 +298,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was attached
-            auth_context = middleware_context.fastmcp_context.get_state("authorization_context")
+            auth_context = await middleware_context.fastmcp_context.get_state("authorization_context")
             assert auth_context is not None
             assert isinstance(auth_context, AuthCtx)
 
@@ -337,7 +337,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
 
     async def test_middleware_handles_key_error_exception(
         self,
@@ -355,7 +355,7 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
 
     async def test_middleware_handles_type_error_exception(
         self,
@@ -373,7 +373,16 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
+
+
+def _make_mock_context() -> MagicMock:
+    """Create a mock Context with async dict-based state (Context requires a session in fastmcp 3.x)."""
+    state: dict[str, Any] = {}
+    ctx = MagicMock()
+    ctx.set_state = AsyncMock(side_effect=lambda k, v: state.__setitem__(k, v))
+    ctx.get_state = AsyncMock(side_effect=lambda k: state.get(k))
+    return ctx
 
 
 class TestGetAuthContext:
@@ -386,8 +395,7 @@ class TestGetAuthContext:
         This test mocks at the fastmcp.server.context level to simulate a real
         Context with state management.
         """
-        mock_fastmcp = MagicMock()
-        context = Context(mock_fastmcp)
+        context = _make_mock_context()
 
         # Create a real AuthCtx object to store in state
         auth_ctx = AuthCtx(
@@ -403,8 +411,7 @@ class TestGetAuthContext:
             metadata={"endpoint": "https://app.datarobot.com", "account_id": "account456"},
         )
 
-        # Set the auth context in the context state
-        context.set_state("authorization_context", auth_ctx)
+        await context.set_state("authorization_context", auth_ctx)
 
         # Patch _get_context (alias used by must_get_auth_context) to return our Context with state
         with patch("datarobot_genai.drtools.core.auth._get_context", return_value=context):
@@ -424,8 +431,7 @@ class TestGetAuthContext:
 
         This test uses a real Context object without any auth context set in state.
         """
-        mock_fastmcp = MagicMock()
-        context = Context(mock_fastmcp)
+        context = _make_mock_context()
 
         # Don't set any auth context - state will be empty
         with patch("datarobot_genai.drtools.core.auth._get_context", return_value=context):
@@ -456,9 +462,8 @@ class TestGetAuthContext:
         This test verifies that different contexts maintain separate state,
         which is important for concurrent request handling.
         """
-        mock_fastmcp = MagicMock()
-        context1 = Context(mock_fastmcp)
-        context2 = Context(mock_fastmcp)
+        context1 = _make_mock_context()
+        context2 = _make_mock_context()
 
         # Create different auth contexts with different users
         auth_ctx1 = AuthCtx(
@@ -488,8 +493,8 @@ class TestGetAuthContext:
         )
 
         # Set different auth contexts in each context
-        context1.set_state("authorization_context", auth_ctx1)
-        context2.set_state("authorization_context", auth_ctx2)
+        await context1.set_state("authorization_context", auth_ctx1)
+        await context2.set_state("authorization_context", auth_ctx2)
 
         # Verify context1 returns the correct auth context
         with patch("datarobot_genai.drtools.core.auth._get_context", return_value=context1):
@@ -510,12 +515,11 @@ class TestGetAuthContext:
         This ensures we're using the right key ('authorization_context') and not
         accidentally retrieving other state values.
         """
-        mock_fastmcp = MagicMock()
-        context = Context(mock_fastmcp)
+        context = _make_mock_context()
 
         # Set multiple state values to ensure we retrieve the correct one
-        context.set_state("other_key", "other_value")
-        context.set_state("another_key", {"some": "data"})
+        await context.set_state("other_key", "other_value")
+        await context.set_state("another_key", {"some": "data"})
 
         auth_ctx = AuthCtx(
             user=User(id="user123", name="Test User", email="test@example.com"),
@@ -529,7 +533,7 @@ class TestGetAuthContext:
             ],
             metadata={},
         )
-        context.set_state("authorization_context", auth_ctx)
+        await context.set_state("authorization_context", auth_ctx)
 
         with patch("datarobot_genai.drtools.core.auth._get_context", return_value=context):
             result = await must_get_auth_context()
@@ -549,8 +553,7 @@ class TestGetAuthContext:
         This verifies that all fields of AuthCtx are properly stored and retrieved
         from the context state.
         """
-        mock_fastmcp = MagicMock()
-        context = Context(mock_fastmcp)
+        context = _make_mock_context()
 
         # Create an auth context with complex metadata
         auth_ctx = AuthCtx(
@@ -577,7 +580,7 @@ class TestGetAuthContext:
             },
         )
 
-        context.set_state("authorization_context", auth_ctx)
+        await context.set_state("authorization_context", auth_ctx)
 
         with patch("datarobot_genai.drtools.core.auth._get_context", return_value=context):
             result = await must_get_auth_context()

--- a/tests/drmcp/unit/test_auth.py
+++ b/tests/drmcp/unit/test_auth.py
@@ -123,7 +123,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was attached to fastmcp_context
-            auth_context = await middleware_context.fastmcp_context.get_state("authorization_context")
+            auth_context = await middleware_context.fastmcp_context.get_state(
+                "authorization_context"
+            )
             assert auth_context is not None
             assert isinstance(auth_context, AuthCtx)
             assert auth_context.user.id == "user123"
@@ -148,7 +150,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None
-            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert (
+                await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            )
 
     async def test_on_call_tool_with_invalid_auth_header(
         self,
@@ -169,7 +173,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to invalid token
-            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert (
+                await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            )
 
     async def test_on_call_tool_with_multiple_headers(
         self,
@@ -193,7 +199,10 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was properly extracted
-            assert await middleware_context.fastmcp_context.get_state("authorization_context") is not None
+            assert (
+                await middleware_context.fastmcp_context.get_state("authorization_context")
+                is not None
+            )
             assert isinstance(
                 await middleware_context.fastmcp_context.get_state("authorization_context"), AuthCtx
             )
@@ -218,7 +227,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert (
+                await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            )
 
     async def test_on_call_tool_propagates_tool_result(
         self,
@@ -276,7 +287,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was attached despite lowercase header name
-            auth_context = await middleware_context.fastmcp_context.get_state("authorization_context")
+            auth_context = await middleware_context.fastmcp_context.get_state(
+                "authorization_context"
+            )
             assert auth_context is not None
             assert isinstance(auth_context, AuthCtx)
             assert auth_context.user.id == "user123"
@@ -298,7 +311,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context was attached
-            auth_context = await middleware_context.fastmcp_context.get_state("authorization_context")
+            auth_context = await middleware_context.fastmcp_context.get_state(
+                "authorization_context"
+            )
             assert auth_context is not None
             assert isinstance(auth_context, AuthCtx)
 
@@ -337,7 +352,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert (
+                await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            )
 
     async def test_middleware_handles_key_error_exception(
         self,
@@ -355,7 +372,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert (
+                await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            )
 
     async def test_middleware_handles_type_error_exception(
         self,
@@ -373,7 +392,9 @@ class TestOAuthMiddleware:
             assert isinstance(result, ToolResult)
 
             # Verify auth_context is None due to exception
-            assert await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            assert (
+                await middleware_context.fastmcp_context.get_state("authorization_context") is None
+            )
 
 
 def _make_mock_context() -> MagicMock:

--- a/tests/drmcp/unit/test_auth.py
+++ b/tests/drmcp/unit/test_auth.py
@@ -109,7 +109,6 @@ class TestGetHttpHeadersWrapper:
     def test_fastmcp_strips_auth_headers_by_default(self) -> None:
         """Confirm fastmcp 3.x strips authorization without include_all."""
         from fastmcp.server.dependencies import get_http_headers
-        from fastmcp.server.dependencies import get_http_request
 
         fake_request = MagicMock()
         fake_request.headers = MagicMock()

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -101,13 +101,11 @@ class TestDuplicateBehavior:
 
             test_mcp = DataRobotMCP(
                 name=config.mcp_server_name,
-                on_duplicate_tools=config.tool_registration_duplicate_behavior,
-                on_duplicate_prompts=config.prompt_registration_duplicate_behavior,
+                on_duplicate=config.tool_registration_duplicate_behavior,
             )
 
             # Verify the setting was applied correctly
-            assert test_mcp._tool_manager.duplicate_behavior == value
-            assert test_mcp._prompt_manager.duplicate_behavior == value
+            assert test_mcp._on_duplicate == value
 
 
 class TestToolConfiguration:

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -267,7 +267,11 @@ class TestDataRobotMCPServer:
         mock_mcp.list_prompts = AsyncMock(return_value=[])
         mock_mcp.list_resources = AsyncMock(return_value=[])
 
-        mock_tools = [MagicMock(name="tool1"), MagicMock(name="tool2")]
+        mock_tool1 = MagicMock()
+        mock_tool1.name = "tool1"
+        mock_tool2 = MagicMock()
+        mock_tool2.name = "tool2"
+        mock_tools = [mock_tool1, mock_tool2]
         mock_mcp.list_tools = AsyncMock(return_value=mock_tools)
 
         # Mock lifecycle methods

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -169,7 +169,7 @@ class TestDataRobotMCPServer:
         server = DataRobotMCPServer(mock_mcp, transport="stdio")
         server.run()
 
-        registered_tools = list(mcp._tool_manager._tools)
+        registered_tools = asyncio.run(mcp.get_tools())
 
         assert "tool3" in registered_tools, f"tool3 missing in tools: {registered_tools}"
         assert "tool4" in registered_tools, f"tool4 missing in tools: {registered_tools}"

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -49,7 +49,7 @@ def mock_mcp(
 ) -> MagicMock:
     """Create a mock FastMCP instance."""
     mock = MagicMock(spec=FastMCP)
-    mock._list_tools_mcp = AsyncMock(
+    mock.list_tools = AsyncMock(
         return_value=[MagicMock(name="tool1"), MagicMock(name="tool2")]
     )
     mock.get_tools = mock_fastmcp_get_tools
@@ -221,7 +221,7 @@ class TestDataRobotMCPServer:
         assert mock_loop.run_until_complete.call_count == 2
 
         # Verify tools were listed
-        mock_mcp._list_tools_mcp.assert_called_once()
+        mock_mcp.list_tools.assert_called_once()
 
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")
@@ -282,11 +282,11 @@ class TestDataRobotMCPServer:
         mock_loop = MagicMock()
         mock_asyncio.new_event_loop.return_value = mock_loop
         mock_mcp.run_stdio_async = AsyncMock()
-        mock_mcp._list_prompts_mcp = AsyncMock(return_value=[])
-        mock_mcp._list_resources_mcp = AsyncMock(return_value=[])
+        mock_mcp.list_prompts = AsyncMock(return_value=[])
+        mock_mcp.list_resources = AsyncMock(return_value=[])
 
         mock_tools = [MagicMock(name="tool1"), MagicMock(name="tool2")]
-        mock_mcp._list_tools_mcp = AsyncMock(return_value=mock_tools)
+        mock_mcp.list_tools = AsyncMock(return_value=mock_tools)
 
         # Mock lifecycle methods
         mock_lifecycle = MagicMock()
@@ -331,7 +331,7 @@ class TestDataRobotMCPServer:
         server.run()
 
         # Verify tools were listed before server start
-        mock_mcp._list_tools_mcp.assert_called_once()
+        mock_mcp.list_tools.assert_called_once()
         # Should be called twice: once for run_server, once for pre_server_shutdown
         assert mock_loop.run_until_complete.call_count == 2
 

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -27,34 +27,16 @@ from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 
 @pytest.fixture
-def mock_fastmcp_get_tools() -> Iterator[AsyncMock]:
-    yield AsyncMock(return_value={})
-
-
-@pytest.fixture
-def mock_fastmcp_get_prompts() -> Iterator[AsyncMock]:
-    yield AsyncMock(return_value={})
-
-
-@pytest.fixture
-def mock_fastmcp_get_resources() -> Iterator[AsyncMock]:
-    yield AsyncMock(return_value={})
-
-
-@pytest.fixture
-def mock_mcp(
-    mock_fastmcp_get_prompts: AsyncMock,
-    mock_fastmcp_get_resources: AsyncMock,
-    mock_fastmcp_get_tools: AsyncMock,
-) -> MagicMock:
+def mock_mcp() -> MagicMock:
     """Create a mock FastMCP instance."""
     mock = MagicMock(spec=FastMCP)
-    mock.list_tools = AsyncMock(
-        return_value=[MagicMock(name="tool1"), MagicMock(name="tool2")]
-    )
-    mock.get_tools = mock_fastmcp_get_tools
-    mock.get_prompts = mock_fastmcp_get_prompts
-    mock.get_resources = mock_fastmcp_get_resources
+    mock_tool1 = MagicMock()
+    mock_tool1.name = "tool1"
+    mock_tool2 = MagicMock()
+    mock_tool2.name = "tool2"
+    mock.list_tools = AsyncMock(return_value=[mock_tool1, mock_tool2])
+    mock.list_prompts = AsyncMock(return_value=[])
+    mock.list_resources = AsyncMock(return_value=[])
     # Mock low-level server for _configure_mcp_capabilities()
     mock._mcp_server = MagicMock()
     mock._mcp_server.notification_options = MagicMock()
@@ -336,43 +318,25 @@ class TestDataRobotMCPServer:
         assert mock_loop.run_until_complete.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_get_tools(
-        self,
-        mock_fastmcp_get_tools: AsyncMock,
-        mock_mcp: MagicMock,
-    ) -> None:
+    async def test_get_tools(self, mock_mcp: MagicMock) -> None:
         dr_mcp_server = DataRobotMCPServer(mock_mcp)
-
-        actual_outputs = await dr_mcp_server.get_tools()
-
-        mock_fastmcp_get_tools.assert_called_once_with()
-        assert actual_outputs == mock_fastmcp_get_tools.return_value
+        result = await dr_mcp_server.get_tools()
+        assert isinstance(result, dict)
+        assert len(result) == 2
+        assert "tool1" in result
+        assert "tool2" in result
 
     @pytest.mark.asyncio
-    async def test_get_prompts(
-        self,
-        mock_fastmcp_get_prompts: AsyncMock,
-        mock_mcp: MagicMock,
-    ) -> None:
+    async def test_get_prompts(self, mock_mcp: MagicMock) -> None:
         dr_mcp_server = DataRobotMCPServer(mock_mcp)
-
-        actual_outputs = await dr_mcp_server.get_prompts()
-
-        mock_fastmcp_get_prompts.assert_called_once_with()
-        assert actual_outputs == mock_fastmcp_get_prompts.return_value
+        result = await dr_mcp_server.get_prompts()
+        assert isinstance(result, dict)
 
     @pytest.mark.asyncio
-    async def test_get_resources(
-        self,
-        mock_fastmcp_get_resources: AsyncMock,
-        mock_mcp: MagicMock,
-    ) -> None:
+    async def test_get_resources(self, mock_mcp: MagicMock) -> None:
         dr_mcp_server = DataRobotMCPServer(mock_mcp)
-
-        actual_outputs = await dr_mcp_server.get_resources()
-
-        mock_fastmcp_get_resources.assert_called_once_with()
-        assert actual_outputs == mock_fastmcp_get_resources.return_value
+        result = await dr_mcp_server.get_resources()
+        assert isinstance(result, dict)
 
 
 def test_mcp_server_capabilities():

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-from collections.abc import Iterator
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch

--- a/tests/drmcp/unit/test_elicitation_test_tool.py
+++ b/tests/drmcp/unit/test_elicitation_test_tool.py
@@ -14,21 +14,33 @@
 
 """Unit tests for elicitation_test_tool.py module."""
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
-from unittest.mock import patch
 
 import pytest
 from fastmcp import Context
 from fastmcp.server.context import AcceptedElicitation
 from fastmcp.server.context import CancelledElicitation
 from fastmcp.server.context import DeclinedElicitation
-from fastmcp.tools.tool import FunctionTool
+from fastmcp.server.context import _current_context
+from fastmcp.tools.function_tool import FunctionTool
 
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 # Import the tool module to register the tool
 from datarobot_genai.drmcp.test_utils import elicitation_test_tool  # noqa: F401
+
+
+@contextmanager
+def _mock_context(**kwargs):
+    """Set a mock Context in fastmcp's context variable for tool.run() dependency injection."""
+    mock_ctx = MagicMock(spec=Context, **kwargs)
+    token = _current_context.set(mock_ctx)
+    try:
+        yield mock_ctx
+    finally:
+        _current_context.reset(token)
 
 
 class TestGetUserGreeting:
@@ -41,12 +53,7 @@ class TestGetUserGreeting:
         tool = await mcp.get_tool("get_user_greeting")
         assert isinstance(tool, FunctionTool)
 
-        # Mock the context (even though we don't use it, FastMCP requires it)
-        mock_ctx = MagicMock(spec=Context)
-
-        # Patch get_context where resolve_dependencies looks it up (tool.run path)
-        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
-            # Call the tool with username provided
+        with _mock_context():
             tool_result = await tool.run({"username": "testuser"})
             result = tool_result.structured_content
 
@@ -57,16 +64,11 @@ class TestGetUserGreeting:
     @pytest.mark.asyncio
     async def test_get_user_greeting_with_elicitation_accepted(self) -> None:
         """Test get_user_greeting when elicitation is accepted."""
-        # Get the tool from the MCP instance
         tool = await mcp.get_tool("get_user_greeting")
         assert isinstance(tool, FunctionTool)
 
-        # Mock the context's elicit method
-        mock_ctx = MagicMock(spec=Context)
-        mock_ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data="accepted_user"))
-
-        # Patch get_context where resolve_dependencies looks it up (tool.run path)
-        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+        with _mock_context() as mock_ctx:
+            mock_ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data="accepted_user"))
             tool_result = await tool.run({})
             result = tool_result.structured_content
 
@@ -78,16 +80,11 @@ class TestGetUserGreeting:
     @pytest.mark.asyncio
     async def test_get_user_greeting_with_elicitation_declined(self) -> None:
         """Test get_user_greeting when elicitation is declined."""
-        # Get the tool from the MCP instance
         tool = await mcp.get_tool("get_user_greeting")
         assert isinstance(tool, FunctionTool)
 
-        # Mock the context's elicit method
-        mock_ctx = MagicMock(spec=Context)
-        mock_ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
-
-        # Patch get_context where resolve_dependencies looks it up (tool.run path)
-        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+        with _mock_context() as mock_ctx:
+            mock_ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
             tool_result = await tool.run({})
             result = tool_result.structured_content
 
@@ -98,16 +95,11 @@ class TestGetUserGreeting:
     @pytest.mark.asyncio
     async def test_get_user_greeting_with_elicitation_cancelled(self) -> None:
         """Test get_user_greeting when elicitation is cancelled."""
-        # Get the tool from the MCP instance
         tool = await mcp.get_tool("get_user_greeting")
         assert isinstance(tool, FunctionTool)
 
-        # Mock the context's elicit method
-        mock_ctx = MagicMock(spec=Context)
-        mock_ctx.elicit = AsyncMock(return_value=CancelledElicitation())
-
-        # Patch get_context where resolve_dependencies looks it up (tool.run path)
-        with patch("fastmcp.server.dependencies.get_context", return_value=mock_ctx):
+        with _mock_context() as mock_ctx:
+            mock_ctx.elicit = AsyncMock(return_value=CancelledElicitation())
             tool_result = await tool.run({})
             result = tool_result.structured_content
 

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -280,7 +280,6 @@ class TestPromptInitArguments:
             "description": None,
             "icons": None,
             "tags": None,
-            "enabled": None,
             "meta": None,
         }
 
@@ -315,7 +314,6 @@ class TestResourceInitArguments:
             "icons": None,
             "mime_type": None,
             "tags": None,
-            "enabled": None,
             "annotations": None,
             "meta": None,
         }

--- a/tests/drmcp/unit/test_register_tools.py
+++ b/tests/drmcp/unit/test_register_tools.py
@@ -95,12 +95,12 @@ def mock_mcp() -> Generator[MagicMock, None, None]:
             registered_tools.append(tool)
             return tool
 
-        async def _list_tools_mcp() -> list[MCPTool]:
-            """Mock _list_tools_mcp that returns registered tools."""
+        async def list_tools() -> list[MCPTool]:
+            """Mock list_tools that returns registered tools."""
             return registered_tools
 
         mock_mcp.add_tool = MagicMock(side_effect=add_tool)
-        mock_mcp._list_tools_mcp = AsyncMock(side_effect=_list_tools_mcp)
+        mock_mcp.list_tools = AsyncMock(side_effect=list_tools)
         yield mock_mcp
 
 
@@ -359,17 +359,17 @@ class TestRegisterTool:
         return "datarobot_genai.drmcp.core.mcp_instance"
 
     @pytest.fixture
-    def mock_datarobot_mcp_server_list_tools_mcp(self) -> AsyncMock:
+    def mock_datarobot_mcp_server_list_tools(self) -> AsyncMock:
         return AsyncMock()
 
     @pytest.fixture
     def mock_datarobot_mcp_server(
         self,
         module_under_test: str,
-        mock_datarobot_mcp_server_list_tools_mcp: AsyncMock,
+        mock_datarobot_mcp_server_list_tools: AsyncMock,
     ) -> Iterator[Mock]:
         with patch(f"{module_under_test}.mcp") as mock_instance:
-            mock_instance._list_tools_mcp = mock_datarobot_mcp_server_list_tools_mcp
+            mock_instance.list_tools = mock_datarobot_mcp_server_list_tools
             yield mock_instance
 
     @pytest.fixture
@@ -401,34 +401,34 @@ class TestRegisterTool:
     async def test_check_tool_registration_status_after_it_finishes_succeeds(
         self,
         mock_datarobot_mcp_server: Mock,
-        mock_datarobot_mcp_server_list_tools_mcp: Mock,
+        mock_datarobot_mcp_server_list_tools: Mock,
     ) -> None:
         mock_function_name = "sadfads"
         mock_registered_tool = Mock()
         mock_registered_tool.name = mock_function_name
-        mock_datarobot_mcp_server_list_tools_mcp.return_value = [mock_registered_tool]
+        mock_datarobot_mcp_server_list_tools.return_value = [mock_registered_tool]
 
         await check_tool_registration_status_after_it_finishes(
             mock_datarobot_mcp_server,
             mock_function_name,
         )
 
-        mock_datarobot_mcp_server_list_tools_mcp.assert_called_once()
+        mock_datarobot_mcp_server_list_tools.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_check_tool_registration_status_after_it_finishes_fails(
         self,
         mock_datarobot_mcp_server: Mock,
-        mock_datarobot_mcp_server_list_tools_mcp: Mock,
+        mock_datarobot_mcp_server_list_tools: Mock,
     ) -> None:
-        mock_datarobot_mcp_server_list_tools_mcp.return_value = [Mock()]
+        mock_datarobot_mcp_server_list_tools.return_value = [Mock()]
 
         with pytest.raises(RuntimeError):
             await check_tool_registration_status_after_it_finishes(
                 mock_datarobot_mcp_server,
                 Mock(),
             )
-            mock_datarobot_mcp_server_list_tools_mcp.assert_called_once()
+            mock_datarobot_mcp_server_list_tools.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_register_tools_with_proper_tool_category(

--- a/tests/drmcp/unit/test_routes.py
+++ b/tests/drmcp/unit/test_routes.py
@@ -986,9 +986,9 @@ class TestMetadataRoute:
         mock_resource2.name = "resource2"
 
         # Setup mocks on self.mock_mcp
-        self.mock_mcp._list_tools_mcp = AsyncMock(return_value=[mock_tool1, mock_tool2])
-        self.mock_mcp._list_prompts_mcp = AsyncMock(return_value=[mock_prompt1, mock_prompt2])
-        self.mock_mcp._list_resources_mcp = AsyncMock(return_value=[mock_resource1, mock_resource2])
+        self.mock_mcp.list_tools = AsyncMock(return_value=[mock_tool1, mock_tool2])
+        self.mock_mcp.list_prompts = AsyncMock(return_value=[mock_prompt1, mock_prompt2])
+        self.mock_mcp.list_resources = AsyncMock(return_value=[mock_resource1, mock_resource2])
 
         mock_get_tool_tags.side_effect = lambda tool: (
             {"tag1", "tag2"} if tool == mock_tool1 else {"tag3"}
@@ -1108,9 +1108,9 @@ class TestMetadataRoute:
     ):
         """Test metadata route with empty lists."""
         # Setup mocks with empty lists
-        self.mock_mcp._list_tools_mcp = AsyncMock(return_value=[])
-        self.mock_mcp._list_prompts_mcp = AsyncMock(return_value=[])
-        self.mock_mcp._list_resources_mcp = AsyncMock(return_value=[])
+        self.mock_mcp.list_tools = AsyncMock(return_value=[])
+        self.mock_mcp.list_prompts = AsyncMock(return_value=[])
+        self.mock_mcp.list_resources = AsyncMock(return_value=[])
 
         # Create mock config
         mock_config = Mock()
@@ -1175,9 +1175,9 @@ class TestMetadataRoute:
     ):
         """Test metadata route with OAuth-enabled tools."""
         # Setup mocks with empty lists
-        self.mock_mcp._list_tools_mcp = AsyncMock(return_value=[])
-        self.mock_mcp._list_prompts_mcp = AsyncMock(return_value=[])
-        self.mock_mcp._list_resources_mcp = AsyncMock(return_value=[])
+        self.mock_mcp.list_tools = AsyncMock(return_value=[])
+        self.mock_mcp.list_prompts = AsyncMock(return_value=[])
+        self.mock_mcp.list_resources = AsyncMock(return_value=[])
 
         # Create mock config with OAuth-enabled tools
         mock_config = Mock()
@@ -1239,7 +1239,7 @@ class TestMetadataRoute:
     async def test_metadata_route_error_scenario(self):
         """Test metadata route when error occurs."""
         # Setup mock to raise exception
-        self.mock_mcp._list_tools_mcp = AsyncMock(side_effect=ValueError("Test error"))
+        self.mock_mcp.list_tools = AsyncMock(side_effect=ValueError("Test error"))
 
         register_routes(self.mock_mcp)
 
@@ -1265,9 +1265,9 @@ class TestMetadataRoute:
     ):
         """Test metadata route with OAuth-required tools but OAuth not configured."""
         # Setup mocks with empty lists
-        self.mock_mcp._list_tools_mcp = AsyncMock(return_value=[])
-        self.mock_mcp._list_prompts_mcp = AsyncMock(return_value=[])
-        self.mock_mcp._list_resources_mcp = AsyncMock(return_value=[])
+        self.mock_mcp.list_tools = AsyncMock(return_value=[])
+        self.mock_mcp.list_prompts = AsyncMock(return_value=[])
+        self.mock_mcp.list_resources = AsyncMock(return_value=[])
 
         # Create mock config with OAuth-required tools but OAuth not configured
         mock_config = Mock()

--- a/tests/drmcp/unit/test_tagged_tools.py
+++ b/tests/drmcp/unit/test_tagged_tools.py
@@ -35,14 +35,11 @@ async def test_tagged_tool_decorator() -> None:
     def test_function() -> str:
         return "test"
 
-    # Get the tool as exposed via MCP (includes meta)
-    tools = await mcp._list_tools_mcp()
+    tools = await mcp.list_tools()
     assert len(tools) == 1
 
     tool = list(tools)[0]
-    assert hasattr(tool, "meta")
-    assert tool.meta is not None
-    assert tool.meta.get("fastmcp", {}).get("tags") == ["example", "test"]
+    assert tool.tags == {"test", "example"}
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/test_tagged_tools.py
+++ b/tests/drmcp/unit/test_tagged_tools.py
@@ -42,7 +42,7 @@ async def test_tagged_tool_decorator() -> None:
     tool = list(tools)[0]
     assert hasattr(tool, "meta")
     assert tool.meta is not None
-    assert tool.meta.get("_fastmcp", {}).get("tags") == ["example", "test"]
+    assert tool.meta.get("fastmcp", {}).get("tags") == ["example", "test"]
 
 
 @pytest.mark.asyncio
@@ -54,7 +54,7 @@ async def test_tagged_tool_with_additional_annotations() -> None:
     def test_function() -> str:
         return "test"
 
-    tools = await mcp._tool_manager.get_tools()
+    tools = await mcp.get_tools()
     assert len(tools) == 1
 
     tool = list(tools.values())[0]
@@ -75,7 +75,7 @@ async def test_tool_without_tags() -> None:
     def test_function() -> str:
         return "test"
 
-    tools = await mcp._tool_manager.get_tools()
+    tools = await mcp.get_tools()
     assert len(tools) == 1
 
     tool = list(tools.values())[0]

--- a/tests/drmcp/unit/test_utils.py
+++ b/tests/drmcp/unit/test_utils.py
@@ -213,7 +213,7 @@ class TestGetToolTags:
         """Test get_tool_tags with MCPTool that has tags in meta._fastmcp.tags."""
         # Create a mock MCPTool with tags in meta
         tool = Mock(spec=MCPTool)
-        tool.meta = {"_fastmcp": {"tags": ["tag1", "tag2", "tag3"]}}
+        tool.meta = {"fastmcp": {"tags": ["tag1", "tag2", "tag3"]}}
 
         result = get_tool_tags(tool)
 
@@ -223,7 +223,7 @@ class TestGetToolTags:
         """Test get_tool_tags with MCPTool that has empty tags list."""
         # Create a mock MCPTool with empty tags list
         tool = Mock(spec=MCPTool)
-        tool.meta = {"_fastmcp": {"tags": []}}
+        tool.meta = {"fastmcp": {"tags": []}}
 
         result = get_tool_tags(tool)
 
@@ -263,7 +263,7 @@ class TestGetToolTags:
         """Test get_tool_tags with MCPTool that has _fastmcp but no tags."""
         # Create a mock MCPTool with _fastmcp but no tags
         tool = Mock(spec=MCPTool)
-        tool.meta = {"_fastmcp": {"other_key": "value"}}
+        tool.meta = {"fastmcp": {"other_key": "value"}}
 
         result = get_tool_tags(tool)
 
@@ -273,7 +273,7 @@ class TestGetToolTags:
         """Test get_tool_tags with MCPTool that has _fastmcp=None."""
         # Create a mock MCPTool with _fastmcp=None
         tool = Mock(spec=MCPTool)
-        tool.meta = {"_fastmcp": None}
+        tool.meta = {"fastmcp": None}
 
         result = get_tool_tags(tool)
 
@@ -283,7 +283,7 @@ class TestGetToolTags:
         """Test get_tool_tags with MCPTool that has _fastmcp as non-dict."""
         # Create a mock MCPTool with _fastmcp as string (not dict)
         tool = Mock(spec=MCPTool)
-        tool.meta = {"_fastmcp": "not_a_dict"}
+        tool.meta = {"fastmcp": "not_a_dict"}
 
         result = get_tool_tags(tool)
 
@@ -425,7 +425,7 @@ class TestFilterToolsByTags:
 
         # Create MCPTool
         mcptool = Mock(spec=MCPTool)
-        mcptool.meta = {"_fastmcp": {"tags": ["tag2", "tag3"]}}
+        mcptool.meta = {"fastmcp": {"tags": ["tag2", "tag3"]}}
 
         tools = [fastmcp_tool, mcptool]
 
@@ -499,7 +499,7 @@ class TestGetPromptTags:
         """Test get_prompt_tags with MCPPrompt that has tags in meta._fastmcp.tags."""
         # Create a mock MCPPrompt with tags in meta
         prompt = Mock(spec=MCPPrompt)
-        prompt.meta = {"_fastmcp": {"tags": ["tag1", "tag2", "tag3"]}}
+        prompt.meta = {"fastmcp": {"tags": ["tag1", "tag2", "tag3"]}}
 
         result = get_prompt_tags(prompt)
 
@@ -509,7 +509,7 @@ class TestGetPromptTags:
         """Test get_prompt_tags with MCPPrompt that has empty tags list."""
         # Create a mock MCPPrompt with empty tags list
         prompt = Mock(spec=MCPPrompt)
-        prompt.meta = {"_fastmcp": {"tags": []}}
+        prompt.meta = {"fastmcp": {"tags": []}}
 
         result = get_prompt_tags(prompt)
 
@@ -549,7 +549,7 @@ class TestGetPromptTags:
         """Test get_prompt_tags with MCPPrompt that has _fastmcp but no tags."""
         # Create a mock MCPPrompt with _fastmcp but no tags
         prompt = Mock(spec=MCPPrompt)
-        prompt.meta = {"_fastmcp": {"other_key": "value"}}
+        prompt.meta = {"fastmcp": {"other_key": "value"}}
 
         result = get_prompt_tags(prompt)
 
@@ -559,7 +559,7 @@ class TestGetPromptTags:
         """Test get_prompt_tags with MCPPrompt that has _fastmcp=None."""
         # Create a mock MCPPrompt with _fastmcp=None
         prompt = Mock(spec=MCPPrompt)
-        prompt.meta = {"_fastmcp": None}
+        prompt.meta = {"fastmcp": None}
 
         result = get_prompt_tags(prompt)
 
@@ -569,7 +569,7 @@ class TestGetPromptTags:
         """Test get_prompt_tags with MCPPrompt that has _fastmcp as non-dict."""
         # Create a mock MCPPrompt with _fastmcp as string (not dict)
         prompt = Mock(spec=MCPPrompt)
-        prompt.meta = {"_fastmcp": "not_a_dict"}
+        prompt.meta = {"fastmcp": "not_a_dict"}
 
         result = get_prompt_tags(prompt)
 
@@ -593,7 +593,7 @@ class TestGetResourceTags:
         """Test get_resource_tags with MCPResource that has tags in meta._fastmcp.tags."""
         # Create a mock MCPResource with tags in meta
         resource = Mock(spec=MCPResource)
-        resource.meta = {"_fastmcp": {"tags": ["tag1", "tag2", "tag3"]}}
+        resource.meta = {"fastmcp": {"tags": ["tag1", "tag2", "tag3"]}}
 
         result = get_resource_tags(resource)
 
@@ -603,7 +603,7 @@ class TestGetResourceTags:
         """Test get_resource_tags with MCPResource that has empty tags list."""
         # Create a mock MCPResource with empty tags list
         resource = Mock(spec=MCPResource)
-        resource.meta = {"_fastmcp": {"tags": []}}
+        resource.meta = {"fastmcp": {"tags": []}}
 
         result = get_resource_tags(resource)
 
@@ -643,7 +643,7 @@ class TestGetResourceTags:
         """Test get_resource_tags with MCPResource that has _fastmcp but no tags."""
         # Create a mock MCPResource with _fastmcp but no tags
         resource = Mock(spec=MCPResource)
-        resource.meta = {"_fastmcp": {"other_key": "value"}}
+        resource.meta = {"fastmcp": {"other_key": "value"}}
 
         result = get_resource_tags(resource)
 
@@ -653,7 +653,7 @@ class TestGetResourceTags:
         """Test get_resource_tags with MCPResource that has _fastmcp=None."""
         # Create a mock MCPResource with _fastmcp=None
         resource = Mock(spec=MCPResource)
-        resource.meta = {"_fastmcp": None}
+        resource.meta = {"fastmcp": None}
 
         result = get_resource_tags(resource)
 
@@ -663,7 +663,7 @@ class TestGetResourceTags:
         """Test get_resource_tags with MCPResource that has _fastmcp as non-dict."""
         # Create a mock MCPResource with _fastmcp as string (not dict)
         resource = Mock(spec=MCPResource)
-        resource.meta = {"_fastmcp": "not_a_dict"}
+        resource.meta = {"fastmcp": "not_a_dict"}
 
         result = get_resource_tags(resource)
 

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,18 @@ boto3 = [
 ]
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -347,15 +359,6 @@ wheels = [
 ]
 
 [[package]]
-name = "async-timeout"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -586,6 +589,27 @@ wheels = [
 ]
 
 [[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -784,15 +808,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
-]
-
-[[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -1007,14 +1022,6 @@ mcp = [
     { name = "mcp" },
     { name = "mcpadapt", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "mcpadapt", version = "0.1.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-
-[[package]]
-name = "cronsim"
-version = "2.7"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -1466,7 +1473,7 @@ requires-dist = [
     { name = "datarobot-predict", marker = "extra == 'llamaindex'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'nat'", specifier = ">=1.13.2,<2.0.0" },
     { name = "fastapi", marker = "extra == 'dragent'", specifier = "<0.133.0" },
-    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=2.13.0.2,<3.0.0" },
+    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=3.2.0,<4.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
@@ -1843,24 +1850,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fakeredis"
-version = "2.34.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "redis" },
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/40/fd09efa66205eb32253d2b2ebc63537281384d2040f0a88bcd2289e120e4/fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b", size = 177315, upload-time = "2026-02-25T13:17:51.315Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b5/82f89307d0d769cd9bf46a54fb9136be08e4e57c5570ae421db4c9a2ba62/fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12", size = 122160, upload-time = "2026-02-25T13:17:49.701Z" },
-]
-
-[package.optional-dependencies]
-lua = [
-    { name = "lupa" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.132.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1879,7 +1868,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.14.5"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1890,22 +1879,26 @@ dependencies = [
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api", version = "1.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
+    { name = "opentelemetry-api", version = "1.40.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
     { name = "packaging" },
     { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pydantic", version = "2.11.10", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version == '3.12.*'" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version != '3.12.*'" },
-    { name = "pydocket" },
     { name = "pyperclip" },
     { name = "python-dotenv", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
     { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
+    { name = "pyyaml" },
     { name = "rich" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/32/982678d44f13849530a74ab101ed80e060c2ee6cf87471f062dcf61705fd/fastmcp-2.14.5.tar.gz", hash = "sha256:38944dc582c541d55357082bda2241cedb42cd3a78faea8a9d6a2662c62a42d7", size = 8296329, upload-time = "2026-02-03T15:35:21.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/c1/1a35ec68ff76ea8443aa115b18bcdee748a4ada2124537ee90522899ff9f/fastmcp-2.14.5-py3-none-any.whl", hash = "sha256:d81e8ec813f5089d3624bec93944beaefa86c0c3a4ef1111cbef676a761ebccf", size = 417784, upload-time = "2026-02-03T15:35:18.489Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [[package]]
@@ -3576,47 +3569,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/52/dc9ef71a43eddb8f7b7f6d887feb4e04e61f07bb99359c4aa1dd112c715b/llama_parse-0.5.20.tar.gz", hash = "sha256:649e256431d3753025b9a320bb03b76849ce4b5a1121394c803df543e6c1006f", size = 16941, upload-time = "2025-01-22T21:04:22.226Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/7c/203b7ffc633b9c0823f0d0701e361e002b93bf4e493f4c494d4bd5934c0b/llama_parse-0.5.20-py3-none-any.whl", hash = "sha256:9617edb3428d3218ea01f1708f0b6105f3ffef142fedbeb8c98d50082c37e226", size = 16163, upload-time = "2025-01-22T21:04:20.751Z" },
-]
-
-[[package]]
-name = "lupa"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/1c/191c3e6ec6502e3dbe25a53e27f69a5daeac3e56de1f73c0138224171ead/lupa-2.6.tar.gz", hash = "sha256:9a770a6e89576be3447668d7ced312cd6fd41d3c13c2462c9dc2c2ab570e45d9", size = 7240282, upload-time = "2025-10-24T07:20:29.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/29/1f66907c1ebf1881735afa695e646762c674f00738ebf66d795d59fc0665/lupa-2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d988c0f9331b9f2a5a55186701a25444ab10a1432a1021ee58011499ecbbdd5", size = 962875, upload-time = "2025-10-24T07:17:39.107Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/67/4a748604be360eb9c1c215f6a0da921cd1a2b44b2c5951aae6fb83019d3a/lupa-2.6-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:ebe1bbf48259382c72a6fe363dea61a0fd6fe19eab95e2ae881e20f3654587bf", size = 1935390, upload-time = "2025-10-24T07:17:41.427Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/0c/8ef9ee933a350428b7bdb8335a37ef170ab0bb008bbf9ca8f4f4310116b6/lupa-2.6-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:a8fcee258487cf77cdd41560046843bb38c2e18989cd19671dd1e2596f798306", size = 992193, upload-time = "2025-10-24T07:17:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/65/46/e6c7facebdb438db8a65ed247e56908818389c1a5abbf6a36aab14f1057d/lupa-2.6-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:561a8e3be800827884e767a694727ed8482d066e0d6edfcbf423b05e63b05535", size = 1165844, upload-time = "2025-10-24T07:17:45.437Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/26/9f1154c6c95f175ccbf96aa96c8f569c87f64f463b32473e839137601a8b/lupa-2.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af880a62d47991cae78b8e9905c008cbfdc4a3a9723a66310c2634fc7644578c", size = 1048069, upload-time = "2025-10-24T07:17:47.181Z" },
-    { url = "https://files.pythonhosted.org/packages/68/67/2cc52ab73d6af81612b2ea24c870d3fa398443af8e2875e5befe142398b1/lupa-2.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80b22923aa4023c86c0097b235615f89d469a0c4eee0489699c494d3367c4c85", size = 2079079, upload-time = "2025-10-24T07:17:49.755Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/dc/f843f09bbf325f6e5ee61730cf6c3409fc78c010d968c7c78acba3019ca7/lupa-2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:153d2cc6b643f7efb9cfc0c6bb55ec784d5bac1a3660cfc5b958a7b8f38f4a75", size = 1071428, upload-time = "2025-10-24T07:17:51.991Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/60/37533a8d85bf004697449acb97ecdacea851acad28f2ad3803662487dd2a/lupa-2.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3fa8777e16f3ded50b72967dc17e23f5a08e4f1e2c9456aff2ebdb57f5b2869f", size = 1181756, upload-time = "2025-10-24T07:17:53.752Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f2/cf29b20dbb4927b6a3d27c339ac5d73e74306ecc28c8e2c900b2794142ba/lupa-2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8dbdcbe818c02a2f56f5ab5ce2de374dab03e84b25266cfbaef237829bc09b3f", size = 2175687, upload-time = "2025-10-24T07:17:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/94/7c/050e02f80c7131b63db1474bff511e63c545b5a8636a24cbef3fc4da20b6/lupa-2.6-cp311-cp311-win32.whl", hash = "sha256:defaf188fde8f7a1e5ce3a5e6d945e533b8b8d547c11e43b96c9b7fe527f56dc", size = 1412592, upload-time = "2025-10-24T07:17:59.062Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/6f2af98aa5d771cea661f66c8eb8f53772ec1ab1dfbce24126cfcd189436/lupa-2.6-cp311-cp311-win_amd64.whl", hash = "sha256:9505ae600b5c14f3e17e70f87f88d333717f60411faca1ddc6f3e61dce85fa9e", size = 1669194, upload-time = "2025-10-24T07:18:01.647Z" },
-    { url = "https://files.pythonhosted.org/packages/94/86/ce243390535c39d53ea17ccf0240815e6e457e413e40428a658ea4ee4b8d/lupa-2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47ce718817ef1cc0c40d87c3d5ae56a800d61af00fbc0fad1ca9be12df2f3b56", size = 951707, upload-time = "2025-10-24T07:18:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/86/85/cedea5e6cbeb54396fdcc55f6b741696f3f036d23cfaf986d50d680446da/lupa-2.6-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7aba985b15b101495aa4b07112cdc08baa0c545390d560ad5cfde2e9e34f4d58", size = 1916703, upload-time = "2025-10-24T07:18:05.6Z" },
-    { url = "https://files.pythonhosted.org/packages/24/be/3d6b5f9a8588c01a4d88129284c726017b2089f3a3fd3ba8bd977292fea0/lupa-2.6-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:b766f62f95b2739f2248977d29b0722e589dcf4f0ccfa827ccbd29f0148bd2e5", size = 985152, upload-time = "2025-10-24T07:18:08.561Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/23/9f9a05beee5d5dce9deca4cb07c91c40a90541fc0a8e09db4ee670da550f/lupa-2.6-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:00a934c23331f94cb51760097ebfab14b005d55a6b30a2b480e3c53dd2fa290d", size = 1159599, upload-time = "2025-10-24T07:18:10.346Z" },
-    { url = "https://files.pythonhosted.org/packages/40/4e/e7c0583083db9d7f1fd023800a9767d8e4391e8330d56c2373d890ac971b/lupa-2.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21de9f38bd475303e34a042b7081aabdf50bd9bafd36ce4faea2f90fd9f15c31", size = 1038686, upload-time = "2025-10-24T07:18:12.112Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9f/5a4f7d959d4feba5e203ff0c31889e74d1ca3153122be4a46dca7d92bf7c/lupa-2.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf3bda96d3fc41237e964a69c23647d50d4e28421111360274d4799832c560e9", size = 2071956, upload-time = "2025-10-24T07:18:14.572Z" },
-    { url = "https://files.pythonhosted.org/packages/92/34/2f4f13ca65d01169b1720176aedc4af17bc19ee834598c7292db232cb6dc/lupa-2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a76ead245da54801a81053794aa3975f213221f6542d14ec4b859ee2e7e0323", size = 1057199, upload-time = "2025-10-24T07:18:16.379Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2a/5f7d2eebec6993b0dcd428e0184ad71afb06a45ba13e717f6501bfed1da3/lupa-2.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8dd0861741caa20886ddbda0a121d8e52fb9b5bb153d82fa9bba796962bf30e8", size = 1173693, upload-time = "2025-10-24T07:18:18.153Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/29/089b4d2f8e34417349af3904bb40bec40b65c8731f45e3fd8d497ca573e5/lupa-2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:239e63948b0b23023f81d9a19a395e768ed3da6a299f84e7963b8f813f6e3f9c", size = 2164394, upload-time = "2025-10-24T07:18:20.403Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1b/79c17b23c921f81468a111cad843b076a17ef4b684c4a8dff32a7969c3f0/lupa-2.6-cp312-cp312-win32.whl", hash = "sha256:325894e1099499e7a6f9c351147661a2011887603c71086d36fe0f964d52d1ce", size = 1420647, upload-time = "2025-10-24T07:18:23.368Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/15/5121e68aad3584e26e1425a5c9a79cd898f8a152292059e128c206ee817c/lupa-2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c735a1ce8ee60edb0fe71d665f1e6b7c55c6021f1d340eb8c865952c602cd36f", size = 1688529, upload-time = "2025-10-24T07:18:25.523Z" },
-    { url = "https://files.pythonhosted.org/packages/28/1d/21176b682ca5469001199d8b95fa1737e29957a3d185186e7a8b55345f2e/lupa-2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:663a6e58a0f60e7d212017d6678639ac8df0119bc13c2145029dcba084391310", size = 947232, upload-time = "2025-10-24T07:18:27.878Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4c/d327befb684660ca13cf79cd1f1d604331808f9f1b6fb6bf57832f8edf80/lupa-2.6-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d1f5afda5c20b1f3217a80e9bc1b77037f8a6eb11612fd3ada19065303c8f380", size = 1908625, upload-time = "2025-10-24T07:18:29.944Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8e/ad22b0a19454dfd08662237a84c792d6d420d36b061f239e084f29d1a4f3/lupa-2.6-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:26f2b3c085fe76e9119e48c1013c1cccdc1f51585d456858290475aa38e7089e", size = 981057, upload-time = "2025-10-24T07:18:31.553Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/48/74859073ab276bd0566c719f9ca0108b0cfc1956ca0d68678d117d47d155/lupa-2.6-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:60d2f902c7b96fb8ab98493dcff315e7bb4d0b44dc9dd76eb37de575025d5685", size = 1156227, upload-time = "2025-10-24T07:18:33.981Z" },
-    { url = "https://files.pythonhosted.org/packages/09/6c/0e9ded061916877253c2266074060eb71ed99fb21d73c8c114a76725bce2/lupa-2.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a02d25dee3a3250967c36590128d9220ae02f2eda166a24279da0b481519cbff", size = 1035752, upload-time = "2025-10-24T07:18:36.32Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/ef/f8c32e454ef9f3fe909f6c7d57a39f950996c37a3deb7b391fec7903dab7/lupa-2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eae1ee16b886b8914ff292dbefbf2f48abfbdee94b33a88d1d5475e02423203", size = 2069009, upload-time = "2025-10-24T07:18:38.072Z" },
-    { url = "https://files.pythonhosted.org/packages/53/dc/15b80c226a5225815a890ee1c11f07968e0aba7a852df41e8ae6fe285063/lupa-2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0edd5073a4ee74ab36f74fe61450148e6044f3952b8d21248581f3c5d1a58be", size = 1056301, upload-time = "2025-10-24T07:18:40.165Z" },
-    { url = "https://files.pythonhosted.org/packages/31/14/2086c1425c985acfb30997a67e90c39457122df41324d3c179d6ee2292c6/lupa-2.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0c53ee9f22a8a17e7d4266ad48e86f43771951797042dd51d1494aaa4f5f3f0a", size = 1170673, upload-time = "2025-10-24T07:18:42.426Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e5/b216c054cf86576c0191bf9a9f05de6f7e8e07164897d95eea0078dca9b2/lupa-2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c0f157a9064a400d828789191a96da7f4ce889969a588b87ec80de9b14772", size = 2162227, upload-time = "2025-10-24T07:18:46.112Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2f/33ecb5bedf4f3bc297ceacb7f016ff951331d352f58e7e791589609ea306/lupa-2.6-cp313-cp313-win32.whl", hash = "sha256:ee9523941ae0a87b5b703417720c5d78f72d2f5bc23883a2ea80a949a3ed9e75", size = 1419558, upload-time = "2025-10-24T07:18:48.371Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b4/55e885834c847ea610e111d87b9ed4768f0afdaeebc00cd46810f25029f6/lupa-2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b1335a5835b0a25ebdbc75cf0bda195e54d133e4d994877ef025e218c2e59db9", size = 1683424, upload-time = "2025-10-24T07:18:50.976Z" },
 ]
 
 [[package]]
@@ -5396,15 +5348,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathvalidate"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
-]
-
-[[package]]
 name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
@@ -5654,15 +5597,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
-]
-
-[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -5812,43 +5746,27 @@ wheels = [
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.3.0"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "py-key-value-shared" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
 ]
 
 [package.optional-dependencies]
-disk = [
-    { name = "diskcache" },
-    { name = "pathvalidate" },
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
-]
-redis = [
-    { name = "redis" },
-]
-
-[[package]]
-name = "py-key-value-shared"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -6255,32 +6173,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydocket"
-version = "0.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "cronsim" },
-    { name = "fakeredis", extra = ["lua"] },
-    { name = "opentelemetry-api", version = "1.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
-    { name = "opentelemetry-api", version = "1.40.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
-    { name = "prometheus-client" },
-    { name = "py-key-value-aio", extra = ["memory", "redis"] },
-    { name = "python-json-logger" },
-    { name = "redis" },
-    { name = "rich" },
-    { name = "typer", version = "0.23.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*'" },
-    { name = "typer", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*'" },
-    { name = "typing-extensions" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-    { name = "uncalled-for" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/5f/82dde9fb6099b960a4203596d3b755d1bd2c0d0210fea104d015d6515d7f/pydocket-0.18.2.tar.gz", hash = "sha256:cc2051d15557f83bb164a83b0743fa9c12c2bfe9a9145cff3a5922b4935ce4f5", size = 354762, upload-time = "2026-03-10T13:09:22.52Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/cf/8c1b6340baf81d7f6c97fe0181bda7cfd500d5e33bf469fbffbdae07b3c9/pydocket-0.18.2-py3-none-any.whl", hash = "sha256:19e48de15e83370f750e362610b777533ff9c0fa48bf36766ed581f91d266556", size = 99041, upload-time = "2026-03-10T13:09:20.598Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -6496,15 +6388,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-json-logger"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -6660,18 +6543,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
-]
-
-[[package]]
-name = "redis"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/82/4d1a5279f6c1251d3d2a603a798a1137c657de9b12cfc1fba4858232c4d2/redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034", size = 4928081, upload-time = "2026-03-06T18:18:16.287Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/28/84e57fce7819e81ec5aa1bd31c42b89607241f4fb1a3ea5b0d2dbeaea26c/redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364", size = 404379, upload-time = "2026-03-06T18:18:14.583Z" },
 ]
 
 [[package]]
@@ -7214,15 +7085,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1164,7 +1164,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

This fixes CVEs:

- [CVE-2026-32871](https://github.com/PrefectHQ/fastmcp/security/advisories/GHSA-vv7q-7jx5-f767)
- [CVE-2026-27124](https://github.com/PrefectHQ/fastmcp/security/advisories/GHSA-rww4-4w9c-7733)
- [CVE-2025-64340](https://github.com/PrefectHQ/fastmcp/security/advisories/GHSA-m8x7-r2rg-vh5g)

While these CVEs likely don't affect us, we want to upgrade to not show up in scans. The upgrade requires a bump to a new major version of fastmcp, and fixing compatibility issues. I tried to maintain `datarobot-genai`'s API compatible so there are fewer changes required downstream.


<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core MCP-server dependency across a major version and updates registration/auth codepaths, which could affect tool/prompt/resource visibility and request authentication behavior at runtime.
> 
> **Overview**
> Upgrades the `drmcp` extra to `fastmcp>=3.2.0` (bumping package version to `0.13.0`) and updates lockfile contents accordingly to address reported CVEs.
> 
> Migrates server integration to FastMCP 3.x APIs: replaces internal `_list_*_mcp()`/`get_*` usage with `list_*()`, switches duplicate-handling to the unified `on_duplicate`, and adds compatibility wrappers on `DataRobotMCP` to preserve dict-returning `get_tools`/`get_prompts`/`get_resources` behavior.
> 
> Adapts component registration to FastMCP 3.x by removing `enabled` from tool/prompt/resource registration payloads and instead calling `mcp.disable(...)` when `enabled=False`; updates tag extraction to read `meta.fastmcp.tags` and makes `Context.set_state`/`get_state` awaits, including an auth header wrapper that forces `get_http_headers(include_all=True)` so authorization headers remain available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330963578a4376890a2655a1b977e81185b0d9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->