### PR TITLE
BUZZOK-29982: Standalone use of LLMs

### DIFF
--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 
 import os
 
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from nat.data_models.common import SecretStr
+
 DEFAULT_MAX_HISTORY_MESSAGES = 20
 
 
@@ -39,3 +42,43 @@ def get_max_history_messages_default() -> int:
     # 0 means "no history". Clamp negatives to 0 to allow "disable history"
     # semantics via env var while preventing unbounded/undefined behavior.
     return max(0, value)
+
+
+class Config(DataRobotAppFrameworkBaseSettings):
+    """
+    Finds variables in the priority order of: env
+    variables (including Runtime Parameters), .env, file_secrets, then
+    Pulumi output variables.
+    """
+
+    datarobot_endpoint: str = "https://app.datarobot.com/api/v2"
+    datarobot_api_token: str | None = None
+    llm_deployment_id: str | None = None
+    nim_deployment_id: str | None = None
+    use_datarobot_llm_gateway: bool = True
+    llm_default_model: str | None = None
+    streamming: bool = False
+
+
+def default_api_key() -> SecretStr | None:
+    config = Config()
+    return SecretStr(config.datarobot_api_token) if config.datarobot_api_token else None
+
+
+def default_llm_deployment_url() -> str:
+    config = Config()
+    return f"{config.datarobot_endpoint}/deployments/{config.llm_deployment_id}"
+
+
+def default_base_url() -> str:
+    config = Config()
+    return (
+        config.datarobot_endpoint.rstrip("/")
+        if config.use_datarobot_llm_gateway
+        else config.datarobot_endpoint + f"/deployments/{config.llm_deployment_id}"
+    )
+
+
+def default_model_name() -> str:
+    config = Config()
+    return config.llm_default_model or "datarobot-deployed-llm"

