### PR TITLE
Rework completions interface to support external mcp tools factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.11.0
+- Reworked legacy interface to support mcp_tool_context being external to an agent.
+
 ## 0.10.3
 - Updated `openai` and `litellm`, and removed unused transitive dependencies.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.10.3"
+version = "0.11.0"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.10.3"
+version = "0.11.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/chat/completions.py
+++ b/src/datarobot_genai/core/chat/completions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from collections.abc import Callable
 from collections.abc import Mapping
 from typing import Any
 from typing import cast
@@ -40,6 +41,11 @@ from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import UsageMetrics
 
 logger = logging.getLogger(__name__)
+
+
+def _merge_mcp_tools_with_agent_tools(mcp_tools: Any, agent: BaseAgent) -> list[Any]:
+    """Return MCP tools followed by any tools already set on the agent (e.g. workflow tools)."""
+    return [*list(mcp_tools), *list(agent.tools)]
 
 
 def is_streaming(completion_create_params: CompletionCreateParams | Mapping[str, Any]) -> bool:
@@ -124,9 +130,14 @@ def convert_chat_completion_params_to_run_agent_input(
 
 
 async def agent_chat_completion_wrapper(
-    agent: BaseAgent, chat_completion_params: CompletionCreateParams | Mapping[str, Any]
+    agent: BaseAgent,
+    chat_completion_params: CompletionCreateParams | Mapping[str, Any],
+    mcp_tools_factory: Callable[[], Any],
 ) -> InvokeReturn | tuple[str, MultiTurnSample | None, UsageMetrics]:
     """Wrap the agent's invoke method in a chat completion wrapper.
+
+    MCP tools from ``mcp_tools_factory`` are combined with any tools already on
+    ``agent`` (MCP first, then existing ``agent.tools``).
 
     Returns
     -------
@@ -139,26 +150,35 @@ async def agent_chat_completion_wrapper(
     run_agent_input = convert_chat_completion_params_to_run_agent_input(chat_completion_params)
 
     if is_streaming(chat_completion_params):
-        return agent.invoke(run_agent_input)
+
+        async def _stream_with_mcp() -> InvokeReturn:
+            async with mcp_tools_factory() as mcp_tools:
+                agent.set_tools(_merge_mcp_tools_with_agent_tools(mcp_tools, agent))
+                async for item in agent.invoke(run_agent_input):
+                    yield item
+
+        return _stream_with_mcp()
     else:
-        final_response = ""
-        pipeline_interactions = None
-        usage_metrics = default_usage_metrics()
-        received_run_finished = False
-        async for event, iter_interactions, iter_metrics in agent.invoke(run_agent_input):
-            # When we work in non-streaming mode, we only send back the final message
-            # It is because of limitation of completions interface we can not send back the
-            # intermediate messages
-            if isinstance(event, TextMessageStartEvent):
-                final_response = ""
-            elif isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
-                final_response += event.delta
-            elif isinstance(event, RunFinishedEvent):
-                received_run_finished = True
-                pipeline_interactions = iter_interactions
-                usage_metrics = iter_metrics
+        async with mcp_tools_factory() as mcp_tools:
+            agent.set_tools(_merge_mcp_tools_with_agent_tools(mcp_tools, agent))
+            final_response = ""
+            pipeline_interactions = None
+            usage_metrics = default_usage_metrics()
+            received_run_finished = False
+            async for event, iter_interactions, iter_metrics in agent.invoke(run_agent_input):
+                # When we work in non-streaming mode, we only send back the final message
+                # It is because of limitation of completions interface we can not send back the
+                # intermediate messages
+                if isinstance(event, TextMessageStartEvent):
+                    final_response = ""
+                elif isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
+                    final_response += event.delta
+                elif isinstance(event, RunFinishedEvent):
+                    received_run_finished = True
+                    pipeline_interactions = iter_interactions
+                    usage_metrics = iter_metrics
 
-        if not received_run_finished:
-            logger.warning("Agent stream ended without RunFinishedEvent")
+            if not received_run_finished:
+                logger.warning("Agent stream ended without RunFinishedEvent")
 
-        return final_response, pipeline_interactions, usage_metrics
+            return final_response, pipeline_interactions, usage_metrics

--- a/src/datarobot_genai/core/chat/responses.py
+++ b/src/datarobot_genai/core/chat/responses.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import queue
 import time
 import traceback as tb
@@ -49,6 +50,8 @@ from datarobot_genai.core.agents import default_usage_metrics
 
 if TYPE_CHECKING:
     from ragas import MultiTurnSample
+
+logger = logging.getLogger(__name__)
 
 
 class CustomModelChatResponse(ChatCompletion):
@@ -171,6 +174,18 @@ def to_custom_model_streaming_response(
                     )
             except StopAsyncIteration:
                 break
+            except RuntimeError as e:
+                if "Attempted to exit cancel scope" in str(e):
+                    # Known issue: MCP/AnyIO cancel scope may be torn down in a different
+                    # asyncio Task than the one that entered it when streaming is driven via
+                    # repeated run_until_complete(anext(...)). Full async execution avoids this;
+                    # log and continue until a sync-free execution path is available.
+                    logger.warning(
+                        "Ignoring MCP context teardown RuntimeError during streaming: %s",
+                        e,
+                    )
+                    continue
+                raise
         event_loop.run_until_complete(streaming_response_generator.aclose())
         # Yield final chunk indicating end of stream
         choice = ChunkChoice(

--- a/tests/core/chat/test_completions.py
+++ b/tests/core/chat/test_completions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Any
 
 import pytest
@@ -36,6 +37,38 @@ from datarobot_genai.core.agents import UsageMetrics
 from datarobot_genai.core.chat.completions import agent_chat_completion_wrapper
 from datarobot_genai.core.chat.completions import convert_chat_completion_params_to_run_agent_input
 from datarobot_genai.core.chat.completions import is_streaming
+
+
+def noop_mcp_tools_factory() -> Any:
+    """Async context manager factory that yields no MCP tools (unit tests)."""
+
+    @asynccontextmanager
+    async def _ctx() -> AsyncGenerator[list[Any], None]:
+        yield []
+
+    return _ctx()
+
+
+def _make_tracking_mcp_tools_factory(
+    trace: list[str],
+    mcp_tools: list[str],
+) -> Any:
+    """Return ``mcp_tools_factory`` that records lifecycle and yields ``mcp_tools``."""
+
+    def factory() -> Any:
+        trace.append("factory_called")
+
+        @asynccontextmanager
+        async def _ctx() -> AsyncGenerator[list[str], None]:
+            trace.append("context_entered")
+            try:
+                yield mcp_tools
+            finally:
+                trace.append("context_exited")
+
+        return _ctx()
+
+    return factory
 
 
 def test_is_streaming_false_by_default() -> None:
@@ -211,6 +244,100 @@ class AGUIAgent(BaseAgent):
             yield event
 
 
+class RecordingAgent(AGUIAgent):
+    """AGUIAgent that records ``set_tools`` arguments."""
+
+    def __init__(self, *, initial_tools: list[Any] | None = None) -> None:
+        super().__init__(tools=initial_tools or [])
+        self.set_tools_calls: list[list[Any]] = []
+
+    def set_tools(self, tools: list[Any]) -> None:  # type: ignore[override]
+        self.set_tools_calls.append(list(tools))
+        super().set_tools(tools)
+
+
+async def test_agent_chat_completion_wrapper_streaming_invokes_mcp_factory_and_sets_tools() -> None:
+    """Streaming: MCP factory runs once per stream and yielded tools are passed via `set_tools`."""
+    trace: list[str] = []
+    mcp_tools = ["mcp-alpha", "mcp-beta"]
+    mcp_factory = _make_tracking_mcp_tools_factory(trace, mcp_tools)
+    params: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": True,
+    }
+    agent = RecordingAgent()
+
+    generator = await agent_chat_completion_wrapper(agent, params, mcp_factory)
+
+    assert trace == [], "factory must not run until the async generator is consumed"
+
+    events = [e async for e in generator]
+
+    assert trace == [
+        "factory_called",
+        "context_entered",
+        "context_exited",
+    ]
+    assert agent.set_tools_calls == [mcp_tools]
+    assert agent.tools == mcp_tools
+    assert len(events) == 8
+
+
+@pytest.mark.parametrize("stream", [True, False])
+async def test_agent_chat_completion_wrapper_merges_mcp_tools_with_existing_agent_tools(
+    stream: bool,
+) -> None:
+    """MCP tools are prepended to tools already configured on the agent."""
+    trace: list[str] = []
+    mcp_tools = ["mcp-alpha", "mcp-beta"]
+    pre_existing = ["workflow-tool"]
+    mcp_factory = _make_tracking_mcp_tools_factory(trace, mcp_tools)
+    params: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": stream,
+    }
+    agent = RecordingAgent(initial_tools=list(pre_existing))
+    expected = [*mcp_tools, *pre_existing]
+
+    wrapper_result = await agent_chat_completion_wrapper(agent, params, mcp_factory)
+
+    if stream:
+        assert trace == []
+        assert isinstance(wrapper_result, AsyncGenerator)
+        async for _ in wrapper_result:
+            pass
+    else:
+        assert isinstance(wrapper_result, tuple)
+
+    assert trace == ["factory_called", "context_entered", "context_exited"]
+    assert agent.set_tools_calls == [expected]
+    assert agent.tools == expected
+
+
+async def test_agent_chat_completion_wrapper_non_streaming_invokes_mcp_factory_and_sets_tools() -> (
+    None
+):
+    """Non-streaming: MCP factory runs once and yielded tools are passed via ``set_tools``."""
+    trace: list[str] = []
+    mcp_tools = ["mcp-alpha", "mcp-beta"]
+    mcp_factory = _make_tracking_mcp_tools_factory(trace, mcp_tools)
+    params: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": False,
+    }
+    agent = RecordingAgent()
+
+    await agent_chat_completion_wrapper(agent, params, mcp_factory)
+
+    assert trace == [
+        "factory_called",
+        "context_entered",
+        "context_exited",
+    ]
+    assert agent.set_tools_calls == [mcp_tools]
+    assert agent.tools == mcp_tools
+
+
 async def test_agent_chat_completion_wrapper_streaming() -> None:
     # GIVEN a chat completion parameters
     params = {
@@ -221,7 +348,7 @@ async def test_agent_chat_completion_wrapper_streaming() -> None:
     }
 
     # WHEN calling the agent chat completion wrapper
-    generator = await agent_chat_completion_wrapper(AGUIAgent(), params)
+    generator = await agent_chat_completion_wrapper(AGUIAgent(), params, noop_mcp_tools_factory)
 
     # THEN the generator returns an async generator
     assert isinstance(generator, AsyncGenerator)
@@ -257,7 +384,7 @@ async def test_agent_chat_completion_wrapper_non_streaming() -> None:
 
     # WHEN calling the agent chat completion wrapper
     response, pipeline_interactions, usage_metrics = await agent_chat_completion_wrapper(
-        AGUIAgent(), params
+        AGUIAgent(), params, noop_mcp_tools_factory
     )
 
     # THEN the response is the expected response

--- a/tests/nat/integration/test_agent.py
+++ b/tests/nat/integration/test_agent.py
@@ -29,6 +29,7 @@ from datarobot_genai.core.chat.responses import (
 )
 from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.nat.agent import NatAgent
+from tests.core.chat.test_completions import noop_mcp_tools_factory
 
 
 class Config(DataRobotAppFrameworkBaseSettings):
@@ -152,7 +153,7 @@ def test_custom_model_streaming_response(agent):
 
     result = thread_pool_executor.submit(
         event_loop.run_until_complete,
-        agent_chat_completion_wrapper(agent, completion_create_params),
+        agent_chat_completion_wrapper(agent, completion_create_params, noop_mcp_tools_factory),
     ).result()
 
     streaming_response_iterator = async_gen_to_sync_thread(result, thread_pool_executor, event_loop)

--- a/uv.lock
+++ b/uv.lock
@@ -1161,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.10.3"
+version = "0.11.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Our legacy flow with drum and passing from sync to async does not work well with an external MCP context. This provides support for it.

Mind that here I am hiding an exception risen when we are closing the mcp context in another coroutine: there is no easy solution for it in the current architecture, and for `dragent` it will not be a problem.

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the chat completions wrapper to manage MCP tool context and mutate `agent.tools` during both streaming and non-streaming execution, and adds a runtime-error suppression path in the streaming sync bridge; these can affect tool availability and error visibility in production.
> 
> **Overview**
> Updates `agent_chat_completion_wrapper` to accept an external `mcp_tools_factory` async context manager, enter it per request/stream, and **prepend MCP-provided tools** to any existing `agent.tools` before invoking the agent.
> 
> Adds a defensive workaround in `to_custom_model_streaming_response` to **ignore a known MCP/AnyIO cancel-scope teardown `RuntimeError`** during thread-driven streaming, and updates/extends tests to cover MCP factory lifecycle/tool merging and to pass a no-op factory where needed. Also bumps the package version to `0.11.0` and records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2388ecf5ea550817d43c59aee7bb1a6c1ddb439e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->