### PR TITLE
[BUZZOK-30387] Standalone documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.3
-- README.md and standalone documentation
+- Added README.md and standalone documentation
 
 ## 0.15.2
 - Removed the dedicated S3 client module from `drtools.core.clients` (S3 is no longer exposed as a first-class tool client here).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.15.3
+## 0.15.5
 - Added README.md and standalone documentation
+- Documented AG-UI integration, multi-agent patterns, and the unified DataRobot-compatible LLM layer (`get_llm()`, shared `Config` / environment) in the root and docs READMEs
 
 ## 0.15.2
 - Removed the dedicated S3 client module from `drtools.core.clients` (S3 is no longer exposed as a first-class tool client here).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.3
+- README.md and standalone documentation
+
 ## 0.15.2
 - Removed the dedicated S3 client module from `drtools.core.clients` (S3 is no longer exposed as a first-class tool client here).
 - Removed the `predict_by_file_path` predictive tool; use catalog or dataset-based prediction flows instead.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,14 @@
 
 
 ## Features
-- Utilities for common GenAI workflows
-- Integrations: CrewAI, LangGraph, LlamaIndex, NAT, MCP
+
+- **AG-UI integration** — Agents expose a standard **AG-UI** event stream (`RunAgentInput` in, lifecycle + text + tool-call events out), so UIs and the DataRobot platform can render runs consistently without bespoke adapters per framework.
+- **Multi-agent systems out of the box** — First-class patterns for **planner/writer crews**, **LangGraph** multi-node graphs, and **LlamaIndex** `AgentWorkflow` handoffs; wrap them with one helper and keep the same streaming contract.
+- **Unified LLM layer (DataRobot-compatible)** — One **`get_llm()`** entry point per integration (**LangGraph**, **LlamaIndex**, **CrewAI**), all backed by the same **LiteLLM**-based routing to the **DataRobot LLM Gateway**, **LLM deployments**, **NIM**, or external providers—driven by the same environment and `Config`, so every component speaks to DataRobot consistently.
+- Utilities for common GenAI workflows.
+- **Integrations:** CrewAI, LangGraph, LlamaIndex, NAT, MCP.
+
+User-facing walkthrough: [docs/README.md](docs/README.md).
 
 ## Installation
 - Requires Python 3.11–3.13.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,11 +16,17 @@
 </p>
 
 Build AI agents with your favorite framework and run them on the DataRobot platform.
-`datarobot-genai` provides thin integration layers for **LangGraph**, **LlamaIndex**, and **CrewAI** so you can:
+`datarobot-genai` provides thin integration layers for **LangGraph**, **LlamaIndex**, and **CrewAI**.
 
-* Use the **DataRobot LLM Gateway** as the model backend (no API keys to manage).
-* Wrap your agent graph/workflow into a **DataRobot-compatible agent class** with one function call.
-* Stream AG-UI events (text, tool calls, steps) back to the DataRobot frontend.
+**AG-UI** — The library is built around the **Agent UI (AG-UI) protocol**: your agent’s `invoke()` takes `RunAgentInput` and **streams AG-UI events** (run lifecycle, streaming text, tool calls, steps/reasoning where applicable). That gives you a **single contract** for chat UIs, observability, and DataRobot-hosted frontends—no per-framework wire-up.
+
+**Multi-agent, out of the box** — You are not limited to a single LLM turn. The same wrappers support **multi-step and multi-role workflows** from day one: LangGraph graphs with several nodes, LlamaIndex `AgentWorkflow` with handoffs, and CrewAI crews with sequential tasks—each mapped to the same AG-UI stream.
+
+**Unified LLM layer** — Regardless of framework, you use the same pattern: **`get_llm()`** in `datarobot_genai.langgraph`, `llama_index`, or `crewai` returns that stack’s native client, but **routing is unified**: **LiteLLM** to the **DataRobot LLM Gateway**, a **deployment**, **NIM**, or an external model—selected from one **`Config`** / environment (`DATAROBOT_API_TOKEN`, `DATAROBOT_ENDPOINT`, `USE_DATAROBOT_LLM_GATEWAY`, `LLM_DEPLOYMENT_ID`, and related vars). All agent components therefore share a **single DataRobot-compatible LLM story** instead of ad hoc endpoints per integration.
+
+You also get:
+
+* **One-call wrapping** — `datarobot_agent_class_from_*` turns your graph, workflow, or crew into a **DataRobot-compatible agent class**.
 
 ## Prerequisites
 
@@ -56,11 +62,11 @@ pip install "datarobot-genai[langgraph,llamaindex,crewai]"
 
 ## Quick overview
 
-Every framework integration follows the same three-step pattern:
+Every framework integration follows the same pattern—**one unified LLM setup, multi-agent optional, AG-UI always**:
 
