### PR TITLE
Self feedback after using library with an agent

### DIFF
--- a/.taskfiles/tests.yml
+++ b/.taskfiles/tests.yml
@@ -1,8 +1,5 @@
 version: '3'
 
-env:
-  PYTHONWARNINGS: "ignore::UserWarning,ignore::RuntimeWarning"
-
 tasks:
   test:
     desc: "Run repo unit tests via pytest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.12
+- Updating documentation for agents: quickstart guide
+
 ## 0.15.11
 - Added backward compatible route `/chat/completions` route to `dragent`
 - Revised documentation based on feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.12
-- Updating documentation for agents: quickstart guide
+- Updated documentation for agents: added quickstart guide
+- Updated documentation for LLMs: getting models for LLM GW, and additional details for each route
+- Fixed an issue with `datarobot-deployed-llm`: this one should only be the default for the deployment case
 
 ## 0.15.11
 - Added backward compatible route `/chat/completions` route to `dragent`

--- a/README.md
+++ b/README.md
@@ -22,48 +22,49 @@
   </a>
 </p>
 
+A toolkit for building agents on DataRobot.
 
-## Features
+- **Unified LLM layer (DataRobot-compatible)**&mdash;you use one **`get_llm()`** entry point per integration (**LangGraph**, **LlamaIndex**, **CrewAI**, **NAT**), all backed by the same **LiteLLM**-based routing to the **DataRobot LLM Gateway**, **LLM deployments**, **NIM**, or external providers.
+- **Library of agentic tools and DataRobot-compatible MCP server**&mdash;use `drtools` and `drmcp` to give your agent first-class capabilities to interact with the world.
+- **AG-UI integration**&mdash;your agents expose a standard **AG-UI** event stream (`RunAgentInput` in, lifecycle + text + tool-call events out), so your UIs and the DataRobot platform render runs consistently without bespoke adapters per framework.
+- **Multi-agent systems out of the box**&mdash;you get first-class patterns for **planner/writer crews**, **LangGraph** multi-node graphs, and **LlamaIndex** `AgentWorkflow` handoffs; wrap them with one helper and keep the same streaming contract.
+- **Orchestration**&mdash;you build agents from universal pieces in the low-code `workflow.yaml` interface. Combine and reuse LLMs, tools, agents, and evaluators. The design stays compatible with and draws inspiration from [NeMo Agentic Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit).
+- **Serving and evaluating with DRAgent**&mdash;you run a front-end server to plug your agent into a real-world application. DRAgent supports distributed tracing, generation and evaluation endpoints, async generations, and two-way communication over WebSockets.
 
-- **AG-UI integration**&mdash;agents expose a standard **AG-UI** event stream (`RunAgentInput` in, lifecycle + text + tool-call events out), so UIs and the DataRobot platform can render runs consistently without bespoke adapters per framework.
-- **Multi-agent systems out of the box**&mdash;first-class patterns for **planner/writer crews**, **LangGraph** multi-node graphs, and **LlamaIndex** `AgentWorkflow` handoffs; wrap them with one helper and keep the same streaming contract.
-- **Unified LLM layer (DataRobot-compatible)**&mdash;one **`get_llm()`** entry point per integration (**LangGraph**, **LlamaIndex**, **CrewAI**, **NAT**), all backed by the same **LiteLLM**-based routing to the **DataRobot LLM Gateway**, **LLM deployments**, **NIM**, or external providers&mdash;driven by the same environment and `Config`, so every component speaks to DataRobot consistently.
-- Utilities for common GenAI workflows.
-- **Orchestration**&mdash;build agents from universal pieces in the low-code `workflow.yaml` interface. Combine and reuse LLMs, tools, agents, and evaluators. The design is compatible with and inspired by [NeMo Agentic Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit).
-- **Evaluating and serving with DRAgent**&mdash;use a front-end server to plug your agent into a real-world application. It supports distributed tracing, generation and evaluation endpoints, async generations, and two-way communication over WebSockets.
-
-User-facing walkthrough: [docs/README.md](docs/README.md).
+# Use
 
 ## Installation
-- Requires Python 3.11–3.13.
-- Install:
-```bash
-pip install --upgrade pip
-pip install "datarobot-genai"
-```
-- Optional extras:
+- You need Python 3.11–3.13.
+- Install the extra that matches the framework you use:
 ```bash
 pip install "datarobot-genai[crewai]"
 pip install "datarobot-genai[langgraph]"
 pip install "datarobot-genai[llamaindex]"
-# Multiple extras
-pip install "datarobot-genai[crewai,langgraph,llamaindex]"
+pip install "datarobot-genai[nat]"
 ```
-  Available extras include: `crewai`, `langgraph`, `llamaindex`, `nat`, `drmcp`, `pydanticai`.
 
-## Excluded Dependencies
+You can also install:
+* `datarobot-genai[dragent]`&mdash;serve and orchestrate your agent with `DRAgent`.
+* `datarobot-genai[drtools]`&mdash;use the standard library of agentic tools DataRobot provides.
+* `datarobot-genai[drmcp]`&mdash;host a custom MCP server in DataRobot.
 
-Some transitive dependencies are excluded via `exclude-dependencies` in `pyproject.toml` because they are unused by this project. Do not re-add them.
+## Credentials
+You need a DataRobot account to use DataRobot-backed features. Export these environment variables:
 
