### PR TITLE
[BUZZOK-30415] Extend RFC-8693 token exchange configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.20
-- OAuth2 token exchange configuration now use a nested two-step structure (passport requirement + exchange payload) instead of flat fields.
+- OAuth2 token exchange configuration now use a nested `subject_token_constraints` and `token_exchange_request`, with AgentCard extension.
 
 ## 0.15.19
 - Removed unnecessary packages with exclude to reduce the dependency footprint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.20
+- A2A `oauth_token_exchange` and its AgentCard extension now use a nested two-step structure (passport requirement + exchange payload) instead of flat fields.
+
 ## 0.15.19
 - Removed unnecessary packages with exclude to reduce the dependency footprint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.20
-- A2A `oauth_token_exchange` and its AgentCard extension now use a nested two-step structure (passport requirement + exchange payload) instead of flat fields.
+- OAuth2 token exchange configuration now use a nested two-step structure (passport requirement + exchange payload) instead of flat fields.
 
 ## 0.15.19
 - Removed unnecessary packages with exclude to reduce the dependency footprint

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -939,7 +939,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.19"
+version = "0.15.20"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.19"
+version = "0.15.20"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -162,19 +162,19 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
     def _token_exchange_capability_extension(
         config: OAuth2TokenExchangeConfig,
     ) -> list[AgentExtension]:
-        """Build the RFC 8693 extension for the agent card (two-step flow).
+        """Build the RFC 8693 extension for the agent card (OAuth2 token exchange).
 
         OpenAPI ``token_url`` / ``scopes`` remain on ``securitySchemes.oauth2.flows``.
-        ``params`` carries Step 1 (passport) and Step 2 (Okta exchange) only, plus a
-        ``ref`` to the client-credentials flow for unambiguous SDK binding.
+        ``params`` carries ``subject_token_constraints``, ``token_exchange_request``,
+        and ``ref`` binding to the client-credentials flow.
         """
         params = {
             "ref": {
                 "scheme": RFC8693_SECURITY_SCHEME_REF,
                 "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
             },
-            "passport_requirement": config.passport_requirement.model_dump(),
-            "exchange_payload": config.exchange_payload.model_dump(),
+            "subject_token_constraints": config.subject_token_constraints.model_dump(),
+            "token_exchange_request": config.token_exchange_request.model_dump(),
         }
         return [
             AgentExtension(

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -58,14 +58,12 @@ OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
     "audience specifications."
 )
 
-# The extension explicitly references the security scheme key so SDKs can resolve
-# the RFC 8693 Token Exchange override without ambiguity.
+# params.ref points at securitySchemes.oauth2 + clientCredentials for SDK binding.
 RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
-RFC8693_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
 RFC8693_SECURITY_SCHEME_REF = "oauth2"  # The key in securitySchemes
 RFC8693_SECURITY_SCHEME_FLOW_REF = "clientCredentials"  # The exact flow being overridden
 RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION = (
-    "Overrides the referenced security scheme with RFC 8693 Token Exchange requirements."
+    "Two-Step RFC 8693 Token Exchange execution parameters."
 )
 
 
@@ -163,20 +161,20 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
     def _token_exchange_capability_extension(
         config: OAuth2TokenExchangeConfig,
     ) -> list[AgentExtension]:
-        """Build the RFC 8693 binder extension for the agent card.
+        """Build the RFC 8693 extension for the agent card (two-step flow).
 
-        Binds the extension to the named security scheme (``security_scheme_ref``) so SDKs
-        can unambiguously resolve which OAuth2 flow requires the token exchange override.
-        Scopes are the single source of truth: they stay under ``flows.clientCredentials``
-        and are never duplicated here.
+        OpenAPI ``token_url`` / ``scopes`` remain on ``securitySchemes.oauth2.flows``.
+        ``params`` carries Step 1 (passport) and Step 2 (Okta exchange) only, plus a
+        ``ref`` to the client-credentials flow for unambiguous SDK binding.
         """
