### PR TITLE
[MODEL-23242] Implement Pagination on Predictive Data Tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
 ## 0.15.18
-- Implement pahination for predictive data MCP tools
+- Implemented pagination for predictive data MCP tools
 
 ## 0.15.17
 - Added option to configure OAuth2 token exchange flow for server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.17
+- Implement pahination for predictive data MCP tools
+
 ## 0.15.16
 - Pinned ag-ui-protocol to version 0.1.15
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,11 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-<<<<<<< HEAD
 version = "0.15.30"
-=======
-version = "0.15.29"
->>>>>>> df057beafef264b00fa0ac3483693bdf5030f20d
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.16"
+version = "0.15.17"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -301,6 +301,20 @@ def test_create_dr_client() -> StubDRClient:
     def list_datasets() -> list[StubDataset]:
         return [stub_dataset]
 
+    def _catalog_stub_datasets() -> list[StubDataset]:
+        """Several catalog rows so ``Dataset.iterate`` can honor offset/limit in tests."""
+        return [
+            StubDataset(f"stub_cat_{i}", name=f"catalog_item_{i}.csv", row_count=10)
+            for i in range(5)
+        ]
+
+    def iterate_datasets(offset: int = 0, limit: int | None = None) -> Any:
+        """Stub ``Dataset.iterate``; supports offset/limit for ``list_ai_catalog_items``."""
+        items = _catalog_stub_datasets()[offset:]
+        if limit is not None:
+            items = items[:limit]
+        return iter(items)
+
     # --- DataStore stubs ---
     stub_datastore = StubDataStore("stub_datastore_id", canonical_name="Test PostgreSQL")
 
@@ -359,6 +373,7 @@ def test_create_dr_client() -> StubDRClient:
     client.Deployment.get = get_deployment
     client.Dataset.get = get_dataset
     client.Dataset.list = list_datasets
+    client.Dataset.iterate = iterate_datasets
     client.DataStore.list = list_datastores
     client.UseCase.get = get_use_case
     # Store REST stubs on the client so integration_mcp_server can wire them

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -343,6 +343,20 @@ def test_create_dr_client() -> StubDRClient:
                 for i in range(min(limit, 5))
             ]
             return StubRestResponse({"data": rows, "next": None})
+        if "externalDataStores" in url:
+            return StubRestResponse(
+                {
+                    "data": [
+                        {
+                            "id": stub_datastore.id,
+                            "canonicalName": stub_datastore.canonical_name,
+                            "creatorId": stub_datastore.creator_id,
+                            "params": dict(stub_datastore.params),
+                        }
+                    ],
+                    "next": None,
+                }
+            )
         if "externalDataDrivers" in url and "tables" in url:
             return StubRestResponse({"data": [{"name": "public.users"}, {"name": "public.orders"}]})
         if "useCases" in url:

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -359,7 +359,6 @@ async def query_datastore(
         "rows": row_data,
         "row_count": len(row_data) if isinstance(row_data, list) else 0,
         "columns": body.get("columns", []),
-        "offset": offset,
     }
     return _merge_pagination_metadata(out, body, offset=offset, limit=limit)
 

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -142,6 +142,8 @@ async def list_ai_catalog_items(
 ) -> dict[str, Any]:
     """List AI Catalog items (datasets) for the authenticated user.
 
+    The ``datasets`` value is always a mapping of dataset id to name (empty mapping when none).
+
     Pagination: the DataRobot SDK's ``Dataset.iterate`` uses ``limit`` as the API page size and
     the iterator can walk every page. When ``limit`` is set, this tool only returns up to
     ``limit`` items after ``offset`` (one page of results). When ``limit`` is omitted, all
@@ -160,7 +162,7 @@ async def list_ai_catalog_items(
 
     if not datasets:
         logger.info("No AI Catalog items found")
-        out: dict[str, Any] = {"datasets": [], "count": 0}
+        out: dict[str, Any] = {"datasets": {}, "count": 0}
         return _merge_pagination_metadata(out, {}, offset=offset, limit=limit)
 
     datasets_dict = {ds.id: ds.name for ds in datasets}

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -166,11 +166,15 @@ async def list_ai_catalog_items(
         return _merge_pagination_metadata(out, {}, offset=offset, limit=limit)
 
     datasets_dict = {ds.id: ds.name for ds in datasets}
-    out = {
-        "datasets": datasets_dict,
-        "count": len(datasets),
-    }
-    _merge_pagination_metadata(out, {}, offset=offset, limit=limit)
+    out = _merge_pagination_metadata(
+        {
+            "datasets": datasets_dict,
+            "count": len(datasets),
+        },
+        {},
+        offset=offset,
+        limit=limit,
+    )
     if limit is not None:
         out["may_have_more"] = len(datasets) == limit
     return out

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -17,6 +17,7 @@ import binascii
 import io
 import itertools
 import logging
+import sys
 from typing import Annotated
 from typing import Any
 
@@ -41,6 +42,29 @@ def _serialize_datastore_params(params: Any) -> dict[str, Any]:
         if isinstance(payload, dict):
             return payload
     return {}
+
+
+def _merge_pagination_metadata(
+    result: dict[str, Any],
+    body: dict[str, Any] | list,
+    *,
+    offset: int | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Add offset/limit echo and DataRobot list pagination (next, previous, total) when present."""
+    if offset is not None:
+        result["offset"] = offset
+    if limit is not None:
+        result["limit"] = limit
+    if isinstance(body, dict):
+        for key in ("next", "previous"):
+            if key in body and body[key] is not None:
+                result[key] = body[key]
+        for total_key in ("total_count", "total"):
+            if total_key in body and body[total_key] is not None:
+                result["total_count"] = body[total_key]
+                break
+    return result
 
 
 @tool_metadata(tags={"predictive", "data", "write", "upload", "catalog", "daria"})
