### PR TITLE
Llamaindex memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.14.1
+- Added opt-in memory retrieval and storage to the LlamaIndex base agent when input messages declare `{memory}`.
+
 ## 0.14.0
 - Reworked agents to only accept `llm`: its not the job of an agent to instantiate the LLM
 - Implemented functions to convert native agentic primitives into DataRobot agents

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.14.0"
+version = "0.14.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -83,15 +83,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         """Extract final response text from workflow state and/or events."""
         raise NotImplementedError
 
-    def make_input_message(self, run_agent_input: RunAgentInput) -> str:
-        """Create an input string for the workflow from the user prompt.
-
-        Subclasses may opt into automatic placeholder replacement by including
-        ``{chat_history}`` and/or ``{memory}`` in the returned string.
-        """
-        user_prompt_content = extract_user_prompt_content(run_agent_input)
-        return str(user_prompt_content)
-
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the LlamaIndex workflow with the provided completion parameters."""
         user_prompt_content = extract_user_prompt_content(run_agent_input)

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -84,13 +84,19 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         raise NotImplementedError
 
     def make_input_message(self, run_agent_input: RunAgentInput) -> str:
-        """Create an input string for the workflow from the user prompt."""
+        """Create an input string for the workflow from the user prompt.
+
+        Subclasses may opt into automatic placeholder replacement by including
+        ``{chat_history}`` and/or ``{memory}`` in the returned string.
+        """
         user_prompt_content = extract_user_prompt_content(run_agent_input)
         return str(user_prompt_content)
 
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the LlamaIndex workflow with the provided completion parameters."""
-        input_message = self.make_input_message(run_agent_input)
+        user_prompt_content = extract_user_prompt_content(run_agent_input)
+        input_message = str(user_prompt_content)
+        uses_memory = "{memory}" in input_message
 
         # Handle {chat_history} placeholder replacement for subclass templates
         if "{chat_history}" in input_message:
@@ -99,6 +105,13 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 f"\n\nPrior conversation:\n{history_summary}" if history_summary else ""
             )
             input_message = input_message.replace("{chat_history}", formatted_history)
+        if uses_memory:
+            memory = ""
+            try:
+                memory = await self.retrieve_memory_for_run(user_prompt_content, run_agent_input)
+            except Exception as exc:
+                logger.warning("LlamaIndex memory retrieval failed: %s", exc)
+            input_message = input_message.replace("{memory}", memory)
 
         logger.info(f"Running agent with user prompt: {input_message}")
 
@@ -289,6 +302,11 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         _ = self.extract_response_text(state, events)
 
         pipeline_interactions = self.create_pipeline_interactions_from_events(events)
+        if uses_memory:
+            try:
+                await self.store_memory_for_run(user_prompt_content, run_agent_input)
+            except Exception as exc:
+                logger.warning("LlamaIndex memory storage failed: %s", exc)
         # TODO: find a way to count usage (LlamaIndex does not report it)
         yield (
             RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id),

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -164,12 +164,6 @@ class MyLlamaAgent(LlamaIndexAgent):
         return f"{result_state}:{len(events)}"
 
 
-class LlamaAgentWithMemory(MyLlamaAgent):
-    def make_input_message(self, run_agent_input: RunAgentInput) -> str:
-        user_prompt = super().make_input_message(run_agent_input)
-        return f"Memory:\n{{memory}}\n\nLatest: {user_prompt}"
-
-
 # --- Tests for DataRobotLiteLLM ---
 
 
@@ -276,19 +270,6 @@ def run_agent_input() -> RunAgentInput:
 
 
 @pytest.fixture
-def run_agent_input_with_structured_prompt() -> RunAgentInput:
-    return RunAgentInput(
-        messages=[UserMessage(content='{"topic": "AI"}', id="message_id")],
-        tools=[],
-        forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
-        thread_id="thread_id",
-        run_id="run_id",
-        state={},
-        context=[],
-    )
-
-
-@pytest.fixture
 def events() -> list[Any]:
     return [
         AgentWorkflowStartEvent(),
@@ -385,25 +366,16 @@ async def test_llama_index_agent_invoke(
     assert usage[-1] == {"completion_tokens": 0, "prompt_tokens": 0, "total_tokens": 0}
 
 
-def test_make_input_message_includes_history_summary(run_agent_input_with_history) -> None:
-    """By default, LlamaIndexAgent.make_input_message should NOT include history."""
-    workflow = Workflow(events=[], state="S")
+async def test_invoke_uses_raw_user_prompt(run_agent_input_with_history) -> None:
+    # GIVEN a llamaindex agent without prompt placeholders
+    workflow = CapturingWorkflow(events=[], state="S")
     agent = MyLlamaAgent(workflow)
 
-    text = agent.make_input_message(run_agent_input_with_history)
+    # WHEN invoking the agent
+    _ = [event async for event in agent.invoke(run_agent_input_with_history)]
 
-    assert text == "Follow-up"
-
-
-def test_make_input_message_zero_history_disables_summary(
-    run_agent_input_with_history,
-) -> None:
-    """When max_history_messages is 0, history should be disabled."""
-    workflow = Workflow(events=[], state="S")
-    agent = MyLlamaAgent(workflow, max_history_messages=0)
-
-    text = agent.make_input_message(run_agent_input_with_history)
-    assert text == "Follow-up"
+    # THEN the workflow receives the raw final user prompt
+    assert workflow.captured_user_msgs == ["Follow-up"]
 
 
 async def test_invoke_agent_output_with_dict_tool_calls(
@@ -470,28 +442,16 @@ async def test_invoke_agent_stream_multiple_agents(
 
 
 async def test_invoke_replaces_chat_history_placeholder() -> None:
-    """invoke() replaces {chat_history} placeholder with actual history."""
-    captured_msgs: list[str] = []
-
-    class CapturingWorkflow(Workflow):
-        def run(self, *, user_msg: str) -> Handler:
-            captured_msgs.append(user_msg)
-            return super().run(user_msg=user_msg)
-
-    class AgentWithPlaceholder(MyLlamaAgent):
-        def make_input_message(self, run_agent_input: Any) -> str:
-            user_prompt = super().make_input_message(run_agent_input)
-            return f"History:\n{{chat_history}}\n\nLatest: {user_prompt}"
-
+    """invoke() replaces {chat_history} inside the raw user prompt."""
     workflow = CapturingWorkflow(events=[], state="S")
-    agent = AgentWithPlaceholder(workflow)
+    agent = MyLlamaAgent(workflow)
 
     run_agent_input = RunAgentInput(
         messages=[
             AgSystemMessage(id="sys_1", content="You are a helper."),
             UserMessage(id="user_1", content="First question"),
             AssistantMessage(id="asst_1", content="First answer"),
-            UserMessage(id="user_2", content="Follow-up"),
+            UserMessage(id="user_2", content="History:\n{chat_history}\n\nLatest: Follow-up"),
         ],
         tools=[],
         forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
@@ -503,8 +463,8 @@ async def test_invoke_replaces_chat_history_placeholder() -> None:
 
     _ = [event async for event in agent.invoke(run_agent_input)]
 
-    assert len(captured_msgs) == 1
-    text = captured_msgs[0]
+    assert workflow.captured_user_msgs
+    text = workflow.captured_user_msgs[0]
     assert "system: You are a helper." in text
     assert "user: First question" in text
     assert "assistant: First answer" in text
@@ -512,34 +472,37 @@ async def test_invoke_replaces_chat_history_placeholder() -> None:
 
 
 async def test_invoke_retrieves_and_stores_memory(
-    run_agent_input_with_structured_prompt: RunAgentInput,
+    run_agent_input: RunAgentInput,
 ) -> None:
-    # GIVEN a llamaindex agent whose input template opts into memory
+    # GIVEN a llamaindex agent whose raw user prompt opts into memory
     workflow = CapturingWorkflow(events=[], state="S")
     memory_client = FakeMemoryClient(retrieved="Use concise answers.")
-    agent = LlamaAgentWithMemory(workflow, memory_client=memory_client)
+    agent = MyLlamaAgent(workflow, memory_client=memory_client)
+    run_agent_input.messages = [
+        UserMessage(id="message_id", content="Memory:\n{memory}\n\nLatest: Follow-up")
+    ]
 
     # WHEN invoking the agent
-    events = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+    events = [event async for event in agent.invoke(run_agent_input)]
 
     # THEN the run completes, the prompt includes retrieved memory, and the turn is stored
-    expected_user_msg = "Memory:\nUse concise answers.\n\nLatest: {'topic': 'AI'}"
+    expected_user_msg = "Memory:\nUse concise answers.\n\nLatest: Follow-up"
     assert isinstance(events[-1][0], RunFinishedEvent)
     assert workflow.captured_user_msgs == [expected_user_msg]
     assert memory_client.retrieve_calls == [
         {
-            "prompt": '{"topic": "AI"}',
+            "prompt": "Memory:\n{memory}\n\nLatest: Follow-up",
             "run_id": None,
-            "agent_id": "LlamaAgentWithMemory",
+            "agent_id": "MyLlamaAgent",
             "app_id": "tests.llamaindex.test_agent",
             "attributes": {"thread_id": "thread_id"},
         }
     ]
     assert memory_client.store_calls == [
         {
-            "user_message": '{"topic": "AI"}',
+            "user_message": "Memory:\n{memory}\n\nLatest: Follow-up",
             "run_id": "run_id",
-            "agent_id": "LlamaAgentWithMemory",
+            "agent_id": "MyLlamaAgent",
             "app_id": "tests.llamaindex.test_agent",
             "attributes": {"thread_id": "thread_id"},
         }
@@ -547,15 +510,15 @@ async def test_invoke_retrieves_and_stores_memory(
 
 
 async def test_invoke_skips_memory_when_placeholder_is_absent(
-    run_agent_input_with_structured_prompt: RunAgentInput,
+    run_agent_input: RunAgentInput,
 ) -> None:
-    # GIVEN a llamaindex agent whose input template does not opt into memory
+    # GIVEN a llamaindex agent whose raw user prompt does not opt into memory
     workflow = Workflow(events=[], state="S")
     memory_client = FakeMemoryClient(retrieved="Use concise answers.")
     agent = MyLlamaAgent(workflow, memory_client=memory_client)
 
     # WHEN invoking the agent
-    _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+    _ = [event async for event in agent.invoke(run_agent_input)]
 
     # THEN memory retrieval and storage are both skipped
     assert memory_client.retrieve_calls == []
@@ -563,23 +526,26 @@ async def test_invoke_skips_memory_when_placeholder_is_absent(
 
 
 async def test_invoke_gracefully_degrades_when_memory_fails(
-    run_agent_input_with_structured_prompt: RunAgentInput,
+    run_agent_input: RunAgentInput,
 ) -> None:
-    # GIVEN a llamaindex agent whose memory provider errors at runtime
+    # GIVEN a llamaindex agent whose raw user prompt opts into memory
     workflow = CapturingWorkflow(events=[], state="S")
-    agent = LlamaAgentWithMemory(workflow, memory_client=FailingMemoryClient())
+    agent = MyLlamaAgent(workflow, memory_client=FailingMemoryClient())
+    run_agent_input.messages = [
+        UserMessage(id="message_id", content="Memory:\n{memory}\n\nLatest: Follow-up")
+    ]
 
     # WHEN invoking the agent
-    events = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+    events = [event async for event in agent.invoke(run_agent_input)]
 
     # THEN the run still completes and the unresolved placeholder is removed
     assert isinstance(events[-1][0], RunFinishedEvent)
-    assert workflow.captured_user_msgs == ["Memory:\n\n\nLatest: {'topic': 'AI'}"]
+    assert workflow.captured_user_msgs == ["Memory:\n\n\nLatest: Follow-up"]
     assert "{memory}" not in workflow.captured_user_msgs[0]
 
 
 async def test_invoke_does_not_store_memory_when_workflow_fails(
-    run_agent_input_with_structured_prompt: RunAgentInput,
+    run_agent_input: RunAgentInput,
 ) -> None:
     class FailingWorkflow(CapturingWorkflow):
         def run(self, *, user_msg: str) -> Handler:
@@ -595,20 +561,23 @@ async def test_invoke_does_not_store_memory_when_workflow_fails(
     # GIVEN a llamaindex agent whose workflow fails after memory retrieval
     workflow = FailingWorkflow(events=[], state="S")
     memory_client = FakeMemoryClient(retrieved="Use concise answers.")
-    agent = LlamaAgentWithMemory(workflow, memory_client=memory_client)
+    agent = MyLlamaAgent(workflow, memory_client=memory_client)
+    run_agent_input.messages = [
+        UserMessage(id="message_id", content="Memory:\n{memory}\n\nLatest: Follow-up")
+    ]
 
     # WHEN invoking the agent and the workflow fails
     with pytest.raises(RuntimeError, match="workflow failed"):
-        _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+        _ = [event async for event in agent.invoke(run_agent_input)]
 
     # THEN retrieval happens, but storage is skipped because the run never finishes
-    expected_user_msg = "Memory:\nUse concise answers.\n\nLatest: {'topic': 'AI'}"
+    expected_user_msg = "Memory:\nUse concise answers.\n\nLatest: Follow-up"
     assert workflow.captured_user_msgs == [expected_user_msg]
     assert memory_client.retrieve_calls == [
         {
-            "prompt": '{"topic": "AI"}',
+            "prompt": "Memory:\n{memory}\n\nLatest: Follow-up",
             "run_id": None,
-            "agent_id": "LlamaAgentWithMemory",
+            "agent_id": "MyLlamaAgent",
             "app_id": "tests.llamaindex.test_agent",
             "attributes": {"thread_id": "thread_id"},
         }

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -41,6 +41,7 @@ from llama_index.core.tools import ToolOutput
 from llama_index.core.tools import ToolSelection
 from ragas import MultiTurnSample
 
+from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.llama_index.agent import DataRobotLiteLLM
 from datarobot_genai.llama_index.agent import LlamaIndexAgent
 from datarobot_genai.llama_index.agent import datarobot_agent_class_from_llamaindex
@@ -75,6 +76,82 @@ class Workflow:
         return Handler(self._events, self._state)
 
 
+class CapturingWorkflow(Workflow):
+    def __init__(self, events: list[Any], state: Any) -> None:
+        super().__init__(events, state)
+        self.captured_user_msgs: list[str] = []
+
+    def run(self, *, user_msg: str) -> Handler:
+        self.captured_user_msgs.append(user_msg)
+        return super().run(user_msg=user_msg)
+
+
+class FakeMemoryClient(BaseMemoryClient):
+    def __init__(self, retrieved: str = "saved memory") -> None:
+        self.retrieved = retrieved
+        self.retrieve_calls: list[dict[str, Any]] = []
+        self.store_calls: list[dict[str, Any]] = []
+
+    async def retrieve(
+        self,
+        prompt: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> str:
+        self.retrieve_calls.append(
+            {
+                "prompt": prompt,
+                "run_id": run_id,
+                "agent_id": agent_id,
+                "app_id": app_id,
+                "attributes": attributes,
+            }
+        )
+        return self.retrieved
+
+    async def store(
+        self,
+        user_message: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        self.store_calls.append(
+            {
+                "user_message": user_message,
+                "run_id": run_id,
+                "agent_id": agent_id,
+                "app_id": app_id,
+                "attributes": attributes,
+            }
+        )
+
+
+class FailingMemoryClient(BaseMemoryClient):
+    async def retrieve(
+        self,
+        prompt: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> str:
+        raise RuntimeError("mem0 retrieve unavailable")
+
+    async def store(
+        self,
+        user_message: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        raise RuntimeError("mem0 store unavailable")
+
+
 class MyLlamaAgent(LlamaIndexAgent):
     def __init__(self, workflow: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -85,6 +162,12 @@ class MyLlamaAgent(LlamaIndexAgent):
 
     def extract_response_text(self, result_state: Any, events: list[Any]) -> str:
         return f"{result_state}:{len(events)}"
+
+
+class LlamaAgentWithMemory(MyLlamaAgent):
+    def make_input_message(self, run_agent_input: RunAgentInput) -> str:
+        user_prompt = super().make_input_message(run_agent_input)
+        return f"Memory:\n{{memory}}\n\nLatest: {user_prompt}"
 
 
 # --- Tests for DataRobotLiteLLM ---
@@ -183,6 +266,19 @@ async def test_datarobot_agent_class_from_llamaindex_invoke_streams(
 def run_agent_input() -> RunAgentInput:
     return RunAgentInput(
         messages=[UserMessage(content="{}", id="message_id")],
+        tools=[],
+        forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
+        thread_id="thread_id",
+        run_id="run_id",
+        state={},
+        context=[],
+    )
+
+
+@pytest.fixture
+def run_agent_input_with_structured_prompt() -> RunAgentInput:
+    return RunAgentInput(
+        messages=[UserMessage(content='{"topic": "AI"}', id="message_id")],
         tools=[],
         forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
         thread_id="thread_id",
@@ -413,3 +509,108 @@ async def test_invoke_replaces_chat_history_placeholder() -> None:
     assert "user: First question" in text
     assert "assistant: First answer" in text
     assert "{chat_history}" not in text
+
+
+async def test_invoke_retrieves_and_stores_memory(
+    run_agent_input_with_structured_prompt: RunAgentInput,
+) -> None:
+    # GIVEN a llamaindex agent whose input template opts into memory
+    workflow = CapturingWorkflow(events=[], state="S")
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    agent = LlamaAgentWithMemory(workflow, memory_client=memory_client)
+
+    # WHEN invoking the agent
+    events = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN the run completes, the prompt includes retrieved memory, and the turn is stored
+    expected_user_msg = "Memory:\nUse concise answers.\n\nLatest: {'topic': 'AI'}"
+    assert isinstance(events[-1][0], RunFinishedEvent)
+    assert workflow.captured_user_msgs == [expected_user_msg]
+    assert memory_client.retrieve_calls == [
+        {
+            "prompt": '{"topic": "AI"}',
+            "run_id": None,
+            "agent_id": "LlamaAgentWithMemory",
+            "app_id": "tests.llamaindex.test_agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+    assert memory_client.store_calls == [
+        {
+            "user_message": '{"topic": "AI"}',
+            "run_id": "run_id",
+            "agent_id": "LlamaAgentWithMemory",
+            "app_id": "tests.llamaindex.test_agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+
+
+async def test_invoke_skips_memory_when_placeholder_is_absent(
+    run_agent_input_with_structured_prompt: RunAgentInput,
+) -> None:
+    # GIVEN a llamaindex agent whose input template does not opt into memory
+    workflow = Workflow(events=[], state="S")
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    agent = MyLlamaAgent(workflow, memory_client=memory_client)
+
+    # WHEN invoking the agent
+    _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN memory retrieval and storage are both skipped
+    assert memory_client.retrieve_calls == []
+    assert memory_client.store_calls == []
+
+
+async def test_invoke_gracefully_degrades_when_memory_fails(
+    run_agent_input_with_structured_prompt: RunAgentInput,
+) -> None:
+    # GIVEN a llamaindex agent whose memory provider errors at runtime
+    workflow = CapturingWorkflow(events=[], state="S")
+    agent = LlamaAgentWithMemory(workflow, memory_client=FailingMemoryClient())
+
+    # WHEN invoking the agent
+    events = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN the run still completes and the unresolved placeholder is removed
+    assert isinstance(events[-1][0], RunFinishedEvent)
+    assert workflow.captured_user_msgs == ["Memory:\n\n\nLatest: {'topic': 'AI'}"]
+    assert "{memory}" not in workflow.captured_user_msgs[0]
+
+
+async def test_invoke_does_not_store_memory_when_workflow_fails(
+    run_agent_input_with_structured_prompt: RunAgentInput,
+) -> None:
+    class FailingWorkflow(CapturingWorkflow):
+        def run(self, *, user_msg: str) -> Handler:
+            self.captured_user_msgs.append(user_msg)
+
+            class FailingHandler:
+                async def stream_events(self) -> AsyncGenerator[Any, None]:
+                    raise RuntimeError("workflow failed")
+                    yield  # pragma: no cover
+
+            return FailingHandler()
+
+    # GIVEN a llamaindex agent whose workflow fails after memory retrieval
+    workflow = FailingWorkflow(events=[], state="S")
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    agent = LlamaAgentWithMemory(workflow, memory_client=memory_client)
+
+    # WHEN invoking the agent and the workflow fails
+    with pytest.raises(RuntimeError, match="workflow failed"):
+        _ = [event async for event in agent.invoke(run_agent_input_with_structured_prompt)]
+
+    # THEN retrieval happens, but storage is skipped because the run never finishes
+    expected_user_msg = "Memory:\nUse concise answers.\n\nLatest: {'topic': 'AI'}"
+    assert workflow.captured_user_msgs == [expected_user_msg]
+    assert memory_client.retrieve_calls == [
+        {
+            "prompt": '{"topic": "AI"}',
+            "run_id": None,
+            "agent_id": "LlamaAgentWithMemory",
+            "app_id": "tests.llamaindex.test_agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+    assert memory_client.store_calls == []

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Llamaindex use memory for storing and retrieving prompts

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `LlamaIndexAgent.invoke` to conditionally call external memory retrieve/store based on a `{memory}` marker in the user prompt, which can affect prompt construction and introduce new runtime dependencies/failure modes.
> 
> **Overview**
> Adds **opt-in long-term memory support** for LlamaIndex agents: when the last user message contains `{memory}`, `LlamaIndexAgent.invoke` now retrieves memory, substitutes it into the prompt, and stores the raw user turn after a successful run (with warnings and safe fallback on failures).
> 
> Updates unit tests to assert raw prompt handling, `{chat_history}` substitution inside the user message, and the new memory behaviors (skip when absent, degrade gracefully on errors, and avoid storing when the workflow fails), and bumps the package version to `0.14.1` with a matching changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bd3847469f23ac869ac089d998ab8258b0c48af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->