### PR TITLE
update early access DR pkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.7
-- **Dependencies**: `datarobot-early-access` is no longer declared on the `drtools` extra; it is declared on `drmcp` instead.
+- **Dependencies**: Moved `datarobot-early-access` from the `drtools` extra to `drmcp`. 
 
 ## 0.15.6
 - Added cli.py-compatible aliases (`--user_prompt`, `--deployment_id`) to `nat dragent run` and `query` for Taskfile passthrough.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.7
+- **Dependencies**: `datarobot-early-access` is no longer declared on the `drtools` extra; it is declared on `drmcp` instead.
+
 ## 0.15.6
 - Added cli.py-compatible aliases (`--user_prompt`, `--deployment_id`) to `nat dragent run` and `query` for Taskfile passthrough.
 - Added `--file` / `--input-file` option to `nat dragent run` and `query`: reads a text file and uses its contents as the prompt.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.6"
+version = "0.15.7"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1000,7 +1000,6 @@ requires-dist = [
     { name = "datarobot-early-access", marker = "extra == 'crewai'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'dragent'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'drmcp'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-early-access", marker = "extra == 'drtools'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'langgraph'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'llamaindex'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'nat'", specifier = "==3.14.0.2026.3.18.162920" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.6"
+version = "0.15.7"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,6 @@ drtools = auth + [
     "datarobot-predict>=1.13.2,<2.0.0",
     "pydantic>=2.6.1,<3.0.0",
     "datarobot>=3.10.0,<4.0.0",
-    "datarobot-early-access==3.14.0.2026.3.18.162920",
     "aiohttp>=3.13.3,<4.0.0",  # CVE-2025-69229 & CVE-2025-69230 fixed in 3.13.3
 ]
 
@@ -139,6 +138,7 @@ drmcp = drtools + [
     "opentelemetry-exporter-otlp>=1.22.0,<2.0.0",
     "opentelemetry-exporter-otlp-proto-http>=1.22.0,<2.0.0",
     "aiohttp-retry>=2.8.3,<3.0.0",
+    "datarobot-early-access==3.14.0.2026.3.18.162920",
 ]
 
 extras_require = {

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.5"
+version = "0.15.7"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1192,7 +1192,6 @@ drtools = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
     { name = "datarobot", extra = ["auth"] },
-    { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
     { name = "httpx" },
     { name = "perplexityai" },
@@ -1330,7 +1329,6 @@ requires-dist = [
     { name = "datarobot-early-access", marker = "extra == 'crewai'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'dragent'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'drmcp'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-early-access", marker = "extra == 'drtools'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'langgraph'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'llamaindex'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'nat'", specifier = "==3.14.0.2026.3.18.162920" },


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the optional-dependency layout so installs using the `drtools` extra no longer pull in `datarobot-early-access`, which could break environments relying on it implicitly. Otherwise this is a packaging/lockfile update with limited runtime impact.
> 
> **Overview**
> Bumps `datarobot-genai` to `0.15.7` and updates the changelog accordingly.
> 
> Moves the pinned `datarobot-early-access` dependency out of the `drtools` extra and into the `drmcp` extra, and refreshes both `uv.lock` files to reflect the new extras/dependency markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07baade15e491573e47ca6ecd1d0856b59b4312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->