--- a/src/datarobot_genai/core/utils/llm.py
+++ b/src/datarobot_genai/core/utils/llm.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import TypeVar
+
+from nat.data_models.llm import LLMBaseConfig
+from nat.data_models.retry_mixin import RetryMixin
+from nat.utils.exception_handlers.automatic_retries import patch_with_retry
+
+if TYPE_CHECKING:
+    ModelType = TypeVar("ModelType")
+
+
+def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> ModelType:
+    if isinstance(llm_config, RetryMixin):
+        client = patch_with_retry(
+            client,
+            retries=llm_config.num_retries,
+            retry_codes=llm_config.retry_on_status_codes,
+            retry_on_messages=llm_config.retry_on_errors,
+        )
+
+    return client

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -1,0 +1,56 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from datarobot_genai.core.config import Config
+from datarobot_genai.core.utils.llm import _patch_llm_based_on_config
+
+if TYPE_CHECKING:
+    from crewai import LLM
+
+
+def get_gateway_llm(llm_name: str) -> LLM:
+    from crewai import LLM  # noqa: PLC0415
+    llm_config = Config(llm_default_model=llm_name, streamming=True, use_datarobot_llm_gateway=True)
+    config = {
+        "api_key": llm_config.default_api_key(),
+    }
+    if not llm_config.llm_default_model.startswith("datarobot/"):
+        config["model"] = "datarobot/" + llm_config.llm_default_model
+    config["base_url"] = llm_config.default_base_url().removesuffix("/api/v2")
+    client = LLM(**config)
+    return _patch_llm_based_on_config(client, llm_config)
+
+
+def get_deployment_llm(deployment_id: str) -> LLM:
+    from crewai import LLM  # noqa: PLC0415
+
+    llm_config = Config(llm_deployment_id=deployment_id, streamming=True)
+    config = {
+        "base_url": llm_config.default_base_url(),
+        "api_key": llm_config.default_api_key()
+    }
+
+    if not llm_config.llm_default_model.startswith("datarobot/"):
+        config["model"] = "datarobot/" + llm_config.llm_default_model
+    config["api_base"] = config.pop("base_url") + "/chat/completions"
+    # TODO do we need headers?
+    if llm_config.headers:
+        config["extra_headers"] = llm_config.headers
+
+    client = LLM(**config)
+    return _patch_llm_based_on_config(client, llm_config)

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -1,0 +1,78 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+
+from datarobot_genai.core.config import Config
+from datarobot_genai.nat.helpers import extract_headers_from_context
+from nat.plugins.langchain.llm import (_patch_llm_based_on_config as langchain_patch_llm_based_on_config)
+
+if TYPE_CHECKING:
+    from langchain_openai import ChatOpenAI
+
+
+def _create_datarobot_chat_openai(config: dict[str, Any]) -> Any:
+    from langchain_openai import ChatOpenAI  # noqa: PLC0415
+
+    class DataRobotChatOpenAI(ChatOpenAI):
+        def _get_request_payload(  # type: ignore[override]
+            self,
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict:
+            # We need to default to include_usage=True for streaming but we get 400 response
+            # if stream_options is present for a non-streaming call.
+            payload = super()._get_request_payload(*args, **kwargs)
+            if not payload.get("stream"):
+                payload.pop("stream_options", None)
+            return payload
+
+    return DataRobotChatOpenAI(**config)
+
+
+async def get_gateway_llm(llm_name: str) -> ChatOpenAI:
+    llm_config = Config(llm_default_model=llm_name, streamming=True, use_datarobot_llm_gateway=True)
+
+    config = {
+        "base_url": llm_config.default_base_url() + "/genai/llmgw",
+        "stream_options": {"include_usage": True},
+        "model": llm_config.llm_default_model.removeprefix("datarobot/"),  #TODO check if needed
+        "api_key": llm_config.default_api_key(),
+    }
+    client = _create_datarobot_chat_openai(config)
+    yield langchain_patch_llm_based_on_config(client, config)
+
+
+async def get_deployment_llm(deployment_id: str) -> ChatOpenAI:
+    # from Config base new Config() 
+    # fetch data from this config stream: parametr false api key and token
+    llm_config = Config(llm_deployment_id=deployment_id, streamming=True)
+    config = {
+        "base_url": llm_config.default_base_url(),
+        "stream_options": {"include_usage": True},
+        "model": llm_config.default_model_name().removeprefix("datarobot/"), #TODO check if needed 
+        "api_key": llm_config.default_api_key()
+    }
+    # TODO do we need headers?
+    context_headers = extract_headers_from_context(["X-DataRobot-Identity-Token"])
+    if llm_config.headers:
+        context_headers = {**context_headers, **llm_config.headers}
+
+    config["default_headers"] = context_headers
+
+    client = _create_datarobot_chat_openai(config)
+    yield langchain_patch_llm_based_on_config(client, config)

--- a/src/datarobot_genai/llama_index/__init__.py
+++ b/src/datarobot_genai/llama_index/__init__.py
@@ -2,10 +2,14 @@
 
 from .agent import DataRobotLiteLLM
 from .agent import LlamaIndexAgent
+from .llm import get_deployment_llm
+from .llm import get_gateway_llm
 from .mcp import mcp_tools_context
 
 __all__ = [
     "DataRobotLiteLLM",
     "LlamaIndexAgent",
+    "get_deployment_llm",
+    "get_gateway_llm",
     "mcp_tools_context",
 ]

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -17,51 +17,73 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import Any
+from datarobot_genai.core.config import Config
+from datarobot_genai.core.utils.llm import _patch_llm_based_on_config
 
-from nat.builder.framework_enum import LLMFrameworkEnum
-from nat.utils.responses_api import validate_no_responses_api
-
-from datarobot_genai.nat.datarobot_llm_clients import _create_datarobot_litellm
-from datarobot_genai.nat.datarobot_llm_clients import _patch_llm_based_on_config
-from datarobot_genai.nat.datarobot_llm_providers import Config
-from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMDeploymentModelConfig
-from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMGatewayModelConfig
 
 if TYPE_CHECKING:
     from llama_index.llms.litellm import LiteLLM
 
 
-def get_gateway_llm(llm_name: str) -> LiteLLM:
-    llm_config = DataRobotLLMGatewayModelConfig(model=llm_name)
-    validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
-    config = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type"},
-        by_alias=True,
-        exclude_none=True,
-    )
-    if not config["model"].startswith("datarobot/"):
-        config["model"] = "datarobot/" + config["model"]
+def _create_datarobot_litellm(config: dict[str, Any]) -> Any:
+    from llama_index.core.base.llms.types import LLMMetadata  # noqa: PLC0415
+    from llama_index.llms.litellm import LiteLLM  # noqa: PLC0415
+
+    class DataRobotLiteLLM(LiteLLM):  # type: ignore[misc]
+        """DataRobotLiteLLM is a small LiteLLM wrapper class that makes all LiteLLM endpoints
+        compatible with the LlamaIndex library.
+        """
+
+        @property
+        def metadata(self) -> LLMMetadata:
+            """Returns the metadata for the LLM.
+
+            This is required to enable the is_chat_model and is_function_calling_model, which are
+            mandatory for LlamaIndex agents. By default, LlamaIndex assumes these are false unless
+            each individual model config in LiteLLM explicitly sets them to true. To use custom LLM
+            endpoints with LlamaIndex agents, you must override this method to return the
+            appropriate metadata.
+            """
+            return LLMMetadata(
+                context_window=128000,
+                num_output=self.max_tokens or -1,
+                is_chat_model=True,
+                is_function_calling_model=True,
+                model_name=self.model,
+            )
+
+    return DataRobotLiteLLM(**config)
+
+
+async def get_gateway_llm(llm_name: str) -> LiteLLM:
+    llm_config = Config(llm_default_model=llm_name, streamming=True, use_datarobot_llm_gateway=True)
+    config = {
+        "base_url": llm_config.default_base_url(),
+        "stream_options": {"include_usage": True},
+        "api_key": llm_config.default_api_key(),
+    }
+    if not llm_config.llm_default_model.startswith("datarobot/"):
+        config["model"] = "datarobot/" + llm_config.llm_default_model
     config["api_base"] = config.pop("base_url").removesuffix("/api/v2")
     client = _create_datarobot_litellm(config)
