### PR TITLE
Store and retrieve memory in NAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.1
+- Added opt-in memory retrieval and storage to the NAT base agent when prompts declare `{memory}`.
+
 ## 0.15.0
 - Migrated NAT dependencies from 1.4.1 to 1.6.0
     - Updated import path for tool_calling_agent (nat.agent -> nat.plugins.langchain.agent)

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.0"
+version = "0.15.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -133,6 +133,8 @@ class NatAgent(BaseAgent[None]):
 
         Chat history is automatically appended by `invoke` when
         max_history_messages > 0 (controlled via DATAROBOT_GENAI_MAX_HISTORY_MESSAGES env var).
+        Include a `{memory}` placeholder in the returned prompt to opt into
+        automatic long-term memory retrieval and storage for the run.
 
         Default implementation returns the raw user message content.
         """
@@ -155,7 +157,17 @@ class NatAgent(BaseAgent[None]):
 
         """
         # Build the user prompt from the template
+        user_prompt_content = extract_user_prompt_content(run_agent_input)
         user_prompt = self.make_user_prompt(run_agent_input)
+        uses_memory = "{memory}" in user_prompt
+
+        if uses_memory:
+            memory = ""
+            try:
+                memory = await self.retrieve_memory_for_run(user_prompt_content, run_agent_input)
+            except Exception as exc:
+                logger.warning("NAT memory retrieval failed: %s", exc)
+            user_prompt = user_prompt.replace("{memory}", memory)
 
         # Automatically inject chat history when enabled (max_history_messages > 0)
         history_summary = self.build_history_summary(run_agent_input)
@@ -244,6 +256,11 @@ class NatAgent(BaseAgent[None]):
                             usage_metrics["completion_tokens"] += token_usage.completion_tokens
 
                     pipeline_interactions = self.create_pipeline_interactions_from_steps(steps)
+                    if uses_memory:
+                        try:
+                            await self.store_memory_for_run(user_prompt_content, run_agent_input)
+                        except Exception as exc:
+                            logger.warning("NAT memory storage failed: %s", exc)
                     yield (
                         RunFinishedEvent(
                             type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id

--- a/tests/nat/test_agent.py
+++ b/tests/nat/test_agent.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -40,6 +42,7 @@ from ragas import MultiTurnSample
 from ragas.messages import AIMessage
 from ragas.messages import HumanMessage
 
+from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.nat.agent import NatAgent
 
 
@@ -64,6 +67,72 @@ def agent_with_headers(workflow_path):
             "Authorization": "Bearer test-api-key",
         },
     )