-        params: dict[str, str] = {
-            "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
-            "flow_ref": RFC8693_SECURITY_SCHEME_FLOW_REF,
-            "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
+        params = {
+            "ref": {
+                "scheme": RFC8693_SECURITY_SCHEME_REF,
+                "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
+            },
+            "passport_requirement": config.passport_requirement.model_dump(),
+            "exchange_payload": config.exchange_payload.model_dump(),
         }
-        if config.audience is not None:
-            params["audience"] = config.audience
         return [
             AgentExtension(
                 uri=RFC8693_GRANT_TYPE_URI,

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -58,7 +58,8 @@ OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
     "audience specifications."
 )
 
-# params.ref points at securitySchemes.oauth2 + clientCredentials for SDK binding.
+# The extension explicitly references the security scheme key so SDKs can resolve
+# the RFC 8693 Token Exchange override without ambiguity.
 RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
 RFC8693_SECURITY_SCHEME_REF = "oauth2"  # The key in securitySchemes
 RFC8693_SECURITY_SCHEME_FLOW_REF = "clientCredentials"  # The exact flow being overridden

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -52,9 +52,9 @@ class DRAgentA2AConfig(BaseModel):
         default=None,
         description=(
             "Configuration for agent authorization using Token Exchange (RFC 8693). "
-            "If provided, the token_url, audience, and scopes will be used to perform a "
-            "token exchange, allowing the client to dynamically obtain a scoped JWT during "
-            "the second phase of authentication."
+            "If provided, `token_url` and `scopes` populate OpenAPI security schemes; "
+            "`passport_requirement` and `exchange_payload` describe the two-step flow "
+            "(ID-JAG passport, then Okta token exchange) in the agent card extension."
         ),
     )
     skills: list[AgentSkill] = Field(

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -15,33 +15,62 @@
 from __future__ import annotations
 
 from nat.data_models.authentication import AuthProviderBaseConfig
+from pydantic import BaseModel
 from pydantic import Field
 
 
-class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
-    """OAuth2 Server-side authentication configuration for token exchange.
+class OAuth2PassportRequirement(BaseModel):
+    """Step 1: SDK prerequisite — ID-JAG passport JWT trusted issuer."""
 
-    This configuration is surfaced in the agent's AgentCard, specifically in the
-    `securitySchemes` section. It should expose the information needed to mint the token
-    used to communicate with this agent (`token_url`, `audience`, and `scopes`)
-    during the second step of the two-step token exchange, where the ID-JAG token is
-    exchanged for the downstream scoped token required to call the agent.
+    trusted_issuer: str = Field(
+        description=(
+            "Issuer URL of the internal passport JWT that must be validated before "
+            "the downstream Okta token exchange."
+        ),
+    )
+
+
+class OAuth2TokenExchangePayload(BaseModel):
+    """Step 2: RFC 8693 token exchange POST body parameters for the authorization server."""
+
+    audience: str = Field(description="Expected resource / audience (`aud`) for the issued token.")
+    subject_token_type: str = Field(
+        description=(
+            "`subject_token_type` value for RFC 8693 (e.g. JWT access token vs id token URN)."
+        ),
+    )
+    requested_token_type: str = Field(
+        description="`requested_token_type` per RFC 8693 (usually an access token URN).",
+    )
+    token_endpoint_auth_method: str = Field(
+        description="OAuth 2.0 token endpoint client authentication method (e.g. private_key_jwt).",
+    )
+
+
+class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
+    """OAuth2 server-side auth for RFC 8693 token exchange surfaced on the AgentCard.
+
+    OpenAPI-relevant fields (`token_url`, `scopes`) populate ``securitySchemes.oauth2``.
+    Step 1 (`passport_requirement`) and Step 2 (`exchange_payload`) are advertised in
+    ``capabilities.extensions`` for SDKs executing the two-step flow.
     """
 
     token_url: str = Field(
         description=(
             "Token URL for Token Exchange (RFC 8693). This is the endpoint to which "
-            "the client will send the token exchange request to obtain a scoped token "
-            "for this agent."
-        )
-    )
-    audience: str | None = Field(
-        default=None,
-        description=("Expected audience (`aud`) claim for this API."),
+            "the client sends the exchange request for a scoped token for this agent."
+        ),
     )
     scopes: list[str] = Field(
         default=["read_data"],
         description=(
-            "Scopes required by this API. Validation ensures the token grants all listed scopes."
+            "Scopes advertised for this API. Listed under OpenAPI flows; validation ensures "
+            "the token grants required scopes."
         ),
+    )
+    passport_requirement: OAuth2PassportRequirement = Field(
+        description="Step 1: trusted issuer for the prerequisite ID-JAG passport JWT.",
+    )
+    exchange_payload: OAuth2TokenExchangePayload = Field(
+        description="Step 2: Okta/token endpoint parameters for the token exchange POST.",
     )

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -19,8 +19,8 @@ from pydantic import BaseModel
 from pydantic import Field
 
 
-class OAuth2PassportRequirement(BaseModel):
-    """Step 1: SDK prerequisite — ID-JAG passport JWT trusted issuer."""
+class OAuth2SubjectTokenConstraints(BaseModel):
+    """Constraints on the subject token used in RFC 8693 token exchange (e.g. trusted issuer)."""
 
     trusted_issuer: str = Field(
         description=(
@@ -30,8 +30,8 @@ class OAuth2PassportRequirement(BaseModel):
     )
 
 
-class OAuth2TokenExchangePayload(BaseModel):
-    """Step 2: RFC 8693 token exchange POST body parameters for the authorization server."""
+class OAuth2TokenExchangeRequest(BaseModel):
+    """RFC 8693 token exchange request parameters for the authorization server."""
 
     audience: str = Field(description="Expected resource / audience (`aud`) for the issued token.")
     subject_token_type: str = Field(
@@ -50,9 +50,10 @@ class OAuth2TokenExchangePayload(BaseModel):
 class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
     """OAuth2 server-side auth for RFC 8693 token exchange surfaced on the AgentCard.
 
-    OpenAPI-relevant fields (`token_url`, `scopes`) populate ``securitySchemes.oauth2``.
-    Step 1 (`passport_requirement`) and Step 2 (`exchange_payload`) are advertised in
-    ``capabilities.extensions`` for SDKs executing the two-step flow.
+    OpenAPI fields (`token_url`, `scopes`) populate ``securitySchemes.oauth2`` client
+    credentials flow.
+    ``subject_token_constraints`` and ``token_exchange_request`` are advertised in
+    ``capabilities.extensions`` for SDKs executing the flow.
     """
 
     token_url: str = Field(
@@ -68,9 +69,9 @@ class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
             "the token grants required scopes."
         ),
     )
-    passport_requirement: OAuth2PassportRequirement = Field(
-        description="Step 1: trusted issuer for the prerequisite ID-JAG passport JWT.",
+    subject_token_constraints: OAuth2SubjectTokenConstraints = Field(
+        description="Requirements for the subject token presented during token exchange.",
     )
-    exchange_payload: OAuth2TokenExchangePayload = Field(
-        description="Step 2: Okta/token endpoint parameters for the token exchange POST.",
+    token_exchange_request: OAuth2TokenExchangeRequest = Field(
+        description="Token endpoint parameters for the token exchange request.",
     )

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -35,14 +35,15 @@ from datarobot_genai.dragent.frontends.fastapi import (
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_GRANT_TYPE_URI
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_SECURITY_SCHEME_FLOW_REF
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_SECURITY_SCHEME_REF
-from datarobot_genai.dragent.frontends.fastapi import RFC8693_SUBJECT_TOKEN_TYPE
 from datarobot_genai.dragent.frontends.fastapi import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
+from datarobot_genai.dragent.frontends.server_auth import OAuth2PassportRequirement
 from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeConfig
+from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangePayload
 from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 
@@ -388,8 +389,16 @@ class TestCreateAgentCard:
         dragent_worker_with_a2a.front_end_config.a2a.oauth_token_exchange = (
             OAuth2TokenExchangeConfig(
                 token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-                audience="https://app.datarobot.com/dr_org_id/my_agent",
                 scopes=["blog:write"],
+                passport_requirement=OAuth2PassportRequirement(
+                    trusted_issuer="https://id-jag.internal.datarobot.com",
+                ),
+                exchange_payload=OAuth2TokenExchangePayload(
+                    audience="https://app.datarobot.com/dr_org_id/my_agent",
+                    subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+                    requested_token_type="urn:ietf:params:oauth:token-type:access_token",
+                    token_endpoint_auth_method="private_key_jwt",
+                ),
             )
         )
         card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
@@ -407,17 +416,26 @@ class TestCreateAgentCard:
 
         assert card.security == [{"oauth2": ["blog:write"]}]
 
-        # RFC 8693 binder extension (scopes only in flows, never in params)
+        # RFC 8693 extension: ref + passport_requirement + exchange_payload (scopes only in flows)
         assert card.capabilities.extensions is not None
         assert len(card.capabilities.extensions) == 1
         ext = card.capabilities.extensions[0]
         assert ext.uri == RFC8693_GRANT_TYPE_URI
         assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
         assert ext.params == {
-            "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
-            "flow_ref": RFC8693_SECURITY_SCHEME_FLOW_REF,
-            "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
-            "audience": "https://app.datarobot.com/dr_org_id/my_agent",
+            "ref": {
+                "scheme": RFC8693_SECURITY_SCHEME_REF,
+                "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
+            },
+            "passport_requirement": {
+                "trusted_issuer": "https://id-jag.internal.datarobot.com",
+            },
+            "exchange_payload": {
+                "audience": "https://app.datarobot.com/dr_org_id/my_agent",
+                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+                "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_endpoint_auth_method": "private_key_jwt",
+            },
         }
 
     async def test_security_schemes_from_server_auth(
@@ -460,8 +478,16 @@ class TestCreateAgentCard:
         dragent_worker_with_a2a.front_end_config.a2a.oauth_token_exchange = (
             OAuth2TokenExchangeConfig(
                 token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-                audience="https://app.datarobot.com/dr_org_id/my_agent",
                 scopes=["blog:write"],
+                passport_requirement=OAuth2PassportRequirement(
+                    trusted_issuer="https://id-jag.internal.datarobot.com",
+                ),
+                exchange_payload=OAuth2TokenExchangePayload(
+                    audience="https://app.datarobot.com/dr_org_id/my_agent",
+                    subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+                    requested_token_type="urn:ietf:params:oauth:token-type:access_token",
+                    token_endpoint_auth_method="private_key_jwt",
+                ),
             )
         )
 
@@ -487,16 +513,25 @@ class TestCreateAgentCard:
         # Merged scopes (deduplicated)
         assert card.security == [{"oauth2": ["read", "blog:write"]}]
 
-        # RFC 8693 binder extension: audience in params, scopes only under flows
+        # RFC 8693 extension: nested params; scopes only under OpenAPI flows
         assert card.capabilities.extensions is not None
         ext = card.capabilities.extensions[0]
         assert ext.uri == RFC8693_GRANT_TYPE_URI
         assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
         assert ext.params == {
-            "security_scheme_ref": RFC8693_SECURITY_SCHEME_REF,
-            "flow_ref": RFC8693_SECURITY_SCHEME_FLOW_REF,
-            "subject_token_type": RFC8693_SUBJECT_TOKEN_TYPE,
-            "audience": "https://app.datarobot.com/dr_org_id/my_agent",
+            "ref": {
+                "scheme": RFC8693_SECURITY_SCHEME_REF,
+                "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
+            },
+            "passport_requirement": {
+                "trusted_issuer": "https://id-jag.internal.datarobot.com",
+            },
+            "exchange_payload": {
+                "audience": "https://app.datarobot.com/dr_org_id/my_agent",
+                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+                "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_endpoint_auth_method": "private_key_jwt",
+            },
         }
 
     async def test_no_security_when_server_auth_absent(
@@ -518,8 +553,16 @@ class TestDRAgentFastApiFrontEndConfig:
     def test_custom_a2a_fields(self):
         oauth = OAuth2TokenExchangeConfig(
             token_url="https://idp.example.com/oauth2/v1/token",
-            audience="api://my-agent",
             scopes=["agent:use"],
+            passport_requirement=OAuth2PassportRequirement(
+                trusted_issuer="https://id-jag.example.com",
+            ),
+            exchange_payload=OAuth2TokenExchangePayload(
+                audience="api://my-agent",
+                subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+                requested_token_type="urn:ietf:params:oauth:token-type:access_token",
+                token_endpoint_auth_method="private_key_jwt",
+            ),
         )
         config = DRAgentFastApiFrontEndConfig(
             a2a=DRAgentA2AConfig(

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -41,9 +41,9 @@ from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlug
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
-from datarobot_genai.dragent.frontends.server_auth import OAuth2PassportRequirement
+from datarobot_genai.dragent.frontends.server_auth import OAuth2SubjectTokenConstraints
 from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeConfig
-from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangePayload
+from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeRequest
 from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 
@@ -390,10 +390,10 @@ class TestCreateAgentCard:
             OAuth2TokenExchangeConfig(
                 token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
                 scopes=["blog:write"],
-                passport_requirement=OAuth2PassportRequirement(
+                subject_token_constraints=OAuth2SubjectTokenConstraints(
                     trusted_issuer="https://id-jag.internal.datarobot.com",
                 ),
-                exchange_payload=OAuth2TokenExchangePayload(
+                token_exchange_request=OAuth2TokenExchangeRequest(
                     audience="https://app.datarobot.com/dr_org_id/my_agent",
                     subject_token_type="urn:ietf:params:oauth:token-type:jwt",
                     requested_token_type="urn:ietf:params:oauth:token-type:access_token",
@@ -416,7 +416,7 @@ class TestCreateAgentCard:
 
         assert card.security == [{"oauth2": ["blog:write"]}]
 
-        # RFC 8693 extension: ref + passport_requirement + exchange_payload (scopes only in flows)
+        # RFC 8693 extension: ref + subject_token_constraints + token_exchange_request
         assert card.capabilities.extensions is not None
         assert len(card.capabilities.extensions) == 1
         ext = card.capabilities.extensions[0]
@@ -427,10 +427,10 @@ class TestCreateAgentCard:
                 "scheme": RFC8693_SECURITY_SCHEME_REF,
                 "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
             },
-            "passport_requirement": {
+            "subject_token_constraints": {
                 "trusted_issuer": "https://id-jag.internal.datarobot.com",
             },
-            "exchange_payload": {
+            "token_exchange_request": {
                 "audience": "https://app.datarobot.com/dr_org_id/my_agent",
                 "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
                 "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
@@ -473,16 +473,16 @@ class TestCreateAgentCard:
             scopes=["read"],
         )
 
-        # Token exchange → client_credentials flow
+        # oauth_token_exchange → client_credentials flow
         assert dragent_worker_with_a2a.front_end_config.a2a is not None
         dragent_worker_with_a2a.front_end_config.a2a.oauth_token_exchange = (
             OAuth2TokenExchangeConfig(
                 token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
                 scopes=["blog:write"],
-                passport_requirement=OAuth2PassportRequirement(
+                subject_token_constraints=OAuth2SubjectTokenConstraints(
                     trusted_issuer="https://id-jag.internal.datarobot.com",
                 ),
-                exchange_payload=OAuth2TokenExchangePayload(
+                token_exchange_request=OAuth2TokenExchangeRequest(
                     audience="https://app.datarobot.com/dr_org_id/my_agent",
                     subject_token_type="urn:ietf:params:oauth:token-type:jwt",
                     requested_token_type="urn:ietf:params:oauth:token-type:access_token",
@@ -523,10 +523,10 @@ class TestCreateAgentCard:
                 "scheme": RFC8693_SECURITY_SCHEME_REF,
                 "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
             },
-            "passport_requirement": {
+            "subject_token_constraints": {
                 "trusted_issuer": "https://id-jag.internal.datarobot.com",
             },
-            "exchange_payload": {
+            "token_exchange_request": {
                 "audience": "https://app.datarobot.com/dr_org_id/my_agent",
                 "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
                 "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
@@ -554,10 +554,10 @@ class TestDRAgentFastApiFrontEndConfig:
         oauth = OAuth2TokenExchangeConfig(
             token_url="https://idp.example.com/oauth2/v1/token",
             scopes=["agent:use"],
-            passport_requirement=OAuth2PassportRequirement(
+            subject_token_constraints=OAuth2SubjectTokenConstraints(
                 trusted_issuer="https://id-jag.example.com",
             ),
-            exchange_payload=OAuth2TokenExchangePayload(
+            token_exchange_request=OAuth2TokenExchangeRequest(
                 audience="api://my-agent",
                 subject_token_type="urn:ietf:params:oauth:token-type:jwt",
                 requested_token_type="urn:ietf:params:oauth:token-type:access_token",

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.19"
+version = "0.15.20"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth-related configuration and AgentCard extension shape, which may break existing deployments/SDK consumers expecting the old `audience`/flat params until they update configs and parsing.
> 
> **Overview**
> Refactors RFC 8693 OAuth2 token-exchange configuration to a **nested schema**: `OAuth2TokenExchangeConfig` drops the top-level `audience` and instead requires `subject_token_constraints` and `token_exchange_request` (audience, token types, auth method), and the AgentCard extension params change to `{ref, subject_token_constraints, token_exchange_request}`.
> 
> Updates dragent FastAPI/A2A wiring and tests to emit and validate the new extension shape while keeping `token_url`/`scopes` on the OpenAPI `client_credentials` flow. Bumps package version to `0.15.23` and updates lockfiles/changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab5b2ee32157c18a8ba46889282b2f04394774f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->