### PR TITLE
[BUZZOK-30222] Fix deployment info MCP tools to gracefully fall back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.14.4
+- Fixed deployment info MCP tools to gracefully handle errors (e.g. 404 for deleted projects)
+
 ## 0.14.3
 - Added `nat dragent` shell frontend for NAT - provides `nat dragent serve`, `nat dragent run`, and `nat dragent query` commands
 - MCP tool loading now gracefully falls back to empty tools on connection errors (CrewAI, LangGraph, LlamaIndex)
-- Fixed deployment info MCP tools to gracefully handle errors (e.g. 404 for deleted projects)
 
 ## 0.14.2
 - Implemented functions to instantiate LLM classes for LLM Gateway, deployment, NIM, and external

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.14.3
 - Added `nat dragent` shell frontend for NAT - provides `nat dragent serve`, `nat dragent run`, and `nat dragent query` commands
 - MCP tool loading now gracefully falls back to empty tools on connection errors (CrewAI, LangGraph, LlamaIndex)
+- Fixed deployment info MCP tools to gracefully handle errors (e.g. 404 for deleted projects)
 
 ## 0.14.2
 - Implemented functions to instantiate LLM classes for LLM Gateway, deployment, NIM, and external

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.14.3"
+version = "0.14.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/predictive/deployment.py
+++ b/src/datarobot_genai/drtools/predictive/deployment.py
@@ -51,7 +51,16 @@ async def get_model_info_from_deployment(
         raise ToolError("Deployment ID must be provided")
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    deployment = client.Deployment.get(deployment_id)
+    try:
+        deployment = client.Deployment.get(deployment_id)
+    except Exception as e:
+        error_str = str(e)
+        if "404" in error_str or "Not Found" in error_str:
+            raise ToolError(
+                f"Deployment '{deployment_id}' not found. Please verify the deployment ID exists "
+                "and you have access to it."
+            )
+        raise ToolError(f"Failed to retrieve deployment '{deployment_id}': {error_str}")
     return deployment.model
 
 
@@ -185,8 +194,19 @@ async def get_prediction_history(
     if end_time:
         params["endTime"] = end_time
 
-    response = rest_client.get(f"deployments/{deployment_id}/predictionResults/", params=params)
-    data = response.json()
+    try:
+        response = rest_client.get(f"deployments/{deployment_id}/predictionResults/", params=params)
+        data = response.json()
+    except Exception as e:
+        error_str = str(e)
+        if "404" in error_str or "Not Found" in error_str:
+            raise ToolError(
+                f"Deployment '{deployment_id}' not found or has no prediction history. "
+                "Please verify the deployment ID exists and you have access to it."
+            )
+        raise ToolError(
+            f"Failed to retrieve prediction history for deployment '{deployment_id}': {error_str}"
+        )
     rows = data.get("data", [])
     next_page = data.get("next")
 

--- a/src/datarobot_genai/drtools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drtools/predictive/deployment_info.py
@@ -46,7 +46,17 @@ async def get_deployment_info(
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    deployment = client.Deployment.get(deployment_id)
+
+    try:
+        deployment = client.Deployment.get(deployment_id)
+    except Exception as e:
+        error_str = str(e)
+        if "404" in error_str or "Not Found" in error_str:
+            raise ToolError(
+                f"Deployment '{deployment_id}' not found. Please verify the deployment ID exists "
+                "and you have access to it."
+            )
+        raise ToolError(f"Failed to retrieve deployment '{deployment_id}': {error_str}")
 
     # get features from the deployment
     features_raw = deployment.get_features()
@@ -68,8 +78,19 @@ async def get_deployment_info(
         target = ""
         target_type = ""
     else:
-        project = client.Project.get(deployment.model["project_id"])
-        model = client.Model.get(project=project, model_id=deployment.model["id"])
+        try:
+            project = client.Project.get(deployment.model["project_id"])
+            model = client.Model.get(project=project, model_id=deployment.model["id"])
+        except Exception as e:
+            error_str = str(e)
+            if "404" in error_str or "Not Found" in error_str:
+                raise ToolError(
+                    f"Project or model associated with deployment '{deployment_id}' not found. "
+                    "The deployment may reference a deleted project."
+                )
+            raise ToolError(
+                f"Failed to retrieve project/model for deployment '{deployment_id}': {error_str}"
+            )
         model_type = model.model_type
         target = project.target
         target_type = project.target_type

--- a/tests/drmcp/unit/predictive_tools/test_deployment.py
+++ b/tests/drmcp/unit/predictive_tools/test_deployment.py
@@ -115,9 +115,9 @@ async def test_get_model_info_from_deployment_not_found() -> None:
         patch("datarobot_genai.drtools.predictive.deployment.DataRobotClient") as mock_drc,
     ):
         mock_drc.return_value.get_client.return_value = mock_client
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ToolError) as exc_info:
             await deployment.get_model_info_from_deployment(deployment_id="dep_id")
-        assert "404 client error: {'message': 'Not Found'}" == str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/predictive_tools/test_deployment_info.py
+++ b/tests/drmcp/unit/predictive_tools/test_deployment_info.py
@@ -652,6 +652,69 @@ async def test_get_deployment_features_missing_fields(mock_get_info: Any) -> Non
 
 
 @pytest.mark.asyncio
+async def test_get_deployment_info_deployment_not_found() -> None:
+    """get_deployment_info raises ToolError when deployment ID doesn't exist."""
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.deployment_info.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.deployment_info.DataRobotClient") as mock_drc,
+    ):
+        mock_client = MagicMock()
+        mock_client.Deployment.get.side_effect = Exception(
+            "404 client error: {'message': 'Not Found'}"
+        )
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError, match=r"Deployment.*not found"):
+            await get_deployment_info(deployment_id="nonexistent_id")
+
+
+@pytest.mark.asyncio
+async def test_get_deployment_info_project_not_found() -> None:
+    """get_deployment_info raises ToolError when associated project doesn't exist."""
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.deployment_info.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.deployment_info.DataRobotClient") as mock_drc,
+    ):
+        mock_client = MagicMock()
+        mock_deployment = MagicMock()
+        mock_deployment.model = {"project_id": "deleted_proj", "id": "model123"}
+        mock_deployment.get_features.return_value = []
+        mock_deployment.get_capabilities.return_value = None
+        mock_client.Deployment.get.return_value = mock_deployment
+        mock_client.Project.get.side_effect = Exception(
+            "404 client error: {'message': \"Project with ID deleted_proj doesn't exist\"}"
+        )
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError, match=r"Project or model.*not found"):
+            await get_deployment_info(deployment_id="dep_with_deleted_project")
+
+
+@pytest.mark.asyncio
+async def test_get_deployment_info_other_error() -> None:
+    """get_deployment_info raises ToolError with context for non-404 errors."""
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.deployment_info.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.deployment_info.DataRobotClient") as mock_drc,
+    ):
+        mock_client = MagicMock()
+        mock_client.Deployment.get.side_effect = Exception("500 server error: internal failure")
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError, match=r"Failed to retrieve deployment"):
+            await get_deployment_info(deployment_id="dep_id")
+
+
+@pytest.mark.asyncio
 async def test_get_deployment_info_custom_model() -> None:
     class DummyDeployment:
         model: dict[str, Any] = {}


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

fixes error:
```
ERROR - Error in get_deployment_info: ClientError: 404 client error: {'message': "Project with ID [REDACTED] doesn't exist"}
```

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily wraps DataRobot SDK/REST calls with clearer `ToolError` messages for 404s and adds/adjusts unit tests; behavior changes are limited to error surfaces returned to callers.
> 
> **Overview**
> Improves the predictive deployment MCP tools’ resiliency by catching DataRobot client/REST exceptions and converting common 404/*Not Found* cases into actionable `ToolError` messages (e.g., missing deployments, deleted projects/models), with contextual errors for other failures.
> 
> Updates unit tests to assert `ToolError` behavior for these scenarios, and bumps the package version to `0.14.4` with a corresponding changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cffab23bb6ec85a43b51cb55c4612e9482afa951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->