### PR TITLE
[BUZZOK-30416][BUZZOK-30415] AgentCard - OAuth2 token exchange configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.19
+- Added option to configure OAuth2 token exchange flow for server
+
 ## 0.15.11
 - Added backward compatible route `/chat/completions` route to `dragent`
 - Revised documentation based on feedback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.11"
+version = "0.15.19"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -21,7 +21,13 @@ from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventQueue
 from a2a.types import AgentCapabilities
 from a2a.types import AgentCard
+from a2a.types import AgentExtension
 from a2a.types import AgentSkill
+from a2a.types import AuthorizationCodeOAuthFlow
+from a2a.types import ClientCredentialsOAuthFlow
+from a2a.types import OAuth2SecurityScheme
+from a2a.types import OAuthFlows
+from a2a.types import SecurityScheme
 from fastapi import FastAPI
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
@@ -103,14 +109,132 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         return sm
 
-    async def _create_agent_card(self, frontend_config: A2AFrontEndConfig) -> AgentCard:
-        assert self._a2a_worker is not None
-        security_schemes = None
-        security = None
-        if frontend_config.server_auth:
-            security_schemes, security = await self._a2a_worker._generate_security_schemes(
-                frontend_config.server_auth
+    async def _build_security_schemes(
+        self, frontend_config: A2AFrontEndConfig
+    ) -> tuple[
+        dict[str, SecurityScheme] | None,
+        list[dict[str, list[str]]] | None,
+        list[AgentExtension] | None,
+    ]:
+        """Build A2A security schemes from the frontend configuration.
+
+        Supports two independent auth sources that are merged into a single
+        ``oauth2`` security scheme with separate flows:
+
+        * ``server_auth`` (OAuth2ResourceServerConfig) → authorization_code flow.
+          Endpoint URLs are resolved via OIDC discovery or derived from the issuer URL.
+        * ``oauth_token_exchange`` (OktaTokenExchangeConfig) → client_credentials flow.
+          Used for RFC 8693 second-phase token acquisition.
+
+        Returns:
+            Tuple of (security_schemes, security requirements, capability extensions),
+            all ``None`` when neither auth source is configured.
+        """
+        has_server_auth = frontend_config.server_auth is not None
+        has_token_exchange = (
+            hasattr(frontend_config, "server_auth_token_exchange")
+            and frontend_config.server_auth_token_exchange is not None
+        )
+
+        if not has_server_auth and not has_token_exchange:
+            return None, None, None
+
+        authorization_code_flow = None
+        client_credentials_flow = None
+        all_scopes: list[str] = []
+        extensions: list[AgentExtension] | None = None
+
+        # (1) server_auth → authorization_code flow
+        if has_server_auth:
+            server_auth = frontend_config.server_auth
+            auth_url, token_url = await self._resolve_oauth_endpoints(server_auth)
+            scope_descriptions = {
+                scope: f"Permission: {scope}" for scope in server_auth.scopes
+            }
+            authorization_code_flow = AuthorizationCodeOAuthFlow(
+                authorization_url=auth_url,
+                token_url=token_url,
+                scopes=scope_descriptions,
             )
+            all_scopes.extend(server_auth.scopes)
+
+        # (2) oauth_token_exchange → client_credentials flow
+        if has_token_exchange:
+            auth_config = frontend_config.server_auth_token_exchange
+            scope_descriptions = {
+                scope: f"Permission: {scope}" for scope in auth_config.scopes
+            }
+            client_credentials_flow = ClientCredentialsOAuthFlow(
+                token_url=auth_config.token_url,
+                scopes=scope_descriptions,
+            )
+            all_scopes.extend(auth_config.scopes)
+            if auth_config.audience:
+                extensions = [
+                    AgentExtension(
+                        uri="urn:ietf:params:oauth:grant-type:token-exchange",
+                        description="RFC 8693 Token Exchange parameters for second-phase token acquisition",
+                        params={"audience": auth_config.audience},
+                    )
+                ]
+
+        security_schemes = {
+            "oauth2": SecurityScheme(
+                root=OAuth2SecurityScheme(
+                    type="oauth2",
+                    description="OAuth 2.0 authentication required to access this agent",
+                    flows=OAuthFlows(
+                        authorization_code=authorization_code_flow,
+                        client_credentials=client_credentials_flow,
+                    ),
+                )
+            )
+        }
+        unique_scopes = list(dict.fromkeys(all_scopes))
+        security = [{"oauth2": unique_scopes}]
+
+        return security_schemes, security, extensions
+
+    @staticmethod
+    async def _resolve_oauth_endpoints(
+        server_auth_config: object,
+    ) -> tuple[str, str]:
+        """Resolve authorization and token URLs from OAuth2ResourceServerConfig.
+
+        Uses OIDC discovery when available, otherwise derives URLs from issuer_url.
+        """
+        import httpx
+
+        if getattr(server_auth_config, "discovery_url", None):
+            try:
+                async with httpx.AsyncClient() as client:
+                    response = await client.get(
+                        server_auth_config.discovery_url, timeout=5.0
+                    )
+                    response.raise_for_status()
+                    metadata = response.json()
+                    auth_url = metadata.get("authorization_endpoint")
+                    token_url = metadata.get("token_endpoint")
+                    if auth_url and token_url:
+                        logger.info(
+                            "Resolved OAuth endpoints via discovery: %s",
+                            server_auth_config.discovery_url,
+                        )
+                        return auth_url, token_url
+            except Exception as e:
+                logger.warning("Failed to discover OAuth endpoints: %s", e)
+
+        issuer = server_auth_config.issuer_url.rstrip("/")
+        auth_url = f"{issuer}/oauth/authorize"
+        token_url = f"{issuer}/oauth/token"
+        logger.info("Using derived OAuth endpoints from issuer: %s", issuer)
+        return auth_url, token_url
+
+    async def _create_agent_card(self, frontend_config: A2AFrontEndConfig) -> AgentCard:
+        security_schemes, security, extensions = await self._build_security_schemes(
+            frontend_config
+        )
+
         if self.front_end_config.a2a.skills:
             skills = self.front_end_config.a2a.skills
         else:
@@ -133,10 +257,11 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             capabilities=AgentCapabilities(
                 streaming=frontend_config.capabilities.streaming,
                 push_notifications=frontend_config.capabilities.push_notifications,
+                extensions=extensions,
             ),
             skills=skills,
-            security_schemes=security_schemes,
-            security=security,
+            security_schemes=security_schemes or None,
+            security=security or None,
         )
         return agent_card
 

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -52,16 +52,18 @@ A2A_MOUNT_PATH = "a2a"
 
 
 OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
-    "OAuth 2.0 with RFC 8693 Token Exchange. "
-    "Requires an internal passport JWT as the subject_token. "
-    "See capabilities.extensions for RFC 8693 Token Exchange override details."
+    "OAuth 2.0 authorization utilizing RFC 8693 Token Exchange. Clients must "
+    "supply a valid internal passport JWT as the subject token. Refer to the "
+    "capabilities.extensions block for strict token exchange parameters and "
+    "audience specifications."
 )
 
 # The extension explicitly references the security scheme key so SDKs can resolve
 # the RFC 8693 Token Exchange override without ambiguity.
 RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
 RFC8693_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
-RFC8693_SECURITY_SCHEME_REF = "oauth2"  # match the key used in securitySchemes
+RFC8693_SECURITY_SCHEME_REF = "oauth2"  # The key in securitySchemes
+RFC8693_SECURITY_SCHEME_FLOW_REF = "clientCredentials"  # The exact flow being overridden
 RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION = (
     "Overrides the referenced security scheme with RFC 8693 Token Exchange requirements."
 )
