### PR TITLE
Remove unnecessary custom route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.14
+- Removed custom chat completions implementations and set the default workflow config to generate it instead
+
 ## 0.15.13
 - Changed CLI model placeholder to `unknown` so the agent resolves the model from config (LLM_DEFAULT_MODEL)
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.13"
+version = "0.15.14"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.13"
+version = "0.15.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -26,7 +26,6 @@ from fastapi import FastAPI
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
-from nat.front_ends.fastapi.routes.chat import add_v1_chat_completions_route
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
 from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
@@ -166,34 +165,16 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
     async def add_routes(self, app: FastAPI, builder: WorkflowBuilder) -> None:
         await super().add_routes(app, builder)
-        await self._add_chat_completion_route(app, self._session_managers[-1])
-        await self._add_a2a_routes(app, builder)
+        if self.front_end_config.a2a:
+            await self._add_a2a_routes(app, builder, self.front_end_config.a2a)
 
-    async def _add_chat_completion_route(
-        self, app: FastAPI, session_manager: SessionManager
+    async def _add_a2a_routes(
+        self, app: FastAPI, builder: WorkflowBuilder, a2a_config: A2AFrontEndConfig
     ) -> None:
-        openai_v1_path = "/chat/completions"
-        description = "OpenAI Chat Completions API compatible"
-        await add_v1_chat_completions_route(
-            self,
-            app,
-            path=openai_v1_path,
-            method="POST",
-            description=description,
-            session_manager=session_manager,
-            enable_interactive=False,
-        )
-
-    async def _add_a2a_routes(self, app: FastAPI, builder: WorkflowBuilder) -> None:
-        if self.front_end_config.a2a is None:
-            logger.info("A2A server endpoints are disabled")
-            return
-
         # A2AFrontEndPluginWorker reads config.general.front_end to get its front_end_config.
-        # We must pass it a full Config with the A2AFrontEndConfig substituted in.
-        # We also inherit host/port from the FastAPI config so the agent card URL is gets mounted
-        # under the correct endpoint.
-        a2a_config = self.front_end_config.a2a.server.model_copy(
+        # Pass a full Config with the A2AFrontEndConfig substituted in, and inherit host/port
+        # from the FastAPI front end so the agent card URL matches where the app is mounted.
+        a2a_config = a2a_config.server.model_copy(
             update={"host": self.front_end_config.host, "port": self.front_end_config.port}
         )
         nat_config = self._config.model_copy(

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -61,6 +61,17 @@ class DRAgentFastApiFrontEndConfig(FastApiFrontEndConfig, name="dragent_fastapi"
         description="Expose this agent via the Agent2Agent protocol. "
         "A2A server endpoints are mounted under /a2a/.",
     )
+    workflow: typing.Annotated[
+        FastApiFrontEndConfig.EndpointBase,
+        Field(description="Endpoint for the default workflow."),
+    ] = FastApiFrontEndConfig.EndpointBase(
+        method="POST",
+        path="/v1/workflow",
+        openai_api_v1_path="/chat/completions",
+        legacy_path="/generate",
+        legacy_openai_api_path="/chat",
+        description="Executes the default NAT workflow from the loaded configuration ",
+    )
 
 
 @register_front_end(config_type=DRAgentFastApiFrontEndConfig)

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -113,20 +113,14 @@ def mock_a2a_worker():
 
 @pytest.fixture
 def patch_super_add_routes():
-    """Mock parent add_routes (append a session manager) and skip chat registration."""
+    """Mock parent add_routes so it appends a session manager (mirrors NAT behavior)."""
 
     async def mock_super_add_routes(self, app, builder):
         self._session_managers.append(MagicMock())
 
-    with (
-        patch(
-            "nat.front_ends.fastapi.fastapi_front_end_plugin_worker.FastApiFrontEndPluginWorker.add_routes",
-            mock_super_add_routes,
-        ),
-        patch(
-            "datarobot_genai.dragent.frontends.fastapi.DRAgentFastApiFrontEndPluginWorker._add_chat_completion_route",
-            new_callable=AsyncMock,
-        ),
+    with patch(
+        "nat.front_ends.fastapi.fastapi_front_end_plugin_worker.FastApiFrontEndPluginWorker.add_routes",
+        mock_super_add_routes,
     ):
         yield
 
@@ -210,10 +204,6 @@ class TestDRAgentFastApiFrontEndPluginWorker:
                 mock_super_add_routes,
             ),
             patch(
-                "datarobot_genai.dragent.frontends.fastapi.add_v1_chat_completions_route",
-                new_callable=AsyncMock,
-            ) as mock_chat_route,
-            patch(
                 "datarobot_genai.dragent.frontends.fastapi.A2AFrontEndPluginWorker",
                 return_value=mock_a2a_worker,
             ) as mock_a2a_worker_cls,
@@ -224,18 +214,6 @@ class TestDRAgentFastApiFrontEndPluginWorker:
             ),
         ):
             await dragent_worker.add_routes(app, mock_builder)
-
-        mock_chat_route.assert_awaited_once()
-        chat_call = mock_chat_route.await_args
-        assert chat_call.args[0] is dragent_worker
-        assert chat_call.args[1] is app
-        assert chat_call.kwargs == {
-            "path": "/chat/completions",
-            "method": "POST",
-            "description": "OpenAI Chat Completions API compatible",
-            "session_manager": nat_session_from_parent,
-            "enable_interactive": False,
-        }
 
         a2a_config_used = mock_a2a_worker_cls.call_args[0][0].general.front_end
         assert a2a_config_used.host == dragent_worker.front_end_config.host

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.13"
+version = "0.15.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes HTTP route registration/compatibility for chat completions and could impact clients relying on the old custom handler. Changes are localized to the FastAPI frontend and covered by updated unit tests.
> 
> **Overview**
> **Dragent FastAPI no longer registers a custom OpenAI-compatible `/chat/completions` route.** Instead, the frontend config now defines a default `workflow` endpoint that maps `openai_api_v1_path` to `/chat/completions` (plus legacy paths), letting NAT generate the route.
> 
> A2A mounting is simplified to only run when `front_end_config.a2a` is set, passing the A2A config explicitly into `_add_a2a_routes`.
> 
> Bumps package version to `0.15.14` and updates tests to drop assertions/mocks for the removed chat-completions route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495fc5a924d134a5cae4cb1712eb760920568f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->