+
+
+class FakeMemoryClient(BaseMemoryClient):
+    def __init__(self, retrieved: str = "saved memory") -> None:
+        self.retrieved = retrieved
+        self.retrieve_calls: list[dict[str, Any]] = []
+        self.store_calls: list[dict[str, Any]] = []
+
+    async def retrieve(
+        self,
+        prompt: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> str:
+        self.retrieve_calls.append(
+            {
+                "prompt": prompt,
+                "run_id": run_id,
+                "agent_id": agent_id,
+                "app_id": app_id,
+                "attributes": attributes,
+            }
+        )
+        return self.retrieved
+
+    async def store(
+        self,
+        user_message: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        self.store_calls.append(
+            {
+                "user_message": user_message,
+                "run_id": run_id,
+                "agent_id": agent_id,
+                "app_id": app_id,
+                "attributes": attributes,
+            }
+        )
+
+
+class FailingMemoryClient(BaseMemoryClient):
+    async def retrieve(
+        self,
+        prompt: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> str:
+        raise RuntimeError("mem0 retrieve unavailable")
+
+    async def store(
+        self,
+        user_message: str,
+        run_id: str | None = None,
+        agent_id: str | None = None,
+        app_id: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        raise RuntimeError("mem0 store unavailable")
 
 
 @pytest.fixture
@@ -210,6 +279,148 @@ async def test_invoke_includes_chat_history(workflow_path):
     assert "user: First question" in text
     assert "assistant: First answer" in text
     assert text.startswith("Follow-up")
+
+
+@pytest.mark.usefixtures("mock_intermediate_structured", "mock_load_workflow")
+async def test_invoke_retrieves_and_stores_memory(workflow_path):
+    # GIVEN: a NAT agent whose prompt opts into memory
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    agent = NatAgent(workflow_path=workflow_path, memory_client=memory_client)
+    run_agent_input = RunAgentInput(
+        messages=[UserMessage(id="message_id", content="Memory:\n{memory}\n\nLatest: Follow-up")],
+        tools=[],
+        forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
+        thread_id="thread_id",
+        run_id="run_id",
+        state={},
+        context=[],
+    )
+    captured_prompts: list[str] = []
+    original = agent.make_chat_request
+
+    def capturing(user_prompt: str):  # type: ignore[no-untyped-def]
+        captured_prompts.append(user_prompt)
+        return original(user_prompt)
+
+    agent.make_chat_request = capturing  # type: ignore[assignment]
+
+    # WHEN: invoke is called
+    events = [event async for event in agent.invoke(run_agent_input)]
+
+    # THEN: retrieved memory is injected and the original user turn is persisted
+    assert isinstance(events[-1][0], RunFinishedEvent)
+    assert captured_prompts == ["Memory:\nUse concise answers.\n\nLatest: Follow-up"]
+    assert memory_client.retrieve_calls == [
+        {
+            "prompt": "Memory:\n{memory}\n\nLatest: Follow-up",
+            "run_id": None,
+            "agent_id": "NatAgent",
+            "app_id": "datarobot_genai.nat.agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+    assert memory_client.store_calls == [
+        {
+            "user_message": "Memory:\n{memory}\n\nLatest: Follow-up",
+            "run_id": "run_id",
+            "agent_id": "NatAgent",
+            "app_id": "datarobot_genai.nat.agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+
+
+@pytest.mark.usefixtures("mock_intermediate_structured", "mock_load_workflow")
+async def test_invoke_skips_memory_when_placeholder_is_absent(workflow_path, run_agent_input):
+    # GIVEN: a NAT agent whose prompt does not opt into memory
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    agent = NatAgent(workflow_path=workflow_path, memory_client=memory_client)
+
+    # WHEN: invoke is called
+    _ = [event async for event in agent.invoke(run_agent_input)]
+
+    # THEN: memory retrieval and storage are both skipped
+    assert memory_client.retrieve_calls == []
+    assert memory_client.store_calls == []
+
+
+@pytest.mark.usefixtures("mock_intermediate_structured", "mock_load_workflow")
+async def test_invoke_gracefully_degrades_when_memory_fails(workflow_path):
+    # GIVEN: a NAT agent whose memory provider errors at runtime
+    agent = NatAgent(workflow_path=workflow_path, memory_client=FailingMemoryClient())
+    run_agent_input = RunAgentInput(
+        messages=[UserMessage(id="message_id", content="Memory:\n{memory}\n\nLatest: Follow-up")],
+        tools=[],
+        forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
+        thread_id="thread_id",
+        run_id="run_id",
+        state={},
+        context=[],
+    )
+    captured_prompts: list[str] = []
+    original = agent.make_chat_request
+
+    def capturing(user_prompt: str):  # type: ignore[no-untyped-def]
+        captured_prompts.append(user_prompt)
+        return original(user_prompt)
+
+    agent.make_chat_request = capturing  # type: ignore[assignment]
+
+    # WHEN: invoke is called
+    events = [event async for event in agent.invoke(run_agent_input)]
+
+    # THEN: the run still completes and the unresolved placeholder is removed
+    assert isinstance(events[-1][0], RunFinishedEvent)
+    assert captured_prompts == ["Memory:\n\n\nLatest: Follow-up"]
+    assert "{memory}" not in captured_prompts[0]
+
+
+async def test_invoke_does_not_store_memory_when_workflow_fails(workflow_path):
+    async def failing_result_stream():
+        raise RuntimeError("workflow failed")
+        yield "unreachable"  # pragma: no cover
+
+    # GIVEN: a NAT agent whose workflow fails after memory retrieval
+    memory_client = FakeMemoryClient(retrieved="Use concise answers.")
+    agent = NatAgent(workflow_path=workflow_path, memory_client=memory_client)
+    run_agent_input = RunAgentInput(
+        messages=[UserMessage(id="message_id", content="Memory:\n{memory}\n\nLatest: Follow-up")],
+        tools=[],
+        forwarded_props=dict(model="m", authorization_context={}, forwarded_headers={}),
+        thread_id="thread_id",
+        run_id="run_id",
+        state={},
+        context=[],
+    )
+    intermediate_future: asyncio.Future[list[IntermediateStep]] = asyncio.Future()
+    intermediate_future.set_result([])
+    mock_run = MagicMock()
+    mock_run.return_value.__aenter__.return_value = AsyncMock(result_stream=failing_result_stream)
+    mock_session = MagicMock()
+    mock_session.return_value.__aenter__.return_value = AsyncMock(run=mock_run)
+
+    with (
+        patch("datarobot_genai.nat.agent.pull_intermediate_structured") as mock_intermediate,
+        patch("datarobot_genai.nat.agent.load_workflow", new_callable=MagicMock) as mock_load,
+    ):
+        mock_intermediate.return_value = intermediate_future
+        mock_load.return_value.__aenter__.return_value = AsyncMock(session=mock_session)
+
+        # WHEN: invoke is called and the workflow fails
+        with pytest.raises(RuntimeError, match="workflow failed"):
+            _ = [event async for event in agent.invoke(run_agent_input)]
+
+    # THEN: retrieval happens, but storage is skipped because the run never finishes
+    assert memory_client.retrieve_calls == [
+        {
+            "prompt": "Memory:\n{memory}\n\nLatest: Follow-up",
+            "run_id": None,
+            "agent_id": "NatAgent",
+            "app_id": "datarobot_genai.nat.agent",
+            "attributes": {"thread_id": "thread_id"},
+        }
+    ]
+    assert memory_client.store_calls == []
 
 
 @pytest.mark.usefixtures("mock_intermediate_structured", "mock_load_workflow")

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Allows NAT to store and retrieve memory

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `NatAgent.invoke()` execution path and prompt construction, which could affect runtime behavior, but the feature is explicitly opt-in and failures degrade to warnings and empty memory.
> 
> **Overview**
> Adds **opt-in long-term memory** support to `NatAgent.invoke()` by detecting a `{memory}` placeholder in the user prompt, retrieving memory to inline into the prompt, and storing the original user turn after a successful run (with warning-only failure handling).
> 
> Extends NAT agent tests to cover memory retrieve/store, skipping when the placeholder is absent, graceful degradation when the memory backend errors, and ensuring memory is not stored if the workflow fails; also bumps the package version to `0.15.1` and updates the changelog/lockfiles accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13639cdd92154a5a4ccb79053b5fd502f98265c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->