### PR TITLE
[BUZZOK-29643] NAT dragent CLI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.3
+- Wired `LangchainProfilerHandler` into LangGraph agent config so `nat dragent run` streams intermediate LLM events to the console frontend.
+- Broadened CrewAI MCP exception handling to catch all exceptions on connection failure, so `nat dragent run` continues without MCP tools instead of crashing.
+
 ## 0.15.2
 - Removed the dedicated S3 client module from `drtools.core.clients` (S3 is no longer exposed as a first-class tool client here).
 - Removed the `predict_by_file_path` predictive tool; use catalog or dataset-based prediction flows instead.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.1"
+version = "0.15.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -982,7 +982,6 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'drmcp'", specifier = ">=4.12.0,<5.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drtools'", specifier = ">=4.12.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'drmcp'", specifier = ">=1.34.0,<2.0.0" },
-    { name = "boto3", marker = "extra == 'drtools'", specifier = ">=1.34.0,<2.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
     { name = "datarobot", marker = "extra == 'core'", specifier = ">=3.10.0,<4.0.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.2"
+version = "0.15.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -46,7 +46,6 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
     try:
         adapter = MCPServerAdapter(mcp_config.server_config)
         tools = adapter.__enter__()
-        logger.info("Successfully connected to MCP server, got %d tools", len(tools))
     except Exception as exc:
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
@@ -57,6 +56,7 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
         return
 
     try:
+        logger.info("Successfully connected to MCP server, got %d tools", len(tools))
         yield tools
     finally:
         adapter.__exit__(None, None, None)

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -47,7 +47,7 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
         with MCPServerAdapter(mcp_config.server_config) as tools:
             logger.info("Successfully connected to MCP server, got %d tools", len(tools))
             yield tools
-    except (ConnectionError, OSError, TimeoutError, ExceptionGroup) as exc:
+    except Exception as exc:
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
             url,

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -44,9 +44,9 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
     logger.info("Connecting to MCP server: %s", url)
 
     try:
-        with MCPServerAdapter(mcp_config.server_config) as tools:
-            logger.info("Successfully connected to MCP server, got %d tools", len(tools))
-            yield tools
+        adapter = MCPServerAdapter(mcp_config.server_config)
+        tools = adapter.__enter__()
+        logger.info("Successfully connected to MCP server, got %d tools", len(tools))
     except Exception as exc:
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
@@ -54,3 +54,9 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
             exc,
         )
         yield []
+        return
+
+    try:
+        yield tools
+    finally:
+        adapter.__exit__(None, None, None)

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -40,6 +40,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langgraph.graph import MessagesState
 from langgraph.graph import StateGraph
 from langgraph.types import Command
+from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
 
 from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
@@ -78,6 +79,7 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
     def langgraph_config(self) -> dict[str, Any]:
         return {
             "recursion_limit": 150,  # Maximum number of steps to take in the graph
+            "callbacks": [LangchainProfilerHandler()],
         }
 
     async def convert_input_message(self, run_agent_input: RunAgentInput) -> Command:

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.2"
+version = "0.15.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Wired LangchainProfilerHandler into LangGraph config so nat dragent run
  streams intermediate LLM events to the console frontend
- Broadened CrewAI MCP exception handling to catch all exceptions on connection
  failure so nat dragent run continues without MCP tools instead of crashing

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [x] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent runtime behavior: adds LangGraph callbacks and changes MCP connection lifecycle/error handling, which could affect streaming output or resource cleanup if mis-handled.
> 
> **Overview**
> Enables `nat dragent run` to stream intermediate LangGraph/LangChain events by wiring `LangchainProfilerHandler` into the default `LangGraphAgent.langgraph_config` callbacks.
> 
> Hardens CrewAI MCP startup by catching *all* connection exceptions and falling back to an empty tools list instead of crashing, while managing `MCPServerAdapter` enter/exit explicitly.
> 
> Bumps project version to `0.15.3` (including lockfiles) and documents the changes in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a40c7f8137210810d27c4cfe6d5bebf020d5a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->