### PR TITLE
[MODEL-23227] Improve error handling in lineage feature flag retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.18
+- Improved error handling during MCP lineage feature flag retrieval
+
 ## 0.15.17
 - Added option to configure OAuth2 token exchange flow for server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.17"
+version = "0.15.18"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -30,12 +30,9 @@ class FeatureFlag:
         flags_json = {"entitlements": [{"name": feature_flag_name}]}
         response = client.post("entitlements/evaluate/", json=flags_json)
 
-        json_response = response.json()
-        has_entitlement_return = "entitlements" in json_response
         try:
-            feature_enabled = (
-                bool(json_response["entitlements"][0]["value"]) if has_entitlement_return else False
-            )
+            json_response = response.json()
+            feature_enabled = bool(json_response["entitlements"][0]["value"])
         except (IndexError, KeyError):
             feature_enabled = False
         return cls(name=feature_flag_name, enabled=feature_enabled)

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -34,7 +34,9 @@ class FeatureFlag:
         has_entitlement_return = "entitlements" in json_response
         return cls(
             name=feature_flag_name,
-            enabled=bool(json_response["entitlements"][0]) if has_entitlement_return else False,
+            enabled=bool(json_response["entitlements"][0]["value"])
+            if has_entitlement_return
+            else False,
         )
 
     @classmethod

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -30,10 +30,11 @@ class FeatureFlag:
         flags_json = {"entitlements": [{"name": feature_flag_name}]}
         response = client.post("entitlements/evaluate/", json=flags_json)
 
-        feature_flag_info = response.json()["entitlements"][0]
+        json_response = response.json()
+        has_entitlement_return = "entitlements" in json_response
         return cls(
-            name=feature_flag_info["name"],
-            enabled=bool(feature_flag_info["value"]),
+            name=feature_flag_name,
+            enabled=bool(json_response["entitlements"][0]) if has_entitlement_return else False,
         )
 
     @classmethod

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -32,12 +32,13 @@ class FeatureFlag:
 
         json_response = response.json()
         has_entitlement_return = "entitlements" in json_response