-    return _patch_llm_based_on_config(client, llm_config)
+    yield _patch_llm_based_on_config(client, llm_config)
 
 
-def get_deployment_llm(deployment_id: str) -> LiteLLM:
-    dr = Config()
-    base = dr.datarobot_endpoint.rstrip("/")
-    base_url = f"{base}/deployments/{deployment_id}"
-    llm_config = DataRobotLLMDeploymentModelConfig(base_url=base_url)
-    validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
-    config = llm_config.model_dump(
-        exclude={"type", "thinking", "headers", "api_type"},
-        by_alias=True,
-        exclude_none=True,
-    )
-    if not config["model"].startswith("datarobot/"):
-        config["model"] = "datarobot/" + config["model"]
+async def get_deployment_llm(deployment_id: str) -> LiteLLM:
+    llm_config = Config(llm_deployment_id=deployment_id, streamming=True)
+    config = {
+        "base_url": llm_config.default_base_url(),
+        "stream_options": {"include_usage": True},
+        "api_key": llm_config.default_api_key()
+    }
+    if not llm_config.llm_default_model.startswith("datarobot/"):
+        config["model"] = "datarobot/" + llm_config.llm_default_model
     config["api_base"] = config.pop("base_url") + "/chat/completions"
+
+    # TODO do we need headers?
     if llm_config.headers:
         config["additional_kwargs"] = {"extra_headers": llm_config.headers}
 
     client = _create_datarobot_litellm(config)