-| Package | Pulled in by | Reason for exclusion |
-|---|---|---|
-| `uv` | build tooling | Not a runtime dependency. |
-| `langchain-milvus` | langchain ecosystem | Unused vector store integration. |
-| `pymilvus` | langchain-milvus | Transitive dependency of langchain-milvus. |
-| `flask` | nvidia-nat-core 1.6.0 | Only used in NAT examples, not core library code ([ref](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/main/packages/nvidia_nat_core/pyproject.toml#L66)). |
+```bash
+# Set your DataRobot API token (replace the placeholder).
+export DATAROBOT_API_TOKEN=YOUR_DATAROBOT_API_TOKEN
+export DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
+```
 
-## Development
-Prerequisites: Python 3.11–3.14, uv, Task CLI, pre-commit.
+## Standalone end-to-end example
+Follow [docs/example.ipynb](docs/example.ipynb) to walk through a LangGraph agent on DataRobot: LLM Gateway, `drtools`, conversion to DataRobot agent format, and running the agent with an AG-UI interface.
+
+## In-depth documentation
+See [docs/README.md](docs/README.md) for guides on every framework and feature in `datarobot-genai`.
+
+# Develop
+You need Python 3.11–3.13, uv, Task CLI, and pre-commit.
 ```bash
 uv sync --all-extras --dev
 pre-commit install
@@ -71,18 +72,18 @@ task test
 ```
 
 ### Semantic versioning
-Every change requires a patch version change and an entry in `CHANGELOG.md`.
-Changes that break backward compatibility require a minor version bump.
+When you change the library, bump the patch version and add an entry to `CHANGELOG.md`.
+When you introduce a backward-incompatible change, bump the minor version.
 
 ### TestPyPI
-Comment `/build` on a PR to build and publish a dev version of the package to TestPyPI.
+Comment `/build` on your PR to build and publish a dev version of the package to TestPyPI.
 
 ## Publishing
 
-- **Same-repo PRs**&mdash;comment `/build` to publish dev builds to TestPyPI (`.devN`).
-- **Merge to `main`**&mdash;creates tag `v{version}` and publishes to PyPI automatically.
-- **Version tags**&mdash;pushing a `v*` tag also triggers PyPI publish.
-- **Local release**&mdash;optional `task release:tag-and-push` creates and pushes `v{version}` locally.
+- **Same-repo PRs**&mdash;comment `/build` on your PR to publish dev builds to TestPyPI (`.devN`).
+- **Merge to `main`**&mdash;the release flow creates tag `v{version}` and publishes to PyPI automatically.
+- **Version tags**&mdash;when you push a `v*` tag, PyPI publish runs as well.
+- **Local release**&mdash;optionally run `task release:tag-and-push` to create and push `v{version}` from your machine.
 
 ## Links
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,79 +15,50 @@
   <a href="https://docs.datarobot.com/en/docs/get-started/troubleshooting/general-help.html">Support</a>
 </p>
 
-Build agents with **LangGraph**, **LlamaIndex**, or **CrewAI**, or define them in a **NAT `workflow.yaml`** and run them with **DRAgent** (HTTP + AG-UI). The docs are aligned with the **examples under [`e2e-tests/dragent/`](https://github.com/datarobot-oss/datarobot-genai/tree/main/e2e-tests/dragent)**&mdash;that folder is the source of truth for what you configure and what you run.
+You can build agents with **LangGraph**, **LlamaIndex**, or **CrewAI**, or define them in a **NAT `workflow.yaml`** and run them with **DRAgent** (HTTP + AG-UI). Use the **examples under [`e2e-tests/dragent/`](https://github.com/datarobot-oss/datarobot-genai/tree/main/e2e-tests/dragent)** as your source of truth for what to configure and how to run that stack&mdash;these docs follow those samples.
 
 **What you see in practice**
 
-- A **`workflow.yaml`** per sample&mdash;names the LLM (`llms:`), chooses the runner (`workflow._type:`), and optionally adds tools, MCP groups, and auth. DRAgent reads this file.
-- A **`myagent.py`** (framework agents)&mdash;where you define the graph, crew, or workflow; DRAgent ties it to the YAML via registration.
-- **Environment variables** for API token, endpoint, and LLM routing&mdash;same ideas everywhere. See [LLM configuration](llm.md).
+- In each sample, **`workflow.yaml`** names the LLM (`llms:`), picks the runner (`workflow._type:`), and optionally adds tools, MCP groups, and auth. DRAgent reads this file.
+- In each sample, **`myagent.py`** (framework agents)&mdash;where you define the graph, crew, or workflow. DRAgent registers it against the YAML.
+- **Environment variables** for API token, endpoint, and LLM routing&mdash;you use the same ideas across stacks. See [LLM configuration](llm.md).
 
-**AG-UI**&mdash;chat UIs and tests consume a stream of **AG-UI events** (run lifecycle, text, tools, steps). DRAgent serves that over SSE; the examples show end-to-end behavior.
-
-**Notebook**&mdash;[`Example.ipynb`](Example.ipynb) is an optional Jupyter walkthrough (credentials, listing gateway models, a **LangGraph** graph + `datarobot_agent_class_from_langgraph`, AG-UI `invoke`).
-
-## Prerequisites
-
-| Requirement | Details |
-|---|---|
-| Python | 3.11–3.13. |
-| DataRobot account | API token and endpoint. |
-
-```bash
-# Set your DataRobot API token (replace the placeholder).
-export DATAROBOT_API_TOKEN=YOUR_DATAROBOT_API_TOKEN
-export DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
-```
-
-Adjust `DATAROBOT_ENDPOINT` for your environment if it differs from the default.
-
-## Installation
-
-```bash
-# Framework SDKs (see each guide for extras)
-pip install "datarobot-genai[langgraph]"
-pip install "datarobot-genai[llamaindex]"
-pip install "datarobot-genai[crewai]"
-
-# NAT workflow + DRAgent (YAML-driven agents)
-pip install "datarobot-genai[dragent]"
-```
+**AG-UI**&mdash;when you build chat UIs or tests, you work with a stream of **AG-UI events** (run lifecycle, text, tools, steps). DRAgent serves those events over SSE; the examples walk you through the flow end to end.
 
 ## Guides (what to edit in the examples)
 
-Each guide explains the **interfaces you see in the repo**: `workflow.yaml` keys, env vars, and the Python file the sample ships with.
+Each guide walks you through the **interfaces in the repo**: `workflow.yaml` keys, env vars, and the Python file each sample ships.
 
-| Integration | Overview | Agent & workflow surface | LLM options | Tools & MCP | Caveats |
+| Integration | Overview | Agent and workflow surface | LLM options | Tools and MCP | Caveats |
 |---|---|---|---|---|---|
 | LangGraph | [langgraph/](langgraph/) | [langgraph/agent.md](langgraph/agent.md) | [LLM configuration](llm.md) | [langgraph/mcp.md](langgraph/mcp.md) | [langgraph/caveats.md](langgraph/caveats.md) |
 | LlamaIndex | [llamaindex/](llamaindex/) | [llamaindex/agent.md](llamaindex/agent.md) | [LLM configuration](llm.md) | [llamaindex/mcp.md](llamaindex/mcp.md) | [llamaindex/caveats.md](llamaindex/caveats.md) |
 | CrewAI | [crewai/](crewai/) | [crewai/agent.md](crewai/agent.md) | [LLM configuration](llm.md) | [crewai/mcp.md](crewai/mcp.md) | [crewai/caveats.md](crewai/caveats.md) |
 | NAT + DRAgent | [nat/](nat/) | [nat/agent.md](nat/agent.md) | [nat/llm.md](nat/llm.md) | [nat/mcp.md](nat/mcp.md) | [nat/caveats.md](nat/caveats.md) |
 
-Shared **LLM routing** (gateway vs deployment vs NIM vs external): [LLM configuration](llm.md).
+For shared **LLM routing** (gateway vs deployment vs NIM vs external), see [LLM configuration](llm.md).
 
-**NAT note:** the contract you edit is **`workflow.yaml`**. DRAgent is the supported way to host those workflows. A legacy in-process Python path exists for loading the same YAML without DRAgent; new work should target DRAgent.
+**Note:** With NAT, you edit **`workflow.yaml`** as the contract. Host workflows with DRAgent for the supported path. You can still load the same YAML in process without DRAgent (legacy); target DRAgent for new work.
 
-Minimal custom agent without a framework wrapper: [`e2e-tests/dragent/base/myagent.py`](../e2e-tests/dragent/base/myagent.py) and its [`workflow.yaml`](../e2e-tests/dragent/base/workflow.yaml).
+For a minimal custom agent without a framework wrapper, start from [`e2e-tests/dragent/base/myagent.py`](../e2e-tests/dragent/base/myagent.py) and its [`workflow.yaml`](../e2e-tests/dragent/base/workflow.yaml).
 
 ## DRAgent CLI
 
-Standalone CLI for running and querying DRAgent workflows via NAT. See [docs/dragent/](dragent/) for full usage (`serve`, `run`, `query`, completion JSON, authentication, debugging).
+The standalone CLI runs and queries DRAgent workflows over NAT. See [docs/dragent/](dragent/) for `serve`, `run`, `query`, completion JSON, authentication, and debugging.
 
 ## Configuration reference
 
-Environment variables the examples and `workflow.yaml` assume (full table): [LLM configuration](llm.md).
+The examples and `workflow.yaml` expect the variables below; see [LLM configuration](llm.md) for the full table and details.
 
 | Variable | Default | Description |
 |---|---|---|
 | `DATAROBOT_API_TOKEN` | — | Your DataRobot API token. |
-| `DATAROBOT_ENDPOINT` | `https://app.datarobot.com/api/v2` | DataRobot API endpoint. |
-| `USE_DATAROBOT_LLM_GATEWAY` | `true` | Use the DataRobot LLM Gateway when `true`. |
-| `LLM_DEPLOYMENT_ID` | — | Route to a specific LLM deployment when the gateway is off. |
-| `NIM_DEPLOYMENT_ID` | — | Route to an NVIDIA NIM deployment when the gateway is off. |
-| `LLM_DEFAULT_MODEL` | `datarobot-deployed-llm` | Default model name. |
-| `DATAROBOT_GENAI_MAX_HISTORY_MESSAGES` | `20` | Maximum prior messages in history. |
+| `DATAROBOT_ENDPOINT` | `https://app.datarobot.com/api/v2` | Base URL for your DataRobot API requests. |
+| `USE_DATAROBOT_LLM_GATEWAY` | `true` | Set to `true` to use the DataRobot LLM Gateway. |
+| `LLM_DEPLOYMENT_ID` | — | Set this to target a specific LLM deployment when the gateway is off. |
+| `NIM_DEPLOYMENT_ID` | — | Set this to target an NVIDIA NIM deployment when the gateway is off. |
+| `LLM_DEFAULT_MODEL` | `datarobot-deployed-llm` | Default model name you run against. |
+| `DATAROBOT_GENAI_MAX_HISTORY_MESSAGES` | `20` | Maximum number of prior messages the client keeps in history. |
 
 ## License
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -14,36 +14,109 @@
   ~ limitations under the License.
 -->
 
-# LLM configuration (what the examples assume)
+# LLM configuration
 
-Whether you use **`workflow.yaml`** (`llms:` blocks) or Python agents, the same **routing idea** applies: DataRobot **LLM Gateway**, a **model deployment**, **NIM**, or an **external** provider via LiteLLM. You steer that with **environment variables** (and optional fields inside YAML for deployment-specific headers).
+Whether you use **`workflow.yaml`** (`llms:` blocks) or Python agents, the same **routing idea** applies: DataRobot **LLM Gateway**, a **model deployment**, **NIM**, or an **external** provider via LiteLLM.
 
-## Environment variables
+In Python, each integration exposes the same helpers from its `llm` submodule&mdash;swap the import path only:
 
-Values are read from the process environment (and `.env` in the working directory when your runner loads it). Typical names:
-
-| Variable | Role |
+| Integration | Import from |
 |---|---|
-| `DATAROBOT_ENDPOINT` | Base API URL (default `https://app.datarobot.com/api/v2`). Used to build gateway and deployment URLs. |
-| `DATAROBOT_API_TOKEN` | Token for DataRobot-hosted LLM routes. |
-| `USE_DATAROBOT_LLM_GATEWAY` | When `true` (default), use the **DataRobot LLM Gateway**. |
-| `LLM_DEPLOYMENT_ID` | When the gateway is off, use this **LLM deployment** chat endpoint. |
-| `NIM_DEPLOYMENT_ID` | When the gateway is off and no LLM deployment id is set, use this **NIM** deployment. |
-| `LLM_DEFAULT_MODEL` | Default model id (often `datarobot-deployed-llm`). |
-| `DATAROBOT_GENAI_MAX_HISTORY_MESSAGES` | How many prior chat turns to include in history summaries. |
+| LangGraph | `datarobot_genai.langgraph.llm` |
+| LlamaIndex | `datarobot_genai.llama_index.llm` |
+| CrewAI | `datarobot_genai.crewai.llm` |
 
-## Routing outcomes (four cases)
+Values are read from the process environment (and `.env` in the working directory when your runner loads it). For DataRobot-hosted routes you typically set `DATAROBOT_ENDPOINT` and `DATAROBOT_API_TOKEN` (see [Example.ipynb](Example.ipynb)).
 
-What you get depends on flags and ids:
+## DataRobot LLM Gateway
 
-1. **Gateway**&mdash;`USE_DATAROBOT_LLM_GATEWAY=true` (default): calls go through the DataRobot LLM Gateway derived from `DATAROBOT_ENDPOINT`.
-2. **Deployment**&mdash;gateway off **and** `LLM_DEPLOYMENT_ID` set: calls go to that deployment’s chat completions URL.
-3. **NIM**&mdash;gateway off, no LLM deployment id, **and** `NIM_DEPLOYMENT_ID` set: same URL style as a deployment, using the NIM id.
-4. **External**&mdash;gateway off and neither deployment id set: LiteLLM talks to external providers using **their** env vars (for example `OPENAI_API_KEY`). Model names should not rely on the `datarobot/` prefix in that mode.
+Use **`get_datarobot_gateway_llm()`** when you always want the gateway regardless of `USE_DATAROBOT_LLM_GATEWAY`. Calls go through the gateway URL derived from `DATAROBOT_ENDPOINT`; use `DATAROBOT_API_TOKEN` as the API key.
+
+**Pick a real gateway model id.** Do **not** rely on the default model name for gateway use: `get_datarobot_gateway_llm()` falls back to `LLM_DEFAULT_MODEL` which might be empty in your env.
+
+1. Install `dr` CLI plugin that lists models your account can use ([get-datarobot-llms](https://github.com/carsongee/get-datarobot-llms)):
+
+   ```bash
+   uv tool install git+https://github.com/carsongee/get-datarobot-llms.git
+   ```
+
+2. With `DATAROBOT_ENDPOINT` and `DATAROBOT_API_TOKEN` set, list ids you can pass as `datarobot-model`:
+
+   ```bash
+   dr get-llms
+   ```
+
+3. Pass a chosen id explicitly (LangGraph example):
+
+   ```python
+   from datarobot_genai.langgraph.llm import get_datarobot_gateway_llm
+
+   llm = get_datarobot_gateway_llm("datarobot/azure/gpt-5-nano-2025-08-07")
+   ```
+
+## LLM deployment
+
+Use **`get_datarobot_deployment_llm(deployment_id, ...)`** to send chat completions to a specific DataRobot deployment. The client uses `DATAROBOT_ENDPOINT` and `DATAROBOT_API_TOKEN` to build `{endpoint}/deployments/{deployment_id}/chat/completions`. You may pass `model_name` and `parameters` like other helpers.
+
+```python
+from datarobot_genai.langgraph.llm import get_datarobot_deployment_llm
+
+llm = get_datarobot_deployment_llm("your-deployment-id")
+```
+
+## NIM deployment
+
+Use **`get_datarobot_nim_llm(nim_deployment_id, ...)`** for an NVIDIA NIM deployment hosted like a DataRobot deployment (same URL shape as **`get_datarobot_deployment_llm`**).
+
+```python
+from datarobot_genai.langgraph.llm import get_datarobot_nim_llm
+
+llm = get_datarobot_nim_llm("your-nim-deployment-id", model_name="optional-model-id")
+```
+
+## External providers (LiteLLM)
+
+Use **`get_external_llm()`** when you want LiteLLM to call **external** providers (for example OpenAI) using **their** environment variables (for example `OPENAI_API_KEY`). Model names should **not** rely on the `datarobot/` prefix in this mode.
+
+```python
+from datarobot_genai.langgraph.llm import get_external_llm
+
+llm = get_external_llm("gpt-4o-mini")
+```
+
+To reach this route via **`get_llm()`**, turn the gateway off and unset both `LLM_DEPLOYMENT_ID` and `NIM_DEPLOYMENT_ID` (see **get_llm()** below).
+
+## `get_llm()` (environment-driven routing)
+
+Prefer the explicit **`get_*`** helpers above when you know the route. Use **`get_llm()`** as a single entry point when you want one code path and you steer behavior entirely with configuration. It inspects settings and delegates to the same underlying helpers as those sections.
+
+Routing order:
+
+1. **Gateway** if `USE_DATAROBOT_LLM_GATEWAY=true` (default).
+2. Else **deployment** if `LLM_DEPLOYMENT_ID` is set.
+3. Else **NIM** if `NIM_DEPLOYMENT_ID` is set.
+4. Else **external** (LiteLLM using provider-specific environment variables).
 
 If both `LLM_DEPLOYMENT_ID` and `NIM_DEPLOYMENT_ID` are set with the gateway off, **deployment wins**.
 
-## In `workflow.yaml`
+These variables control **`get_llm()`** specifically:
+
+| Variable | Role |
+|---|---|
+| `USE_DATAROBOT_LLM_GATEWAY` | When `true` (default), use the **DataRobot LLM Gateway**. |
+| `LLM_DEPLOYMENT_ID` | When the gateway is off, use this **LLM deployment** chat endpoint. |
+| `NIM_DEPLOYMENT_ID` | When the gateway is off and no LLM deployment id is set, use this **NIM** deployment. |
+| `LLM_DEFAULT_MODEL` | Default model id when you omit `model_name` on **`get_llm()`** |
+
+Example (LangGraph; adjust the import for LlamaIndex or CrewAI):
+
+```python
+from datarobot_genai.langgraph.llm import get_llm
+
+llm = get_llm()  # optional: model_name="...", parameters={...}, streaming=True
+```
+
+# In `workflow.yaml`
 
 The e2e samples usually declare one named LLM and reference it from `workflow`:
 
@@ -53,4 +126,4 @@ llms:
     _type: datarobot-llm-component
 ```
 
-That component follows the same four outcomes using fields on the block (gateway flag, deployment ids, etc.) and the environment above. NAT-specific YAML details live in [nat/llm.md](nat/llm.md). LangGraph, LlamaIndex, and CrewAI samples use the same environment-driven routing described on this page.
+That component follows the same four outcomes using fields on the block (gateway flag, deployment ids, etc.) and the environment.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.11"
+version = "0.15.12"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.11"
+version = "0.15.12"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -20,6 +20,7 @@ from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from pydantic import Field
 
 DEFAULT_MAX_HISTORY_MESSAGES = 20
+DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM = "datarobot/datarobot-deployed-llm"
 
 
 class LLMType(StrEnum):
@@ -74,9 +75,9 @@ def default_api_key() -> str | None:
     return config.datarobot_api_token if config.datarobot_api_token else None
 
 
-def default_model_name() -> str:
+def default_model_name() -> str | None:
     config = Config()
-    return config.llm_default_model or "datarobot-deployed-llm"
+    return config.llm_default_model
 
 
 def default_use_datarobot_llm_gateway() -> bool:

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from crewai import LLM
 
+from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
 from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
@@ -54,6 +55,9 @@ def get_datarobot_gateway_llm(model_name: str | None = None, parameters: dict | 
         config.update(parameters)
 
     model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
     if not model_name.startswith("datarobot/"):
         model_name = "datarobot/" + model_name
 
@@ -73,7 +77,7 @@ def get_datarobot_deployment_llm(
     if parameters:
         config.update(parameters)
 
-    model_name = model_name or default_model_name()
+    model_name = model_name or default_model_name() or DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
     if not model_name.startswith("datarobot/"):
         model_name = "datarobot/" + model_name
 
@@ -84,7 +88,23 @@ def get_datarobot_deployment_llm(
 def get_datarobot_nim_llm(
     nim_deployment_id: str, model_name: str | None = None, parameters: dict | None = None
 ) -> LLM:
-    return get_datarobot_deployment_llm(nim_deployment_id, model_name, parameters)
+    config = {
+        "api_key": default_api_key(),
+        "api_base": default_deployment_url(nim_deployment_id),
+    }
+
+    if parameters:
+        config.update(parameters)
+
+    model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
+    if not model_name.startswith("datarobot/"):
+        model_name = "datarobot/" + model_name
+
+    config["model"] = model_name
+    return _crewai_model_factory(config)
 
 
 def get_external_llm(model_name: str | None = None, parameters: dict | None = None) -> LLM:
@@ -95,6 +115,9 @@ def get_external_llm(model_name: str | None = None, parameters: dict | None = No
     if parameters:
         config.update(parameters)
     model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
     model_name = model_name.removeprefix("datarobot/")
     config["model"] = model_name
 

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 
+from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
 from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
@@ -48,6 +49,9 @@ def get_datarobot_gateway_llm(
         config.update(parameters)
 
     model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
     if not model_name.startswith("datarobot/"):
         model_name = "datarobot/" + model_name
 
@@ -69,7 +73,7 @@ def get_datarobot_deployment_llm(
     if parameters:
         config.update(parameters)
 
-    model_name = model_name or default_model_name()
+    model_name = model_name or default_model_name() or DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
     if not model_name.startswith("datarobot/"):
         model_name = "datarobot/" + model_name
 
@@ -83,7 +87,23 @@ def get_datarobot_nim_llm(
     parameters: dict | None = None,
     streaming: bool = True,
 ) -> BaseChatModel:
-    return get_datarobot_deployment_llm(nim_deployment_id, model_name, parameters, streaming)
+    config: dict[str, Any] = {
+        "api_key": default_api_key(),
+        "api_base": default_deployment_url(nim_deployment_id),
+        "streaming": streaming,
+    }
+    if parameters:
+        config.update(parameters)
+
+    model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
+    if not model_name.startswith("datarobot/"):
+        model_name = "datarobot/" + model_name
+
+    config["model"] = model_name
+    return _create_datarobot_chat_litellm(config)
 
 
 def get_external_llm(
@@ -96,6 +116,9 @@ def get_external_llm(
         config.update(parameters)
 
     model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
     model_name = model_name.removeprefix("datarobot/")
 
     config["model"] = model_name

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from llama_index.llms.litellm import LiteLLM
 
+from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
 from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
@@ -67,6 +68,8 @@ def get_datarobot_gateway_llm(
         config.update(parameters)
 
     model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
 
     if not model_name.startswith("datarobot/"):
         model_name = "datarobot/" + model_name
@@ -87,7 +90,7 @@ def get_datarobot_deployment_llm(
     if parameters:
         config.update(parameters)
 
-    model_name = model_name or default_model_name()
+    model_name = model_name or default_model_name() or DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
     if not model_name.startswith("datarobot/"):
         model_name = "datarobot/" + model_name
 
@@ -98,7 +101,24 @@ def get_datarobot_deployment_llm(
 def get_datarobot_nim_llm(
     nim_deployment_id: str, model_name: str | None = None, parameters: dict | None = None
 ) -> LiteLLM:
-    return get_datarobot_deployment_llm(nim_deployment_id, model_name, parameters)
+    config = {
+        "api_key": default_api_key(),
+        "api_base": default_deployment_url(nim_deployment_id),
+        "stream_options": {"include_usage": True},
+    }
+
+    if parameters:
+        config.update(parameters)
+
+    model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
+    if not model_name.startswith("datarobot/"):
+        model_name = "datarobot/" + model_name
+
+    config["model"] = model_name
+    return _create_datarobot_litellm(config)
 
 
 def get_external_llm(model_name: str | None = None, parameters: dict | None = None) -> LiteLLM:
@@ -109,6 +129,9 @@ def get_external_llm(model_name: str | None = None, parameters: dict | None = No
         config.update(parameters)
 
     model_name = model_name or default_model_name()
+    if model_name is None:
+        raise ValueError("Model name is required")
+
     model_name = model_name.removeprefix("datarobot/")
     config["model"] = model_name
     return _create_datarobot_litellm(config)

--- a/src/datarobot_genai/nat/datarobot_llm_providers.py
+++ b/src/datarobot_genai/nat/datarobot_llm_providers.py
@@ -35,7 +35,7 @@ class DataRobotLLMComponentModelConfig(OpenAIModelConfig, name="datarobot-llm-co
         validation_alias=AliasChoices("model_name", "model"),
         serialization_alias="model",
         description=(
-            "The model name (required for gateway, NIM, and external; optional for deployment).",
+            "The model name (required for gateway, NIM, and external; optional for deployment)."
         ),
         default=None,
     )

--- a/src/datarobot_genai/nat/datarobot_llm_providers.py
+++ b/src/datarobot_genai/nat/datarobot_llm_providers.py
@@ -21,9 +21,9 @@ from nat.llm.openai_llm import OpenAIModelConfig
 from pydantic import AliasChoices
 from pydantic import Field
 
+from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_llm_deployment_id
-from datarobot_genai.core.config import default_model_name
 from datarobot_genai.core.config import default_nim_deployment_id
 from datarobot_genai.core.config import default_use_datarobot_llm_gateway
 
@@ -31,11 +31,13 @@ from datarobot_genai.core.config import default_use_datarobot_llm_gateway
 class DataRobotLLMComponentModelConfig(OpenAIModelConfig, name="datarobot-llm-component"):  # type: ignore[call-arg]
     """A DataRobot LLM provider to be used with an LLM client."""
 
-    model_name: str = Field(
+    model_name: str | None = Field(
         validation_alias=AliasChoices("model_name", "model"),
         serialization_alias="model",
-        description="The model name.",
-        default_factory=default_model_name,
+        description=(
+            "The model name (required for gateway, NIM, and external; optional for deployment).",
+        ),
+        default=None,
     )
     use_datarobot_llm_gateway: bool = Field(
         default_factory=default_use_datarobot_llm_gateway,
@@ -94,7 +96,7 @@ class DataRobotLLMDeploymentModelConfig(OpenAIModelConfig, name="datarobot-llm-d
         validation_alias=AliasChoices("model_name", "model"),
         serialization_alias="model",
         description="The model name to pass through to the deployment.",
-        default="datarobot-deployed-llm",
+        default=DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM,
     )
     llm_deployment_id: str = Field(
         description="The LLM deployment ID.",
@@ -118,11 +120,11 @@ async def datarobot_llm_deployment(
 class DataRobotNIMModelConfig(NIMModelConfig, name="datarobot-nim"):  # type: ignore[call-arg]
     """A DataRobot NIM LLM provider to be used with an LLM client."""
 
-    model_name: str = Field(
+    model_name: str | None = Field(
         validation_alias=AliasChoices("model_name", "model"),
         serialization_alias="model",
-        description="The model name to pass through to the deployment.",
-        default="datarobot-deployed-llm",
+        description="The model name to pass through to the NIM deployment.",
+        default=None,
     )
     nim_deployment_id: str = Field(
         description="The LLM deployment ID.",
@@ -140,11 +142,11 @@ async def datarobot_nim(config: DataRobotNIMModelConfig, _builder: Builder) -> L
 class DataRobotLitellmConfig(LiteLlmModelConfig, name="datarobot-litellm"):  # type: ignore[call-arg]
     """A DataRobot Litellm provider to be used with an LLM client."""
 
-    model_name: str = Field(
+    model_name: str | None = Field(
         validation_alias=AliasChoices("model_name", "model"),
         serialization_alias="model",
         description="The model name.",
-        default_factory=default_model_name,
+        default=None,
     )
 
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -122,10 +122,10 @@ def test_default_model_name_returns_configured_value() -> None:
         assert default_model_name() == "azure/gpt-4o"
 
 
-def test_default_model_name_falls_back_to_builtin() -> None:
+def test_default_model_name_returns_none_when_unset() -> None:
     cfg = _make_config(llm_default_model=None)
     with patch.object(config_mod, "Config", return_value=cfg):
-        assert default_model_name() == "datarobot-deployed-llm"
+        assert default_model_name() is None
 
 
 # --- default_use_datarobot_llm_gateway ---

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pytest
 from crewai import LLM
 
+from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.crewai import llm as crewai_llm
 
@@ -102,16 +103,36 @@ def test_get_datarobot_deployment_llm_merges_parameters() -> None:
     assert llm.temperature == 0.4
 
 
-def test_get_datarobot_nim_llm_delegates_to_deployment_llm() -> None:
-    with patch.object(
-        crewai_llm,
-        "get_datarobot_deployment_llm",
-        wraps=crewai_llm.get_datarobot_deployment_llm,
-    ) as spy:
-        llm = crewai_llm.get_datarobot_nim_llm("nim-1", "m", {"max_tokens": 10})
-    spy.assert_called_once_with("nim-1", "m", {"max_tokens": 10})
+def test_get_datarobot_deployment_llm_uses_deployed_placeholder_when_default_model_unset() -> None:
+    with patch.object(crewai_llm, "default_model_name", return_value=None):
+        llm = crewai_llm.get_datarobot_deployment_llm("dep-abc-123")
+    assert llm.model == DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
+
+
+def test_get_datarobot_gateway_llm_raises_when_model_unset() -> None:
+    with patch.object(crewai_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            crewai_llm.get_datarobot_gateway_llm()
+
+
+def test_get_datarobot_nim_llm_builds_nim_endpoint_and_model() -> None:
+    llm = crewai_llm.get_datarobot_nim_llm("nim-1", "m", {"max_tokens": 10})
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
+    assert llm.api_base == "https://example.test/deployments/nim-1/chat/completions"
+    assert llm.model == "datarobot/m"
+
+
+def test_get_datarobot_nim_llm_raises_when_model_unset() -> None:
+    with patch.object(crewai_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            crewai_llm.get_datarobot_nim_llm("nim-1")
+
+
+def test_get_external_llm_raises_when_model_unset() -> None:
+    with patch.object(crewai_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            crewai_llm.get_external_llm()
 
 
 def test_get_external_llm_returns_crewai_llm() -> None:

--- a/tests/langgraph/test_llm.py
+++ b/tests/langgraph/test_llm.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pytest
 from langchain_core.language_models import BaseChatModel
 
+from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.langgraph import llm as langgraph_llm
 
@@ -83,15 +84,35 @@ def test_get_datarobot_deployment_llm_sets_deployment_api_base() -> None:
     assert llm.stream_options == {"include_usage": True}
 
 
-def test_get_datarobot_nim_llm_delegates_to_deployment_llm() -> None:
-    with patch.object(
-        langgraph_llm,
-        "get_datarobot_deployment_llm",
-        wraps=langgraph_llm.get_datarobot_deployment_llm,
-    ) as spy:
-        llm = langgraph_llm.get_datarobot_nim_llm("nim-1", "m", {"max_tokens": 10})
-    spy.assert_called_once_with("nim-1", "m", {"max_tokens": 10}, True)
+def test_get_datarobot_deployment_llm_uses_deployed_placeholder_when_default_model_unset() -> None:
+    with patch.object(langgraph_llm, "default_model_name", return_value=None):
+        llm = langgraph_llm.get_datarobot_deployment_llm("dep-abc-123")
+    assert llm.model == DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
+
+
+def test_get_datarobot_gateway_llm_raises_when_model_unset() -> None:
+    with patch.object(langgraph_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            langgraph_llm.get_datarobot_gateway_llm()
+
+
+def test_get_datarobot_nim_llm_builds_nim_endpoint_and_model() -> None:
+    llm = langgraph_llm.get_datarobot_nim_llm("nim-1", "m", {"max_tokens": 10})
     assert isinstance(llm, BaseChatModel)
+    assert llm.api_base == "https://example.test/deployments/nim-1/chat/completions"
+    assert llm.model == "datarobot/m"
+
+
+def test_get_datarobot_nim_llm_raises_when_model_unset() -> None:
+    with patch.object(langgraph_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            langgraph_llm.get_datarobot_nim_llm("nim-1")
+
+
+def test_get_external_llm_raises_when_model_unset() -> None:
+    with patch.object(langgraph_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            langgraph_llm.get_external_llm()
 
 
 def test_gateway_llm_factory_omits_stream_options_kwarg_when_not_streaming() -> None:

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pytest
 from llama_index.llms.litellm import LiteLLM
 
+from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.llama_index import llm as llama_index_llm
 
@@ -92,15 +93,36 @@ def test_get_datarobot_deployment_llm_appends_chat_completions_to_api_base() -> 
     )
 
 
-def test_get_datarobot_nim_llm_delegates_to_deployment_llm() -> None:
-    with patch.object(
-        llama_index_llm,
-        "get_datarobot_deployment_llm",
-        wraps=llama_index_llm.get_datarobot_deployment_llm,
-    ) as spy:
-        llm = llama_index_llm.get_datarobot_nim_llm("nim-1", "m", {"max_tokens": 10})
-    spy.assert_called_once_with("nim-1", "m", {"max_tokens": 10})
+def test_get_datarobot_deployment_llm_uses_deployed_placeholder_when_default_model_unset() -> None:
+    with patch.object(llama_index_llm, "default_model_name", return_value=None):
+        llm = llama_index_llm.get_datarobot_deployment_llm("dep-abc-123")
+    assert llm.model == DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
+
+
+def test_get_datarobot_gateway_llm_raises_when_model_unset() -> None:
+    with patch.object(llama_index_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            llama_index_llm.get_datarobot_gateway_llm()
+
+
+def test_get_datarobot_nim_llm_builds_nim_endpoint_and_model() -> None:
+    llm = llama_index_llm.get_datarobot_nim_llm("nim-1", "m", {"max_tokens": 10})
     assert isinstance(llm, LiteLLM)
+    extras = llm.additional_kwargs or {}
+    assert extras.get("api_base") == "https://example.test/deployments/nim-1/chat/completions"
+    assert llm.model == "datarobot/m"
+
+
+def test_get_datarobot_nim_llm_raises_when_model_unset() -> None:
+    with patch.object(llama_index_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            llama_index_llm.get_datarobot_nim_llm("nim-1")
+
+
+def test_get_external_llm_raises_when_model_unset() -> None:
+    with patch.object(llama_index_llm, "default_model_name", return_value=None):
+        with pytest.raises(ValueError, match="Model name is required"):
+            llama_index_llm.get_external_llm()
 
 
 def test_datarobot_litellm_metadata_enables_chat_and_tooling() -> None:

--- a/tests/nat/integration/test_nat_adaptors.py
+++ b/tests/nat/integration/test_nat_adaptors.py
@@ -161,7 +161,7 @@ async def test_datarobot_llm_deployment_llamaindex():
 async def test_datarobot_nim_langchain():
     prompt = ChatPromptTemplate.from_messages([("human", "{input}")])
 
-    llm_config = DataRobotNIMModelConfig(temperature=0.0)
+    llm_config = DataRobotNIMModelConfig(temperature=0.0, model_name="azure/gpt-4o-2024-11-20")
 
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -178,7 +178,7 @@ async def test_datarobot_nim_crewai():
     input = "What is 1+2?"
     messages = [{"role": "user", "content": f"{input}"}]
 
-    llm_config = DataRobotNIMModelConfig(temperature=0.0)
+    llm_config = DataRobotNIMModelConfig(temperature=0.0, model_name="azure/gpt-4o-2024-11-20")
 
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -195,7 +195,7 @@ async def test_datarobot_nim_llamaindex():
         ChatMessage.from_str(input, "user"),
     ]
 
-    llm_config = DataRobotNIMModelConfig(temperature=0.0)
+    llm_config = DataRobotNIMModelConfig(temperature=0.0, model_name="azure/gpt-4o-2024-11-20")
 
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)

--- a/tests/nat/test_nat_llm.py
+++ b/tests/nat/test_nat_llm.py
@@ -148,7 +148,10 @@ async def test_datarobot_llm_deployment_llamaindex_with_identity_token():
 
 async def test_datarobot_nim_langchain():
     llm_config = DataRobotNIMModelConfig(
-        nim_deployment_id="123", temperature=0.0, api_key="some_token"
+        nim_deployment_id="123",
+        model_name="azure/gpt-4o-2024-11-20",
+        temperature=0.0,
+        api_key="some_token",
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -158,7 +161,10 @@ async def test_datarobot_nim_langchain():
 
 async def test_datarobot_nim_crewai():
     llm_config = DataRobotNIMModelConfig(
-        nim_deployment_id="123", temperature=0.0, api_key="some_token"
+        nim_deployment_id="123",
+        model_name="azure/gpt-4o-2024-11-20",
+        temperature=0.0,
+        api_key="some_token",
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -168,7 +174,10 @@ async def test_datarobot_nim_crewai():
 
 async def test_datarobot_nim_llamaindex():
     llm_config = DataRobotNIMModelConfig(
-        nim_deployment_id="123", temperature=0.0, api_key="some_token"
+        nim_deployment_id="123",
+        model_name="azure/gpt-4o-2024-11-20",
+        temperature=0.0,
+        api_key="some_token",
     )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
@@ -177,7 +186,9 @@ async def test_datarobot_nim_llamaindex():
 
 
 async def test_datarobot_llm_component_langchain_use_gateway():
-    llm_config = DataRobotLLMComponentModelConfig(api_key="some_token")
+    llm_config = DataRobotLLMComponentModelConfig(
+        api_key="some_token", model_name="azure/gpt-4o-2024-11-20"
+    )
     async with WorkflowBuilder() as builder:
         await builder.add_llm("datarobot_llm", llm_config)
         llm = await builder.get_llm("datarobot_llm", wrapper_type=LLMFrameworkEnum.LANGCHAIN)

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.11"
+version = "0.15.12"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- Updated documentation for agents: added quickstart guide
- Updated documentation for LLMs: getting models for LLM GW, and additional details for each route
- Fixed an issue with `datarobot-deployed-llm`: this one should only be the default for the deployment case

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM defaulting behavior across LangGraph/CrewAI/LlamaIndex/NAT: gateway/NIM/external now error if no model is configured, while deployments fall back to a specific placeholder model. This can break existing setups that relied on implicit `LLM_DEFAULT_MODEL` defaults, but is covered by updated unit/integration tests and documentation.
> 
> **Overview**
> **Fixes incorrect model defaulting across LLM helpers.** `default_model_name()` now returns `None` when unset, and a new `DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM` placeholder is used *only* for deployment-backed LLMs.
> 
> Gateway, NIM, and external LLM constructors in `crewai`, `langgraph`, and `llama_index` now **require an explicit model name** (raising `ValueError` if none is provided), while deployment constructors keep working via the deployment-only fallback.
> 
> Docs and release metadata are refreshed: version bumped to `0.15.12`, LLM routing documentation expanded, README/docs wording updated, NAT provider configs loosen `model_name` defaults (tests updated to pass explicit models), and Task test config stops globally suppressing Python warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c654b3094b29d25da14d593be76334704e27666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->