### PR TITLE
Add optional NAT e2e tests for LLM router failover

### DIFF
--- a/.github/workflows/e2e-router.yml
+++ b/.github/workflows/e2e-router.yml
@@ -5,17 +5,11 @@ on:
   push:
     branches: [main]
     paths:
-      - "src/datarobot_genai/core/router.py"
-      - "src/datarobot_genai/core/config.py"
-      - "src/datarobot_genai/nat/datarobot_llm_providers.py"
-      - "src/datarobot_genai/nat/datarobot_llm_clients.py"
+      - "src/datarobot_genai/core/**"
+      - "src/datarobot_genai/nat/**"
       - "src/datarobot_genai/langgraph/router_llm.py"
-      - "src/datarobot_genai/langgraph/llm.py"
       - "e2e-tests/dragent/router/**"
       - "e2e-tests/dragent_tests/test_router.py"
-      - "e2e-tests/dragent/Taskfile.yaml"
-      - "e2e-tests/Taskfile.yaml"
-      - "e2e-tests/pyproject.toml"
       - ".github/workflows/e2e-router.yml"
 
 env:
@@ -29,14 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         router_scenario: [primary-only, with-fallback, fallback-used]
-        python-version: ["3.12"]
     permissions:
       contents: read
     env:
       DATAROBOT_API_TOKEN: ${{ secrets.E2E_DATAROBOT_API_TOKEN }}
       DATAROBOT_ENDPOINT: ${{ secrets.E2E_DATAROBOT_ENDPOINT }}
       DATAROBOT_USER_ID: ${{ secrets.E2E_DATAROBOT_USER_ID }}
-      MCP_DEPLOYMENT_ID: ${{ secrets.E2E_MCP_DEPLOYMENT_ID }}
       SESSION_SECRET_KEY: ${{ secrets.E2E_SESSION_SECRET_KEY }}
 
       AGENT: router
@@ -53,7 +45,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Setup Task
         uses: arduino/setup-task@v2
@@ -70,9 +62,9 @@ jobs:
           path: |
             e2e-tests/.venv
             ~/.cache/uv
-          key: e2e-router-uv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.router_scenario }}-${{ hashFiles('e2e-tests/uv.lock') }}
+          key: e2e-router-uv-${{ runner.os }}-${{ hashFiles('e2e-tests/uv.lock') }}
           restore-keys: |
-            e2e-router-uv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.router_scenario }}-
+            e2e-router-uv-${{ runner.os }}-
 
       - name: Install dependencies
         working-directory: e2e-tests
@@ -88,8 +80,6 @@ jobs:
 
       - name: Run router e2e tests
         working-directory: e2e-tests
-        env:
-          LLM_DEFAULT_MODEL: datarobot/bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0
         run: |
           uv run pytest dragent_tests/test_router.py -vv -s --timeout=60 --tb=short --reruns=2 --reruns-delay=5 --junitxml=test_results/results.xml
 
@@ -97,6 +87,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-router-results-${{ matrix.router_scenario }}-py${{ matrix.python-version }}
+          name: e2e-router-results-${{ matrix.router_scenario }}
           path: e2e-tests/test_results/
           if-no-files-found: ignore

