### PR TITLE
[BUZZOK-30091] Updated to remove print, but use logging instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.13.1
+- Updated to remove prints, but instead use logging instead in our agents outputs
+
 ## 0.13.0
 - Upgraded fastmcp from 2.x to 3.2.0+ (CVE-2026-32871, CVE-2026-27124, CVE-2025-64340)
 - Replaced `on_duplicate_tools`/`on_duplicate_prompts` with unified `on_duplicate` (fastmcp 3.x API)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.13.1
+## 0.13.2
 - Updated to remove prints, but instead use logging instead in our agents outputs
 
 ## 0.13.0

--- a/e2e-tests/dragent/nat/register.py
+++ b/e2e-tests/dragent/nat/register.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datarobot_genai.core.utils.logging import setup_logging
 from datarobot_genai.nat.tool import nat_tool
 
 from dragent.tool import generate_objectid
 
-setup_logging()
 nat_tool(generate_objectid, "generate_objectid")

--- a/e2e-tests/dragent/nat/register.py
+++ b/e2e-tests/dragent/nat/register.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datarobot_genai.core.utils.logging import setup_logging
 from datarobot_genai.nat.tool import nat_tool
 
 from dragent.tool import generate_objectid
 
+setup_logging()
 nat_tool(generate_objectid, "generate_objectid")

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.12.0"
+version = "0.13.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1027,7 +1027,7 @@ requires-dist = [
     { name = "datarobot-predict", marker = "extra == 'llamaindex'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'nat'", specifier = ">=1.13.2,<2.0.0" },
     { name = "fastapi", marker = "extra == 'dragent'", specifier = "<0.133.0" },
-    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=2.13.0.2,<3.0.0" },
+    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=3.2.0,<4.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.13.0"
+version = "0.13.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.13.1"
+version = "0.13.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/logging.py
+++ b/src/datarobot_genai/dragent/frontends/logging.py
@@ -1,0 +1,61 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+
+def logging_handler_setup() -> None:
+    # Noisy NAT messages that are safe to suppress globally.
+    suppressed_nat_messages = [
+        "StepAdaptor is disabled",
+        "Dask is not installed",
+        "Dask is not available",
+        "feature is experimental and the API may change",
+        "Using provided input_schema for multi-argument function",
+    ]
+
+    orig_handler_handle = logging.Handler.handle
+
+    def _filtered_handle(self: logging.Handler, record: logging.LogRecord) -> bool | None:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            return orig_handler_handle(self, record)
+
+        # Drop log records that match any of the suppressed NAT messages.
+        if any(s in msg for s in suppressed_nat_messages):
+            return None
+
+        # Strip newlines from the format string so multi-line messages are
+        # collapsed to a single line. This keeps log output clean in environments
+        # that treat each line as a separate log entry (e.g. structured logging).
+        if isinstance(record.msg, str):
+            record.msg = record.msg.replace("\n", " ")
+
+        # Also strip newlines from any string values in the format args so that
+        # newlines coming from interpolated values are removed too.
+        # The structure and length of record.args is preserved so downstream
+        # handlers that unpack it (e.g. structured/JSON loggers) continue to work.
+        if isinstance(record.args, dict):
+            record.args = {
+                k: v.replace("\n", " ") if isinstance(v, str) else v for k, v in record.args.items()
+            }
+        elif isinstance(record.args, tuple):
+            record.args = tuple(
+                v.replace("\n", " ") if isinstance(v, str) else v for v in record.args
+            )
+
+        return orig_handler_handle(self, record)
+
+    logging.Handler.handle = _filtered_handle  # type: ignore[assignment]

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import typing
 import warnings
 from collections.abc import AsyncGenerator
@@ -32,6 +31,7 @@ from .converters import convert_dragent_run_agent_input_to_chat_request
 from .converters import convert_dragent_run_agent_input_to_chat_request_or_message
 from .converters import convert_str_to_dragent_event_response
 from .converters import convert_tool_message_to_str
+from .logging import logging_handler_setup
 from .patches import patch_crewai_callback_handler
 
 # Patch nvidia-nat-crewai callback handler for crewai >= 1.1.0 compatibility.
@@ -41,35 +41,7 @@ patch_crewai_callback_handler()
 # Suppress specific non-actionable NAT warning messages by content.
 # Patch Handler.handle (inherited by all subclasses - they only override emit)
 # because root-logger filters are skipped during log propagation.