-        return cls(
-            name=feature_flag_name,
-            enabled=bool(json_response["entitlements"][0]["value"])
-            if has_entitlement_return
-            else False,
-        )
+        try:
+            feature_enabled = (
+                bool(json_response["entitlements"][0]["value"]) if has_entitlement_return else False
+            )
+        except (IndexError, KeyError):
+            feature_enabled = False
+        return cls(name=feature_flag_name, enabled=feature_enabled)
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from dataclasses import dataclass
 from functools import lru_cache
 
 from datarobot_genai.drmcp.core.clients import (
     setup_and_return_dr_api_client_with_static_config_in_container,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -34,6 +37,8 @@ class FeatureFlag:
             json_response = response.json()
             feature_enabled = bool(json_response["entitlements"][0]["value"])
         except (IndexError, KeyError, TypeError):
+            message = f"Feature flag {feature_flag_name} can't be evaluated. It falls back to False"
+            logger.warning(message)
             feature_enabled = False
         return cls(name=feature_flag_name, enabled=feature_enabled)
 

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -33,7 +33,7 @@ class FeatureFlag:
         try:
             json_response = response.json()
             feature_enabled = bool(json_response["entitlements"][0]["value"])
-        except (IndexError, KeyError):
+        except (IndexError, KeyError, TypeError):
             feature_enabled = False
         return cls(name=feature_flag_name, enabled=feature_enabled)
 

--- a/tests/drmcp/unit/core/test_feature_flags.py
+++ b/tests/drmcp/unit/core/test_feature_flags.py
@@ -59,7 +59,7 @@ class TestFeatureFlags:
 
     @pytest.mark.parametrize(
         "feature_flag_api_response",
-        [{}, {"entitlements": []}, {"entitlements": [{}]}],
+        [{}, {"entitlements": []}, {"entitlements": [{}]}, {"entitlements": None}],
     )
     def test_fallback_to_feature_flag_enablement_false(
         self,

--- a/tests/drmcp/unit/core/test_feature_flags.py
+++ b/tests/drmcp/unit/core/test_feature_flags.py
@@ -55,6 +55,21 @@ class TestFeatureFlags:
             name=expected_feature_flag_name, enabled=bool(expected_feature_status)
         )
 
+    def test_fallback_to_feature_flag_enablement_false(
+        self, mock_get_datarobot_client: Mock
+    ) -> None:
+        mock_datarobot_client = mock_get_datarobot_client.return_value
+        mock_datarobot_client.post.return_value.json.return_value = {}
+
+        expected_feature_flag_name = Mock()
+        output = FeatureFlag.create(expected_feature_flag_name)
+
+        mock_datarobot_client.post.assert_called_once_with(
+            "entitlements/evaluate/",
+            json={"entitlements": [{"name": expected_feature_flag_name}]},
+        )
+        assert output == FeatureFlag(name=expected_feature_flag_name, enabled=False)
+
     def test_is_mcp_tools_gallery_support_enabled(self, mock_feature_flag_create: Mock) -> None:
         output = FeatureFlag.is_mcp_tools_gallery_support_enabled()
 

--- a/tests/drmcp/unit/core/test_feature_flags.py
+++ b/tests/drmcp/unit/core/test_feature_flags.py
@@ -37,12 +37,12 @@ class TestFeatureFlags:
         with patch.object(FeatureFlag, "create") as mock_func:
             yield mock_func
 
-    def test_create(self, mock_get_datarobot_client: Mock) -> None:
+    @pytest.mark.parametrize("feature_flag_value", [True, False], ids=str)
+    def test_create(self, mock_get_datarobot_client: Mock, feature_flag_value: bool) -> None:
         mock_datarobot_client = mock_get_datarobot_client.return_value
         expected_feature_flag_name = Mock()
-        expected_feature_status = Mock()
         mock_datarobot_client.post.return_value.json.return_value = {
-            "entitlements": [{"name": expected_feature_flag_name, "value": expected_feature_status}]
+            "entitlements": [{"name": expected_feature_flag_name, "value": feature_flag_value}]
         }
 
         output = FeatureFlag.create(expected_feature_flag_name)
@@ -52,7 +52,8 @@ class TestFeatureFlags:
             json={"entitlements": [{"name": expected_feature_flag_name}]},
         )
         assert output == FeatureFlag(
-            name=expected_feature_flag_name, enabled=bool(expected_feature_status)
+            name=expected_feature_flag_name,
+            enabled=feature_flag_value,
         )
 
     def test_fallback_to_feature_flag_enablement_false(

--- a/tests/drmcp/unit/core/test_feature_flags.py
+++ b/tests/drmcp/unit/core/test_feature_flags.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Iterator
+from typing import Any
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -56,11 +57,17 @@ class TestFeatureFlags:
             enabled=feature_flag_value,
         )
 
+    @pytest.mark.parametrize(
+        "feature_flag_api_response",
+        [{}, {"entitlements": []}, {"entitlements": [{}]}],
+    )
     def test_fallback_to_feature_flag_enablement_false(
-        self, mock_get_datarobot_client: Mock
+        self,
+        mock_get_datarobot_client: Mock,
+        feature_flag_api_response: dict[str, Any],
     ) -> None:
         mock_datarobot_client = mock_get_datarobot_client.return_value
-        mock_datarobot_client.post.return_value.json.return_value = {}
+        mock_datarobot_client.post.return_value.json.return_value = feature_flag_api_response
 
         expected_feature_flag_name = Mock()
         output = FeatureFlag.create(expected_feature_flag_name)

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.17"
+version = "0.15.18"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
This PR improved the error handling during MCP lineage feature flag retrieval.


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change that adds defensive parsing and a warning log for malformed feature-flag API responses, plus unit test coverage and a version bump.
> 
> **Overview**
> **Improves robustness of feature flag evaluation** by making `FeatureFlag.create()` tolerate malformed/empty `entitlements/evaluate/` responses, logging a warning and defaulting the flag to `False` instead of raising.
> 
> Updates unit tests to cover both `True`/`False` values and multiple invalid API response shapes, and bumps the package/changelog version to `0.15.18`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3c2c8a65ed344722e9a5890639cf83d479fad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->