-    return _patch_llm_based_on_config(client, llm_config)
+    yield _patch_llm_based_on_config(client, llm_config)

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -1,0 +1,67 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Construct LlamaIndex LiteLLM clients for DataRobot gateway and deployments."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.utils.responses_api import validate_no_responses_api
+
+from datarobot_genai.nat.datarobot_llm_clients import _create_datarobot_litellm
+from datarobot_genai.nat.datarobot_llm_clients import _patch_llm_based_on_config
+from datarobot_genai.nat.datarobot_llm_providers import Config
+from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMDeploymentModelConfig
+from datarobot_genai.nat.datarobot_llm_providers import DataRobotLLMGatewayModelConfig
+
+if TYPE_CHECKING:
+    from llama_index.llms.litellm import LiteLLM
+
+
+def get_gateway_llm(llm_name: str) -> LiteLLM:
+    llm_config = DataRobotLLMGatewayModelConfig(model=llm_name)
+    validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
+    config = llm_config.model_dump(
+        exclude={"type", "thinking", "api_type"},
+        by_alias=True,
+        exclude_none=True,
+    )
+    if not config["model"].startswith("datarobot/"):
+        config["model"] = "datarobot/" + config["model"]
+    config["api_base"] = config.pop("base_url").removesuffix("/api/v2")
+    client = _create_datarobot_litellm(config)
+    return _patch_llm_based_on_config(client, llm_config)
+
+
+def get_deployment_llm(deployment_id: str) -> LiteLLM:
+    dr = Config()
+    base = dr.datarobot_endpoint.rstrip("/")
+    base_url = f"{base}/deployments/{deployment_id}"
+    llm_config = DataRobotLLMDeploymentModelConfig(base_url=base_url)
+    validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
+    config = llm_config.model_dump(
+        exclude={"type", "thinking", "headers", "api_type"},
+        by_alias=True,
+        exclude_none=True,
+    )
+    if not config["model"].startswith("datarobot/"):
+        config["model"] = "datarobot/" + config["model"]
+    config["api_base"] = config.pop("base_url") + "/chat/completions"
+    if llm_config.headers:
+        config["additional_kwargs"] = {"extra_headers": llm_config.headers}
+
+    client = _create_datarobot_litellm(config)
+    return _patch_llm_based_on_config(client, llm_config)

--- a/src/datarobot_genai/nat/datarobot_llm_providers.py
+++ b/src/datarobot_genai/nat/datarobot_llm_providers.py
@@ -12,50 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from nat.builder.builder import Builder
 from nat.builder.llm import LLMProviderInfo
 from nat.cli.register_workflow import register_llm_provider
 from nat.data_models.common import OptionalSecretStr
-from nat.data_models.common import SecretStr
 from nat.llm.openai_llm import OpenAIModelConfig
 from pydantic import AliasChoices
 from pydantic import Field
 
-
-class Config(DataRobotAppFrameworkBaseSettings):
-    """
-    Finds variables in the priority order of: env
-    variables (including Runtime Parameters), .env, file_secrets, then
-    Pulumi output variables.
-    """
-
-    datarobot_endpoint: str = "https://app.datarobot.com/api/v2"
-    datarobot_api_token: str | None = None
-    llm_deployment_id: str | None = None
-    nim_deployment_id: str | None = None
-    use_datarobot_llm_gateway: bool = True
-    llm_default_model: str | None = None
-
-
-def default_base_url() -> str:
-    config = Config()
-    return (
-        config.datarobot_endpoint.rstrip("/")
-        if config.use_datarobot_llm_gateway
-        else config.datarobot_endpoint + f"/deployments/{config.llm_deployment_id}"
-    )
-
-
-def default_api_key() -> SecretStr | None:
-    config = Config()
-    return SecretStr(config.datarobot_api_token) if config.datarobot_api_token else None
-
-
-def default_model_name() -> str:
-    config = Config()
-    return config.llm_default_model or "datarobot-deployed-llm"
-
+from datarobot_genai.core.config import Config
+from datarobot_genai.core.config import default_api_key
+from datarobot_genai.core.config import default_base_url
+from datarobot_genai.core.config import default_model_name
 
 class DataRobotLLMComponentModelConfig(OpenAIModelConfig, name="datarobot-llm-component"):  # type: ignore[call-arg]
     """A DataRobot LLM provider to be used with an LLM client."""


### PR DESCRIPTION
# RATIONALE


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new LLM client construction paths across CrewAI/LangGraph/LlamaIndex and refactors shared config utilities, which can affect runtime connectivity/auth if URLs, headers, or retry behavior are miswired.
> 
> **Overview**
> Enables **standalone creation of DataRobot-backed LLM clients** for multiple frameworks by introducing new helpers to build gateway- and deployment-targeted clients for `crewai`, `langgraph` (LangChain `ChatOpenAI`), and `llama_index` (LiteLLM), including streaming defaults and model name normalization.
> 
> Centralizes DataRobot LLM configuration in `core/config.py` (new `Config` + default `api_key`/`base_url`/model helpers and a `streamming` flag) and adds a shared `_patch_llm_based_on_config` utility to apply retry behavior; `nat/datarobot_llm_providers.py` is updated to import these centralized defaults instead of defining its own config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f117068449a979f701c1d2422875a92b7e0098a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->