### PR TITLE
[MODEL-22469] Improve MCP lineage logic in drmcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.14.3
+- Improved lineage sync logic in drmcp server
+
 ## 0.14.2
 - Implemented functions to instantiate LLM classes for LLM Gateway, deployment, NIM, and external
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.14.2"
+version = "0.14.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -27,6 +27,9 @@ from fastmcp.resources import Resource
 from fastmcp.tools import Tool
 from starlette.middleware import Middleware
 
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drtools.core.auth import initialize_oauth_middleware
 from datarobot_genai.drtools.core.credentials import get_credentials
 
@@ -240,6 +243,15 @@ class DataRobotMCPServer:
             if self._config.mcp_server_register_dynamic_prompts_on_startup:
                 self._logger.info("Registering dynamic prompts from prompt management...")
                 asyncio.run(register_prompts_from_datarobot_prompt_management())
+
+            if FeatureFlag.is_mcp_tools_gallery_support_enabled():
+                try:
+                    linear_manager = LineageManager(self._mcp)
+                    asyncio.run(linear_manager.sync_mcp_tools())
+                    asyncio.run(linear_manager.sync_mcp_prompts())
+                except LRSEnvVarIsNotSetError as error:
+                    error_message = f"MCP item metadata is not sync. {str(error)}"
+                    self._logger.warning(error_message)
 
             # Execute pre-server start actions
             asyncio.run(self._lifecycle.pre_server_start(self._mcp))

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
@@ -23,10 +23,6 @@ from fastmcp.prompts.prompt import Prompt
 from pydantic import Field
 
 from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
-from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
-from datarobot_genai.drmcp.core.lineage.manager import LineageManager
-from datarobot_genai.drmcp.core.mcp_instance import mcp
 from datarobot_genai.drmcp.core.mcp_instance import register_prompt
 
 from .dr_lib import get_datarobot_prompt_template_versions
@@ -56,14 +52,6 @@ async def register_prompts_from_datarobot_prompt_management() -> None:
             await register_prompt_from_datarobot_prompt_management(prompt, latest_version)
         except DynamicPromptRegistrationError:
             pass