@@ -170,6 +172,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         """
         params: dict[str, str] = {
             "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
+            "flow_ref": RFC8693_SECURITY_SCHEME_FLOW_REF,
             "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
         }
         if config.audience is not None:

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -53,12 +53,18 @@ A2A_MOUNT_PATH = "a2a"
 
 
 OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
-    "Authorization using Okta and Token Exchange (RFC 8693)."
+    "OAuth 2.0 with RFC 8693 Token Exchange. "
+    "Requires an internal passport JWT as the subject_token. "
+    "See capabilities.extensions for RFC 8693 Token Exchange override details."
 )
-OAUTH2_SECURITY_DESCRIPTION_DEFAULT = "OAuth 2.0 authentication required to access this agent"
+
+# The extension explicitly references the security scheme key so SDKs can resolve
+# the RFC 8693 Token Exchange override without ambiguity.
 RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
+RFC8693_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+RFC8693_SECURITY_SCHEME_REF = "oauth2"  # match the key used in securitySchemes
 RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION = (
-    "RFC 8693 Token Exchange parameters for second-phase token acquisition"
+    "Overrides the referenced security scheme with RFC 8693 Token Exchange requirements."
 )
 
 
@@ -156,16 +162,24 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
     def _token_exchange_capability_extension(
         config: OAuth2TokenExchangeConfig,
     ) -> list[AgentExtension]:
-        """Mark RFC 8693 token exchange on the agent card (only when this flow is configured).
+        """Build the RFC 8693 binder extension for the agent card.
 
-        Single source of truth for scopes: `flows.clientCredentials.scopes` only.
-        Extensions carry metadata the OpenAPI model lacks (e.g. audience for RFC 8693).
+        Binds the extension to the named security scheme (``security_scheme_ref``) so SDKs
+        can unambiguously resolve which OAuth2 flow requires the token exchange override.
+        Scopes are the single source of truth: they stay under ``flows.clientCredentials``
+        and are never duplicated here.
         """
+        params: dict[str, str] = {
+            "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
+            "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
+        }
+        if config.audience is not None:
+            params["audience"] = config.audience
         return [
             AgentExtension(
                 uri=RFC8693_GRANT_TYPE_URI,
                 description=RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION,
-                params={"audience": config.audience} if config.audience is not None else None,
+                params=params,
             )
         ]
 
