### PR TITLE
Example

### DIFF
--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -44,8 +44,14 @@ from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import TextMessageStartEvent
+from ag_ui.core import ToolCallArgsEvent
+from ag_ui.core import ToolCallEndEvent
+from ag_ui.core import ToolCallResultEvent
+from ag_ui.core import ToolCallStartEvent
 from crewai import Crew
+from crewai.events import ToolUsageFinishedEvent
 from crewai.events import crewai_event_bus
+from crewai.events.types.tool_usage_events import ToolUsageStartedEvent
 from crewai.tools import BaseTool
 from crewai.types.streaming import CrewStreamingOutput
 from crewai.types.streaming import StreamChunkType
@@ -213,6 +219,26 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                 reasoning_started = False
                 text_started = False
                 async for chunk in crew_output:
+                    @crewai_event_bus.on(ToolUsageStartedEvent)
+                    def on_tool_usage_started(_: Any, event: Any) -> None:
+                        yield (
+                            ToolCallStartEvent(
+                                type=EventType.TOOL_CALL_START,
+                                tool_call_id=event.tool_call_id,
+                                tool_name=event.tool_name,
+                            ),
+                        )
+
+                    @crewai_event_bus.on(ToolUsageFinishedEvent)
+                    def on_tool_usage_finished(_: Any, event: Any) -> None:
+                        yield (
+                            ToolCallEndEvent(
+                                type=EventType.TOOL_CALL_END,
+                                tool_call_id=event.tool_call_id,
+                                tool_name=event.tool_name,
+                            ),
+                        )
+
                     # Show task transitions
                     logger.debug(f"CrewAI chunk: {chunk.model_dump_json()}")
                     if chunk.agent_role != current_agent_role:


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new event-bus hooks to surface tool start/end events during streaming, which changes runtime event emission and could impact clients consuming the stream if handlers fire unexpectedly or multiple times.
> 
> **Overview**
> Adds **tool-call lifecycle streaming support** for CrewAI agents by wiring CrewAI `ToolUsageStartedEvent`/`ToolUsageFinishedEvent` into AG-UI `ToolCallStartEvent` and `ToolCallEndEvent` emissions.
> 
> This expands `CrewAIAgent.invoke()` to register these tool-usage handlers during streaming runs so frontends can observe when tools begin and finish, alongside existing step/reasoning/text events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13e855667431873724d6960b19dad92d3b710e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->