--- a/.github/workflows/e2e-router.yml
+++ b/.github/workflows/e2e-router.yml
@@ -1,0 +1,102 @@
+name: E2E Router (optional)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "src/datarobot_genai/core/router.py"
+      - "src/datarobot_genai/core/config.py"
+      - "src/datarobot_genai/nat/datarobot_llm_providers.py"
+      - "src/datarobot_genai/nat/datarobot_llm_clients.py"
+      - "src/datarobot_genai/langgraph/router_llm.py"
+      - "src/datarobot_genai/langgraph/llm.py"
+      - "e2e-tests/dragent/router/**"
+      - "e2e-tests/dragent_tests/test_router.py"
+      - "e2e-tests/dragent/Taskfile.yaml"
+      - "e2e-tests/Taskfile.yaml"
+      - "e2e-tests/pyproject.toml"
+      - ".github/workflows/e2e-router.yml"
+
+env:
+  TASK_VERSION: 3.48.0
+
+jobs:
+  e2e-router:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        router_scenario: [primary-only, with-fallback, fallback-used]
+        python-version: ["3.12"]
+    permissions:
+      contents: read
+    env:
+      DATAROBOT_API_TOKEN: ${{ secrets.E2E_DATAROBOT_API_TOKEN }}
+      DATAROBOT_ENDPOINT: ${{ secrets.E2E_DATAROBOT_ENDPOINT }}
+      DATAROBOT_USER_ID: ${{ secrets.E2E_DATAROBOT_USER_ID }}
+      MCP_DEPLOYMENT_ID: ${{ secrets.E2E_MCP_DEPLOYMENT_ID }}
+      SESSION_SECRET_KEY: ${{ secrets.E2E_SESSION_SECRET_KEY }}
+
+      AGENT: router
+      LLM: llmgw
+      ROUTER_SCENARIO: ${{ matrix.router_scenario }}
+
+      LLM_DEFAULT_MODEL: datarobot/bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: ${{ env.TASK_VERSION }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Cache uv and virtualenv
+        uses: actions/cache@v4
+        with:
+          path: |
+            e2e-tests/.venv
+            ~/.cache/uv
+          key: e2e-router-uv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.router_scenario }}-${{ hashFiles('e2e-tests/uv.lock') }}
+          restore-keys: |
+            e2e-router-uv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.router_scenario }}-
+
+      - name: Install dependencies
+        working-directory: e2e-tests
+        run: uv sync --group dragent-router
+
+      - name: Run router dragent in background
+        uses: JarvusInnovations/background-action@v1
+        with:
+          working-directory: e2e-tests
+          run: task dragent:run-router &
+          wait-on: http-get://localhost:8080/health
+          wait-for: 30s
+
+      - name: Run router e2e tests
+        working-directory: e2e-tests
+        env:
+          LLM_DEFAULT_MODEL: datarobot/bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0
+        run: |
+          uv run pytest dragent_tests/test_router.py -vv -s --timeout=60 --tb=short --reruns=2 --reruns-delay=5 --junitxml=test_results/results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-router-results-${{ matrix.router_scenario }}-py${{ matrix.python-version }}
+          path: e2e-tests/test_results/
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.3
-- Added optional NAT-based e2e coverage for the LLM provider router (`AGENT=router`), including GitHub Actions workflow `e2e-router.yml` and YAML workflows under `e2e-tests/dragent/router/`.
 - Wired `LangchainProfilerHandler` into LangGraph agent config so `nat dragent run` streams intermediate LLM events to the console frontend.
 - Broadened CrewAI MCP exception handling to catch all exceptions on connection failure, so `nat dragent run` continues without MCP tools instead of crashing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.3
+- Added optional NAT-based e2e coverage for the LLM provider router (`AGENT=router`), including GitHub Actions workflow `e2e-router.yml` and YAML workflows under `e2e-tests/dragent/router/`.
 - Wired `LangchainProfilerHandler` into LangGraph agent config so `nat dragent run` streams intermediate LLM events to the console frontend.
 - Broadened CrewAI MCP exception handling to catch all exceptions on connection failure, so `nat dragent run` continues without MCP tools instead of crashing.
 

--- a/e2e-tests/Taskfile.yaml
+++ b/e2e-tests/Taskfile.yaml
@@ -39,6 +39,7 @@ tasks:
           - langgraph
           - llamaindex
           - base
+          - router
     cmds:
       - echo "🔧 Installing dependencies for {{.AGENT}}"
       - uv sync --group dragent-{{.AGENT}} --group lint
@@ -58,6 +59,7 @@ tasks:
           - langgraph
           - llamaindex
           - base
