### PR TITLE
[-] Use 'unknown' as CLI model placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.13
+- Changed CLI model placeholder to `unknown` so the agent resolves the model from config (LLM_DEFAULT_MODEL)
+
 ## 0.15.12
 - Updated documentation for agents: added quickstart guide
 - Updated documentation for LLMs: getting models for LLM GW, and additional details for each route

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.12"
+version = "0.15.13"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.12"
+version = "0.15.13"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/cli/agent_kernel.py
+++ b/src/datarobot_genai/core/cli/agent_kernel.py
@@ -66,7 +66,7 @@ class AgentKernel:
         }
         if stream:
             return CompletionCreateParamsStreaming(
-                model="datarobot-deployed-llm",
+                model="unknown",
                 messages=[
                     ChatCompletionSystemMessageParam(
                         content="You are a helpful assistant",
@@ -84,7 +84,7 @@ class AgentKernel:
             )
         else:
             return CompletionCreateParamsNonStreaming(
-                model="datarobot-deployed-llm",
+                model="unknown",
                 messages=[
                     ChatCompletionSystemMessageParam(
                         content="You are a helpful assistant",

--- a/tests/core/cli/test_agent_kernel.py
+++ b/tests/core/cli/test_agent_kernel.py
@@ -40,7 +40,7 @@ class TestAgentKernel:
         result_dict = kernel.construct_prompt(user_prompt, verbose=True)
 
         # Assert
-        assert result_dict["model"] == "datarobot-deployed-llm"
+        assert result_dict["model"] == "unknown"
         assert len(result_dict["messages"]) == 2
         assert result_dict["messages"][0]["content"] == "You are a helpful assistant"
         assert result_dict["messages"][0]["role"] == "system"
@@ -62,7 +62,7 @@ class TestAgentKernel:
         result_dict = kernel.construct_prompt(user_prompt, verbose=False)
 
         # Assert
-        assert result_dict["model"] == "datarobot-deployed-llm"
+        assert result_dict["model"] == "unknown"
         assert len(result_dict["messages"]) == 2
         assert result_dict["messages"][0]["content"] == "You are a helpful assistant"
         assert result_dict["messages"][0]["role"] == "system"
@@ -109,7 +109,7 @@ class TestAgentKernel:
 
         # Verify chat.completions.create was called with correct parameters
         mock_completions.create.assert_called_once_with(
-            model="datarobot-deployed-llm",
+            model="unknown",
             messages=[
                 {"content": "You are a helpful assistant", "role": "system"},
                 {"content": "Hello, assistant!", "role": "user"},
@@ -161,7 +161,7 @@ class TestAgentKernel:
 
         # Verify chat.completions.create was called with correct parameters
         mock_completions.create.assert_called_once_with(
-            model="datarobot-deployed-llm",
+            model="unknown",
             messages=[
                 {"content": "You are a helpful assistant", "role": "system"},
                 {"content": "Hello, assistant!", "role": "user"},
@@ -261,7 +261,7 @@ class TestAgentKernel:
 
         # Verify chat.completions.create was called with correct parameters
         mock_completions.create.assert_called_once_with(
-            model="datarobot-deployed-llm",
+            model="unknown",
             messages=[
                 {"content": "You are a helpful assistant", "role": "system"},
                 {"content": "Hello, assistant!", "role": "user"},
@@ -312,7 +312,7 @@ class TestAgentKernel:
 
         # Verify chat.completions.create was called with correct parameters
         mock_completions.create.assert_called_once_with(
-            model="datarobot-deployed-llm",
+            model="unknown",
             messages=[
                 {"content": "You are a helpful assistant", "role": "system"},
                 {"content": "Hello, assistant!", "role": "user"},

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.12"
+version = "0.15.13"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The CLI was sending 'datarobot-deployed-llm' which only works in deployed contexts. Using 'unknown' lets the agent discard it and fall back to the configured LLM_DEFAULT_MODEL.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small CLI prompt-construction change plus version/lockfile bumps; main risk is unexpected behavior if downstream services reject the `unknown` model value.
> 
> **Overview**
> Updates the CLI `AgentKernel.construct_prompt()` to send `model="unknown"` instead of the deployment-specific `datarobot-deployed-llm`, allowing the agent/runtime to resolve the actual model from configuration (e.g., `LLM_DEFAULT_MODEL`).
> 
> Bumps package version to `0.15.13`, updates lockfiles, and adjusts unit tests and changelog to match the new placeholder behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60621eeebfb2683355ccfc1c0d01c7c1fa9791ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->