@@ -215,11 +229,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             "oauth2": SecurityScheme(
                 root=OAuth2SecurityScheme(
                     type="oauth2",
-                    description=(
-                        OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
-                        if token_exchange
-                        else OAUTH2_SECURITY_DESCRIPTION_DEFAULT
-                    ),
+                    description=OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE,
                     flows=OAuthFlows(
                         authorization_code=auth_code_flow,
                         client_credentials=client_creds_flow,

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -51,6 +51,17 @@ from .step_adaptor import DRAgentNestedReasoningStepAdaptor
 DATAROBOT_EXPECTED_HEALTH_ROUTES = ["/", "/ping", "/ping/", "/health", "/health/"]
 A2A_MOUNT_PATH = "a2a"
 
+
+OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
+    "Authorization using Okta and Token Exchange (RFC 8693)."
+)
+OAUTH2_SECURITY_DESCRIPTION_DEFAULT = "OAuth 2.0 authentication required to access this agent"
+RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
+RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION = (
+    "RFC 8693 Token Exchange parameters for second-phase token acquisition"
+)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -111,46 +122,52 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         return sm
 
+    @staticmethod
     async def _oauth_flow_from_server_auth(
-        self, server_auth: OAuth2ResourceServerConfig
+        server_auth: OAuth2ResourceServerConfig,
     ) -> tuple[AuthorizationCodeOAuthFlow, list[str]]:
         """Build the authorization_code OAuth2 flow and scopes for NAT ``server_auth``."""
-        auth_url, token_url = await self._resolve_oauth_endpoints(server_auth)
-        scope_descriptions = {scope: f"Permission: {scope}" for scope in server_auth.scopes}
+        auth_url, token_url = await DRAgentFastApiFrontEndPluginWorker._resolve_oauth_endpoints(
+            server_auth
+        )
         flow = AuthorizationCodeOAuthFlow(
             authorization_url=auth_url,
             token_url=token_url,
-            scopes=scope_descriptions,
+            scopes={scope: f"Permission: {scope}" for scope in server_auth.scopes},
         )
         return flow, list(server_auth.scopes)
 
+    @staticmethod
     def _oauth_flow_from_token_exchange(
-        self, config: OAuth2TokenExchangeConfig
-    ) -> tuple[ClientCredentialsOAuthFlow, list[str], list[AgentExtension] | None]:
-        """Build the client_credentials flow, scopes, and optional RFC 8693 extensions.
+        config: OAuth2TokenExchangeConfig,
+    ) -> tuple[ClientCredentialsOAuthFlow, list[str]]:
+        """Build the client_credentials flow and scopes for ``a2a.oauth_token_exchange``.
 
-        DataRobot ``a2a.oauth_token_exchange``; not part of the NAT A2A frontend model.
+        Token URL and scopes live only here (OpenAPI-compatible). RFC 8693 second-phase
+        requirements are signaled separately via :meth:`_token_exchange_capability_extension`.
         """
-        scope_descriptions = {scope: f"Permission: {scope}" for scope in config.scopes}
         flow = ClientCredentialsOAuthFlow(
             token_url=config.token_url,
-            scopes=scope_descriptions,
+            scopes={scope: f"Permission: {scope}" for scope in config.scopes},
         )
+        return flow, list(config.scopes)
 
-        # Extensions are reserved for metadata the A2A spec lacks (e.g., audience).
-        # Scopes are excluded here to maintain a single source of truth in 'flows'.
-        # This prevents configuration drift and keeps the A2A Agent Card clean for
-        # both RFC 8693 and standard OpenAPI clients.
-        extensions: list[AgentExtension] | None = None
-        if config.audience:
-            extensions = [
-                AgentExtension(
-                    uri="urn:ietf:params:oauth:grant-type:token-exchange",
-                    description="RFC 8693 Token Exchange parameters for token acquisition",
-                    params={"audience": config.audience},
-                )
-            ]
-        return flow, list(config.scopes), extensions
+    @staticmethod
+    def _token_exchange_capability_extension(
+        config: OAuth2TokenExchangeConfig,
+    ) -> list[AgentExtension]:
+        """Mark RFC 8693 token exchange on the agent card (only when this flow is configured).
+
+        Single source of truth for scopes: `flows.clientCredentials.scopes` only.
+        Extensions carry metadata the OpenAPI model lacks (e.g. audience for RFC 8693).
+        """
+        return [
+            AgentExtension(
+                uri=RFC8693_GRANT_TYPE_URI,
+                description=RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION,
+                params={"audience": config.audience} if config.audience is not None else None,
+            )
+        ]
 
     async def _build_security_schemes(
         self, frontend_config: A2AFrontEndConfig
@@ -183,13 +200,14 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         if not server_auth and not token_exchange:
             return None, None, None
 
-        authorization_code_flow, server_auth_scopes = (
+        auth_code_flow, server_auth_scopes = (
             await self._oauth_flow_from_server_auth(server_auth) if server_auth else (None, [])
         )
-        client_credentials_flow, token_exchange_scopes, extensions = (
-            self._oauth_flow_from_token_exchange(token_exchange)
-            if token_exchange
-            else (None, [], None)
+        client_creds_flow, token_exchange_scopes = (
+            self._oauth_flow_from_token_exchange(token_exchange) if token_exchange else (None, [])
+        )
+        extensions = (
+            self._token_exchange_capability_extension(token_exchange) if token_exchange else None
         )
 
         all_scopes = list(dict.fromkeys(server_auth_scopes + token_exchange_scopes))
@@ -197,10 +215,14 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             "oauth2": SecurityScheme(
                 root=OAuth2SecurityScheme(
                     type="oauth2",
-                    description="OAuth 2.0 authentication required to access this agent",
+                    description=(
+                        OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
+                        if token_exchange
+                        else OAUTH2_SECURITY_DESCRIPTION_DEFAULT
+                    ),
                     flows=OAuthFlows(
-                        authorization_code=authorization_code_flow,
-                        client_credentials=client_credentials_flow,
+                        authorization_code=auth_code_flow,
+                        client_credentials=client_creds_flow,
                     ),
                 )
             )

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -35,6 +35,7 @@ from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManage
 from nat.front_ends.fastapi.routes.chat import add_v1_chat_completions_route
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
 from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
+from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
 from nat.runtime.loader import WorkflowBuilder
@@ -194,7 +195,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
     @staticmethod
     async def _resolve_oauth_endpoints(
-        server_auth_config: object,
+        server_auth_config: OAuth2ResourceServerConfig,
     ) -> tuple[str, str]:
         """Resolve authorization and token URLs from OAuth2ResourceServerConfig.
 
@@ -202,7 +203,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         """
         import httpx
 
-        if getattr(server_auth_config, "discovery_url", None):
+        if server_auth_config.discovery_url:
             try:
                 async with httpx.AsyncClient() as client:
                     response = await client.get(server_auth_config.discovery_url, timeout=5.0)

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -29,13 +29,13 @@ from a2a.types import OAuth2SecurityScheme
 from a2a.types import OAuthFlows
 from a2a.types import SecurityScheme
 from fastapi import FastAPI
+from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
 from nat.front_ends.fastapi.routes.chat import add_v1_chat_completions_route
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
 from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
-from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
 from nat.runtime.loader import WorkflowBuilder

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -123,7 +123,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         * ``server_auth`` (OAuth2ResourceServerConfig) → authorization_code flow.
           Endpoint URLs are resolved via OIDC discovery or derived from the issuer URL.
-        * ``oauth_token_exchange`` (OktaTokenExchangeConfig) → client_credentials flow.
+        * ``server_auth_token_exchange`` (OAuth2TokenExchangeConfig) → client_credentials flow.
           Used for RFC 8693 second-phase token acquisition.
 
         Returns:

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -44,6 +44,7 @@ from pydantic import Field
 
 from datarobot_genai.core.utils.logging import setup_logging
 
+from .server_auth import OAuth2TokenExchangeConfig
 from .session import DRAgentAGUISessionManager
 from .step_adaptor import DRAgentNestedReasoningStepAdaptor
 
@@ -110,6 +111,47 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         return sm
 
+    async def _oauth_flow_from_server_auth(
+        self, server_auth: OAuth2ResourceServerConfig
+    ) -> tuple[AuthorizationCodeOAuthFlow, list[str]]:
+        """Build the authorization_code OAuth2 flow and scopes for NAT ``server_auth``."""
+        auth_url, token_url = await self._resolve_oauth_endpoints(server_auth)
+        scope_descriptions = {scope: f"Permission: {scope}" for scope in server_auth.scopes}
+        flow = AuthorizationCodeOAuthFlow(
+            authorization_url=auth_url,
+            token_url=token_url,
+            scopes=scope_descriptions,
+        )
+        return flow, list(server_auth.scopes)
+
+    def _oauth_flow_from_token_exchange(
+        self, config: OAuth2TokenExchangeConfig
+    ) -> tuple[ClientCredentialsOAuthFlow, list[str], list[AgentExtension] | None]:
+        """Build the client_credentials flow, scopes, and optional RFC 8693 extensions.
+
+        DataRobot ``a2a.oauth_token_exchange``; not part of the NAT A2A frontend model.
+        """
+        scope_descriptions = {scope: f"Permission: {scope}" for scope in config.scopes}
+        flow = ClientCredentialsOAuthFlow(
+            token_url=config.token_url,
+            scopes=scope_descriptions,
+        )
+
+        # Extensions are reserved for metadata the A2A spec lacks (e.g., audience).
+        # Scopes are excluded here to maintain a single source of truth in 'flows'.
+        # This prevents configuration drift and keeps the A2A Agent Card clean for
+        # both RFC 8693 and standard OpenAPI clients.
+        extensions: list[AgentExtension] | None = None
+        if config.audience:
+            extensions = [
+                AgentExtension(
+                    uri="urn:ietf:params:oauth:grant-type:token-exchange",
+                    description="RFC 8693 Token Exchange parameters for token acquisition",
+                    params={"audience": config.audience},
+                )
+            ]
+        return flow, list(config.scopes), extensions
+
     async def _build_security_schemes(
         self, frontend_config: A2AFrontEndConfig
     ) -> tuple[
@@ -134,49 +176,23 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             Tuple of (security_schemes, security requirements, capability extensions),
             all ``None`` when neither auth source is configured.
         """
-        has_server_auth = frontend_config.server_auth is not None
+        server_auth = frontend_config.server_auth
         a2a_cfg = self.front_end_config.a2a
-        has_token_exchange = a2a_cfg is not None and a2a_cfg.oauth_token_exchange is not None
+        token_exchange = a2a_cfg.oauth_token_exchange if a2a_cfg else None
 
-        if not has_server_auth and not has_token_exchange:
+        if not server_auth and not token_exchange:
             return None, None, None
 
-        authorization_code_flow = None
-        client_credentials_flow = None
-        all_scopes: list[str] = []
-        extensions: list[AgentExtension] | None = None
+        authorization_code_flow, server_auth_scopes = (
+            await self._oauth_flow_from_server_auth(server_auth) if server_auth else (None, [])
+        )
+        client_credentials_flow, token_exchange_scopes, extensions = (
+            self._oauth_flow_from_token_exchange(token_exchange)
+            if token_exchange
+            else (None, [], None)
+        )
 
-        # (1) server_auth → authorization_code flow
-        if has_server_auth:
-            server_auth = frontend_config.server_auth
-            auth_url, token_url = await self._resolve_oauth_endpoints(server_auth)
-            scope_descriptions = {scope: f"Permission: {scope}" for scope in server_auth.scopes}
-            authorization_code_flow = AuthorizationCodeOAuthFlow(
-                authorization_url=auth_url,
-                token_url=token_url,
-                scopes=scope_descriptions,
-            )
-            all_scopes.extend(server_auth.scopes)
-
-        # (2) oauth_token_exchange → client_credentials flow
-        if has_token_exchange:
-            assert a2a_cfg is not None
-            auth_config = a2a_cfg.oauth_token_exchange
-            scope_descriptions = {scope: f"Permission: {scope}" for scope in auth_config.scopes}
-            client_credentials_flow = ClientCredentialsOAuthFlow(
-                token_url=auth_config.token_url,
-                scopes=scope_descriptions,
-            )
-            all_scopes.extend(auth_config.scopes)
-            if auth_config.audience:
-                extensions = [
-                    AgentExtension(
-                        uri="urn:ietf:params:oauth:grant-type:token-exchange",
-                        description="RFC 8693 Token Exchange parameters for token acquisition",
-                        params={"audience": auth_config.audience},
-                    )
-                ]
-
+        all_scopes = list(dict.fromkeys(server_auth_scopes + token_exchange_scopes))
         security_schemes = {
             "oauth2": SecurityScheme(
                 root=OAuth2SecurityScheme(
@@ -189,10 +205,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
                 )
             )
         }
-        unique_scopes = list(dict.fromkeys(all_scopes))
-        security = [{"oauth2": unique_scopes}]
-
-        return security_schemes, security, extensions
+        return security_schemes, [{"oauth2": all_scopes}], extensions
 
     @staticmethod
     async def _resolve_oauth_endpoints(

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -124,8 +124,10 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         * ``server_auth`` (OAuth2ResourceServerConfig) → authorization_code flow.
           Endpoint URLs are resolved via OIDC discovery or derived from the issuer URL.
-        * ``server_auth_token_exchange`` (OAuth2TokenExchangeConfig) → client_credentials flow.
-          Used for RFC 8693 second-phase token acquisition.
+        * ``a2a.oauth_token_exchange`` (OAuth2TokenExchangeConfig) → client_credentials flow.
+          Used for RFC 8693 second-phase token acquisition. Configured on the DataRobot
+          ``a2a`` block, not on NAT's A2A frontend model, so it stays stable if NAT's
+          config types change.
 
         Returns
         -------
@@ -133,10 +135,8 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             all ``None`` when neither auth source is configured.
         """
         has_server_auth = frontend_config.server_auth is not None
-        has_token_exchange = (
-            hasattr(frontend_config, "server_auth_token_exchange")
-            and frontend_config.server_auth_token_exchange is not None
-        )
+        a2a_cfg = self.front_end_config.a2a
+        has_token_exchange = a2a_cfg is not None and a2a_cfg.oauth_token_exchange is not None
 
         if not has_server_auth and not has_token_exchange:
             return None, None, None
@@ -160,7 +160,8 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         # (2) oauth_token_exchange → client_credentials flow
         if has_token_exchange:
-            auth_config = frontend_config.server_auth_token_exchange
+            assert a2a_cfg is not None
+            auth_config = a2a_cfg.oauth_token_exchange
             scope_descriptions = {scope: f"Permission: {scope}" for scope in auth_config.scopes}
             client_credentials_flow = ClientCredentialsOAuthFlow(
                 token_url=auth_config.token_url,

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -126,7 +126,8 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         * ``server_auth_token_exchange`` (OAuth2TokenExchangeConfig) → client_credentials flow.
           Used for RFC 8693 second-phase token acquisition.
 
-        Returns:
+        Returns
+        -------
             Tuple of (security_schemes, security requirements, capability extensions),
             all ``None`` when neither auth source is configured.
         """
@@ -148,9 +149,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         if has_server_auth:
             server_auth = frontend_config.server_auth
             auth_url, token_url = await self._resolve_oauth_endpoints(server_auth)
-            scope_descriptions = {
-                scope: f"Permission: {scope}" for scope in server_auth.scopes
-            }
+            scope_descriptions = {scope: f"Permission: {scope}" for scope in server_auth.scopes}
             authorization_code_flow = AuthorizationCodeOAuthFlow(
                 authorization_url=auth_url,
                 token_url=token_url,
@@ -161,9 +160,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         # (2) oauth_token_exchange → client_credentials flow
         if has_token_exchange:
             auth_config = frontend_config.server_auth_token_exchange
-            scope_descriptions = {
-                scope: f"Permission: {scope}" for scope in auth_config.scopes
-            }
+            scope_descriptions = {scope: f"Permission: {scope}" for scope in auth_config.scopes}
             client_credentials_flow = ClientCredentialsOAuthFlow(
                 token_url=auth_config.token_url,
                 scopes=scope_descriptions,
@@ -173,7 +170,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
                 extensions = [
                     AgentExtension(
                         uri="urn:ietf:params:oauth:grant-type:token-exchange",
-                        description="RFC 8693 Token Exchange parameters for second-phase token acquisition",
+                        description="RFC 8693 Token Exchange parameters for token acquisition",
                         params={"audience": auth_config.audience},
                     )
                 ]
@@ -208,9 +205,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         if getattr(server_auth_config, "discovery_url", None):
             try:
                 async with httpx.AsyncClient() as client:
-                    response = await client.get(
-                        server_auth_config.discovery_url, timeout=5.0
-                    )
+                    response = await client.get(server_auth_config.discovery_url, timeout=5.0)
                     response.raise_for_status()
                     metadata = response.json()
                     auth_url = metadata.get("authorization_endpoint")
@@ -231,9 +226,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         return auth_url, token_url
 
     async def _create_agent_card(self, frontend_config: A2AFrontEndConfig) -> AgentCard:
-        security_schemes, security, extensions = await self._build_security_schemes(
-            frontend_config
-        )
+        security_schemes, security, extensions = await self._build_security_schemes(frontend_config)
 
         if self.front_end_config.a2a.skills:
             skills = self.front_end_config.a2a.skills

--- a/src/datarobot_genai/dragent/frontends/okta_auth.py
+++ b/src/datarobot_genai/dragent/frontends/okta_auth.py
@@ -1,0 +1,50 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from nat.data_models.authentication import AuthProviderBaseConfig
+from pydantic import Field
+
+class OktaA2AServerAuthConfig(AuthProviderBaseConfig, name="okta_server_auth"):
+    """NAT A2A server-side authentication configuration.
+
+    This configuration is surfaced in the agent's AgentCard, specifically in the
+    `authSchemes` section. It should expose the information needed to mint the token
+    used to communicate with this agent (`token_url`, `audience`, and `scopes`)
+    during the second step of the two-step token exchange, where the ID-JAG token is
+    exchanged for the downstream scoped token required to call the agent.
+    """
+
+    okta_domain: str = Field(
+        description="Okta organisation URL (e.g. https://your-org.okta.com).",
+    )
+    authorization_server_id: str = Field(
+        default="default",
+        description="Custom authorisation server ID (e.g. 'ausscimnps4vnh9zE1d7').",
+    )
+    audience: str | None = Field(
+        default=None,
+        description=(
+            "Expected audience (`aud`) claim for this API."
+        ),
+    )
+    scopes: list[str] = Field(
+        default=["read_data"],
+        description="Scopes required by this API. Validation ensures the token grants all listed scopes.",
+    )
+
+    @property
+    def token_url(self) -> str:
+        return f"{self.okta_domain}/oauth2/{self.authorization_server_id}/v1/token"

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -44,8 +44,11 @@ logging_handler_setup()
 warnings.filterwarnings("ignore", message=".*stream_options is not default parameter.*")
 
 
-class DRA2AFrontEndConfig(A2AFrontEndConfig):
-    server_auth_token_exchange: OAuth2TokenExchangeConfig | None = Field(
+class DRAgentA2AConfig(BaseModel):
+    """DR-owned wrapper around NAT's A2AFrontEndConfig with optional skill definitions."""
+
+    server: A2AFrontEndConfig = Field(description="NAT A2A server configuration.")
+    oauth_token_exchange: OAuth2TokenExchangeConfig | None = Field(
         default=None,
         description=(
             "Configuration for agent authorization using Token Exchange (RFC 8693). "
@@ -54,12 +57,6 @@ class DRA2AFrontEndConfig(A2AFrontEndConfig):
             "the second phase of authentication."
         ),
     )
-
-
-class DRAgentA2AConfig(BaseModel):
-    """DR-owned wrapper around NAT's A2AFrontEndConfig with optional skill definitions."""
-
-    server: DRA2AFrontEndConfig = Field(description="NAT A2A server configuration.")
     skills: list[AgentSkill] = Field(
         default=[],
         description="Skills to advertise in the A2A agent card. "

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -32,6 +32,7 @@ from .converters import convert_dragent_run_agent_input_to_chat_request
 from .converters import convert_dragent_run_agent_input_to_chat_request_or_message
 from .converters import convert_str_to_dragent_event_response
 from .converters import convert_tool_message_to_str
+from .okta_auth import OktaA2AServerAuthConfig
 from .logging import logging_handler_setup
 
 # Suppress specific non-actionable NAT warning messages by content.
@@ -43,10 +44,22 @@ logging_handler_setup()
 warnings.filterwarnings("ignore", message=".*stream_options is not default parameter.*")
 
 
+class DRA2AFrontEndConfig(A2AFrontEndConfig):
+
+    server_auth: OktaA2AServerAuthConfig | None = Field(
+        default=None,
+        description=("Configuration about authorization requirements for the agent."
+                     "Provided information about token_url, audience and scopes should"
+                     "be used for Okta Token Exchange (RFC 8693) process, where client "
+                     "dynamically negotiates a final, scoped JWT during the second phase "
+                     "Token Exchange."),
+    )
+
+
 class DRAgentA2AConfig(BaseModel):
     """DR-owned wrapper around NAT's A2AFrontEndConfig with optional skill definitions."""
 
-    server: A2AFrontEndConfig = Field(description="NAT A2A server configuration.")
+    server: DRA2AFrontEndConfig = Field(description="NAT A2A server configuration.")
     skills: list[AgentSkill] = Field(
         default=[],
         description="Skills to advertise in the A2A agent card. "

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -32,8 +32,8 @@ from .converters import convert_dragent_run_agent_input_to_chat_request
 from .converters import convert_dragent_run_agent_input_to_chat_request_or_message
 from .converters import convert_str_to_dragent_event_response
 from .converters import convert_tool_message_to_str
-from .server_auth import OAuth2TokenExchangeConfig
 from .logging import logging_handler_setup
+from .server_auth import OAuth2TokenExchangeConfig
 
 # Suppress specific non-actionable NAT warning messages by content.
 # Patch Handler.handle (inherited by all subclasses - they only override emit)
@@ -45,7 +45,6 @@ warnings.filterwarnings("ignore", message=".*stream_options is not default param
 
 
 class DRA2AFrontEndConfig(A2AFrontEndConfig):
-
     server_auth_token_exchange: OAuth2TokenExchangeConfig | None = Field(
         default=None,
         description=(

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -32,7 +32,7 @@ from .converters import convert_dragent_run_agent_input_to_chat_request
 from .converters import convert_dragent_run_agent_input_to_chat_request_or_message
 from .converters import convert_str_to_dragent_event_response
 from .converters import convert_tool_message_to_str
-from .server_auth import TokenExchangeConfig
+from .server_auth import OAuth2TokenExchangeConfig
 from .logging import logging_handler_setup
 
 # Suppress specific non-actionable NAT warning messages by content.
@@ -46,7 +46,7 @@ warnings.filterwarnings("ignore", message=".*stream_options is not default param
 
 class DRA2AFrontEndConfig(A2AFrontEndConfig):
 
-    server_auth_token_exchange: TokenExchangeConfig | None = Field(
+    server_auth_token_exchange: OAuth2TokenExchangeConfig | None = Field(
         default=None,
         description=(
             "Configuration for agent authorization using Token Exchange (RFC 8693). "

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -32,7 +32,7 @@ from .converters import convert_dragent_run_agent_input_to_chat_request
 from .converters import convert_dragent_run_agent_input_to_chat_request_or_message
 from .converters import convert_str_to_dragent_event_response
 from .converters import convert_tool_message_to_str
-from .okta_auth import OktaA2AServerAuthConfig
+from .server_auth import TokenExchangeConfig
 from .logging import logging_handler_setup
 
 # Suppress specific non-actionable NAT warning messages by content.
@@ -46,13 +46,14 @@ warnings.filterwarnings("ignore", message=".*stream_options is not default param
 
 class DRA2AFrontEndConfig(A2AFrontEndConfig):
 
-    server_auth: OktaA2AServerAuthConfig | None = Field(
+    server_auth_token_exchange: TokenExchangeConfig | None = Field(
         default=None,
-        description=("Configuration about authorization requirements for the agent."
-                     "Provided information about token_url, audience and scopes should"
-                     "be used for Okta Token Exchange (RFC 8693) process, where client "
-                     "dynamically negotiates a final, scoped JWT during the second phase "
-                     "Token Exchange."),
+        description=(
+            "Configuration for agent authorization using Token Exchange (RFC 8693). "
+            "If provided, the token_url, audience, and scopes will be used to perform a "
+            "token exchange, allowing the client to dynamically obtain a scoped JWT during "
+            "the second phase of authentication."
+        ),
     )
 
 

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 from nat.data_models.authentication import AuthProviderBaseConfig
 from pydantic import Field
 
-class TokenExchangeConfig(AuthProviderBaseConfig):
-    """NAT A2A server-side authentication configuration.
+class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
+    """OAuth2 Server-side authentication configuration for token exchange.
 
     This configuration is surfaced in the agent's AgentCard, specifically in the
     `securitySchemes` section. It should expose the information needed to mint the token

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from nat.data_models.authentication import AuthProviderBaseConfig
 from pydantic import Field
 
+
 class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
     """OAuth2 Server-side authentication configuration for token exchange.
 
@@ -36,11 +37,11 @@ class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
     )
     audience: str | None = Field(
         default=None,
-        description=(
-            "Expected audience (`aud`) claim for this API."
-        ),
+        description=("Expected audience (`aud`) claim for this API."),
     )
     scopes: list[str] = Field(
         default=["read_data"],
-        description="Scopes required by this API. Validation ensures the token grants all listed scopes.",
+        description=(
+            "Scopes required by this API. Validation ensures the token grants all listed scopes."
+        ),
     )

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -17,22 +17,22 @@ from __future__ import annotations
 from nat.data_models.authentication import AuthProviderBaseConfig
 from pydantic import Field
 
-class OktaA2AServerAuthConfig(AuthProviderBaseConfig, name="okta_server_auth"):
+class TokenExchangeConfig(AuthProviderBaseConfig):
     """NAT A2A server-side authentication configuration.
 
     This configuration is surfaced in the agent's AgentCard, specifically in the
-    `authSchemes` section. It should expose the information needed to mint the token
+    `securitySchemes` section. It should expose the information needed to mint the token
     used to communicate with this agent (`token_url`, `audience`, and `scopes`)
     during the second step of the two-step token exchange, where the ID-JAG token is
     exchanged for the downstream scoped token required to call the agent.
     """
 
-    okta_domain: str = Field(
-        description="Okta organisation URL (e.g. https://your-org.okta.com).",
-    )
-    authorization_server_id: str = Field(
-        default="default",
-        description="Custom authorisation server ID (e.g. 'ausscimnps4vnh9zE1d7').",
+    token_url: str = Field(
+        description=(
+            "Token URL for Token Exchange (RFC 8693). This is the endpoint to which "
+            "the client will send the token exchange request to obtain a scoped token "
+            "for this agent."
+        )
     )
     audience: str | None = Field(
         default=None,
@@ -44,7 +44,3 @@ class OktaA2AServerAuthConfig(AuthProviderBaseConfig, name="okta_server_auth"):
         default=["read_data"],
         description="Scopes required by this API. Validation ensures the token grants all listed scopes.",
     )
-
-    @property
-    def token_url(self) -> str:
-        return f"{self.okta_domain}/oauth2/{self.authorization_server_id}/v1/token"

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -33,6 +33,7 @@ from datarobot_genai.dragent.frontends.fastapi import (
     OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE,
 )
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_GRANT_TYPE_URI
+from datarobot_genai.dragent.frontends.fastapi import RFC8693_SECURITY_SCHEME_FLOW_REF
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_SECURITY_SCHEME_REF
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_SUBJECT_TOKEN_TYPE
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
@@ -414,6 +415,7 @@ class TestCreateAgentCard:
         assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
         assert ext.params == {
             "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
+            "flow_ref": RFC8693_SECURITY_SCHEME_FLOW_REF,
             "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
             "audience": "https://app.datarobot.com/dr_org_id/my_agent",
         }
@@ -492,6 +494,7 @@ class TestCreateAgentCard:
         assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
         assert ext.params == {
             "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
+            "flow_ref": RFC8693_SECURITY_SCHEME_FLOW_REF,
             "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
             "audience": "https://app.datarobot.com/dr_org_id/my_agent",
         }

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -32,6 +32,8 @@ from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
+from datarobot_genai.dragent.frontends.server_auth import TokenExchangeConfig
+from datarobot_genai.dragent.frontends.register import DRA2AFrontEndConfig
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
 from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
@@ -50,9 +52,14 @@ def dragent_worker():
         general=GeneralConfig(
             front_end=DRAgentFastApiFrontEndConfig(
                 a2a=DRAgentA2AConfig(
-                    server=A2AFrontEndConfig(
+                    server=DRA2AFrontEndConfig(
                         name="Test Agent",
                         description="A test agent",
+                        server_auth_token_exchange=TokenExchangeConfig(
+                            token_url="https://example.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+                            audience="api://dr-blog-writer",
+                            scopes=["blog:write"],
+                        )
                     )
                 ),
             )
@@ -70,7 +77,7 @@ def dragent_worker_with_a2a(dragent_worker, mock_a2a_worker):
 
 @pytest.fixture
 def a2a_frontend_config():
-    return A2AFrontEndConfig(
+    return DRA2AFrontEndConfig(
         name="My Agent", description="Does things", host="localhost", port=8000
     )
 
@@ -381,7 +388,7 @@ class TestCreateAgentCard:
         assert card.skills[0].id == "summarize"
 
     async def test_agent_card_fields_from_frontend_config(self, dragent_worker_with_a2a):
-        cfg = A2AFrontEndConfig(
+        cfg = DRA2AFrontEndConfig(
             name="My Agent",
             description="Does things",
             version="2.0.0",
@@ -394,23 +401,90 @@ class TestCreateAgentCard:
         assert card.version == "2.0.0"
         assert card.url == "http://localhost:9000/a2a/"
 
-    async def test_security_schemes_set_when_server_auth_present(
-        self, dragent_worker_with_a2a, mock_a2a_worker, a2a_frontend_config
+    async def test_security_schemes_set_when_oauth_token_exchange_present(
+        self, dragent_worker_with_a2a, a2a_frontend_config
     ):
-        mock_schemes = MagicMock()
-        mock_security = MagicMock()
-        mock_a2a_worker._generate_security_schemes = AsyncMock(
-            return_value=(mock_schemes, mock_security)
+        a2a_frontend_config.server_auth_token_exchange = TokenExchangeConfig(
+            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+            audience="https://app.datarobot.com/dr_org_id/my_agent",
+            scopes=["blog:write"],
         )
-        a2a_frontend_config.server_auth = MagicMock()
-        with patch("datarobot_genai.dragent.frontends.fastapi.AgentCard") as mock_agent_card_cls:
-            await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
-        mock_a2a_worker._generate_security_schemes.assert_awaited_once_with(
-            a2a_frontend_config.server_auth
+        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+
+        assert "oauth2" in card.security_schemes
+        oauth_scheme = card.security_schemes["oauth2"].root
+        assert oauth_scheme.type == "oauth2"
+
+        # Only client_credentials flow, no authorization_code
+        assert oauth_scheme.flows.authorization_code is None
+        flow = oauth_scheme.flows.client_credentials
+        assert flow.token_url == "https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
+        assert flow.scopes == {"blog:write": "Permission: blog:write"}
+
+        assert card.security == [{"oauth2": ["blog:write"]}]
+
+        # audience exposed via A2A capabilities extension
+        assert card.capabilities.extensions is not None
+        assert len(card.capabilities.extensions) == 1
+        ext = card.capabilities.extensions[0]
+        assert ext.uri == "urn:ietf:params:oauth:grant-type:token-exchange"
+        assert ext.params == {"audience": "https://app.datarobot.com/dr_org_id/my_agent"}
+
+    async def test_security_schemes_from_server_auth(
+        self, dragent_worker_with_a2a, a2a_frontend_config
+    ):
+        a2a_frontend_config.server_auth = MagicMock(
+            issuer_url="https://issuer.example.com",
+            discovery_url=None,
+            scopes=["read"],
         )
-        _, kwargs = mock_agent_card_cls.call_args
-        assert kwargs["security_schemes"] is mock_schemes
-        assert kwargs["security"] is mock_security
+        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+
+        oauth_scheme = card.security_schemes["oauth2"].root
+        # Only authorization_code flow, no client_credentials
+        assert oauth_scheme.flows.authorization_code is not None
+        assert oauth_scheme.flows.authorization_code.authorization_url == "https://issuer.example.com/oauth/authorize"
+        assert oauth_scheme.flows.authorization_code.token_url == "https://issuer.example.com/oauth/token"
+        assert oauth_scheme.flows.client_credentials is None
+        assert card.security == [{"oauth2": ["read"]}]
+
+    async def test_both_server_auth_and_token_exchange(
+        self, dragent_worker_with_a2a, a2a_frontend_config
+    ):
+        # server_auth → authorization_code flow
+        a2a_frontend_config.server_auth = MagicMock(
+            issuer_url="https://issuer.example.com",
+            discovery_url=None,
+            scopes=["read"],
+        )
+
+        # Token exchange → client_credentials flow
+        a2a_frontend_config.server_auth_token_exchange = TokenExchangeConfig(
+            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+            audience="https://app.datarobot.com/dr_org_id/my_agent",
+            scopes=["blog:write"],
+        )
+
+        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+
+        # Single oauth2 scheme with both flows
+        assert len(card.security_schemes) == 1
+        oauth_scheme = card.security_schemes["oauth2"].root
+
+        assert oauth_scheme.flows.authorization_code is not None
+        assert oauth_scheme.flows.authorization_code.authorization_url == "https://issuer.example.com/oauth/authorize"
+
+        assert oauth_scheme.flows.client_credentials is not None
+        assert oauth_scheme.flows.client_credentials.token_url == "https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
+
+        # Merged scopes (deduplicated)
+        assert card.security == [{"oauth2": ["read", "blog:write"]}]
+
+        # Extension for audience
+        assert card.capabilities.extensions is not None
+        assert card.capabilities.extensions[0].params == {
+            "audience": "https://app.datarobot.com/dr_org_id/my_agent"
+        }
 
     async def test_no_security_when_server_auth_absent(
         self, dragent_worker_with_a2a, a2a_frontend_config
@@ -431,7 +505,7 @@ class TestDRAgentFastApiFrontEndConfig:
     def test_custom_a2a_fields(self):
         config = DRAgentFastApiFrontEndConfig(
             a2a=DRAgentA2AConfig(
-                server=A2AFrontEndConfig(
+                server=DRA2AFrontEndConfig(
                     name="My Agent",
                     description="Does things",
                     version="2.0.0",
@@ -444,10 +518,10 @@ class TestDRAgentFastApiFrontEndConfig:
 
     def test_is_not_a2a_front_end_config(self):
         config = DRAgentFastApiFrontEndConfig()
-        assert not isinstance(config, A2AFrontEndConfig)
+        assert not isinstance(config, DRA2AFrontEndConfig)
 
     def test_a2a_enables_endpoints(self):
-        config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=A2AFrontEndConfig()))
+        config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=DRA2AFrontEndConfig()))
         assert config.a2a is not None
 
 

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -32,7 +32,6 @@ from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
-from datarobot_genai.dragent.frontends.register import DRA2AFrontEndConfig
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
 from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeConfig
@@ -52,14 +51,9 @@ def dragent_worker():
         general=GeneralConfig(
             front_end=DRAgentFastApiFrontEndConfig(
                 a2a=DRAgentA2AConfig(
-                    server=DRA2AFrontEndConfig(
+                    server=A2AFrontEndConfig(
                         name="Test Agent",
                         description="A test agent",
-                        server_auth_token_exchange=OAuth2TokenExchangeConfig(
-                            token_url="https://example.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-                            audience="api://dr-blog-writer",
-                            scopes=["blog:write"],
-                        ),
                     )
                 ),
             )
@@ -77,7 +71,7 @@ def dragent_worker_with_a2a(dragent_worker, mock_a2a_worker):
 
 @pytest.fixture
 def a2a_frontend_config():
-    return DRA2AFrontEndConfig(
+    return A2AFrontEndConfig(
         name="My Agent", description="Does things", host="localhost", port=8000
     )
 
@@ -388,7 +382,7 @@ class TestCreateAgentCard:
         assert card.skills[0].id == "summarize"
 
     async def test_agent_card_fields_from_frontend_config(self, dragent_worker_with_a2a):
-        cfg = DRA2AFrontEndConfig(
+        cfg = A2AFrontEndConfig(
             name="My Agent",
             description="Does things",
             version="2.0.0",
@@ -404,10 +398,13 @@ class TestCreateAgentCard:
     async def test_security_schemes_set_when_oauth_token_exchange_present(
         self, dragent_worker_with_a2a, a2a_frontend_config
     ):
-        a2a_frontend_config.server_auth_token_exchange = OAuth2TokenExchangeConfig(
-            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-            audience="https://app.datarobot.com/dr_org_id/my_agent",
-            scopes=["blog:write"],
+        assert dragent_worker_with_a2a.front_end_config.a2a is not None
+        dragent_worker_with_a2a.front_end_config.a2a.oauth_token_exchange = (
+            OAuth2TokenExchangeConfig(
+                token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+                audience="https://app.datarobot.com/dr_org_id/my_agent",
+                scopes=["blog:write"],
+            )
         )
         card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
 
@@ -465,10 +462,13 @@ class TestCreateAgentCard:
         )
 
         # Token exchange → client_credentials flow
-        a2a_frontend_config.server_auth_token_exchange = OAuth2TokenExchangeConfig(
-            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-            audience="https://app.datarobot.com/dr_org_id/my_agent",
-            scopes=["blog:write"],
+        assert dragent_worker_with_a2a.front_end_config.a2a is not None
+        dragent_worker_with_a2a.front_end_config.a2a.oauth_token_exchange = (
+            OAuth2TokenExchangeConfig(
+                token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+                audience="https://app.datarobot.com/dr_org_id/my_agent",
+                scopes=["blog:write"],
+            )
         )
 
         card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
@@ -515,25 +515,32 @@ class TestDRAgentFastApiFrontEndConfig:
         assert config.a2a is None
 
     def test_custom_a2a_fields(self):
+        oauth = OAuth2TokenExchangeConfig(
+            token_url="https://idp.example.com/oauth2/v1/token",
+            audience="api://my-agent",
+            scopes=["agent:use"],
+        )
         config = DRAgentFastApiFrontEndConfig(
             a2a=DRAgentA2AConfig(
-                server=DRA2AFrontEndConfig(
+                server=A2AFrontEndConfig(
                     name="My Agent",
                     description="Does things",
                     version="2.0.0",
-                )
+                ),
+                oauth_token_exchange=oauth,
             )
         )
         assert config.a2a.server.name == "My Agent"
         assert config.a2a.server.description == "Does things"
         assert config.a2a.server.version == "2.0.0"
+        assert config.a2a.oauth_token_exchange == oauth
 
     def test_is_not_a2a_front_end_config(self):
         config = DRAgentFastApiFrontEndConfig()
-        assert not isinstance(config, DRA2AFrontEndConfig)
+        assert not isinstance(config, A2AFrontEndConfig)
 
     def test_a2a_enables_endpoints(self):
-        config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=DRA2AFrontEndConfig()))
+        config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=A2AFrontEndConfig()))
         assert config.a2a is not None
 
 

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -29,11 +29,12 @@ from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfi
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 
 from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_ROUTES
-from datarobot_genai.dragent.frontends.fastapi import OAUTH2_SECURITY_DESCRIPTION_DEFAULT
 from datarobot_genai.dragent.frontends.fastapi import (
     OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE,
 )
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_GRANT_TYPE_URI
+from datarobot_genai.dragent.frontends.fastapi import RFC8693_SECURITY_SCHEME_REF
+from datarobot_genai.dragent.frontends.fastapi import RFC8693_SUBJECT_TOKEN_TYPE
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
@@ -427,13 +428,17 @@ class TestCreateAgentCard:
 
         assert card.security == [{"oauth2": ["blog:write"]}]
 
-        # audience exposed via A2A capabilities extension (RFC 8693; scopes only in flows)
+        # RFC 8693 binder extension (scopes only in flows, never in params)
         assert card.capabilities.extensions is not None
         assert len(card.capabilities.extensions) == 1
         ext = card.capabilities.extensions[0]
         assert ext.uri == RFC8693_GRANT_TYPE_URI
         assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
-        assert ext.params == {"audience": "https://app.datarobot.com/dr_org_id/my_agent"}
+        assert ext.params == {
+            "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
+            "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
+            "audience": "https://app.datarobot.com/dr_org_id/my_agent",
+        }
 
     async def test_security_schemes_from_server_auth(
         self, dragent_worker_with_a2a, a2a_frontend_config
@@ -446,7 +451,7 @@ class TestCreateAgentCard:
         card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
 
         oauth_scheme = card.security_schemes["oauth2"].root
-        assert oauth_scheme.description == OAUTH2_SECURITY_DESCRIPTION_DEFAULT
+        assert oauth_scheme.description == OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
         # Only authorization_code flow, no client_credentials
         assert oauth_scheme.flows.authorization_code is not None
         assert (
@@ -502,12 +507,16 @@ class TestCreateAgentCard:
         # Merged scopes (deduplicated)
         assert card.security == [{"oauth2": ["read", "blog:write"]}]
 
-        # RFC 8693 extension: audience in params only, scopes only under flows
+        # RFC 8693 binder extension: audience in params, scopes only under flows
         assert card.capabilities.extensions is not None
         ext = card.capabilities.extensions[0]
         assert ext.uri == RFC8693_GRANT_TYPE_URI
         assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
-        assert ext.params == {"audience": "https://app.datarobot.com/dr_org_id/my_agent"}
+        assert ext.params == {
+            "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
+            "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
+            "audience": "https://app.datarobot.com/dr_org_id/my_agent",
+        }
 
     async def test_no_security_when_server_auth_absent(
         self, dragent_worker_with_a2a, a2a_frontend_config

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -32,7 +32,7 @@ from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
-from datarobot_genai.dragent.frontends.server_auth import TokenExchangeConfig
+from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeConfig
 from datarobot_genai.dragent.frontends.register import DRA2AFrontEndConfig
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
@@ -55,7 +55,7 @@ def dragent_worker():
                     server=DRA2AFrontEndConfig(
                         name="Test Agent",
                         description="A test agent",
-                        server_auth_token_exchange=TokenExchangeConfig(
+                        server_auth_token_exchange=OAuth2TokenExchangeConfig(
                             token_url="https://example.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
                             audience="api://dr-blog-writer",
                             scopes=["blog:write"],
@@ -404,7 +404,7 @@ class TestCreateAgentCard:
     async def test_security_schemes_set_when_oauth_token_exchange_present(
         self, dragent_worker_with_a2a, a2a_frontend_config
     ):
-        a2a_frontend_config.server_auth_token_exchange = TokenExchangeConfig(
+        a2a_frontend_config.server_auth_token_exchange = OAuth2TokenExchangeConfig(
             token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
             audience="https://app.datarobot.com/dr_org_id/my_agent",
             scopes=["blog:write"],
@@ -459,7 +459,7 @@ class TestCreateAgentCard:
         )
 
         # Token exchange → client_credentials flow
-        a2a_frontend_config.server_auth_token_exchange = TokenExchangeConfig(
+        a2a_frontend_config.server_auth_token_exchange = OAuth2TokenExchangeConfig(
             token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
             audience="https://app.datarobot.com/dr_org_id/my_agent",
             scopes=["blog:write"],

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -29,6 +29,12 @@ from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfi
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 
 from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_ROUTES
+from datarobot_genai.dragent.frontends.fastapi import OAUTH2_SECURITY_DESCRIPTION_DEFAULT
+from datarobot_genai.dragent.frontends.fastapi import (
+    OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE,
+)
+from datarobot_genai.dragent.frontends.fastapi import RFC8693_GRANT_TYPE_URI
+from datarobot_genai.dragent.frontends.fastapi import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
@@ -411,6 +417,7 @@ class TestCreateAgentCard:
         assert "oauth2" in card.security_schemes
         oauth_scheme = card.security_schemes["oauth2"].root
         assert oauth_scheme.type == "oauth2"
+        assert oauth_scheme.description == OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
 
         # Only client_credentials flow, no authorization_code
         assert oauth_scheme.flows.authorization_code is None
@@ -420,11 +427,12 @@ class TestCreateAgentCard:
 
         assert card.security == [{"oauth2": ["blog:write"]}]
 
-        # audience exposed via A2A capabilities extension
+        # audience exposed via A2A capabilities extension (RFC 8693; scopes only in flows)
         assert card.capabilities.extensions is not None
         assert len(card.capabilities.extensions) == 1
         ext = card.capabilities.extensions[0]
-        assert ext.uri == "urn:ietf:params:oauth:grant-type:token-exchange"
+        assert ext.uri == RFC8693_GRANT_TYPE_URI
+        assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
         assert ext.params == {"audience": "https://app.datarobot.com/dr_org_id/my_agent"}
 
     async def test_security_schemes_from_server_auth(
@@ -438,6 +446,7 @@ class TestCreateAgentCard:
         card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
 
         oauth_scheme = card.security_schemes["oauth2"].root
+        assert oauth_scheme.description == OAUTH2_SECURITY_DESCRIPTION_DEFAULT
         # Only authorization_code flow, no client_credentials
         assert oauth_scheme.flows.authorization_code is not None
         assert (
@@ -476,6 +485,7 @@ class TestCreateAgentCard:
         # Single oauth2 scheme with both flows
         assert len(card.security_schemes) == 1
         oauth_scheme = card.security_schemes["oauth2"].root
+        assert oauth_scheme.description == OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
 
         assert oauth_scheme.flows.authorization_code is not None
         assert (
@@ -492,11 +502,12 @@ class TestCreateAgentCard:
         # Merged scopes (deduplicated)
         assert card.security == [{"oauth2": ["read", "blog:write"]}]
 
-        # Extension for audience
+        # RFC 8693 extension: audience in params only, scopes only under flows
         assert card.capabilities.extensions is not None
-        assert card.capabilities.extensions[0].params == {
-            "audience": "https://app.datarobot.com/dr_org_id/my_agent"
-        }
+        ext = card.capabilities.extensions[0]
+        assert ext.uri == RFC8693_GRANT_TYPE_URI
+        assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
+        assert ext.params == {"audience": "https://app.datarobot.com/dr_org_id/my_agent"}
 
     async def test_no_security_when_server_auth_absent(
         self, dragent_worker_with_a2a, a2a_frontend_config

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -32,10 +32,10 @@ from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
-from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeConfig
 from datarobot_genai.dragent.frontends.register import DRA2AFrontEndConfig
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
+from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeConfig
 from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 
@@ -59,7 +59,7 @@ def dragent_worker():
                             token_url="https://example.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
                             audience="api://dr-blog-writer",
                             scopes=["blog:write"],
-                        )
+                        ),
                     )
                 ),
             )
@@ -443,8 +443,14 @@ class TestCreateAgentCard:
         oauth_scheme = card.security_schemes["oauth2"].root
         # Only authorization_code flow, no client_credentials
         assert oauth_scheme.flows.authorization_code is not None
-        assert oauth_scheme.flows.authorization_code.authorization_url == "https://issuer.example.com/oauth/authorize"
-        assert oauth_scheme.flows.authorization_code.token_url == "https://issuer.example.com/oauth/token"
+        assert (
+            oauth_scheme.flows.authorization_code.authorization_url
+            == "https://issuer.example.com/oauth/authorize"
+        )
+        assert (
+            oauth_scheme.flows.authorization_code.token_url
+            == "https://issuer.example.com/oauth/token"
+        )
         assert oauth_scheme.flows.client_credentials is None
         assert card.security == [{"oauth2": ["read"]}]
 
@@ -472,10 +478,16 @@ class TestCreateAgentCard:
         oauth_scheme = card.security_schemes["oauth2"].root
 
         assert oauth_scheme.flows.authorization_code is not None
-        assert oauth_scheme.flows.authorization_code.authorization_url == "https://issuer.example.com/oauth/authorize"
+        assert (
+            oauth_scheme.flows.authorization_code.authorization_url
+            == "https://issuer.example.com/oauth/authorize"
+        )
 
         assert oauth_scheme.flows.client_credentials is not None
-        assert oauth_scheme.flows.client_credentials.token_url == "https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
+        assert (
+            oauth_scheme.flows.client_credentials.token_url
+            == "https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
+        )
 
         # Merged scopes (deduplicated)
         assert card.security == [{"oauth2": ["read", "blog:write"]}]

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.13"
+version = "0.15.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This changeset adds option to configure OAuth2 token exchange (client credentials) flow for NAT and surface it in the AgentCard.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies how `AgentCard` OAuth security metadata is constructed and introduces OIDC discovery network calls, which could affect client authentication flows and startup behavior if misconfigured.
> 
> **Overview**
> Adds an optional *OAuth2 token exchange (RFC 8693)* configuration on the `a2a` block (`oauth_token_exchange`) and surfaces it in the published `AgentCard`.
> 
> `DRAgentFastApiFrontEndPluginWorker` now builds a single `oauth2` security scheme that can include **authorization-code** (from `server_auth`, with optional OIDC discovery / issuer-derived endpoints) and **client-credentials** (from token exchange) flows, merges scopes, and advertises RFC8693 requirements via `capabilities.extensions`.
> 
> Includes a new `OAuth2TokenExchangeConfig` model, updates unit tests to cover server-auth-only, token-exchange-only, and combined configurations, and bumps the package version/changelog to `0.15.17`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7009d4b2db9a3ad6d48769eccc5c7b56a38bc9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->