-_SUPPRESSED_NAT_MESSAGES = [
-    "StepAdaptor is disabled",
-    "Dask is not installed",
-    "Dask is not available",
-    "feature is experimental and the API may change",
-    "Using provided input_schema for multi-argument function",
-]
-_orig_handler_handle = logging.Handler.handle
-
-
-def _filtered_handle(self: logging.Handler, record: logging.LogRecord) -> bool | None:
-    try:
-        msg = record.getMessage()
-    except Exception:
-        return _orig_handler_handle(self, record)
-    if any(s in msg for s in _SUPPRESSED_NAT_MESSAGES):
-        return None
-    if isinstance(record.msg, str):
-        record.msg = record.msg.replace("\n", " ")
-    if isinstance(record.args, dict):
-        record.args = {
-            k: v.replace("\n", " ") if isinstance(v, str) else v for k, v in record.args.items()
-        }
-    elif isinstance(record.args, tuple):
-        record.args = tuple(v.replace("\n", " ") if isinstance(v, str) else v for v in record.args)
-    return _orig_handler_handle(self, record)
-
-
-logging.Handler.handle = _filtered_handle  # type: ignore[assignment]
+logging_handler_setup()
 
 # Suppress UserWarning from langchain about non-default parameters (uses warnings.warn, not logging)
 warnings.filterwarnings("ignore", message=".*stream_options is not default parameter.*")

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -58,6 +58,14 @@ def _filtered_handle(self: logging.Handler, record: logging.LogRecord) -> bool |
         return _orig_handler_handle(self, record)
     if any(s in msg for s in _SUPPRESSED_NAT_MESSAGES):
         return None
+    if isinstance(record.msg, str):
+        record.msg = record.msg.replace("\n", " ")
+    if isinstance(record.args, dict):
+        record.args = {
+            k: v.replace("\n", " ") if isinstance(v, str) else v for k, v in record.args.items()
+        }
+    elif isinstance(record.args, tuple):
+        record.args = tuple(v.replace("\n", " ") if isinstance(v, str) else v for v in record.args)
     return _orig_handler_handle(self, record)
 
 

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -26,6 +27,8 @@ from langchain_mcp_adapters.tools import load_mcp_tools
 from pydantic import PrivateAttr
 
 from datarobot_genai.core.mcp import MCPConfig
+
+logger = logging.getLogger(__name__)
 
 
 def _wrap_mcp_tool_for_langgraph(inner: BaseTool) -> BaseTool:
@@ -89,7 +92,7 @@ async def mcp_tools_context(
     server_config = mcp_config.server_config
 
     if not server_config:
-        print("No MCP server configured, using empty tools list", flush=True)
+        logger.info("No MCP server configured, using empty tools list")
         yield []
         return
 
@@ -97,7 +100,7 @@ async def mcp_tools_context(
     server_config = copy.deepcopy(server_config)
 
     url = server_config["url"]
-    print(f"Connecting to MCP server: {url}", flush=True)
+    logger.info(f"Connecting to MCP server: {url}")
 
     # Pop transport from server_config to avoid passing it twice
     # Use .pop() with default to never error
@@ -116,5 +119,5 @@ async def mcp_tools_context(
         # Wrap so LangGraph-injected 'runtime' is filtered from callback inputs (avoids
         # copy.deepcopy of non-serializable ToolRuntime in NAT profiler).
         tools = [_wrap_mcp_tool_for_langgraph(t) for t in raw_tools]
-        print(f"Successfully loaded {len(tools)} MCP tools", flush=True)
+        logger.info(f"Successfully connected to MCP server, got {len(tools)} tools")
         yield tools

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import abc
 import inspect
 import json
+import logging
 import uuid
 from typing import TYPE_CHECKING
 from typing import Any
@@ -47,6 +48,8 @@ from datarobot_genai.core.agents.base import extract_user_prompt_content
 
 if TYPE_CHECKING:
     from ragas import MultiTurnSample
+
+logger = logging.getLogger(__name__)
 
 
 class DataRobotLiteLLM(LiteLLM):
@@ -94,12 +97,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
             )
             input_message = input_message.replace("{chat_history}", formatted_history)
 
-        # Preserve prior template startup print for CLI parity
-        try:
-            print("Running agent with user prompt:", input_message, flush=True)
-        except Exception:
-            # Printing is best-effort; proceed regardless
-            pass
+        logger.info(f"Running agent with user prompt: {input_message}")
 
         thread_id = run_agent_input.thread_id
         run_id = run_agent_input.run_id
@@ -174,19 +172,16 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     )
                     current_agent_name = agent
                     agent = None
-                    # Print banner for agent switch (do not emit as streamed content)
-                    print("\n" + "=" * 50, flush=True)
-                    print(f"🤖 Agent: {current_agent_name}", flush=True)
-                    print("=" * 50 + "\n", flush=True)
+                    logger.info(f"Agent: {current_agent_name}")
 
             event_type = type(event).__name__
             if event_type == "AgentInput" and hasattr(event, "input"):
-                print("📥 Input:", getattr(event, "input"), flush=True)
+                logger.info(f"Input: {getattr(event, 'input')}")
             elif event_type == "AgentOutput":
                 # Output content
                 resp = getattr(event, "response", None)
                 if resp is not None and hasattr(resp, "content") and getattr(resp, "content"):
-                    print("📤 Output:", getattr(resp, "content"), flush=True)
+                    logger.info(f"Output: {getattr(resp, 'content')}")
                 # Planned tool calls
                 tcalls = getattr(event, "tool_calls", None)
                 if isinstance(tcalls, list) and tcalls:
@@ -201,15 +196,15 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                         except Exception:
                             pass
                     if names:
-                        print("🛠️  Planning to use tools:", names, flush=True)
+                        logger.info(f"Planning to use tools: {names}")
             elif event_type == "ToolCallResult":
                 tname = getattr(event, "tool_name", None)
                 tid = getattr(event, "tool_id", None)
                 tkwargs = getattr(event, "tool_kwargs", None)
                 tout = getattr(event, "tool_output", None)
-                print(f"🔧 Tool Result ({tname}):", flush=True)
-                print(f"  Arguments: {tkwargs}", flush=True)
-                print(f"  Output: {tout}", flush=True)
+                logger.info(f"Tool Result: {tname}")
+                logger.debug(f"Arguments: {tkwargs}")
+                logger.debug(f"Output: {tout}")
                 yield (
                     ToolCallEndEvent(
                         type=EventType.TOOL_CALL_END,
@@ -233,8 +228,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 tname = getattr(event, "tool_name", None)
                 tkwargs = getattr(event, "tool_kwargs", None)
                 tid = getattr(event, "tool_id", None)
-                print(f"🔨 Calling Tool: {tname}", flush=True)
-                print(f"  With arguments: {tkwargs}", flush=True)
+                logger.info(f"Calling Tool: {tname}")
+                logger.debug(f"With arguments: {tkwargs}")
                 yield (
                     ToolCallStartEvent(
                         type=EventType.TOOL_CALL_START,

--- a/src/datarobot_genai/llama_index/mcp.py
+++ b/src/datarobot_genai/llama_index/mcp.py
@@ -20,6 +20,7 @@ Unlike CrewAI which uses a context manager, LlamaIndex uses async calls to
 fetch tools from MCP servers.
 """
 
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -28,6 +29,8 @@ from llama_index.tools.mcp import BasicMCPClient
 from llama_index.tools.mcp import aget_tools_from_mcp_url
 
 from datarobot_genai.core.mcp import MCPConfig
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -48,14 +51,14 @@ async def mcp_tools_context(
     server_params = mcp_config.server_config
 
     if not server_params:
-        print("No MCP server configured, using empty tools list", flush=True)
+        logger.info("No MCP server configured, using empty tools list")
         yield []
         return
 
     url = server_params["url"]
     headers = server_params.get("headers", {})
 
-    print(f"Connecting to MCP server: {url}", flush=True)
+    logger.info(f"Connecting to MCP server: {url}")
     # Create BasicMCPClient with headers to pass authentication
     client = BasicMCPClient(command_or_url=url, headers=headers)
     tools = await aget_tools_from_mcp_url(
@@ -64,9 +67,6 @@ async def mcp_tools_context(
     )
     # Ensure list
     tools = list(tools) if tools is not None else []
-    print(
-        f"Successfully connected to MCP server, got {len(tools)} tools",
-        flush=True,
-    )
+    logger.info(f"Successfully connected to MCP server, got {len(tools)} tools")
 
     yield tools

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -177,7 +177,9 @@ class NatAgent(BaseAgent[None]):
         chat_request = self.make_chat_request(user_prompt)
 
         # Print commands may need flush=True to ensure they are displayed in real-time.
-        print("Running agent with user prompt:", chat_request.messages[0].content, flush=True)
+        logger.info(
+            f"Running agent with user prompt: {chat_request.messages[0].content}",
+        )
 
         thread_id = run_agent_input.thread_id
         run_id = run_agent_input.run_id
@@ -286,7 +288,7 @@ class NatAgent(BaseAgent[None]):
         prefix = f"{line}\nWorkflow Result:\n"
         suffix = f"\n{line}"
 
-        print(f"{prefix}{runner_outputs}{suffix}")
+        logger.info(f"{prefix}{runner_outputs}{suffix}")
 
         return runner_outputs, steps
 

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.12.0"
+version = "0.13.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
- Removed `print`s to standardize logging
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a global monkeypatch of `logging.Handler.handle` to filter/sanitize records, which could affect logging behavior across the process if assumptions differ in downstream handlers.
> 
> **Overview**
> Standardizes agent runtime output by replacing various `print(..., flush=True)` calls with `logging` across NAT, LlamaIndex, and MCP tool-loading paths, including more granular `info` vs `debug` for tool arguments/results.
> 
> Adds `dragent.frontends.logging.logging_handler_setup()` and wires it into frontend registration to globally suppress known-noisy NAT log messages and collapse multi-line log records into single-line entries (including sanitizing `record.args`).
> 
> Bumps the package version to `0.13.2` (and lockfiles) and records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475f3ac7d9fc66d5763ad795e361be479c17188e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->