+          - router
     cmds:
       - echo "🧪 Running tests for dragent"
       - uv run pytest dragent_tests -vv -s
@@ -83,6 +85,7 @@ tasks:
           - langgraph
           - llamaindex
           - base
+          - router
     cmds:
       - echo "🔨 Running dragent"
       - task: install

--- a/e2e-tests/dragent/Taskfile.yaml
+++ b/e2e-tests/dragent/Taskfile.yaml
@@ -42,3 +42,8 @@ tasks:
     cmds:
       - echo "🔨 Running base agent via NAT"
       - uv run nat dragent serve --config_file workflow.yaml --port {{.AGENT_PORT}}
+  run-router:
+    desc: "🔨 Running Router agent via NAT"
+    dir: ./router
+    cmds:
+      - uv run nat dragent serve --config_file workflow-${ROUTER_SCENARIO:-with-fallback}.yaml --port {{.AGENT_PORT}}

--- a/e2e-tests/dragent/router/workflow-fallback-used.yaml
+++ b/e2e-tests/dragent/router/workflow-fallback-used.yaml
@@ -1,0 +1,38 @@
+---
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+functions:
+  responder:
+    _type: chat_completion
+    llm_name: datarobot_llm
+    system_prompt: "You are a helpful assistant. Reply concisely."
+    description: "Responds to user messages."
+
+llms:
+  datarobot_llm:
+    _type: datarobot-llm-router
+    primary:
+      use_datarobot_llm_gateway: false
+      llm_deployment_id: "asdf-invalid-deployment-id"
+    fallbacks:
+      - use_datarobot_llm_gateway: true
+    allowed_fails: 1
+
+workflow:
+  _type: per_user_tool_calling_agent
+  llm_name: datarobot_llm
+  tool_names: [responder]
+  return_direct: [responder]
+  system_prompt: "Forward all user requests to the responder."
+  verbose: true

--- a/e2e-tests/dragent/router/workflow-primary-only.yaml
+++ b/e2e-tests/dragent/router/workflow-primary-only.yaml
@@ -1,0 +1,32 @@
+---
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+functions:
+  responder:
+    _type: chat_completion
+    llm_name: datarobot_llm
+    system_prompt: "You are a helpful assistant. Reply concisely."
+    description: "Responds to user messages."
+
+llms:
+  datarobot_llm:
+    _type: datarobot-llm-component
+
+workflow:
+  _type: per_user_tool_calling_agent
+  llm_name: datarobot_llm
+  tool_names: [responder]
+  return_direct: [responder]
+  system_prompt: "Forward all user requests to the responder."
+  verbose: true

--- a/e2e-tests/dragent/router/workflow-with-fallback.yaml
+++ b/e2e-tests/dragent/router/workflow-with-fallback.yaml
@@ -1,0 +1,37 @@
+---
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+functions:
+  responder:
+    _type: chat_completion
+    llm_name: datarobot_llm
+    system_prompt: "You are a helpful assistant. Reply concisely."
+    description: "Responds to user messages."
+
+llms:
+  datarobot_llm:
+    _type: datarobot-llm-router
+    primary:
+      use_datarobot_llm_gateway: true
+    fallbacks:
+      - use_datarobot_llm_gateway: true
+    allowed_fails: 1
+
+workflow:
+  _type: per_user_tool_calling_agent
+  llm_name: datarobot_llm
+  tool_names: [responder]
+  return_direct: [responder]
+  system_prompt: "Forward all user requests to the responder."
+  verbose: true

