### PR TITLE
[BUZZOK-29775] Editable agents and creating agent from a native example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.14.0
-- Make agents only accept `llm`
-- Functions to convert native agentic primitives into DataRobot agents
+- Reworked agents to only accept `llm`: its not the job of an agent to instantiate the LLM
+- Implemented functions to convert native agentic primitives into DataRobot agents
 
 ## 0.13.3
 - Enabled functionalities of synchronizing MCP item metadata within MCP server (still behind the feature flag).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.14.0
+- Make agents only accept `llm`
+- Functions to convert native agentic primitives into DataRobot agents
+
 ## 0.13.0
 - Upgraded fastmcp from 2.x to 3.2.0+ (CVE-2026-32871, CVE-2026-27124, CVE-2025-64340)
 - Replaced `on_duplicate_tools`/`on_duplicate_prompts` with unified `on_duplicate` (fastmcp 3.x API)

--- a/e2e-tests/Taskfile.yaml
+++ b/e2e-tests/Taskfile.yaml
@@ -33,6 +33,11 @@ tasks:
     cmds:
       - echo "🔧 Installing dependencies for {{.GROUP}}"
       - uv sync --group dragent-{{.GROUP}} --group lint
+  install-all:
+    desc: "🔧 Install dependencies for all groups"
+    cmds:
+      - echo "🔧 Installing dependencies for all groups"
+      - uv sync --group dragent-nat --group dragent-langgraph --group dragent-crewai --group dragent-llamaindex --group lint
   test-dragent:
     desc: "🧪 Run tests for dragent"
     cmds:

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-
 from crewai import Agent
+from crewai import Crew
 from crewai import Task
+from crewai.llm import LLM
 from crewai.tools import tool
 from datarobot_genai.core.agents import make_system_prompt
-from datarobot_genai.crewai.agent import CrewAIAgent
+from datarobot_genai.crewai.agent import datarobot_agent_class_from_crew
 from datarobot_genai.drtools.calculator import calculator
 
 from dragent.tool import generate_objectid
@@ -26,82 +26,59 @@ from dragent.tool import generate_objectid
 generate_objectid_tool = tool(generate_objectid)
 calculator_tool = tool(calculator)
 
+llm = LLM(model="datarobot/azure-openai-gpt-5-codex", is_litellm=True)
 
-class MyAgent(CrewAIAgent):
-    """Planner -> Writer CrewAI agent with calculator tool for e2e testing."""
+agent_planner = Agent(
+    role="Content Planner",
+    goal="Create a short bullet-point outline with 3-5 key points about: {topic}.",
+    backstory=make_system_prompt(
+        "You are a content planner. Given a topic, produce a short bullet-point "
+        "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
+    ),
+    llm=llm,
+    tools=[generate_objectid_tool, calculator_tool],
+)
 
-    def __init__(
-        self,
-        llm: Any = None,
-        **kwargs: Any,
-    ):
-        super().__init__(**kwargs)
-        self._llm = llm
+agent_writer = Agent(
+    role="Content Writer",
+    goal="Write a 2-3 sentence response based on the planner's outline about: {topic}.",
+    backstory=make_system_prompt(
+        "You are a concise writer. Using the planner's outline, write a short response "
+        "in 2-3 sentences. "
+    ),
+    llm=llm,
+    tools=[generate_objectid_tool, calculator_tool],
+)
 
-    @property
-    def agents(self) -> list[Any]:
-        planner = Agent(
-            role="Content Planner",
-            goal="Create a short bullet-point outline with 3-5 key points about: {topic}.",
-            backstory=make_system_prompt(
-                "You are a content planner. Given a topic, produce a short bullet-point "
-                "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
-                "Use the generate_objectid tool when asked to generate an object ID for a "
-                "deployment. Use the calculator tool when asked to compute a mathematical "
-                "expression."
-            ),
-            llm=self._llm,
-            function_calling_llm=self._llm,
-            tools=[generate_objectid_tool, calculator_tool] + self.tools,
-            verbose=self.verbose,
-        )
-        writer = Agent(
-            role="Content Writer",
-            goal="Write a 2-3 sentence response based on the planner's outline about: {topic}.",
-            backstory=make_system_prompt(
-                "You are a concise writer. Using the planner's outline, write a short response "
-                "in 2-3 sentences. Use the generate_objectid tool when asked to "
-                "generate an object ID for a deployment. Use the calculator tool when asked to "
-                "compute a mathematical expression."
-            ),
-            llm=self._llm,
-            function_calling_llm=self._llm,
-            tools=[generate_objectid_tool, calculator_tool] + self.tools,
-            verbose=self.verbose,
-        )
-        return [planner, writer]
+agents = [agent_planner, agent_writer]
 
-    @property
-    def tasks(self) -> list[Any]:
-        return self._tasks_for(self.agents)
+task_planner = Task(
+    description=(
+        "Create a short outline about: {topic}. "
+        "Prior conversation context (may be empty): {chat_history}. "
+        "Execute tool calls if requested instead of this task."
+    ),
+    expected_output=("A bullet-point outline with 3-5 key points. Or the result of a tool call."),
+    agent=agent_planner,
+)
 
-    def _tasks_for(self, agents: list[Any]) -> list[Any]:
-        planner, writer = agents
-        return [
-            Task(
-                description=(
-                    "Create a short outline about: {topic}. "
-                    "Prior conversation context (may be empty): {chat_history}. "
-                    "Execute tool calls if requested instead of this task."
-                ),
-                expected_output=(
-                    "A bullet-point outline with 3-5 key points. Or the result of a tool call."
-                ),
-                agent=planner,
-            ),
-            Task(
-                description=(
-                    "Using the planner's outline, write a short response about: {topic}. "
-                    "Prior conversation context (may be empty): {chat_history}. "
-                    "Execute tool calls if requested instead of this task."
-                ),
-                expected_output="A concise 2-3 sentence response. Or the result of a tool call.",
-                agent=writer,
-            ),
-        ]
+task_writer = Task(
+    description=(
+        "Using the planner's outline, write a short response about: {topic}. "
+        "Prior conversation context (may be empty): {chat_history}. "
+        "Execute tool calls if requested instead of this task."
+    ),
+    expected_output="A concise 2-3 sentence response. Or the result of a tool call.",
+    agent=agent_writer,
+)
 
-    def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
-        return {
-            "topic": user_prompt_content,
-            "chat_history": "",
-        }
+tasks = [task_planner, task_writer]
+
+crew = Crew(agents=agents, tasks=tasks, stream=True)
+
+kickoff_inputs = lambda user_prompt_content: {  # noqa: E731
+    "topic": user_prompt_content,
+    "chat_history": "",
+}
+
+agent_class = datarobot_agent_class_from_crew(crew, agents, tasks, kickoff_inputs)

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -81,4 +81,4 @@ kickoff_inputs = lambda user_prompt_content: {
     "chat_history": "",
 }
 
