### PR TITLE
Crewai add memory capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.13.1
+- Added opt-in memory retrieval and storage to the CrewAI base agent when kickoff inputs declare `memory`.
+
 ## 0.13.0
 - Upgraded fastmcp from 2.x to 3.2.0+ (CVE-2026-32871, CVE-2026-27124, CVE-2025-64340)
 - Replaced `on_duplicate_tools`/`on_duplicate_prompts` with unified `on_duplicate` (fastmcp 3.x API)

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.12.0"
+version = "0.13.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1027,7 +1027,7 @@ requires-dist = [
     { name = "datarobot-predict", marker = "extra == 'llamaindex'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'nat'", specifier = ">=1.13.2,<2.0.0" },
     { name = "fastapi", marker = "extra == 'dragent'", specifier = "<0.133.0" },
-    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=2.13.0.2,<3.0.0" },
+    { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=3.2.0,<4.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.13.0"
+version = "0.13.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -111,6 +111,13 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
           of prior conversation turns. Use ``{chat_history}`` in agent
           goals/backstories or task descriptions to reference it.
 
+        - ``memory`` (optional): Include this key with an empty string value
+          (``""``) to opt into automatic memory retrieval. When present, the
+          base class will populate it with relevant long-term memory before
+          kickoff and store the user turn after a successful run. Use
+          ``{memory}`` in agent goals/backstories or task descriptions to
+          reference it.
+
         Returns
         -------
         dict[str, Any]
@@ -205,6 +212,16 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
                 if history_summary and not existing_history_text.strip():
                     kickoff_inputs["chat_history"] = f"\n\nPrior conversation:\n{history_summary}"
+            if "memory" in kickoff_inputs:
+                existing_memory_text = str(kickoff_inputs.get("memory") or "")
+                if not existing_memory_text.strip():
+                    try:
+                        kickoff_inputs["memory"] = await self.retrieve_memory_for_run(
+                            user_prompt_content,
+                            run_agent_input,
+                        )
+                    except Exception as exc:
+                        logger.warning("CrewAI memory retrieval failed: %s", exc)
             message_id = str(uuid.uuid4())
             crew_output = await crew.kickoff_async(inputs=kickoff_inputs)
             current_agent_role = ""
@@ -363,6 +380,11 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                     None,
                     usage_metrics,
                 )
+            if "memory" in kickoff_inputs:
+                try:
+                    await self.store_memory_for_run(user_prompt_content, run_agent_input)
+                except Exception as exc:
+                    logger.warning("CrewAI memory storage failed: %s", exc)
             yield (
                 RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id),
                 pipeline_interactions,

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -30,6 +30,7 @@ from ragas.messages import AIMessage
 from ragas.messages import HumanMessage
 
 from datarobot_genai.core.agents.base import UsageMetrics
+from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.crewai.agent import CrewAIAgent
 
 
@@ -53,6 +54,72 @@ class ListenerForTest:
 
     def setup_listeners(self, crewai_event_bus: Any) -> None:
         self.called_setup = True
