### PR TITLE
[BUZZOK-30397] Remove py3.13 restriction for mem0ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.8
+- **Dependencies**: Removed the python<3.13 restriction from mem0ai when including the memory dependency.
+
 ## 0.15.7
-- **Dependencies**: Moved `datarobot-early-access` from the `drtools` extra to `drmcp`. 
+- **Dependencies**: Moved `datarobot-early-access` from the `drtools` extra to `drmcp`.
 
 ## 0.15.6
 - Added cli.py-compatible aliases (`--user_prompt`, `--deployment_id`) to `nat dragent run` and `query` for Taskfile passthrough.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.7"
+version = "0.15.8"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1029,7 +1029,7 @@ requires-dist = [
     { name = "llama-index-llms-litellm", marker = "extra == 'llamaindex'", specifier = ">=0.4.1,<0.7.0" },
     { name = "llama-index-llms-openai", marker = "extra == 'llamaindex'", specifier = ">=0.6.0,<0.7.0" },
     { name = "llama-index-tools-mcp", marker = "extra == 'llamaindex'", specifier = ">=0.1.0,<0.5.0" },
-    { name = "mem0ai", marker = "python_full_version < '3.13' and extra == 'memory'", specifier = ">=1.0.4,<2.0.0" },
+    { name = "mem0ai", marker = "extra == 'memory'", specifier = ">=1.0.4,<2.0.0" },
     { name = "nvidia-nat", marker = "extra == 'dragent'", specifier = "==1.6.0" },
     { name = "nvidia-nat", marker = "extra == 'nat'", specifier = "==1.6.0" },
     { name = "nvidia-nat-a2a", marker = "extra == 'dragent'", specifier = "==1.6.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.7"
+version = "0.15.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ core = [
 ]
 
 memory = [
-    "mem0ai>=1.0.4,<2.0.0; python_version < '3.13'",
+    "mem0ai>=1.0.4,<2.0.0",
 ]
 
 crewai = core + [

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.7"
+version = "0.15.8"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1251,7 +1251,7 @@ llamaindex = [
     { name = "requests" },
 ]
 memory = [
-    { name = "mem0ai", marker = "python_full_version < '3.13'" },
+    { name = "mem0ai" },
 ]
 nat = [
     { name = "ag-ui-protocol" },
@@ -1358,7 +1358,7 @@ requires-dist = [
     { name = "llama-index-llms-litellm", marker = "extra == 'llamaindex'", specifier = ">=0.4.1,<0.7.0" },
     { name = "llama-index-llms-openai", marker = "extra == 'llamaindex'", specifier = ">=0.6.0,<0.7.0" },
     { name = "llama-index-tools-mcp", marker = "extra == 'llamaindex'", specifier = ">=0.1.0,<0.5.0" },
-    { name = "mem0ai", marker = "python_full_version < '3.13' and extra == 'memory'", specifier = ">=1.0.4,<2.0.0" },
+    { name = "mem0ai", marker = "extra == 'memory'", specifier = ">=1.0.4,<2.0.0" },
     { name = "nvidia-nat", marker = "extra == 'dragent'", specifier = "==1.6.0" },
     { name = "nvidia-nat", marker = "extra == 'nat'", specifier = "==1.6.0" },
     { name = "nvidia-nat-a2a", marker = "extra == 'dragent'", specifier = "==1.6.0" },
@@ -2112,8 +2112,8 @@ name = "h2"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "hpack", marker = "python_full_version < '3.13'" },
-    { name = "hyperframe", marker = "python_full_version < '3.13'" },
+    { name = "hpack" },
+    { name = "hyperframe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
@@ -2212,7 +2212,7 @@ wheels = [
 
 [package.optional-dependencies]
 http2 = [
-    { name = "h2", marker = "python_full_version < '3.13'" },
+    { name = "h2" },
 ]
 
 [[package]]
@@ -3689,13 +3689,13 @@ name = "mem0ai"
 version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openai", marker = "python_full_version < '3.13'" },
-    { name = "posthog", marker = "python_full_version < '3.13'" },
-    { name = "protobuf", marker = "python_full_version < '3.13'" },
-    { name = "pydantic", marker = "python_full_version < '3.13'" },
-    { name = "pytz", marker = "python_full_version < '3.13'" },
-    { name = "qdrant-client", marker = "python_full_version < '3.13'" },
-    { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
+    { name = "openai" },
+    { name = "posthog" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pytz" },
+    { name = "qdrant-client" },
+    { name = "sqlalchemy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/a7/ad272ecb8e67690d08f6fb59d7162260dbbbaf9f1b9336c52bef254bfbcd/mem0ai-1.0.7.tar.gz", hash = "sha256:57ec923d9703cd0f9bc0ffac511d2839ed99448a28c9ad8c017335083846d338", size = 188641, upload-time = "2026-03-20T22:46:24.734Z" }
 wheels = [
@@ -5783,13 +5783,13 @@ name = "qdrant-client"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "grpcio", marker = "python_full_version < '3.13'" },
-    { name = "httpx", extra = ["http2"], marker = "python_full_version < '3.13'" },
-    { name = "numpy", marker = "python_full_version < '3.13'" },
-    { name = "portalocker", marker = "python_full_version < '3.13'" },
-    { name = "protobuf", marker = "python_full_version < '3.13'" },
-    { name = "pydantic", marker = "python_full_version < '3.13'" },
-    { name = "urllib3", marker = "python_full_version < '3.13'" },
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/dd/f8a8261b83946af3cd65943c93c4f83e044f01184e8525404989d22a81a5/qdrant_client-1.17.1.tar.gz", hash = "sha256:22f990bbd63485ed97ba551a4c498181fcb723f71dcab5d6e4e43fe1050a2bc0", size = 344979, upload-time = "2026-03-13T17:13:44.678Z" }
 wheels = [


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
We need mem0 for all supported python version.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Remove the py3.13 restriction for mem0ai.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk packaging-only change, but it may surface runtime incompatibilities if `mem0ai` (or its transitive deps) is not actually compatible with Python 3.13 in some environments.
> 
> **Overview**
> Releases `0.15.8` and documents the change in `CHANGELOG.md`.
> 
> Removes the `python<3.13` environment marker from the `memory` extra’s `mem0ai` dependency in `setup.py` and propagates that marker removal through `uv.lock` (and `e2e-tests/uv.lock`), enabling `mem0ai` installation on Python 3.13.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566a896f9ed470d538d9514400837125bb9b1b22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->