-1. **Get an LLM** — call `get_llm()` from the framework sub-package. It reads your DataRobot credentials from the environment and returns a framework-native LLM object.
-2. **Define your agent** — build your graph / workflow / crew using the framework's own API.
-3. **Wrap it** — call the `datarobot_agent_class_from_*` helper to produce a `BaseAgent` subclass that streams AG-UI events.
+1. **Get an LLM** — call `get_llm()` from `datarobot_genai.langgraph`, `llama_index`, or `crewai`. The same **DataRobot-aligned configuration** applies everywhere; you receive a **framework-native** chat client wired through the **unified LiteLLM layer**.
+2. **Define your agent** — one agent or many: build a **LangGraph** `StateGraph`, a **LlamaIndex** `AgentWorkflow`, or a **CrewAI** `Crew` using the framework’s native APIs.
+3. **Wrap it** — call `datarobot_agent_class_from_*` to get a `BaseAgent` subclass whose **`invoke()` streams AG-UI events** (text, tools, steps) to any compatible UI or platform.
 
 ## Framework guides
 
@@ -97,15 +103,16 @@ The library reads configuration from environment variables (via `datarobot-genai
 
 ```
 ┌─────────────────────────────────────────────┐
-│  Your agent code (LangGraph / LlamaIndex /  │
-│  CrewAI graph definition)                   │
+│  Multi-agent graph / workflow / crew        │  ← LangGraph, LlamaIndex, CrewAI
 ├─────────────────────────────────────────────┤
 │  datarobot_agent_class_from_*()             │  ← thin wrapper
-│  BaseAgent.invoke() → AG-UI event stream    │
+│  BaseAgent.invoke(RunAgentInput)            │
+│       → async stream of AG-UI Events        │  ← AG-UI protocol
 ├─────────────────────────────────────────────┤
-│  get_llm() → framework-native LLM client   │  ← LiteLLM under the hood
+│  Unified LLM layer: get_llm() per stack      │  ← same Config / env for all
+│       → framework-native LLM client         │  ← LiteLLM
 ├─────────────────────────────────────────────┤
-│  DataRobot LLM Gateway / Deployment / NIM   │
+│  DataRobot Gateway / Deployment / NIM / ext  │  ← DataRobot-compatible routing
 └─────────────────────────────────────────────┘
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,114 @@
+<p align="center">
+  <a href="https://github.com/datarobot-oss/datarobot-genai">
+    <img src="img/datarobot_logo.avif" width="600px" alt="DataRobot Logo"/>
+  </a>
+</p>
+<p align="center">
+    <span style="font-size: 1.5em; font-weight: bold; display: block;">DataRobot GenAI Library</span>
+</p>
+
+<p align="center">
+  <a href="https://www.datarobot.com/">Homepage</a>
+  ·
+  <a href="https://pypi.org/project/datarobot-genai/">PyPI</a>
+  ·
+  <a href="https://docs.datarobot.com/en/docs/get-started/troubleshooting/general-help.html">Support</a>
+</p>
+
+Build AI agents with your favorite framework and run them on the DataRobot platform.
+`datarobot-genai` provides thin integration layers for **LangGraph**, **LlamaIndex**, and **CrewAI** so you can:
+
+* Use the **DataRobot LLM Gateway** as the model backend (no API keys to manage).
+* Wrap your agent graph/workflow into a **DataRobot-compatible agent class** with one function call.
+* Stream AG-UI events (text, tool calls, steps) back to the DataRobot frontend.
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| Python | 3.11 – 3.13 |
+| DataRobot account | You need an API token and endpoint |
+
+Set the following environment variables (or put them in a `.env` file):
+
+```bash
+export DATAROBOT_API_TOKEN="<your-api-token>"
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"   # adjust for your environment
+```
+
+## Installation
+
+Install the base package plus the extra for your framework of choice:
+
+```bash
+# LangGraph
+pip install "datarobot-genai[langgraph]"
+
+# LlamaIndex
+pip install "datarobot-genai[llamaindex]"
+
+# CrewAI
+pip install "datarobot-genai[crewai]"
+
+# Multiple frameworks at once
+pip install "datarobot-genai[langgraph,llamaindex,crewai]"
+```
+
+## Quick overview
+
+Every framework integration follows the same three-step pattern:
+
+1. **Get an LLM** — call `get_llm()` from the framework sub-package. It reads your DataRobot credentials from the environment and returns a framework-native LLM object.
+2. **Define your agent** — build your graph / workflow / crew using the framework's own API.
+3. **Wrap it** — call the `datarobot_agent_class_from_*` helper to produce a `BaseAgent` subclass that streams AG-UI events.
+
+## Framework guides
+
+| Framework | Guide | Example | Extend the example |
+|---|---|---|---|
+| LangGraph | [docs/langgraph/](langgraph/) | [langgraph/agent_example.py](langgraph/agent_example.py) | [langgraph/AGENTS.md](langgraph/AGENTS.md) |
+| LlamaIndex | [docs/llamaindex/](llamaindex/) | [llamaindex/agent_example.py](llamaindex/agent_example.py) | [llamaindex/AGENTS.md](llamaindex/AGENTS.md) |
+| CrewAI | [docs/crewai/](crewai/) | [crewai/agent_example.py](crewai/agent_example.py) | [crewai/AGENTS.md](crewai/AGENTS.md) |
+
+## Configuration reference
+
+The library reads configuration from environment variables (via `datarobot-genai.core.config.Config`):
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATAROBOT_API_TOKEN` | — | Your DataRobot API token |
+| `DATAROBOT_ENDPOINT` | `https://app.datarobot.com/api/v2` | DataRobot API endpoint |
+| `USE_DATAROBOT_LLM_GATEWAY` | `true` | When `true`, route LLM calls through the DataRobot LLM Gateway |
+| `LLM_DEPLOYMENT_ID` | — | Use a specific LLM deployment instead of the gateway |
+| `NIM_DEPLOYMENT_ID` | — | Use an NVIDIA NIM deployment |
+| `LLM_DEFAULT_MODEL` | `datarobot-deployed-llm` | Default model name passed to LiteLLM |
+| `DATAROBOT_GENAI_MAX_HISTORY_MESSAGES` | `20` | Max prior messages included in chat history |
+
+### LLM routing
+
+`get_llm()` picks the backend automatically based on which variables are set:
+
+1. `USE_DATAROBOT_LLM_GATEWAY=true` (default) → DataRobot LLM Gateway
+2. `LLM_DEPLOYMENT_ID` is set → DataRobot deployment proxy
+3. `NIM_DEPLOYMENT_ID` is set → NVIDIA NIM deployment
+4. None of the above → external LiteLLM (reads provider keys from the environment)
+
+## Architecture at a glance
+
+```
+┌─────────────────────────────────────────────┐
+│  Your agent code (LangGraph / LlamaIndex /  │
+│  CrewAI graph definition)                   │
+├─────────────────────────────────────────────┤
+│  datarobot_agent_class_from_*()             │  ← thin wrapper
+│  BaseAgent.invoke() → AG-UI event stream    │
+├─────────────────────────────────────────────┤
+│  get_llm() → framework-native LLM client   │  ← LiteLLM under the hood
+├─────────────────────────────────────────────┤
+│  DataRobot LLM Gateway / Deployment / NIM   │
+└─────────────────────────────────────────────┘
+```
+
+## License
+
+Apache-2.0 — see [LICENSE](../LICENSE).

--- a/docs/crewai/AGENTS.md
+++ b/docs/crewai/AGENTS.md
@@ -1,0 +1,54 @@
+<!--
+  ~ Copyright 2026 DataRobot, Inc. and its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+# Developing from this CrewAI example
+
+Use [agent_example.py](agent_example.py) as a starting point for a DataRobot-backed CrewAI crew.
+
+## What this example does
+
+- **`get_llm()`** — returns a CrewAI `LLM` using LiteLLM against the DataRobot LLM Gateway.
+- **`Agent` / `Task` / `Crew`** — standard CrewAI objects. Task `description` and agent `goal` / `backstory` use placeholders such as `{topic}`; they must match keys returned by `kickoff_inputs`.
+- **`kickoff_inputs(user_prompt)`** — maps the incoming user string to `crew.kickoff_async(inputs=...)`. Include `"chat_history": ""` to opt into automatic multi-turn history (the base class fills it from prior messages).
+- **`datarobot_agent_class_from_crew(crew, agents, tasks, kickoff_inputs)`** — merges injected tools with each agent’s original tools on `set_tools`.
+
+## Typical changes
+
+1. **More tasks or agents** — add `Agent` and `Task` rows, order tasks in `tasks`, and keep `Crew(agents=..., tasks=..., stream=True)` aligned with CrewAI’s execution order.
+2. **New placeholders** — add keys to `kickoff_inputs` and use `{key}` in task descriptions and agent goals consistently.
+3. **Tools** — register CrewAI tools (for example `@tool`) on agents; injected tools are appended by the DataRobot wrapper.
+4. **Chat history** — use `{chat_history}` in descriptions and return `"chat_history": ""` from `kickoff_inputs` so the base class can inject a transcript.
+5. **Avoid lambda for kickoff** — use a named `def kickoff_inputs(...)` so you can add logic (parsing JSON user prompts, default values).
+
+## Run and debug
+
+```bash
+export DATAROBOT_API_TOKEN="..."
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+python docs/crewai/agent_example.py
+```
+
+Use `verbose=True` on the agent if you need Crew/agent verbosity.
+
+## Where to look in the library
+
+- `datarobot_genai.crewai.agent` — `CrewAIAgent`, `datarobot_agent_class_from_crew`
+- `datarobot_genai.crewai.llm` — `get_llm`
+- `datarobot_genai.core.agents` — `make_system_prompt`, `BaseAgent`
+
+## Reference implementation
+
+See `e2e-tests/dragent/crewai/myagent.py` for a fuller crew (extra tools, history in tasks).

--- a/docs/crewai/README.md
+++ b/docs/crewai/README.md
@@ -1,0 +1,65 @@
+# CrewAI + DataRobot
+
+Build a CrewAI crew and run it as a DataRobot agent.
+
+## Installation
+
+```bash
+pip install "datarobot-genai[crewai]"
+```
+
+## Key imports
+
+```python
+from datarobot_genai.crewai.llm import get_llm
+from datarobot_genai.crewai.agent import datarobot_agent_class_from_crew
+from datarobot_genai.core.agents import make_system_prompt
+```
+
+## How it works
+
+1. **`get_llm()`** returns a CrewAI `LLM` instance backed by the DataRobot LLM Gateway (via LiteLLM). It reads `DATAROBOT_API_TOKEN` and `DATAROBOT_ENDPOINT` from the environment.
+
+2. **Define your crew** using the standard CrewAI `Agent`, `Task`, and `Crew` API. Define agents with roles, goals, and backstories; tasks with descriptions and expected outputs.
+
+3. **`datarobot_agent_class_from_crew(crew, agents, tasks, kickoff_inputs)`** produces a `CrewAIAgent` subclass that:
+   - Runs `crew.kickoff_async()` with your inputs.
+   - Streams AG-UI events (text, reasoning, tool calls, step transitions) to the DataRobot frontend.
+   - Propagates the platform-injected LLM and tools to every agent at runtime.
+   - Tracks token usage from CrewAI output.
+
+### `kickoff_inputs` callable
+
+You provide a function that maps the raw user prompt to the dictionary of inputs your tasks expect:
+
+```python
+kickoff_inputs = lambda user_prompt: {
+    "topic": user_prompt,
+    "chat_history": "",   # include this key to opt into automatic history injection
+}
+```
+
+The keys must match the `{placeholders}` used in your task descriptions and agent goals.
+
+## Chat history
+
+History injection is **opt-in**. Include a `"chat_history"` key with an empty string value in your kickoff inputs. The wrapper auto-populates it with prior conversation turns. Use `{chat_history}` in your task descriptions or agent backstories.
+
+## Streaming
+
+CrewAI crews are created with `stream=True` by default in the wrapper. The agent streams text chunks, reasoning steps, and tool calls as they happen.
+
+## Example
+
+See [agent_example.py](agent_example.py) for a complete, runnable planner + writer crew.
+
+```bash
+export DATAROBOT_API_TOKEN="<token>"
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+
+python docs/crewai/agent_example.py
+```
+
+## Developing from this example
+
+See [AGENTS.md](AGENTS.md) for how to extend the crew, tasks, `kickoff_inputs`, and tools.

--- a/docs/crewai/agent_example.py
+++ b/docs/crewai/agent_example.py
@@ -1,0 +1,127 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal CrewAI agent running on DataRobot.
+
+Two-agent crew: a planner creates a bullet-point outline, then a writer turns
+it into a short paragraph.  Uses the DataRobot LLM Gateway for model calls.
+
+Prerequisites
+-------------
+pip install "datarobot-genai[crewai]"
+
+Environment variables
+---------------------
+DATAROBOT_API_TOKEN  – your DataRobot API token
+DATAROBOT_ENDPOINT   – e.g. https://app.datarobot.com/api/v2
+
+How to extend this example
+--------------------------
+See AGENTS.md next to this file.
+"""
+
+import asyncio
+import uuid
+
+from ag_ui.core import Message
+from ag_ui.core import RunAgentInput
+from crewai import Agent
+from crewai import Crew
+from crewai import Task
+
+from datarobot_genai.core.agents import make_system_prompt
+from datarobot_genai.crewai.agent import datarobot_agent_class_from_crew
+from datarobot_genai.crewai.llm import get_llm
+
+# ---------------------------------------------------------------------------
+# 1. Get a DataRobot-backed LLM
+# ---------------------------------------------------------------------------
+llm = get_llm()
+
+# ---------------------------------------------------------------------------
+# 2. Define CrewAI agents and tasks
+# ---------------------------------------------------------------------------
+agent_planner = Agent(
+    role="Content Planner",
+    goal="Create a short bullet-point outline with 3-5 key points about: {topic}.",
+    backstory=make_system_prompt(
+        "You are a content planner. Given a topic, produce a short "
+        "bullet-point outline with 3-5 key points."
+    ),
+    llm=llm,
+)
+
+agent_writer = Agent(
+    role="Content Writer",
+    goal="Write a 2-3 sentence response based on the planner's outline about: {topic}.",
+    backstory=make_system_prompt(
+        "You are a concise writer. Using the planner's outline, "
+        "write a short response in 2-3 sentences."
+    ),
+    llm=llm,
+)
+
+agents = [agent_planner, agent_writer]
+
+task_planner = Task(
+    description="Create a short outline about: {topic}.",
+    expected_output="A bullet-point outline with 3-5 key points.",
+    agent=agent_planner,
+)
+
+task_writer = Task(
+    description="Using the planner's outline, write a short response about: {topic}.",
+    expected_output="A concise 2-3 sentence response.",
+    agent=agent_writer,
+)
+
+tasks = [task_planner, task_writer]
+
+crew = Crew(agents=agents, tasks=tasks, stream=True)
+
+# ---------------------------------------------------------------------------
+# 3. Wrap into a DataRobot agent class
+# ---------------------------------------------------------------------------
+
+
+def kickoff_inputs(user_prompt: str) -> dict[str, str]:
+    return {
+        "topic": user_prompt,
+        "chat_history": "",
+    }
+
+
+MyAgent = datarobot_agent_class_from_crew(crew, agents, tasks, kickoff_inputs)
+
+
+# ---------------------------------------------------------------------------
+# 4. Run it locally
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    agent = MyAgent(llm=llm)
+
+    run_input = RunAgentInput(
+        thread_id=str(uuid.uuid4()),
+        run_id=str(uuid.uuid4()),
+        messages=[Message(role="user", content="Benefits of Python for data science")],
+    )
+
+    async for event, _interactions, usage in agent.invoke(run_input):
+        print(event)
+
+    print(f"\nToken usage: {usage}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/langgraph/AGENTS.md
+++ b/docs/langgraph/AGENTS.md
@@ -1,0 +1,54 @@
+<!--
+  ~ Copyright 2026 DataRobot, Inc. and its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+# Developing from this LangGraph example
+
+Use [agent_example.py](agent_example.py) as a starting point for a DataRobot-backed LangGraph agent.
+
+## What this example does
+
+- **`get_llm()`** — wires the LangChain chat model to the DataRobot LLM Gateway (env: `DATAROBOT_API_TOKEN`, `DATAROBOT_ENDPOINT`).
+- **`graph_factory(llm, tools, verbose)`** — builds an uncompiled `StateGraph`. The platform can inject extra `tools` (for example MCP); merge them into your agents like the e2e tests: `tools=[...] + tools` or pass `tools` into `create_agent`.
+- **`prompt_template`** — shapes each user turn. Variables in the template (for example `{topic}`, `{chat_history}`) must match what you pass from the user message (JSON object or plain text mapping in `LangGraphAgent.convert_input_message`).
+- **`datarobot_agent_class_from_langgraph(...)`** — produces a class whose `invoke()` streams AG-UI events.
+
+## Typical changes
+
+1. **Add nodes or edges** — extend `graph_factory`: new `graph.add_node`, `add_edge`, or conditional routing. Keep the factory signature `(llm, tools, verbose)` so the wrapper stays valid.
+2. **Add tools** — define LangChain `@tool` functions or `StructuredTool` instances and include them in `create_agent(..., tools=[my_tool] + tools, ...)`.
+3. **Prompts** — adjust `ChatPromptTemplate` and `make_system_prompt(...)` strings. If you add `{chat_history}` to the template, prior turns are injected automatically.
+4. **Structured input** — if the last user message is JSON, keys can fill template variables (for example `"topic": "..."`).
+5. **Subclass instead of the helper** — for full control, subclass `LangGraphAgent`, implement `workflow` and `prompt_template`, and keep the same `invoke` contract.
+
+## Run and debug
+
+```bash
+export DATAROBOT_API_TOKEN="..."
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+python docs/langgraph/agent_example.py
+```
+
+Set `verbose=True` on `MyAgent(..., verbose=True)` to enable LangGraph debug output from the factory.
+
+## Where to look in the library
+
+- `datarobot_genai.langgraph.agent` — `LangGraphAgent`, `datarobot_agent_class_from_langgraph`
+- `datarobot_genai.langgraph.llm` — `get_llm` and deployment/gateway helpers
+- `datarobot_genai.core.agents` — `make_system_prompt`, `BaseAgent`
+
+## Reference implementation
+
+The e2e agent under `e2e-tests/dragent/langgraph/myagent.py` follows the same pattern with an extra tool and NAT-injected LLM; compare when wiring production deployments.

--- a/docs/langgraph/README.md
+++ b/docs/langgraph/README.md
@@ -1,0 +1,66 @@
+# LangGraph + DataRobot
+
+Build a multi-agent LangGraph workflow and run it as a DataRobot agent.
+
+## Installation
+
+```bash
+pip install "datarobot-genai[langgraph]"
+```
+
+## Key imports
+
+```python
+from datarobot_genai.langgraph.llm import get_llm
+from datarobot_genai.langgraph.agent import datarobot_agent_class_from_langgraph
+from datarobot_genai.core.agents import make_system_prompt
+```
+
+## How it works
+
+1. **`get_llm()`** returns a LangChain `BaseChatModel` backed by the DataRobot LLM Gateway (via LiteLLM). It reads `DATAROBOT_API_TOKEN` and `DATAROBOT_ENDPOINT` from the environment.
+
+2. **Define your graph** using the standard LangGraph `StateGraph` API. Write a *graph factory* function with the signature:
+
+   ```python
+   def graph_factory(
+       llm: BaseChatModel,
+       tools: list[BaseTool],
+       verbose: bool,
+   ) -> StateGraph[MessagesState]:
+       ...
+   ```
+
+   The factory receives the LLM, any platform-injected tools, and a verbosity flag. Return an **uncompiled** `StateGraph` — the wrapper compiles it at invocation time.
+
+3. **`datarobot_agent_class_from_langgraph(graph_factory, prompt_template)`** produces a `LangGraphAgent` subclass (inheriting from `BaseAgent`) that:
+   - Compiles and runs your graph on every call.
+   - Streams AG-UI events (text messages, tool calls, run lifecycle) to the DataRobot frontend.
+   - Automatically tracks token usage.
+
+## Chat history
+
+History injection is **opt-in**. If your `ChatPromptTemplate` declares a `{chat_history}` input variable, prior conversation turns are automatically included. Otherwise no history is passed.
+
+```python
+prompt_template = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant. {chat_history}"),
+    ("user", "{topic}"),
+])
+```
+
+## Example
+
+See [agent_example.py](agent_example.py) for a complete, runnable two-agent (planner + writer) workflow.
+
+```bash
+# Set environment
+export DATAROBOT_API_TOKEN="<token>"
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+
+python docs/langgraph/agent_example.py
+```
+
+## Developing from this example
+
+See [AGENTS.md](AGENTS.md) for how to extend the graph, tools, prompts, and integration points.

--- a/docs/langgraph/agent_example.py
+++ b/docs/langgraph/agent_example.py
@@ -1,0 +1,130 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal LangGraph agent running on DataRobot.
+
+Two-agent pipeline: a planner creates a bullet-point outline, then a writer
+turns it into a short paragraph.  Uses the DataRobot LLM Gateway for model
+calls.
+
+Prerequisites
+-------------
+pip install "datarobot-genai[langgraph]"
+
+Environment variables
+---------------------
+DATAROBOT_API_TOKEN  – your DataRobot API token
+DATAROBOT_ENDPOINT   – e.g. https://app.datarobot.com/api/v2
+
+How to extend this example
+--------------------------
+See AGENTS.md next to this file.
+"""
+
+import asyncio
+import uuid
+
+from ag_ui.core import Message
+from ag_ui.core import RunAgentInput
+from langchain.agents import create_agent
+from langchain.chat_models import BaseChatModel
+from langchain.tools import BaseTool
+from langchain_core.prompts import ChatPromptTemplate
+from langgraph.graph import END
+from langgraph.graph import START
+from langgraph.graph import MessagesState
+from langgraph.graph import StateGraph
+
+from datarobot_genai.core.agents import make_system_prompt
+from datarobot_genai.langgraph.agent import datarobot_agent_class_from_langgraph
+from datarobot_genai.langgraph.llm import get_llm
+
+# ---------------------------------------------------------------------------
+# 1. Get a DataRobot-backed LLM
+# ---------------------------------------------------------------------------
+llm = get_llm()
+
+# ---------------------------------------------------------------------------
+# 2. Define the LangGraph workflow via a factory function
+# ---------------------------------------------------------------------------
+prompt_template = ChatPromptTemplate.from_messages(
+    [
+        ("system", "You are a helpful assistant. {chat_history}"),
+        ("user", "{topic}"),
+    ]
+)
+
+
+def graph_factory(
+    llm: BaseChatModel,
+    tools: list[BaseTool],
+    verbose: bool = False,
+) -> StateGraph[MessagesState]:
+    planner = create_agent(
+        llm,
+        tools=tools,
+        system_prompt=make_system_prompt(
+            "You are a content planner. Given a topic, produce a short "
+            "bullet-point outline with 3-5 key points."
+        ),
+        name="planner",
+        debug=verbose,
+    )
+
+    writer = create_agent(
+        llm,
+        tools=tools,
+        system_prompt=make_system_prompt(
+            "You are a concise writer. Using the planner's outline, "
+            "write a short response in 2-3 sentences."
+        ),
+        name="writer",
+        debug=verbose,
+    )
+
+    graph = StateGraph(MessagesState)
+    graph.add_node("planner", planner)
+    graph.add_node("writer", writer)
+    graph.add_edge(START, "planner")
+    graph.add_edge("planner", "writer")
+    graph.add_edge("writer", END)
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# 3. Wrap into a DataRobot agent class
+# ---------------------------------------------------------------------------
+MyAgent = datarobot_agent_class_from_langgraph(graph_factory, prompt_template)
+
+
+# ---------------------------------------------------------------------------
+# 4. Run it locally
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    agent = MyAgent(llm=llm)
+
+    run_input = RunAgentInput(
+        thread_id=str(uuid.uuid4()),
+        run_id=str(uuid.uuid4()),
+        messages=[Message(role="user", content="Benefits of Python for data science")],
+    )
+
+    async for event, _interactions, usage in agent.invoke(run_input):
+        print(event)
+
+    print(f"\nToken usage: {usage}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/llamaindex/AGENTS.md
+++ b/docs/llamaindex/AGENTS.md
@@ -1,0 +1,53 @@
+<!--
+  ~ Copyright 2026 DataRobot, Inc. and its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+# Developing from this LlamaIndex example
+
+Use [agent_example.py](agent_example.py) as a starting point for a DataRobot-backed LlamaIndex `AgentWorkflow`.
+
+## What this example does
+
+- **`get_llm()`** — returns a LlamaIndex LiteLLM client pointed at the DataRobot LLM Gateway.
+- **`FunctionAgent` instances** — each has a name, system prompt, `llm`, optional tools, and optional `can_handoff_to` for multi-agent routing.
+- **`AgentWorkflow`** — `root_agent` is the entry agent; handoffs follow `can_handoff_to`.
+- **`extract_response_text(state, events)`** — required by `datarobot_agent_class_from_llamaindex`. Adjust it if your workflow stores the final answer elsewhere (for example last `AgentOutput` event).
+- **`datarobot_agent_class_from_llamaindex(workflow, agents, extract_response_text)`** — at runtime, `set_llm` / `set_tools` on the DataRobot class updates every `FunctionAgent` in `agents`.
+
+## Typical changes
+
+1. **More agents** — add another `FunctionAgent`, list it in `agents`, wire `can_handoff_to` / workflow edges as LlamaIndex expects, and set `AgentWorkflow(..., root_agent="...")` appropriately.
+2. **Tools** — attach `FunctionTool` (or LlamaIndex tools) to each agent. Injected platform tools are appended in the wrapper; keep agent-specific tools on the agent when you build the workflow.
+3. **Model** — pass `model_name="datarobot/your-model"` to `get_llm(...)` if you do not rely on `LLM_DEFAULT_MODEL` in the environment.
+4. **History / memory** — in user messages you can include placeholders `{chat_history}` and `{memory}` in the string sent to `workflow.run`; see `LlamaIndexAgent.invoke` in the library for behavior.
+5. **Stronger extraction** — if streaming shows the right text but evaluation needs a single string, refine `extract_response_text` to match your event stream.
+
+## Run and debug
+
+```bash
+export DATAROBOT_API_TOKEN="..."
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+python docs/llamaindex/agent_example.py
+```
+
+## Where to look in the library
+
+- `datarobot_genai.llama_index.agent` — `LlamaIndexAgent`, `datarobot_agent_class_from_llamaindex`
+- `datarobot_genai.llama_index.llm` — `get_llm`
+- `datarobot_genai.core.agents` — `make_system_prompt`, `BaseAgent`
+
+## Reference implementation
+
+See `e2e-tests/dragent/llamaindex/myagent.py` for the same planner/writer pattern with tools and gateway model naming.

--- a/docs/llamaindex/README.md
+++ b/docs/llamaindex/README.md
@@ -1,0 +1,70 @@
+# LlamaIndex + DataRobot
+
+Build a multi-agent LlamaIndex workflow and run it as a DataRobot agent.
+
+## Installation
+
+```bash
+pip install "datarobot-genai[llamaindex]"
+```
+
+## Key imports
+
+```python
+from datarobot_genai.llama_index.llm import get_llm
+from datarobot_genai.llama_index.agent import datarobot_agent_class_from_llamaindex
+from datarobot_genai.core.agents import make_system_prompt
+```
+
+## How it works
+
+1. **`get_llm()`** returns a LlamaIndex `LiteLLM` instance backed by the DataRobot LLM Gateway. It reads `DATAROBOT_API_TOKEN` and `DATAROBOT_ENDPOINT` from the environment.
+
+2. **Define your workflow** using the standard LlamaIndex `AgentWorkflow` API. Create `FunctionAgent` instances, wire them together, and build an `AgentWorkflow`.
+
+3. **`datarobot_agent_class_from_llamaindex(workflow, agents, extract_response_text)`** produces a `LlamaIndexAgent` subclass that:
+   - Runs the workflow and streams events from `handler.stream_events()`.
+   - Emits AG-UI events (text messages, tool calls, agent-switch steps) to the DataRobot frontend.
+   - Propagates the platform-injected LLM and tools to every agent at runtime.
+
+### `extract_response_text` callback
+
+You must provide a function that extracts the final text from the workflow result. This is framework-specific because LlamaIndex workflows can return state in different shapes:
+
+```python
+def extract_response_text(result_state, events):
+    for event in reversed(events):
+        resp = getattr(event, "response", None)
+        if resp is not None:
+            content = getattr(resp, "content", None)
+            if content:
+                return str(content)
+    return ""
+```
+
+## Agent handoffs
+
+LlamaIndex agents can hand off to each other via `can_handoff_to`. The wrapper automatically emits `StepStartedEvent` / `StepFinishedEvent` for each agent transition.
+
+```python
+planner = FunctionAgent(
+    name="planner",
+    ...,
+    can_handoff_to=["writer"],
+)
+```
+
+## Example
+
+See [agent_example.py](agent_example.py) for a complete, runnable two-agent workflow.
+
+```bash
+export DATAROBOT_API_TOKEN="<token>"
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+
+python docs/llamaindex/agent_example.py
+```
+
+## Developing from this example
+
+See [AGENTS.md](AGENTS.md) for how to extend the workflow, tools, prompts, and `extract_response_text`.

--- a/docs/llamaindex/agent_example.py
+++ b/docs/llamaindex/agent_example.py
@@ -1,0 +1,119 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal LlamaIndex agent running on DataRobot.
+
+Two-agent pipeline: a planner creates a bullet-point outline, then hands off
+to a writer that turns it into a short paragraph.  Uses the DataRobot LLM
+Gateway for model calls.
+
+Prerequisites
+-------------
+pip install "datarobot-genai[llamaindex]"
+
+Environment variables
+---------------------
+DATAROBOT_API_TOKEN  – your DataRobot API token
+DATAROBOT_ENDPOINT   – e.g. https://app.datarobot.com/api/v2
+
+How to extend this example
+--------------------------
+See AGENTS.md next to this file.
+"""
+
+import asyncio
+import uuid
+from typing import Any
+
+from ag_ui.core import Message
+from ag_ui.core import RunAgentInput
+from llama_index.core.agent.workflow import AgentWorkflow
+from llama_index.core.agent.workflow import FunctionAgent
+
+from datarobot_genai.core.agents import make_system_prompt
+from datarobot_genai.llama_index.agent import datarobot_agent_class_from_llamaindex
+from datarobot_genai.llama_index.llm import get_llm
+
+# ---------------------------------------------------------------------------
+# 1. Get a DataRobot-backed LLM
+# ---------------------------------------------------------------------------
+llm = get_llm()
+
+# ---------------------------------------------------------------------------
+# 2. Define LlamaIndex agents and workflow
+# ---------------------------------------------------------------------------
+planner = FunctionAgent(
+    name="planner",
+    description="Creates short bullet-point outlines",
+    system_prompt=make_system_prompt(
+        "You are a content planner. Given a topic, produce a short "
+        "bullet-point outline with 3-5 key points."
+    ),
+    llm=llm,
+    can_handoff_to=["writer"],
+)
+
+writer = FunctionAgent(
+    name="writer",
+    description="Writes concise responses based on outlines",
+    system_prompt=make_system_prompt(
+        "You are a concise writer. Using the planner's outline, "
+        "write a short response in 2-3 sentences."
+    ),
+    llm=llm,
+)
+
+agents = [planner, writer]
+workflow = AgentWorkflow(agents=agents, root_agent="planner")
+
+
+# ---------------------------------------------------------------------------
+# 3. Response extractor
+# ---------------------------------------------------------------------------
+def extract_response_text(result_state: Any, events: list[Any]) -> str:
+    for event in reversed(events):
+        resp = getattr(event, "response", None)
+        if resp is not None:
+            content = getattr(resp, "content", None)
+            if content:
+                return str(content)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# 4. Wrap into a DataRobot agent class
+# ---------------------------------------------------------------------------
+MyAgent = datarobot_agent_class_from_llamaindex(workflow, agents, extract_response_text)
+
+
+# ---------------------------------------------------------------------------
+# 5. Run it locally
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    agent = MyAgent(llm=llm)
+
+    run_input = RunAgentInput(
+        thread_id=str(uuid.uuid4()),
+        run_id=str(uuid.uuid4()),
+        messages=[Message(role="user", content="Benefits of Python for data science")],
+    )
+
+    async for event, _interactions, usage in agent.invoke(run_input):
+        print(event)
+
+    print(f"\nToken usage: {usage}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.1"
+version = "0.15.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -982,7 +982,6 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'drmcp'", specifier = ">=4.12.0,<5.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drtools'", specifier = ">=4.12.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'drmcp'", specifier = ">=1.34.0,<2.0.0" },
-    { name = "boto3", marker = "extra == 'drtools'", specifier = ">=1.34.0,<2.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
     { name = "datarobot", marker = "extra == 'core'", specifier = ">=3.10.0,<4.0.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.2"
+version = "0.15.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -124,6 +124,9 @@ fixable = [
 ]
 "src/datarobot_genai/**/*.py" = [
     "PLC0415",# pylint import-outside-toplevel: allow lazy imports for memory optimization
+]
+"docs/**/*.py" = [
+    "INP001", # implicit-namespace-package: standalone example scripts
 ]
 "tests/**/*.py" = [
     "PLC0415",# pylint import-outside-toplevel: allow imports in test functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.3"
+version = "0.15.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.2"
+version = "0.15.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [x] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a version bump and a lint ignore for example scripts; no runtime library behavior is modified.
> 
> **Overview**
> Adds a standalone documentation site under `docs/` with framework-specific guides and runnable example agents for **LangGraph**, **LlamaIndex**, and **CrewAI**, centered on the library’s **AG-UI streaming contract**, multi-agent patterns, and the unified `get_llm()` configuration.
> 
> Updates the root `README.md` to highlight these concepts and link to `docs/README.md`, bumps the project version to `0.15.4` (including `uv.lock`), and adjusts Ruff config to ignore `INP001` for `docs/**/*.py` example scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93bdaaa20e0625c50fedaf2c798c451d2e0f2241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->