--- a/e2e-tests/dragent_tests/test_router.py
+++ b/e2e-tests/dragent_tests/test_router.py
@@ -1,0 +1,48 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+from ag_ui.verify import validate_sequence
+
+from dragent_tests.helpers import GENERATE_STREAM_PATH
+from dragent_tests.helpers import collect_ag_ui_events
+from dragent_tests.helpers import collect_text
+from dragent_tests.helpers import make_generate_payload
+from dragent_tests.helpers import parse_sse_responses
+
+if os.environ.get("AGENT") != "router":
+    pytest.skip("Router e2e tests require AGENT=router", allow_module_level=True)
+
+
+def test_router_streaming_ag_ui(http_client: httpx.Client) -> None:
+    """Streaming /generate/stream returns a valid non-empty AG-UI sequence."""
+    # GIVEN: a user message for the router-backed agent
+    payload = make_generate_payload("Say 'hello' and nothing else.")
+
+    # WHEN: the client streams the request to /generate/stream
+    with http_client.stream("POST", GENERATE_STREAM_PATH, json=payload) as response:
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers.get("content-type", "")
+        sse_responses = parse_sse_responses(response)
+
+    # THEN: SSE payloads decode to a valid AG-UI event sequence with non-empty text
+    ag_ui_events = collect_ag_ui_events(sse_responses)
+    validate_sequence(ag_ui_events)
+    full_text = collect_text(ag_ui_events)
+    assert len(full_text) > 0, "Expected non-empty text response"

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -30,6 +30,9 @@ dragent-llamaindex = [
 dragent-base = [
     "datarobot-genai[dragent]",
 ]
+dragent-router = [
+    "datarobot-genai[dragent]"
+]
 lint = [
     "mypy>=1.19.1",
     "ruff>=0.15.2",

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1188,6 +1188,9 @@ dragent-llamaindex = [
 dragent-nat = [
     { name = "datarobot-genai", extra = ["dragent"] },
 ]
+dragent-router = [
+    { name = "datarobot-genai", extra = ["dragent"] },
+]
 lint = [
     { name = "mypy" },
     { name = "ruff" },
@@ -1210,6 +1213,7 @@ dragent-crewai = [{ name = "datarobot-genai", extras = ["dragent", "crewai"], ed
 dragent-langgraph = [{ name = "datarobot-genai", extras = ["dragent", "langgraph"], editable = "../" }]
 dragent-llamaindex = [{ name = "datarobot-genai", extras = ["dragent", "llamaindex"], editable = "../" }]
 dragent-nat = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]
+dragent-router = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]
 lint = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "ruff", specifier = ">=0.15.2" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# RATIONALE

The LLM provider fallback path uses `litellm.Router` and benefits from dedicated end-to-end coverage that is separate from the main PR e2e matrix. These tests exercise the same NAT workflow shape across three router configurations so regressions in routing, YAML loading, and streaming are caught when this workflow is run manually or after router-related changes on `main`.

## CHANGES

- Added three NAT workflow YAMLs under `e2e-tests/dragent/router/` (primary-only component, healthy router with gateway fallback, invalid primary with gateway fallback).
- Added `dragent_tests/test_router.py`, skipped unless `AGENT=router`, asserting a successful streaming `/generate/stream` response with a valid AG-UI sequence and non-empty assistant text.
- Extended `e2e-tests/dragent/Taskfile.yaml` with `run-router` using `ROUTER_SCENARIO` to pick the workflow file; extended root `e2e-tests/Taskfile.yaml` so `AGENT=router` works for `install` and `run-dragent`.
- Added `dragent-router` dependency group in `e2e-tests/pyproject.toml` and refreshed `e2e-tests/uv.lock`.
- Added optional GitHub Actions workflow `.github/workflows/e2e-router.yml` (manual dispatch and path-filtered pushes to `main`) with a matrix over the three scenarios.
- Simplified the router workflow by removing redundant env, hardcoding Python 3.12, and using shared dependency cache keys.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

## TESTING

- `uv run pytest dragent_tests/test_router.py` (without `AGENT=router`): test collection skips as intended.
- Full router e2e against a live DataRobot stack was not run in this environment (no credentials); CI/manual verification should follow the commands in the plan.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b4d0411-4b7d-42a1-a5b8-312ea8a05606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b4d0411-4b7d-42a1-a5b8-312ea8a05606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

