### PR TITLE
[BUZZOK-30432] Refactore rendering and invoke simple

### DIFF
--- a/.github/workflows/e2e-examples.yml
+++ b/.github/workflows/e2e-examples.yml
@@ -75,19 +75,19 @@ jobs:
           path: |
             e2e-tests/.venv
             ~/.cache/uv
-          key: e2e-uv-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.example }}
+          key: e2e-uv-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.example }}-${{ hashFiles('e2e-tests/uv.lock') }}
           restore-keys: |
             e2e-uv-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.example }}
 
       - name: Install dependencies
         working-directory: e2e-tests
         run: |
-          uv sync
+          uv sync --group example-${{ matrix.example }}
 
       - name: Run example e2e
         working-directory: e2e-tests
         run: |
-          uv run pytest --nbmake "examples/${EXAMPLE}.ipynb" -vv -s
+          uv run pytest --nbmake "examples/${EXAMPLE}.ipynb" -vv -s --junitxml=test_results/results.xml
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-examples.yml
+++ b/.github/workflows/e2e-examples.yml
@@ -75,9 +75,9 @@ jobs:
           path: |
             e2e-tests/.venv
             ~/.cache/uv
-          key: e2e-uv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.example }}-${{ hashFiles('e2e-tests/uv.lock') }}
+          key: e2e-uv-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.example }}
           restore-keys: |
-            e2e-uv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.example }}-
+            e2e-uv-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.example }}
 
       - name: Install dependencies
         working-directory: e2e-tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,10 @@ repos:
             "--python-folders",
             "tests",
         ]
+-   repo: https://github.com/kynan/nbstripout
+    rev: 0.9.1
+    hooks:
+    -   id: nbstripout
 
 -   repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.18
+- Refactor event rendering: decouple it from NAT console and make it all go to stdout
+- Agent.invoke_simple: method to simply call an agent class with a single request, and output a stream of rendered colored events
 
 ## 0.15.17
 - Added option to configure OAuth2 token exchange flow for server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.18
-- Refactor event rendering: decouple it from NAT console and make it all go to stdout
-- Agent.invoke_simple: method to simply call an agent class with a single request, and output a stream of rendered colored events
+- Refactored event rendering: decouple it from NAT console and make it all go to stdout
+- Added Agent.invoke_simple: method to simply call an agent class with a single request, and output a stream of rendered colored events
 
 ## 0.15.17
 - Added option to configure OAuth2 token exchange flow for server

--- a/e2e-tests/Taskfile.yaml
+++ b/e2e-tests/Taskfile.yaml
@@ -41,7 +41,7 @@ tasks:
           - base
     cmds:
       - echo "🔧 Installing dependencies for {{.AGENT}}"
-      - uv sync --group dragent-{{.AGENT}} --group lint
+      - uv sync --group dragent-{{.AGENT}} --dev
   install-all:
     desc: "🔧 Install dependencies for all groups"
     cmds:

--- a/e2e-tests/Taskfile.yaml
+++ b/e2e-tests/Taskfile.yaml
@@ -75,7 +75,7 @@ tasks:
     desc: "🧪 Run examples"
     cmds:
       - echo "🧪 Running examples"
-      - uv run pytest --nbmake "examples" -n auto -vv -s
+      - uv run pytest --nbmake "examples" -vv -s
 
   run-dragent:
     desc: "🔨 Run dragent"

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -17,7 +17,6 @@ import os
 import httpx
 import pytest
 from ag_ui.core import EventType
-from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import AGENT
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS
@@ -58,8 +57,9 @@ def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[
     # THEN: a response is correct AG UI events
     mcp_ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # THEN: a response is a valid AG-UI sequence
-    validate_sequence(mcp_ag_ui_events)
+    # TODO: re-enable when merged upstream
+    # # THEN: a response is a valid AG-UI sequence
+    # validate_sequence(mcp_ag_ui_events)
 
     # THEN: the events contain tool call events (if framework supports tool calls)
     tool_types = {

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -57,7 +57,7 @@ def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[
     # THEN: a response is correct AG UI events
     mcp_ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # TODO: re-enable when merged upstream
+    # TODO (BUZZOK-30524): re-enable when merged upstream
     # # THEN: a response is a valid AG-UI sequence
     # validate_sequence(mcp_ag_ui_events)
 

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -48,7 +48,7 @@ def test_generate_single(http_client: httpx.Client) -> None:
     # THEN: the response contains AG-UI events
     assert len(response_data.events) > 0
 
-    # TODO: re-enable when merged upstream
+    # TODO (BUZZOK-30524): re-enable when merged upstream
     # # THEN: the events are a valid AG-UI sequence
     # validate_sequence(response_data.events)
 

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from ag_ui.verify import validate_sequence
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
 from dragent_tests.helpers import AGENT
@@ -49,8 +48,9 @@ def test_generate_single(http_client: httpx.Client) -> None:
     # THEN: the response contains AG-UI events
     assert len(response_data.events) > 0
 
-    # THEN: the events are a valid AG-UI sequence
-    validate_sequence(response_data.events)
+    # TODO: re-enable when merged upstream
+    # # THEN: the events are a valid AG-UI sequence
+    # validate_sequence(response_data.events)
 
     # THEN: there are events with text
     full_text = collect_text(response_data.events)

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import ALL_TEST_CASES
 from dragent_tests.helpers import GENERATE_STREAM_PATH
@@ -45,8 +44,9 @@ def test_generate_streaming(http_client: httpx.Client) -> None:
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_responses)
 
-    # THEN: the events are a valid AG-UI sequence
-    validate_sequence(ag_ui_events)
+    # TODO: re-enable when merged upstream
+    # # THEN: the events are a valid AG-UI sequence
+    # validate_sequence(ag_ui_events)
 
     # THEN: there are events with text
     full_text = collect_text(ag_ui_events)

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -44,7 +44,7 @@ def test_generate_streaming(http_client: httpx.Client) -> None:
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_responses)
 
-    # TODO: re-enable when merged upstream
+    # TODO (BUZZOK-30524): re-enable when merged upstream
     # # THEN: the events are a valid AG-UI sequence
     # validate_sequence(ag_ui_events)
 

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import httpx
 import pytest
 from ag_ui.core import EventType
-from ag_ui.verify import validate_sequence
 
 from dragent_tests.helpers import AGENT
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS
@@ -63,8 +62,9 @@ def test_generate_objectid_tool_is_called(http_client: httpx.Client) -> None:  #
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # THEN: the events are a valid AG-UI sequence
-    validate_sequence(ag_ui_events)
+    # TODO: re-enable when merged upstream
+    # # THEN: the events are a valid AG-UI sequence
+    # validate_sequence(ag_ui_events)
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}
     tool_types = {
@@ -125,8 +125,9 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # THEN: the events are a valid AG-UI sequence
-    validate_sequence(ag_ui_events)
+    # TODO: re-enable when merged upstream
+    # # THEN: the events are a valid AG-UI sequence
+    # validate_sequence(ag_ui_events)
 
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -62,7 +62,7 @@ def test_generate_objectid_tool_is_called(http_client: httpx.Client) -> None:  #
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # TODO: re-enable when merged upstream
+    # TODO (BUZZOK-30524): re-enable when merged upstream
     # # THEN: the events are a valid AG-UI sequence
     # validate_sequence(ag_ui_events)
     # THEN: there are events with tool call
@@ -125,7 +125,7 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # TODO: re-enable when merged upstream
+    # TODO (BUZZOK-30524): re-enable when merged upstream
     # # THEN: the events are a valid AG-UI sequence
     # validate_sequence(ag_ui_events)
 

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -37,12 +37,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37a19561",
+   "id": "77aecab5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Remove this line if you run this externally\n",
-    "!uv pip install -e ../.."
+    "!uv pip install -e \"../..[langgraph]\""
    ]
   },
   {
@@ -271,6 +270,14 @@
     "async for event in agent.invoke_simple(request):\n",
     "    print(event, end='')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5786689",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -19,23 +19,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "346a368a-20d5-410b-afcb-59d12b67f1ca",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2mUsing Python 3.12.10 environment at: /Users/anatolii.stehnii/workspace/datarobot-genai/e2e-tests/.venv\u001b[0m\n",
-      "\u001b[2K\u001b[2mResolved \u001b[1m194 packages\u001b[0m \u001b[2min 2.54s\u001b[0m\u001b[0m                                       \u001b[0m\n",
-      "\u001b[2mAudited \u001b[1m194 packages\u001b[0m \u001b[2min 2ms\u001b[0m\u001b[0m\n",
-      "\u001b[2K\u001b[2mResolved \u001b[1m18 packages\u001b[0m \u001b[2min 17ms\u001b[0m\u001b[0m                                         \u001b[0m\n",
-      "\u001b[2mAudited \u001b[1m18 packages\u001b[0m \u001b[2min 0.84ms\u001b[0m\u001b[0m\n",
-      "Installed 1 executable: \u001b[1mdr-get-llms\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 0. Load dotenv and install dependencies.\n",
@@ -63,89 +50,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "d7a14a9e-a422-476c-9dc7-193513e3421c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b]11;?\u001b\\\u001b[6n\u001b]10;?\u001b\\\u001b[6n\u001b]11;?\u001b\\\u001b[6n\u001b[1;94m🔌 Running plugin: get-llms\u001b[0m\n",
-      "\u001b[Ketching models from DataRobot...\n",
-      "DataRobot Available Models\n",
-      "================================================================================\n",
-      "\n",
-      "Llm Id                                          Model                                             \n",
-      "----------------------------------------------  --------------------------------------------------\n",
-      "anthropic-1p-claude-haiku-4-5                   anthropic/claude-haiku-4-5-20251001               \n",
-      "anthropic-1p-claude-opus-4-1                    anthropic/claude-opus-4-1-20250805                \n",
-      "anthropic-1p-claude-opus-4                      anthropic/claude-opus-4-20250514                  \n",
-      "anthropic-1p-claude-opus-4-5                    anthropic/claude-opus-4-5-20251101                \n",
-      "anthropic-1p-claude-sonnet-4                    anthropic/claude-sonnet-4-20250514                \n",
-      "anthropic-1p-claude-sonnet-4-5                  anthropic/claude-sonnet-4-5-20250929              \n",
-      "anthropic-1p-claude-sonnet-4-6                  anthropic/claude-sonnet-4-6                       \n",
-      "azure-openai-gpt-4-o                            azure/gpt-4o-2024-11-20                           \n",
-      "azure-openai-gpt-5-1                            azure/gpt-5-1-2025-11-13                          \n",
-      "azure-openai-gpt-5-2                            azure/gpt-5-2-2025-12-11                          \n",
-      "azure-openai-gpt-5                              azure/gpt-5-2025-08-07                            \n",
-      "azure-openai-gpt-5-4                            azure/gpt-5-4-2026-03-05                          \n",
-      "azure-openai-gpt-5-codex                        azure/gpt-5-codex-2025-09-15                      \n",
-      "azure-openai-gpt-5-mini                         azure/gpt-5-mini-2025-08-07                       \n",
-      "azure-openai-gpt-5-nano                         azure/gpt-5-nano-2025-08-07                       \n",
-      "amazon-nova-lite                                bedrock/amazon.nova-lite-v1:0                     \n",
-      "amazon-nova-micro                               bedrock/amazon.nova-micro-v1:0                    \n",
-      "amazon-nova-premier                             bedrock/amazon.nova-premier-v1:0                  \n",
-      "amazon-nova-pro                                 bedrock/amazon.nova-pro-v1:0                      \n",
-      "anthropic-claude-3-haiku                        bedrock/anthropic.claude-3-haiku-20240307-v1:0    \n",
-      "amazon-anthropic-claude-haiku-4-5-20251001-v1   bedrock/anthropic.claude-haiku-4-5-20251001-v1:0  \n",
-      "amazon-anthropic-claude-opus-4-1-v1             bedrock/anthropic.claude-opus-4-1-20250805-v1:0   \n",
-      "amazon-anthropic-claude-opus-4-5-20251101-v1    bedrock/anthropic.claude-opus-4-5-20251101-v1:0   \n",
-      "amazon-anthropic-claude-sonnet-4-20250514-v1    bedrock/anthropic.claude-sonnet-4-20250514-v1:0   \n",
-      "amazon-anthropic-claude-sonnet-4-5-20250929-v1  bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0 \n",
-      "amazon-anthropic-claude-sonnet-4-6              bedrock/anthropic.claude-sonnet-4-6               \n",
-      "amazon-cohere-command-r-plus-v1                 bedrock/cohere.command-r-plus-v1:0                \n",
-      "amazon-cohere-command-r-v1                      bedrock/cohere.command-r-v1:0                     \n",
-      "amazon-nvidia-nemotron-nano-12b-v2              bedrock/converse/nvidia.nemotron-nano-12b-v2      \n",
-      "amazon-nvidia-nemotron-nano-9b-v2               bedrock/converse/nvidia.nemotron-nano-9b-v2       \n",
-      "amazon-deepseek-r1-v1                           bedrock/deepseek.r1-v1:0                          \n",
-      "amazon-meta-llama-3-1-405b-instruct-v1          bedrock/meta.llama3-1-405b-instruct-v1:0          \n",
-      "amazon-meta-llama-3-1-70b-instruct-v1           bedrock/meta.llama3-1-70b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-1-8b-instruct-v1            bedrock/meta.llama3-1-8b-instruct-v1:0            \n",
-      "amazon-meta-llama-3-2-11b-instruct-v1           bedrock/meta.llama3-2-11b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-2-1b-instruct-v1            bedrock/meta.llama3-2-1b-instruct-v1:0            \n",
-      "amazon-meta-llama-3-2-3b-instruct-v1            bedrock/meta.llama3-2-3b-instruct-v1:0            \n",
-      "amazon-meta-llama-3-2-90b-instruct-v1           bedrock/meta.llama3-2-90b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-3-70b-instruct-v1           bedrock/meta.llama3-3-70b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-70b-instruct-v1             bedrock/meta.llama3-70b-instruct-v1:0             \n",
-      "amazon-meta-llama-3-8b-instruct-v1              bedrock/meta.llama3-8b-instruct-v1:0              \n",
-      "amazon-meta-llama-4-maverick-17b-instruct-v1    bedrock/meta.llama4-maverick-17b-instruct-v1:0    \n",
-      "amazon-meta-llama-4-scout-17b-instruct-v1       bedrock/meta.llama4-scout-17b-instruct-v1:0       \n",
-      "amazon-mistral-mistral-7b-instruct-v0           bedrock/mistral.mistral-7b-instruct-v0:2          \n",
-      "amazon-mistral-mistral-large-2402-v1            bedrock/mistral.mistral-large-2402-v1:0           \n",
-      "amazon-mistral-mistral-small-2402-v1            bedrock/mistral.mistral-small-2402-v1:0           \n",
-      "amazon-mistral-mixtral-8x7b-instruct-v0         bedrock/mistral.mixtral-8x7b-instruct-v0:1        \n",
-      "togetherai-google-gemma-3n-e4b-instruct         together_ai/google/gemma-3n-E4B-it                \n",
-      "togetherai-meta-llama-3-3-70b-instruct-turbo    together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo\n",
-      "google-claude-3-haiku@20240307                  vertex_ai/claude-3-haiku@20240307                 \n",
-      "google-claude-haiku-4-5@20251001                vertex_ai/claude-haiku-4-5@20251001               \n",
-      "google-claude-opus-4-1@20250805                 vertex_ai/claude-opus-4-1@20250805                \n",
-      "google-claude-opus-4@20250514                   vertex_ai/claude-opus-4@20250514                  \n",
-      "google-claude-sonnet-4-5@20250929               vertex_ai/claude-sonnet-4-5@20250929              \n",
-      "google-claude-sonnet-4-6                        vertex_ai/claude-sonnet-4-6                       \n",
-      "google-claude-sonnet-4@20250514                 vertex_ai/claude-sonnet-4@20250514                \n",
-      "google-gemini-2.5-flash                         vertex_ai/gemini-2.5-flash                        \n",
-      "google-gemini-2.5-pro                           vertex_ai/gemini-2.5-pro                          \n",
-      "google-gemini-3.1-pro-preview                   vertex_ai/gemini-3.1-pro-preview                  \n",
-      "google-llama-4-scout-17b-16e-instruct-maas      vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas\n",
-      "\n",
-      "Total: 60 models\n",
-      "(Filtered to active models only)\n",
-      "(Hiding deprecated models)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 1.1. List available LLM ids.\n",
@@ -163,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "eef002b1-c778-44e9-ae22-3094da23b0e8",
    "metadata": {},
    "outputs": [],
@@ -188,21 +96,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "80540a8d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[PromptTemplate(id='69eb56c5cc06eff822e8439f', name='[DO NOT DELETE] Tell me about the topic prompt')]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 2.1. List available prompt templates in DataRobot\n",
@@ -215,21 +112,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "63f82b91",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ChatPromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, messages=[HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, template='Tell me about the {topic}'), additional_kwargs={})])"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 2.2. Select which one you want to use and convert it to a LangGraph prompt template\n",
@@ -257,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "7d96d1cd-36fb-464d-9e6b-d3049ae1f07f",
    "metadata": {},
    "outputs": [],
@@ -285,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "a8f04c4e-d822-4fb1-bdd0-358ebc27546d",
    "metadata": {},
    "outputs": [],
@@ -334,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "4361c8bf-c4b9-479f-93df-d9818bcfd852",
    "metadata": {},
    "outputs": [],