+
+
+class FakeMemoryClient(BaseMemoryClient):
+    def __init__(self, retrieved: str = "saved memory") -> None:
+        self.retrieved = retrieved
+        self.retrieve_calls: list[dict[str, Any]] = []
+        self.store_calls: list[dict[str, Any]] = []
+
+    async def retrieve(
+        self,
+        prompt: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> str:
+        self.retrieve_calls.append(
+            {
+                "prompt": prompt,
+                "run_id": run_id,
+                "agent_id": agent_id,
+                "app_id": app_id,
+                "attributes": attributes,
+            }
+        )
+        return self.retrieved
+
+    async def store(
+        self,
+        user_message: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        self.store_calls.append(
+            {
+                "user_message": user_message,
+                "run_id": run_id,
+                "agent_id": agent_id,
+                "app_id": app_id,
+                "attributes": attributes,
+            }
+        )
+
+
+class FailingMemoryClient(BaseMemoryClient):
+    async def retrieve(
+        self,
+        prompt: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> str:
+        raise RuntimeError("mem0 retrieve unavailable")
+
+    async def store(
+        self,
+        user_message: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        raise RuntimeError("mem0 store unavailable")
 
 
 @pytest.fixture
@@ -108,6 +175,19 @@ def test_create_pipeline_interactions_from_messages_returns_sample() -> None:
 def run_agent_input() -> RunAgentInput:
     return RunAgentInput(
         messages=[UserMessage(content="{}", id="message_id")],
+        tools=[],
+        forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
+        thread_id="thread_id",
+        run_id="run_id",
+        state={},
+        context=[],
+    )
+
+
+@pytest.fixture
+def run_agent_input_with_structured_prompt() -> RunAgentInput:
+    return RunAgentInput(
+        messages=[UserMessage(content='{"topic": "AI"}', id="message_id")],
         tools=[],
         forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
         thread_id="thread_id",
@@ -242,3 +322,201 @@ async def test_invoke_does_not_overwrite_non_empty_chat_history_override(
     _ = [event async for event in agent.invoke(run_agent_input_with_history)]
 
     assert captured_inputs["chat_history"] == "CUSTOM OVERRIDE"
+
+
+async def test_invoke_retrieves_and_stores_memory(
+    mock_ragas_event_listener, run_agent_input_with_structured_prompt
+) -> None:
+    captured_inputs: dict[str, Any] = {}
+
+    class CapturingCrew(CrewForTest):
+        async def kickoff_async(
+            self, *, inputs: dict[str, Any]
+        ) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+            captured_inputs.update(inputs)
+            return await super().kickoff_async(inputs=inputs)
+
+    class AgentWithMemory(AgentForTest):
+        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+            return {"topic": user_prompt_content, "memory": ""}
+
+    # GIVEN a CrewAI agent whose kickoff inputs opt into memory
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    out = CrewOutput(raw="agent result")
+    agent = AgentWithMemory(
+        out,
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        memory_client=memory_client,
+    )
+    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
+
+    # WHEN invoke is called
+    _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN the retrieved memory is injected and the user prompt is persisted after success
+    assert captured_inputs["memory"] == "Use concise answers."
+    assert memory_client.retrieve_calls == [
+        {
+            "prompt": '{"topic": "AI"}',
+            "run_id": None,
+            "agent_id": "AgentWithMemory",
+            "app_id": "tests.crewai.test_agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+    assert memory_client.store_calls == [
+        {
+            "user_message": '{"topic": "AI"}',
+            "run_id": "run_id",
+            "agent_id": "AgentWithMemory",
+            "app_id": "tests.crewai.test_agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+
+
+async def test_invoke_skips_memory_when_prompt_does_not_use_it(
+    mock_ragas_event_listener, run_agent_input_with_structured_prompt
+) -> None:
+    # GIVEN a CrewAI agent whose kickoff inputs do not opt into memory
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    out = CrewOutput(raw="agent result")
+    agent = AgentForTest(
+        out,
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        memory_client=memory_client,
+    )
+
+    # WHEN invoke is called
+    _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN memory retrieval and storage are both skipped
+    assert memory_client.retrieve_calls == []
+    assert memory_client.store_calls == []
+
+
+async def test_invoke_does_not_overwrite_non_empty_memory_override(
+    mock_ragas_event_listener, run_agent_input_with_structured_prompt
+) -> None:
+    captured_inputs: dict[str, Any] = {}
+
+    class CapturingCrew(CrewForTest):
+        async def kickoff_async(
+            self, *, inputs: dict[str, Any]
+        ) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+            captured_inputs.update(inputs)
+            return await super().kickoff_async(inputs=inputs)
+
+    class AgentWithMemoryOverride(AgentForTest):
+        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+            return {"topic": user_prompt_content, "memory": "CUSTOM MEMORY"}
+
+    # GIVEN a CrewAI agent that provides its own memory override
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    out = CrewOutput(raw="agent result")
+    agent = AgentWithMemoryOverride(
+        out,
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        memory_client=memory_client,
+    )
+    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
+
+    # WHEN invoke is called
+    _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN the explicit override is preserved and the turn is still stored
+    assert captured_inputs["memory"] == "CUSTOM MEMORY"
+    assert memory_client.retrieve_calls == []
+    assert memory_client.store_calls == [
+        {
+            "user_message": '{"topic": "AI"}',
+            "run_id": "run_id",
+            "agent_id": "AgentWithMemoryOverride",
+            "app_id": "tests.crewai.test_agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+
+
+async def test_invoke_gracefully_degrades_when_memory_fails(
+    mock_ragas_event_listener, run_agent_input_with_structured_prompt
+) -> None:
+    captured_inputs: dict[str, Any] = {}
+
+    class CapturingCrew(CrewForTest):
+        async def kickoff_async(
+            self, *, inputs: dict[str, Any]
+        ) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+            captured_inputs.update(inputs)
+            return await super().kickoff_async(inputs=inputs)
+
+    class AgentWithMemory(AgentForTest):
+        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+            return {"topic": user_prompt_content, "memory": ""}
+
+    # GIVEN a CrewAI agent whose memory provider errors at runtime
+    out = CrewOutput(raw="agent result")
+    agent = AgentWithMemory(
+        out,
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        memory_client=FailingMemoryClient(),
+    )
+    agent.crew = lambda: CapturingCrew(out)  # type: ignore[assignment]
+
+    # WHEN invoke is called
+    events = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN the run still completes and the memory placeholder remains empty
+    assert events
+    assert isinstance(events[-1][0], RunFinishedEvent)
+    assert captured_inputs["memory"] == ""
+
+
+async def test_invoke_does_not_store_memory_when_run_fails(
+    mock_ragas_event_listener, run_agent_input_with_structured_prompt
+) -> None:
+    class FailingCrew(CrewForTest):
+        async def kickoff_async(
+            self, *, inputs: dict[str, Any]
+        ) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+            raise RuntimeError("crew failed")
+
+    class AgentWithMemory(AgentForTest):
+        def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
+            return {"topic": user_prompt_content, "memory": ""}
+
+    # GIVEN a CrewAI agent whose run fails after retrieving memory
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    out = CrewOutput(raw="agent result")
+    agent = AgentWithMemory(
+        out,
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        memory_client=memory_client,
+    )
+    agent.crew = lambda: FailingCrew(out)  # type: ignore[assignment]
+
+    # WHEN invoke is called and the crew fails
+    with pytest.raises(RuntimeError, match="crew failed"):
+        _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN retrieval may happen, but storage is skipped because the run never finishes
+    assert memory_client.retrieve_calls == [
+        {
+            "prompt": '{"topic": "AI"}',
+            "run_id": None,
+            "agent_id": "AgentWithMemory",
+            "app_id": "tests.crewai.test_agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+    assert memory_client.store_calls == []

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.12.0"
+version = "0.13.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
Add memory capabilities to crewai template
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new memory retrieve/store calls into the `CrewAIAgent.invoke` execution path (with best-effort error handling), which can affect runtime behavior and external service usage when enabled.
> 
> **Overview**
> Adds an *opt-in* `memory` kickoff input to `CrewAIAgent` so templates can have long-term memory automatically retrieved before `kickoff_async` and the user turn stored after a successful run (with warnings and graceful degradation on memory errors).
> 
> Updates unit tests to cover memory injection, override/skip behavior, failure handling, and ensuring storage is skipped when the Crew run raises. Bumps package version to `0.13.1` (locks updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24137a76e47bfcbb43c7c5c9f6222aa8c54f0c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->