### PR TITLE
[BUZZOK-29643] Suppressed CrewAI MCPServerAdapter when not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.2
+- Suppressed CrewAI MCPServerAdapter thread exceptions to prevent large tracebacks when MCP server is unavailable
+
 ## 0.15.1
 - Added opt-in memory retrieval and storage to the NAT base agent when prompts declare `{memory}`.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.1"
+version = "0.15.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -19,6 +19,7 @@ This module provides MCP server connection management for CrewAI agents.
 """
 
 import logging
+import threading
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -43,14 +44,26 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
     url = mcp_config.server_config["url"]
     logger.info("Connecting to MCP server: %s", url)
 
+    # MCPServerAdapter uses a background thread that prints a huge traceback
+    # to stderr when it can't connect. Suppress it so our graceful fallback
+    # is the only output the user sees.
+    original_excepthook = threading.excepthook
+
+    def _suppress_mcp_thread_exceptions(args: threading.ExceptHookArgs) -> None:
+        logger.debug("Suppressed MCPServerAdapter thread exception: %s", args.exc_value)
+
     try:
+        threading.excepthook = _suppress_mcp_thread_exceptions
         with MCPServerAdapter(mcp_config.server_config) as tools:
+            threading.excepthook = original_excepthook
             logger.info("Successfully connected to MCP server, got %d tools", len(tools))
             yield tools
-    except (ConnectionError, OSError, TimeoutError, ExceptionGroup) as exc:
+    except (ConnectionError, OSError, TimeoutError, ExceptionGroup, RuntimeError) as exc:
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
             url,
             exc,
         )
         yield []
+    finally:
+        threading.excepthook = original_excepthook

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

MCPServerAdapter uses a background thread that prints a huge traceback to stderr when it can't connect. Suppress it so our graceful fallback is the only output the user sees.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Temporarily overrides the process-wide `threading.excepthook`, which could mask unrelated thread exceptions if other threads fail during the connection window (though it is restored in `finally`).
> 
> **Overview**
> Improves CrewAI MCP tool loading to *quietly* fall back when the MCP server is unreachable by temporarily overriding `threading.excepthook` around `MCPServerAdapter` setup, preventing large background-thread tracebacks from being printed.
> 
> Also broadens the handled connection-failure exceptions to include `RuntimeError`, and bumps the package version to `0.15.2` (changelog + lockfiles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2955e6e1806799bfb5b5808440d852e92ca577d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->