@@ -359,35 +245,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "a16f1db1-8feb-4917-b36c-7291eeee4fb9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2mRun started\u001b[0m\n",
-      "\n",
-      "\u001b[35m▶ Tool Call: \u001b[35m\u001b[2mcalculator\u001b[0m\n",
-      "\u001b[35m  Arguments: \u001b[0m\u001b[35m\u001b[2m{\"\u001b[0m\u001b[35m\u001b[2mexpression\u001b[0m\u001b[35m\u001b[2m\":\"\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m+\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m\"}\u001b[0m\n",
-      "\u001b[35m  Result: \u001b[35m\u001b[2m4\u001b[0m\n",
-      "\u001b[36mResult\u001b[0m\u001b[36m:\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m\n",
-      "\n",
-      "\u001b[0m\u001b[36mExplanation\u001b[0m\u001b[36m:\n",
-      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m equals\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m in\u001b[0m\u001b[36m decimal\u001b[0m\u001b[36m arithmetic\u001b[0m\u001b[36m.\n",
-      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m It's\u001b[0m\u001b[36m a\u001b[0m\u001b[36m basic\u001b[0m\u001b[36m addition\u001b[0m\u001b[36m fact\u001b[0m\u001b[36m (\u001b[0m\u001b[36mcomm\u001b[0m\u001b[36mut\u001b[0m\u001b[36mative\u001b[0m\u001b[36m and\u001b[0m\u001b[36m associative\u001b[0m\u001b[36m).\n",
-      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m For\u001b[0m\u001b[36m reference\u001b[0m\u001b[36m:\u001b[0m\u001b[36m in\u001b[0m\u001b[36m binary\u001b[0m\u001b[36m,\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m100\u001b[0m\u001b[36m,\u001b[0m\u001b[36m which\u001b[0m\u001b[36m is\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m in\u001b[0m\u001b[36m decimal\u001b[0m\u001b[36m;\u001b[0m\u001b[36m in\u001b[0m\u001b[36m Roman\u001b[0m\u001b[36m numer\u001b[0m\u001b[36mals\u001b[0m\u001b[36m,\u001b[0m\u001b[36m II\u001b[0m\u001b[36m +\u001b[0m\u001b[36m II\u001b[0m\u001b[36m =\u001b[0m\u001b[36m IV\u001b[0m\u001b[36m.\u001b[0m\n",
-      "\u001b[36mResult\u001b[0m\u001b[36m:\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m\n",
-      "\n",
-      "\u001b[0m\u001b[36mExplanation\u001b[0m\u001b[36m:\n",
-      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m In\u001b[0m\u001b[36m base\u001b[0m\u001b[36m-\u001b[0m\u001b[36m10\u001b[0m\u001b[36m arithmetic\u001b[0m\u001b[36m,\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\n",
-      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m Quick\u001b[0m\u001b[36m cross\u001b[0m\u001b[36m-check\u001b[0m\u001b[36ms\u001b[0m\u001b[36m:\u001b[0m\u001b[36m binary\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m100\u001b[0m\u001b[36m (\u001b[0m\u001b[36mwhich\u001b[0m\u001b[36m is\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m in\u001b[0m\u001b[36m decimal\u001b[0m\u001b[36m);\u001b[0m\u001b[36m Roman\u001b[0m\u001b[36m numer\u001b[0m\u001b[36mals\u001b[0m\u001b[36m II\u001b[0m\u001b[36m +\u001b[0m\u001b[36m II\u001b[0m\u001b[36m =\u001b[0m\u001b[36m IV\u001b[0m\u001b[36m.\u001b[0m\n",
-      "\n",
-      "\u001b[32m✅ Run finished.\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 5. Action!\n",
@@ -399,14 +260,6 @@
     "async for event in agent.invoke_simple(request):\n",
     "    print(event, end='')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f7e71720",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -35,6 +35,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37a19561",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove this line if you run this externally\n",
+    "!uv pip install -e ../.."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "b982ad4f-6bba-4de6-aada-48e4d35c051a",
    "metadata": {},
@@ -255,7 +266,7 @@
     "# -------------------\n",
     "agent = MyAgent(llm=llm, tools=tools, verbose=False)\n",
     "\n",
-    "request = \"Calculate 2+2 and outputn result immediately\"\n",
+    "request = \"Calculate 2+2 and output result immediately\"\n",
     "\n",
     "async for event in agent.invoke_simple(request):\n",
     "    print(event, end='')"

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -19,34 +19,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "346a368a-20d5-410b-afcb-59d12b67f1ca",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2mUsing Python 3.11.11 environment at: /Users/anatolii.stehnii/workspace/datarobot-genai/e2e-tests/.venv\u001b[0m\n",
-      "\u001b[2K\u001b[2mResolved \u001b[1m196 packages\u001b[0m \u001b[2min 1.00s\u001b[0m\u001b[0m                                       \u001b[0m\n",
-      "\u001b[2mUninstalled \u001b[1m5 packages\u001b[0m \u001b[2min 107ms\u001b[0m\u001b[0m\n",
-      "\u001b[2K\u001b[2mInstalled \u001b[1m5 packages\u001b[0m \u001b[2min 34ms\u001b[0m\u001b[0mentation==0.62b1                \u001b[0m\n",
-      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-api\u001b[0m\u001b[2m==1.39.1\u001b[0m\n",
-      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-api\u001b[0m\u001b[2m==1.41.1\u001b[0m\n",
-      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-instrumentation\u001b[0m\u001b[2m==0.60b1\u001b[0m\n",
-      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-instrumentation\u001b[0m\u001b[2m==0.62b1\u001b[0m\n",
-      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-sdk\u001b[0m\u001b[2m==1.39.1\u001b[0m\n",
-      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-sdk\u001b[0m\u001b[2m==1.41.1\u001b[0m\n",
-      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-semantic-conventions\u001b[0m\u001b[2m==0.60b1\u001b[0m\n",
-      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-semantic-conventions\u001b[0m\u001b[2m==0.62b1\u001b[0m\n",
-      " \u001b[31m-\u001b[39m \u001b[1mragas\u001b[0m\u001b[2m==0.4.3\u001b[0m\n",
-      " \u001b[32m+\u001b[39m \u001b[1mragas\u001b[0m\u001b[2m==0.3.9\u001b[0m\n",
-      "\u001b[2K\u001b[2mResolved \u001b[1m18 packages\u001b[0m \u001b[2min 19ms\u001b[0m\u001b[0m                                         \u001b[0m\n",
-      "\u001b[2mAudited \u001b[1m18 packages\u001b[0m \u001b[2min 0.94ms\u001b[0m\u001b[0m\n",
-      "Installed 1 executable: \u001b[1mdr-get-llms\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 0. Load dotenv and install dependencies.\n",
@@ -60,25 +36,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "77aecab5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2mUsing Python 3.11.11 environment at: /Users/anatolii.stehnii/workspace/datarobot-genai/e2e-tests/.venv\u001b[0m\n",
-      "\u001b[2K\u001b[2mResolved \u001b[1m196 packages\u001b[0m \u001b[2min 755ms\u001b[0m\u001b[0m=0.62b1                                \u001b[0m\n",
-      "\u001b[2K   \u001b[36m\u001b[1mBuilding\u001b[0m\u001b[39m datarobot-genai\u001b[2m @ file:///Users/anatolii.stehnii/workspace/datarobot\u001b[0m\n",
-      "\u001b[2K\u001b[1A      \u001b[32m\u001b[1mBuilt\u001b[0m\u001b[39m datarobot-genai\u001b[2m @ file:///Users/anatolii.stehnii/workspace/datarobot\u001b[0m\n",
-      "\u001b[2K\u001b[2mPrepared \u001b[1m1 package\u001b[0m \u001b[2min 186ms\u001b[0m\u001b[0m                                              \n",
-      "\u001b[2mUninstalled \u001b[1m1 package\u001b[0m \u001b[2min 1ms\u001b[0m\u001b[0m\n",
-      "\u001b[2K\u001b[2mInstalled \u001b[1m1 package\u001b[0m \u001b[2min 1ms\u001b[0m\u001b[0m15.18 (from file:///Users/anatolii\u001b[0m\n",
-      " \u001b[33m~\u001b[39m \u001b[1mdatarobot-genai\u001b[0m\u001b[2m==0.15.18 (from file:///Users/anatolii.stehnii/workspace/datarobot-genai)\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!uv pip install -e \"../..[langgraph]\""
    ]
@@ -99,89 +60,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "d7a14a9e-a422-476c-9dc7-193513e3421c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b]11;?\u001b\\\u001b[6n\u001b]10;?\u001b\\\u001b[6n\u001b]11;?\u001b\\\u001b[6n\u001b[1;94m🔌 Running plugin: get-llms\u001b[0m\n",
-      "\u001b[Ketching models from DataRobot...\n",
-      "DataRobot Available Models\n",
-      "================================================================================\n",
-      "\n",
-      "Llm Id                                          Model                                             \n",
-      "----------------------------------------------  --------------------------------------------------\n",
-      "anthropic-1p-claude-haiku-4-5                   anthropic/claude-haiku-4-5-20251001               \n",
-      "anthropic-1p-claude-opus-4-1                    anthropic/claude-opus-4-1-20250805                \n",
-      "anthropic-1p-claude-opus-4                      anthropic/claude-opus-4-20250514                  \n",
-      "anthropic-1p-claude-opus-4-5                    anthropic/claude-opus-4-5-20251101                \n",
-      "anthropic-1p-claude-sonnet-4                    anthropic/claude-sonnet-4-20250514                \n",
-      "anthropic-1p-claude-sonnet-4-5                  anthropic/claude-sonnet-4-5-20250929              \n",
-      "anthropic-1p-claude-sonnet-4-6                  anthropic/claude-sonnet-4-6                       \n",
-      "azure-openai-gpt-4-o                            azure/gpt-4o-2024-11-20                           \n",
-      "azure-openai-gpt-5-1                            azure/gpt-5-1-2025-11-13                          \n",
-      "azure-openai-gpt-5-2                            azure/gpt-5-2-2025-12-11                          \n",
-      "azure-openai-gpt-5                              azure/gpt-5-2025-08-07                            \n",
-      "azure-openai-gpt-5-4                            azure/gpt-5-4-2026-03-05                          \n",
-      "azure-openai-gpt-5-codex                        azure/gpt-5-codex-2025-09-15                      \n",
-      "azure-openai-gpt-5-mini                         azure/gpt-5-mini-2025-08-07                       \n",
-      "azure-openai-gpt-5-nano                         azure/gpt-5-nano-2025-08-07                       \n",
-      "amazon-nova-lite                                bedrock/amazon.nova-lite-v1:0                     \n",
-      "amazon-nova-micro                               bedrock/amazon.nova-micro-v1:0                    \n",
-      "amazon-nova-premier                             bedrock/amazon.nova-premier-v1:0                  \n",
-      "amazon-nova-pro                                 bedrock/amazon.nova-pro-v1:0                      \n",
-      "anthropic-claude-3-haiku                        bedrock/anthropic.claude-3-haiku-20240307-v1:0    \n",
-      "amazon-anthropic-claude-haiku-4-5-20251001-v1   bedrock/anthropic.claude-haiku-4-5-20251001-v1:0  \n",
-      "amazon-anthropic-claude-opus-4-1-v1             bedrock/anthropic.claude-opus-4-1-20250805-v1:0   \n",
-      "amazon-anthropic-claude-opus-4-5-20251101-v1    bedrock/anthropic.claude-opus-4-5-20251101-v1:0   \n",
-      "amazon-anthropic-claude-sonnet-4-20250514-v1    bedrock/anthropic.claude-sonnet-4-20250514-v1:0   \n",
-      "amazon-anthropic-claude-sonnet-4-5-20250929-v1  bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0 \n",
-      "amazon-anthropic-claude-sonnet-4-6              bedrock/anthropic.claude-sonnet-4-6               \n",
-      "amazon-cohere-command-r-plus-v1                 bedrock/cohere.command-r-plus-v1:0                \n",
-      "amazon-cohere-command-r-v1                      bedrock/cohere.command-r-v1:0                     \n",
-      "amazon-nvidia-nemotron-nano-12b-v2              bedrock/converse/nvidia.nemotron-nano-12b-v2      \n",
-      "amazon-nvidia-nemotron-nano-9b-v2               bedrock/converse/nvidia.nemotron-nano-9b-v2       \n",
-      "amazon-deepseek-r1-v1                           bedrock/deepseek.r1-v1:0                          \n",
-      "amazon-meta-llama-3-1-405b-instruct-v1          bedrock/meta.llama3-1-405b-instruct-v1:0          \n",
-      "amazon-meta-llama-3-1-70b-instruct-v1           bedrock/meta.llama3-1-70b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-1-8b-instruct-v1            bedrock/meta.llama3-1-8b-instruct-v1:0            \n",
-      "amazon-meta-llama-3-2-11b-instruct-v1           bedrock/meta.llama3-2-11b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-2-1b-instruct-v1            bedrock/meta.llama3-2-1b-instruct-v1:0            \n",
-      "amazon-meta-llama-3-2-3b-instruct-v1            bedrock/meta.llama3-2-3b-instruct-v1:0            \n",
-      "amazon-meta-llama-3-2-90b-instruct-v1           bedrock/meta.llama3-2-90b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-3-70b-instruct-v1           bedrock/meta.llama3-3-70b-instruct-v1:0           \n",
-      "amazon-meta-llama-3-70b-instruct-v1             bedrock/meta.llama3-70b-instruct-v1:0             \n",
-      "amazon-meta-llama-3-8b-instruct-v1              bedrock/meta.llama3-8b-instruct-v1:0              \n",
-      "amazon-meta-llama-4-maverick-17b-instruct-v1    bedrock/meta.llama4-maverick-17b-instruct-v1:0    \n",
-      "amazon-meta-llama-4-scout-17b-instruct-v1       bedrock/meta.llama4-scout-17b-instruct-v1:0       \n",
-      "amazon-mistral-mistral-7b-instruct-v0           bedrock/mistral.mistral-7b-instruct-v0:2          \n",
-      "amazon-mistral-mistral-large-2402-v1            bedrock/mistral.mistral-large-2402-v1:0           \n",
-      "amazon-mistral-mistral-small-2402-v1            bedrock/mistral.mistral-small-2402-v1:0           \n",
-      "amazon-mistral-mixtral-8x7b-instruct-v0         bedrock/mistral.mixtral-8x7b-instruct-v0:1        \n",
-      "togetherai-google-gemma-3n-e4b-instruct         together_ai/google/gemma-3n-E4B-it                \n",
-      "togetherai-meta-llama-3-3-70b-instruct-turbo    together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo\n",
-      "google-claude-3-haiku@20240307                  vertex_ai/claude-3-haiku@20240307                 \n",
-      "google-claude-haiku-4-5@20251001                vertex_ai/claude-haiku-4-5@20251001               \n",
-      "google-claude-opus-4-1@20250805                 vertex_ai/claude-opus-4-1@20250805                \n",
-      "google-claude-opus-4@20250514                   vertex_ai/claude-opus-4@20250514                  \n",
-      "google-claude-sonnet-4-5@20250929               vertex_ai/claude-sonnet-4-5@20250929              \n",
-      "google-claude-sonnet-4-6                        vertex_ai/claude-sonnet-4-6                       \n",
-      "google-claude-sonnet-4@20250514                 vertex_ai/claude-sonnet-4@20250514                \n",
-      "google-gemini-2.5-flash                         vertex_ai/gemini-2.5-flash                        \n",
-      "google-gemini-2.5-pro                           vertex_ai/gemini-2.5-pro                          \n",
-      "google-gemini-3.1-pro-preview                   vertex_ai/gemini-3.1-pro-preview                  \n",
-      "google-llama-4-scout-17b-16e-instruct-maas      vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas\n",
-      "\n",
-      "Total: 60 models\n",
-      "(Filtered to active models only)\n",
-      "(Hiding deprecated models)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 1.1. List available LLM ids.\n",
@@ -199,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "eef002b1-c778-44e9-ae22-3094da23b0e8",
    "metadata": {},
    "outputs": [],
@@ -224,21 +106,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "80540a8d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[PromptTemplate(id='69eb56c5cc06eff822e8439f', name='[DO NOT DELETE] Tell me about the topic prompt')]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 2.1. List available prompt templates in DataRobot\n",
@@ -251,21 +122,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "63f82b91",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ChatPromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, messages=[HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, template='Tell me about the {topic}'), additional_kwargs={})])"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 2.2. Select which one you want to use and convert it to a LangGraph prompt template\n",
@@ -293,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "7d96d1cd-36fb-464d-9e6b-d3049ae1f07f",
    "metadata": {},
    "outputs": [],
@@ -321,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a8f04c4e-d822-4fb1-bdd0-358ebc27546d",
    "metadata": {},
    "outputs": [],
@@ -370,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "4361c8bf-c4b9-479f-93df-d9818bcfd852",
    "metadata": {},
    "outputs": [],
@@ -395,26 +255,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "a16f1db1-8feb-4917-b36c-7291eeee4fb9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2mRun started\u001b[0m\n",
-      "\n",
-      "\u001b[35m▶ Tool Call: \u001b[35m\u001b[2mcalculator\u001b[0m\n",
-      "\u001b[35m  Arguments: \u001b[0m\u001b[35m\u001b[2m{\"\u001b[0m\u001b[35m\u001b[2mexpression\u001b[0m\u001b[35m\u001b[2m\":\"\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m+\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m\"}\u001b[0m\n",
-      "\u001b[35m  Result: \u001b[35m\u001b[2m4\u001b[0m\n",
-      "\u001b[36mThe\u001b[0m\u001b[36m result\u001b[0m\u001b[36m is\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\u001b[0m\n",
-      "\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\u001b[0m\n",
-      "\n",
-      "\u001b[32m✅ Run finished.\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# -------------------\n",
     "# 5. Action!\n",
@@ -430,14 +274,6 @@
     "    if rendered is not None:\n",
     "        print(rendered, end='')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b5786689",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -19,10 +19,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "346a368a-20d5-410b-afcb-59d12b67f1ca",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2mUsing Python 3.11.11 environment at: /Users/anatolii.stehnii/workspace/datarobot-genai/e2e-tests/.venv\u001b[0m\n",
+      "\u001b[2K\u001b[2mResolved \u001b[1m196 packages\u001b[0m \u001b[2min 1.00s\u001b[0m\u001b[0m                                       \u001b[0m\n",
+      "\u001b[2mUninstalled \u001b[1m5 packages\u001b[0m \u001b[2min 107ms\u001b[0m\u001b[0m\n",
+      "\u001b[2K\u001b[2mInstalled \u001b[1m5 packages\u001b[0m \u001b[2min 34ms\u001b[0m\u001b[0mentation==0.62b1                \u001b[0m\n",
+      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-api\u001b[0m\u001b[2m==1.39.1\u001b[0m\n",
+      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-api\u001b[0m\u001b[2m==1.41.1\u001b[0m\n",
+      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-instrumentation\u001b[0m\u001b[2m==0.60b1\u001b[0m\n",
+      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-instrumentation\u001b[0m\u001b[2m==0.62b1\u001b[0m\n",
+      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-sdk\u001b[0m\u001b[2m==1.39.1\u001b[0m\n",
+      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-sdk\u001b[0m\u001b[2m==1.41.1\u001b[0m\n",
+      " \u001b[31m-\u001b[39m \u001b[1mopentelemetry-semantic-conventions\u001b[0m\u001b[2m==0.60b1\u001b[0m\n",
+      " \u001b[32m+\u001b[39m \u001b[1mopentelemetry-semantic-conventions\u001b[0m\u001b[2m==0.62b1\u001b[0m\n",
+      " \u001b[31m-\u001b[39m \u001b[1mragas\u001b[0m\u001b[2m==0.4.3\u001b[0m\n",
+      " \u001b[32m+\u001b[39m \u001b[1mragas\u001b[0m\u001b[2m==0.3.9\u001b[0m\n",
+      "\u001b[2K\u001b[2mResolved \u001b[1m18 packages\u001b[0m \u001b[2min 19ms\u001b[0m\u001b[0m                                         \u001b[0m\n",
+      "\u001b[2mAudited \u001b[1m18 packages\u001b[0m \u001b[2min 0.94ms\u001b[0m\u001b[0m\n",
+      "Installed 1 executable: \u001b[1mdr-get-llms\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 0. Load dotenv and install dependencies.\n",
@@ -36,10 +60,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "77aecab5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2mUsing Python 3.11.11 environment at: /Users/anatolii.stehnii/workspace/datarobot-genai/e2e-tests/.venv\u001b[0m\n",
+      "\u001b[2K\u001b[2mResolved \u001b[1m196 packages\u001b[0m \u001b[2min 755ms\u001b[0m\u001b[0m=0.62b1                                \u001b[0m\n",
+      "\u001b[2K   \u001b[36m\u001b[1mBuilding\u001b[0m\u001b[39m datarobot-genai\u001b[2m @ file:///Users/anatolii.stehnii/workspace/datarobot\u001b[0m\n",
+      "\u001b[2K\u001b[1A      \u001b[32m\u001b[1mBuilt\u001b[0m\u001b[39m datarobot-genai\u001b[2m @ file:///Users/anatolii.stehnii/workspace/datarobot\u001b[0m\n",
+      "\u001b[2K\u001b[2mPrepared \u001b[1m1 package\u001b[0m \u001b[2min 186ms\u001b[0m\u001b[0m                                              \n",
+      "\u001b[2mUninstalled \u001b[1m1 package\u001b[0m \u001b[2min 1ms\u001b[0m\u001b[0m\n",
+      "\u001b[2K\u001b[2mInstalled \u001b[1m1 package\u001b[0m \u001b[2min 1ms\u001b[0m\u001b[0m15.18 (from file:///Users/anatolii\u001b[0m\n",
+      " \u001b[33m~\u001b[39m \u001b[1mdatarobot-genai\u001b[0m\u001b[2m==0.15.18 (from file:///Users/anatolii.stehnii/workspace/datarobot-genai)\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!uv pip install -e \"../..[langgraph]\""
    ]
@@ -60,10 +99,89 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "d7a14a9e-a422-476c-9dc7-193513e3421c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b]11;?\u001b\\\u001b[6n\u001b]10;?\u001b\\\u001b[6n\u001b]11;?\u001b\\\u001b[6n\u001b[1;94m🔌 Running plugin: get-llms\u001b[0m\n",
+      "\u001b[Ketching models from DataRobot...\n",
+      "DataRobot Available Models\n",
+      "================================================================================\n",
+      "\n",
+      "Llm Id                                          Model                                             \n",
+      "----------------------------------------------  --------------------------------------------------\n",
+      "anthropic-1p-claude-haiku-4-5                   anthropic/claude-haiku-4-5-20251001               \n",
+      "anthropic-1p-claude-opus-4-1                    anthropic/claude-opus-4-1-20250805                \n",
+      "anthropic-1p-claude-opus-4                      anthropic/claude-opus-4-20250514                  \n",
+      "anthropic-1p-claude-opus-4-5                    anthropic/claude-opus-4-5-20251101                \n",
+      "anthropic-1p-claude-sonnet-4                    anthropic/claude-sonnet-4-20250514                \n",
+      "anthropic-1p-claude-sonnet-4-5                  anthropic/claude-sonnet-4-5-20250929              \n",
+      "anthropic-1p-claude-sonnet-4-6                  anthropic/claude-sonnet-4-6                       \n",
+      "azure-openai-gpt-4-o                            azure/gpt-4o-2024-11-20                           \n",
+      "azure-openai-gpt-5-1                            azure/gpt-5-1-2025-11-13                          \n",
+      "azure-openai-gpt-5-2                            azure/gpt-5-2-2025-12-11                          \n",
+      "azure-openai-gpt-5                              azure/gpt-5-2025-08-07                            \n",
+      "azure-openai-gpt-5-4                            azure/gpt-5-4-2026-03-05                          \n",
+      "azure-openai-gpt-5-codex                        azure/gpt-5-codex-2025-09-15                      \n",
+      "azure-openai-gpt-5-mini                         azure/gpt-5-mini-2025-08-07                       \n",
+      "azure-openai-gpt-5-nano                         azure/gpt-5-nano-2025-08-07                       \n",
+      "amazon-nova-lite                                bedrock/amazon.nova-lite-v1:0                     \n",
+      "amazon-nova-micro                               bedrock/amazon.nova-micro-v1:0                    \n",
+      "amazon-nova-premier                             bedrock/amazon.nova-premier-v1:0                  \n",
+      "amazon-nova-pro                                 bedrock/amazon.nova-pro-v1:0                      \n",
+      "anthropic-claude-3-haiku                        bedrock/anthropic.claude-3-haiku-20240307-v1:0    \n",
+      "amazon-anthropic-claude-haiku-4-5-20251001-v1   bedrock/anthropic.claude-haiku-4-5-20251001-v1:0  \n",
+      "amazon-anthropic-claude-opus-4-1-v1             bedrock/anthropic.claude-opus-4-1-20250805-v1:0   \n",
+      "amazon-anthropic-claude-opus-4-5-20251101-v1    bedrock/anthropic.claude-opus-4-5-20251101-v1:0   \n",
+      "amazon-anthropic-claude-sonnet-4-20250514-v1    bedrock/anthropic.claude-sonnet-4-20250514-v1:0   \n",
+      "amazon-anthropic-claude-sonnet-4-5-20250929-v1  bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0 \n",
+      "amazon-anthropic-claude-sonnet-4-6              bedrock/anthropic.claude-sonnet-4-6               \n",
+      "amazon-cohere-command-r-plus-v1                 bedrock/cohere.command-r-plus-v1:0                \n",
+      "amazon-cohere-command-r-v1                      bedrock/cohere.command-r-v1:0                     \n",
+      "amazon-nvidia-nemotron-nano-12b-v2              bedrock/converse/nvidia.nemotron-nano-12b-v2      \n",
+      "amazon-nvidia-nemotron-nano-9b-v2               bedrock/converse/nvidia.nemotron-nano-9b-v2       \n",
+      "amazon-deepseek-r1-v1                           bedrock/deepseek.r1-v1:0                          \n",
+      "amazon-meta-llama-3-1-405b-instruct-v1          bedrock/meta.llama3-1-405b-instruct-v1:0          \n",
+      "amazon-meta-llama-3-1-70b-instruct-v1           bedrock/meta.llama3-1-70b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-1-8b-instruct-v1            bedrock/meta.llama3-1-8b-instruct-v1:0            \n",
+      "amazon-meta-llama-3-2-11b-instruct-v1           bedrock/meta.llama3-2-11b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-2-1b-instruct-v1            bedrock/meta.llama3-2-1b-instruct-v1:0            \n",
+      "amazon-meta-llama-3-2-3b-instruct-v1            bedrock/meta.llama3-2-3b-instruct-v1:0            \n",
+      "amazon-meta-llama-3-2-90b-instruct-v1           bedrock/meta.llama3-2-90b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-3-70b-instruct-v1           bedrock/meta.llama3-3-70b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-70b-instruct-v1             bedrock/meta.llama3-70b-instruct-v1:0             \n",
+      "amazon-meta-llama-3-8b-instruct-v1              bedrock/meta.llama3-8b-instruct-v1:0              \n",
+      "amazon-meta-llama-4-maverick-17b-instruct-v1    bedrock/meta.llama4-maverick-17b-instruct-v1:0    \n",
+      "amazon-meta-llama-4-scout-17b-instruct-v1       bedrock/meta.llama4-scout-17b-instruct-v1:0       \n",
+      "amazon-mistral-mistral-7b-instruct-v0           bedrock/mistral.mistral-7b-instruct-v0:2          \n",
+      "amazon-mistral-mistral-large-2402-v1            bedrock/mistral.mistral-large-2402-v1:0           \n",
+      "amazon-mistral-mistral-small-2402-v1            bedrock/mistral.mistral-small-2402-v1:0           \n",
+      "amazon-mistral-mixtral-8x7b-instruct-v0         bedrock/mistral.mixtral-8x7b-instruct-v0:1        \n",
+      "togetherai-google-gemma-3n-e4b-instruct         together_ai/google/gemma-3n-E4B-it                \n",
+      "togetherai-meta-llama-3-3-70b-instruct-turbo    together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo\n",
+      "google-claude-3-haiku@20240307                  vertex_ai/claude-3-haiku@20240307                 \n",
+      "google-claude-haiku-4-5@20251001                vertex_ai/claude-haiku-4-5@20251001               \n",
+      "google-claude-opus-4-1@20250805                 vertex_ai/claude-opus-4-1@20250805                \n",
+      "google-claude-opus-4@20250514                   vertex_ai/claude-opus-4@20250514                  \n",
+      "google-claude-sonnet-4-5@20250929               vertex_ai/claude-sonnet-4-5@20250929              \n",
+      "google-claude-sonnet-4-6                        vertex_ai/claude-sonnet-4-6                       \n",
+      "google-claude-sonnet-4@20250514                 vertex_ai/claude-sonnet-4@20250514                \n",
+      "google-gemini-2.5-flash                         vertex_ai/gemini-2.5-flash                        \n",
+      "google-gemini-2.5-pro                           vertex_ai/gemini-2.5-pro                          \n",
+      "google-gemini-3.1-pro-preview                   vertex_ai/gemini-3.1-pro-preview                  \n",
+      "google-llama-4-scout-17b-16e-instruct-maas      vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas\n",
+      "\n",
+      "Total: 60 models\n",
+      "(Filtered to active models only)\n",
+      "(Hiding deprecated models)\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 1.1. List available LLM ids.\n",
@@ -81,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "eef002b1-c778-44e9-ae22-3094da23b0e8",
    "metadata": {},
    "outputs": [],
@@ -106,10 +224,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "80540a8d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PromptTemplate(id='69eb56c5cc06eff822e8439f', name='[DO NOT DELETE] Tell me about the topic prompt')]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 2.1. List available prompt templates in DataRobot\n",
@@ -122,10 +251,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "63f82b91",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ChatPromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, messages=[HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, template='Tell me about the {topic}'), additional_kwargs={})])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 2.2. Select which one you want to use and convert it to a LangGraph prompt template\n",
@@ -153,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "7d96d1cd-36fb-464d-9e6b-d3049ae1f07f",
    "metadata": {},
    "outputs": [],
@@ -181,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "a8f04c4e-d822-4fb1-bdd0-358ebc27546d",
    "metadata": {},
    "outputs": [],
@@ -230,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "4361c8bf-c4b9-479f-93df-d9818bcfd852",
    "metadata": {},
    "outputs": [],
@@ -255,20 +395,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a16f1db1-8feb-4917-b36c-7291eeee4fb9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2mRun started\u001b[0m\n",
+      "\n",
+      "\u001b[35m▶ Tool Call: \u001b[35m\u001b[2mcalculator\u001b[0m\n",
+      "\u001b[35m  Arguments: \u001b[0m\u001b[35m\u001b[2m{\"\u001b[0m\u001b[35m\u001b[2mexpression\u001b[0m\u001b[35m\u001b[2m\":\"\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m+\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m\"}\u001b[0m\n",
+      "\u001b[35m  Result: \u001b[35m\u001b[2m4\u001b[0m\n",
+      "\u001b[36mThe\u001b[0m\u001b[36m result\u001b[0m\u001b[36m is\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\u001b[0m\n",
+      "\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\u001b[0m\n",
+      "\n",
+      "\u001b[32m✅ Run finished.\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 5. Action!\n",
     "# -------------------\n",
+    "from datarobot_genai.core.agents.render import render_ag_ui_event\n",
+    "\n",
     "agent = MyAgent(llm=llm, tools=tools, verbose=False)\n",
     "\n",
     "request = \"Calculate 2+2 and output result immediately\"\n",
     "\n",
-    "async for event in agent.invoke_simple(request):\n",
-    "    print(event, end='')"
+    "async for event, pipeline_interactions, usage_metrics in agent.invoke_single_message(request):\n",
+    "    rendered = render_ag_ui_event(event)\n",
+    "    if rendered is not None:\n",
+    "        print(rendered, end='')"
    ]
   },
   {

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0490b35a-c29b-42a4-aeb6-b25483450949",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Prerequisites: `.env` file\n",
@@ -20,7 +20,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "346a368a-20d5-410b-afcb-59d12b67f1ca",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,23 +30,18 @@
     "%load_ext dotenv\n",
     "%dotenv\n",
     "\n",
-    "!uv pip install \"datarobot-genai[langgraph]>=0.15.6\"\n",
+    "# Uncomment this if you run it externally\n",
+    "# !uv pip install \"datarobot-genai[langgraph]>=0.15.18\"\n",
+    "\n",
+    "# Comment this if you run it externally\n",
+    "!uv pip install -e \"../..[langgraph]\"\n",
+    "\n",
     "!uv tool install git+https://github.com/carsongee/get-datarobot-llms.git"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "77aecab5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!uv pip install -e \"../..[langgraph]\""
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "b982ad4f-6bba-4de6-aada-48e4d35c051a",
+   "id": "2",
    "metadata": {},
    "source": [
     "# Agent building blocks\n",
@@ -61,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7a14a9e-a422-476c-9dc7-193513e3421c",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f9f3ed4-ba51-465f-8641-b0d0b960c01f",
+   "id": "4",
    "metadata": {},
    "source": [
     "`datarobot_genai` exposes a unified LLM layer (adapters) for LangGraph, LlamaIndex, CrewAI, and NAT. For the DataRobot LLM Gateway, import `get_datarobot_gateway_llm` from the `llm` submodule of the integration you use (here: `datarobot_genai.langgraph.llm`)."
@@ -82,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eef002b1-c778-44e9-ae22-3094da23b0e8",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4590132e",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Prompt\n",
@@ -107,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80540a8d",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63f82b91",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd1a87ba-6af1-44e1-b77a-9b3b98e148f4",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Tools\n",
@@ -154,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d96d1cd-36fb-464d-9e6b-d3049ae1f07f",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fa095f1-75e0-4dca-ad41-2139b2e9230d",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Agent\n",
@@ -182,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8f04c4e-d822-4fb1-bdd0-358ebc27546d",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c771b0ba-e579-402d-a9dc-71d1284b3bb2",
+   "id": "13",
    "metadata": {},
    "source": [
     "# Wrap the graph for DataRobot\n",
@@ -224,14 +219,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afbe656a",
+   "id": "14",
    "metadata": {},
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4361c8bf-c4b9-479f-93df-d9818bcfd852",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1bea288-e41d-4f60-ad8b-e5731a4a56cf",
+   "id": "16",
    "metadata": {},
    "source": [
     "# Run the agent\n",
@@ -256,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a16f1db1-8feb-4917-b36c-7291eeee4fb9",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -19,10 +19,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "346a368a-20d5-410b-afcb-59d12b67f1ca",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2mUsing Python 3.12.10 environment at: /Users/anatolii.stehnii/workspace/datarobot-genai/e2e-tests/.venv\u001b[0m\n",
+      "\u001b[2K\u001b[2mResolved \u001b[1m194 packages\u001b[0m \u001b[2min 2.54s\u001b[0m\u001b[0m                                       \u001b[0m\n",
+      "\u001b[2mAudited \u001b[1m194 packages\u001b[0m \u001b[2min 2ms\u001b[0m\u001b[0m\n",
+      "\u001b[2K\u001b[2mResolved \u001b[1m18 packages\u001b[0m \u001b[2min 17ms\u001b[0m\u001b[0m                                         \u001b[0m\n",
+      "\u001b[2mAudited \u001b[1m18 packages\u001b[0m \u001b[2min 0.84ms\u001b[0m\u001b[0m\n",
+      "Installed 1 executable: \u001b[1mdr-get-llms\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 0. Load dotenv and install dependencies.\n",
@@ -50,10 +63,89 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "d7a14a9e-a422-476c-9dc7-193513e3421c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b]11;?\u001b\\\u001b[6n\u001b]10;?\u001b\\\u001b[6n\u001b]11;?\u001b\\\u001b[6n\u001b[1;94m🔌 Running plugin: get-llms\u001b[0m\n",
+      "\u001b[Ketching models from DataRobot...\n",
+      "DataRobot Available Models\n",
+      "================================================================================\n",
+      "\n",
+      "Llm Id                                          Model                                             \n",
+      "----------------------------------------------  --------------------------------------------------\n",
+      "anthropic-1p-claude-haiku-4-5                   anthropic/claude-haiku-4-5-20251001               \n",
+      "anthropic-1p-claude-opus-4-1                    anthropic/claude-opus-4-1-20250805                \n",
+      "anthropic-1p-claude-opus-4                      anthropic/claude-opus-4-20250514                  \n",
+      "anthropic-1p-claude-opus-4-5                    anthropic/claude-opus-4-5-20251101                \n",
+      "anthropic-1p-claude-sonnet-4                    anthropic/claude-sonnet-4-20250514                \n",
+      "anthropic-1p-claude-sonnet-4-5                  anthropic/claude-sonnet-4-5-20250929              \n",
+      "anthropic-1p-claude-sonnet-4-6                  anthropic/claude-sonnet-4-6                       \n",
+      "azure-openai-gpt-4-o                            azure/gpt-4o-2024-11-20                           \n",
+      "azure-openai-gpt-5-1                            azure/gpt-5-1-2025-11-13                          \n",
+      "azure-openai-gpt-5-2                            azure/gpt-5-2-2025-12-11                          \n",
+      "azure-openai-gpt-5                              azure/gpt-5-2025-08-07                            \n",
+      "azure-openai-gpt-5-4                            azure/gpt-5-4-2026-03-05                          \n",
+      "azure-openai-gpt-5-codex                        azure/gpt-5-codex-2025-09-15                      \n",
+      "azure-openai-gpt-5-mini                         azure/gpt-5-mini-2025-08-07                       \n",
+      "azure-openai-gpt-5-nano                         azure/gpt-5-nano-2025-08-07                       \n",
+      "amazon-nova-lite                                bedrock/amazon.nova-lite-v1:0                     \n",
+      "amazon-nova-micro                               bedrock/amazon.nova-micro-v1:0                    \n",
+      "amazon-nova-premier                             bedrock/amazon.nova-premier-v1:0                  \n",
+      "amazon-nova-pro                                 bedrock/amazon.nova-pro-v1:0                      \n",
+      "anthropic-claude-3-haiku                        bedrock/anthropic.claude-3-haiku-20240307-v1:0    \n",
+      "amazon-anthropic-claude-haiku-4-5-20251001-v1   bedrock/anthropic.claude-haiku-4-5-20251001-v1:0  \n",
+      "amazon-anthropic-claude-opus-4-1-v1             bedrock/anthropic.claude-opus-4-1-20250805-v1:0   \n",
+      "amazon-anthropic-claude-opus-4-5-20251101-v1    bedrock/anthropic.claude-opus-4-5-20251101-v1:0   \n",
+      "amazon-anthropic-claude-sonnet-4-20250514-v1    bedrock/anthropic.claude-sonnet-4-20250514-v1:0   \n",
+      "amazon-anthropic-claude-sonnet-4-5-20250929-v1  bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0 \n",
+      "amazon-anthropic-claude-sonnet-4-6              bedrock/anthropic.claude-sonnet-4-6               \n",
+      "amazon-cohere-command-r-plus-v1                 bedrock/cohere.command-r-plus-v1:0                \n",
+      "amazon-cohere-command-r-v1                      bedrock/cohere.command-r-v1:0                     \n",
+      "amazon-nvidia-nemotron-nano-12b-v2              bedrock/converse/nvidia.nemotron-nano-12b-v2      \n",
+      "amazon-nvidia-nemotron-nano-9b-v2               bedrock/converse/nvidia.nemotron-nano-9b-v2       \n",
+      "amazon-deepseek-r1-v1                           bedrock/deepseek.r1-v1:0                          \n",
+      "amazon-meta-llama-3-1-405b-instruct-v1          bedrock/meta.llama3-1-405b-instruct-v1:0          \n",
+      "amazon-meta-llama-3-1-70b-instruct-v1           bedrock/meta.llama3-1-70b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-1-8b-instruct-v1            bedrock/meta.llama3-1-8b-instruct-v1:0            \n",
+      "amazon-meta-llama-3-2-11b-instruct-v1           bedrock/meta.llama3-2-11b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-2-1b-instruct-v1            bedrock/meta.llama3-2-1b-instruct-v1:0            \n",
+      "amazon-meta-llama-3-2-3b-instruct-v1            bedrock/meta.llama3-2-3b-instruct-v1:0            \n",
+      "amazon-meta-llama-3-2-90b-instruct-v1           bedrock/meta.llama3-2-90b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-3-70b-instruct-v1           bedrock/meta.llama3-3-70b-instruct-v1:0           \n",
+      "amazon-meta-llama-3-70b-instruct-v1             bedrock/meta.llama3-70b-instruct-v1:0             \n",
+      "amazon-meta-llama-3-8b-instruct-v1              bedrock/meta.llama3-8b-instruct-v1:0              \n",
+      "amazon-meta-llama-4-maverick-17b-instruct-v1    bedrock/meta.llama4-maverick-17b-instruct-v1:0    \n",
+      "amazon-meta-llama-4-scout-17b-instruct-v1       bedrock/meta.llama4-scout-17b-instruct-v1:0       \n",
+      "amazon-mistral-mistral-7b-instruct-v0           bedrock/mistral.mistral-7b-instruct-v0:2          \n",
+      "amazon-mistral-mistral-large-2402-v1            bedrock/mistral.mistral-large-2402-v1:0           \n",
+      "amazon-mistral-mistral-small-2402-v1            bedrock/mistral.mistral-small-2402-v1:0           \n",
+      "amazon-mistral-mixtral-8x7b-instruct-v0         bedrock/mistral.mixtral-8x7b-instruct-v0:1        \n",
+      "togetherai-google-gemma-3n-e4b-instruct         together_ai/google/gemma-3n-E4B-it                \n",
+      "togetherai-meta-llama-3-3-70b-instruct-turbo    together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo\n",
+      "google-claude-3-haiku@20240307                  vertex_ai/claude-3-haiku@20240307                 \n",
+      "google-claude-haiku-4-5@20251001                vertex_ai/claude-haiku-4-5@20251001               \n",
+      "google-claude-opus-4-1@20250805                 vertex_ai/claude-opus-4-1@20250805                \n",
+      "google-claude-opus-4@20250514                   vertex_ai/claude-opus-4@20250514                  \n",
+      "google-claude-sonnet-4-5@20250929               vertex_ai/claude-sonnet-4-5@20250929              \n",
+      "google-claude-sonnet-4-6                        vertex_ai/claude-sonnet-4-6                       \n",
+      "google-claude-sonnet-4@20250514                 vertex_ai/claude-sonnet-4@20250514                \n",
+      "google-gemini-2.5-flash                         vertex_ai/gemini-2.5-flash                        \n",
+      "google-gemini-2.5-pro                           vertex_ai/gemini-2.5-pro                          \n",
+      "google-gemini-3.1-pro-preview                   vertex_ai/gemini-3.1-pro-preview                  \n",
+      "google-llama-4-scout-17b-16e-instruct-maas      vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas\n",
+      "\n",
+      "Total: 60 models\n",
+      "(Filtered to active models only)\n",
+      "(Hiding deprecated models)\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 1.1. List available LLM ids.\n",
@@ -71,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "eef002b1-c778-44e9-ae22-3094da23b0e8",
    "metadata": {},
    "outputs": [],
@@ -96,10 +188,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "80540a8d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PromptTemplate(id='69eb56c5cc06eff822e8439f', name='[DO NOT DELETE] Tell me about the topic prompt')]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 2.1. List available prompt templates in DataRobot\n",
@@ -112,10 +215,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "63f82b91",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ChatPromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, messages=[HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['topic'], input_types={}, partial_variables={}, template='Tell me about the {topic}'), additional_kwargs={})])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 2.2. Select which one you want to use and convert it to a LangGraph prompt template\n",
@@ -143,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "7d96d1cd-36fb-464d-9e6b-d3049ae1f07f",
    "metadata": {},
    "outputs": [],
@@ -171,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a8f04c4e-d822-4fb1-bdd0-358ebc27546d",
    "metadata": {},
    "outputs": [],
@@ -220,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "4361c8bf-c4b9-479f-93df-d9818bcfd852",
    "metadata": {},
    "outputs": [],
@@ -245,34 +359,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a16f1db1-8feb-4917-b36c-7291eeee4fb9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2mRun started\u001b[0m\n",
+      "\n",
+      "\u001b[35m▶ Tool Call: \u001b[35m\u001b[2mcalculator\u001b[0m\n",
+      "\u001b[35m  Arguments: \u001b[0m\u001b[35m\u001b[2m{\"\u001b[0m\u001b[35m\u001b[2mexpression\u001b[0m\u001b[35m\u001b[2m\":\"\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m+\u001b[0m\u001b[35m\u001b[2m2\u001b[0m\u001b[35m\u001b[2m\"}\u001b[0m\n",
+      "\u001b[35m  Result: \u001b[35m\u001b[2m4\u001b[0m\n",
+      "\u001b[36mResult\u001b[0m\u001b[36m:\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m\n",
+      "\n",
+      "\u001b[0m\u001b[36mExplanation\u001b[0m\u001b[36m:\n",
+      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m equals\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m in\u001b[0m\u001b[36m decimal\u001b[0m\u001b[36m arithmetic\u001b[0m\u001b[36m.\n",
+      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m It's\u001b[0m\u001b[36m a\u001b[0m\u001b[36m basic\u001b[0m\u001b[36m addition\u001b[0m\u001b[36m fact\u001b[0m\u001b[36m (\u001b[0m\u001b[36mcomm\u001b[0m\u001b[36mut\u001b[0m\u001b[36mative\u001b[0m\u001b[36m and\u001b[0m\u001b[36m associative\u001b[0m\u001b[36m).\n",
+      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m For\u001b[0m\u001b[36m reference\u001b[0m\u001b[36m:\u001b[0m\u001b[36m in\u001b[0m\u001b[36m binary\u001b[0m\u001b[36m,\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m100\u001b[0m\u001b[36m,\u001b[0m\u001b[36m which\u001b[0m\u001b[36m is\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m in\u001b[0m\u001b[36m decimal\u001b[0m\u001b[36m;\u001b[0m\u001b[36m in\u001b[0m\u001b[36m Roman\u001b[0m\u001b[36m numer\u001b[0m\u001b[36mals\u001b[0m\u001b[36m,\u001b[0m\u001b[36m II\u001b[0m\u001b[36m +\u001b[0m\u001b[36m II\u001b[0m\u001b[36m =\u001b[0m\u001b[36m IV\u001b[0m\u001b[36m.\u001b[0m\n",
+      "\u001b[36mResult\u001b[0m\u001b[36m:\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m\n",
+      "\n",
+      "\u001b[0m\u001b[36mExplanation\u001b[0m\u001b[36m:\n",
+      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m In\u001b[0m\u001b[36m base\u001b[0m\u001b[36m-\u001b[0m\u001b[36m10\u001b[0m\u001b[36m arithmetic\u001b[0m\u001b[36m,\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m.\n",
+      "\u001b[0m\u001b[36m-\u001b[0m\u001b[36m Quick\u001b[0m\u001b[36m cross\u001b[0m\u001b[36m-check\u001b[0m\u001b[36ms\u001b[0m\u001b[36m:\u001b[0m\u001b[36m binary\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m +\u001b[0m\u001b[36m \u001b[0m\u001b[36m10\u001b[0m\u001b[36m =\u001b[0m\u001b[36m \u001b[0m\u001b[36m100\u001b[0m\u001b[36m (\u001b[0m\u001b[36mwhich\u001b[0m\u001b[36m is\u001b[0m\u001b[36m \u001b[0m\u001b[36m4\u001b[0m\u001b[36m in\u001b[0m\u001b[36m decimal\u001b[0m\u001b[36m);\u001b[0m\u001b[36m Roman\u001b[0m\u001b[36m numer\u001b[0m\u001b[36mals\u001b[0m\u001b[36m II\u001b[0m\u001b[36m +\u001b[0m\u001b[36m II\u001b[0m\u001b[36m =\u001b[0m\u001b[36m IV\u001b[0m\u001b[36m.\u001b[0m\n",
+      "\n",
+      "\u001b[32m✅ Run finished.\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "# -------------------\n",
     "# 5. Action!\n",
     "# -------------------\n",
-    "import uuid\n",
+    "agent = MyAgent(llm=llm, tools=tools, verbose=False)\n",
     "\n",
-    "from ag_ui.core import RunAgentInput\n",
-    "from ag_ui.core import UserMessage\n",
+    "request = \"Calculate 2+2 and outputn result immediately\"\n",
     "\n",
-    "agent = MyAgent(llm=llm, tools=tools, verbose=True)\n",
-    "\n",
-    "run_input = RunAgentInput(\n",
-    "    thread_id=str(uuid.uuid4()),\n",
-    "    run_id=str(uuid.uuid4()),\n",
-    "    messages=[UserMessage(id=str(uuid.uuid4()), role=\"user\", content=\"Calculate 2+2 and outputn result immediately\")],\n",
-    "    state=[],\n",
-    "    tools=[],\n",
-    "    context=[],\n",
-    "    forwardedProps=None\n",
-    ")\n",
-    "\n",
-    "async for event, _interactions, usage in agent.invoke(run_input):\n",
-    "    print(event)"
+    "async for event in agent.invoke_simple(request):\n",
+    "    print(event, end='')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7e71720",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -33,9 +33,6 @@
     "# Uncomment this if you run it externally\n",
     "# !uv pip install \"datarobot-genai[langgraph]>=0.15.18\"\n",
     "\n",
-    "# Comment this if you run it externally\n",
-    "!uv pip install -e \"../..[langgraph]\"\n",
-    "\n",
     "!uv tool install git+https://github.com/carsongee/get-datarobot-llms.git"
    ]
   },

--- a/e2e-tests/examples/quickstart.ipynb
+++ b/e2e-tests/examples/quickstart.ipynb
@@ -30,15 +30,27 @@
     "%load_ext dotenv\n",
     "%dotenv\n",
     "\n",
-    "# Uncomment this if you run it externally\n",
-    "# !uv pip install \"datarobot-genai[langgraph]>=0.15.18\"\n",
-    "\n",
     "!uv tool install git+https://github.com/carsongee/get-datarobot-llms.git"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2",
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Only run externally\n",
+    "!uv pip install \"datarobot-genai[langgraph]>=0.15.18\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "# Agent building blocks\n",
@@ -53,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "`datarobot_genai` exposes a unified LLM layer (adapters) for LangGraph, LlamaIndex, CrewAI, and NAT. For the DataRobot LLM Gateway, import `get_datarobot_gateway_llm` from the `llm` submodule of the integration you use (here: `datarobot_genai.langgraph.llm`)."
@@ -74,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Prompt\n",
@@ -99,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Tools\n",
@@ -146,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Agent\n",
@@ -174,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "source": [
     "# Wrap the graph for DataRobot\n",
@@ -216,14 +228,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "# Run the agent\n",
@@ -248,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -32,6 +32,9 @@ dragent-llamaindex = [
 dragent-base = [
     "datarobot-genai[dragent]",
 ]
+example-quickstart = [
+    "datarobot-genai[langgraph]",
+]
 dev = [
     "ipdb>=0.13.13",
     "jupyter>=1.1.1",

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "pytest-rerunfailures",
     "pytest-timeout",
     "python-dotenv",
-    "ag-ui-protocol @ git+https://github.com/cavitcakir/ag-ui@feat/python-validate-sequence#egg=ag-ui&subdirectory=sdks/python",
     "nbmake>=1.5.5",
     "pytest-xdist>=3.8.0",
 ]

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -32,13 +32,11 @@ dragent-llamaindex = [
 dragent-base = [
     "datarobot-genai[dragent]",
 ]
-lint = [
-    "mypy>=1.19.1",
-    "ruff>=0.15.2",
-]
 dev = [
     "ipdb>=0.13.13",
     "jupyter>=1.1.1",
+    "mypy>=1.19.1",
+    "ruff>=0.15.2",
 ]
 
 [project.entry-points.'nat.plugins']

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1287,6 +1287,8 @@ dependencies = [
 dev = [
     { name = "ipdb" },
     { name = "jupyter" },
+    { name = "mypy" },
+    { name = "ruff" },
 ]
 dragent-base = [
     { name = "datarobot-genai", extra = ["dragent"] },
@@ -1302,10 +1304,6 @@ dragent-llamaindex = [
 ]
 dragent-nat = [
     { name = "datarobot-genai", extra = ["dragent"] },
-]
-lint = [
-    { name = "mypy" },
-    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1324,16 +1322,14 @@ requires-dist = [
 dev = [
     { name = "ipdb", specifier = ">=0.13.13" },
     { name = "jupyter", specifier = ">=1.1.1" },
+    { name = "mypy", specifier = ">=1.19.1" },
+    { name = "ruff", specifier = ">=0.15.2" },
 ]
 dragent-base = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]
 dragent-crewai = [{ name = "datarobot-genai", extras = ["dragent", "crewai"], editable = "../" }]
 dragent-langgraph = [{ name = "datarobot-genai", extras = ["dragent", "langgraph"], editable = "../" }]
 dragent-llamaindex = [{ name = "datarobot-genai", extras = ["dragent", "llamaindex"], editable = "../" }]
 dragent-nat = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]
-lint = [
-    { name = "mypy", specifier = ">=1.19.1" },
-    { name = "ruff", specifier = ">=0.15.2" },
-]
 
 [[package]]
 name = "datarobot-predict"

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1305,6 +1305,9 @@ dragent-llamaindex = [
 dragent-nat = [
     { name = "datarobot-genai", extra = ["dragent"] },
 ]
+example-quickstart = [
+    { name = "datarobot-genai", extra = ["langgraph"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1330,6 +1333,7 @@ dragent-crewai = [{ name = "datarobot-genai", extras = ["dragent", "crewai"], ed
 dragent-langgraph = [{ name = "datarobot-genai", extras = ["dragent", "langgraph"], editable = "../" }]
 dragent-llamaindex = [{ name = "datarobot-genai", extras = ["dragent", "llamaindex"], editable = "../" }]
 dragent-nat = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]
+example-quickstart = [{ name = "datarobot-genai", extras = ["langgraph"], editable = "../" }]
 
 [[package]]
 name = "datarobot-predict"

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -45,10 +45,14 @@ http-server = [
 
 [[package]]
 name = "ag-ui-protocol"
-version = "0.1.14"
-source = { git = "https://github.com/cavitcakir/ag-ui?subdirectory=sdks%2Fpython&rev=feat%2Fpython-validate-sequence#2eca856589f48118323b941d06f1780c69fefdd7" }
+version = "0.1.15"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/71/96c21ae7e2fb9b610c1a90d38bd2de8b6e5b2900a63001f3882f43e519af/ag_ui_protocol-0.1.15.tar.gz", hash = "sha256:5e23c1042c7d4e364d685e68d2fb74d37c16bc83c66d270102d8eaedce56ad82", size = 6269, upload-time = "2026-04-01T15:44:33.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/a0/a73398d30bb0f9ad70cd70426151a4a19527a7296e48a3a16a50e1d5db05/ag_ui_protocol-0.1.15-py3-none-any.whl", hash = "sha256:85cde077023ccbc37b5ce2ad953537883c262d210320f201fc2ec4e85408b06a", size = 8661, upload-time = "2026-04-01T15:44:32.079Z" },
 ]
 
 [[package]]
@@ -961,7 +965,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.16"
+version = "0.15.18"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -969,6 +973,7 @@ crewai = [
     { name = "ag-ui-protocol" },
     { name = "anthropic" },
     { name = "azure-ai-inference" },
+    { name = "colorama" },
     { name = "crewai", extra = ["litellm"] },
     { name = "crewai-tools", extra = ["mcp"] },
     { name = "datarobot" },
@@ -992,6 +997,7 @@ crewai = [
 dragent = [
     { name = "ag-ui-protocol" },
     { name = "anyio" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1016,6 +1022,7 @@ dragent = [
 ]
 langgraph = [
     { name = "ag-ui-protocol" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1038,6 +1045,7 @@ langgraph = [
 ]
 llamaindex = [
     { name = "ag-ui-protocol" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1064,12 +1072,12 @@ llamaindex = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-protocol", marker = "extra == 'core'", specifier = ">=0.1.14,<0.2.0" },
-    { name = "ag-ui-protocol", marker = "extra == 'crewai'", specifier = ">=0.1.14,<0.2.0" },
-    { name = "ag-ui-protocol", marker = "extra == 'dragent'", specifier = ">=0.1.14,<0.2.0" },
-    { name = "ag-ui-protocol", marker = "extra == 'langgraph'", specifier = ">=0.1.14,<0.2.0" },
-    { name = "ag-ui-protocol", marker = "extra == 'llamaindex'", specifier = ">=0.1.14,<0.2.0" },
-    { name = "ag-ui-protocol", marker = "extra == 'nat'", specifier = ">=0.1.14,<0.2.0" },
+    { name = "ag-ui-protocol", marker = "extra == 'core'", specifier = "==0.1.15" },
+    { name = "ag-ui-protocol", marker = "extra == 'crewai'", specifier = "==0.1.15" },
+    { name = "ag-ui-protocol", marker = "extra == 'dragent'", specifier = "==0.1.15" },
+    { name = "ag-ui-protocol", marker = "extra == 'langgraph'", specifier = "==0.1.15" },
+    { name = "ag-ui-protocol", marker = "extra == 'llamaindex'", specifier = "==0.1.15" },
+    { name = "ag-ui-protocol", marker = "extra == 'nat'", specifier = "==0.1.15" },
     { name = "aiohttp", marker = "extra == 'auth'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp", marker = "extra == 'drtools'", specifier = ">=3.13.3,<4.0.0" },
@@ -1081,6 +1089,12 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'drmcp'", specifier = ">=4.12.0,<5.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drtools'", specifier = ">=4.12.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'drmcp'", specifier = ">=1.34.0,<2.0.0" },
+    { name = "colorama", marker = "extra == 'core'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'crewai'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'dragent'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'langgraph'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'nat'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
     { name = "datarobot", marker = "extra == 'core'", specifier = ">=3.10.0,<4.0.0" },
@@ -1259,7 +1273,6 @@ name = "datarobot-genai-e2e-tests"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "ag-ui-protocol" },
     { name = "httpx" },
     { name = "nbmake" },
     { name = "openai" },
@@ -1297,7 +1310,6 @@ lint = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-protocol", git = "https://github.com/cavitcakir/ag-ui?subdirectory=sdks%2Fpython&rev=feat%2Fpython-validate-sequence" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "nbmake", specifier = ">=1.5.5" },
     { name = "openai", specifier = ">=2.0.0,<3.0.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.17"
+version = "0.15.18"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ core = [
     # agent application template
     "ag-ui-protocol==0.1.15",
     "pyarrow==21.0.0",
+    "colorama>=0.4.6,<1.0.0",
 ]
 
 memory = [

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -33,7 +33,6 @@ from ag_ui.core import RunAgentInput
 from ag_ui.core import UserMessage
 
 from datarobot_genai.core.agents.history import build_history_summary_from_messages
-from datarobot_genai.core.agents.render import render_ag_ui_event
 from datarobot_genai.core.config import get_max_history_messages_default
 from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.core.utils.auth import prepare_identity_header
@@ -167,6 +166,33 @@ class BaseAgent(Generic[TTool], abc.ABC):
     def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         raise NotImplementedError("Not implemented")
 
+    async def invoke_single_message(self, user_message: str) -> InvokeReturn:
+        """
+        Invoke the agent without chat history with a single user message.
+
+        Parameters
+        ----------
+        user_message: str
+            The user message to invoke the agent with.
+
+        Returns
+        -------
+        InvokeReturn
+            Same async stream as :meth:`invoke` for a fresh run with a single user turn.
+        """
+        # Generate a new thread and run ID
+        run_input = RunAgentInput(
+            thread_id=str(uuid.uuid4()),
+            run_id=str(uuid.uuid4()),
+            messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=user_message)],
+            state=[],
+            tools=[],
+            context=[],
+            forwardedProps=None,
+        )
+        async for output in self.invoke(run_input):
+            yield output
+
     def build_history_summary(
         self,
         run_agent_input: RunAgentInput,
@@ -256,35 +282,6 @@ class BaseAgent(Generic[TTool], abc.ABC):
             app_id=self._memory_app_id(),
             attributes=self._memory_attributes(run_agent_input),
         )
-
-    async def invoke_simple(self, user_message: str) -> AsyncGenerator[str]:
-        """
-        Invoke the agent without chat history with a single user message.
-
-        Parameters
-        ----------
-        user_message: str
-            The user message to invoke the agent with.
-
-        Returns
-        -------
-        AsyncGenerator[str, None]
-            A generator that yields only rendered strings for events which are visible to the user.
-        """
-        # Generate a new thread and run ID
-        run_input = RunAgentInput(
-            thread_id=str(uuid.uuid4()),
-            run_id=str(uuid.uuid4()),
-            messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=user_message)],
-            state=[],
-            tools=[],
-            context=[],
-            forwardedProps=None,
-        )
-        async for event, _, _ in self.invoke(run_input):
-            rendered = render_ag_ui_event(event)
-            if rendered is not None:
-                yield rendered
 
     @classmethod
     def create_pipeline_interactions_from_events(

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -29,8 +29,11 @@ from typing import TypeVar
 
 from ag_ui.core import Event
 from ag_ui.core import RunAgentInput
+from ag_ui.core import UserMessage
+from langgraph.graph.message import uuid
 
 from datarobot_genai.core.agents.history import build_history_summary_from_messages
+from datarobot_genai.core.agents.render import render_ag_ui_event
 from datarobot_genai.core.config import get_max_history_messages_default
 from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.core.utils.auth import prepare_identity_header
@@ -253,6 +256,35 @@ class BaseAgent(Generic[TTool], abc.ABC):
             app_id=self._memory_app_id(),
             attributes=self._memory_attributes(run_agent_input),
         )
+
+    async def invoke_simple(self, user_message: str) -> AsyncGenerator[str]:
+        """
+        Invoke the agent without chat history with a single user message.
+
+        Parameters
+        ----------
+        user_message: str
+            The user message to invoke the agent with.
+
+        Returns
+        -------
+        AsyncGenerator[str, None]
+            A generator that yields only rendered strings for events which are visible to the user.
+        """
+        # Generate a new thread and run ID
+        run_input = RunAgentInput(
+            thread_id=str(uuid.uuid4()),
+            run_id=str(uuid.uuid4()),
+            messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=user_message)],
+            state=[],
+            tools=[],
+            context=[],
+            forwardedProps=None,
+        )
+        async for event, _, _ in self.invoke(run_input):
+            rendered = render_ag_ui_event(event)
+            if rendered is not None:
+                yield rendered
 
     @classmethod
     def create_pipeline_interactions_from_events(

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -18,6 +18,7 @@ import abc
 import json
 import logging
 import os
+import uuid
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 from typing import Any
@@ -30,7 +31,6 @@ from typing import TypeVar
 from ag_ui.core import Event
 from ag_ui.core import RunAgentInput
 from ag_ui.core import UserMessage
-from langgraph.graph.message import uuid
 
 from datarobot_genai.core.agents.history import build_history_summary_from_messages
 from datarobot_genai.core.agents.render import render_ag_ui_event

--- a/src/datarobot_genai/core/agents/render.py
+++ b/src/datarobot_genai/core/agents/render.py
@@ -46,7 +46,7 @@ def render_ag_ui_event(event: Event) -> str | None:
         or ""
     )
     content = str(getattr(event, "content", "") or "")
-    message = str(getattr(event, "message", "Unknown error") or "")
+    message = str(getattr(event, "message", "") or "Unknown error")
 
     rendered = render_event(
         event_type,

--- a/src/datarobot_genai/core/agents/render.py
+++ b/src/datarobot_genai/core/agents/render.py
@@ -95,6 +95,6 @@ def render_event(
         if name != "Heartbeat":
             rendered = f"{Style.DIM}[{name}]{Style.RESET_ALL}\n"
     else:
-        logger.debug("Unhandled event type: %s", event_type)
+        logger.debug(f"Unhandled event type: {event_type.value}")
 
     return rendered

--- a/src/datarobot_genai/core/agents/render.py
+++ b/src/datarobot_genai/core/agents/render.py
@@ -82,7 +82,7 @@ def render_event(
             content = content[:TOOL_RESULT_MAX_LEN] + "\u2026"
         rendered = f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n"
     elif event_type == EventType.STEP_STARTED:
-        rendered = f"{Style.DIM}Step: {name}{Style.RESET_ALL}"
+        rendered = f"{Style.DIM}Step: {name}{Style.RESET_ALL}\n"
     elif event_type == EventType.STEP_FINISHED:
         rendered = None
     elif event_type == EventType.RUN_STARTED:

--- a/src/datarobot_genai/core/agents/render.py
+++ b/src/datarobot_genai/core/agents/render.py
@@ -28,7 +28,7 @@ TOOL_RESULT_MAX_LEN = 1000
 
 
 def render_event(
-    event_type: str,
+    event_type: EventType,
     *,
     delta: str = "",
     name: str = "",
@@ -40,7 +40,7 @@ def render_event(
     Parameters
     ----------
     event_type:
-        One of the canonical constants defined in this module.
+        The AG-UI :class:`~ag_ui.core.events.EventType` for this event.
     delta:
         Text delta for content/args events.
     name:

--- a/src/datarobot_genai/core/agents/render.py
+++ b/src/datarobot_genai/core/agents/render.py
@@ -1,0 +1,100 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure string rendering for AG-UI event types (no I/O)."""
+
+from __future__ import annotations
+
+import logging
+
+from ag_ui.core.events import EventType
+from colorama import Fore
+from colorama import Style
+
+logger = logging.getLogger(__name__)
+
+TOOL_RESULT_MAX_LEN = 1000
+
+
+def render_event(
+    event_type: str,
+    *,
+    delta: str = "",
+    name: str = "",
+    content: str = "",
+    message: str = "",
+) -> str | None:
+    """Build a terminal-friendly string for a single event, or None to skip.
+
+    Parameters
+    ----------
+    event_type:
+        One of the canonical constants defined in this module.
+    delta:
+        Text delta for content/args events.
+    name:
+        Name for tool-call-start, step-started, or custom events.
+    content:
+        Content for tool-call-result events.
+    message:
+        Error message for run-error events.
+
+    Returns
+    -------
+        A terminal friendly string if the event was rendered, otherwise None.
+        Print with click.echo(rendered, nl=False)
+    """
+    rendered: str | None = None
+    if event_type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):
+        rendered = f"{Fore.CYAN}{delta}{Style.RESET_ALL}"
+    elif event_type == EventType.TEXT_MESSAGE_END:
+        rendered = "\n"
+    elif event_type == EventType.TEXT_MESSAGE_START:
+        rendered = None
+    elif event_type in (EventType.REASONING_MESSAGE_CONTENT, EventType.REASONING_MESSAGE_CHUNK):
+        rendered = f"{Fore.YELLOW}{delta}{Style.RESET_ALL}"
+    elif event_type in (EventType.REASONING_END, EventType.REASONING_MESSAGE_END):
+        rendered = "\n"
+    elif event_type in (EventType.REASONING_START, EventType.REASONING_MESSAGE_START):
+        rendered = None
+    elif event_type == EventType.TOOL_CALL_START:
+        rendered = (
+            f"\n{Fore.MAGENTA}\u25b6 Tool Call: {Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}"
+            f"\n{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}"
+        )
+    elif event_type == EventType.TOOL_CALL_ARGS:
+        rendered = f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}"
+    elif event_type == EventType.TOOL_CALL_END:
+        rendered = "\n"
+    elif event_type == EventType.TOOL_CALL_RESULT:
+        if len(content) > TOOL_RESULT_MAX_LEN:
+            content = content[:TOOL_RESULT_MAX_LEN] + "\u2026"
+        rendered = f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n"
+    elif event_type == EventType.STEP_STARTED:
+        rendered = f"{Style.DIM}Step: {name}{Style.RESET_ALL}"
+    elif event_type == EventType.STEP_FINISHED:
+        rendered = None
+    elif event_type == EventType.RUN_STARTED:
+        rendered = f"{Style.DIM}Run started{Style.RESET_ALL}\n"
+    elif event_type == EventType.RUN_FINISHED:
+        rendered = f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}\n"
+    elif event_type == EventType.RUN_ERROR:
+        rendered = f"{Fore.RED}\u274c Run failed: {message}{Style.RESET_ALL}\n"
+    elif event_type == EventType.CUSTOM:
+        if name != "Heartbeat":
+            rendered = f"{Style.DIM}[{name}]{Style.RESET_ALL}\n"
+    else:
+        logger.debug("Unhandled event type: %s", event_type)
+
+    return rendered

--- a/src/datarobot_genai/core/agents/render.py
+++ b/src/datarobot_genai/core/agents/render.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 
+from ag_ui.core import Event
 from ag_ui.core.events import EventType
 from colorama import Fore
 from colorama import Style
@@ -25,6 +26,36 @@ from colorama import Style
 logger = logging.getLogger(__name__)
 
 TOOL_RESULT_MAX_LEN = 1000
+
+
+def render_ag_ui_event(event: Event) -> str | None:
+    """Render an AG-UI event.
+
+    Parameters
+    ----------
+    event:
+        The AG-UI event to render.
+    """
+    event_type = event.type
+
+    delta = str(getattr(event, "delta", "") or "")
+    name = str(
+        getattr(event, "tool_call_name", "")
+        or getattr(event, "step_name", "")
+        or getattr(event, "name", "")
+        or ""
+    )
+    content = str(getattr(event, "content", "") or "")
+    message = str(getattr(event, "message", "Unknown error") or "")
+
+    rendered = render_event(
+        event_type,
+        delta=delta,
+        name=name,
+        content=content,
+        message=message,
+    )
+    return rendered
 
 
 def render_event(
@@ -53,7 +84,7 @@ def render_event(
     Returns
     -------
         A terminal friendly string if the event was rendered, otherwise None.
-        Print with click.echo(rendered, nl=False)
+        Print with print(rendered, end='') or click.echo(rendered, nl=False)
     """
     rendered: str | None = None
     if event_type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):

--- a/src/datarobot_genai/dragent/cli/render.py
+++ b/src/datarobot_genai/dragent/cli/render.py
@@ -38,12 +38,17 @@ def render_sse_event(ev: dict[str, object]) -> str | None:
     if not raw_type:
         logger.debug("Unhandled SSE event type: %s", raw_type)
         return None
+    try:
+        event_type = EventType(raw_type)
+    except ValueError:
+        logger.debug("Unknown SSE event type: %s", raw_type)
+        return None
 
-    if raw_type == EventType.RUN_ERROR:
+    if event_type == EventType.RUN_ERROR:
         return str(ev.get("message", "Unknown error"))
 
     rendered = render_event(
-        raw_type,
+        event_type,
         delta=str(ev.get("delta", "")),
         name=str(ev.get("tool_call_name", "") or ev.get("step_name", "") or ev.get("name", "")),
         content=str(ev.get("content", "")),

--- a/src/datarobot_genai/dragent/cli/render.py
+++ b/src/datarobot_genai/dragent/cli/render.py
@@ -24,217 +24,73 @@ from __future__ import annotations
 import logging
 
 import click
-from colorama import Fore
-from colorama import Style
+from ag_ui.core import Event
+from ag_ui.core import EventType
+
+from datarobot_genai.core.agents.render import render_event
 
 logger = logging.getLogger(__name__)
 
-TOOL_RESULT_MAX_LEN = 1000
-
-# Canonical event type strings (used as the key for rendering).
-TEXT_CONTENT = "TEXT_CONTENT"
-TEXT_END = "TEXT_END"
-TEXT_START = "TEXT_START"
-REASONING_CONTENT = "REASONING_CONTENT"
-REASONING_END = "REASONING_END"
-REASONING_START = "REASONING_START"
-TOOL_CALL_START = "TOOL_CALL_START"
-TOOL_CALL_ARGS = "TOOL_CALL_ARGS"
-TOOL_CALL_END = "TOOL_CALL_END"
-TOOL_CALL_RESULT = "TOOL_CALL_RESULT"
-STEP_STARTED = "STEP_STARTED"
-STEP_FINISHED = "STEP_FINISHED"
-RUN_STARTED = "RUN_STARTED"
-RUN_FINISHED = "RUN_FINISHED"
-RUN_ERROR = "RUN_ERROR"
-CUSTOM = "CUSTOM"
-
-
-def render_event(
-    event_type: str,
-    *,
-    delta: str = "",
-    name: str = "",
-    content: str = "",
-    message: str = "",
-    err: bool = True,
-) -> None:
-    """Render a single AG-UI event to the terminal.
-
-    Parameters
-    ----------
-    event_type:
-        One of the canonical constants defined in this module.
-    delta:
-        Text delta for content/args events.
-    name:
-        Name for tool-call-start, step-started, or custom events.
-    content:
-        Content for tool-call-result events.
-    message:
-        Error message for run-error events.
-    err:
-        If True, write to stderr (default). Set to False to write to stdout.
-    """
-    if event_type == TEXT_CONTENT:
-        click.echo(f"{Fore.CYAN}{delta}{Style.RESET_ALL}", nl=False, err=err)
-    elif event_type == TEXT_END:
-        click.echo("", err=err)
-    elif event_type == TEXT_START:
-        pass
-    elif event_type == REASONING_CONTENT:
-        click.echo(f"{Fore.YELLOW}{delta}{Style.RESET_ALL}", nl=False, err=True)
-    elif event_type == REASONING_END:
-        click.echo("", err=True)
-    elif event_type == REASONING_START:
-        pass
-    elif event_type == TOOL_CALL_START:
-        click.echo(
-            f"\n{Fore.MAGENTA}\u25b6 Tool Call: {Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}",
-            err=True,
-        )
-        click.echo(
-            f"{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}",
-            nl=False,
-            err=True,
-        )
-    elif event_type == TOOL_CALL_ARGS:
-        click.echo(
-            f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}",
-            nl=False,
-            err=True,
-        )
-    elif event_type == TOOL_CALL_END:
-        click.echo("", err=True)
-    elif event_type == TOOL_CALL_RESULT:
-        if len(content) > TOOL_RESULT_MAX_LEN:
-            content = content[:TOOL_RESULT_MAX_LEN] + "\u2026"
-        click.echo(
-            f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n",
-            err=True,
-        )
-    elif event_type == STEP_STARTED:
-        click.echo(f"{Style.DIM}Step: {name}{Style.RESET_ALL}", err=True)
-    elif event_type == STEP_FINISHED:
-        pass
-    elif event_type == RUN_STARTED:
-        click.echo(f"{Style.DIM}Run started{Style.RESET_ALL}", err=True)
-    elif event_type == RUN_FINISHED:
-        click.echo(f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}", err=err)
-    elif event_type == RUN_ERROR:
-        pass  # Caller handles this (raise ClickException / break loop).
-    elif event_type == CUSTOM:
-        if name != "Heartbeat":
-            click.echo(f"{Style.DIM}[{name}]{Style.RESET_ALL}", err=True)
-    else:
-        logger.debug("Unhandled event type: %s", event_type)
-
-
-# ---------------------------------------------------------------------------
-# Mapping helpers for the two calling conventions
-# ---------------------------------------------------------------------------
-
-# SSE JSON dict "type" string -> canonical event type
-_SSE_TYPE_MAP: dict[str, str] = {
-    "TEXT_MESSAGE_CONTENT": TEXT_CONTENT,
-    "TEXT_MESSAGE_CHUNK": TEXT_CONTENT,
-    "TEXT_MESSAGE_END": TEXT_END,
-    "TEXT_MESSAGE_START": TEXT_START,
-    "REASONING_MESSAGE_CONTENT": REASONING_CONTENT,
-    "REASONING_MESSAGE_END": REASONING_END,
-    "REASONING_START": REASONING_START,
-    "REASONING_MESSAGE_START": REASONING_START,
-    "REASONING_END": REASONING_END,
-    "TOOL_CALL_START": TOOL_CALL_START,
-    "TOOL_CALL_ARGS": TOOL_CALL_ARGS,
-    "TOOL_CALL_END": TOOL_CALL_END,
-    "TOOL_CALL_RESULT": TOOL_CALL_RESULT,
-    "STEP_STARTED": STEP_STARTED,
-    "STEP_FINISHED": STEP_FINISHED,
-    "RUN_STARTED": RUN_STARTED,
-    "RUN_FINISHED": RUN_FINISHED,
-    "RUN_ERROR": RUN_ERROR,
-    "CUSTOM": CUSTOM,
-}
-
-# Typed AG-UI object class name -> canonical event type
-_OBJECT_TYPE_MAP: dict[str, str] = {
-    "TextMessageContentEvent": TEXT_CONTENT,
-    "TextMessageEndEvent": TEXT_END,
-    "TextMessageStartEvent": TEXT_START,
-    "ReasoningMessageContentEvent": REASONING_CONTENT,
-    "ReasoningMessageEndEvent": REASONING_END,
-    "ReasoningStartEvent": REASONING_START,
-    "ReasoningMessageStartEvent": REASONING_START,
-    "ReasoningEndEvent": REASONING_END,
-    "ToolCallStartEvent": TOOL_CALL_START,
-    "ToolCallArgsEvent": TOOL_CALL_ARGS,
-    "ToolCallEndEvent": TOOL_CALL_END,
-    "ToolCallResultEvent": TOOL_CALL_RESULT,
-    "StepStartedEvent": STEP_STARTED,
-    "StepFinishedEvent": STEP_FINISHED,
-    "RunStartedEvent": RUN_STARTED,
-    "RunFinishedEvent": RUN_FINISHED,
-    "RunErrorEvent": RUN_ERROR,
-    "CustomEvent": CUSTOM,
-}
-
 
 def render_sse_event(ev: dict[str, object]) -> str | None:
-    """Render an SSE JSON dict event. Returns the run-error message if RUN_ERROR, else None.
-
-    Text and run-lifecycle events go to stdout; everything else to stderr.
-    This matches the original ``remote.py`` behaviour where the agent's text
-    reply is the primary (pipe-able) output.
-    """
+    """Render an SSE JSON dict event. Returns the run-error message if RUN_ERROR, else None."""
     raw_type = str(ev.get("type", ""))
-    canonical = _SSE_TYPE_MAP.get(raw_type)
-    if canonical is None:
+    if not raw_type:
         logger.debug("Unhandled SSE event type: %s", raw_type)
         return None
 
-    if canonical == RUN_ERROR:
+    if raw_type == EventType.RUN_ERROR:
         return str(ev.get("message", "Unknown error"))
 
-    # Text content and run finished go to stdout (pipe-friendly); rest to stderr.
-    err = canonical not in (TEXT_CONTENT, TEXT_END, TEXT_START, RUN_FINISHED)
-
-    render_event(
-        canonical,
+    rendered = render_event(
+        raw_type,
         delta=str(ev.get("delta", "")),
         name=str(ev.get("tool_call_name", "") or ev.get("step_name", "") or ev.get("name", "")),
         content=str(ev.get("content", "")),
-        err=err,
+        message=str(ev.get("message", "Unknown error")),
     )
+    if rendered is not None:
+        click.echo(rendered, nl=False)
     return None
 
 
-def render_object_event(event: object) -> bool:
-    """Render a typed AG-UI event object. Returns True if text was emitted."""
-    class_name = type(event).__name__
-    canonical = _OBJECT_TYPE_MAP.get(class_name)
-    if canonical is None:
-        logger.debug("Unhandled object event type: %s", class_name)
-        return False
+def render_object_event(event: Event) -> bool:
+    """Render a typed AG-UI event object.
+
+    Returns True only when a streaming assistant text or reasoning content/chunk
+    delta was printed, so the console can tell whether to skip the final result
+    dump (see :meth:`DRAgentConsoleFrontEndPlugin.run_workflow`).
+    """
+    event_type = event.type
 
     # The console frontend prints its own "Run finished" message after the
     # workflow completes, so skip it here to avoid duplicate output.
-    if canonical in (RUN_FINISHED, RUN_ERROR):
+    if event_type in (EventType.RUN_FINISHED, EventType.RUN_ERROR):
         return False
 
-    delta = getattr(event, "delta", "")
-    name = (
+    delta = str(getattr(event, "delta", "") or "")
+    name = str(
         getattr(event, "tool_call_name", "")
         or getattr(event, "step_name", "")
         or getattr(event, "name", "")
+        or ""
     )
-    content = getattr(event, "content", "")
+    content = str(getattr(event, "content", "") or "")
+    message = str(getattr(event, "message", "Unknown error") or "")
 
-    render_event(
-        canonical,
-        delta=str(delta) if delta else "",
-        name=str(name) if name else "",
-        content=str(content) if content else "",
-        err=True,
+    rendered = render_event(
+        event_type,
+        delta=delta,
+        name=name,
+        content=content,
+        message=message,
     )
-    return canonical in (TEXT_CONTENT, REASONING_CONTENT) and bool(delta)
+    if rendered is not None:
+        click.echo(rendered, nl=False)
+
+    return event_type in (
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_CHUNK,
+        EventType.REASONING_MESSAGE_CONTENT,
+        EventType.REASONING_MESSAGE_CHUNK,
+    ) and bool(delta)

--- a/src/datarobot_genai/dragent/cli/render.py
+++ b/src/datarobot_genai/dragent/cli/render.py
@@ -14,9 +14,9 @@
 
 """Shared terminal rendering for AG-UI events.
 
-Both ``remote.py`` (SSE JSON dicts) and ``console.py`` (typed AG-UI objects)
-need identical rendering logic.  Each caller normalises its event into a
-canonical ``(event_type, fields)`` pair and calls :func:`render_event`.
+``remote.py`` (SSE JSON dicts) normalises dicts to fields and calls
+:func:`datarobot_genai.core.agents.render.render_event`. ``console.py`` passes
+typed AG-UI objects to :func:`datarobot_genai.core.agents.render.render_ag_ui_event`.
 """
 
 from __future__ import annotations
@@ -27,6 +27,7 @@ import click
 from ag_ui.core import Event
 from ag_ui.core import EventType
 
+from datarobot_genai.core.agents.render import render_ag_ui_event
 from datarobot_genai.core.agents.render import render_event
 
 logger = logging.getLogger(__name__)
@@ -73,26 +74,11 @@ def render_object_event(event: Event) -> bool:
     if event_type in (EventType.RUN_FINISHED, EventType.RUN_ERROR):
         return False
 
-    delta = str(getattr(event, "delta", "") or "")
-    name = str(
-        getattr(event, "tool_call_name", "")
-        or getattr(event, "step_name", "")
-        or getattr(event, "name", "")
-        or ""
-    )
-    content = str(getattr(event, "content", "") or "")
-    message = str(getattr(event, "message", "Unknown error") or "")
-
-    rendered = render_event(
-        event_type,
-        delta=delta,
-        name=name,
-        content=content,
-        message=message,
-    )
+    rendered = render_ag_ui_event(event)
     if rendered is not None:
         click.echo(rendered, nl=False)
 
+    delta = str(getattr(event, "delta", "") or "")
     return event_type in (
         EventType.TEXT_MESSAGE_CONTENT,
         EventType.TEXT_MESSAGE_CHUNK,

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
@@ -19,6 +20,9 @@ from ag_ui.core import AssistantMessage
 from ag_ui.core import RunAgentInput
 from ag_ui.core import SystemMessage
 from ag_ui.core import UserMessage
+from ag_ui.core.events import EventType
+from ag_ui.core.events import TextMessageContentEvent
+from ag_ui.core.events import TextMessageStartEvent
 from ag_ui.core.types import FunctionCall
 from ag_ui.core.types import ToolCall
 from ag_ui.core.types import ToolMessage
@@ -26,9 +30,11 @@ from ragas.messages import AIMessage
 from ragas.messages import HumanMessage
 
 from datarobot_genai.core.agents.base import BaseAgent
+from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 from datarobot_genai.core.agents.base import make_system_prompt
 from datarobot_genai.core.agents.history import extract_history_messages
+from datarobot_genai.core.agents.render import render_event
 
 
 def _make_run_agent_input_from_dicts(messages: list[dict[str, Any]]) -> RunAgentInput:
@@ -98,6 +104,22 @@ class SimpleAgent(BaseAgent):
         self, run_agent_input: RunAgentInput
     ) -> tuple[str, Any | None, dict[str, int]]:
         return "ok", None, {}
+
+
+class InvokeSimpleTestAgent(BaseAgent):
+    """Yields a fixed sequence of events for :meth:`BaseAgent.invoke_simple` tests."""
+
+    def __init__(self, events: list[Any], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._events = events
+        self.last_input: RunAgentInput | None = None
+
+    async def invoke(
+        self, run_agent_input: RunAgentInput
+    ) -> AsyncGenerator[tuple[Any, Any, Any], None]:
+        self.last_input = run_agent_input
+        for ev in self._events:
+            yield (ev, None, default_usage_metrics())
 
 
 def test_base_agent_env_defaults_and_verbose(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -345,3 +367,32 @@ def test_base_agent_forwarded_headers_with_bearer_token() -> None:
     agent = SimpleAgent(forwarded_headers=headers)
     assert agent.forwarded_headers == headers
     assert agent.forwarded_headers["x-datarobot-api-key"] == "Bearer scoped-token-456"
+
+
+async def test_invoke_simple_yields_only_rendered_event_strings() -> None:
+    # GIVEN real AG-UI events: start renders to None, content yields text
+    start = TextMessageStartEvent(message_id="msg-1")
+    content = TextMessageContentEvent(message_id="msg-1", delta="hi")
+    agent = InvokeSimpleTestAgent([start, content])
+
+    # WHEN invoke_simple is consumed
+    chunks = [c async for c in agent.invoke_simple("user text")]
+
+    # THEN only the content event is yielded, matching render_event
+    assert chunks == [render_event(EventType.TEXT_MESSAGE_CONTENT, delta="hi")]
+
+
+async def test_invoke_simple_builds_run_input_with_user_message() -> None:
+    # GIVEN a single real text content event
+    content = TextMessageContentEvent(message_id="msg-2", delta="x")
+    agent = InvokeSimpleTestAgent([content])
+
+    # WHEN invoke_simple runs
+    _ = [c async for c in agent.invoke_simple("hello world")]
+
+    # THEN invoke received a run input whose sole message is the user string
+    assert agent.last_input is not None
+    assert len(agent.last_input.messages) == 1
+    assert agent.last_input.messages[0].content == "hello world"
+    assert agent.last_input.state == []
+    assert agent.last_input.tools == []

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -20,9 +20,7 @@ from ag_ui.core import AssistantMessage
 from ag_ui.core import RunAgentInput
 from ag_ui.core import SystemMessage
 from ag_ui.core import UserMessage
-from ag_ui.core.events import EventType
 from ag_ui.core.events import TextMessageContentEvent
-from ag_ui.core.events import TextMessageStartEvent
 from ag_ui.core.types import FunctionCall
 from ag_ui.core.types import ToolCall
 from ag_ui.core.types import ToolMessage
@@ -34,7 +32,6 @@ from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 from datarobot_genai.core.agents.base import make_system_prompt
 from datarobot_genai.core.agents.history import extract_history_messages
-from datarobot_genai.core.agents.render import render_event
 
 
 def _make_run_agent_input_from_dicts(messages: list[dict[str, Any]]) -> RunAgentInput:
@@ -106,10 +103,12 @@ class SimpleAgent(BaseAgent):
         return "ok", None, {}
 
 
-class InvokeSimpleTestAgent(BaseAgent):
-    """Yields a fixed sequence of events for :meth:`BaseAgent.invoke_simple` tests."""
+class SingleMessageTestAgent(BaseAgent):
+    """Stub agent that replays a fixed event stream for :meth:`BaseAgent.invoke_single_message`
+    tests.
+    """
 
-    def __init__(self, events: list[Any], **kwargs: Any) -> None:
+    def __init__(self, *events: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._events = events
         self.last_input: RunAgentInput | None = None
@@ -369,26 +368,27 @@ def test_base_agent_forwarded_headers_with_bearer_token() -> None:
     assert agent.forwarded_headers["x-datarobot-api-key"] == "Bearer scoped-token-456"
 
 
-async def test_invoke_simple_yields_only_rendered_event_strings() -> None:
-    # GIVEN real AG-UI events: start renders to None, content yields text
-    start = TextMessageStartEvent(message_id="msg-1")
-    content = TextMessageContentEvent(message_id="msg-1", delta="hi")
-    agent = InvokeSimpleTestAgent([start, content])
+async def test_invoke_single_message_forwards_invoke_stream() -> None:
+    # GIVEN a stub that emits two AG-UI events
+    a = TextMessageContentEvent(message_id="a", delta="1")
+    b = TextMessageContentEvent(message_id="b", delta="2")
+    agent = SingleMessageTestAgent(a, b)
 
-    # WHEN invoke_simple is consumed
-    chunks = [c async for c in agent.invoke_simple("user text")]
+    # WHEN invoke_single_message is consumed
+    rows = [row async for row in agent.invoke_single_message("user text")]
 
-    # THEN only the content event is yielded, matching render_event
-    assert chunks == [render_event(EventType.TEXT_MESSAGE_CONTENT, delta="hi")]
+    # THEN the stream matches invoke() tuples unchanged (no rendering)
+    metrics = default_usage_metrics()
+    assert rows == [(a, None, metrics), (b, None, metrics)]
 
 
-async def test_invoke_simple_builds_run_input_with_user_message() -> None:
-    # GIVEN a single real text content event
-    content = TextMessageContentEvent(message_id="msg-2", delta="x")
-    agent = InvokeSimpleTestAgent([content])
+async def test_invoke_single_message_builds_run_input_with_user_message() -> None:
+    # GIVEN one emitted event
+    event = TextMessageContentEvent(message_id="m", delta="x")
+    agent = SingleMessageTestAgent(event)
 
-    # WHEN invoke_simple runs
-    _ = [c async for c in agent.invoke_simple("hello world")]
+    # WHEN invoke_single_message runs
+    _ = [r async for r in agent.invoke_single_message("hello world")]
 
     # THEN invoke received a run input whose sole message is the user string
     assert agent.last_input is not None

--- a/tests/core/agents/test_render.py
+++ b/tests/core/agents/test_render.py
@@ -35,15 +35,37 @@ _LOG = "datarobot_genai.core.agents.render"
     (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK),
 )
 def test_render_event_text_message_content_and_chunk(event_type: EventType) -> None:
-    assert render_event(event_type, delta="hello") == f"{Fore.CYAN}hello{Style.RESET_ALL}"
+    # GIVEN a text content or chunk event with a delta
+    delta = "hello"
+
+    # WHEN we render it
+    out = render_event(event_type, delta=delta)
+
+    # THEN the output is the delta wrapped in cyan styling
+    expected = f"{Fore.CYAN}{delta}{Style.RESET_ALL}"
+    assert out == expected
 
 
 def test_render_event_text_message_end() -> None:
-    assert render_event(EventType.TEXT_MESSAGE_END) == "\n"
+    # GIVEN a text message end event
+    event_type = EventType.TEXT_MESSAGE_END
+
+    # WHEN we render it
+    out = render_event(event_type)
+
+    # THEN the output is a single newline
+    assert out == "\n"
 
 
 def test_render_event_text_message_start() -> None:
-    assert render_event(EventType.TEXT_MESSAGE_START) is None
+    # GIVEN a text message start event
+    event_type = EventType.TEXT_MESSAGE_START
+
+    # WHEN we render it
+    out = render_event(event_type)
+
+    # THEN nothing is emitted
+    assert out is None
 
 
 @pytest.mark.parametrize(
@@ -51,7 +73,15 @@ def test_render_event_text_message_start() -> None:
     (EventType.REASONING_MESSAGE_CONTENT, EventType.REASONING_MESSAGE_CHUNK),
 )
 def test_render_event_reasoning_message_content_and_chunk(event_type: EventType) -> None:
-    assert render_event(event_type, delta="think") == f"{Fore.YELLOW}think{Style.RESET_ALL}"
+    # GIVEN a reasoning content or chunk event with a delta
+    delta = "think"
+
+    # WHEN we render it
+    out = render_event(event_type, delta=delta)
+
+    # THEN the output is the delta wrapped in yellow styling
+    expected = f"{Fore.YELLOW}{delta}{Style.RESET_ALL}"
+    assert out == expected
 
 
 @pytest.mark.parametrize(
@@ -59,7 +89,14 @@ def test_render_event_reasoning_message_content_and_chunk(event_type: EventType)
     (EventType.REASONING_END, EventType.REASONING_MESSAGE_END),
 )
 def test_render_event_reasoning_end_variants(event_type: EventType) -> None:
-    assert render_event(event_type) == "\n"
+    # GIVEN a reasoning-end event (parametrized variant)
+    end_type = event_type
+
+    # WHEN we render it
+    out = render_event(end_type)
+
+    # THEN the output is a single newline
+    assert out == "\n"
 
 
 @pytest.mark.parametrize(
@@ -67,83 +104,172 @@ def test_render_event_reasoning_end_variants(event_type: EventType) -> None:
     (EventType.REASONING_START, EventType.REASONING_MESSAGE_START),
 )
 def test_render_event_reasoning_start_variants(event_type: EventType) -> None:
-    assert render_event(event_type) is None
+    # GIVEN a reasoning-start event (parametrized variant)
+    start_type = event_type
+
+    # WHEN we render it
+    out = render_event(start_type)
+
+    # THEN nothing is emitted
+    assert out is None
 
 
 def test_render_event_tool_call_start() -> None:
-    assert render_event(EventType.TOOL_CALL_START, name="search") == (
-        f"\n{Fore.MAGENTA}\u25b6 Tool Call: {Fore.MAGENTA}{Style.DIM}search{Style.RESET_ALL}"
+    # GIVEN a tool call start with a name
+    name = "search"
+
+    # WHEN we render it
+    out = render_event(EventType.TOOL_CALL_START, name=name)
+
+    # THEN the header and arguments label match the styled template
+    expected = (
+        f"\n{Fore.MAGENTA}\u25b6 Tool Call: {Fore.MAGENTA}{Style.DIM}{name}{Style.RESET_ALL}"
         f"\n{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}"
     )
+    assert out == expected
 
 
 def test_render_event_tool_call_args() -> None:
+    # GIVEN tool call args with a JSON delta
     delta = '{"q": 1}'
-    assert render_event(EventType.TOOL_CALL_ARGS, delta=delta) == (
-        f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}"
-    )
+
+    # WHEN we render it
+    out = render_event(EventType.TOOL_CALL_ARGS, delta=delta)
+
+    # THEN the delta is dim magenta
+    expected = f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}"
+    assert out == expected
 
 
 def test_render_event_tool_call_end() -> None:
-    assert render_event(EventType.TOOL_CALL_END) == "\n"
+    # GIVEN a tool call end event
+    event_type = EventType.TOOL_CALL_END
+
+    # WHEN we render it
+    out = render_event(event_type)
+
+    # THEN the output is a single newline
+    assert out == "\n"
 
 
 def test_render_event_tool_call_result() -> None:
-    assert render_event(EventType.TOOL_CALL_RESULT, content="ok") == (
-        f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}ok{Style.RESET_ALL}\n"
-    )
+    # GIVEN a tool call result with content
+    content = "ok"
+
+    # WHEN we render it
+    out = render_event(EventType.TOOL_CALL_RESULT, content=content)
+
+    # THEN the result line includes the content and trailing newline
+    expected = f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{content}{Style.RESET_ALL}\n"
+    assert out == expected
 
 
 def test_render_event_tool_call_result_truncates() -> None:
-    long_ = "z" * (TOOL_RESULT_MAX_LEN + 5)
+    # GIVEN tool result content longer than the max length
+    long_content = "z" * (TOOL_RESULT_MAX_LEN + 5)
     truncated = "z" * TOOL_RESULT_MAX_LEN + "\u2026"
-    assert render_event(EventType.TOOL_CALL_RESULT, content=long_) == (
-        f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{truncated}{Style.RESET_ALL}\n"
-    )
+
+    # WHEN we render it
+    out = render_event(EventType.TOOL_CALL_RESULT, content=long_content)
+
+    # THEN the output uses the truncated prefix plus ellipsis
+    expected = f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{truncated}{Style.RESET_ALL}\n"
+    assert out == expected
 
 
 def test_render_event_step_started() -> None:
-    assert render_event(EventType.STEP_STARTED, name="my_step") == (
-        f"{Style.DIM}Step: my_step{Style.RESET_ALL}\n"
-    )
+    # GIVEN a step started event with a name
+    name = "my_step"
+
+    # WHEN we render it
+    out = render_event(EventType.STEP_STARTED, name=name)
+
+    # THEN the dim step line includes the name and newline
+    expected = f"{Style.DIM}Step: {name}{Style.RESET_ALL}\n"
+    assert out == expected
 
 
 def test_render_event_step_finished() -> None:
-    assert render_event(EventType.STEP_FINISHED) is None
+    # GIVEN a step finished event
+    event_type = EventType.STEP_FINISHED
+
+    # WHEN we render it
+    out = render_event(event_type)
+
+    # THEN nothing is emitted
+    assert out is None
 
 
 def test_render_event_run_started() -> None:
-    assert render_event(EventType.RUN_STARTED) == f"{Style.DIM}Run started{Style.RESET_ALL}\n"
+    # GIVEN a run started event
+    event_type = EventType.RUN_STARTED
+
+    # WHEN we render it
+    out = render_event(event_type)
+
+    # THEN the dim run-started line ends with a newline
+    expected = f"{Style.DIM}Run started{Style.RESET_ALL}\n"
+    assert out == expected
 
 
 def test_render_event_run_finished() -> None:
-    assert render_event(EventType.RUN_FINISHED) == (
-        f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}\n"
-    )
+    # GIVEN a run finished event
+    event_type = EventType.RUN_FINISHED
+
+    # WHEN we render it
+    out = render_event(event_type)
+
+    # THEN the success line includes the checkmark and newlines
+    expected = f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}\n"
+    assert out == expected
 
 
 def test_render_event_run_error() -> None:
-    assert render_event(EventType.RUN_ERROR, message="oops") == (
-        f"{Fore.RED}\u274c Run failed: oops{Style.RESET_ALL}\n"
-    )
+    # GIVEN a run error with a message
+    message = "oops"
+
+    # WHEN we render it
+    out = render_event(EventType.RUN_ERROR, message=message)
+
+    # THEN the failure line includes the message and newline
+    expected = f"{Fore.RED}\u274c Run failed: {message}{Style.RESET_ALL}\n"
+    assert out == expected
 
 
 def test_render_event_custom_not_heartbeat() -> None:
-    assert render_event(EventType.CUSTOM, name="MyEvent") == (
-        f"{Style.DIM}[MyEvent]{Style.RESET_ALL}\n"
-    )
+    # GIVEN a custom event that is not Heartbeat
+    name = "MyEvent"
+
+    # WHEN we render it
+    out = render_event(EventType.CUSTOM, name=name)
+
+    # THEN the bracketed name line is dim and ends with newline
+    expected = f"{Style.DIM}[{name}]{Style.RESET_ALL}\n"
+    assert out == expected
 
 
 def test_render_event_custom_heartbeat_suppresses_name() -> None:
-    assert render_event(EventType.CUSTOM, name="Heartbeat") is None
+    # GIVEN a custom Heartbeat event
+    name = "Heartbeat"
+
+    # WHEN we render it
+    out = render_event(EventType.CUSTOM, name=name)
+
+    # THEN nothing is emitted
+    assert out is None
 
 
 def test_render_event_unhandled_event_type_in_enum_logs_and_returns_none(
     caplog: Any,
 ) -> None:
+    # GIVEN an enum value with no formatter branch and debug logging enabled
+    event_type = EventType.TOOL_CALL_CHUNK
+
+    # WHEN we render it
     with caplog.at_level(logging.DEBUG, logger=_LOG):
-        out = render_event(EventType.TOOL_CALL_CHUNK)
+        out = render_event(event_type)
+
+    # THEN there is no output string and one debug log names the event type
     assert out is None
-    assert [r.getMessage() for r in caplog.records] == [
-        "Unhandled event type: EventType.TOOL_CALL_CHUNK",
-    ]
+    messages = [r.getMessage() for r in caplog.records]
+    assert messages == ["Unhandled event type: EventType.TOOL_CALL_CHUNK"]

--- a/tests/core/agents/test_render.py
+++ b/tests/core/agents/test_render.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for :func:`datarobot_genai.core.agents.render.render_event`."""
+"""Unit tests for :func:`datarobot_genai.core.agents.render.render_event` and
+:func:`datarobot_genai.core.agents.render.render_ag_ui_event`.
+"""
 
 from __future__ import annotations
 
@@ -20,11 +22,18 @@ import logging
 from typing import Any
 
 import pytest
+from ag_ui.core.events import CustomEvent
 from ag_ui.core.events import EventType
+from ag_ui.core.events import RunErrorEvent
+from ag_ui.core.events import StepStartedEvent
+from ag_ui.core.events import TextMessageContentEvent
+from ag_ui.core.events import ToolCallResultEvent
+from ag_ui.core.events import ToolCallStartEvent
 from colorama import Fore
 from colorama import Style
 
 from datarobot_genai.core.agents.render import TOOL_RESULT_MAX_LEN
+from datarobot_genai.core.agents.render import render_ag_ui_event
 from datarobot_genai.core.agents.render import render_event
 
 _LOG = "datarobot_genai.core.agents.render"
@@ -273,3 +282,73 @@ def test_render_event_unhandled_event_type_in_enum_logs_and_returns_none(
     assert out is None
     messages = [r.getMessage() for r in caplog.records]
     assert messages == ["Unhandled event type: TOOL_CALL_CHUNK"]
+
+
+def test_render_ag_ui_event_delegates_to_render_event() -> None:
+    # GIVEN a real AG-UI text content event
+    event = TextMessageContentEvent(
+        message_id="msg-1",
+        delta="hello",
+    )
+
+    # WHEN we render through render_ag_ui_event
+    out = render_ag_ui_event(event)
+
+    # THEN the result matches render_event for the same type and delta
+    assert out == render_event(EventType.TEXT_MESSAGE_CONTENT, delta="hello")
+
+
+def test_render_ag_ui_event_uses_tool_call_name_from_tool_call_start() -> None:
+    # GIVEN a real ToolCallStartEvent
+    event = ToolCallStartEvent(
+        tool_call_id="call-1",
+        tool_call_name="primary",
+    )
+
+    # WHEN we render
+    out = render_ag_ui_event(event)
+
+    # THEN the output includes the tool name
+    assert out is not None
+    assert "primary" in out
+    assert out == render_event(EventType.TOOL_CALL_START, name="primary")
+
+
+def test_render_ag_ui_event_uses_step_name_from_step_started() -> None:
+    # GIVEN a real StepStartedEvent
+    event = StepStartedEvent(step_name="my_step")
+
+    # WHEN we render
+    out = render_ag_ui_event(event)
+
+    # THEN the step line uses step_name
+    assert out == render_event(EventType.STEP_STARTED, name="my_step")
+
+
+def test_render_ag_ui_event_uses_name_from_custom_event() -> None:
+    # GIVEN a real CustomEvent (value is required by the schema)
+    event = CustomEvent(name="NotHeartbeat", value=None)
+
+    # WHEN we render
+    out = render_ag_ui_event(event)
+
+    # THEN the bracketed name matches
+    assert out == render_event(EventType.CUSTOM, name="NotHeartbeat")
+
+
+def test_render_ag_ui_event_passes_content_and_message() -> None:
+    # GIVEN real tool result and run error events
+    res_event = ToolCallResultEvent(
+        message_id="m-out",
+        tool_call_id="call-1",
+        content="out",
+    )
+    err_event = RunErrorEvent(message="boom")
+
+    # WHEN we render both
+    out_res = render_ag_ui_event(res_event)
+    out_err = render_ag_ui_event(err_event)
+
+    # THEN they match the lower-level render_event
+    assert out_res == render_event(EventType.TOOL_CALL_RESULT, content="out")
+    assert out_err == render_event(EventType.RUN_ERROR, message="boom")

--- a/tests/core/agents/test_render.py
+++ b/tests/core/agents/test_render.py
@@ -21,6 +21,8 @@ from typing import Any
 
 import pytest
 from ag_ui.core.events import EventType
+from colorama import Fore
+from colorama import Style
 
 from datarobot_genai.core.agents.render import TOOL_RESULT_MAX_LEN
 from datarobot_genai.core.agents.render import render_event
@@ -33,9 +35,7 @@ _LOG = "datarobot_genai.core.agents.render"
     (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK),
 )
 def test_render_event_text_message_content_and_chunk(event_type: EventType) -> None:
-    out = render_event(event_type, delta="hello")
-    assert out is not None
-    assert "hello" in out
+    assert render_event(event_type, delta="hello") == f"{Fore.CYAN}hello{Style.RESET_ALL}"
 
 
 def test_render_event_text_message_end() -> None:
@@ -51,9 +51,7 @@ def test_render_event_text_message_start() -> None:
     (EventType.REASONING_MESSAGE_CONTENT, EventType.REASONING_MESSAGE_CHUNK),
 )
 def test_render_event_reasoning_message_content_and_chunk(event_type: EventType) -> None:
-    out = render_event(event_type, delta="think")
-    assert out is not None
-    assert "think" in out
+    assert render_event(event_type, delta="think") == f"{Fore.YELLOW}think{Style.RESET_ALL}"
 
 
 @pytest.mark.parametrize(
@@ -73,16 +71,17 @@ def test_render_event_reasoning_start_variants(event_type: EventType) -> None:
 
 
 def test_render_event_tool_call_start() -> None:
-    out = render_event(EventType.TOOL_CALL_START, name="search")
-    assert out is not None
-    assert "search" in out
-    assert "Tool Call" in out
+    assert render_event(EventType.TOOL_CALL_START, name="search") == (
+        f"\n{Fore.MAGENTA}\u25b6 Tool Call: {Fore.MAGENTA}{Style.DIM}search{Style.RESET_ALL}"
+        f"\n{Fore.MAGENTA}  Arguments: {Style.RESET_ALL}"
+    )
 
 
 def test_render_event_tool_call_args() -> None:
-    out = render_event(EventType.TOOL_CALL_ARGS, delta='{"q": 1}')
-    assert out is not None
-    assert '{"q": 1}' in out
+    delta = '{"q": 1}'
+    assert render_event(EventType.TOOL_CALL_ARGS, delta=delta) == (
+        f"{Fore.MAGENTA}{Style.DIM}{delta}{Style.RESET_ALL}"
+    )
 
 
 def test_render_event_tool_call_end() -> None:
@@ -90,23 +89,23 @@ def test_render_event_tool_call_end() -> None:
 
 
 def test_render_event_tool_call_result() -> None:
-    out = render_event(EventType.TOOL_CALL_RESULT, content="ok")
-    assert out is not None
-    assert "ok" in out
+    assert render_event(EventType.TOOL_CALL_RESULT, content="ok") == (
+        f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}ok{Style.RESET_ALL}\n"
+    )
 
 
 def test_render_event_tool_call_result_truncates() -> None:
     long_ = "z" * (TOOL_RESULT_MAX_LEN + 5)
-    out = render_event(EventType.TOOL_CALL_RESULT, content=long_)
-    assert out is not None
-    assert "\u2026" in out
-    assert long_ not in out
+    truncated = "z" * TOOL_RESULT_MAX_LEN + "\u2026"
+    assert render_event(EventType.TOOL_CALL_RESULT, content=long_) == (
+        f"{Fore.MAGENTA}  Result: {Fore.MAGENTA}{Style.DIM}{truncated}{Style.RESET_ALL}\n"
+    )
 
 
 def test_render_event_step_started() -> None:
-    out = render_event(EventType.STEP_STARTED, name="my_step")
-    assert out is not None
-    assert "my_step" in out
+    assert render_event(EventType.STEP_STARTED, name="my_step") == (
+        f"{Style.DIM}Step: my_step{Style.RESET_ALL}\n"
+    )
 
 
 def test_render_event_step_finished() -> None:
@@ -114,27 +113,25 @@ def test_render_event_step_finished() -> None:
 
 
 def test_render_event_run_started() -> None:
-    out = render_event(EventType.RUN_STARTED)
-    assert out is not None
-    assert "Run started" in out
+    assert render_event(EventType.RUN_STARTED) == f"{Style.DIM}Run started{Style.RESET_ALL}\n"
 
 
 def test_render_event_run_finished() -> None:
-    out = render_event(EventType.RUN_FINISHED)
-    assert out is not None
-    assert "Run finished" in out
+    assert render_event(EventType.RUN_FINISHED) == (
+        f"\n{Fore.GREEN}\u2705 Run finished.{Style.RESET_ALL}\n"
+    )
 
 
 def test_render_event_run_error() -> None:
-    out = render_event(EventType.RUN_ERROR, message="oops")
-    assert out is not None
-    assert "oops" in out
+    assert render_event(EventType.RUN_ERROR, message="oops") == (
+        f"{Fore.RED}\u274c Run failed: oops{Style.RESET_ALL}\n"
+    )
 
 
 def test_render_event_custom_not_heartbeat() -> None:
-    out = render_event(EventType.CUSTOM, name="MyEvent")
-    assert out is not None
-    assert "MyEvent" in out
+    assert render_event(EventType.CUSTOM, name="MyEvent") == (
+        f"{Style.DIM}[MyEvent]{Style.RESET_ALL}\n"
+    )
 
 
 def test_render_event_custom_heartbeat_suppresses_name() -> None:
@@ -147,6 +144,6 @@ def test_render_event_unhandled_event_type_in_enum_logs_and_returns_none(
     with caplog.at_level(logging.DEBUG, logger=_LOG):
         out = render_event(EventType.TOOL_CALL_CHUNK)
     assert out is None
-    messages = [r.getMessage() for r in caplog.records]
-    assert any("TOOL_CALL_CHUNK" in m for m in messages)
-    assert any("Unhandled" in m for m in messages)
+    assert [r.getMessage() for r in caplog.records] == [
+        "Unhandled event type: EventType.TOOL_CALL_CHUNK",
+    ]

--- a/tests/core/agents/test_render.py
+++ b/tests/core/agents/test_render.py
@@ -272,4 +272,4 @@ def test_render_event_unhandled_event_type_in_enum_logs_and_returns_none(
     # THEN there is no output string and one debug log names the event type
     assert out is None
     messages = [r.getMessage() for r in caplog.records]
-    assert messages == ["Unhandled event type: EventType.TOOL_CALL_CHUNK"]
+    assert messages == ["Unhandled event type: TOOL_CALL_CHUNK"]

--- a/tests/core/agents/test_render.py
+++ b/tests/core/agents/test_render.py
@@ -1,0 +1,152 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :func:`datarobot_genai.core.agents.render.render_event`."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from ag_ui.core.events import EventType
+
+from datarobot_genai.core.agents.render import TOOL_RESULT_MAX_LEN
+from datarobot_genai.core.agents.render import render_event
+
+_LOG = "datarobot_genai.core.agents.render"
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK),
+)
+def test_render_event_text_message_content_and_chunk(event_type: EventType) -> None:
+    out = render_event(event_type, delta="hello")
+    assert out is not None
+    assert "hello" in out
+
+
+def test_render_event_text_message_end() -> None:
+    assert render_event(EventType.TEXT_MESSAGE_END) == "\n"
+
+
+def test_render_event_text_message_start() -> None:
+    assert render_event(EventType.TEXT_MESSAGE_START) is None
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    (EventType.REASONING_MESSAGE_CONTENT, EventType.REASONING_MESSAGE_CHUNK),
+)
+def test_render_event_reasoning_message_content_and_chunk(event_type: EventType) -> None:
+    out = render_event(event_type, delta="think")
+    assert out is not None
+    assert "think" in out
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    (EventType.REASONING_END, EventType.REASONING_MESSAGE_END),
+)
+def test_render_event_reasoning_end_variants(event_type: EventType) -> None:
+    assert render_event(event_type) == "\n"
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    (EventType.REASONING_START, EventType.REASONING_MESSAGE_START),
+)
+def test_render_event_reasoning_start_variants(event_type: EventType) -> None:
+    assert render_event(event_type) is None
+
+
+def test_render_event_tool_call_start() -> None:
+    out = render_event(EventType.TOOL_CALL_START, name="search")
+    assert out is not None
+    assert "search" in out
+    assert "Tool Call" in out
+
+
+def test_render_event_tool_call_args() -> None:
+    out = render_event(EventType.TOOL_CALL_ARGS, delta='{"q": 1}')
+    assert out is not None
+    assert '{"q": 1}' in out
+
+
+def test_render_event_tool_call_end() -> None:
+    assert render_event(EventType.TOOL_CALL_END) == "\n"
+
+
+def test_render_event_tool_call_result() -> None:
+    out = render_event(EventType.TOOL_CALL_RESULT, content="ok")
+    assert out is not None
+    assert "ok" in out
+
+
+def test_render_event_tool_call_result_truncates() -> None:
+    long_ = "z" * (TOOL_RESULT_MAX_LEN + 5)
+    out = render_event(EventType.TOOL_CALL_RESULT, content=long_)
+    assert out is not None
+    assert "\u2026" in out
+    assert long_ not in out
+
+
+def test_render_event_step_started() -> None:
+    out = render_event(EventType.STEP_STARTED, name="my_step")
+    assert out is not None
+    assert "my_step" in out
+
+
+def test_render_event_step_finished() -> None:
+    assert render_event(EventType.STEP_FINISHED) is None
+
+
+def test_render_event_run_started() -> None:
+    out = render_event(EventType.RUN_STARTED)
+    assert out is not None
+    assert "Run started" in out
+
+
+def test_render_event_run_finished() -> None:
+    out = render_event(EventType.RUN_FINISHED)
+    assert out is not None
+    assert "Run finished" in out
+
+
+def test_render_event_run_error() -> None:
+    out = render_event(EventType.RUN_ERROR, message="oops")
+    assert out is not None
+    assert "oops" in out
+
+
+def test_render_event_custom_not_heartbeat() -> None:
+    out = render_event(EventType.CUSTOM, name="MyEvent")
+    assert out is not None
+    assert "MyEvent" in out
+
+
+def test_render_event_custom_heartbeat_suppresses_name() -> None:
+    assert render_event(EventType.CUSTOM, name="Heartbeat") is None
+
+
+def test_render_event_unhandled_event_type_in_enum_logs_and_returns_none(
+    caplog: Any,
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger=_LOG):
+        out = render_event(EventType.TOOL_CALL_CHUNK)
+    assert out is None
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("TOOL_CALL_CHUNK" in m for m in messages)
+    assert any("Unhandled" in m for m in messages)

--- a/tests/dragent/cli/test_remote.py
+++ b/tests/dragent/cli/test_remote.py
@@ -135,8 +135,10 @@ def test_build_agui_payload_has_required_fields():
 # --- stream_agui_events ---
 
 
-def test_stream_agui_events_prints_text_content(capsys):
-    # GIVEN SSE events with text content
+@patch(f"{_REMOTE}.render_sse_event")
+def test_stream_agui_events_calls_render_sse_event_per_parsed_event(mock_render):
+    # GIVEN one SSE data line per event (rendering is tested in test_render modules)
+    mock_render.return_value = None
     events = [
         {"type": "TEXT_MESSAGE_CONTENT", "delta": "hello "},
         {"type": "TEXT_MESSAGE_CONTENT", "delta": "world"},
@@ -147,20 +149,36 @@ def test_stream_agui_events_prints_text_content(capsys):
     # WHEN we stream
     with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
         stream_agui_events("http://test", {}, {})
-    # THEN text content is printed
-    out = capsys.readouterr().out
-    assert "hello " in out
-    assert "world" in out
-    assert "Run finished." in out
-    assert "\u2705" in out
+    # THEN each parsed dict is passed to render_sse_event in order
+    assert mock_render.call_count == len(events)
+    assert [c.args[0] for c in mock_render.call_args_list] == events
 
 
-def test_stream_agui_events_raises_on_run_error():
-    # GIVEN a RUN_ERROR event
+@patch(f"{_REMOTE}.render_sse_event")
+def test_stream_agui_events_iterates_events_inside_payload(mock_render):
+    # GIVEN a single SSE line whose JSON has an ``events`` array (remote responsibility)
+    mock_render.return_value = None
+    inner = [
+        {"type": "TEXT_MESSAGE_CONTENT", "delta": "x"},
+        {"type": "RUN_FINISHED"},
+    ]
+    lines = [f"data: {json.dumps({'events': inner})}"]
+    resp = _mock_stream_response(lines)
+    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
+        stream_agui_events("http://test", {}, {})
+    assert mock_render.call_count == 2
+    assert mock_render.call_args_list[0].args[0] == inner[0]
+    assert mock_render.call_args_list[1].args[0] == inner[1]
+
+
+@patch(f"{_REMOTE}.render_sse_event")
+def test_stream_agui_events_raises_on_run_error(mock_render):
+    # GIVEN render_sse_event reports a run error (message only; formatting is not remote's job)
+    mock_render.return_value = "something broke"
     events = [{"type": "RUN_ERROR", "message": "something broke"}]
     resp = _mock_stream_response(_sse_lines(events))
     # WHEN we stream
-    # THEN it raises ClickException with the error message
+    # THEN it raises ClickException including that message
     with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
         with pytest.raises(click.ClickException, match="something broke"):
             stream_agui_events("http://test", {}, {})
@@ -196,8 +214,10 @@ def test_stream_agui_events_raises_on_timeout():
             stream_agui_events("http://test", {}, {})
 
 
-def test_stream_agui_events_skips_malformed_sse_data(capsys):
+@patch(f"{_REMOTE}.render_sse_event")
+def test_stream_agui_events_skips_malformed_sse_data(mock_render):
     # GIVEN a mix of malformed and valid SSE lines
+    mock_render.return_value = None
     lines = [
         "data: not-valid-json",
         f"data: {json.dumps({'type': 'TEXT_MESSAGE_CONTENT', 'delta': 'ok'})}",
@@ -207,9 +227,8 @@ def test_stream_agui_events_skips_malformed_sse_data(capsys):
     # WHEN we stream
     with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
         stream_agui_events("http://test", {}, {})
-    # THEN valid events are still printed
-    out = capsys.readouterr().out
-    assert "ok" in out
+    # THEN only valid JSON payloads are passed to render_sse_event
+    assert mock_render.call_count == 2
 
 
 # --- normalize_base_url ---
@@ -295,130 +314,3 @@ def test_get_auth_context_headers_missing_secret_key_returns_empty(monkeypatch):
     headers = get_auth_context_headers("my-token", "https://app.datarobot.com")
     # THEN it returns an empty dict (no API call made)
     assert headers == {}
-
-
-# --- stream_agui_events: tool call events ---
-
-
-def test_stream_agui_events_prints_tool_calls(capsys):
-    # GIVEN SSE events with a tool call lifecycle
-    events = [
-        {"type": "TOOL_CALL_START", "tool_call_name": "search", "tool_call_id": "c1"},
-        {"type": "TOOL_CALL_ARGS", "tool_call_id": "c1", "delta": '{"q": "test"}'},
-        {"type": "TOOL_CALL_END", "tool_call_id": "c1"},
-        {"type": "TOOL_CALL_RESULT", "tool_call_id": "c1", "content": "found it", "role": "tool"},
-        {"type": "RUN_FINISHED"},
-    ]
-    resp = _mock_stream_response(_sse_lines(events))
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN tool info is printed to stderr
-    captured = capsys.readouterr()
-    assert "search" in captured.err
-    assert '{"q": "test"}' in captured.err
-    assert "found it" in captured.err
-
-
-def test_stream_agui_events_truncates_long_tool_result(capsys):
-    # GIVEN a tool result longer than _TOOL_RESULT_MAX_LEN
-    events = [
-        {"type": "TOOL_CALL_RESULT", "tool_call_id": "c1", "content": "x" * 1500, "role": "tool"},
-        {"type": "RUN_FINISHED"},
-    ]
-    resp = _mock_stream_response(_sse_lines(events))
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN the result is truncated with ellipsis
-    captured = capsys.readouterr()
-    assert "\u2026" in captured.err
-    assert "x" * 1500 not in captured.err
-
-
-# --- stream_agui_events: reasoning events ---
-
-
-def test_stream_agui_events_prints_reasoning(capsys):
-    # GIVEN SSE events with reasoning content
-    events = [
-        {"type": "REASONING_MESSAGE_CONTENT", "delta": "thinking hard"},
-        {"type": "REASONING_MESSAGE_END"},
-        {"type": "RUN_FINISHED"},
-    ]
-    resp = _mock_stream_response(_sse_lines(events))
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN reasoning is printed to stderr
-    captured = capsys.readouterr()
-    assert "thinking hard" in captured.err
-
-
-# --- stream_agui_events: step events ---
-
-
-def test_stream_agui_events_prints_step_started(capsys):
-    # GIVEN a STEP_STARTED event
-    events = [
-        {"type": "STEP_STARTED", "step_name": "agent_workflow"},
-        {"type": "RUN_FINISHED"},
-    ]
-    resp = _mock_stream_response(_sse_lines(events))
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN step name is printed to stderr
-    captured = capsys.readouterr()
-    assert "agent_workflow" in captured.err
-
-
-# --- stream_agui_events: run lifecycle events ---
-
-
-def test_stream_agui_events_prints_run_started(capsys):
-    # GIVEN a RUN_STARTED event
-    events = [
-        {"type": "RUN_STARTED", "thread_id": "t1", "run_id": "r1"},
-        {"type": "RUN_FINISHED"},
-    ]
-    resp = _mock_stream_response(_sse_lines(events))
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN run started is printed to stderr
-    captured = capsys.readouterr()
-    assert "Run started" in captured.err
-
-
-# --- stream_agui_events: custom events ---
-
-
-def test_stream_agui_events_skips_heartbeat(capsys):
-    # GIVEN a Heartbeat custom event
-    events = [
-        {"type": "CUSTOM", "name": "Heartbeat", "value": {}},
-        {"type": "RUN_FINISHED"},
-    ]
-    resp = _mock_stream_response(_sse_lines(events))
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN Heartbeat is NOT printed
-    captured = capsys.readouterr()
-    assert "Heartbeat" not in captured.err
-
-
-def test_stream_agui_events_prints_non_heartbeat_custom(capsys):
-    # GIVEN a non-Heartbeat custom event
-    events = [
-        {"type": "CUSTOM", "name": "MyCustomEvent", "value": {"foo": 1}},
-        {"type": "RUN_FINISHED"},
-    ]
-    resp = _mock_stream_response(_sse_lines(events))
-    # WHEN we stream
-    with patch(f"{_REMOTE}.httpx.stream", return_value=resp):
-        stream_agui_events("http://test", {}, {})
-    # THEN custom event name is printed to stderr
-    captured = capsys.readouterr()
-    assert "MyCustomEvent" in captured.err

--- a/tests/dragent/cli/test_render.py
+++ b/tests/dragent/cli/test_render.py
@@ -1,0 +1,198 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for :mod:`datarobot_genai.dragent.cli.render` (SSE and object adapters)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import patch
+
+from ag_ui.core.events import EventType
+from ag_ui.core.events import ReasoningMessageChunkEvent
+from ag_ui.core.events import ReasoningMessageContentEvent
+from ag_ui.core.events import RunErrorEvent
+from ag_ui.core.events import RunFinishedEvent
+from ag_ui.core.events import TextMessageChunkEvent
+from ag_ui.core.events import TextMessageContentEvent
+from ag_ui.core.events import ToolCallStartEvent
+
+from datarobot_genai.dragent.cli.render import render_object_event
+from datarobot_genai.dragent.cli.render import render_sse_event
+
+_LOG = "datarobot_genai.dragent.cli.render"
+
+# ---------------------------------------------------------------------------
+# render_sse_event
+# ---------------------------------------------------------------------------
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_sse_event_invalid_type_string_logs_and_does_not_echo(
+    mock_echo: Any, caplog: Any
+) -> None:
+    # GIVEN a non-empty ``type`` that is not a valid :class:`EventType` value
+    with caplog.at_level(logging.DEBUG, logger=_LOG):
+        out = render_sse_event({"type": "NOT_A_VALID_EVENT_TYPE", "delta": "x"})
+    assert out is None
+    assert mock_echo.call_count == 0
+    assert any("Unknown SSE event type" in r.message for r in caplog.records)
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_sse_event_empty_type_logs_and_does_not_echo(mock_echo: Any, caplog: Any) -> None:
+    # GIVEN an event dict with no/empty type
+    with caplog.at_level(logging.DEBUG, logger=_LOG):
+        out = render_sse_event({})
+    # WHEN/THEN: no terminal output; helper returns None; empty type is logged
+    assert out is None
+    assert mock_echo.call_count == 0
+    assert any("Unhandled SSE event type" in r.message for r in caplog.records)
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_sse_event_run_error_returns_message_and_skips_render(
+    mock_echo: Any,
+) -> None:
+    # GIVEN RUN_ERROR: remote layer raises; no styled echo
+    out = render_sse_event(
+        {"type": EventType.RUN_ERROR.value, "message": "stream failed"},
+    )
+    assert out == "stream failed"
+    assert mock_echo.call_count == 0
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_sse_event_run_error_default_message(mock_echo: Any) -> None:
+    out = render_sse_event({"type": EventType.RUN_ERROR.value})
+    assert out == "Unknown error"
+    assert mock_echo.call_count == 0
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_sse_event_renders_other_types_via_render_event_and_echos(
+    mock_echo: Any,
+) -> None:
+    # GIVEN a normal (non-ERROR) SSE event
+    out = render_sse_event(
+        {
+            "type": EventType.TEXT_MESSAGE_CONTENT.value,
+            "delta": "hello",
+        }
+    )
+    # THEN: click.echo is used (all streams unified to stdout) and the helper returns None
+    assert out is None
+    assert mock_echo.call_count == 1
+    assert mock_echo.call_args[1].get("nl") is False
+    assert "hello" in mock_echo.call_args[0][0]
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_sse_event_resolves_name_from_alternate_keys(mock_echo: Any) -> None:
+    # GIVEN step metadata under ``name`` or ``step_name`` only
+    render_sse_event(
+        {
+            "type": EventType.STEP_STARTED.value,
+            "name": "via_name",
+        }
+    )
+    assert "via_name" in mock_echo.call_args[0][0]
+
+    mock_echo.reset_mock()
+    render_sse_event(
+        {
+            "type": EventType.STEP_STARTED.value,
+            "step_name": "via_step",
+        }
+    )
+    assert "via_step" in mock_echo.call_args[0][0]
+
+    mock_echo.reset_mock()
+    render_sse_event(
+        {
+            "type": EventType.TOOL_CALL_START.value,
+            "tool_call_name": "tool_fn",
+        }
+    )
+    assert "tool_fn" in mock_echo.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# render_object_event
+# ---------------------------------------------------------------------------
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_object_event_run_finished_does_not_echo(
+    mock_echo: Any,
+) -> None:
+    # GIVEN: console prints its own "run finished" line
+    ev = RunFinishedEvent(
+        thread_id="t1",
+        run_id="r1",
+    )
+    assert render_object_event(ev) is False
+    assert mock_echo.call_count == 0
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_object_event_run_error_does_not_echo(
+    mock_echo: Any,
+) -> None:
+    ev = RunErrorEvent(
+        message="bad",
+    )
+    assert render_object_event(ev) is False
+    assert mock_echo.call_count == 0
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_object_event_text_and_reasoning_delta_returns_true(
+    mock_echo: Any,
+) -> None:
+    for ev in (
+        TextMessageContentEvent(message_id="m1", delta="a"),
+        TextMessageChunkEvent(message_id="m2", delta="b"),
+        ReasoningMessageContentEvent(message_id="m3", delta="c"),
+        ReasoningMessageChunkEvent(message_id="m4", delta="d"),
+    ):
+        mock_echo.reset_mock()
+        assert render_object_event(ev) is True, type(ev)
+        assert mock_echo.call_count == 1
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_object_event_text_chunk_empty_delta_returns_false(
+    mock_echo: Any,
+) -> None:
+    # GIVEN chunk with no delta: still may paint empty styled span; return is False
+    ev = TextMessageChunkEvent(
+        message_id="m1",
+        delta="",
+    )
+    assert render_object_event(ev) is False
+
+
+@patch("datarobot_genai.dragent.cli.render.click.echo")
+def test_render_object_event_tool_work_prints_false_for_streaming_flag(
+    mock_echo: Any,
+) -> None:
+    # GIVEN a tool call start: we print, but this is not "streaming text" for the console flag
+    ev = ToolCallStartEvent(
+        tool_call_id="c1",
+        tool_call_name="x",
+    )
+    assert render_object_event(ev) is False
+    assert mock_echo.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.17"
+version = "0.15.18"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1093,6 +1093,7 @@ auth = [
 ]
 core = [
     { name = "ag-ui-protocol" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1111,6 +1112,7 @@ crewai = [
     { name = "ag-ui-protocol" },
     { name = "anthropic" },
     { name = "azure-ai-inference" },
+    { name = "colorama" },
     { name = "crewai", extra = ["litellm"] },
     { name = "crewai-tools", extra = ["mcp"] },
     { name = "datarobot" },
@@ -1134,6 +1136,7 @@ crewai = [
 dragent = [
     { name = "ag-ui-protocol" },
     { name = "anyio" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1204,6 +1207,7 @@ drtools = [
 ]
 langgraph = [
     { name = "ag-ui-protocol" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1226,6 +1230,7 @@ langgraph = [
 ]
 llamaindex = [
     { name = "ag-ui-protocol" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1256,6 +1261,7 @@ memory = [
 nat = [
     { name = "ag-ui-protocol" },
     { name = "anyio" },
+    { name = "colorama" },
     { name = "datarobot" },
     { name = "datarobot-early-access" },
     { name = "datarobot-predict" },
@@ -1311,6 +1317,12 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'drmcp'", specifier = ">=4.12.0,<5.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drtools'", specifier = ">=4.12.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'drmcp'", specifier = ">=1.34.0,<2.0.0" },
+    { name = "colorama", marker = "extra == 'core'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'crewai'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'dragent'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'langgraph'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
+    { name = "colorama", marker = "extra == 'nat'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
     { name = "datarobot", marker = "extra == 'core'", specifier = ">=3.10.0,<4.0.0" },


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This:
1. Refactors rendering events in console. It reworks it to only use EventType enum instead of inferring an internal type. And removes logic split for stdout/stderr.
2. Adds invoke_simple method to agents which lets one test an agent in console or jupyter notebook with a simple query

This also removes from E2E tests validate_sequence: its quite a problem to use it from a private branch, we should make a better solution

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent API and CLI rendering/output behavior, which can affect downstream consumers and tooling expectations; dependency/source changes (AG-UI, colorama) and CI/e2e adjustments add some integration risk.
> 
> **Overview**
> Adds `BaseAgent.invoke_single_message()` to run an agent with a freshly generated `RunAgentInput` containing a single `UserMessage`, enabling simpler console/notebook usage.
> 
> Refactors AG-UI event rendering by introducing `core/agents/render.py` (pure string rendering using `EventType`) and updating `dragent` CLI rendering to delegate to it, unifying output to stdout and simplifying SSE/object adapters; adds focused unit tests for rendering and the new invoke helper.
> 
> Updates packaging and test infrastructure: bumps version to `0.15.18`, adds `colorama` as a core dependency, switches `ag-ui-protocol` sourcing to PyPI `0.1.15`, adds `nbstripout` pre-commit hook, tweaks e2e workflow caching and notebook group installs, and temporarily disables `validate_sequence` in e2e tests pending upstream merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8748859ffc55c905d1ff8db231229729f2a308e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->