-
-    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_prompts()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
 
 
 async def register_prompt_from_datarobot_prompt_management(

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
@@ -20,10 +20,6 @@ from datarobot_genai.drmcp.core.clients import get_api_client
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.config import create_deployment_tool_config
 from datarobot_genai.drmcp.core.dynamic_tools.register import register_external_tool
 from datarobot_genai.drmcp.core.exceptions import DynamicToolRegistrationError
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
-from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
-from datarobot_genai.drmcp.core.lineage.manager import LineageManager
-from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
 
@@ -43,14 +39,6 @@ async def register_tools_of_datarobot_deployments() -> None:
         except Exception as exc:
             logger.error(f"Unexpected error for deployment {deployment_id}: {exc}")
             pass
-
-    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_tools()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
 
 
 async def register_tool_of_datarobot_deployment(

--- a/tests/drmcp/unit/dynamic_prompts/test_register.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_register.py
@@ -14,8 +14,6 @@
 
 """Tests for external prompt registration."""
 
-from collections.abc import Iterator
-from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 from uuid import UUID
@@ -96,40 +94,6 @@ class TestToValidFunctionName:
 class TestRegisterPrompt:
     """Tests for register_prompt - happy path."""
 
-    @pytest.fixture
-    def module_under_test(self) -> str:
-        return "datarobot_genai.drmcp.core.dynamic_prompts.register"
-
-    @pytest.fixture
-    def mock_get_datarobot_prompt_templates(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.get_datarobot_prompt_templates") as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_get_datarobot_prompt_template_versions(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.get_datarobot_prompt_template_versions") as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_register_prompt_from_datarobot_prompt_management(
-        self, module_under_test: str
-    ) -> Iterator[AsyncMock]:
-        with patch(
-            f"{module_under_test}.register_prompt_from_datarobot_prompt_management",
-            new_callable=AsyncMock,
-        ) as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_mcp_server(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.mcp") as mock_mcp:
-            yield mock_mcp
-
-    @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
-        "mock_lineage_manager_init",
-        "mock_sync_mcp_prompts",
-    )
     @pytest.mark.asyncio
     async def test_register_prompt_from_datarobot_prompt_management(
         self,
@@ -143,11 +107,6 @@ class TestRegisterPrompt:
         assert "Dummy prompt name" in prompts, "`Dummy prompt name` is missing."
 
     @pytest.mark.asyncio
-    @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
-        "mock_lineage_manager_init",
-        "mock_sync_mcp_prompts",
-    )
     @patch("datarobot_genai.drmcp.core.dynamic_prompts.utils.uuid4")
     async def test_register_prompt_from_datarobot_prompt_management_duplicated_prompt_names(
         self,
@@ -163,35 +122,3 @@ class TestRegisterPrompt:
 
         assert "Dummy prompt name" in prompts, "`Dummy prompt name` is missing."
         assert "Dummy prompt name (f2bd)" in prompts, "`Dummy prompt name (f2bd)` is missing."
-
-    @pytest.mark.asyncio
-    async def test_sync_mcp_metadata_after_register_prompts(
-        self,
-        mock_get_datarobot_prompt_templates: Mock,
-        mock_get_datarobot_prompt_template_versions: Mock,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
-        mock_lineage_manager_init: Mock,
-        mock_sync_mcp_prompts: Mock,
-        mock_mcp_server: Mock,
-        mock_register_prompt_from_datarobot_prompt_management: AsyncMock,
-    ) -> None:
-        mock_prompt = Mock()
-        mock_get_datarobot_prompt_templates.return_value = [mock_prompt]
-        prompt_template_version = dr.genai.PromptTemplateVersion("adsf", version=1)
-        mock_get_datarobot_prompt_template_versions.return_value = {
-            mock_prompt.id: [prompt_template_version],
-        }
-
-        await register_prompts_from_datarobot_prompt_management()
-
-        mock_get_datarobot_prompt_templates.assert_called_once_with()
-        mock_get_datarobot_prompt_template_versions.assert_called_once_with(
-            prompt_template_ids=[mock_prompt.id],
-        )
-        mock_register_prompt_from_datarobot_prompt_management.assert_called_once_with(
-            mock_prompt,
-            prompt_template_version,
-        )
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
-        mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
-        mock_sync_mcp_prompts.assert_called_once_with()

--- a/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
+++ b/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
@@ -11,52 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import Iterator
-from unittest.mock import AsyncMock
-from unittest.mock import Mock
 from unittest.mock import patch
-
-import datarobot as dr
-import pytest
 
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
     get_datarobot_tool_deployments,
 )
-from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
-    register_tools_of_datarobot_deployments,
-)
-
-
-@pytest.fixture
-def module_under_test() -> str:
-    return "datarobot_genai.drmcp.core.dynamic_tools.deployment.register"
-
-
-@pytest.fixture
-def mock_get_datarobot_tool_deployments(module_under_test: str) -> Iterator[Mock]:
-    with patch(f"{module_under_test}.get_datarobot_tool_deployments") as mock_func:
-        yield mock_func
-
-
-@pytest.fixture
-def mock_register_tool_of_datarobot_deployment(module_under_test: str) -> Iterator[AsyncMock]:
-    with patch(
-        f"{module_under_test}.register_tool_of_datarobot_deployment",
-        new_callable=AsyncMock,
-    ) as mock_func:
-        yield mock_func
-
-
-@pytest.fixture
-def mock_mcp_server(module_under_test: str) -> Iterator[Mock]:
-    with patch(f"{module_under_test}.mcp") as mock_mcp:
-        yield mock_mcp
-
-
-@pytest.fixture
-def mock_datarobot_deployment_get() -> Iterator[Mock]:
-    with patch.object(dr.Deployment, "get") as mock_func:
-        yield mock_func
 
 
 @patch("datarobot_genai.drmcp.core.dynamic_tools.deployment.register.get_api_client")
@@ -107,28 +66,3 @@ def test_get_datarobot_tool_deployments_filters_tags_correctly(mock_dr, mock_get
     )
 
     assert result == ["deployment_1", "deployment_5"]
-
-
-@pytest.mark.asyncio
-async def test_sync_mcp_metadata_after_register_tools(
-    mock_datarobot_deployment_get: Mock,
-    mock_is_mcp_tools_gallery_support_enabled: Mock,
-    mock_get_datarobot_tool_deployments: Mock,
-    mock_lineage_manager_init: Mock,
-    mock_sync_mcp_tools: Mock,
-    mock_mcp_server: Mock,
-    mock_register_tool_of_datarobot_deployment: AsyncMock,
-) -> None:
-    mock_deployment_id = Mock()
-    mock_get_datarobot_tool_deployments.return_value = [mock_deployment_id]
-
-    await register_tools_of_datarobot_deployments()
-
-    mock_get_datarobot_tool_deployments.assert_called_once_with()
-    mock_datarobot_deployment_get.assert_called_once_with(mock_deployment_id)
-    mock_register_tool_of_datarobot_deployment.assert_called_once_with(
-        mock_datarobot_deployment_get.return_value,
-    )
-    mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
-    mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
-    mock_sync_mcp_tools.assert_called_once_with()

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+from collections.abc import Iterator
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +23,7 @@ from fastmcp import FastMCP
 
 from datarobot_genai.drmcp.core.dr_mcp_server import DataRobotMCPServer
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.adapters.default import Metadata
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 
@@ -84,6 +87,23 @@ def metadata_factory():
 class TestDataRobotMCPServer:
     """Test suite for DataRobotMCPServer class."""
 
+    @pytest.fixture
+    def mock_is_mcp_tools_gallery_support_enabled(self) -> Iterator[Mock]:
+        with patch.object(FeatureFlag, "is_mcp_tools_gallery_support_enabled") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_lineage_manager_cls(self) -> Iterator[Mock]:
+        with patch("datarobot_genai.drmcp.core.dr_mcp_server.LineageManager") as mock_cls:
+            yield mock_cls
+
+    @pytest.fixture
+    def mock_lineage_manager(self, mock_lineage_manager_cls: Mock) -> Iterator[Mock]:
+        mock_lineage_manager = mock_lineage_manager_cls.return_value
+        mock_lineage_manager.sync_mcp_tools = AsyncMock()
+        mock_lineage_manager.sync_mcp_prompts = AsyncMock()
+        return mock_lineage_manager
+
     def test_initialization(self, mock_mcp: MagicMock) -> None:
         """Test server initialization with default transport."""
         server = DataRobotMCPServer(mock_mcp)
@@ -97,9 +117,8 @@ class TestDataRobotMCPServer:
         assert server._mcp_transport == "stdio"
 
     @pytest.mark.usefixtures(
-        "mock_lineage_manager_init",
-        "mock_sync_mcp_tools",
         "mock_is_mcp_tools_gallery_support_enabled",
+        "mock_lineage_manager",
     )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch(
@@ -175,6 +194,7 @@ class TestDataRobotMCPServer:
         with pytest.raises(ValueError, match="Missing required DataRobot credentials"):
             server.run()
 
+    @pytest.mark.usefixtures("mock_is_mcp_tools_gallery_support_enabled")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_credentials")
@@ -185,6 +205,8 @@ class TestDataRobotMCPServer:
         mock_get_config: MagicMock,
         mock_mcp: MagicMock,
         mock_config: MagicMock,
+        mock_lineage_manager_cls: Mock,
+        mock_lineage_manager: Mock,
     ) -> None:
         """Test successful server run."""
         mock_get_config.return_value = mock_config
@@ -209,6 +231,15 @@ class TestDataRobotMCPServer:
         # Verify tools were listed
         mock_mcp.list_tools.assert_called_once()
 
+        # Check linage is collected
+        mock_lineage_manager_cls.assert_called_once_with(mock_mcp)
+        mock_lineage_manager.sync_mcp_tools.assert_called_once_with()
+        mock_lineage_manager.sync_mcp_prompts.assert_called_once_with()
+
+    @pytest.mark.usefixtures(
+        "mock_is_mcp_tools_gallery_support_enabled",
+        "mock_lineage_manager",
+    )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_credentials")
@@ -237,6 +268,10 @@ class TestDataRobotMCPServer:
         with pytest.raises(Exception, match="Server failed to start"):
             server.run()
 
+    @pytest.mark.usefixtures(
+        "mock_is_mcp_tools_gallery_support_enabled",
+        "mock_lineage_manager",
+    )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_credentials")


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when lineage metadata sync runs (now during server startup) and adds new startup-time API calls gated by a feature flag, which could affect server boot behavior and error handling if misconfigured.
> 
> **Overview**
> Improves MCP lineage/metadata synchronization by moving the `LineageManager.sync_mcp_tools()`/`sync_mcp_prompts()` calls out of dynamic tool/prompt registration and into `DataRobotMCPServer.run()` (behind `FeatureFlag.is_mcp_tools_gallery_support_enabled()`), with a warning-only fallback when required LRS env vars are missing.
> 
> Cleans up unit tests accordingly (removes metadata-sync assertions from dynamic registration tests and adds server-level mocks/assertions) and bumps the package version to `0.14.3` with a matching changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e97754a372be6de826db89aeb3e195b098c4b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->