@@ -131,10 +155,8 @@ async def list_ai_catalog_items(
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
     gen = client.Dataset.iterate(offset=offset, limit=limit)
-    if limit is not None:
-        datasets = list(itertools.islice(gen, limit))
-    else:
-        datasets = list(gen)
+    slice_stop = limit if limit is not None else sys.maxsize
+    datasets = list(itertools.islice(gen, slice_stop))
 
     if not datasets:
         logger.info("No AI Catalog items found")
@@ -153,11 +175,25 @@ async def get_dataset_details(
     *,
     dataset_id: Annotated[str, "The ID of the DataRobot dataset"] | None = None,
     include_sample: Annotated[bool, "Whether to include sample rows"] = True,
-    sample_rows: Annotated[int, "Number of sample rows to return"] = 10,
+    sample_offset: Annotated[
+        int,
+        (
+            "0-based index of the first sample row to return; use with sample_rows to page "
+            "through data."
+        ),
+    ] = 0,
+    sample_rows: Annotated[int, "Max sample rows to return in this call (page size)"] = 10,
 ) -> dict[str, Any]:
-    """Get DataRobot dataset metadata and optional sample rows."""
+    """Get DataRobot dataset metadata and optional sample rows.
+
+    Paginate the sample with sample_offset and sample_rows.
+    """
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
+    if sample_offset < 0:
+        raise ToolError("sample_offset must be non-negative")
+    if sample_rows < 1:
+        raise ToolError("sample_rows must be at least 1")
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -173,7 +209,22 @@ async def get_dataset_details(
         try:
             df = dataset.get_raw_sample_data()
             result["columns"] = list(df.columns)
-            result["sample"] = df.head(sample_rows).to_dict(orient="records")
+            n = len(df)
+            end = min(sample_offset + sample_rows, n)
+            if sample_offset < n:
+                if hasattr(df, "iloc"):
+                    sample_df = df.iloc[sample_offset:end]
+                else:
+                    sample_df = df[sample_offset:end]
+            elif hasattr(df, "iloc"):
+                sample_df = df.iloc[0:0]
+            else:
+                sample_df = df[0:0]
+            result["sample"] = sample_df.to_dict(orient="records")
+            result["sample_offset"] = sample_offset
+            result["sample_rows"] = sample_rows
+            result["sample_count"] = len(result["sample"])
+            result["sample_total_available"] = n
         except Exception as exc:
             result["sample_error"] = str(exc)
 
@@ -207,20 +258,24 @@ async def list_datastores(
     if limit is not None:
         params["limit"] = limit
     response = rest_client.get("externalDataStores/", params=params)
-    items = response.json().get("data", [])
+    body = response.json()
+    items = body.get("data", [])
+    if not isinstance(items, list):
+        items = []
 
-    return {
+    out: dict[str, Any] = {
         "datastores": [
             {
                 "id": ds.get("id", ""),
                 "canonical_name": ds.get("canonicalName", ""),
                 "creator_id": ds.get("creatorId", ""),
-                "params": ds.get("params", {}),
+                "params": _serialize_datastore_params(ds.get("params", {})),
             }
             for ds in items
         ],
         "count": len(items),
     }
+    return _merge_pagination_metadata(out, body, offset=offset, limit=limit)
 
 
 @tool_metadata(tags={"predictive", "data", "read", "datastore", "browse", "daria"})
@@ -248,13 +303,17 @@ async def browse_datastore(
     response = rest_client.get(f"externalDataDrivers/{datastore_id}/tables/", params=params)
     data = response.json()
     items = data.get("data", data) if isinstance(data, dict) else data
+    if not isinstance(items, list):
+        items = [items] if items is not None else []
 
-    return {
+    out: dict[str, Any] = {
         "datastore_id": datastore_id,
         "path": path or "/",
         "items": items,
         "count": len(items),
     }
+    body = data if isinstance(data, dict) else {}
+    return _merge_pagination_metadata(out, body, offset=offset, limit=limit)
 
 
 @tool_metadata(
@@ -287,14 +346,16 @@ async def query_datastore(
 
     payload = {"query": sql, "offset": offset, "limit": limit}
     response = rest_client.post(f"externalDataDrivers/{datastore_id}/execute/", json=payload)
-    data = response.json()
+    body = response.json()
+    row_data = body.get("data", [])
 
-    return {
-        "rows": data.get("data", []),
-        "row_count": len(data.get("data", [])),
-        "columns": data.get("columns", []),
+    out: dict[str, Any] = {
+        "rows": row_data,
+        "row_count": len(row_data) if isinstance(row_data, list) else 0,
+        "columns": body.get("columns", []),
         "offset": offset,
     }
+    return _merge_pagination_metadata(out, body, offset=offset, limit=limit)
 
 
 # from fastmcp import Context

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -32,6 +32,22 @@ logger = logging.getLogger(__name__)
 DR_PREDICTIVE_API_PAGINATION_MAX = 1000
 
 
+def _clamp_limit(limit: int) -> tuple[int, str | None]:
+    """Clamp page size to [1, DR_PREDICTIVE_API_PAGINATION_MAX] and an optional user-facing note."""
+    m = DR_PREDICTIVE_API_PAGINATION_MAX
+    if limit < 1:
+        return (
+            m,
+            f"Limit must be at least 1. The maximum limit of {m} was applied.",
+        )
+    if limit > m:
+        return (
+            m,
+            f"Limit cannot exceed {m}. The maximum limit of {m} was applied.",
+        )
+    return (limit, None)
+
+
 def _serialize_datastore_params(params: Any) -> dict[str, Any]:
     """Return JSON-serializable params; DataRobot SDK uses DataStoreParameters, not a dict."""
     if params is None:
@@ -159,13 +175,7 @@ async def list_ai_catalog_items(
     if offset is not None and offset < 0:
         raise ToolError("offset must be non-negative")
 
-    message = None
-    if limit < 1:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit must be at least 1. The maximum limit of 1000 was applied."
-    elif limit > DR_PREDICTIVE_API_PAGINATION_MAX:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit cannot exceed 1000. The maximum limit of 1000 was applied."
+    limit, message = _clamp_limit(limit)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -250,13 +260,7 @@ async def list_datastores(
     if offset is not None and offset < 0:
         raise ToolError("offset must be non-negative")
 
-    message = None
-    if limit < 1:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit must be at least 1. The maximum limit of 1000 was applied."
-    elif limit > DR_PREDICTIVE_API_PAGINATION_MAX:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit cannot exceed 1000. The maximum limit of 1000 was applied."
+    limit, message = _clamp_limit(limit)
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
@@ -313,13 +317,7 @@ async def browse_datastore(
     if offset < 0:
         raise ToolError("offset must be non-negative")
 
-    message = None
-    if limit < 1:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit must be at least 1. The maximum limit of 1000 was applied."
-    elif limit > DR_PREDICTIVE_API_PAGINATION_MAX:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit cannot exceed 1000. The maximum limit of 1000 was applied."
+    limit, message = _clamp_limit(limit)
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
@@ -380,13 +378,7 @@ async def query_datastore(
     if offset < 0:
         raise ToolError("offset must be non-negative")
 
-    message = None
-    if limit < 1:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit must be at least 1. The maximum limit of 1000 was applied."
-    elif limit > DR_PREDICTIVE_API_PAGINATION_MAX:
-        limit = DR_PREDICTIVE_API_PAGINATION_MAX
-        message = "Limit cannot exceed 1000. The maximum limit of 1000 was applied."
+    limit, message = _clamp_limit(limit)
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -33,7 +33,7 @@ from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_erro
 logger = logging.getLogger(__name__)
 
 # Max page / batch size for predictive `data` tools
-DR_PREDICTIVE_API_PAGINATION_MAX = 1000
+DR_PREDICTIVE_API_PAGINATION_MAX = 100
 
 
 def _clamp_limit(limit: int) -> tuple[int, str | None]:
@@ -179,10 +179,6 @@ async def upload_dataset_to_ai_catalog(
         "as id-to-name map. Read-only. Not project-attached datasets "
         "(get_project_dataset_by_name), not modeling projects (list_projects). Follow with "
         "get_dataset_details or scoring tools that take dataset_id."
-        "Pagination: the DataRobot SDK's ``Dataset.iterate`` is called with a finite "
-        "``limit`` (default 1000) so the gateway and MCP process avoid unbounded responses."
-        " Use ``offset`` and additional calls to walk large catalogs. The response echoes "
-        "the effective limit and may set ``may_have_more`` when the page is full."
     ),
 )
 async def list_ai_catalog_items(
@@ -193,8 +189,8 @@ async def list_ai_catalog_items(
     limit: Annotated[
         int,
         (
-            "Max datasets to return in this call (default 1000). Use with offset to page. "
-            "Values above 1000 are rejected; use offset to continue."
+            "Max datasets to return in this call (default 100). Use with offset to page. "
+            "Values above 100 are rejected; use offset to continue."
         ),
     ] = DR_PREDICTIVE_API_PAGINATION_MAX,
 ) -> dict[str, Any]:
@@ -302,7 +298,7 @@ async def list_datastores(
     limit: Annotated[
         int,
         (
-            "Max datastores to return (default 1000). Values above 1000 are rejected; "
+            "Max datastores to return (default 100). Values above 100 are rejected; "
             "use offset to page."
         ),
     ] = DR_PREDICTIVE_API_PAGINATION_MAX,
@@ -366,7 +362,7 @@ async def browse_datastore(
     limit: Annotated[
         int,
         (
-            "Maximum items to return (default 1000). Values above 1000 are rejected; "
+            "Maximum items to return (default 100). Values above 100 are rejected; "
             "use offset to page."
         ),
     ] = DR_PREDICTIVE_API_PAGINATION_MAX,
@@ -423,13 +419,14 @@ async def browse_datastore(
     ),
 )
 async def query_datastore(
+    *,
     datastore_id: Annotated[str, "Connection id from list_datastores."] | None = None,
     sql: Annotated[str, "SQL statement to run against that connection."] | None = None,
     offset: Annotated[int, "Number of rows to skip (0-based) for pagination"] = 0,
     limit: Annotated[
         int,
         (
-            "Maximum rows to return (default 1000). Values above 1000 are rejected; "
+            "Maximum rows to return (default 100). Values above 100 are rejected; "
             "use offset to page."
         ),
     ] = DR_PREDICTIVE_API_PAGINATION_MAX,

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -34,15 +34,16 @@ DR_PREDICTIVE_API_PAGINATION_MAX = 1000
 
 def _clamp_limit(limit: int) -> tuple[int, str | None]:
     """Clamp page size to [1, DR_PREDICTIVE_API_PAGINATION_MAX] and an optional user-facing note."""
-    if limit < 0:
+    m = DR_PREDICTIVE_API_PAGINATION_MAX
+    if limit < 1:
         return (
-            DR_PREDICTIVE_API_PAGINATION_MAX,
-            f"Limit must be at least 0. The maximum limit of {DR_PREDICTIVE_API_PAGINATION_MAX} was applied.",
+            m,
+            f"Limit must be at least 1. The maximum limit of {m} was applied.",
         )
-    if limit > DR_PREDICTIVE_API_PAGINATION_MAX:
+    if limit > m:
         return (
-            DR_PREDICTIVE_API_PAGINATION_MAX,
-            f"Limit cannot exceed {DR_PREDICTIVE_API_PAGINATION_MAX}. The maximum limit of {DR_PREDICTIVE_API_PAGINATION_MAX} was applied.",
+            m,
+            f"Limit cannot exceed {m}. The maximum limit of {m} was applied.",
         )
     return (limit, None)
 

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -17,7 +17,6 @@ import binascii
 import io
 import itertools
 import logging
-import sys
 from typing import Annotated
 from typing import Any
 
@@ -28,6 +27,9 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.utils import is_valid_url
 
 logger = logging.getLogger(__name__)
+
+# Max page / batch size for predictive `data` tools
+DR_PREDICTIVE_API_PAGINATION_MAX = 1000
 
 
 def _serialize_datastore_params(params: Any) -> dict[str, Any]:
@@ -136,34 +138,43 @@ async def list_ai_catalog_items(
     ] = None,
     limit: Annotated[
         int | None,
-        "Max datasets to return in this call. Use with offset to page (e.g. 3 items per page). "
-        "Omit to return the full catalog.",
+        (
+            "Max datasets to return in this call. Use with offset to page. "
+            "Omit to use 1000; values above 1000 are rejected; use offset to continue."
+        ),
     ] = None,
 ) -> dict[str, Any]:
     """List AI Catalog items (datasets) for the authenticated user.
 
     The ``datasets`` value is always a mapping of dataset id to name (empty mapping when none).
 
-    Pagination: the DataRobot SDK's ``Dataset.iterate`` uses ``limit`` as the API page size and
-    the iterator can walk every page. When ``limit`` is set, this tool only returns up to
-    ``limit`` items after ``offset`` (one page of results). When ``limit`` is omitted, all
-    items from ``offset`` through the end of the catalog are returned.
+    Pagination: the DataRobot SDK's ``Dataset.iterate`` is called with a finite ``limit`` (your
+    argument, or 1000 when omitted) so the gateway and MCP process avoid unbounded
+    responses. Use ``offset`` and additional calls to walk large catalogs. The response echoes the
+    effective limit and may set ``may_have_more`` when the page is full.
     """
     if offset is not None and offset < 0:
         raise ToolError("offset must be non-negative")
-    if limit is not None and limit < 1:
-        raise ToolError("limit must be at least 1 when provided")
+
+    max_per = DR_PREDICTIVE_API_PAGINATION_MAX
+    if limit is not None:
+        if limit < 1:
+            raise ToolError("limit must be at least 1 when provided")
+        if limit > max_per:
+            raise ToolError(
+                f"limit cannot exceed {max_per}; use offset to page through the catalog."
+            )
+    apply_limit = limit if limit is not None else max_per
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    gen = client.Dataset.iterate(offset=offset, limit=limit)
-    slice_stop = limit if limit is not None else sys.maxsize
-    datasets = list(itertools.islice(gen, slice_stop))
+    gen = client.Dataset.iterate(offset=offset, limit=apply_limit)
+    datasets = list(itertools.islice(gen, apply_limit))
 
     if not datasets:
         logger.info("No AI Catalog items found")
         out: dict[str, Any] = {"datasets": {}, "count": 0}
-        return _merge_pagination_metadata(out, {}, offset=offset, limit=limit)
+        return _merge_pagination_metadata(out, {}, offset=offset, limit=apply_limit)
 
     datasets_dict = {ds.id: ds.name for ds in datasets}
     out = _merge_pagination_metadata(
@@ -173,10 +184,9 @@ async def list_ai_catalog_items(
         },
         {},
         offset=offset,
-        limit=limit,
+        limit=apply_limit,
     )
-    if limit is not None:
-        out["may_have_more"] = len(datasets) == limit
+    out["may_have_more"] = len(datasets) == apply_limit
     return out
 
 
@@ -192,7 +202,10 @@ async def get_dataset_details(
             "through data."
         ),
     ] = 0,
-    sample_rows: Annotated[int, "Max sample rows to return in this call (page size)"] = 10,
+    sample_rows: Annotated[
+        int,
+        "Max sample rows; larger values are capped at 1000 for large previews.",
+    ] = 10,
 ) -> dict[str, Any]:
     """Get DataRobot dataset metadata and optional sample rows.
 
@@ -204,6 +217,16 @@ async def get_dataset_details(
         raise ToolError("sample_offset must be non-negative")
     if sample_rows < 1:
         raise ToolError("sample_rows must be at least 1")
+
+    max_per = DR_PREDICTIVE_API_PAGINATION_MAX
+    apply_sample_rows = min(sample_rows, max_per)
+    if apply_sample_rows < sample_rows:
+        logger.warning(
+            "get_dataset_details: sample_rows %s exceeds cap %s, using %s",
+            sample_rows,
+            max_per,
+            apply_sample_rows,
+        )
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -220,7 +243,7 @@ async def get_dataset_details(
             df = dataset.get_raw_sample_data()
             result["columns"] = list(df.columns)
             n = len(df)
-            end = min(sample_offset + sample_rows, n)
+            end = min(sample_offset + apply_sample_rows, n)
             if sample_offset < n:
                 if hasattr(df, "iloc"):
                     sample_df = df.iloc[sample_offset:end]
@@ -232,7 +255,7 @@ async def get_dataset_details(
                 sample_df = df[0:0]
             result["sample"] = sample_df.to_dict(orient="records")
             result["sample_offset"] = sample_offset
-            result["sample_rows"] = sample_rows
+            result["sample_rows"] = apply_sample_rows
             result["sample_count"] = len(result["sample"])
             result["sample_total_available"] = n
         except Exception as exc:
@@ -249,24 +272,31 @@ async def list_datastores(
     ] = None,
     limit: Annotated[
         int | None,
-        "Max datastores to return in this call (server page size). Omit to list all.",
+        (
+            "Max datastores to return. Omit to use 1000; values above 1000 are rejected; "
+            "use offset to page."
+        ),
     ] = None,
 ) -> dict[str, Any]:
     """List available DataRobot data connections (datastores)."""
     if offset is not None and offset < 0:
         raise ToolError("offset must be non-negative")
-    if limit is not None and limit < 1:
-        raise ToolError("limit must be at least 1 when provided")
+
+    max_per = DR_PREDICTIVE_API_PAGINATION_MAX
+    if limit is not None:
+        if limit < 1:
+            raise ToolError("limit must be at least 1 when provided")
+        if limit > max_per:
+            raise ToolError(f"limit cannot exceed {max_per}; use offset to page.")
+    apply_limit = limit if limit is not None else max_per
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
     rest_client = dr_module.client.get_client()
 
-    params: dict = {}
+    params: dict[str, Any] = {"limit": apply_limit}
     if offset is not None:
         params["offset"] = offset
-    if limit is not None:
-        params["limit"] = limit
     response = rest_client.get("externalDataStores/", params=params)
     body = response.json()
     items = body.get("data", [])
@@ -285,7 +315,7 @@ async def list_datastores(
         ],
         "count": len(items),
     }
-    return _merge_pagination_metadata(out, body, offset=offset, limit=limit)
+    return _merge_pagination_metadata(out, body, offset=offset, limit=apply_limit)
 
 
 @tool_metadata(tags={"predictive", "data", "read", "datastore", "browse", "daria"})
@@ -294,18 +324,35 @@ async def browse_datastore(
     datastore_id: Annotated[str, "The ID of the datastore to browse"] | None = None,
     path: Annotated[str, "The path to browse within the datastore"] | None = None,
     offset: Annotated[int, "Pagination offset"] = 0,
-    limit: Annotated[int, "Maximum number of items to return"] = 100,
+    limit: Annotated[
+        int,
+        "Maximum items to return; values above 1000 are reduced to 1000.",
+    ] = 100,
     search: Annotated[str, "Search filter for items"] | None = None,
 ) -> dict[str, Any]:
     """Browse a DataRobot data connection to list catalogs, schemas, and tables."""
     if not datastore_id:
         raise ToolError("Datastore ID must be provided")
+    if offset < 0:
+        raise ToolError("offset must be non-negative")
+    if limit < 1:
+        raise ToolError("limit must be at least 1")
+
+    max_per = DR_PREDICTIVE_API_PAGINATION_MAX
+    apply_limit = min(limit, max_per)
+    if apply_limit < limit:
+        logger.warning(
+            "browse_datastore: limit %s exceeds cap %s, using %s",
+            limit,
+            max_per,
+            apply_limit,
+        )
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
     rest_client = dr_module.client.get_client()
 
-    params: dict = {"offset": offset, "limit": limit}
+    params: dict = {"offset": offset, "limit": apply_limit}
     if path:
         params["path"] = path
     if search:
@@ -323,7 +370,7 @@ async def browse_datastore(
         "count": len(items),
     }
     body = data if isinstance(data, dict) else {}
-    return _merge_pagination_metadata(out, body, offset=offset, limit=limit)
+    return _merge_pagination_metadata(out, body, offset=offset, limit=apply_limit)
 
 
 @tool_metadata(
@@ -334,7 +381,10 @@ async def query_datastore(
     datastore_id: Annotated[str, "The ID of the datastore to query"] | None = None,
     sql: Annotated[str, "The SQL query to execute"] | None = None,
     offset: Annotated[int, "Number of rows to skip (0-based) for pagination"] = 0,
-    limit: Annotated[int, "Maximum number of rows to return"] = 1000,
+    limit: Annotated[
+        int,
+        "Maximum rows to return; values above 1000 are reduced to 1000.",
+    ] = 1000,
 ) -> dict[str, Any]:
     """Execute a SQL query against a DataRobot datastore connection.
 
@@ -350,11 +400,18 @@ async def query_datastore(
     if limit < 1:
         raise ToolError("limit must be at least 1")
 
+    max_per = DR_PREDICTIVE_API_PAGINATION_MAX
+    apply_limit = min(limit, max_per)
+    if apply_limit < limit:
+        logger.warning(
+            "query_datastore: limit %s exceeds cap %s, using %s", limit, max_per, apply_limit
+        )
+
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
     rest_client = dr_module.client.get_client()
 
-    payload = {"query": sql, "offset": offset, "limit": limit}
+    payload = {"query": sql, "offset": offset, "limit": apply_limit}
     response = rest_client.post(f"externalDataDrivers/{datastore_id}/execute/", json=payload)
     body = response.json()
     row_data = body.get("data", [])
@@ -364,7 +421,7 @@ async def query_datastore(
         "row_count": len(row_data) if isinstance(row_data, list) else 0,
         "columns": body.get("columns", []),
     }
-    return _merge_pagination_metadata(out, body, offset=offset, limit=limit)
+    return _merge_pagination_metadata(out, body, offset=offset, limit=apply_limit)
 
 
 # from fastmcp import Context

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -34,16 +34,15 @@ DR_PREDICTIVE_API_PAGINATION_MAX = 1000
 
 def _clamp_limit(limit: int) -> tuple[int, str | None]:
     """Clamp page size to [1, DR_PREDICTIVE_API_PAGINATION_MAX] and an optional user-facing note."""
-    m = DR_PREDICTIVE_API_PAGINATION_MAX
-    if limit < 1:
+    if limit < 0:
         return (
-            m,
-            f"Limit must be at least 1. The maximum limit of {m} was applied.",
+            DR_PREDICTIVE_API_PAGINATION_MAX,
+            f"Limit must be at least 0. The maximum limit of {DR_PREDICTIVE_API_PAGINATION_MAX} was applied.",
         )
-    if limit > m:
+    if limit > DR_PREDICTIVE_API_PAGINATION_MAX:
         return (
-            m,
-            f"Limit cannot exceed {m}. The maximum limit of {m} was applied.",
+            DR_PREDICTIVE_API_PAGINATION_MAX,
+            f"Limit cannot exceed {DR_PREDICTIVE_API_PAGINATION_MAX}. The maximum limit of {DR_PREDICTIVE_API_PAGINATION_MAX} was applied.",
         )
     return (limit, None)
 

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -15,6 +15,7 @@
 import base64
 import binascii
 import io
+import itertools
 import logging
 from typing import Annotated
 from typing import Any
@@ -104,11 +105,36 @@ async def upload_dataset_to_ai_catalog(
 
 
 @tool_metadata(tags={"predictive", "data", "read", "list", "catalog", "daria"})
-async def list_ai_catalog_items() -> dict[str, Any]:
-    """List all AI Catalog items (datasets) for the authenticated user."""
+async def list_ai_catalog_items(
+    offset: Annotated[
+        int | None,
+        "Skip this many catalog items (0-based). Example: page 2 with page size 3 uses offset=3.",
+    ] = None,
+    limit: Annotated[
+        int | None,
+        "Max datasets to return in this call. Use with offset to page (e.g. 3 items per page). "
+        "Omit to return the full catalog.",
+    ] = None,
+) -> dict[str, Any]:
+    """List AI Catalog items (datasets) for the authenticated user.
+
+    Pagination: the DataRobot SDK's ``Dataset.iterate`` uses ``limit`` as the API page size and
+    the iterator can walk every page. When ``limit`` is set, this tool only returns up to
+    ``limit`` items after ``offset`` (one page of results). When ``limit`` is omitted, all
+    items from ``offset`` through the end of the catalog are returned.
+    """
+    if offset is not None and offset < 0:
+        raise ToolError("offset must be non-negative")
+    if limit is not None and limit < 1:
+        raise ToolError("limit must be at least 1 when provided")
+
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    datasets = client.Dataset.list()
+    gen = client.Dataset.iterate(offset=offset, limit=limit)
+    if limit is not None:
+        datasets = list(itertools.islice(gen, limit))
+    else:
+        datasets = list(gen)
 
     if not datasets:
         logger.info("No AI Catalog items found")
@@ -155,23 +181,45 @@ async def get_dataset_details(
 
 
 @tool_metadata(tags={"predictive", "data", "read", "datastore", "list", "daria"})
-async def list_datastores() -> dict[str, Any]:
+async def list_datastores(
+    offset: Annotated[
+        int | None,
+        "Skip this many datastores (0-based). Use with limit for paged listing; omit for all.",
+    ] = None,
+    limit: Annotated[
+        int | None,
+        "Max datastores to return in this call (server page size). Omit to list all.",
+    ] = None,
+) -> dict[str, Any]:
     """List available DataRobot data connections (datastores)."""
+    if offset is not None and offset < 0:
+        raise ToolError("offset must be non-negative")
+    if limit is not None and limit < 1:
+        raise ToolError("limit must be at least 1 when provided")
+
     token = await get_datarobot_access_token()
-    client = DataRobotClient(token).get_client()
-    datastores = client.DataStore.list()
+    dr_module = DataRobotClient(token).get_client()
+    rest_client = dr_module.client.get_client()
+
+    params: dict = {}
+    if offset is not None:
+        params["offset"] = offset
+    if limit is not None:
+        params["limit"] = limit
+    response = rest_client.get("externalDataStores/", params=params)
+    items = response.json().get("data", [])
 
     return {
         "datastores": [
             {
-                "id": ds.id,
-                "canonical_name": getattr(ds, "canonical_name", ""),
-                "creator_id": getattr(ds, "creator_id", ""),
-                "params": _serialize_datastore_params(getattr(ds, "params", None)),
+                "id": ds.get("id", ""),
+                "canonical_name": ds.get("canonicalName", ""),
+                "creator_id": ds.get("creatorId", ""),
+                "params": ds.get("params", {}),
             }
-            for ds in datastores
+            for ds in items
         ],
-        "count": len(datastores),
+        "count": len(items),
     }
 
 
@@ -216,6 +264,7 @@ async def query_datastore(
     *,
     datastore_id: Annotated[str, "The ID of the datastore to query"] | None = None,
     sql: Annotated[str, "The SQL query to execute"] | None = None,
+    offset: Annotated[int, "Number of rows to skip (0-based) for pagination"] = 0,
     limit: Annotated[int, "Maximum number of rows to return"] = 1000,
 ) -> dict[str, Any]:
     """Execute a SQL query against a DataRobot datastore connection.
@@ -227,12 +276,16 @@ async def query_datastore(
         raise ToolError("Datastore ID must be provided")
     if not sql:
         raise ToolError("SQL query must be provided")
+    if offset < 0:
+        raise ToolError("offset must be non-negative")
+    if limit < 1:
+        raise ToolError("limit must be at least 1")
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
     rest_client = dr_module.client.get_client()
 
-    payload = {"query": sql, "limit": limit}
+    payload = {"query": sql, "offset": offset, "limit": limit}
     response = rest_client.post(f"externalDataDrivers/{datastore_id}/execute/", json=payload)
     data = response.json()
 
@@ -240,6 +293,7 @@ async def query_datastore(
         "rows": data.get("data", []),
         "row_count": len(data.get("data", [])),
         "columns": data.get("columns", []),
+        "offset": offset,
     }
 
 

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -137,38 +137,37 @@ async def list_ai_catalog_items(
         "Skip this many catalog items (0-based). Example: page 2 with page size 3 uses offset=3.",
     ] = None,
     limit: Annotated[
-        int | None,
+        int,
         (
-            "Max datasets to return in this call. Use with offset to page. "
-            "Omit to use 1000; values above 1000 are rejected; use offset to continue."
+            "Max datasets to return in this call (default 1000). Use with offset to page. "
+            "Values above 1000 are rejected; use offset to continue."
         ),
-    ] = None,
+    ] = DR_PREDICTIVE_API_PAGINATION_MAX,
 ) -> dict[str, Any]:
     """List AI Catalog items (datasets) for the authenticated user.
 
     The ``datasets`` value is always a mapping of dataset id to name (empty mapping when none).
 
-    Pagination: the DataRobot SDK's ``Dataset.iterate`` is called with a finite ``limit`` (your
-    argument, or 1000 when omitted) so the gateway and MCP process avoid unbounded
-    responses. Use ``offset`` and additional calls to walk large catalogs. The response echoes the
-    effective limit and may set ``may_have_more`` when the page is full.
+    Pagination: the DataRobot SDK's ``Dataset.iterate`` is called with a finite ``limit`` (default
+    1000) so the gateway and MCP process avoid unbounded responses. Use ``offset`` and additional
+    calls to walk large catalogs. The response echoes the effective limit and may set
+    ``may_have_more`` when the page is full.
     """
     if offset is not None and offset < 0:
         raise ToolError("offset must be non-negative")
 
     max_per = DR_PREDICTIVE_API_PAGINATION_MAX
-    if limit is not None:
-        if limit < 1:
-            raise ToolError("limit must be at least 1 when provided")
-        if limit > max_per:
-            raise ToolError(
-                f"limit cannot exceed {max_per}; use offset to page through the catalog."
-            )
-    apply_limit = limit if limit is not None else max_per
+    if limit < 1:
+        raise ToolError("limit must be at least 1")
+    if limit > max_per:
+        raise ToolError(f"limit cannot exceed {max_per}; use offset to page through the catalog.")
+    apply_limit = limit
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    gen = client.Dataset.iterate(offset=offset, limit=apply_limit)
+    # DataRobot ``Dataset.iterate`` expects an int; do not pass ``None`` when offset is omitted.
+    iterate_offset = 0 if offset is None else offset
+    gen = client.Dataset.iterate(offset=iterate_offset, limit=apply_limit)
     datasets = list(itertools.islice(gen, apply_limit))
 
     if not datasets:
@@ -271,24 +270,23 @@ async def list_datastores(
         "Skip this many datastores (0-based). Use with limit for paged listing; omit for all.",
     ] = None,
     limit: Annotated[
-        int | None,
+        int,
         (
-            "Max datastores to return. Omit to use 1000; values above 1000 are rejected; "
+            "Max datastores to return (default 1000). Values above 1000 are rejected; "
             "use offset to page."
         ),
-    ] = None,
+    ] = DR_PREDICTIVE_API_PAGINATION_MAX,
 ) -> dict[str, Any]:
     """List available DataRobot data connections (datastores)."""
     if offset is not None and offset < 0:
         raise ToolError("offset must be non-negative")
 
     max_per = DR_PREDICTIVE_API_PAGINATION_MAX
-    if limit is not None:
-        if limit < 1:
-            raise ToolError("limit must be at least 1 when provided")
-        if limit > max_per:
-            raise ToolError(f"limit cannot exceed {max_per}; use offset to page.")
-    apply_limit = limit if limit is not None else max_per
+    if limit < 1:
+        raise ToolError("limit must be at least 1")
+    if limit > max_per:
+        raise ToolError(f"limit cannot exceed {max_per}; use offset to page.")
+    apply_limit = limit
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
@@ -326,8 +324,8 @@ async def browse_datastore(
     offset: Annotated[int, "Pagination offset"] = 0,
     limit: Annotated[
         int,
-        "Maximum items to return; values above 1000 are reduced to 1000.",
-    ] = 100,
+        "Maximum items to return (default 1000); values above 1000 are reduced to 1000.",
+    ] = DR_PREDICTIVE_API_PAGINATION_MAX,
     search: Annotated[str, "Search filter for items"] | None = None,
 ) -> dict[str, Any]:
     """Browse a DataRobot data connection to list catalogs, schemas, and tables."""
@@ -383,8 +381,8 @@ async def query_datastore(
     offset: Annotated[int, "Number of rows to skip (0-based) for pagination"] = 0,
     limit: Annotated[
         int,
-        "Maximum rows to return; values above 1000 are reduced to 1000.",
-    ] = 1000,
+        "Maximum rows to return (default 1000); values above 1000 are reduced to 1000.",
+    ] = DR_PREDICTIVE_API_PAGINATION_MAX,
 ) -> dict[str, Any]:
     """Execute a SQL query against a DataRobot datastore connection.
 

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -47,26 +47,26 @@ def _serialize_datastore_params(params: Any) -> dict[str, Any]:
 
 
 def _merge_pagination_metadata(
-    result: dict[str, Any],
-    body: dict[str, Any] | list,
+    final_results: dict[str, Any],
+    api_response: dict[str, Any] | list,
     *,
     offset: int | None = None,
     limit: int | None = None,
 ) -> dict[str, Any]:
     """Add offset/limit echo and DataRobot list pagination (next, previous, total) when present."""
     if offset is not None:
-        result["offset"] = offset
+        final_results["offset"] = offset
     if limit is not None:
-        result["limit"] = limit
-    if isinstance(body, dict):
+        final_results["limit"] = limit
+    if isinstance(api_response, dict):
         for key in ("next", "previous"):
-            if key in body and body[key] is not None:
-                result[key] = body[key]
+            if key in api_response and api_response[key] is not None:
+                final_results[key] = api_response[key]
         for total_key in ("total_count", "total"):
-            if total_key in body and body[total_key] is not None:
-                result["total_count"] = body[total_key]
+            if total_key in api_response and api_response[total_key] is not None:
+                final_results["total_count"] = api_response[total_key]
                 break
-    return result
+    return final_results
 
 
 @tool_metadata(tags={"predictive", "data", "write", "upload", "catalog", "daria"})
@@ -324,7 +324,10 @@ async def browse_datastore(
     offset: Annotated[int, "Pagination offset"] = 0,
     limit: Annotated[
         int,
-        "Maximum items to return (default 1000); values above 1000 are reduced to 1000.",
+        (
+            "Maximum items to return (default 1000). Values above 1000 are rejected; "
+            "use offset to page."
+        ),
     ] = DR_PREDICTIVE_API_PAGINATION_MAX,
     search: Annotated[str, "Search filter for items"] | None = None,
 ) -> dict[str, Any]:
@@ -337,14 +340,9 @@ async def browse_datastore(
         raise ToolError("limit must be at least 1")
 
     max_per = DR_PREDICTIVE_API_PAGINATION_MAX
-    apply_limit = min(limit, max_per)
-    if apply_limit < limit:
-        logger.warning(
-            "browse_datastore: limit %s exceeds cap %s, using %s",
-            limit,
-            max_per,
-            apply_limit,
-        )
+    if limit > max_per:
+        raise ToolError(f"limit cannot exceed {max_per}; use offset to page.")
+    apply_limit = limit
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
@@ -381,7 +379,10 @@ async def query_datastore(
     offset: Annotated[int, "Number of rows to skip (0-based) for pagination"] = 0,
     limit: Annotated[
         int,
-        "Maximum rows to return (default 1000); values above 1000 are reduced to 1000.",
+        (
+            "Maximum rows to return (default 1000). Values above 1000 are rejected; "
+            "use offset to page."
+        ),
     ] = DR_PREDICTIVE_API_PAGINATION_MAX,
 ) -> dict[str, Any]:
     """Execute a SQL query against a DataRobot datastore connection.
@@ -399,11 +400,9 @@ async def query_datastore(
         raise ToolError("limit must be at least 1")
 
     max_per = DR_PREDICTIVE_API_PAGINATION_MAX
-    apply_limit = min(limit, max_per)
-    if apply_limit < limit:
-        logger.warning(
-            "query_datastore: limit %s exceeds cap %s, using %s", limit, max_per, apply_limit
-        )
+    if limit > max_per:
+        raise ToolError(f"limit cannot exceed {max_per}; use offset to page.")
+    apply_limit = limit
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -155,12 +155,18 @@ async def upload_dataset_to_ai_catalog(
         )
         buffer = io.BytesIO(raw)
         buffer.name = fname
-        catalog_item = client.Dataset.create_from_file(filelike=buffer)
+        try:
+            catalog_item = client.Dataset.create_from_file(filelike=buffer)
+        except ClientError as e:
+            raise_tool_error_for_client_error(e)
     else:
         if file_url is None or not is_valid_url(file_url):
             logger.error("Invalid file URL: %s", file_url)
             raise ToolError(f"Invalid file URL: {file_url}", kind=ToolErrorKind.VALIDATION)
-        catalog_item = client.Dataset.create_from_url(file_url)
+        try:
+            catalog_item = client.Dataset.create_from_url(file_url)
+        except ClientError as e:
+            raise_tool_error_for_client_error(e)
 
     if not catalog_item:
         raise ToolError("Failed to upload dataset.", kind=ToolErrorKind.UPSTREAM)
@@ -206,9 +212,9 @@ async def list_ai_catalog_items(
     iterate_offset = 0 if offset is None else offset
     try:
         gen = client.Dataset.iterate(offset=iterate_offset, limit=limit)
+        datasets = list(itertools.islice(gen, limit))
     except ClientError as e:
         raise_tool_error_for_client_error(e)
-    datasets = list(itertools.islice(gen, limit))
 
     if not datasets:
         logger.info("No AI Catalog items found")

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -160,14 +160,18 @@ async def list_ai_catalog_items(
 
     if not datasets:
         logger.info("No AI Catalog items found")
-        return {"datasets": []}
+        out: dict[str, Any] = {"datasets": [], "count": 0}
+        return _merge_pagination_metadata(out, {}, offset=offset, limit=limit)
 
     datasets_dict = {ds.id: ds.name for ds in datasets}
-
-    return {
+    out = {
         "datasets": datasets_dict,
         "count": len(datasets),
     }
+    _merge_pagination_metadata(out, {}, offset=offset, limit=limit)
+    if limit is not None:
+        out["may_have_more"] = len(datasets) == limit
+    return out
 
 
 @tool_metadata(tags={"predictive", "data", "read", "dataset", "metadata", "daria"})

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -264,9 +264,9 @@ async def test_list_ai_catalog_items_success() -> None:
         # datasets is now a dict mapping id to name
         assert result["datasets"]["1"] == "ds1"
         assert result["datasets"]["2"] == "ds2"
-        assert result["limit"] == 1000
+        assert result["limit"] == 100
         assert result["may_have_more"] is False
-        mock_client.Dataset.iterate.assert_called_once_with(offset=0, limit=1000)
+        mock_client.Dataset.iterate.assert_called_once_with(offset=0, limit=100)
 
 
 @pytest.mark.asyncio
@@ -309,7 +309,7 @@ async def test_list_ai_catalog_items_rejects_negative_offset() -> None:
 
 @pytest.mark.asyncio
 async def test_list_ai_catalog_items_clamps_invalid_limit_below_one() -> None:
-    """limit<1 is clamped to 1000; response includes a note; iterate uses limit 1000."""
+    """limit<1 is clamped to 100; response includes a note; iterate uses limit 100."""
     with (
         patch(
             "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
@@ -323,9 +323,9 @@ async def test_list_ai_catalog_items_clamps_invalid_limit_below_one() -> None:
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items(limit=0)
-        assert result["limit"] == 1000
+        assert result["limit"] == 100
         assert "Limit must be at least 1" in (result.get("note") or "")
-        mock_client.Dataset.iterate.assert_called_once_with(offset=0, limit=1000)
+        mock_client.Dataset.iterate.assert_called_once_with(offset=0, limit=100)
 
 
 @pytest.mark.asyncio
@@ -343,14 +343,14 @@ async def test_list_ai_catalog_items_clamps_limit_above_max() -> None:
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items(limit=1001)
-        assert result["limit"] == 1000
-        assert "Limit cannot exceed 1000" in (result.get("note") or "")
-        mock_client.Dataset.iterate.assert_called_once_with(offset=0, limit=1000)
+        assert result["limit"] == 100
+        assert "Limit cannot exceed 100" in (result.get("note") or "")
+        mock_client.Dataset.iterate.assert_called_once_with(offset=0, limit=100)
 
 
 @pytest.mark.asyncio
 async def test_list_ai_catalog_items_uses_default_limit() -> None:
-    """Default limit 1000 is passed to iterate and echoed in the result when not overridden."""
+    """Default limit 100 is passed to iterate and echoed in the result when not overridden."""
     with (
         patch(
             "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
@@ -373,9 +373,9 @@ async def test_list_ai_catalog_items_uses_default_limit() -> None:
         assert result["count"] == 3
         assert set(result["datasets"].keys()) == {"3", "4", "5"}
         assert result["offset"] == 2
-        assert result["limit"] == 1000
+        assert result["limit"] == 100
         assert result["may_have_more"] is False
-        mock_client.Dataset.iterate.assert_called_once_with(offset=2, limit=1000)
+        mock_client.Dataset.iterate.assert_called_once_with(offset=2, limit=100)
 
 
 @pytest.mark.asyncio
@@ -396,7 +396,7 @@ async def test_list_ai_catalog_items_empty() -> None:
         assert result["datasets"] == {}
         assert result["count"] == 0
         assert "offset" not in result
-        assert result["limit"] == 1000
+        assert result["limit"] == 100
 
 
 @pytest.mark.asyncio
@@ -529,7 +529,7 @@ async def test_get_dataset_details_sample_rows_zero_returns_no_rows() -> None:
 
 @pytest.mark.asyncio
 async def test_get_dataset_details_large_sample_rows_returns_full_frame() -> None:
-    """head(sample_rows) is bounded by the preview frame; no 1000-row cap in the tool body."""
+    """head(sample_rows) is bounded by the preview frame; unrelated to catalog pagination max."""
     with (
         patch(
             "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
@@ -663,8 +663,8 @@ async def test_list_datastores_serializes_params_from_response() -> None:
         assert data._serialize_datastore_params(params) == expected
         assert result["datastores"][0]["params"] == expected
         assert "offset" not in result
-        assert result["limit"] == 1000
-        mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 1000})
+        assert result["limit"] == 100
+        mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 100})
 
 
 @pytest.mark.asyncio
@@ -727,9 +727,9 @@ async def test_list_datastores_clamps_limit_above_max() -> None:
         mock_data_robot_client.return_value.get_client.return_value = mock_dr
 
         result = await data.list_datastores(limit=1001)
-        assert result["limit"] == 1000
-        assert "Limit cannot exceed 1000" in (result.get("note") or "")
-        mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 1000})
+        assert result["limit"] == 100
+        assert "Limit cannot exceed 100" in (result.get("note") or "")
+        mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 100})
 
 
 @pytest.mark.asyncio
@@ -755,7 +755,7 @@ async def test_browse_datastore_success() -> None:
         assert result["count"] == 2
         assert result["datastore_id"] == "store1"
         assert result["offset"] == 0
-        assert result["limit"] == 1000
+        assert result["limit"] == 100
 
 
 @pytest.mark.asyncio
@@ -823,10 +823,10 @@ async def test_browse_datastore_clamps_limit_above_max() -> None:
         mock_data_robot_client.return_value.get_client.return_value = mock_dr
 
         result = await data.browse_datastore(datastore_id="s1", limit=2000)
-        assert result["limit"] == 1000
-        assert "Limit cannot exceed 1000" in (result.get("note") or "")
+        assert result["limit"] == 100
+        assert "Limit cannot exceed 100" in (result.get("note") or "")
         mock_rest.get.assert_called_once_with(
-            "externalDataDrivers/s1/tables/", params={"offset": 0, "limit": 1000}
+            "externalDataDrivers/s1/tables/", params={"offset": 0, "limit": 100}
         )
 
 
@@ -856,7 +856,7 @@ async def test_query_datastore_success() -> None:
         assert result["row_count"] == 1
         assert result["columns"] == ["id", "val"]
         assert result["offset"] == 0
-        assert result["limit"] == 1000
+        assert result["limit"] == 100
 
 
 @pytest.mark.asyncio
@@ -878,11 +878,11 @@ async def test_query_datastore_clamps_limit_above_max() -> None:
         mock_data_robot_client.return_value.get_client.return_value = mock_dr
 
         out = await data.query_datastore(datastore_id="ds1", sql="SELECT 1", limit=2000)
-        assert out["limit"] == 1000
-        assert "Limit cannot exceed 1000" in (out.get("note") or "")
+        assert out["limit"] == 100
+        assert "Limit cannot exceed 100" in (out.get("note") or "")
         mock_rest.post.assert_called_once_with(
             "externalDataDrivers/ds1/execute/",
-            json={"query": "SELECT 1", "offset": 0, "limit": 1000},
+            json={"query": "SELECT 1", "offset": 0, "limit": 100},
         )
 
 

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -25,6 +25,41 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.predictive import data
 
 
+def test_merge_pagination_metadata_adds_offset_limit_next_total() -> None:
+    """_merge_pagination_metadata echoes offset/limit and normalizes list API pagination fields."""
+    base: dict = {"datastores": []}
+    body = {
+        "next": "https://example/api?offset=10",
+        "previous": None,
+        "total": 25,
+    }
+    out = data._merge_pagination_metadata(base, body, offset=0, limit=10)
+    assert out is base
+    assert out["offset"] == 0
+    assert out["limit"] == 10
+    assert out["next"] == "https://example/api?offset=10"
+    assert "previous" not in out
+    assert out["total_count"] == 25
+
+
+def test_merge_pagination_metadata_total_count_wins_over_total() -> None:
+    """If both total_count and total are present, total_count is used (first in iteration)."""
+    base: dict = {"x": 1}
+    body = {"total_count": 7, "total": 99}
+    out = data._merge_pagination_metadata(base, body)
+    assert out["total_count"] == 7
+
+
+def test_merge_pagination_metadata_list_body_ignored() -> None:
+    """Non-dict body does not add next/previous/total (browse/query edge cases)."""
+    base: dict = {"k": 1}
+    empty_list: list = []
+    out = data._merge_pagination_metadata(base, empty_list, offset=1, limit=2)
+    assert out["offset"] == 1
+    assert out["limit"] == 2
+    assert "next" not in out
+
+
 @pytest.mark.asyncio
 async def test_upload_dataset_to_ai_catalog_success_from_bytes() -> None:
     raw = b"a,b\n1,2\n"
@@ -262,6 +297,45 @@ async def test_list_ai_catalog_items_pagination_respects_limit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_ai_catalog_items_rejects_negative_offset() -> None:
+    with pytest.raises(ToolError, match="offset must be non-negative"):
+        await data.list_ai_catalog_items(offset=-1)
+
+
+@pytest.mark.asyncio
+async def test_list_ai_catalog_items_rejects_invalid_limit() -> None:
+    with pytest.raises(ToolError, match="limit must be at least 1"):
+        await data.list_ai_catalog_items(limit=0)
+
+
+@pytest.mark.asyncio
+async def test_list_ai_catalog_items_omit_limit_returns_rest_after_offset() -> None:
+    """When limit is None, islice stop is unbounded; all items from the iterator are returned."""
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mocks = []
+        for i in range(3, 6):
+            m = MagicMock()
+            m.id = str(i)
+            m.name = f"ds{i}"
+            mocks.append(m)
+        mock_client = MagicMock()
+        mock_client.Dataset.iterate.return_value = iter(mocks)
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        result = await data.list_ai_catalog_items(offset=2, limit=None)
+        assert result["count"] == 3
+        assert set(result["datasets"].keys()) == {"3", "4", "5"}
+        mock_client.Dataset.iterate.assert_called_once_with(offset=2, limit=None)
+
+
+@pytest.mark.asyncio
 async def test_list_ai_catalog_items_empty() -> None:
     with (
         patch(
@@ -307,6 +381,81 @@ async def test_get_dataset_details_success() -> None:
         assert result["name"] == "Test Dataset"
         assert "columns" in result
         assert "sample" in result
+        assert result["sample_offset"] == 0
+        assert result["sample_rows"] == 10
+        assert result["sample_count"] == 2
+        assert result["sample_total_available"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_dataset_details_sample_pagination_offset() -> None:
+    """sample_offset and sample_rows slice the preview frame (paged sample rows)."""
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_client = MagicMock()
+        mock_dataset = MagicMock()
+        mock_dataset.id = "ds1"
+        mock_dataset.name = "S"
+        mock_dataset.created_at = "2025-01-01"
+        mock_dataset.row_count = 5
+        mock_df = pl.DataFrame({"a": list(range(5)), "b": list(range(5, 10))}).to_pandas()
+        mock_dataset.get_raw_sample_data.return_value = mock_df
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        result = await data.get_dataset_details(
+            dataset_id="ds1",
+            sample_offset=2,
+            sample_rows=2,
+        )
+        assert result["sample_offset"] == 2
+        assert result["sample_rows"] == 2
+        assert result["sample_total_available"] == 5
+        assert result["sample_count"] == 2
+        assert result["sample"] == [
+            {"a": 2, "b": 7},
+            {"a": 3, "b": 8},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_get_dataset_details_sample_beyond_length_returns_empty() -> None:
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_client = MagicMock()
+        mock_dataset = MagicMock()
+        mock_dataset.id = "ds1"
+        mock_dataset.name = "S"
+        mock_dataset.created_at = "2025-01-01"
+        mock_df = pl.DataFrame({"a": [0]}).to_pandas()
+        mock_dataset.get_raw_sample_data.return_value = mock_df
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        result = await data.get_dataset_details(dataset_id="ds1", sample_offset=5, sample_rows=3)
+        assert result["sample"] == []
+        assert result["sample_count"] == 0
+        assert result["sample_total_available"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_dataset_details_rejects_invalid_sample_pagination() -> None:
+    with pytest.raises(ToolError, match="sample_offset must be non-negative"):
+        await data.get_dataset_details(dataset_id="x", sample_offset=-1)
+    with pytest.raises(ToolError, match="sample_rows must be at least 1"):
+        await data.get_dataset_details(dataset_id="x", sample_rows=0)
 
 
 @pytest.mark.asyncio
@@ -340,6 +489,18 @@ async def test_get_dataset_details_no_sample() -> None:
 
 @pytest.mark.asyncio
 async def test_list_datastores_success() -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "id": "store1",
+                "canonicalName": "My Store",
+                "creatorId": "user1",
+                "params": {"type": "jdbc"},
+            }
+        ],
+        "next": "https://app.datarobot.com/api/v2/externalDataStores/?offset=10&limit=10",
+    }
     with (
         patch(
             "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
@@ -348,30 +509,48 @@ async def test_list_datastores_success() -> None:
         ),
         patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
     ):
-        mock_client = MagicMock()
-        mock_ds = MagicMock()
-        mock_ds.id = "store1"
-        mock_ds.canonical_name = "My Store"
-        mock_ds.creator_id = "user1"
-        mock_ds.params = {"type": "jdbc"}
-        mock_client.DataStore.list.return_value = [mock_ds]
-        mock_data_robot_client.return_value.get_client.return_value = mock_client
+        mock_rest = MagicMock()
+        mock_rest.get.return_value = mock_response
+        mock_dr = MagicMock()
+        mock_dr.client.get_client.return_value = mock_rest
+        mock_data_robot_client.return_value.get_client.return_value = mock_dr
 
-        result = await data.list_datastores()
+        result = await data.list_datastores(offset=0, limit=10)
         assert isinstance(result, dict)
         assert result["count"] == 1
         assert result["datastores"][0]["id"] == "store1"
+        assert result["offset"] == 0
+        assert result["limit"] == 10
+        assert "next" in result
+        mock_rest.get.assert_called_once_with(
+            "externalDataStores/", params={"offset": 0, "limit": 10}
+        )
 
 
 @pytest.mark.asyncio
-async def test_list_datastores_serializes_sdk_params() -> None:
-    """SDK returns DataStoreParameters objects; tool output must be JSON-serializable."""
+async def test_list_datastores_serializes_params_from_response() -> None:
+    """API `params` may be plain dicts; _serialize_datastore_params keeps output JSON-friendly."""
     params = DataStoreParameters(
         driver_id="pg",
         jdbc_url="jdbc:postgresql://host/db",
         fields=None,
         connector_id=None,
     )
+    expected = {
+        "driver_id": "pg",
+        "jdbc_url": "jdbc:postgresql://host/db",
+    }
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "id": "store1",
+                "canonicalName": "My Store",
+                "creatorId": "user1",
+                "params": expected,
+            }
+        ],
+    }
     with (
         patch(
             "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
@@ -380,20 +559,58 @@ async def test_list_datastores_serializes_sdk_params() -> None:
         ),
         patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
     ):
-        mock_client = MagicMock()
-        mock_ds = MagicMock()
-        mock_ds.id = "store1"
-        mock_ds.canonical_name = "My Store"
-        mock_ds.creator_id = "user1"
-        mock_ds.params = params
-        mock_client.DataStore.list.return_value = [mock_ds]
-        mock_data_robot_client.return_value.get_client.return_value = mock_client
+        mock_rest = MagicMock()
+        mock_rest.get.return_value = mock_response
+        mock_dr = MagicMock()
+        mock_dr.client.get_client.return_value = mock_rest
+        mock_data_robot_client.return_value.get_client.return_value = mock_dr
 
         result = await data.list_datastores()
-        assert result["datastores"][0]["params"] == {
-            "driver_id": "pg",
-            "jdbc_url": "jdbc:postgresql://host/db",
-        }
+        assert data._serialize_datastore_params(params) == expected
+        assert result["datastores"][0]["params"] == expected
+        assert "offset" not in result
+        assert "limit" not in result
+
+
+@pytest.mark.asyncio
+async def test_list_datastores_pagination_total_count_from_api() -> None:
+    """API may return total_count; merge exposes it as total_count on the tool result."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "id": "a",
+                "canonicalName": "A",
+                "creatorId": "c1",
+                "params": {},
+            }
+        ],
+        "total_count": 42,
+        "previous": "https://api/prev",
+    }
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_rest = MagicMock()
+        mock_rest.get.return_value = mock_response
+        mock_dr = MagicMock()
+        mock_dr.client.get_client.return_value = mock_rest
+        mock_data_robot_client.return_value.get_client.return_value = mock_dr
+
+        result = await data.list_datastores(offset=5, limit=1)
+        assert result["count"] == 1
+        assert result["offset"] == 5
+        assert result["limit"] == 1
+        assert result["total_count"] == 42
+        assert result["previous"] == "https://api/prev"
+        mock_rest.get.assert_called_once_with(
+            "externalDataStores/", params={"offset": 5, "limit": 1}
+        )
 
 
 @pytest.mark.asyncio
@@ -418,6 +635,48 @@ async def test_browse_datastore_success() -> None:
         assert isinstance(result, dict)
         assert result["count"] == 2
         assert result["datastore_id"] == "store1"
+        assert result["offset"] == 0
+        assert result["limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_browse_datastore_pagination_from_api_response() -> None:
+    """Browse passes offset/limit to the API and forwards next/total from the response body."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [{"name": "t1"}],
+        "next": "https://x/tables?offset=20",
+        "total": 100,
+    }
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_rest = MagicMock()
+        mock_rest.get.return_value = mock_response
+        mock_dr = MagicMock()
+        mock_dr.client.get_client.return_value = mock_rest
+        mock_data_robot_client.return_value.get_client.return_value = mock_dr
+
+        result = await data.browse_datastore(
+            datastore_id="store1",
+            path="/s",
+            offset=10,
+            limit=5,
+        )
+        assert result["count"] == 1
+        assert result["offset"] == 10
+        assert result["limit"] == 5
+        assert result["next"] == "https://x/tables?offset=20"
+        assert result["total_count"] == 100
+        mock_rest.get.assert_called_once_with(
+            "externalDataDrivers/store1/tables/",
+            params={"offset": 10, "limit": 5, "path": "/s"},
+        )
 
 
 @pytest.mark.asyncio
@@ -451,6 +710,49 @@ async def test_query_datastore_success() -> None:
         assert isinstance(result, dict)
         assert result["row_count"] == 1
         assert result["columns"] == ["id", "val"]
+        assert result["offset"] == 0
+        assert result["limit"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_query_datastore_pagination_offset_limit_and_response_metadata() -> None:
+    """Query sends offset/limit in the JSON body and merges pagination fields from the response."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [],
+        "columns": ["a"],
+        "next": "https://x/execute?offset=75",
+        "total_count": 200,
+    }
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_rest = MagicMock()
+        mock_rest.post.return_value = mock_response
+        mock_dr = MagicMock()
+        mock_dr.client.get_client.return_value = mock_rest
+        mock_data_robot_client.return_value.get_client.return_value = mock_dr
+
+        result = await data.query_datastore(
+            datastore_id="ds99",
+            sql="SELECT 1",
+            offset=50,
+            limit=25,
+        )
+        assert result["row_count"] == 0
+        assert result["offset"] == 50
+        assert result["limit"] == 25
+        assert result["next"] == "https://x/execute?offset=75"
+        assert result["total_count"] == 200
+        mock_rest.post.assert_called_once_with(
+            "externalDataDrivers/ds99/execute/",
+            json={"query": "SELECT 1", "offset": 50, "limit": 25},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -780,28 +780,9 @@ async def test_browse_datastore_missing_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_browse_datastore_clamps_limit_to_pagination_max() -> None:
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"data": []}
-    with (
-        patch(
-            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
-            new_callable=AsyncMock,
-            return_value="token",
-        ),
-        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
-    ):
-        mock_rest = MagicMock()
-        mock_rest.get.return_value = mock_response
-        mock_dr = MagicMock()
-        mock_dr.client.get_client.return_value = mock_rest
-        mock_data_robot_client.return_value.get_client.return_value = mock_dr
-
-        result = await data.browse_datastore(datastore_id="s1", limit=2000)
-        assert result["limit"] == 1000
-        mock_rest.get.assert_called_once_with(
-            "externalDataDrivers/s1/tables/", params={"offset": 0, "limit": 1000}
-        )
+async def test_browse_datastore_rejects_limit_above_max() -> None:
+    with pytest.raises(ToolError, match="limit cannot exceed 1000"):
+        await data.browse_datastore(datastore_id="s1", limit=2000)
 
 
 @pytest.mark.asyncio
@@ -834,28 +815,9 @@ async def test_query_datastore_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_query_datastore_clamps_limit_to_pagination_max() -> None:
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"data": [], "columns": []}
-    with (
-        patch(
-            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
-            new_callable=AsyncMock,
-            return_value="token",
-        ),
-        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
-    ):
-        mock_rest = MagicMock()
-        mock_rest.post.return_value = mock_response
-        mock_dr = MagicMock()
-        mock_dr.client.get_client.return_value = mock_rest
-        mock_data_robot_client.return_value.get_client.return_value = mock_dr
-
+async def test_query_datastore_rejects_limit_above_max() -> None:
+    with pytest.raises(ToolError, match="limit cannot exceed 1000"):
         await data.query_datastore(datastore_id="ds1", sql="SELECT 1", limit=2000)
-        mock_rest.post.assert_called_once_with(
-            "externalDataDrivers/ds1/execute/",
-            json={"query": "SELECT 1", "offset": 0, "limit": 1000},
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -293,6 +293,9 @@ async def test_list_ai_catalog_items_pagination_respects_limit() -> None:
 
         assert result["count"] == 3
         assert set(result["datasets"].keys()) == {"1", "2", "3"}
+        assert result["offset"] == 1
+        assert result["limit"] == 3
+        assert result["may_have_more"] is True
         mock_client.Dataset.iterate.assert_called_once_with(offset=1, limit=3)
 
 
@@ -332,6 +335,9 @@ async def test_list_ai_catalog_items_omit_limit_returns_rest_after_offset() -> N
         result = await data.list_ai_catalog_items(offset=2, limit=None)
         assert result["count"] == 3
         assert set(result["datasets"].keys()) == {"3", "4", "5"}
+        assert result["offset"] == 2
+        assert "limit" not in result
+        assert "may_have_more" not in result
         mock_client.Dataset.iterate.assert_called_once_with(offset=2, limit=None)
 
 
@@ -351,6 +357,53 @@ async def test_list_ai_catalog_items_empty() -> None:
 
         result = await data.list_ai_catalog_items()
         assert result["datasets"] == []
+        assert result["count"] == 0
+        assert "offset" not in result
+        assert "limit" not in result
+
+
+@pytest.mark.asyncio
+async def test_list_ai_catalog_items_empty_paged_includes_count_and_pagination_echo() -> None:
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_client = MagicMock()
+        mock_client.Dataset.iterate.return_value = iter([])
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        result = await data.list_ai_catalog_items(offset=10, limit=5)
+        assert result["datasets"] == []
+        assert result["count"] == 0
+        assert result["offset"] == 10
+        assert result["limit"] == 5
+        assert "may_have_more" not in result
+
+
+@pytest.mark.asyncio
+async def test_list_ai_catalog_may_have_more_false_when_page_not_full() -> None:
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        m1, m2 = MagicMock(), MagicMock()
+        m1.id, m1.name = "a", "A"
+        m2.id, m2.name = "b", "B"
+        mock_client = MagicMock()
+        mock_client.Dataset.iterate.return_value = iter([m1, m2])
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        result = await data.list_ai_catalog_items(offset=0, limit=5)
+        assert result["count"] == 2
+        assert result["may_have_more"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -19,9 +19,11 @@ from unittest.mock import patch
 
 import polars as pl
 import pytest
+from datarobot.errors import ClientError
 from datarobot.models.data_store import DataStoreParameters
 
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.predictive import data
 
 
@@ -956,3 +958,32 @@ async def test_list_ai_catalog_items_error() -> None:
         with pytest.raises(Exception) as exc_info:
             await data.list_ai_catalog_items()
         assert "fail" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_list_ai_catalog_items_client_error_during_lazy_iteration() -> None:
+
+    def _gen_raises_on_consume():
+        raise ClientError(
+            "500 client error: {'message': 'Server Error'}",
+            status_code=500,
+            json={"message": "Server Error"},
+        )
+        yield  # pragma: no cover — makes this a generator; first next() runs raise first
+
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_client = MagicMock()
+        mock_client.Dataset.iterate.return_value = _gen_raises_on_consume()
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        with pytest.raises(ToolError) as exc_info:
+            await data.list_ai_catalog_items()
+        assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+        assert "500" in str(exc_info.value)

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -356,7 +356,7 @@ async def test_list_ai_catalog_items_empty() -> None:
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items()
-        assert result["datasets"] == []
+        assert result["datasets"] == {}
         assert result["count"] == 0
         assert "offset" not in result
         assert "limit" not in result
@@ -377,7 +377,7 @@ async def test_list_ai_catalog_items_empty_paged_includes_count_and_pagination_e
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items(offset=10, limit=5)
-        assert result["datasets"] == []
+        assert result["datasets"] == {}
         assert result["count"] == 0
         assert result["offset"] == 10
         assert result["limit"] == 5

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -264,7 +264,9 @@ async def test_list_ai_catalog_items_success() -> None:
         # datasets is now a dict mapping id to name
         assert result["datasets"]["1"] == "ds1"
         assert result["datasets"]["2"] == "ds2"
-        mock_client.Dataset.iterate.assert_called_once_with(offset=None, limit=None)
+        assert result["limit"] == 1000
+        assert result["may_have_more"] is False
+        mock_client.Dataset.iterate.assert_called_once_with(offset=None, limit=1000)
 
 
 @pytest.mark.asyncio
@@ -312,8 +314,14 @@ async def test_list_ai_catalog_items_rejects_invalid_limit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_ai_catalog_items_omit_limit_returns_rest_after_offset() -> None:
-    """When limit is None, islice stop is unbounded; all items from the iterator are returned."""
+async def test_list_ai_catalog_items_rejects_limit_above_max() -> None:
+    with pytest.raises(ToolError, match="limit cannot exceed 1000"):
+        await data.list_ai_catalog_items(limit=1001)
+
+
+@pytest.mark.asyncio
+async def test_list_ai_catalog_items_omit_limit_uses_default_cap() -> None:
+    """When limit is None, 1000 is passed to iterate and echoed in the result."""
     with (
         patch(
             "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
@@ -336,9 +344,9 @@ async def test_list_ai_catalog_items_omit_limit_returns_rest_after_offset() -> N
         assert result["count"] == 3
         assert set(result["datasets"].keys()) == {"3", "4", "5"}
         assert result["offset"] == 2
-        assert "limit" not in result
-        assert "may_have_more" not in result
-        mock_client.Dataset.iterate.assert_called_once_with(offset=2, limit=None)
+        assert result["limit"] == 1000
+        assert result["may_have_more"] is False
+        mock_client.Dataset.iterate.assert_called_once_with(offset=2, limit=1000)
 
 
 @pytest.mark.asyncio
@@ -359,7 +367,7 @@ async def test_list_ai_catalog_items_empty() -> None:
         assert result["datasets"] == {}
         assert result["count"] == 0
         assert "offset" not in result
-        assert "limit" not in result
+        assert result["limit"] == 1000
 
 
 @pytest.mark.asyncio
@@ -512,6 +520,32 @@ async def test_get_dataset_details_rejects_invalid_sample_pagination() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_dataset_details_clamps_sample_rows_to_pagination_max() -> None:
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_client = MagicMock()
+        mock_dataset = MagicMock()
+        mock_dataset.id = "ds1"
+        mock_dataset.name = "S"
+        mock_dataset.created_at = "2025-01-01"
+        mock_df = pl.DataFrame({"a": list(range(10))}).to_pandas()
+        mock_dataset.get_raw_sample_data.return_value = mock_df
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        result = await data.get_dataset_details(dataset_id="ds1", sample_offset=0, sample_rows=5000)
+        assert result["sample_rows"] == 1000
+        assert result["sample_count"] == 10
+        assert len(result["sample"]) == 10
+
+
+@pytest.mark.asyncio
 async def test_get_dataset_details_missing_id() -> None:
     with pytest.raises(ToolError, match="Dataset ID must be provided"):
         await data.get_dataset_details()
@@ -622,7 +656,8 @@ async def test_list_datastores_serializes_params_from_response() -> None:
         assert data._serialize_datastore_params(params) == expected
         assert result["datastores"][0]["params"] == expected
         assert "offset" not in result
-        assert "limit" not in result
+        assert result["limit"] == 1000
+        mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 1000})
 
 
 @pytest.mark.asyncio
@@ -664,6 +699,12 @@ async def test_list_datastores_pagination_total_count_from_api() -> None:
         mock_rest.get.assert_called_once_with(
             "externalDataStores/", params={"offset": 5, "limit": 1}
         )
+
+
+@pytest.mark.asyncio
+async def test_list_datastores_rejects_limit_above_max() -> None:
+    with pytest.raises(ToolError, match="limit cannot exceed 1000"):
+        await data.list_datastores(limit=1001)
 
 
 @pytest.mark.asyncio
@@ -739,6 +780,31 @@ async def test_browse_datastore_missing_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_browse_datastore_clamps_limit_to_pagination_max() -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": []}
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_rest = MagicMock()
+        mock_rest.get.return_value = mock_response
+        mock_dr = MagicMock()
+        mock_dr.client.get_client.return_value = mock_rest
+        mock_data_robot_client.return_value.get_client.return_value = mock_dr
+
+        result = await data.browse_datastore(datastore_id="s1", limit=2000)
+        assert result["limit"] == 1000
+        mock_rest.get.assert_called_once_with(
+            "externalDataDrivers/s1/tables/", params={"offset": 0, "limit": 1000}
+        )
+
+
+@pytest.mark.asyncio
 async def test_query_datastore_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -765,6 +831,31 @@ async def test_query_datastore_success() -> None:
         assert result["columns"] == ["id", "val"]
         assert result["offset"] == 0
         assert result["limit"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_query_datastore_clamps_limit_to_pagination_max() -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [], "columns": []}
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        mock_rest = MagicMock()
+        mock_rest.post.return_value = mock_response
+        mock_dr = MagicMock()
+        mock_dr.client.get_client.return_value = mock_rest
+        mock_data_robot_client.return_value.get_client.return_value = mock_dr
+
+        await data.query_datastore(datastore_id="ds1", sql="SELECT 1", limit=2000)
+        mock_rest.post.assert_called_once_with(
+            "externalDataDrivers/ds1/execute/",
+            json={"query": "SELECT 1", "offset": 0, "limit": 1000},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -221,7 +221,7 @@ async def test_list_ai_catalog_items_success() -> None:
         mock_ds2 = MagicMock()
         mock_ds2.id = "2"
         mock_ds2.name = "ds2"
-        mock_client.Dataset.list.return_value = [mock_ds1, mock_ds2]
+        mock_client.Dataset.iterate.return_value = iter([mock_ds1, mock_ds2])
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items()
@@ -229,6 +229,36 @@ async def test_list_ai_catalog_items_success() -> None:
         # datasets is now a dict mapping id to name
         assert result["datasets"]["1"] == "ds1"
         assert result["datasets"]["2"] == "ds2"
+        mock_client.Dataset.iterate.assert_called_once_with(offset=None, limit=None)
+
+
+@pytest.mark.asyncio
+async def test_list_ai_catalog_items_pagination_respects_limit() -> None:
+    """``limit`` caps items per call even if the iterator would yield more (SDK pages)."""
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
+    ):
+        row_mocks = []
+        for i in range(5):
+            m = MagicMock()
+            m.id = str(i)
+            m.name = f"ds{i}"
+            row_mocks.append(m)
+        mock_client = MagicMock()
+        # Simulate a generator that would keep going (e.g. multiple server pages)
+        mock_client.Dataset.iterate.return_value = iter(row_mocks[1:])
+        mock_data_robot_client.return_value.get_client.return_value = mock_client
+
+        result = await data.list_ai_catalog_items(offset=1, limit=3)
+
+        assert result["count"] == 3
+        assert set(result["datasets"].keys()) == {"1", "2", "3"}
+        mock_client.Dataset.iterate.assert_called_once_with(offset=1, limit=3)
 
 
 @pytest.mark.asyncio
@@ -242,7 +272,7 @@ async def test_list_ai_catalog_items_empty() -> None:
         patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
     ):
         mock_client = MagicMock()
-        mock_client.Dataset.list.return_value = []
+        mock_client.Dataset.iterate.return_value = iter([])
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         result = await data.list_ai_catalog_items()
@@ -446,7 +476,7 @@ async def test_list_ai_catalog_items_error() -> None:
         patch("datarobot_genai.drtools.predictive.data.DataRobotClient") as mock_data_robot_client,
     ):
         mock_client = MagicMock()
-        mock_client.Dataset.list.side_effect = Exception("fail")
+        mock_client.Dataset.iterate.side_effect = Exception("fail")
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
         with pytest.raises(Exception) as exc_info:

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -266,7 +266,7 @@ async def test_list_ai_catalog_items_success() -> None:
         assert result["datasets"]["2"] == "ds2"
         assert result["limit"] == 1000
         assert result["may_have_more"] is False
-        mock_client.Dataset.iterate.assert_called_once_with(offset=None, limit=1000)
+        mock_client.Dataset.iterate.assert_called_once_with(offset=0, limit=1000)
 
 
 @pytest.mark.asyncio
@@ -320,8 +320,8 @@ async def test_list_ai_catalog_items_rejects_limit_above_max() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_ai_catalog_items_omit_limit_uses_default_cap() -> None:
-    """When limit is None, 1000 is passed to iterate and echoed in the result."""
+async def test_list_ai_catalog_items_uses_default_limit() -> None:
+    """Default limit 1000 is passed to iterate and echoed in the result when not overridden."""
     with (
         patch(
             "datarobot_genai.drtools.predictive.data.get_datarobot_access_token",
@@ -340,7 +340,7 @@ async def test_list_ai_catalog_items_omit_limit_uses_default_cap() -> None:
         mock_client.Dataset.iterate.return_value = iter(mocks)
         mock_data_robot_client.return_value.get_client.return_value = mock_client
 
-        result = await data.list_ai_catalog_items(offset=2, limit=None)
+        result = await data.list_ai_catalog_items(offset=2)
         assert result["count"] == 3
         assert set(result["datasets"].keys()) == {"3", "4", "5"}
         assert result["offset"] == 2
@@ -730,7 +730,7 @@ async def test_browse_datastore_success() -> None:
         assert result["count"] == 2
         assert result["datastore_id"] == "store1"
         assert result["offset"] == 0
-        assert result["limit"] == 100
+        assert result["limit"] == 1000
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.16"
+version = "0.15.17"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Implements pagination for predictive data MCP tools for catalog, dataset samples, and datastore browsing/querying.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the request/response shapes and defaults for several predictive data tools (`list_ai_catalog_items`, `list_datastores`, `browse_datastore`, `query_datastore`), which could break clients relying on prior non-paginated behavior. Also switches `list_datastores` to a raw REST endpoint, so correctness depends on response shape and pagination fields.
> 
> **Overview**
> **Adds first-class pagination across predictive data MCP tools.** `list_ai_catalog_items`, `list_datastores`, `browse_datastore`, and `query_datastore` now accept `offset`/`limit`, enforce a max page size of `100`, and return pagination metadata (`offset`, `limit`, optional `note`, plus `next`/`previous`/`total_count` when provided by the API).
> 
> `list_ai_catalog_items` switches from `Dataset.list()` to `Dataset.iterate()` and changes empty results from a list to an empty dict, adding a `may_have_more` hint when a page is full. `list_datastores` switches from SDK listing to calling `GET externalDataStores/` directly and normalizes returned fields/params.
> 
> Also tightens error handling by mapping DataRobot `ClientError` to tool errors for dataset uploads and the new paginated calls, updates stubs/tests accordingly, and bumps the package version to `0.15.30` with a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d0f79e11a4328e1ec3ca7208c3c0c04df7dc6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->