-agent_class = datarobot_agent_class_from_crew(crew, agents, tasks, kickoff_inputs)
+MyAgent = datarobot_agent_class_from_crew(crew, agents, tasks, kickoff_inputs)

--- a/e2e-tests/dragent/crewai/myagent.py
+++ b/e2e-tests/dragent/crewai/myagent.py
@@ -76,7 +76,7 @@ tasks = [task_planner, task_writer]
 
 crew = Crew(agents=agents, tasks=tasks, stream=True)
 
-kickoff_inputs = lambda user_prompt_content: {  # noqa: E731
+kickoff_inputs = lambda user_prompt_content: {
     "topic": user_prompt_content,
     "chat_history": "",
 }

--- a/e2e-tests/dragent/crewai/register.py
+++ b/e2e-tests/dragent/crewai/register.py
@@ -46,7 +46,7 @@ async def crewai_agent(config: CrewaiAgentConfig, builder: Builder) -> AsyncGene
     from nat.builder.function_info import FunctionInfo
     from nat.builder.function_info import Streaming
 
-    from dragent.crewai.myagent import agent_class
+    from dragent.crewai.myagent import MyAgent
 
     async def _response_fn(
         input_message: RunAgentInput,
@@ -66,7 +66,7 @@ async def crewai_agent(config: CrewaiAgentConfig, builder: Builder) -> AsyncGene
             forwarded_headers=forwarded_headers, authorization_context=authorization_context
         )
         async with mcp_tools_context(mcp_config) as tools:
-            agent = agent_class(
+            agent = MyAgent(
                 llm=llm,
                 forwarded_headers=forwarded_headers,
                 tools=tools,

--- a/e2e-tests/dragent/crewai/register.py
+++ b/e2e-tests/dragent/crewai/register.py
@@ -46,7 +46,7 @@ async def crewai_agent(config: CrewaiAgentConfig, builder: Builder) -> AsyncGene
     from nat.builder.function_info import FunctionInfo
     from nat.builder.function_info import Streaming
 
-    from dragent.crewai.myagent import MyAgent
+    from dragent.crewai.myagent import agent_class
 
     async def _response_fn(
         input_message: RunAgentInput,
@@ -66,10 +66,11 @@ async def crewai_agent(config: CrewaiAgentConfig, builder: Builder) -> AsyncGene
             forwarded_headers=forwarded_headers, authorization_context=authorization_context
         )
         async with mcp_tools_context(mcp_config) as tools:
-            agent = MyAgent(
+            agent = agent_class(
                 llm=llm,
                 forwarded_headers=forwarded_headers,
                 tools=tools,
+                verbose=config.verbose,
             )
 
             async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):

--- a/e2e-tests/dragent/langgraph/myagent.py
+++ b/e2e-tests/dragent/langgraph/myagent.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-
 from datarobot_genai.core.agents import make_system_prompt
-from datarobot_genai.langgraph.agent import LangGraphAgent
+from datarobot_genai.langgraph.agent import datarobot_agent_class_from_langgraph
 from langchain.agents import create_agent
-from langchain_core.language_models import BaseChatModel
+from langchain.chat_models import BaseChatModel
+from langchain.tools import BaseTool
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.tools import tool
 from langgraph.graph import END
@@ -29,60 +28,50 @@ from dragent.tool import generate_objectid
 
 generate_objectid_tool = tool(generate_objectid)
 
+prompt_template = ChatPromptTemplate.from_messages(
+    [
+        ("system", "You are a helpful assistant. {chat_history}"),
+        ("user", "{topic}"),
+    ]
+)
 
-class MyAgent(LangGraphAgent):
-    """Planner -> Writer LangGraph agent with calculator tool for e2e testing."""
 
-    def __init__(
-        self,
-        llm: BaseChatModel | None = None,
-        **kwargs: Any,
-    ):
-        super().__init__(**kwargs)
-        self._llm = llm
+def graph_factory(
+    llm: BaseChatModel, tools: list[BaseTool], verbose: bool = False
+) -> StateGraph[MessagesState]:
+    agent_planner = create_agent(
+        llm,
+        tools=[generate_objectid_tool] + tools,
+        system_prompt=make_system_prompt(
+            "You are a content planner. Given a topic, produce a short bullet-point "
+            "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
+            "Use the generate_objectid tool when asked to generate an object ID for a "
+            "deployment."
+        ),
+        name="planner",
+        debug=verbose,
+    )
 
-    @property
-    def prompt_template(self) -> ChatPromptTemplate:
-        return ChatPromptTemplate.from_messages(
-            [
-                ("system", "You are a helpful assistant. {chat_history}"),
-                ("user", "{topic}"),
-            ]
-        )
+    agent_writer = create_agent(
+        llm,
+        tools=[generate_objectid_tool] + tools,
+        system_prompt=make_system_prompt(
+            "You are a concise writer. Using the planner's outline, write a short response "
+            "in 2-3 sentences. Use the generate_objectid tool when asked to "
+            "generate an object ID for a deployment."
+        ),
+        name="writer",
+        debug=verbose,
+    )
 
-    @property
-    def workflow(self) -> StateGraph[MessagesState]:
-        graph = StateGraph(MessagesState)
-        graph.add_node("planner_node", self.agent_planner)
-        graph.add_node("writer_node", self.agent_writer)
-        graph.add_edge(START, "planner_node")
-        graph.add_edge("planner_node", "writer_node")
-        graph.add_edge("writer_node", END)
-        return graph
+    graph = StateGraph(MessagesState)
+    graph.add_node("planner_node", agent_planner)
+    graph.add_node("writer_node", agent_writer)
+    graph.add_edge(START, "planner_node")
+    graph.add_edge("planner_node", "writer_node")
+    graph.add_edge("writer_node", END)
 
-    @property
-    def agent_planner(self) -> Any:
-        return create_agent(
-            self._llm,
-            tools=[generate_objectid_tool] + self.tools,
-            system_prompt=make_system_prompt(
-                "You are a content planner. Given a topic, produce a short bullet-point "
-                "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
-                "Use the generate_objectid tool when asked to generate an object ID for a "
-                "deployment."
-            ),
-            name="planner",
-        )
+    return graph
 
-    @property
-    def agent_writer(self) -> Any:
-        return create_agent(
-            self._llm,
-            tools=[generate_objectid_tool] + self.tools,
-            system_prompt=make_system_prompt(
-                "You are a concise writer. Using the planner's outline, write a short response "
-                "in 2-3 sentences. Use the generate_objectid tool when asked to "
-                "generate an object ID for a deployment."
-            ),
-            name="writer",
-        )
+
+MyAgent = datarobot_agent_class_from_langgraph(graph_factory, prompt_template)

--- a/e2e-tests/dragent/langgraph/register.py
+++ b/e2e-tests/dragent/langgraph/register.py
@@ -71,6 +71,7 @@ async def langgraph_agent(config: LanggraphAgentConfig, builder: Builder) -> Asy
                 llm=llm,
                 forwarded_headers=forwarded_headers,
                 tools=tools,
+                verbose=config.verbose,
             )
 
             async for event, pipeline_interactions, usage_metrics in agent.invoke(input_message):

--- a/e2e-tests/dragent/langgraph/workflow.yaml
+++ b/e2e-tests/dragent/langgraph/workflow.yaml
@@ -26,3 +26,4 @@ workflow:
   _type: langgraph_agent
   llm_name: datarobot_llm
   description: LangGraph planner/writer agent
+  verbose: true

--- a/e2e-tests/dragent/llamaindex/myagent.py
+++ b/e2e-tests/dragent/llamaindex/myagent.py
@@ -15,59 +15,54 @@
 from typing import Any
 
 from datarobot_genai.core.agents import make_system_prompt
-from datarobot_genai.llama_index.agent import LlamaIndexAgent
+from datarobot_genai.llama_index.agent import datarobot_agent_class_from_llamaindex
 from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.core.tools import FunctionTool
+from llama_index.llms.litellm import LiteLLM
 
 from dragent.tool import generate_objectid
 
 generate_objectid_tool = FunctionTool.from_defaults(fn=generate_objectid, name="generate_objectid")
 
+llm = LiteLLM(model="datarobot/azure-openai-gpt-5-codex")
 
-class MyAgent(LlamaIndexAgent):
-    """Planner -> Writer LlamaIndex agent with calculator tool for e2e testing."""
+planner = FunctionAgent(
+    name="planner",
+    description="Creates short bullet-point outlines",
+    system_prompt=make_system_prompt(
+        "You are a content planner. Given a topic, produce a short bullet-point "
+        "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
+        "Use the generate_objectid tool when asked to generate an object ID for a "
+        "deployment."
+    ),
+    llm=llm,
+    tools=[generate_objectid_tool],
+    can_handoff_to=["writer"],
+)
+writer = FunctionAgent(
+    name="writer",
+    description="Writes concise responses based on outlines",
+    system_prompt=make_system_prompt(
+        "You are a concise writer. Using the planner's outline, write a short response "
+        "in 2-3 sentences. Use the generate_objectid tool when asked to "
+        "generate an object ID for a deployment."
+    ),
+    llm=llm,
+    tools=[generate_objectid_tool],
+)
+agents = [planner, writer]
+workflow = AgentWorkflow(agents=agents, root_agent="planner")
 
-    def __init__(
-        self,
-        llm: Any = None,
-        **kwargs: Any,
-    ):
-        super().__init__(**kwargs)
-        self._llm = llm
 
-    async def build_workflow(self) -> AgentWorkflow:
-        planner = FunctionAgent(
-            name="planner",
-            description="Creates short bullet-point outlines",
-            system_prompt=make_system_prompt(
-                "You are a content planner. Given a topic, produce a short bullet-point "
-                "outline with 3-5 key points. No paragraphs, no explanations — just the list. "
-                "Use the generate_objectid tool when asked to generate an object ID for a "
-                "deployment."
-            ),
-            llm=self._llm,
-            tools=[generate_objectid_tool] + self.tools,
-            can_handoff_to=["writer"],
-        )
-        writer = FunctionAgent(
-            name="writer",
-            description="Writes concise responses based on outlines",
-            system_prompt=make_system_prompt(
-                "You are a concise writer. Using the planner's outline, write a short response "
-                "in 2-3 sentences. Use the generate_objectid tool when asked to "
-                "generate an object ID for a deployment."
-            ),
-            llm=self._llm,
-            tools=[generate_objectid_tool] + self.tools,
-        )
-        return AgentWorkflow(agents=[planner, writer], root_agent="planner")
+def extract_response_text(result_state: Any, events: list[Any]) -> str:
+    for event in reversed(events):
+        resp = getattr(event, "response", None)
+        if resp is not None:
+            content = getattr(resp, "content", None)
+            if content:
+                return str(content)
+    return ""
 
-    def extract_response_text(self, result_state: Any, events: list[Any]) -> str:
-        for event in reversed(events):
-            resp = getattr(event, "response", None)
-            if resp is not None:
-                content = getattr(resp, "content", None)
-                if content:
-                    return str(content)
-        return ""
+
+MyAgent = datarobot_agent_class_from_llamaindex(workflow, agents, extract_response_text)

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -97,6 +97,8 @@ extend-ignore = [
     "PLR0912",
     # inline imports
     "PLC0415",
+    # assigning a lambda
+    "E731",
 ]
 fixable = [
     "I",    # isort

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.11.1"
+version = "0.14.0"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.11.1"
+version = "0.12.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.12.0"
+version = "0.14.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.11.0"
+version = "0.11.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -62,10 +62,11 @@ class BaseAgent(Generic[TTool], abc.ABC):
         self,
         api_key: str | None = None,
         api_base: str | None = None,
-        model: str | None = None,
+        model_name: str | None = None,
+        llm: Any | None = None,
         tools: list[TTool] | None = None,
         verbose: bool = True,
-        timeout: int | None = 90,
+        timeout: int = 90,
         forwarded_headers: dict[str, str] | None = None,
         max_history_messages: int | None = None,
         memory_client: BaseMemoryClient | None = None,
@@ -74,14 +75,63 @@ class BaseAgent(Generic[TTool], abc.ABC):
         self.api_base = (
             api_base or os.environ.get("DATAROBOT_ENDPOINT") or "https://app.datarobot.com"
         )
-        self.model = model
-        self.timeout = timeout if timeout is not None else 90
-        self.verbose = verbose
-        self._tools: list[TTool] = tools or []
+        if llm and model_name:
+            raise ValueError("Cannot set both llm and model_name")
+        self.set_model_name(model_name)
+        self.set_llm(llm)
+        self.set_tools(tools or [])
+        self.set_timeout(timeout)
+        self.set_verbose(verbose)
+        self.set_memory_client(memory_client)
         self._forwarded_headers: dict[str, str] = forwarded_headers or {}
         self._identity_header: dict[str, str] = prepare_identity_header(self._forwarded_headers)
         self._max_history_messages = max_history_messages
-        self._memory_client: BaseMemoryClient | None = memory_client
+
+    def set_llm(self, llm: Any | None) -> None:
+        self._llm = llm
+
+    @property
+    def llm(self) -> Any | None:
+        return self._llm
+
+    def set_model_name(self, model_name: str | None) -> None:
+        self._model_name = model_name
+
+    @property
+    def model_name(self) -> str | None:
+        return self._model_name
+
+    def set_timeout(self, timeout: int) -> None:
+        self._timeout = timeout
+
+    @property
+    def timeout(self) -> int:
+        return self._timeout
+
+    def set_verbose(self, verbose: bool) -> None:
+        self._verbose = verbose
+
+    @property
+    def verbose(self) -> bool:
+        return self._verbose
+
+    def set_memory_client(self, memory_client: BaseMemoryClient | None) -> None:
+        self._memory_client = memory_client
+
+    @property
+    def memory_client(self) -> BaseMemoryClient | None:
+        return self._memory_client
+
+    def set_tools(self, tools: list[TTool]) -> None:
+        self._tools = tools
+
+    @property
+    def tools(self) -> list[TTool]:
+        """Return the list of tools available to this agent.
+
+        Subclasses can use this to wire tools into the agent.
+        """
+        return self._tools
 
     @property
     def max_history_messages(self) -> int:
@@ -94,17 +144,6 @@ class BaseAgent(Generic[TTool], abc.ABC):
         if self._max_history_messages is not None:
             return self._max_history_messages
         return get_max_history_messages_default()
-
-    def set_tools(self, tools: list[TTool]) -> None:
-        self._tools = tools
-
-    @property
-    def tools(self) -> list[TTool]:
-        """Return the list of tools available to this agent.
-
-        Subclasses can use this to wire tools into the agent.
-        """
-        return self._tools
 
     @property
     def forwarded_headers(self) -> dict[str, str]:

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -50,7 +50,7 @@ class BaseAgent(Generic[TTool], abc.ABC):
     Fields:
       - api_key: DataRobot API token
       - api_base: Endpoint for DataRobot, normalized for LLM Gateway usage
-      - model: Preferred model name
+      - llm: Framework-specific LLM client (constructed outside the agent and passed in)
       - timeout: Request timeout
       - verbose: Verbosity flag
       - forwarded_headers: Forwarded headers for the agent
@@ -62,7 +62,6 @@ class BaseAgent(Generic[TTool], abc.ABC):
         self,
         api_key: str | None = None,
         api_base: str | None = None,
-        model_name: str | None = None,
         llm: Any | None = None,
         tools: list[TTool] | None = None,
         verbose: bool = True,
@@ -75,9 +74,6 @@ class BaseAgent(Generic[TTool], abc.ABC):
         self.api_base = (
             api_base or os.environ.get("DATAROBOT_ENDPOINT") or "https://app.datarobot.com"
         )
-        if llm and model_name:
-            raise ValueError("Cannot set both llm and model_name")
-        self.set_model_name(model_name)
         self.set_llm(llm)
         self.set_tools(tools or [])
         self.set_timeout(timeout)
@@ -93,13 +89,6 @@ class BaseAgent(Generic[TTool], abc.ABC):
     @property
     def llm(self) -> Any | None:
         return self._llm
-
-    def set_model_name(self, model_name: str | None) -> None:
-        self._model_name = model_name
-
-    @property
-    def model_name(self) -> str | None:
-        return self._model_name
 
     def set_timeout(self, timeout: int) -> None:
         self._timeout = timeout

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -423,6 +423,42 @@ def datarobot_agent_class_from_crew(
     tasks: list[Task],
     kickoff_inputs: Callable[[str], dict[str, Any]],
 ) -> type[CrewAIAgent]:
+    """Create a CrewAI agent class from a pre-built crew, agents, and tasks.
+
+    This is a convenience helper that dynamically builds a concrete
+    :class:`CrewAIAgent` subclass so that callers can define an agent
+    entirely from existing CrewAI objects without writing a class by hand.
+
+    When the returned class is instantiated, calling ``set_tools``
+    propagates the platform-injected tools to every agent in *agents*
+    while preserving each agent's originally configured tools.
+
+    Parameters
+    ----------
+    crew : Crew
+        A fully configured CrewAI :class:`Crew` instance that orchestrates
+        the provided agents and tasks.
+    agents : list[Agent]
+        The list of CrewAI :class:`Agent` instances participating in the crew.
+        Their ``llm`` and ``tools`` attributes are updated at runtime when the
+        DataRobot platform injects the LLM and MCP tools.
+    tasks : list[Task]
+        The list of CrewAI :class:`Task` instances that define the work to be
+        performed during kickoff.
+    kickoff_inputs : Callable[[str], dict[str, Any]]
+        A callable that receives the raw user prompt string and returns a
+        dictionary of inputs for ``Crew.kickoff()``. The dictionary keys
+        should match placeholder names used in task descriptions and agent
+        configurations (e.g. ``{topic}``). Include a ``"chat_history"`` key
+        with an empty string value to opt into automatic history injection.
+
+    Returns
+    -------
+    type[CrewAIAgent]
+        A new :class:`CrewAIAgent` subclass wired to the provided crew,
+        agents, tasks, and kickoff-input builder.
+    """
+
     class DataRobotAgent(CrewAIAgent):
         def __init__(
             self,

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import abc
 import logging
 import uuid
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -44,8 +45,11 @@ from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import TextMessageStartEvent
+from crewai import Agent
 from crewai import Crew
+from crewai import Task
 from crewai.events import crewai_event_bus
+from crewai.llm import LLM
 from crewai.tools import BaseTool
 from crewai.types.streaming import CrewStreamingOutput
 from crewai.types.streaming import StreamChunkType
@@ -74,16 +78,35 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
     and may override ``crew`` to customize the workflow construction.
     """
 
+    def set_llm(self, llm: LLM) -> None:
+        super().set_llm(llm)
+        for agent in self.agents:
+            agent.llm = llm
+            agent.function_calling_llm = llm
+
+    def set_tools(self, tools: list[BaseTool]) -> None:
+        super().set_tools(tools)
+        for agent in self.agents:
+            agent.tools = tools
+
+    def set_verbose(self, verbose: bool) -> None:
+        super().set_verbose(verbose)
+        for agent in self.agents:
+            agent.verbose = verbose
+
+        self.crew.verbose = verbose
+
     @property
     @abc.abstractmethod
-    def agents(self) -> list[Any]:  # CrewAI Agent list
+    def agents(self) -> list[Agent]:  # CrewAI Agent list
         raise NotImplementedError
 
     @property
     @abc.abstractmethod
-    def tasks(self) -> list[Any]:  # CrewAI Task list
+    def tasks(self) -> list[Task]:  # CrewAI Task list
         raise NotImplementedError
 
+    @property
     def crew(self) -> Crew:
         """Create a CrewAI workflow instance.
 
@@ -193,7 +216,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
             streaming_event_listener = CrewAIStreamingEventListener()
             streaming_event_listener.setup_listeners(crewai_event_bus)
 
-            crew = self.crew()
+            crew = self.crew
 
             kickoff_inputs = self.make_kickoff_inputs(str(user_prompt_content))
             # Chat history is opt-in: only populate it if the agent/template
@@ -368,3 +391,42 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                 pipeline_interactions,
                 usage_metrics,
             )
+
+
+def datarobot_agent_class_from_crew(
+    crew: Crew,
+    agents: list[Agent],
+    tasks: list[Task],
+    kickoff_inputs: Callable[[str], dict[str, Any]],
+) -> type[CrewAIAgent]:
+    class DataRobotAgent(CrewAIAgent):
+        def __init__(
+            self,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            self._original_agent_tools = {agent: agent.tools for agent in agents}
+            super().__init__(*args, **kwargs)
+
+        def set_tools(self, tools: list[BaseTool]) -> None:
+            super().set_tools(tools)
+            for agent in agents:
+                # make sure we don't overwrite the original tools
+                agent.tools = self._original_agent_tools[agent] + tools
+
+        @property
+        def crew(self) -> Crew:
+            return crew
+
+        @property
+        def agents(self) -> list[Agent]:
+            return agents
+
+        @property
+        def tasks(self) -> list[Task]:
+            return tasks
+
+        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+            return kickoff_inputs(user_prompt_content)
+
+    return DataRobotAgent

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -78,8 +78,10 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
     and may override ``crew`` to customize the workflow construction.
     """
 
-    def set_llm(self, llm: LLM) -> None:
+    def set_llm(self, llm: LLM | None) -> None:
         super().set_llm(llm)
+        if llm is None:
+            return
         for agent in self.agents:
             agent.llm = llm
             agent.function_calling_llm = llm

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -380,6 +380,31 @@ def datarobot_agent_class_from_langgraph(
     graph_factory: Callable[[BaseChatModel, list[BaseTool], bool], StateGraph[MessagesState]],
     prompt_template: ChatPromptTemplate,
 ) -> type[LangGraphAgent]:
+    """Create a LangGraph agent class from a graph factory and prompt template.
+
+    This is a convenience helper that dynamically builds a concrete
+    :class:`LangGraphAgent` subclass so that callers can define an agent
+    entirely from a graph-building function and a prompt template without
+    writing a class by hand.
+
+    Parameters
+    ----------
+    graph_factory : Callable[[BaseChatModel, list[BaseTool], bool], StateGraph[MessagesState]]
+        A callable that receives the LLM client, the list of tools bound to
+        the agent, and a ``verbose`` flag, and returns a compiled LangGraph
+        :class:`StateGraph` ready for execution.
+    prompt_template : ChatPromptTemplate
+        The LangChain prompt template used to format user input before it is
+        fed into the graph. If the template declares a ``{chat_history}``
+        input variable, prior conversation turns are automatically injected.
+
+    Returns
+    -------
+    type[LangGraphAgent]
+        A new :class:`LangGraphAgent` subclass whose ``workflow`` and
+        ``prompt_template`` properties are wired to the provided arguments.
+    """
+
     class DataRobotLangAgent(LangGraphAgent):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -14,6 +14,7 @@
 import abc
 import logging
 from collections.abc import AsyncGenerator
+from collections.abc import Callable
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 from typing import Any
@@ -31,6 +32,7 @@ from ag_ui.core import ToolCallArgsEvent
 from ag_ui.core import ToolCallEndEvent
 from ag_ui.core import ToolCallResultEvent
 from ag_ui.core import ToolCallStartEvent
+from langchain.chat_models import BaseChatModel
 from langchain.tools import BaseTool
 from langchain_core.messages import AIMessageChunk
 from langchain_core.messages import ToolMessage
@@ -372,3 +374,22 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
 
         ragas_trace = convert_to_ragas_messages(messages)
         return MultiTurnSample(user_input=ragas_trace)
+
+
+def datarobot_agent_class_from_langgraph(
+    graph_factory: Callable[[BaseChatModel, list[BaseTool], bool], StateGraph[MessagesState]],
+    prompt_template: ChatPromptTemplate,
+) -> type[LangGraphAgent]:
+    class DataRobotLangAgent(LangGraphAgent):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+
+        @property
+        def workflow(self) -> StateGraph[MessagesState]:
+            return graph_factory(self.llm, self.tools, self.verbose)
+
+        @property
+        def prompt_template(self) -> ChatPromptTemplate:
+            return prompt_template
+
+    return DataRobotLangAgent

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -17,6 +17,7 @@ import abc
 import inspect
 import json
 import uuid
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -34,6 +35,8 @@ from ag_ui.core import ToolCallArgsEvent
 from ag_ui.core import ToolCallEndEvent
 from ag_ui.core import ToolCallResultEvent
 from ag_ui.core import ToolCallStartEvent
+from llama_index.core.agent.workflow import AgentWorkflow
+from llama_index.core.agent.workflow import BaseWorkflowAgent
 from llama_index.core.base.llms.types import LLMMetadata
 from llama_index.core.tools import BaseTool
 from llama_index.core.workflow import Event
@@ -316,3 +319,30 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         ragas_trace = convert_to_ragas_messages(list(events))
         ragas_messages = cast(list[HumanMessage | AIMessage | ToolMessage], ragas_trace)
         return MultiTurnSample(user_input=ragas_messages)
+
+
+def datarobot_agent_class_from_llamaindex(
+    workflow: AgentWorkflow,
+    agents: list[BaseWorkflowAgent],
+    extract_response_text: Callable[[Any, list[Any]], str],
+) -> type[LlamaIndexAgent]:
+    original_agent_tools = {agent.name: agent.tools for agent in agents}
+
+    class DataRobotLlamaIndexAgent(LlamaIndexAgent):
+        def set_llm(self, llm: Any) -> None:
+            super().set_llm(llm)
+            for agent in agents:
+                agent.llm = llm
+
+        def set_tools(self, tools: list[BaseTool]) -> None:
+            super().set_tools(tools)
+            for agent in agents:
+                agent.tools = original_agent_tools[agent.name] + tools
+
+        async def build_workflow(self) -> AgentWorkflow:
+            return workflow
+
+        def extract_response_text(self, result_state: Any, events: list[Any]) -> str:
+            return extract_response_text(result_state, events)
+
+    return DataRobotLlamaIndexAgent

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -321,6 +321,37 @@ def datarobot_agent_class_from_llamaindex(
     agents: list[BaseWorkflowAgent],
     extract_response_text: Callable[[Any, list[Any]], str],
 ) -> type[LlamaIndexAgent]:
+    """Create a LlamaIndex agent class from a pre-built workflow and agents.
+
+    This is a convenience helper that dynamically builds a concrete
+    :class:`LlamaIndexAgent` subclass so that callers can define an agent
+    entirely from an existing :class:`AgentWorkflow` and its constituent
+    agents without writing a class by hand.
+
+    When the returned class is instantiated, calling ``set_llm`` or
+    ``set_tools`` propagates the LLM / tools to every agent in *agents*
+    while preserving each agent's originally configured tools.
+
+    Parameters
+    ----------
+    workflow : AgentWorkflow
+        A fully configured LlamaIndex :class:`AgentWorkflow` instance that
+        orchestrates the provided agents.
+    agents : list[BaseWorkflowAgent]
+        The list of LlamaIndex workflow agents participating in the workflow.
+        Their ``llm`` and ``tools`` attributes are updated at runtime when the
+        DataRobot platform injects the LLM and MCP tools.
+    extract_response_text : Callable[[Any, list[Any]], str]
+        A callback that extracts the final human-readable response from the
+        workflow result state and the list of streamed events.  Receives
+        ``(result_state, events)`` and must return a ``str``.
+
+    Returns
+    -------
+    type[LlamaIndexAgent]
+        A new :class:`LlamaIndexAgent` subclass wired to the provided
+        workflow, agents, and response extractor.
+    """
     original_agent_tools = {agent.name: agent.tools for agent in agents}
 
     class DataRobotLlamaIndexAgent(LlamaIndexAgent):

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -122,21 +122,10 @@ class NatAgent(BaseAgent[None]):
     def __init__(
         self,
         workflow_path: StrPath,
-        api_key: str | None = None,
-        api_base: str | None = None,
-        model: str | None = None,
-        verbose: bool = True,
-        timeout: int | None = 90,
-        forwarded_headers: dict[str, str] | None = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(
-            api_key=api_key,
-            api_base=api_base,
-            model=model,
-            verbose=verbose,
-            timeout=timeout,
-            forwarded_headers=forwarded_headers,
-        )
+        super().__init__(*args, **kwargs)
         self.workflow_path = workflow_path
 
     def make_user_prompt(self, run_agent_input: RunAgentInput) -> str:

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -112,6 +112,26 @@ def test_base_agent_env_defaults_and_verbose(monkeypatch: pytest.MonkeyPatch) ->
     assert agent.verbose is False
 
 
+def test_base_agent_model_name_and_llm_optional() -> None:
+    agent = SimpleAgent(model_name="m1")
+    assert agent.model_name == "m1"
+    assert agent.llm is None
+
+    llm = object()
+    agent2 = SimpleAgent(llm=llm)
+    assert agent2.llm is llm
+    assert agent2.model_name is None
+
+
+def test_base_agent_rejects_llm_and_model_name_together() -> None:
+    with pytest.raises(ValueError, match="Cannot set both"):
+        SimpleAgent(model_name="x", llm=object())
+
+
+def test_base_agent_timeout_default() -> None:
+    assert SimpleAgent().timeout == 90
+
+
 def test_base_agent_litellm_api_base_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATAROBOT_API_TOKEN", "token")
     monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2")

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -112,20 +112,12 @@ def test_base_agent_env_defaults_and_verbose(monkeypatch: pytest.MonkeyPatch) ->
     assert agent.verbose is False
 
 
-def test_base_agent_model_name_and_llm_optional() -> None:
-    agent = SimpleAgent(model_name="m1")
-    assert agent.model_name == "m1"
-    assert agent.llm is None
+def test_base_agent_llm_optional() -> None:
+    assert SimpleAgent().llm is None
 
     llm = object()
-    agent2 = SimpleAgent(llm=llm)
-    assert agent2.llm is llm
-    assert agent2.model_name is None
-
-
-def test_base_agent_rejects_llm_and_model_name_together() -> None:
-    with pytest.raises(ValueError, match="Cannot set both"):
-        SimpleAgent(model_name="x", llm=object())
+    agent = SimpleAgent(llm=llm)
+    assert agent.llm is llm
 
 
 def test_base_agent_timeout_default() -> None:

--- a/tests/core/chat/test_completions.py
+++ b/tests/core/chat/test_completions.py
@@ -248,8 +248,8 @@ class RecordingAgent(AGUIAgent):
     """AGUIAgent that records ``set_tools`` arguments."""
 
     def __init__(self, *, initial_tools: list[Any] | None = None) -> None:
-        super().__init__(tools=initial_tools or [])
         self.set_tools_calls: list[list[Any]] = []
+        super().__init__(tools=initial_tools or [])
 
     def set_tools(self, tools: list[Any]) -> None:  # type: ignore[override]
         self.set_tools_calls.append(list(tools))
@@ -278,7 +278,7 @@ async def test_agent_chat_completion_wrapper_streaming_invokes_mcp_factory_and_s
         "context_entered",
         "context_exited",
     ]
-    assert agent.set_tools_calls == [mcp_tools]
+    assert agent.set_tools_calls == [[], mcp_tools]
     assert agent.tools == mcp_tools
     assert len(events) == 8
 
@@ -310,7 +310,7 @@ async def test_agent_chat_completion_wrapper_merges_mcp_tools_with_existing_agen
         assert isinstance(wrapper_result, tuple)
 
     assert trace == ["factory_called", "context_entered", "context_exited"]
-    assert agent.set_tools_calls == [expected]
+    assert agent.set_tools_calls == [pre_existing, expected]
     assert agent.tools == expected
 
 
@@ -334,7 +334,7 @@ async def test_agent_chat_completion_wrapper_non_streaming_invokes_mcp_factory_a
         "context_entered",
         "context_exited",
     ]
-    assert agent.set_tools_calls == [mcp_tools]
+    assert agent.set_tools_calls == [[], mcp_tools]
     assert agent.tools == mcp_tools
 
 

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -421,6 +421,7 @@ def test_crewai_agent_set_llm_skips_propagation_when_none() -> None:
     assert agent._inner.llm is agent._preserved
     assert agent._inner.function_calling_llm is agent._preserved
 
+
 async def test_invoke_retrieves_and_stores_memory(
     mock_ragas_event_listener, run_agent_input_with_structured_prompt
 ) -> None:
@@ -446,8 +447,8 @@ async def test_invoke_retrieves_and_stores_memory(
         api_key="k",
         verbose=False,
         memory_client=memory_client,
+        crew=CapturingCrew(out),
     )
-    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
 
     # WHEN invoke is called
     _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
@@ -521,8 +522,8 @@ async def test_invoke_does_not_overwrite_non_empty_memory_override(
         api_key="k",
         verbose=False,
         memory_client=memory_client,
+        crew=CapturingCrew(out),
     )
-    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
 
     # WHEN invoke is called
     _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
@@ -565,8 +566,8 @@ async def test_invoke_gracefully_degrades_when_memory_fails(
         api_key="k",
         verbose=False,
         memory_client=FailingMemoryClient(),
+        crew=CapturingCrew(out),
     )
-    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
 
     # WHEN invoke is called
     events = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
@@ -599,8 +600,8 @@ async def test_invoke_does_not_store_memory_when_run_fails(
         api_key="k",
         verbose=False,
         memory_client=memory_client,
+        crew=FailingCrew(out),
     )
-    agent.crew = lambda: FailingCrew(out)  # type: ignore[assignment]
 
     # WHEN invoke is called and the crew fails
     with pytest.raises(RuntimeError, match="crew failed"):

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -15,6 +15,7 @@
 # ruff: noqa: I001
 from collections.abc import AsyncGenerator
 from typing import Any
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from crewai.types.streaming import CrewStreamingOutput
@@ -31,9 +32,19 @@ from ragas.messages import HumanMessage
 
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.crewai.agent import CrewAIAgent
+from datarobot_genai.crewai.agent import datarobot_agent_class_from_crew
 
 
 # --- Test helpers ---
+
+
+def _mock_crewai_agent() -> MagicMock:
+    agent = MagicMock()
+    agent.llm = None
+    agent.function_calling_llm = None
+    agent.tools = []
+    agent.verbose = True
+    return agent
 
 
 class CrewForTest:
@@ -41,6 +52,7 @@ class CrewForTest:
         self.args = args
         self.kwargs = kwargs
         self.output = output
+        self.verbose = True
 
     async def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[name-defined]
         return self.output or CrewOutput(raw="final-output")
@@ -68,23 +80,28 @@ def mock_ragas_event_listener() -> ListenerForTest:
 
 
 class AgentForTest(CrewAIAgent):
-    def __init__(self, crew_output: CrewOutput | None = None, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
+    def __init__(self, crew_output: CrewOutput | None = None, *args: Any, **kwargs: Any) -> None:
+        crew_kw = kwargs.pop("crew", None)
         self.crew_output = crew_output
+        self._crew_for_test: Any = crew_kw if crew_kw is not None else CrewForTest(crew_output)
+        self._agents_for_test: list[MagicMock] = [_mock_crewai_agent(), _mock_crewai_agent()]
+        self._tasks_for_test: list[MagicMock] = [MagicMock(), MagicMock()]
+        super().__init__(*args, **kwargs)
 
     @property
     def agents(self) -> list[Any]:
-        return [object()]
+        return self._agents_for_test
 
     @property
     def tasks(self) -> list[Any]:
-        return [object()]
+        return self._tasks_for_test
 
     def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
         return {"topic": user_prompt_content}
 
+    @property
     def crew(self) -> Any:
-        return CrewForTest(self.crew_output)
+        return self._crew_for_test
 
 
 # --- Tests for create_pipeline_interactions_from_messages ---
@@ -182,8 +199,9 @@ async def test_invoke_does_not_include_chat_history_by_default(
             return super().kickoff_async(inputs=inputs)
 
     out = CrewOutput(raw="agent result")
-    agent = AgentForTest(out, api_base="https://x/", api_key="k", verbose=False)
-    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
+    agent = AgentForTest(
+        out, api_base="https://x/", api_key="k", verbose=False, crew=CapturingCrew(out)
+    )
 
     _ = [event async for event in agent.invoke(run_agent_input_with_history)]
 
@@ -206,8 +224,9 @@ async def test_invoke_overwrites_blank_chat_history_placeholder(
             return {"topic": user_prompt_content, "chat_history": ""}
 
     out = CrewOutput(raw="agent result")
-    agent = AgentWithPlaceholder(out, api_base="https://x/", api_key="k", verbose=False)
-    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
+    agent = AgentWithPlaceholder(
+        out, api_base="https://x/", api_key="k", verbose=False, crew=CapturingCrew(out)
+    )
 
     _ = [event async for event in agent.invoke(run_agent_input_with_history)]
 
@@ -236,9 +255,88 @@ async def test_invoke_does_not_overwrite_non_empty_chat_history_override(
             return {"topic": user_prompt_content, "chat_history": "CUSTOM OVERRIDE"}
 
     out = CrewOutput(raw="agent result")
-    agent = AgentWithOverride(out, api_base="https://x/", api_key="k", verbose=False)
-    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
+    agent = AgentWithOverride(
+        out, api_base="https://x/", api_key="k", verbose=False, crew=CapturingCrew(out)
+    )
 
     _ = [event async for event in agent.invoke(run_agent_input_with_history)]
 
     assert captured_inputs["chat_history"] == "CUSTOM OVERRIDE"
+
+
+# --- datarobot_agent_class_from_crew ---
+
+
+def test_datarobot_agent_class_from_crew_subclass_and_kickoff_inputs() -> None:
+    crew = MagicMock()
+    crew.verbose = True
+    ca = _mock_crewai_agent()
+    cb = _mock_crewai_agent()
+    ta, tb = MagicMock(), MagicMock()
+
+    def kickoff(u: str) -> dict[str, Any]:
+        return {"topic": u, "extra": 1}
+
+    agent_cls = datarobot_agent_class_from_crew(crew, [ca, cb], [ta, tb], kickoff)
+    assert issubclass(agent_cls, CrewAIAgent)
+
+    instance = agent_cls(api_base="https://x/", api_key="k", verbose=False)
+    assert instance.crew is crew
+    assert instance.agents == [ca, cb]
+    assert instance.tasks == [ta, tb]
+    assert instance.make_kickoff_inputs("hello") == {"topic": "hello", "extra": 1}
+
+
+def test_datarobot_agent_class_from_crew_set_tools_merges_with_original() -> None:
+    crew = MagicMock()
+    crew.verbose = True
+    orig_a = MagicMock()
+    orig_b = MagicMock()
+    mcp_tool = MagicMock()
+
+    ca = _mock_crewai_agent()
+    ca.tools = [orig_a]
+    cb = _mock_crewai_agent()
+    cb.tools = [orig_b]
+
+    agent_cls = datarobot_agent_class_from_crew(
+        crew, [ca, cb], [MagicMock(), MagicMock()], lambda u: {"topic": u}
+    )
+    instance = agent_cls()
+    instance.set_tools([mcp_tool])
+
+    assert ca.tools == [orig_a, mcp_tool]
+    assert cb.tools == [orig_b, mcp_tool]
+    assert instance.tools == [mcp_tool]
+
+
+def test_crewai_agent_set_llm_skips_propagation_when_none() -> None:
+    """Pre-built CrewAI agents keep their LLM when BaseAgent is constructed without llm."""
+
+    class _Agent(CrewAIAgent):
+        def __init__(self) -> None:
+            self._preserved = object()
+            self._inner = _mock_crewai_agent()
+            self._inner.llm = self._preserved
+            self._inner.function_calling_llm = self._preserved
+            self._test_crew = CrewForTest()
+            super().__init__(api_key="k", api_base="https://x/", verbose=False)
+
+        @property
+        def agents(self) -> list[Any]:
+            return [self._inner]
+
+        @property
+        def tasks(self) -> list[Any]:
+            return [MagicMock()]
+
+        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+            return {"topic": user_prompt_content}
+
+        @property
+        def crew(self) -> Any:
+            return self._test_crew
+
+    agent = _Agent()
+    assert agent._inner.llm is agent._preserved
+    assert agent._inner.function_calling_llm is agent._preserved

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -34,6 +34,7 @@ from langgraph.graph.state import StateGraph
 
 from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.langgraph.agent import LangGraphAgent
+from datarobot_genai.langgraph.agent import datarobot_agent_class_from_langgraph
 
 
 @pytest.fixture
@@ -178,6 +179,57 @@ class SimpleLangGraphAgent(LangGraphAgent):
     @property
     def langgraph_config(self) -> dict[str, Any]:
         return {}
+
+
+def test_datarobot_agent_class_from_langgraph_factory_receives_llm_tools_verbose() -> None:
+    """graph_factory(llm, tools, verbose) is called when building workflow (each access)."""
+    inner = SimpleLangGraphAgent()
+    mock_graph = inner.workflow
+    calls: list[tuple[Any, list[Any], bool]] = []
+
+    def graph_factory(llm: Any, tools: list[Any], verbose: bool) -> Any:
+        calls.append((llm, list(tools), verbose))
+        return mock_graph
+
+    pt = inner.prompt_template
+    cls = datarobot_agent_class_from_langgraph(graph_factory, pt)
+    mock_llm = Mock()
+    extra_tools = [Mock()]
+    agent = cls(
+        llm=mock_llm,
+        tools=extra_tools,
+        verbose=True,
+        api_key="k",
+        api_base="https://x/",
+    )
+    _ = agent.workflow
+    assert calls == [(mock_llm, extra_tools, True)]
+    assert agent.prompt_template is pt
+
+    _ = agent.workflow
+    assert len(calls) == 2
+    assert calls[1] == (mock_llm, extra_tools, True)
+
+
+@pytest.mark.asyncio
+async def test_datarobot_agent_class_from_langgraph_invoke_streams(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Factory-built agent runs the same invoke/astream path as a hand-written subclass."""
+    inner = SimpleLangGraphAgent()
+    mock_graph = inner.workflow
+
+    def graph_factory(llm: Any, tools: list[Any], verbose: bool) -> Any:
+        return mock_graph
+
+    cls = datarobot_agent_class_from_langgraph(graph_factory, inner.prompt_template)
+    agent = cls(llm=Mock(), tools=[], verbose=True, api_key="k", api_base="https://x/")
+
+    events = [e async for e in agent.invoke(run_agent_input)]
+    assert events
+    assert events[-1][0].type == EventType.RUN_FINISHED
+    mock_graph.compile.assert_called()
+    mock_graph.compile.return_value.astream.assert_called_once()
 
 
 class HistoryAwareLangGraphAgent(LangGraphAgent):

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -14,9 +14,11 @@
 
 from collections.abc import AsyncGenerator
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from ag_ui.core import AssistantMessage
+from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
@@ -41,6 +43,7 @@ from ragas import MultiTurnSample
 
 from datarobot_genai.llama_index.agent import DataRobotLiteLLM
 from datarobot_genai.llama_index.agent import LlamaIndexAgent
+from datarobot_genai.llama_index.agent import datarobot_agent_class_from_llamaindex
 
 
 class Handler:
@@ -103,6 +106,74 @@ def test_datarobot_litellm_metadata_properties() -> None:
 
 def test_create_pipeline_interactions_from_events_none() -> None:
     assert LlamaIndexAgent.create_pipeline_interactions_from_events(None) is None
+
+
+# --- Tests for datarobot_agent_class_from_llamaindex ---
+
+
+@pytest.mark.asyncio
+async def test_datarobot_agent_class_from_llamaindex_build_workflow_returns_bound_workflow() -> (
+    None
+):
+    workflow = Mock(name="agent_workflow")
+    cls = datarobot_agent_class_from_llamaindex(workflow, [], lambda _s, _e: "")
+    agent = cls()
+    assert await agent.build_workflow() is workflow
+
+
+def test_datarobot_agent_class_from_llamaindex_set_llm_propagates_to_agents() -> None:
+    a1 = Mock()
+    a1.name = "planner"
+    a1.tools = []
+    a2 = Mock()
+    a2.name = "writer"
+    a2.tools = []
+    cls = datarobot_agent_class_from_llamaindex(Mock(), [a1, a2], lambda _s, _e: "")
+    llm = object()
+    _ = cls(llm=llm)
+    assert a1.llm is llm
+    assert a2.llm is llm
+
+
+def test_datarobot_agent_class_from_llamaindex_set_tools_merges_original_plus_mcp() -> None:
+    orig1 = Mock(name="static_tool_1")
+    orig2 = Mock(name="static_tool_2")
+    a1 = Mock()
+    a1.name = "planner"
+    a1.tools = [orig1]
+    a2 = Mock()
+    a2.name = "writer"
+    a2.tools = [orig2]
+    mcp = Mock(name="mcp_tool")
+    cls = datarobot_agent_class_from_llamaindex(Mock(), [a1, a2], lambda _s, _e: "")
+    agent = cls(tools=[mcp])
+    assert a1.tools == [orig1, mcp]
+    assert a2.tools == [orig2, mcp]
+    assert agent.tools == [mcp]
+
+
+def test_datarobot_agent_class_from_llamaindex_delegates_extract_response_text() -> None:
+    captured: list[tuple[Any, int]] = []
+
+    def extract(state: Any, events: list[Any]) -> str:
+        captured.append((state, len(events)))
+        return "extracted"
+
+    cls = datarobot_agent_class_from_llamaindex(Mock(), [], extract)
+    agent = cls()
+    assert agent.extract_response_text("final_state", [1, 2, 3]) == "extracted"
+    assert captured == [("final_state", 3)]
+
+
+@pytest.mark.asyncio
+async def test_datarobot_agent_class_from_llamaindex_invoke_streams(
+    workflow: Workflow, run_agent_input: RunAgentInput
+) -> None:
+    cls = datarobot_agent_class_from_llamaindex(workflow, [], lambda _s, _e: "")
+    agent = cls(forwarded_headers={"x-datarobot-api-key": "scoped-token-123"})
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    assert events_out
+    assert events_out[-1][0].type == EventType.RUN_FINISHED
 
 
 # --- Tests for LlamaIndexAgent ---

--- a/uv.lock
+++ b/uv.lock
@@ -1161,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1161,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.12.0"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1161,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Our north star for this project is to allow users converting their agents implemented in CrewAI/llamaindex/langgraph into DataRobot agents without writing a DataRobot agent class. This PR implements it for all frameworks.

In order to enable this approach, we're also extending the base class to allow changing tools, llms, and other parameters at runtime.

NOTE: this way of defining agents will be a breaking change for our agentic templates, we should prepare for documentation updates and communication.

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [x] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new dynamic agent-construction helpers and refactors core agent initialization/propagation of `llm`/tools/verbosity across CrewAI/LangGraph/LlamaIndex, which may affect runtime behavior of existing templates and tool wiring. Broad framework-touching changes raise regression risk despite added tests and e2e updates.
> 
> **Overview**
> Bumps the library to `0.14.0` and **reworks agent initialization to accept an injected `llm` (not a model string)**, adding runtime setters/getters for `llm`, `tools`, `timeout`, `verbose`, and `memory_client` in `BaseAgent`.
> 
> Adds **factory helpers** (`datarobot_agent_class_from_crew`, `..._from_langgraph`, `..._from_llamaindex`) to build concrete DataRobot agent classes directly from native CrewAI/LangGraph/LlamaIndex primitives, and updates framework agents (notably `CrewAIAgent`) to propagate injected `llm`/tools/verbose into underlying framework objects while preserving original tool lists.
> 
> Updates e2e examples/configs and unit tests to use the new factories, adjust tool-setting expectations, and adds a convenience `install-all` task for e2e dependency groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62abd94d82bd243e894c592441c4eadcb5b9b501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->