### PR TITLE
[BUZZOK-29946] Fix NAT text extraction for DRAgentEventResponse objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.10
+- Fixed `NatAgent` text extraction for `DRAgentEventResponse` objects.
+
 ## 0.15.9
 - Adding parameters to Crew AI and LlamaIndex Agents
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.9"
+version = "0.15.10"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.9"
+version = "0.15.10"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
+++ b/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
@@ -29,8 +29,6 @@ using ``DRAgentNestedReasoningStepAdaptor.process_chunks()`` to produce
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from ag_ui.core import RunFinishedEvent
-from ag_ui.core import StepFinishedEvent
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_per_user_function
 from nat.data_models.api_server import ChatRequest
@@ -39,7 +37,6 @@ from nat.data_models.api_server import ChatResponse
 from nat.plugins.langchain.agent.tool_calling_agent.register import ToolCallAgentWorkflowConfig
 from nat.plugins.langchain.agent.tool_calling_agent.register import tool_calling_agent_workflow
 
-from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.stream_converter import convert_chunks_to_agui_events
 
@@ -76,21 +73,6 @@ async def _per_user_tool_calling_agent(
                 original_stream_fn(chat_request_or_message)
             ):
                 yield event
-            # Emit lifecycle events so the DRAgent server's SSE stream closes.
-            # NAT's step adaptor emits these on WORKFLOW_END, but when tool calls
-            # are involved the WORKFLOW_END intermediate step arrives after the
-            # stream_fn has already returned and the SSE connection has stalled.
-            # The recipe's DRAgentAGUIAgent filters RunFinishedEvent and emits
-            # its own with the correct thread/run IDs, so the empty IDs here
-            # are harmless.
-            step_name = config.name or "per_user_tool_calling_agent"
-            yield DRAgentEventResponse(
-                events=[
-                    StepFinishedEvent(step_name=step_name),
-                    RunFinishedEvent(run_id="", thread_id=""),
-                ],
-                usage_metrics=default_usage_metrics(),
-            )
 
         yield FunctionInfo.create(
             single_fn=fn_info.single_fn,

--- a/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
+++ b/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
@@ -29,6 +29,8 @@ using ``DRAgentNestedReasoningStepAdaptor.process_chunks()`` to produce
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from ag_ui.core import RunFinishedEvent
+from ag_ui.core import StepFinishedEvent
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_per_user_function
 from nat.data_models.api_server import ChatRequest
@@ -37,6 +39,7 @@ from nat.data_models.api_server import ChatResponse
 from nat.plugins.langchain.agent.tool_calling_agent.register import ToolCallAgentWorkflowConfig
 from nat.plugins.langchain.agent.tool_calling_agent.register import tool_calling_agent_workflow
 
+from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.stream_converter import convert_chunks_to_agui_events
 
@@ -73,6 +76,21 @@ async def _per_user_tool_calling_agent(
                 original_stream_fn(chat_request_or_message)
             ):
                 yield event
+            # Emit lifecycle events so the DRAgent server's SSE stream closes.
+            # NAT's step adaptor emits these on WORKFLOW_END, but when tool calls
+            # are involved the WORKFLOW_END intermediate step arrives after the
+            # stream_fn has already returned and the SSE connection has stalled.
+            # The recipe's DRAgentAGUIAgent filters RunFinishedEvent and emits
+            # its own with the correct thread/run IDs, so the empty IDs here
+            # are harmless.
+            step_name = config.name or "per_user_tool_calling_agent"
+            yield DRAgentEventResponse(
+                events=[
+                    StepFinishedEvent(step_name=step_name),
+                    RunFinishedEvent(run_id="", thread_id=""),
+                ],
+                usage_metrics=default_usage_metrics(),
+            )
 
         yield FunctionInfo.create(
             single_fn=fn_info.single_fn,

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -60,7 +60,7 @@ def _extract_text(result: Any) -> str:
         return result.choices[0].message.content or ""
     if hasattr(result, "events"):
         return "".join(
-            event.delta
+            event.delta or ""
             for event in result.events
             if isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent))
         )

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -48,6 +48,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _extract_text(result: Any) -> str:
+    """Pull plain text from a stream result.
+
+    ``ChatResponse`` → ``choices[0].message.content``
+    ``DRAgentEventResponse`` (has *events*) → joined text deltas
+    Anything else → ``str(result)``
+    """
+    if isinstance(result, ChatResponse):
+        return result.choices[0].message.content or ""
+    if hasattr(result, "events"):
+        return "".join(
+            event.delta for event in result.events if isinstance(event, TextMessageContentEvent)
+        )
+    return str(result)
+
+
 def convert_to_ragas_messages(
     steps: list[IntermediateStep],
 ) -> list[HumanMessage | AIMessage | ToolMessage]:
@@ -205,16 +221,13 @@ class NatAgent(BaseAgent[None]):
                 async with session.run(chat_request) as runner:
                     intermediate_future = pull_intermediate_structured()
                     async for result in runner.result_stream():
-                        if isinstance(result, ChatResponse):
-                            result_text = result.choices[0].message.content
-                        else:
-                            result_text = str(result)
-
+                        result_text = _extract_text(result)
                         if result_text:
                             if not text_started:
                                 yield (
                                     TextMessageStartEvent(
-                                        type=EventType.TEXT_MESSAGE_START, message_id=message_id
+                                        type=EventType.TEXT_MESSAGE_START,
+                                        message_id=message_id,
                                     ),
                                     None,
                                     zero_metrics,

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -23,6 +23,7 @@ from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
+from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import TextMessageStartEvent
@@ -59,7 +60,9 @@ def _extract_text(result: Any) -> str:
         return result.choices[0].message.content or ""
     if hasattr(result, "events"):
         return "".join(
-            event.delta for event in result.events if isinstance(event, TextMessageContentEvent)
+            event.delta
+            for event in result.events
+            if isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent))
         )
     return str(result)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.9"
+version = "0.15.10"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to NAT result-stream parsing plus a version/changelog bump; main impact is user-visible streaming output formatting if event types differ from expectations.
> 
> **Overview**
> Fixes `NatAgent` streaming to correctly extract and emit plain text when the NAT runner yields `DRAgentEventResponse`-like objects (joining `TextMessageContentEvent`/`TextMessageChunkEvent` deltas) instead of falling back to `str(result)`.
> 
> Bumps the library version to `0.15.10` and records the fix in `CHANGELOG.md` (locks updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f15570ebe4b8b828cd46520bdd959d592ca0a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->