### PR TITLE
[BUZZOK-30517][BUZZOK-30418][BUZZOK-30516][BUZZOK-30417] Support OKTA XAA (Cross-Application Access) in A2A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.24
+- Added Okta Cross-Application Access (XAA) support for A2A agent-to-agent calls via the new `okta_cross_app_access` auth provider.
+- Server-side XAA parameters are declared in `workflow.yaml` under `cross_application_access` and published on the AgentCard: OpenAPI `clientCredentials` security scheme plus a JWT Bearer capability extension containing the two-step flow parameters (RFC 8693 → RFC 7523).
+- Client-side: `OktaCrossApplicationAccessAuthProvider` reads the AgentCard extension at runtime, performs the two-step token exchange via `okta-client-python`, and requires only `PRINCIPAL_ID` / `PRIVATE_JWK` env vars.
+- Added `okta-client-python` dependency into the `auth` extra.
 
 ## 0.15.33
 - Fixed CrewAI AG-UI streaming so each agent role in a multi-agent crew emits its own assistant message with a unique `messageId`. Previously, `TEXT_MESSAGE_END` was missing at agent-role boundaries and a single `messageId` was reused across the whole run, collapsing every agent's output into one merged message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.15.24
+## 0.15.34
 - Added Okta Cross-Application Access (XAA) support for A2A agent-to-agent calls via the new `okta_cross_app_access` auth provider.
 - Server-side XAA parameters are declared in `workflow.yaml` under `cross_application_access` and published on the AgentCard: OpenAPI `clientCredentials` security scheme plus a JWT Bearer capability extension containing the two-step flow parameters (RFC 8693 → RFC 7523).
 - Client-side: `OktaCrossApplicationAccessAuthProvider` reads the AgentCard extension at runtime, performs the two-step token exchange via `okta-client-python`, and requires only `PRINCIPAL_ID` / `PRIVATE_JWK` env vars.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.15.34
+## 0.15.35
 - Added Okta Cross-Application Access (XAA) support for A2A agent-to-agent calls via the new `okta_cross_app_access` auth provider.
 - Server-side XAA parameters are declared in `workflow.yaml` under `cross_application_access` and published on the AgentCard: OpenAPI `clientCredentials` security scheme plus a JWT Bearer capability extension containing the two-step flow parameters (RFC 8693 → RFC 7523).
 - Client-side: `OktaCrossApplicationAccessAuthProvider` reads the AgentCard extension at runtime, performs the two-step token exchange via `okta-client-python`, and requires only `PRINCIPAL_ID` / `PRIVATE_JWK` env vars.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Server-side XAA parameters are declared in `workflow.yaml` under `cross_application_access` and published on the AgentCard: OpenAPI `clientCredentials` security scheme plus a JWT Bearer capability extension containing the two-step flow parameters (RFC 8693 → RFC 7523).
 - Client-side: `OktaCrossApplicationAccessAuthProvider` reads the AgentCard extension at runtime, performs the two-step token exchange via `okta-client-python`, and requires only `PRINCIPAL_ID` / `PRIVATE_JWK` env vars.
 - Added `okta-client-python` dependency into the `auth` extra.
+- Server-side config tag was renamed from `oauth_token_exchange` into `cross_application_access`.
 
 ## 0.15.33
 - Fixed CrewAI AG-UI streaming so each agent role in a multi-agent crew emits its own assistant message with a unique `messageId`. Previously, `TEXT_MESSAGE_END` was missing at agent-role boundaries and a single `messageId` was reused across the whole run, collapsing every agent's output into one merged message.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1061,6 +1061,7 @@ requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'llamaindex'", specifier = "==0.1.15" },
     { name = "ag-ui-protocol", marker = "extra == 'nat'", specifier = "==0.1.15" },
     { name = "aiohttp", marker = "extra == 'auth'", specifier = ">=3.13.3,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'auth-okta'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp", marker = "extra == 'drtools'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp-retry", marker = "extra == 'drmcp'", specifier = ">=2.8.3,<3.0.0" },
@@ -1088,6 +1089,7 @@ requires-dist = [
     { name = "datarobot", marker = "extra == 'llamaindex'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", marker = "extra == 'nat'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.10.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth-okta'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
@@ -1138,6 +1140,7 @@ requires-dist = [
     { name = "nvidia-nat-mcp", marker = "extra == 'nat'", specifier = "==1.6.0" },
     { name = "nvidia-nat-opentelemetry", marker = "extra == 'dragent'", specifier = "==1.6.0" },
     { name = "nvidia-nat-opentelemetry", marker = "extra == 'nat'", specifier = "==1.6.0" },
+    { name = "okta-client-python", marker = "extra == 'auth-okta'", specifier = ">=0.2.0,<1.0.0" },
     { name = "openai", marker = "extra == 'core'", specifier = ">=2.0.0,<3.0.0" },
     { name = "openai", marker = "extra == 'crewai'", specifier = ">=2.0.0,<3.0.0" },
     { name = "openai", marker = "extra == 'dragent'", specifier = ">=2.0.0,<3.0.0" },
@@ -1199,6 +1202,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'nat'", specifier = "==21.0.0" },
     { name = "pybase64", marker = "extra == 'crewai'", specifier = ">=1.4.2,<2.0.0" },
     { name = "pydantic", marker = "extra == 'auth'", specifier = ">=2.6.1,<3.0.0" },
+    { name = "pydantic", marker = "extra == 'auth-okta'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic", marker = "extra == 'drmcp'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic", marker = "extra == 'drtools'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic-settings", marker = "extra == 'drmcp'", specifier = ">=2.1.0,<3.0.0" },
@@ -1233,7 +1237,7 @@ requires-dist = [
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]
-provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "drmcp", "drtools", "dragent", "memory"]
+provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "auth-okta", "drmcp", "drtools", "dragent", "memory"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.33"
+version = "0.15.34"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1061,7 +1061,6 @@ requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'llamaindex'", specifier = "==0.1.15" },
     { name = "ag-ui-protocol", marker = "extra == 'nat'", specifier = "==0.1.15" },
     { name = "aiohttp", marker = "extra == 'auth'", specifier = ">=3.13.3,<4.0.0" },
-    { name = "aiohttp", marker = "extra == 'auth-okta'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp", marker = "extra == 'drmcp'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp", marker = "extra == 'drtools'", specifier = ">=3.13.3,<4.0.0" },
     { name = "aiohttp-retry", marker = "extra == 'drmcp'", specifier = ">=2.8.3,<3.0.0" },
@@ -1089,7 +1088,6 @@ requires-dist = [
     { name = "datarobot", marker = "extra == 'llamaindex'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", marker = "extra == 'nat'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.10.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth-okta'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.10.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
@@ -1140,7 +1138,9 @@ requires-dist = [
     { name = "nvidia-nat-mcp", marker = "extra == 'nat'", specifier = "==1.6.0" },
     { name = "nvidia-nat-opentelemetry", marker = "extra == 'dragent'", specifier = "==1.6.0" },
     { name = "nvidia-nat-opentelemetry", marker = "extra == 'nat'", specifier = "==1.6.0" },
-    { name = "okta-client-python", marker = "extra == 'auth-okta'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "okta-client-python", marker = "extra == 'auth'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "okta-client-python", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "okta-client-python", marker = "extra == 'drtools'", specifier = ">=0.2.0,<1.0.0" },
     { name = "openai", marker = "extra == 'core'", specifier = ">=2.0.0,<3.0.0" },
     { name = "openai", marker = "extra == 'crewai'", specifier = ">=2.0.0,<3.0.0" },
     { name = "openai", marker = "extra == 'dragent'", specifier = ">=2.0.0,<3.0.0" },
@@ -1202,7 +1202,6 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'nat'", specifier = "==21.0.0" },
     { name = "pybase64", marker = "extra == 'crewai'", specifier = ">=1.4.2,<2.0.0" },
     { name = "pydantic", marker = "extra == 'auth'", specifier = ">=2.6.1,<3.0.0" },
-    { name = "pydantic", marker = "extra == 'auth-okta'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic", marker = "extra == 'drmcp'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic", marker = "extra == 'drtools'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pydantic-settings", marker = "extra == 'drmcp'", specifier = ">=2.1.0,<3.0.0" },
@@ -1237,7 +1236,7 @@ requires-dist = [
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]
-provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "auth-okta", "drmcp", "drtools", "dragent", "memory"]
+provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "drmcp", "drtools", "dragent", "memory"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ Homepage = "https://github.com/datarobot-oss/datarobot-genai"
 
 [project.entry-points.'nat.plugins']
 authenticated_a2a_client = "datarobot_genai.dragent.plugins.auth_a2a_client"
+okta_token_exchange = "datarobot_genai.dragent.plugins.okta_a2a_auth"
 per_user_tool_calling_agent = "datarobot_genai.dragent.plugins.per_user_tool_calling_agent"
 datarobot_llm_providers = "datarobot_genai.nat.datarobot_llm_providers"
 datarobot_llm_clients = "datarobot_genai.nat.datarobot_llm_clients"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.33"
+version = "0.15.34"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -19,7 +19,7 @@ Homepage = "https://github.com/datarobot-oss/datarobot-genai"
 
 [project.entry-points.'nat.plugins']
 authenticated_a2a_client = "datarobot_genai.dragent.plugins.auth_a2a_client"
-okta_token_exchange = "datarobot_genai.dragent.plugins.okta_a2a_auth"
+okta_cross_app_access = "datarobot_genai.dragent.plugins.okta_a2a_auth"
 per_user_tool_calling_agent = "datarobot_genai.dragent.plugins.per_user_tool_calling_agent"
 datarobot_llm_providers = "datarobot_genai.nat.datarobot_llm_providers"
 datarobot_llm_clients = "datarobot_genai.nat.datarobot_llm_clients"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,10 @@ auth = [
   "pydantic>=2.6.1,<3.0.0",
 ]
 
+auth_okta = auth + [
+    "okta-client-python>=0.2.0,<1.0.0",
+]
+
 # drtools: no subpackages dependencies other than auth.
 # polars for internal tabular data; pandas only at predict API boundary (datarobot-predict).
 drtools = auth + [
@@ -151,6 +155,7 @@ extras_require = {
     "llamaindex": llamaindex,
     "nat": nat,
     "auth": auth,
+    "auth-okta": auth_okta,
     "drmcp": drmcp,
     "drtools": drtools,
     "dragent": dragent,

--- a/setup.py
+++ b/setup.py
@@ -102,10 +102,7 @@ auth = [
   "datarobot[auth]>=3.10.0,<4.0.0",
   "aiohttp>=3.13.3,<4.0.0",  # CVE-2025-69229 & CVE-2025-69230 fixed in 3.13.3
   "pydantic>=2.6.1,<3.0.0",
-]
-
-auth_okta = auth + [
-    "okta-client-python>=0.2.0,<1.0.0",
+  "okta-client-python>=0.2.0,<1.0.0",
 ]
 
 # drtools: no subpackages dependencies other than auth.
@@ -155,7 +152,6 @@ extras_require = {
     "llamaindex": llamaindex,
     "nat": nat,
     "auth": auth,
-    "auth-okta": auth_okta,
     "drmcp": drmcp,
     "drtools": drtools,
     "dragent": dragent,

--- a/src/datarobot_genai/dragent/deployment_urls.py
+++ b/src/datarobot_genai/dragent/deployment_urls.py
@@ -1,0 +1,108 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared URL construction utilities for DataRobot deployment endpoints.
+
+These helpers are the single source of truth for the URL patterns used to reach
+a DataRobot-hosted A2A agent and to look up its agent card from the central
+registry.  Both the server side (advertising its own URL in the agent card) and
+the client side (deriving the RPC base URL from a ``deployment_id``) use these
+functions so that the patterns stay in sync automatically.
+"""
+
+import os
+
+A2A_DIRECT_ACCESS_PATH = "directAccess/a2a"
+
+_DEFAULT_DATAROBOT_ENDPOINT = "https://app.datarobot.com/api/v2"
+
+
+def resolve_datarobot_endpoint(require: bool = False) -> str | None:
+    """Return the effective DataRobot API endpoint from the environment.
+
+    Checks environment variables in priority order:
+
+    1. ``DATAROBOT_PUBLIC_API_ENDPOINT`` — preferred for externally reachable URLs
+       (on-prem deployments often set ``DATAROBOT_ENDPOINT`` to an internal k8s
+       address while ``DATAROBOT_PUBLIC_API_ENDPOINT`` holds the public URL).
+    2. ``DATAROBOT_ENDPOINT`` — standard SDK variable.
+    3. Built-in default (``https://app.datarobot.com/api/v2``) when ``require``
+       is *False*.
+
+    Parameters
+    ----------
+    require:
+        When *True*, raises :class:`ValueError` if neither env var is set.
+        When *False* (default), falls back to the built-in default endpoint.
+
+    Returns
+    -------
+    str | None
+        The resolved endpoint string, or *None* only when ``require`` is
+        *False* **and** both env vars are unset (returns the default instead,
+        so in practice this always returns a non-None value when
+        ``require=False``).
+
+    Raises
+    ------
+    ValueError
+        If ``require=True`` and neither ``DATAROBOT_PUBLIC_API_ENDPOINT`` nor
+        ``DATAROBOT_ENDPOINT`` is set.
+    """
+    endpoint = os.getenv("DATAROBOT_PUBLIC_API_ENDPOINT") or os.getenv("DATAROBOT_ENDPOINT")
+    if endpoint:
+        return endpoint
+    if require:
+        raise ValueError("DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set.")
+    return _DEFAULT_DATAROBOT_ENDPOINT
+
+
+def build_deployment_a2a_url(endpoint: str, deployment_id: str) -> str:
+    """Construct the A2A direct-access URL for a DataRobot deployment.
+
+    Parameters
+    ----------
+    endpoint:
+        DataRobot API endpoint base URL, e.g. ``https://app.datarobot.com/api/v2``.
+        A trailing slash is stripped before composing the URL.
+    deployment_id:
+        The DataRobot deployment ID.
+
+    Returns
+    -------
+    str
+        A URL of the form ``{endpoint}/deployments/{deployment_id}/directAccess/a2a/``.
+    """
+    base = endpoint.rstrip("/")
+    return f"{base}/deployments/{deployment_id}/{A2A_DIRECT_ACCESS_PATH}/"
+
+
+def build_deployment_agent_card_url(endpoint: str, deployment_id: str) -> str:
+    """Construct the agent card registry URL for a DataRobot deployment.
+
+    Parameters
+    ----------
+    endpoint:
+        DataRobot API endpoint base URL, e.g. ``https://app.datarobot.com/api/v2``.
+        A trailing slash is stripped before composing the URL.
+    deployment_id:
+        The DataRobot deployment ID.
+
+    Returns
+    -------
+    str
+        A URL of the form ``{endpoint}/deployments/{deployment_id}/agentCard/``.
+    """
+    base = endpoint.rstrip("/")
+    return f"{base}/deployments/{deployment_id}/agentCard/"

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -1,0 +1,339 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A2A server helpers for DataRobot-hosted agents.
+
+This module owns the A2A protocol layer: agent card construction, OAuth2
+security scheme assembly, RFC 8693 capability extensions, endpoint URL
+resolution, and the per-user executor adapter.  The FastAPI framework glue
+lives in :mod:`~datarobot_genai.dragent.frontends.fastapi`.
+"""
+
+import logging
+
+import httpx
+from a2a.server.agent_execution import RequestContext
+from a2a.server.events import EventQueue
+from a2a.types import AgentCapabilities
+from a2a.types import AgentCard
+from a2a.types import AgentExtension
+from a2a.types import AgentSkill
+from a2a.types import AuthorizationCodeOAuthFlow
+from a2a.types import ClientCredentialsOAuthFlow
+from a2a.types import OAuth2SecurityScheme
+from a2a.types import OAuthFlows
+from a2a.types import SecurityScheme
+from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
+from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
+from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
+from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
+
+from datarobot_genai.dragent.deployment_urls import build_deployment_a2a_url
+from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
+
+from .server_auth import OAuth2TokenExchangeConfig
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+A2A_MOUNT_PATH = "a2a"
+
+OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
+    "OAuth 2.0 authorization utilizing RFC 8693 Token Exchange. Clients must "
+    "supply a valid internal passport JWT as the subject token. Refer to the "
+    "capabilities.extensions block for strict token exchange parameters and "
+    "audience specifications."
+)
+
+# The extension explicitly references the security scheme key so SDKs can resolve
+# the RFC 8693 Token Exchange override without ambiguity.
+RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
+RFC8693_SECURITY_SCHEME_REF = "oauth2"
+RFC8693_SECURITY_SCHEME_FLOW_REF = "clientCredentials"
+RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION = (
+    "Two-Step RFC 8693 Token Exchange execution parameters."
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-user executor adapter
+# ---------------------------------------------------------------------------
+
+
+class PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
+    """Subclass of NATWorkflowAgentExecutor that supports per-user workflows.
+
+    Two problems with the parent class for per-user workflows:
+
+    1. ``__init__`` accesses ``session_manager.workflow`` which raises ``ValueError``
+       for per-user workflows.  We bypass it and log via ``config.workflow.type`` instead.
+
+    2. ``execute`` calls ``self.session_manager.session()`` with no ``user_id``, which
+       raises ``ValueError`` for per-user workflows.  We override it to pass the A2A
+       ``context_id`` as the ``user_id``, giving each conversation its own isolated
+       per-user workflow instance.
+    """
+
+    def __init__(self, session_manager: SessionManager) -> None:
+        # Bypass parent __init__ to avoid session_manager.workflow access,
+        # which raises ValueError for per-user workflows.
+        self.session_manager = session_manager
+        logger.info(
+            "Initialized NATWorkflowAgentExecutor (message-only) for workflow: %s",
+            session_manager.config.workflow.type,
+        )
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:  # type: ignore[override]
+        # Inject the A2A context_id as user_id before delegating to the parent execute.
+        # The parent calls self.session_manager.session() with no user_id, which raises
+        # ValueError for per-user workflows.  Setting the context var here means the
+        # SessionManager's _get_user_id_from_context() will find it automatically.
+        token = None
+        if context.context_id:
+            token = self.session_manager._context_state.user_id.set(context.context_id)
+        try:
+            await super().execute(context, event_queue)
+        finally:
+            if token is not None:
+                self.session_manager._context_state.user_id.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint URL
+# ---------------------------------------------------------------------------
+
+
+def get_a2a_endpoint_url(host: str, port: int) -> str:
+    """Construct the A2A endpoint URL for the running server.
+
+    In a DataRobot deployment (``MLOPS_DEPLOYMENT_ID`` is set), uses the
+    deployment's direct-access URL built from ``DATAROBOT_PUBLIC_API_ENDPOINT``
+    / ``DATAROBOT_ENDPOINT``.  Otherwise falls back to the local
+    ``http://{host}:{port}/a2a/`` URL.
+    """
+    import os
+
+    mlops_deployment_id = os.getenv("MLOPS_DEPLOYMENT_ID", "")
+    if mlops_deployment_id:
+        datarobot_endpoint = resolve_datarobot_endpoint(require=True)
+        return build_deployment_a2a_url(datarobot_endpoint, mlops_deployment_id)
+    return f"http://{host}:{port}/{A2A_MOUNT_PATH}/"
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 / RFC 8693 security scheme helpers
+# ---------------------------------------------------------------------------
+
+
+async def resolve_oauth_endpoints(
+    server_auth_config: OAuth2ResourceServerConfig,
+) -> tuple[str, str]:
+    """Resolve authorization and token URLs from an OAuth2ResourceServerConfig.
+
+    Uses OIDC discovery when ``discovery_url`` is set, otherwise derives URLs
+    from ``issuer_url``.
+
+    Returns
+    -------
+    tuple[str, str]
+        ``(authorization_url, token_url)``
+    """
+    if server_auth_config.discovery_url:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(server_auth_config.discovery_url, timeout=5.0)
+                response.raise_for_status()
+                metadata = response.json()
+                auth_url = metadata.get("authorization_endpoint")
+                token_url = metadata.get("token_endpoint")
+                if auth_url and token_url:
+                    logger.info(
+                        "Resolved OAuth endpoints via discovery: %s",
+                        server_auth_config.discovery_url,
+                    )
+                    return auth_url, token_url
+        except Exception as e:
+            logger.warning("Failed to discover OAuth endpoints: %s", e)
+
+    issuer = server_auth_config.issuer_url.rstrip("/")
+    auth_url = f"{issuer}/oauth/authorize"
+    token_url = f"{issuer}/oauth/token"
+    logger.info("Using derived OAuth endpoints from issuer: %s", issuer)
+    return auth_url, token_url
+
+
+async def build_oauth_flow_from_server_auth(
+    server_auth: OAuth2ResourceServerConfig,
+) -> tuple[AuthorizationCodeOAuthFlow, list[str]]:
+    """Build the authorization_code OAuth2 flow and scopes from a NAT server_auth config."""
+    auth_url, token_url = await resolve_oauth_endpoints(server_auth)
+    flow = AuthorizationCodeOAuthFlow(
+        authorization_url=auth_url,
+        token_url=token_url,
+        scopes={scope: f"Permission: {scope}" for scope in server_auth.scopes},
+    )
+    return flow, list(server_auth.scopes)
+
+
+def build_oauth_flow_from_token_exchange(
+    config: OAuth2TokenExchangeConfig,
+) -> tuple[ClientCredentialsOAuthFlow, list[str]]:
+    """Build the client_credentials flow and scopes from an OAuth2TokenExchangeConfig.
+
+    Token URL and scopes live only here (OpenAPI-compatible). RFC 8693 second-phase
+    requirements are signaled separately via
+    :func:`build_token_exchange_capability_extension`.
+    """
+    flow = ClientCredentialsOAuthFlow(
+        token_url=config.token_url,
+        scopes={scope: f"Permission: {scope}" for scope in config.scopes},
+    )
+    return flow, list(config.scopes)
+
+
+def build_token_exchange_capability_extension(
+    config: OAuth2TokenExchangeConfig,
+) -> list[AgentExtension]:
+    """Build the RFC 8693 agent card extension for OAuth2 token exchange.
+
+    OpenAPI ``token_url`` / ``scopes`` remain on ``securitySchemes.oauth2.flows``.
+    ``params`` carries ``subject_token_constraints``, ``token_exchange_request``,
+    and a ``ref`` binding to the client-credentials flow.
+    """
+    params = {
+        "ref": {
+            "scheme": RFC8693_SECURITY_SCHEME_REF,
+            "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
+        },
+        "subject_token_constraints": config.subject_token_constraints.model_dump(),
+        "token_exchange_request": config.token_exchange_request.model_dump(),
+    }
+    return [
+        AgentExtension(
+            uri=RFC8693_GRANT_TYPE_URI,
+            description=RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION,
+            params=params,
+        )
+    ]
+
+
+async def build_security_schemes(
+    frontend_config: A2AFrontEndConfig,
+    token_exchange: OAuth2TokenExchangeConfig | None,
+) -> tuple[
+    dict[str, SecurityScheme] | None,
+    list[dict[str, list[str]]] | None,
+    list[AgentExtension] | None,
+]:
+    """Assemble A2A security schemes from a frontend configuration.
+
+    Supports two independent auth sources merged into a single ``oauth2``
+    security scheme with separate flows:
+
+    * ``server_auth`` (OAuth2ResourceServerConfig) → authorization_code flow.
+    * ``token_exchange`` (OAuth2TokenExchangeConfig) → client_credentials flow
+      + RFC 8693 capability extension.
+
+    Returns
+    -------
+    tuple
+        ``(security_schemes, security_requirements, capability_extensions)`` —
+        all ``None`` when neither auth source is configured.
+    """
+    server_auth = frontend_config.server_auth
+
+    if not server_auth and not token_exchange:
+        return None, None, None
+
+    auth_code_flow, server_auth_scopes = (
+        await build_oauth_flow_from_server_auth(server_auth) if server_auth else (None, [])
+    )
+    client_creds_flow, token_exchange_scopes = (
+        build_oauth_flow_from_token_exchange(token_exchange) if token_exchange else (None, [])
+    )
+    extensions = (
+        build_token_exchange_capability_extension(token_exchange) if token_exchange else None
+    )
+
+    all_scopes = list(dict.fromkeys(server_auth_scopes + token_exchange_scopes))
+    security_schemes = {
+        "oauth2": SecurityScheme(
+            root=OAuth2SecurityScheme(
+                type="oauth2",
+                description=OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE,
+                flows=OAuthFlows(
+                    authorization_code=auth_code_flow,
+                    client_credentials=client_creds_flow,
+                ),
+            )
+        )
+    }
+    return security_schemes, [{"oauth2": all_scopes}], extensions
+
+
+# ---------------------------------------------------------------------------
+# Agent card factory
+# ---------------------------------------------------------------------------
+
+
+async def create_agent_card(
+    frontend_config: A2AFrontEndConfig,
+    token_exchange: OAuth2TokenExchangeConfig | None,
+    skills: list[AgentSkill],
+) -> AgentCard:
+    """Build an :class:`~a2a.types.AgentCard` for a DataRobot-hosted A2A agent.
+
+    Parameters
+    ----------
+    frontend_config:
+        NAT A2A frontend configuration (name, description, capabilities, etc.).
+    token_exchange:
+        Optional DR OAuth2 token exchange configuration for RFC 8693.
+    skills:
+        Skills to advertise. When empty, a single default skill is generated
+        from ``frontend_config.name`` and ``frontend_config.description``.
+    """
+    security_schemes, security, extensions = await build_security_schemes(
+        frontend_config, token_exchange
+    )
+
+    resolved_skills = skills or [
+        AgentSkill(
+            id="call",
+            name=frontend_config.name,
+            description=frontend_config.description,
+            tags=[],
+            examples=[],
+        )
+    ]
+
+    return AgentCard(
+        name=frontend_config.name,
+        description=frontend_config.description,
+        url=get_a2a_endpoint_url(frontend_config.host, frontend_config.port),
+        version=frontend_config.version,
+        default_input_modes=frontend_config.default_input_modes,
+        default_output_modes=frontend_config.default_output_modes,
+        capabilities=AgentCapabilities(
+            streaming=frontend_config.capabilities.streaming,
+            push_notifications=frontend_config.capabilities.push_notifications,
+            extensions=extensions,
+        ),
+        skills=resolved_skills,
+        security_schemes=security_schemes or None,
+        security=security or None,
+    )

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -16,15 +16,13 @@
 
 This module owns the A2A protocol layer: agent card construction, OAuth2
 security scheme assembly, Cross-Application Access capability extensions,
-endpoint URL resolution, and the per-user executor adapter.  The FastAPI
-framework glue lives in :mod:`~datarobot_genai.dragent.frontends.fastapi`.
+and endpoint URL resolution.  The FastAPI framework glue lives in
+:mod:`~datarobot_genai.dragent.frontends.fastapi`.
 """
 
 import logging
 
 import httpx
-from a2a.server.agent_execution import RequestContext
-from a2a.server.events import EventQueue
 from a2a.types import AgentCapabilities
 from a2a.types import AgentCard
 from a2a.types import AgentExtension
@@ -35,8 +33,6 @@ from a2a.types import OAuth2SecurityScheme
 from a2a.types import OAuthFlows
 from a2a.types import SecurityScheme
 from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
-from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
-from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 
 from datarobot_genai.dragent.deployment_urls import build_deployment_a2a_url
@@ -73,49 +69,6 @@ CROSS_APP_EXTENSION_DESCRIPTION = (
 
 
 # ---------------------------------------------------------------------------
-# Per-user executor adapter
-# ---------------------------------------------------------------------------
-
-
-class PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
-    """Subclass of NATWorkflowAgentExecutor that supports per-user workflows.
-
-    Two problems with the parent class for per-user workflows:
-
-    1. ``__init__`` accesses ``session_manager.workflow`` which raises ``ValueError``
-       for per-user workflows.  We bypass it and log via ``config.workflow.type`` instead.
-
-    2. ``execute`` calls ``self.session_manager.session()`` with no ``user_id``, which
-       raises ``ValueError`` for per-user workflows.  We override it to pass the A2A
-       ``context_id`` as the ``user_id``, giving each conversation its own isolated
-       per-user workflow instance.
-    """
-
-    def __init__(self, session_manager: SessionManager) -> None:
-        # Bypass parent __init__ to avoid session_manager.workflow access,
-        # which raises ValueError for per-user workflows.
-        self.session_manager = session_manager
-        logger.info(
-            "Initialized NATWorkflowAgentExecutor (message-only) for workflow: %s",
-            session_manager.config.workflow.type,
-        )
-
-    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:  # type: ignore[override]
-        # Inject the A2A context_id as user_id before delegating to the parent execute.
-        # The parent calls self.session_manager.session() with no user_id, which raises
-        # ValueError for per-user workflows.  Setting the context var here means the
-        # SessionManager's _get_user_id_from_context() will find it automatically.
-        token = None
-        if context.context_id:
-            token = self.session_manager._context_state.user_id.set(context.context_id)
-        try:
-            await super().execute(context, event_queue)
-        finally:
-            if token is not None:
-                self.session_manager._context_state.user_id.reset(token)
-
-
-# ---------------------------------------------------------------------------
 # Endpoint URL
 # ---------------------------------------------------------------------------
 
@@ -145,15 +98,9 @@ def get_a2a_endpoint_url(host: str, port: int) -> str:
 async def resolve_oauth_endpoints(
     server_auth_config: OAuth2ResourceServerConfig,
 ) -> tuple[str, str]:
-    """Resolve authorization and token URLs from an OAuth2ResourceServerConfig.
+    """Resolve ``(authorization_url, token_url)`` from an OAuth2ResourceServerConfig.
 
-    Uses OIDC discovery when ``discovery_url`` is set, otherwise derives URLs
-    from ``issuer_url``.
-
-    Returns
-    -------
-    tuple[str, str]
-        ``(authorization_url, token_url)``
+    Uses OIDC discovery when ``discovery_url`` is set, otherwise derives from ``issuer_url``.
     """
     if server_auth_config.discovery_url:
         try:
@@ -211,21 +158,10 @@ def build_oauth_flow_from_cross_app_access(
 def build_cross_app_capability_extension(
     config: CrossApplicationAccessConfig,
 ) -> list[AgentExtension]:
-    """Build the Cross-Application Access agent card extension.
+    """Build the JWT Bearer Grant extension entry for ``capabilities.extensions``.
 
-    Compiles the RFC 7523 JWT Bearer Grant extension entry for
-    ``capabilities.extensions``.  Only extension-bound fields are included in
-    ``params``; ``token_url`` and ``scopes`` are intentionally excluded because
-    they belong to the OpenAPI ``securitySchemes`` layer, not to this extension.
-
-    The ``params`` structure:
-
-    * ``ref`` — binds this extension to the ``oauth2 / clientCredentials`` scheme.
-    * ``target_audience`` — final resource identifier (the agent being called).
-    * ``token_endpoint_auth_method`` — client authentication method.
-    * ``token_exchange`` — nested RFC 8693 Step 1 params:
-      ``trusted_issuer`` and ``audience`` (Step 1 AS destination).
-    * ``token_request`` — nested RFC 7523 Step 2 params: ``grant_type``.
+    Only extension-bound fields go in ``params``; ``token_url`` and ``scopes``
+    are intentionally omitted — they belong to OpenAPI ``securitySchemes``.
     """
     params: dict = {
         "ref": {
@@ -254,21 +190,13 @@ async def build_security_schemes(
     list[dict[str, list[str]]] | None,
     list[AgentExtension] | None,
 ]:
-    """Assemble A2A security schemes from a frontend configuration.
+    """Assemble A2A security schemes, merging up to two auth sources.
 
-    Supports two independent auth sources merged into a single ``oauth2``
-    security scheme with separate flows:
+    * ``server_auth`` → authorization_code flow.
+    * ``cross_app_access`` → client_credentials flow + JWT Bearer capability extension.
 
-    * ``server_auth`` (OAuth2ResourceServerConfig) → authorization_code flow.
-    * ``cross_app_access`` (CrossApplicationAccessConfig) → client_credentials
-      flow (OpenAPI ``token_url``/``scopes``) + JWT Bearer capability extension
-      (all other negotiation params).
-
-    Returns
-    -------
-    tuple
-        ``(security_schemes, security_requirements, capability_extensions)`` —
-        all ``None`` when neither auth source is configured.
+    Returns ``(security_schemes, security_requirements, extensions)``, all ``None``
+    when neither source is configured.
     """
     server_auth = frontend_config.server_auth
 
@@ -313,17 +241,8 @@ async def create_agent_card(
 ) -> AgentCard:
     """Build an :class:`~a2a.types.AgentCard` for a DataRobot-hosted A2A agent.
 
-    Parameters
-    ----------
-    frontend_config:
-        NAT A2A frontend configuration (name, description, capabilities, etc.).
-    cross_app_access:
-        Optional Cross-Application Access configuration. When provided, populates
-        the OpenAPI ``clientCredentials`` security scheme and the JWT Bearer
-        capability extension.
-    skills:
-        Skills to advertise. When empty, a single default skill is generated
-        from ``frontend_config.name`` and ``frontend_config.description``.
+    When ``skills`` is empty, a single default skill is generated from
+    ``frontend_config.name`` / ``frontend_config.description``.
     """
     security_schemes, security, extensions = await build_security_schemes(
         frontend_config, cross_app_access

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -21,6 +21,7 @@ and endpoint URL resolution.  The FastAPI framework glue lives in
 """
 
 import logging
+import os
 
 import httpx
 from a2a.types import AgentCapabilities
@@ -81,11 +82,10 @@ def get_a2a_endpoint_url(host: str, port: int) -> str:
     / ``DATAROBOT_ENDPOINT``.  Otherwise falls back to the local
     ``http://{host}:{port}/a2a/`` URL.
     """
-    import os
-
     mlops_deployment_id = os.getenv("MLOPS_DEPLOYMENT_ID", "")
     if mlops_deployment_id:
         datarobot_endpoint = resolve_datarobot_endpoint(require=True)
+        assert datarobot_endpoint is not None  # guaranteed by require=True
         return build_deployment_a2a_url(datarobot_endpoint, mlops_deployment_id)
     return f"http://{host}:{port}/{A2A_MOUNT_PATH}/"
 

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -15,9 +15,9 @@
 """A2A server helpers for DataRobot-hosted agents.
 
 This module owns the A2A protocol layer: agent card construction, OAuth2
-security scheme assembly, RFC 8693 capability extensions, endpoint URL
-resolution, and the per-user executor adapter.  The FastAPI framework glue
-lives in :mod:`~datarobot_genai.dragent.frontends.fastapi`.
+security scheme assembly, Cross-Application Access capability extensions,
+endpoint URL resolution, and the per-user executor adapter.  The FastAPI
+framework glue lives in :mod:`~datarobot_genai.dragent.frontends.fastapi`.
 """
 
 import logging
@@ -42,7 +42,7 @@ from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from datarobot_genai.dragent.deployment_urls import build_deployment_a2a_url
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
 
-from .server_auth import OAuth2TokenExchangeConfig
+from .server_auth import CrossApplicationAccessConfig
 
 logger = logging.getLogger(__name__)
 
@@ -53,19 +53,22 @@ logger = logging.getLogger(__name__)
 A2A_MOUNT_PATH = "a2a"
 
 OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
-    "OAuth 2.0 authorization utilizing RFC 8693 Token Exchange. Clients must "
-    "supply a valid internal passport JWT as the subject token. Refer to the "
-    "capabilities.extensions block for strict token exchange parameters and "
-    "audience specifications."
+    "OAuth 2.0 authorization utilizing RFC 7523 JWT Bearer Grant. Requires a prerequisite "
+    "identity assertion via RFC 8693 Token Exchange. Refer to the capabilities.extensions "
+    "block for strict execution parameters and routing."
 )
 
-# The extension explicitly references the security scheme key so SDKs can resolve
-# the RFC 8693 Token Exchange override without ambiguity.
-RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
-RFC8693_SECURITY_SCHEME_REF = "oauth2"
-RFC8693_SECURITY_SCHEME_FLOW_REF = "clientCredentials"
-RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION = (
-    "Two-Step RFC 8693 Token Exchange execution parameters."
+# Extension URI for the RFC 7523 JWT Bearer Grant (outer grant type for the hybrid flow).
+JWT_BEARER_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+# Binding references linking the extension to the OpenAPI security scheme.
+CROSS_APP_SECURITY_SCHEME_REF = "oauth2"
+CROSS_APP_SECURITY_SCHEME_FLOW_REF = "clientCredentials"
+
+CROSS_APP_EXTENSION_DESCRIPTION = (
+    "Two-Step Cross-Application Access execution parameters. "
+    "Step 1: RFC 8693 Token Exchange prerequisite. "
+    "Step 2: RFC 7523 JWT Bearer Grant."
 )
 
 
@@ -135,7 +138,7 @@ def get_a2a_endpoint_url(host: str, port: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# OAuth2 / RFC 8693 security scheme helpers
+# OAuth2 / security scheme helpers
 # ---------------------------------------------------------------------------
 
 
@@ -189,14 +192,14 @@ async def build_oauth_flow_from_server_auth(
     return flow, list(server_auth.scopes)
 
 
-def build_oauth_flow_from_token_exchange(
-    config: OAuth2TokenExchangeConfig,
+def build_oauth_flow_from_cross_app_access(
+    config: CrossApplicationAccessConfig,
 ) -> tuple[ClientCredentialsOAuthFlow, list[str]]:
-    """Build the client_credentials flow and scopes from an OAuth2TokenExchangeConfig.
+    """Build the client_credentials flow and scopes from a CrossApplicationAccessConfig.
 
-    Token URL and scopes live only here (OpenAPI-compatible). RFC 8693 second-phase
-    requirements are signaled separately via
-    :func:`build_token_exchange_capability_extension`.
+    Extracts the OpenAPI-standard fields (``token_url``, ``scopes``) only.
+    Cross-Application Access extension parameters are handled separately by
+    :func:`build_cross_app_capability_extension` and MUST NOT appear here.
     """
     flow = ClientCredentialsOAuthFlow(
         token_url=config.token_url,
@@ -205,27 +208,39 @@ def build_oauth_flow_from_token_exchange(
     return flow, list(config.scopes)
 
 
-def build_token_exchange_capability_extension(
-    config: OAuth2TokenExchangeConfig,
+def build_cross_app_capability_extension(
+    config: CrossApplicationAccessConfig,
 ) -> list[AgentExtension]:
-    """Build the RFC 8693 agent card extension for OAuth2 token exchange.
+    """Build the Cross-Application Access agent card extension.
 
-    OpenAPI ``token_url`` / ``scopes`` remain on ``securitySchemes.oauth2.flows``.
-    ``params`` carries ``subject_token_constraints``, ``token_exchange_request``,
-    and a ``ref`` binding to the client-credentials flow.
+    Compiles the RFC 7523 JWT Bearer Grant extension entry for
+    ``capabilities.extensions``.  Only extension-bound fields are included in
+    ``params``; ``token_url`` and ``scopes`` are intentionally excluded because
+    they belong to the OpenAPI ``securitySchemes`` layer, not to this extension.
+
+    The ``params`` structure:
+
+    * ``ref`` — binds this extension to the ``oauth2 / clientCredentials`` scheme.
+    * ``target_audience`` — final resource identifier (the agent being called).
+    * ``token_endpoint_auth_method`` — client authentication method.
+    * ``token_exchange`` — nested RFC 8693 Step 1 params:
+      ``trusted_issuer`` and ``audience`` (Step 1 AS destination).
+    * ``token_request`` — nested RFC 7523 Step 2 params: ``grant_type``.
     """
-    params = {
+    params: dict = {
         "ref": {
-            "scheme": RFC8693_SECURITY_SCHEME_REF,
-            "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
+            "scheme": CROSS_APP_SECURITY_SCHEME_REF,
+            "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
         },
-        "subject_token_constraints": config.subject_token_constraints.model_dump(),
-        "token_exchange_request": config.token_exchange_request.model_dump(),
+        "target_audience": config.target_audience,
+        "token_endpoint_auth_method": config.token_endpoint_auth_method,
+        "token_exchange": config.token_exchange.model_dump(),
+        "token_request": config.token_request.model_dump(),
     }
     return [
         AgentExtension(
-            uri=RFC8693_GRANT_TYPE_URI,
-            description=RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION,
+            uri=JWT_BEARER_GRANT_TYPE_URI,
+            description=CROSS_APP_EXTENSION_DESCRIPTION,
             params=params,
         )
     ]
@@ -233,7 +248,7 @@ def build_token_exchange_capability_extension(
 
 async def build_security_schemes(
     frontend_config: A2AFrontEndConfig,
-    token_exchange: OAuth2TokenExchangeConfig | None,
+    cross_app_access: CrossApplicationAccessConfig | None,
 ) -> tuple[
     dict[str, SecurityScheme] | None,
     list[dict[str, list[str]]] | None,
@@ -245,8 +260,9 @@ async def build_security_schemes(
     security scheme with separate flows:
 
     * ``server_auth`` (OAuth2ResourceServerConfig) → authorization_code flow.
-    * ``token_exchange`` (OAuth2TokenExchangeConfig) → client_credentials flow
-      + RFC 8693 capability extension.
+    * ``cross_app_access`` (CrossApplicationAccessConfig) → client_credentials
+      flow (OpenAPI ``token_url``/``scopes``) + JWT Bearer capability extension
+      (all other negotiation params).
 
     Returns
     -------
@@ -256,20 +272,20 @@ async def build_security_schemes(
     """
     server_auth = frontend_config.server_auth
 
-    if not server_auth and not token_exchange:
+    if not server_auth and not cross_app_access:
         return None, None, None
 
     auth_code_flow, server_auth_scopes = (
         await build_oauth_flow_from_server_auth(server_auth) if server_auth else (None, [])
     )
-    client_creds_flow, token_exchange_scopes = (
-        build_oauth_flow_from_token_exchange(token_exchange) if token_exchange else (None, [])
+    client_creds_flow, cross_app_scopes = (
+        build_oauth_flow_from_cross_app_access(cross_app_access) if cross_app_access else (None, [])
     )
     extensions = (
-        build_token_exchange_capability_extension(token_exchange) if token_exchange else None
+        build_cross_app_capability_extension(cross_app_access) if cross_app_access else None
     )
 
-    all_scopes = list(dict.fromkeys(server_auth_scopes + token_exchange_scopes))
+    all_scopes = list(dict.fromkeys(server_auth_scopes + cross_app_scopes))
     security_schemes = {
         "oauth2": SecurityScheme(
             root=OAuth2SecurityScheme(
@@ -292,7 +308,7 @@ async def build_security_schemes(
 
 async def create_agent_card(
     frontend_config: A2AFrontEndConfig,
-    token_exchange: OAuth2TokenExchangeConfig | None,
+    cross_app_access: CrossApplicationAccessConfig | None,
     skills: list[AgentSkill],
 ) -> AgentCard:
     """Build an :class:`~a2a.types.AgentCard` for a DataRobot-hosted A2A agent.
@@ -301,14 +317,16 @@ async def create_agent_card(
     ----------
     frontend_config:
         NAT A2A frontend configuration (name, description, capabilities, etc.).
-    token_exchange:
-        Optional DR OAuth2 token exchange configuration for RFC 8693.
+    cross_app_access:
+        Optional Cross-Application Access configuration. When provided, populates
+        the OpenAPI ``clientCredentials`` security scheme and the JWT Bearer
+        capability extension.
     skills:
         Skills to advertise. When empty, a single default skill is generated
         from ``frontend_config.name`` and ``frontend_config.description``.
     """
     security_schemes, security, extensions = await build_security_schemes(
-        frontend_config, token_exchange
+        frontend_config, cross_app_access
     )
 
     resolved_skills = skills or [

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -149,10 +149,10 @@ def build_oauth_flow_from_cross_app_access(
     :func:`build_cross_app_capability_extension` and MUST NOT appear here.
     """
     flow = ClientCredentialsOAuthFlow(
-        token_url=config.token_url,
-        scopes={scope: f"Permission: {scope}" for scope in config.scopes},
+        token_url=config.token_request.token_url,
+        scopes={scope: f"Permission: {scope}" for scope in config.token_request.scopes},
     )
-    return flow, list(config.scopes)
+    return flow, list(config.token_request.scopes)
 
 
 def build_cross_app_capability_extension(
@@ -168,10 +168,12 @@ def build_cross_app_capability_extension(
             "scheme": CROSS_APP_SECURITY_SCHEME_REF,
             "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
         },
-        "target_audience": config.target_audience,
         "token_endpoint_auth_method": config.token_endpoint_auth_method,
         "token_exchange": config.token_exchange.model_dump(),
-        "token_request": config.token_request.model_dump(),
+        "token_request": {
+            "grant_type": config.token_request.grant_type,
+            "audience": config.token_request.audience,
+        },
     }
     return [
         AgentExtension(

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -13,28 +13,14 @@
 # limitations under the License.
 
 import logging
-import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from a2a.server.agent_execution import RequestContext
-from a2a.server.events import EventQueue
-from a2a.types import AgentCapabilities
-from a2a.types import AgentCard
-from a2a.types import AgentExtension
-from a2a.types import AgentSkill
-from a2a.types import AuthorizationCodeOAuthFlow
-from a2a.types import ClientCredentialsOAuthFlow
-from a2a.types import OAuth2SecurityScheme
-from a2a.types import OAuthFlows
-from a2a.types import SecurityScheme
 from fastapi import FastAPI
-from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
-from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
 from nat.runtime.loader import WorkflowBuilder
@@ -43,70 +29,22 @@ from pydantic import Field
 
 from datarobot_genai.core.utils.logging import setup_logging
 
-from .server_auth import OAuth2TokenExchangeConfig
+from .a2a import A2A_MOUNT_PATH
+from .a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE  # noqa: F401 (re-exported)
+from .a2a import RFC8693_GRANT_TYPE_URI  # noqa: F401 (re-exported)
+from .a2a import RFC8693_SECURITY_SCHEME_FLOW_REF  # noqa: F401 (re-exported)
+from .a2a import RFC8693_SECURITY_SCHEME_REF  # noqa: F401 (re-exported)
+from .a2a import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION  # noqa: F401 (re-exported)
+from .a2a import (
+    PerUserCompatibleAgentExecutor as _PerUserCompatibleAgentExecutor,  # noqa: F401 (re-exported)
+)
+from .a2a import create_agent_card
 from .session import DRAgentAGUISessionManager
 from .step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 DATAROBOT_EXPECTED_HEALTH_ROUTES = ["/", "/ping", "/ping/", "/health", "/health/"]
-A2A_MOUNT_PATH = "a2a"
-
-
-OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
-    "OAuth 2.0 authorization utilizing RFC 8693 Token Exchange. Clients must "
-    "supply a valid internal passport JWT as the subject token. Refer to the "
-    "capabilities.extensions block for strict token exchange parameters and "
-    "audience specifications."
-)
-
-# The extension explicitly references the security scheme key so SDKs can resolve
-# the RFC 8693 Token Exchange override without ambiguity.
-RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
-RFC8693_SECURITY_SCHEME_REF = "oauth2"  # The key in securitySchemes
-RFC8693_SECURITY_SCHEME_FLOW_REF = "clientCredentials"  # The exact flow being overridden
-RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION = (
-    "Two-Step RFC 8693 Token Exchange execution parameters."
-)
-
 
 logger = logging.getLogger(__name__)
-
-
-class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
-    """Subclass of NATWorkflowAgentExecutor that supports per-user workflows.
-
-    Two problems with the parent class for per-user workflows:
-
-    1. ``__init__`` accesses ``session_manager.workflow`` which raises ``ValueError``
-       for per-user workflows.  We bypass it and log via ``config.workflow.type`` instead.
-
-    2. ``execute`` calls ``self.session_manager.session()`` with no ``user_id``, which
-       raises ``ValueError`` for per-user workflows.  We override it to pass the A2A
-       ``context_id`` as the ``user_id``, giving each conversation its own isolated
-       per-user workflow instance.
-    """
-
-    def __init__(self, session_manager: SessionManager) -> None:
-        # Bypass parent __init__ to avoid session_manager.workflow access,
-        # which raises ValueError for per-user workflows. Log via config instead.
-        self.session_manager = session_manager
-        logger.info(
-            "Initialized NATWorkflowAgentExecutor (message-only) for workflow: %s",
-            session_manager.config.workflow.type,
-        )
-
-    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:  # type: ignore[override]
-        # Inject the A2A context_id as user_id before delegating to the parent execute.
-        # The parent calls self.session_manager.session() with no user_id, which raises
-        # ValueError for per-user workflows.  Setting the context var here means the
-        # SessionManager's _get_user_id_from_context() will find it automatically.
-        token = None
-        if context.context_id:
-            token = self.session_manager._context_state.user_id.set(context.context_id)
-        try:
-            await super().execute(context, event_queue)
-        finally:
-            if token is not None:
-                self.session_manager._context_state.user_id.reset(token)
 
 
 class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
@@ -125,210 +63,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             config=self._config, shared_builder=builder, entry_function=entry_function
         )
         self._session_managers.append(sm)
-
         return sm
-
-    @staticmethod
-    async def _oauth_flow_from_server_auth(
-        server_auth: OAuth2ResourceServerConfig,
-    ) -> tuple[AuthorizationCodeOAuthFlow, list[str]]:
-        """Build the authorization_code OAuth2 flow and scopes for NAT ``server_auth``."""
-        auth_url, token_url = await DRAgentFastApiFrontEndPluginWorker._resolve_oauth_endpoints(
-            server_auth
-        )
-        flow = AuthorizationCodeOAuthFlow(
-            authorization_url=auth_url,
-            token_url=token_url,
-            scopes={scope: f"Permission: {scope}" for scope in server_auth.scopes},
-        )
-        return flow, list(server_auth.scopes)
-
-    @staticmethod
-    def _oauth_flow_from_token_exchange(
-        config: OAuth2TokenExchangeConfig,
-    ) -> tuple[ClientCredentialsOAuthFlow, list[str]]:
-        """Build the client_credentials flow and scopes for ``a2a.oauth_token_exchange``.
-
-        Token URL and scopes live only here (OpenAPI-compatible). RFC 8693 second-phase
-        requirements are signaled separately via :meth:`_token_exchange_capability_extension`.
-        """
-        flow = ClientCredentialsOAuthFlow(
-            token_url=config.token_url,
-            scopes={scope: f"Permission: {scope}" for scope in config.scopes},
-        )
-        return flow, list(config.scopes)
-
-    @staticmethod
-    def _token_exchange_capability_extension(
-        config: OAuth2TokenExchangeConfig,
-    ) -> list[AgentExtension]:
-        """Build the RFC 8693 extension for the agent card (OAuth2 token exchange).
-
-        OpenAPI ``token_url`` / ``scopes`` remain on ``securitySchemes.oauth2.flows``.
-        ``params`` carries ``subject_token_constraints``, ``token_exchange_request``,
-        and ``ref`` binding to the client-credentials flow.
-        """
-        params = {
-            "ref": {
-                "scheme": RFC8693_SECURITY_SCHEME_REF,
-                "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
-            },
-            "subject_token_constraints": config.subject_token_constraints.model_dump(),
-            "token_exchange_request": config.token_exchange_request.model_dump(),
-        }
-        return [
-            AgentExtension(
-                uri=RFC8693_GRANT_TYPE_URI,
-                description=RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION,
-                params=params,
-            )
-        ]
-
-    async def _build_security_schemes(
-        self, frontend_config: A2AFrontEndConfig
-    ) -> tuple[
-        dict[str, SecurityScheme] | None,
-        list[dict[str, list[str]]] | None,
-        list[AgentExtension] | None,
-    ]:
-        """Build A2A security schemes from the frontend configuration.
-
-        Supports two independent auth sources that are merged into a single
-        ``oauth2`` security scheme with separate flows:
-
-        * ``server_auth`` (OAuth2ResourceServerConfig) → authorization_code flow.
-          Endpoint URLs are resolved via OIDC discovery or derived from the issuer URL.
-        * ``a2a.oauth_token_exchange`` (OAuth2TokenExchangeConfig) → client_credentials flow.
-          Used for RFC 8693 second-phase token acquisition. Configured on the DataRobot
-          ``a2a`` block, not on NAT's A2A frontend model, so it stays stable if NAT's
-          config types change.
-
-        Returns
-        -------
-            Tuple of (security_schemes, security requirements, capability extensions),
-            all ``None`` when neither auth source is configured.
-        """
-        server_auth = frontend_config.server_auth
-        a2a_cfg = self.front_end_config.a2a
-        token_exchange = a2a_cfg.oauth_token_exchange if a2a_cfg else None
-
-        if not server_auth and not token_exchange:
-            return None, None, None
-
-        auth_code_flow, server_auth_scopes = (
-            await self._oauth_flow_from_server_auth(server_auth) if server_auth else (None, [])
-        )
-        client_creds_flow, token_exchange_scopes = (
-            self._oauth_flow_from_token_exchange(token_exchange) if token_exchange else (None, [])
-        )
-        extensions = (
-            self._token_exchange_capability_extension(token_exchange) if token_exchange else None
-        )
-
-        all_scopes = list(dict.fromkeys(server_auth_scopes + token_exchange_scopes))
-        security_schemes = {
-            "oauth2": SecurityScheme(
-                root=OAuth2SecurityScheme(
-                    type="oauth2",
-                    description=OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE,
-                    flows=OAuthFlows(
-                        authorization_code=auth_code_flow,
-                        client_credentials=client_creds_flow,
-                    ),
-                )
-            )
-        }
-        return security_schemes, [{"oauth2": all_scopes}], extensions
-
-    @staticmethod
-    async def _resolve_oauth_endpoints(
-        server_auth_config: OAuth2ResourceServerConfig,
-    ) -> tuple[str, str]:
-        """Resolve authorization and token URLs from OAuth2ResourceServerConfig.
-
-        Uses OIDC discovery when available, otherwise derives URLs from issuer_url.
-        """
-        import httpx
-
-        if server_auth_config.discovery_url:
-            try:
-                async with httpx.AsyncClient() as client:
-                    response = await client.get(server_auth_config.discovery_url, timeout=5.0)
-                    response.raise_for_status()
-                    metadata = response.json()
-                    auth_url = metadata.get("authorization_endpoint")
-                    token_url = metadata.get("token_endpoint")
-                    if auth_url and token_url:
-                        logger.info(
-                            "Resolved OAuth endpoints via discovery: %s",
-                            server_auth_config.discovery_url,
-                        )
-                        return auth_url, token_url
-            except Exception as e:
-                logger.warning("Failed to discover OAuth endpoints: %s", e)
-
-        issuer = server_auth_config.issuer_url.rstrip("/")
-        auth_url = f"{issuer}/oauth/authorize"
-        token_url = f"{issuer}/oauth/token"
-        logger.info("Using derived OAuth endpoints from issuer: %s", issuer)
-        return auth_url, token_url
-
-    async def _create_agent_card(self, frontend_config: A2AFrontEndConfig) -> AgentCard:
-        security_schemes, security, extensions = await self._build_security_schemes(frontend_config)
-
-        if self.front_end_config.a2a.skills:
-            skills = self.front_end_config.a2a.skills
-        else:
-            skills = [
-                AgentSkill(
-                    id="call",
-                    name=frontend_config.name,
-                    description=frontend_config.description,
-                    tags=[],
-                    examples=[],
-                )
-            ]
-        agent_card = AgentCard(
-            name=frontend_config.name,
-            description=frontend_config.description,
-            url=self._get_a2a_endpoint_url(frontend_config),
-            version=frontend_config.version,
-            default_input_modes=frontend_config.default_input_modes,
-            default_output_modes=frontend_config.default_output_modes,
-            capabilities=AgentCapabilities(
-                streaming=frontend_config.capabilities.streaming,
-                push_notifications=frontend_config.capabilities.push_notifications,
-                extensions=extensions,
-            ),
-            skills=skills,
-            security_schemes=security_schemes or None,
-            security=security or None,
-        )
-        return agent_card
-
-    def _get_a2a_endpoint_url(self, frontend_config: A2AFrontEndConfig) -> str:
-        """Construct the A2A endpoint URL.
-
-        In a DataRobot deployment, uses the deployment's direct access URL.
-        Otherwise, appends the /a2a/ mount path to the default base URL.
-        """
-        mlops_deployment_id = os.getenv("MLOPS_DEPLOYMENT_ID", "")
-        if mlops_deployment_id:
-            # Prefer DATAROBOT_PUBLIC_API_ENDPOINT over DATAROBOT_ENDPOINT because on-prem
-            # deployments often set DATAROBOT_ENDPOINT to an internal k8s URL, while
-            # DATAROBOT_PUBLIC_API_ENDPOINT holds the externally reachable URL needed here
-            # to construct a publicly accessible agent-card URL.
-            datarobot_endpoint = os.getenv("DATAROBOT_PUBLIC_API_ENDPOINT") or os.getenv(
-                "DATAROBOT_ENDPOINT", ""
-            )
-            if not datarobot_endpoint:
-                raise ValueError(
-                    "DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set "
-                    "when MLOPS_DEPLOYMENT_ID is set"
-                )
-            base = datarobot_endpoint.rstrip("/")
-            return f"{base}/deployments/{mlops_deployment_id}/directAccess/{A2A_MOUNT_PATH}/"
-        return f"http://{frontend_config.host}:{frontend_config.port}/{A2A_MOUNT_PATH}/"
 
     async def add_routes(self, app: FastAPI, builder: WorkflowBuilder) -> None:
         await super().add_routes(app, builder)
@@ -349,7 +84,16 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         )
         self._a2a_worker = A2AFrontEndPluginWorker(nat_config)
 
-        agent_card = await self._create_agent_card(self._a2a_worker.front_end_config)
+        token_exchange = (
+            self.front_end_config.a2a.oauth_token_exchange if self.front_end_config.a2a else None
+        )
+        skills = self.front_end_config.a2a.skills if self.front_end_config.a2a else []
+
+        agent_card = await create_agent_card(
+            frontend_config=self._a2a_worker.front_end_config,
+            token_exchange=token_exchange,
+            skills=skills,
+        )
         session_manager = await DRAgentAGUISessionManager.create(
             config=self._config,
             shared_builder=builder,
@@ -417,7 +161,6 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
                     }
                 },
             )
-
             logger.info(f"Added health check endpoint at {path}")
 
 

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -16,11 +16,14 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+from a2a.server.agent_execution import RequestContext
+from a2a.server.events import EventQueue
 from fastapi import FastAPI
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import SessionManager
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
+from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
 from nat.runtime.loader import WorkflowBuilder
@@ -35,9 +38,6 @@ from .a2a import CROSS_APP_SECURITY_SCHEME_FLOW_REF  # noqa: F401 (re-exported)
 from .a2a import CROSS_APP_SECURITY_SCHEME_REF  # noqa: F401 (re-exported)
 from .a2a import JWT_BEARER_GRANT_TYPE_URI  # noqa: F401 (re-exported)
 from .a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE  # noqa: F401 (re-exported)
-from .a2a import (
-    PerUserCompatibleAgentExecutor as _PerUserCompatibleAgentExecutor,  # noqa: F401 (re-exported)
-)
 from .a2a import create_agent_card
 from .session import DRAgentAGUISessionManager
 from .step_adaptor import DRAgentNestedReasoningStepAdaptor
@@ -45,6 +45,44 @@ from .step_adaptor import DRAgentNestedReasoningStepAdaptor
 DATAROBOT_EXPECTED_HEALTH_ROUTES = ["/", "/ping", "/ping/", "/health", "/health/"]
 
 logger = logging.getLogger(__name__)
+
+
+class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
+    """Subclass of NATWorkflowAgentExecutor that supports per-user workflows.
+
+    Two problems with the parent class for per-user workflows:
+
+    1. ``__init__`` accesses ``session_manager.workflow`` which raises ``ValueError``
+       for per-user workflows.  We bypass it and log via ``config.workflow.type`` instead.
+
+    2. ``execute`` calls ``self.session_manager.session()`` with no ``user_id``, which
+       raises ``ValueError`` for per-user workflows.  We override it to pass the A2A
+       ``context_id`` as the ``user_id``, giving each conversation its own isolated
+       per-user workflow instance.
+    """
+
+    def __init__(self, session_manager: SessionManager) -> None:
+        # Bypass parent __init__ to avoid session_manager.workflow access,
+        # which raises ValueError for per-user workflows. Log via config instead.
+        self.session_manager = session_manager
+        logger.info(
+            "Initialized NATWorkflowAgentExecutor (message-only) for workflow: %s",
+            session_manager.config.workflow.type,
+        )
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:  # type: ignore[override]
+        # Inject the A2A context_id as user_id before delegating to the parent execute.
+        # The parent calls self.session_manager.session() with no user_id, which raises
+        # ValueError for per-user workflows.  Setting the context var here means the
+        # SessionManager's _get_user_id_from_context() will find it automatically.
+        token = None
+        if context.context_id:
+            token = self.session_manager._context_state.user_id.set(context.context_id)
+        try:
+            await super().execute(context, event_queue)
+        finally:
+            if token is not None:
+                self.session_manager._context_state.user_id.reset(token)
 
 
 class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -33,11 +33,6 @@ from pydantic import Field
 from datarobot_genai.core.utils.logging import setup_logging
 
 from .a2a import A2A_MOUNT_PATH
-from .a2a import CROSS_APP_EXTENSION_DESCRIPTION  # noqa: F401 (re-exported)
-from .a2a import CROSS_APP_SECURITY_SCHEME_FLOW_REF  # noqa: F401 (re-exported)
-from .a2a import CROSS_APP_SECURITY_SCHEME_REF  # noqa: F401 (re-exported)
-from .a2a import JWT_BEARER_GRANT_TYPE_URI  # noqa: F401 (re-exported)
-from .a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE  # noqa: F401 (re-exported)
 from .a2a import create_agent_card
 from .session import DRAgentAGUISessionManager
 from .step_adaptor import DRAgentNestedReasoningStepAdaptor

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -202,6 +202,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
                     }
                 },
             )
+
             logger.info(f"Added health check endpoint at {path}")
 
 

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -101,6 +101,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             config=self._config, shared_builder=builder, entry_function=entry_function
         )
         self._session_managers.append(sm)
+
         return sm
 
     async def add_routes(self, app: FastAPI, builder: WorkflowBuilder) -> None:

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -30,11 +30,11 @@ from pydantic import Field
 from datarobot_genai.core.utils.logging import setup_logging
 
 from .a2a import A2A_MOUNT_PATH
+from .a2a import CROSS_APP_EXTENSION_DESCRIPTION  # noqa: F401 (re-exported)
+from .a2a import CROSS_APP_SECURITY_SCHEME_FLOW_REF  # noqa: F401 (re-exported)
+from .a2a import CROSS_APP_SECURITY_SCHEME_REF  # noqa: F401 (re-exported)
+from .a2a import JWT_BEARER_GRANT_TYPE_URI  # noqa: F401 (re-exported)
 from .a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE  # noqa: F401 (re-exported)
-from .a2a import RFC8693_GRANT_TYPE_URI  # noqa: F401 (re-exported)
-from .a2a import RFC8693_SECURITY_SCHEME_FLOW_REF  # noqa: F401 (re-exported)
-from .a2a import RFC8693_SECURITY_SCHEME_REF  # noqa: F401 (re-exported)
-from .a2a import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION  # noqa: F401 (re-exported)
 from .a2a import (
     PerUserCompatibleAgentExecutor as _PerUserCompatibleAgentExecutor,  # noqa: F401 (re-exported)
 )
@@ -84,14 +84,16 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         )
         self._a2a_worker = A2AFrontEndPluginWorker(nat_config)
 
-        token_exchange = (
-            self.front_end_config.a2a.oauth_token_exchange if self.front_end_config.a2a else None
+        cross_app_access = (
+            self.front_end_config.a2a.cross_application_access
+            if self.front_end_config.a2a
+            else None
         )
         skills = self.front_end_config.a2a.skills if self.front_end_config.a2a else []
 
         agent_card = await create_agent_card(
             frontend_config=self._a2a_worker.front_end_config,
-            token_exchange=token_exchange,
+            cross_app_access=cross_app_access,
             skills=skills,
         )
         session_manager = await DRAgentAGUISessionManager.create(

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -33,7 +33,7 @@ from .converters import convert_dragent_run_agent_input_to_chat_request_or_messa
 from .converters import convert_str_to_dragent_event_response
 from .converters import convert_tool_message_to_str
 from .logging import logging_handler_setup
-from .server_auth import OAuth2TokenExchangeConfig
+from .server_auth import CrossApplicationAccessConfig
 
 # Suppress specific non-actionable NAT warning messages by content.
 # Patch Handler.handle (inherited by all subclasses - they only override emit)
@@ -48,13 +48,14 @@ class DRAgentA2AConfig(BaseModel):
     """DR-owned wrapper around NAT's A2AFrontEndConfig with optional skill definitions."""
 
     server: A2AFrontEndConfig = Field(description="NAT A2A server configuration.")
-    oauth_token_exchange: OAuth2TokenExchangeConfig | None = Field(
+    cross_application_access: CrossApplicationAccessConfig | None = Field(
         default=None,
         description=(
-            "Configuration for agent authorization using Token Exchange (RFC 8693). "
-            "If provided, `token_url` and `scopes` populate OpenAPI security schemes; "
-            "`passport_requirement` and `exchange_payload` describe the two-step flow "
-            "(ID-JAG passport, then Okta token exchange) in the agent card extension."
+            "Configuration for Cross-Application Access utilizing a hybrid RFC 8693 / "
+            "RFC 7523 flow. If provided, `token_url` and `scopes` populate the OpenAPI "
+            "``securitySchemes`` client credentials flow; `target_audience`, "
+            "`token_endpoint_auth_method`, `token_exchange`, and `token_request` are "
+            "advertised in ``capabilities.extensions`` for SDK consumption."
         ),
     )
     skills: list[AgentSkill] = Field(

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -52,10 +52,7 @@ class DRAgentA2AConfig(BaseModel):
         default=None,
         description=(
             "Configuration for Cross-Application Access utilizing a hybrid RFC 8693 / "
-            "RFC 7523 flow. If provided, `token_url` and `scopes` populate the OpenAPI "
-            "``securitySchemes`` client credentials flow; `target_audience`, "
-            "`token_endpoint_auth_method`, `token_exchange`, and `token_request` are "
-            "advertised in ``capabilities.extensions`` for SDK consumption."
+            "RFC 7523 flow."
         ),
     )
     skills: list[AgentSkill] = Field(

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -39,6 +39,25 @@ class CrossAppTokenRequest(BaseModel):
     grant_type: str = Field(
         description="Must be ``urn:ietf:params:oauth:grant-type:jwt-bearer`` (RFC 7523).",
     )
+    token_url: str = Field(
+        description=(
+            "Token endpoint of the resource AS. "
+            "Published as ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``."
+        ),
+    )
+    audience: str = Field(
+        description=(
+            "Final resource identifier for the agent. "
+            "Published in ``capabilities.extensions[].params.token_request.audience``."
+        ),
+    )
+    scopes: list[str] = Field(
+        default=["read_data"],
+        description=(
+            "Scopes requested in Step 2. "
+            "Published as ``securitySchemes.oauth2.flows.clientCredentials.scopes``."
+        ),
+    )
 
 
 class CrossApplicationAccessConfig(AuthProviderBaseConfig):
@@ -47,20 +66,11 @@ class CrossApplicationAccessConfig(AuthProviderBaseConfig):
     Hybrid RFC 8693 / RFC 7523 flow: Step 1 exchanges the incoming access token for
     an ID-JAG via ``token_exchange.audience``; Step 2 uses the ID-JAG for the final token.
 
-    ``token_url`` / ``scopes`` → ``securitySchemes.oauth2.flows.clientCredentials`` only.
+    ``token_request.token_url`` / ``token_request.scopes`` →
+    ``securitySchemes.oauth2.flows.clientCredentials`` only.
     All other fields → ``capabilities.extensions.params`` only.
     """
 
-    token_url: str = Field(
-        description="Published as ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``.",
-    )
-    scopes: list[str] = Field(
-        default=["read_data"],
-        description="Published as ``securitySchemes.oauth2.flows.clientCredentials.scopes``.",
-    )
-    target_audience: str = Field(
-        description="Published as ``capabilities.extensions[].params.target_audience``.",
-    )
     token_endpoint_auth_method: str = Field(
         description=(
             "Client auth method (e.g. ``private_key_jwt``). "

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -23,18 +23,12 @@ class CrossAppTokenExchange(BaseModel):
     """Step 1 parameters: RFC 8693 Token Exchange prerequisite to obtain the ID-JAG."""
 
     trusted_issuer: str = Field(
-        description=(
-            "Issuer URL of the trusted identity provider that must validate the "
-            "subject token before the downstream token exchange. Used as ``issuer`` "
-            "in the OAuth2 client configuration and as the base for JWT client "
-            "assertion audience claims."
-        ),
+        description="Org-level AS issuer URL. Validates the subject token in Step 1.",
     )
     audience: str = Field(
         description=(
-            "Authorization Server destination for Step 1: the Okta custom AS token "
-            "endpoint base URL (e.g. ``https://your-org.okta.com/oauth2/<as-id>``). "
-            "This is where the ID-JAG prerequisite is fetched."
+            "Step 1 AS base URL (e.g. ``https://your-org.okta.com/oauth2/<as-id>``). "
+            "ID-JAG is fetched from here."
         ),
     )
 
@@ -43,56 +37,34 @@ class CrossAppTokenRequest(BaseModel):
     """Step 2 parameters: RFC 7523 JWT Bearer Grant to obtain the final access token."""
 
     grant_type: str = Field(
-        description=(
-            "OAuth 2.0 grant type for the final token request. Must be "
-            "``urn:ietf:params:oauth:grant-type:jwt-bearer`` per RFC 7523."
-        ),
+        description="Must be ``urn:ietf:params:oauth:grant-type:jwt-bearer`` (RFC 7523).",
     )
 
 
 class CrossApplicationAccessConfig(AuthProviderBaseConfig):
-    """OAuth2 server-side auth for Cross-Application Access surfaced on the AgentCard.
+    """Server-side Cross-Application Access config surfaced on the AgentCard.
 
-    Implements a hybrid RFC 8693 / RFC 7523 flow:
+    Hybrid RFC 8693 / RFC 7523 flow: Step 1 exchanges the incoming access token for
+    an ID-JAG via ``token_exchange.audience``; Step 2 uses the ID-JAG for the final token.
 
-    * **Step 1** (RFC 8693 Token Exchange): exchange an incoming access token for
-      an ID-JAG prerequisite via the authorization server specified in
-      ``token_exchange.audience``.
-    * **Step 2** (RFC 7523 JWT Bearer Grant): use the ID-JAG to obtain the final
-      scoped agent token.
-
-    **OpenAPI fields** (``token_url``, ``scopes``) populate
-    ``securitySchemes.oauth2.flows.clientCredentials`` in the Agent Card.
-    They are NOT included in ``capabilities.extensions.params``.
-
-    **Extension fields** (``target_audience``, ``token_endpoint_auth_method``,
-    ``token_exchange``, ``token_request``) are placed exclusively in the
-    ``capabilities.extensions`` block for SDK consumption.
+    ``token_url`` / ``scopes`` → ``securitySchemes.oauth2.flows.clientCredentials`` only.
+    All other fields → ``capabilities.extensions.params`` only.
     """
 
     token_url: str = Field(
-        description=(
-            "Token endpoint URL for the final RFC 7523 grant. Published under "
-            "OpenAPI ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``."
-        ),
+        description="Published as ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``.",
     )
     scopes: list[str] = Field(
         default=["read_data"],
-        description=(
-            "Scopes advertised for this API. Published under OpenAPI "
-            "``securitySchemes.oauth2.flows.clientCredentials.scopes``."
-        ),
+        description="Published as ``securitySchemes.oauth2.flows.clientCredentials.scopes``.",
     )
     target_audience: str = Field(
-        description=(
-            "Final resource identifier for the agent being called. Published as "
-            "``capabilities.extensions[].params.target_audience`` in the Agent Card."
-        ),
+        description="Published as ``capabilities.extensions[].params.target_audience``.",
     )
     token_endpoint_auth_method: str = Field(
         description=(
-            "OAuth 2.0 token endpoint client authentication method "
-            "(e.g. ``private_key_jwt``). Published in the extension params."
+            "Client auth method (e.g. ``private_key_jwt``). "
+            "Published in ``capabilities.extensions[].params``."
         ),
     )
     token_exchange: CrossAppTokenExchange = Field(

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -19,59 +19,85 @@ from pydantic import BaseModel
 from pydantic import Field
 
 
-class OAuth2SubjectTokenConstraints(BaseModel):
-    """Constraints on the subject token used in RFC 8693 token exchange (e.g. trusted issuer)."""
+class CrossAppTokenExchange(BaseModel):
+    """Step 1 parameters: RFC 8693 Token Exchange prerequisite to obtain the ID-JAG."""
 
     trusted_issuer: str = Field(
         description=(
-            "Issuer URL of the internal passport JWT that must be validated before "
-            "the downstream Okta token exchange."
+            "Issuer URL of the trusted identity provider that must validate the "
+            "subject token before the downstream token exchange. Used as ``issuer`` "
+            "in the OAuth2 client configuration and as the base for JWT client "
+            "assertion audience claims."
         ),
     )
-
-
-class OAuth2TokenExchangeRequest(BaseModel):
-    """RFC 8693 token exchange request parameters for the authorization server."""
-
-    audience: str = Field(description="Expected resource / audience (`aud`) for the issued token.")
-    subject_token_type: str = Field(
+    audience: str = Field(
         description=(
-            "`subject_token_type` value for RFC 8693 (e.g. JWT access token vs id token URN)."
+            "Authorization Server destination for Step 1: the Okta custom AS token "
+            "endpoint base URL (e.g. ``https://your-org.okta.com/oauth2/<as-id>``). "
+            "This is where the ID-JAG prerequisite is fetched."
         ),
     )
-    requested_token_type: str = Field(
-        description="`requested_token_type` per RFC 8693 (usually an access token URN).",
+
+
+class CrossAppTokenRequest(BaseModel):
+    """Step 2 parameters: RFC 7523 JWT Bearer Grant to obtain the final access token."""
+
+    grant_type: str = Field(
+        description=(
+            "OAuth 2.0 grant type for the final token request. Must be "
+            "``urn:ietf:params:oauth:grant-type:jwt-bearer`` per RFC 7523."
+        ),
     )
-    token_endpoint_auth_method: str = Field(
-        description="OAuth 2.0 token endpoint client authentication method (e.g. private_key_jwt).",
-    )
 
 
-class OAuth2TokenExchangeConfig(AuthProviderBaseConfig):
-    """OAuth2 server-side auth for RFC 8693 token exchange surfaced on the AgentCard.
+class CrossApplicationAccessConfig(AuthProviderBaseConfig):
+    """OAuth2 server-side auth for Cross-Application Access surfaced on the AgentCard.
 
-    OpenAPI fields (`token_url`, `scopes`) populate ``securitySchemes.oauth2`` client
-    credentials flow.
-    ``subject_token_constraints`` and ``token_exchange_request`` are advertised in
-    ``capabilities.extensions`` for SDKs executing the flow.
+    Implements a hybrid RFC 8693 / RFC 7523 flow:
+
+    * **Step 1** (RFC 8693 Token Exchange): exchange an incoming access token for
+      an ID-JAG prerequisite via the authorization server specified in
+      ``token_exchange.audience``.
+    * **Step 2** (RFC 7523 JWT Bearer Grant): use the ID-JAG to obtain the final
+      scoped agent token.
+
+    **OpenAPI fields** (``token_url``, ``scopes``) populate
+    ``securitySchemes.oauth2.flows.clientCredentials`` in the Agent Card.
+    They are NOT included in ``capabilities.extensions.params``.
+
+    **Extension fields** (``target_audience``, ``token_endpoint_auth_method``,
+    ``token_exchange``, ``token_request``) are placed exclusively in the
+    ``capabilities.extensions`` block for SDK consumption.
     """
 
     token_url: str = Field(
         description=(
-            "Token URL for Token Exchange (RFC 8693). This is the endpoint to which "
-            "the client sends the exchange request for a scoped token for this agent."
+            "Token endpoint URL for the final RFC 7523 grant. Published under "
+            "OpenAPI ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``."
         ),
     )
     scopes: list[str] = Field(
         default=["read_data"],
         description=(
-            "Scopes advertised for this API. Listed under OpenAPI flows; validation ensures "
-            "the token grants required scopes."
+            "Scopes advertised for this API. Published under OpenAPI "
+            "``securitySchemes.oauth2.flows.clientCredentials.scopes``."
         ),
     )
-    subject_token_constraints: OAuth2SubjectTokenConstraints = Field(
-        description="Requirements for the subject token presented during token exchange.",
+    target_audience: str = Field(
+        description=(
+            "Final resource identifier for the agent being called. Published as "
+            "``capabilities.extensions[].params.target_audience`` in the Agent Card."
+        ),
     )
-    token_exchange_request: OAuth2TokenExchangeRequest = Field(
-        description="Token endpoint parameters for the token exchange request.",
+    token_endpoint_auth_method: str = Field(
+        description=(
+            "OAuth 2.0 token endpoint client authentication method "
+            "(e.g. ``private_key_jwt``). Published in the extension params."
+        ),
+    )
+    token_exchange: CrossAppTokenExchange = Field(
+        description="RFC 8693 Token Exchange parameters (Step 1: ID-JAG prerequisite).",
+    )
+    token_request: CrossAppTokenRequest = Field(
+        description="RFC 7523 JWT Bearer Grant parameters (Step 2: final access token).",
     )

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -16,12 +16,15 @@ import abc
 import logging
 from collections.abc import AsyncGenerator
 from typing import Any
+from typing import Protocol
+from typing import runtime_checkable
 
 import httpx
 from a2a.client import A2ACardResolver
 from a2a.client import AuthInterceptor
 from a2a.client import ClientConfig
 from a2a.client import ClientFactory
+from a2a.types import AgentCard
 from nat.authentication.interfaces import AuthProviderBase
 from nat.builder.builder import Builder
 from nat.builder.context import Context
@@ -46,6 +49,25 @@ def _extract_auth_headers(auth_result: Any) -> dict[str, str]:
             headers[cred.name] = cred.value.get_secret_value()
 
     return headers
+
+
+@runtime_checkable
+class AgentCardAware(Protocol):
+    """Auth providers that need the resolved agent card before ``authenticate()``.
+
+    Implement this protocol on an auth provider to receive the fetched
+    :class:`~a2a.types.AgentCard` before the first ``authenticate()`` call.
+    :class:`_AuthenticatedA2ABaseClient` checks for this protocol via
+    ``isinstance`` and calls :meth:`set_agent_card` automatically.
+    """
+
+    def set_agent_card(self, card: AgentCard) -> None:
+        """Receive the resolved agent card.
+
+        Called by :class:`_AuthenticatedA2ABaseClient` immediately after the
+        card is fetched, before ``authenticate()`` is ever invoked.
+        """
+        ...
 
 
 class A2ADiscoveryAuthMixin(abc.ABC):
@@ -75,12 +97,15 @@ class A2ADiscoveryAuthMixin(abc.ABC):
 class _AuthenticatedA2ABaseClient(A2ABaseClient):
     """A2A client that authenticates agent card discovery and A2A RPC independently.
 
-    * **Agent card** ``GET`` — if the configured ``auth_provider`` implements
-      :class:`A2ADiscoveryAuthMixin`, ``authenticate_for_discovery()`` is called
-      and its result is used as headers on a short-lived ``httpx.AsyncClient``.
-      Otherwise ``authenticate()`` is called and its credentials are extracted as
-      headers (default behavior for e.g. ``DataRobotAPIKeyAuthProvider``).
-      When no provider is set the card is fetched unauthenticated.
+    * **Agent card** ``GET`` — two mutually exclusive paths:
+
+      1. *Discovery mixin*: if the configured ``auth_provider`` implements
+         :class:`A2ADiscoveryAuthMixin`, ``authenticate_for_discovery()`` is called
+         and its result is used as headers on a short-lived ``httpx.AsyncClient``.
+      2. *Default*: ``authenticate()`` is called and its credentials are extracted
+         as headers (e.g. ``DataRobotAPIKeyAuthProvider``).  When no provider is
+         set the card is fetched unauthenticated.
+
     * **Task / message** traffic uses NAT's ``AuthInterceptor`` +
       ``A2ACredentialService``, which calls ``authenticate()`` per-request.
     """
@@ -137,6 +162,11 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
         if not self._agent_card:
             raise RuntimeError("Agent card not resolved")
 
+        # Allow auth providers that need agent-card parameters (e.g. OktaTokenExchangeAuthProvider)
+        # to receive the resolved card before the interceptor is set up.
+        if isinstance(self._auth_provider, AgentCardAware):
+            self._auth_provider.set_agent_card(self._agent_card)
+
         interceptors: list[Any] = []
         if self._auth_provider:
             credential_service = A2ACredentialService(
@@ -158,12 +188,14 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
 
 
 class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_client"):  # type: ignore[call-arg]
-    """A2A client config for DataRobot deployments.
+    """A2A client config with separate discovery and call-phase auth.
 
-    Uses ``auth_provider`` (from the parent ``A2AClientConfig``) for both agent
-    card discovery and A2A RPC calls.  If the referenced provider implements
-    :class:`A2ADiscoveryAuthMixin` it can supply different credentials for the
-    two phases; otherwise the same ``authenticate()`` result is used for both.
+    Inherits all fields from :class:`~nat.plugins.a2a.client.client_config.A2AClientConfig`
+    (``url``, ``auth_provider``, ``agent_card_path``, ``task_timeout``, ``streaming``).
+
+    If the referenced ``auth_provider`` implements :class:`A2ADiscoveryAuthMixin`,
+    it supplies different credentials for agent card discovery vs A2A RPC calls.
+    Otherwise the same ``authenticate()`` result is used for both phases.
     """
 
 
@@ -171,8 +203,7 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
     """Uses :class:`_AuthenticatedA2ABaseClient` so both A2A phases are authenticated."""
 
     async def __aenter__(self) -> "AuthenticatedA2AClientFunctionGroup":
-        config: A2AClientConfig = self._config  # type: ignore[assignment]
-        base_url = str(config.url)
+        config: AuthenticatedA2AClientConfig = self._config  # type: ignore[assignment]
 
         user_id = Context.get().user_id
         if not user_id:
@@ -194,6 +225,7 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
                 )
                 raise RuntimeError(f"Failed to resolve auth provider: {e}") from e
 
+        base_url = str(config.url)
         self._client = _AuthenticatedA2ABaseClient(
             base_url=base_url,
             agent_card_path=config.agent_card_path,

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
 import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
 import httpx
+from a2a.client import A2ACardResolver
+from a2a.client import AuthInterceptor
 from a2a.client import ClientConfig
 from a2a.client import ClientFactory
 from nat.authentication.interfaces import AuthProviderBase
@@ -25,6 +28,7 @@ from nat.builder.context import Context
 from nat.cli.register_workflow import register_per_user_function_group
 from nat.data_models.authentication import BearerTokenCred
 from nat.data_models.authentication import HeaderCred
+from nat.plugins.a2a.auth.credential_service import A2ACredentialService
 from nat.plugins.a2a.client.client_base import A2ABaseClient
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 from nat.plugins.a2a.client.client_impl import A2AClientFunctionGroup
@@ -44,79 +48,127 @@ def _extract_auth_headers(auth_result: Any) -> dict[str, str]:
     return headers
 
 
-class _AuthenticatedA2ABaseClient(A2ABaseClient):
-    """A2ABaseClient that authenticates all requests to the remote agent.
+class A2ADiscoveryAuthMixin(abc.ABC):
+    """Mixin for auth providers that need different credentials for agent card discovery.
 
-    Overrides ``__aenter__`` to pre-authenticate via the auth provider and embed
-    the Bearer token in the ``httpx.AsyncClient`` default headers.  This ensures
-    every request — agent-card fetch *and* every ``send_message`` — carries auth.
+    By default :meth:`_AuthenticatedA2ABaseClient._resolve_agent_card` calls
+    ``authenticate()`` and extracts the resulting credentials as HTTP headers.
+    Implement this mixin to return different headers for the agent card GET
+    without affecting the call-phase ``authenticate()`` used by ``AuthInterceptor``.
+
+    Example: :class:`~datarobot_genai.dragent.plugins.okta_a2a_auth.OktaTokenExchangeAuthProvider`
+    uses this to forward the incoming Okta bearer token for discovery while
+    performing a two-step RFC 8693 exchange for the actual A2A calls.
     """
+
+    @abc.abstractmethod
+    async def authenticate_for_discovery(self, user_id: str | None = None) -> dict[str, str]:
+        """Return HTTP headers for the agent card GET request.
+
+        Returns
+        -------
+        dict[str, str]
+            Header name → value pairs to attach to the agent card HTTP request.
+        """
+
+
+class _AuthenticatedA2ABaseClient(A2ABaseClient):
+    """A2A client that authenticates agent card discovery and A2A RPC independently.
+
+    * **Agent card** ``GET`` — if the configured ``auth_provider`` implements
+      :class:`A2ADiscoveryAuthMixin`, ``authenticate_for_discovery()`` is called
+      and its result is used as headers on a short-lived ``httpx.AsyncClient``.
+      Otherwise ``authenticate()`` is called and its credentials are extracted as
+      headers (default behavior for e.g. ``DataRobotAPIKeyAuthProvider``).
+      When no provider is set the card is fetched unauthenticated.
+    * **Task / message** traffic uses NAT's ``AuthInterceptor`` +
+      ``A2ACredentialService``, which calls ``authenticate()`` per-request.
+    """
+
+    async def _resolve_agent_card(self) -> None:
+        user_id = Context.get().user_id or "default-user"
+
+        if isinstance(self._auth_provider, A2ADiscoveryAuthMixin):
+            headers = await self._auth_provider.authenticate_for_discovery(user_id)
+            logger.info(
+                "Fetching agent card (custom discovery auth) from: %s%s",
+                self._base_url,
+                self._agent_card_path,
+            )
+        elif self._auth_provider:
+            auth_result = await self._auth_provider.authenticate(user_id=user_id)
+            headers = _extract_auth_headers(auth_result) if auth_result else {}
+            logger.info(
+                "Fetching agent card (auth_provider authenticate()) from: %s%s",
+                self._base_url,
+                self._agent_card_path,
+            )
+        else:
+            headers = {}
+            logger.info(
+                "Fetching agent card (unauthenticated) from: %s%s",
+                self._base_url,
+                self._agent_card_path,
+            )
+
+        timeout = httpx.Timeout(self._task_timeout.total_seconds())
+        try:
+            async with httpx.AsyncClient(timeout=timeout, headers=headers) as card_client:
+                resolver = A2ACardResolver(
+                    httpx_client=card_client,
+                    base_url=self._base_url,
+                    agent_card_path=self._agent_card_path,
+                )
+                self._agent_card = await resolver.get_agent_card()
+                logger.info("Successfully fetched agent card")
+        except Exception as e:
+            logger.error("Failed to fetch agent card: %s", e, exc_info=True)
+            raise RuntimeError(f"Failed to fetch agent card from {self._base_url}") from e
 
     async def __aenter__(self) -> "_AuthenticatedA2ABaseClient":
         if self._httpx_client is not None or self._client is not None:  # type: ignore[has-type]
             raise RuntimeError("A2ABaseClient already initialized")
 
-        # Pre-authenticate to embed Bearer token in every httpx request.
-        default_headers: dict[str, str] = {}
-        if self._auth_provider:
-            try:
-                user_id = Context.get().user_id or "default-user"
-                auth_result = await self._auth_provider.authenticate(user_id=user_id)
-                if auth_result:
-                    default_headers = _extract_auth_headers(auth_result)
-                    logger.info(
-                        "Pre-authenticated: injecting %d auth header(s) into httpx client",
-                        len(default_headers),
-                    )
-            except Exception:
-                logger.warning("Failed to pre-authenticate for A2A client", exc_info=True)
-
-        # Create httpx client with auth headers as defaults (applied to ALL requests).
         self._httpx_client = httpx.AsyncClient(
             timeout=httpx.Timeout(self._task_timeout.total_seconds()),
-            headers=default_headers,
         )
 
-        # Resolve agent card — our override below; auth already in httpx headers.
         await self._resolve_agent_card()
         if not self._agent_card:
             raise RuntimeError("Agent card not resolved")
 
-        # Create A2A client without AuthInterceptor — auth is at the httpx level.
+        interceptors: list[Any] = []
+        if self._auth_provider:
+            credential_service = A2ACredentialService(
+                auth_provider=self._auth_provider,
+                agent_card=self._agent_card,
+            )
+            interceptors.append(AuthInterceptor(credential_service))
+            logger.info("Task-phase authentication configured for A2A client (AuthInterceptor)")
+
         client_config = ClientConfig(
             httpx_client=self._httpx_client,
             streaming=self._streaming,
         )
         factory = ClientFactory(client_config)
-        self._client = factory.create(self._agent_card)
+        self._client = factory.create(self._agent_card, interceptors=interceptors)
 
-        logger.info(
-            "Connected to A2A agent at %s with pre-injected auth headers",
-            self._base_url,
-        )
+        logger.info("Connected to A2A agent at %s", self._base_url)
         return self
 
 
 class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_client"):  # type: ignore[call-arg]
-    """A2AClientConfig variant that authenticates the agent-card fetch.
+    """A2A client config for DataRobot deployments.
 
-    Identical to ``A2AClientConfig`` — the separate ``name`` avoids a
-    registration conflict with the upstream ``a2a_client`` function group.
-
-    Use ``_type: authenticated_a2a_client`` in workflow.yaml instead of
-    ``_type: a2a_client`` when the remote agent requires authentication
-    for the agent-card endpoint.
+    Uses ``auth_provider`` (from the parent ``A2AClientConfig``) for both agent
+    card discovery and A2A RPC calls.  If the referenced provider implements
+    :class:`A2ADiscoveryAuthMixin` it can supply different credentials for the
+    two phases; otherwise the same ``authenticate()`` result is used for both.
     """
 
 
 class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
-    """A2AClientFunctionGroup that uses ``_AuthenticatedA2ABaseClient`` so the
-    agent-card fetch is authenticated.
-
-    Upstream ``__aenter__`` hardcodes ``A2ABaseClient(...)`` so we must
-    override it, but the body is a minimal copy — the only delta is the
-    client class on the construction line.
-    """
+    """Uses :class:`_AuthenticatedA2ABaseClient` so both A2A phases are authenticated."""
 
     async def __aenter__(self) -> "AuthenticatedA2AClientFunctionGroup":
         config: A2AClientConfig = self._config  # type: ignore[assignment]
@@ -130,7 +182,10 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
         if config.auth_provider:
             try:
                 auth_provider = await self._builder.get_auth_provider(config.auth_provider)
-                logger.info("Resolved authentication provider for A2A client")
+                logger.info(
+                    "Resolved authentication provider '%s' for A2A client",
+                    config.auth_provider,
+                )
             except Exception as e:
                 logger.error(
                     "Failed to resolve auth provider '%s': %s",
@@ -139,7 +194,6 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
                 )
                 raise RuntimeError(f"Failed to resolve auth provider: {e}") from e
 
-        # Only difference from upstream: _AuthenticatedA2ABaseClient instead of A2ABaseClient
         self._client = _AuthenticatedA2ABaseClient(
             base_url=base_url,
             agent_card_path=config.agent_card_path,
@@ -149,14 +203,12 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
         )
         await self._client.__aenter__()
 
-        if auth_provider:
-            logger.info(
-                "Connected to A2A agent at %s with authentication (user_id: %s)",
-                base_url,
-                user_id,
-            )
-        else:
-            logger.info("Connected to A2A agent at %s (user_id: %s)", base_url, user_id)
+        logger.info(
+            "Connected to A2A agent at %s (auth_provider: %s, user_id: %s)",
+            base_url,
+            config.auth_provider or "none",
+            user_id,
+        )
 
         self._register_functions()
         return self
@@ -166,8 +218,12 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
 async def authenticated_a2a_client(
     config: AuthenticatedA2AClientConfig, _builder: Builder
 ) -> AsyncGenerator[Any, None]:
-    """Drop-in replacement for the upstream ``a2a_client`` function group that
-    authenticates all api calls, including the agent-card fetch request.
+    """A2A function group with authenticated agent card discovery and RPC.
+
+    The ``auth_provider`` field controls both phases.  If the provider
+    implements :class:`A2ADiscoveryAuthMixin` it supplies separate credentials
+    for agent card discovery; otherwise the same ``authenticate()`` is used
+    for both phases.
     """
     async with AuthenticatedA2AClientFunctionGroup(config, _builder) as group:
         yield group

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -143,8 +143,9 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
         if not self._agent_card:
             raise RuntimeError("Agent card not resolved")
 
-        # Allow auth providers that need agent-card parameters (e.g. OktaTokenExchangeAuthProvider)
-        # to receive the resolved card before the interceptor is set up.
+        # Allow auth providers that need agent-card parameters
+        # (e.g. OktaCrossApplicationAccessAuthProvider) to receive
+        # the resolved card before the interceptor is set up.
         if isinstance(self._auth_provider, AgentCardAware):
             self._auth_provider.set_agent_card(self._agent_card)
 

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -53,34 +53,23 @@ def _extract_auth_headers(auth_result: Any) -> dict[str, str]:
 
 @runtime_checkable
 class AgentCardAware(Protocol):
-    """Auth providers that need the resolved agent card before ``authenticate()``.
+    """Protocol for auth providers that need the agent card before ``authenticate()``.
 
-    Implement this protocol on an auth provider to receive the fetched
-    :class:`~a2a.types.AgentCard` before the first ``authenticate()`` call.
-    :class:`_AuthenticatedA2ABaseClient` checks for this protocol via
-    ``isinstance`` and calls :meth:`set_agent_card` automatically.
+    :class:`_AuthenticatedA2ABaseClient` checks for this via ``isinstance``
+    and calls :meth:`set_agent_card` automatically after card resolution.
     """
 
     def set_agent_card(self, card: AgentCard) -> None:
-        """Receive the resolved agent card.
-
-        Called by :class:`_AuthenticatedA2ABaseClient` immediately after the
-        card is fetched, before ``authenticate()`` is ever invoked.
-        """
+        """Receive the resolved agent card before ``authenticate()`` is invoked."""
         ...
 
 
 class A2ADiscoveryAuthMixin(abc.ABC):
     """Mixin for auth providers that need different credentials for agent card discovery.
 
-    By default :meth:`_AuthenticatedA2ABaseClient._resolve_agent_card` calls
-    ``authenticate()`` and extracts the resulting credentials as HTTP headers.
-    Implement this mixin to return different headers for the agent card GET
-    without affecting the call-phase ``authenticate()`` used by ``AuthInterceptor``.
-
-    Example: :class:`~datarobot_genai.dragent.plugins.okta_a2a_auth.OktaTokenExchangeAuthProvider`
-    uses this to forward the incoming Okta bearer token for discovery while
-    performing a two-step RFC 8693 exchange for the actual A2A calls.
+    Without this mixin, ``_AuthenticatedA2ABaseClient`` calls ``authenticate()`` for
+    both discovery and call phases.  Implement ``authenticate_for_discovery()`` to
+    supply separate headers for the agent card GET.
     """
 
     @abc.abstractmethod
@@ -95,19 +84,11 @@ class A2ADiscoveryAuthMixin(abc.ABC):
 
 
 class _AuthenticatedA2ABaseClient(A2ABaseClient):
-    """A2A client that authenticates agent card discovery and A2A RPC independently.
+    """A2A client with independent auth for card discovery and RPC calls.
 
-    * **Agent card** ``GET`` — two mutually exclusive paths:
-
-      1. *Discovery mixin*: if the configured ``auth_provider`` implements
-         :class:`A2ADiscoveryAuthMixin`, ``authenticate_for_discovery()`` is called
-         and its result is used as headers on a short-lived ``httpx.AsyncClient``.
-      2. *Default*: ``authenticate()`` is called and its credentials are extracted
-         as headers (e.g. ``DataRobotAPIKeyAuthProvider``).  When no provider is
-         set the card is fetched unauthenticated.
-
-    * **Task / message** traffic uses NAT's ``AuthInterceptor`` +
-      ``A2ACredentialService``, which calls ``authenticate()`` per-request.
+    Discovery uses ``authenticate_for_discovery()`` when the provider implements
+    :class:`A2ADiscoveryAuthMixin`, otherwise falls back to ``authenticate()``.
+    Task traffic always uses ``AuthInterceptor`` + ``A2ACredentialService``.
     """
 
     async def _resolve_agent_card(self) -> None:
@@ -190,12 +171,8 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
 class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_client"):  # type: ignore[call-arg]
     """A2A client config with separate discovery and call-phase auth.
 
-    Inherits all fields from :class:`~nat.plugins.a2a.client.client_config.A2AClientConfig`
-    (``url``, ``auth_provider``, ``agent_card_path``, ``task_timeout``, ``streaming``).
-
-    If the referenced ``auth_provider`` implements :class:`A2ADiscoveryAuthMixin`,
-    it supplies different credentials for agent card discovery vs A2A RPC calls.
-    Otherwise the same ``authenticate()`` result is used for both phases.
+    If ``auth_provider`` implements :class:`A2ADiscoveryAuthMixin`, it supplies
+    different credentials for discovery vs RPC calls.
     """
 
 
@@ -250,12 +227,6 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
 async def authenticated_a2a_client(
     config: AuthenticatedA2AClientConfig, _builder: Builder
 ) -> AsyncGenerator[Any, None]:
-    """A2A function group with authenticated agent card discovery and RPC.
-
-    The ``auth_provider`` field controls both phases.  If the provider
-    implements :class:`A2ADiscoveryAuthMixin` it supplies separate credentials
-    for agent card discovery; otherwise the same ``authenticate()`` is used
-    for both phases.
-    """
+    """NAT factory for :class:`AuthenticatedA2AClientFunctionGroup`."""
     async with AuthenticatedA2AClientFunctionGroup(config, _builder) as group:
         yield group

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -1,0 +1,530 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Okta token exchange auth provider for A2A agent communication.
+
+Registered as ``_type: okta_token_exchange`` in workflow YAML.
+
+Discovery phase: forwards the incoming ``x-datarobot-okta-access-token`` header
+directly to the agent card endpoint as a Bearer token.
+
+Call phase: executes a two-step Okta Cross App Access (XAA) token exchange:
+
+  Step 1 — exchange the incoming Okta access token for an ID-JAG token via the
+  org authorization server (``{trusted_issuer}/v1/token``).
+
+  Step 2 — exchange the ID-JAG token for a scoped agent token via the custom
+  authorization server token endpoint published in the agent card's
+  ``securitySchemes`` / RFC 8693 extension.
+
+Credentials (``principal_id``, ``private_jwk``) are loaded automatically from
+environment variables / Runtime Parameters / ``.env`` / ``file_secrets`` via
+:class:`_OktaSettings`.  They do **not** need to be specified in
+``workflow.yaml`` — the minimal YAML is::
+
+    authentication:
+      okta_auth:
+        _type: okta_token_exchange
+
+    function_groups:
+      remote_agent:
+        _type: authenticated_a2a_client
+        url: "https://..."
+        auth_provider: okta_auth
+
+Environment variables consumed (map to the reference ``Config`` field names):
+
+* ``PRINCIPAL_ID``     — Okta AI agent principal ID
+* ``PRIVATE_JWK``      — base64-encoded or raw-JSON private JWK
+"""
+
+import base64
+import json
+import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
+
+from a2a.types import AgentCard
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from nat.authentication.interfaces import AuthProviderBase
+from nat.builder.builder import Builder
+from nat.builder.context import Context
+from nat.cli.register_workflow import register_auth_provider
+from nat.data_models.authentication import AuthProviderBaseConfig
+from nat.data_models.authentication import AuthResult
+from nat.data_models.authentication import BearerTokenCred
+from pydantic import Field
+from pydantic import SecretStr
+
+from datarobot_genai.dragent.plugins.auth_a2a_client import A2ADiscoveryAuthMixin
+
+try:
+    from okta_client.authfoundation import LocalKeyProvider
+    from okta_client.authfoundation import OAuth2Client
+    from okta_client.authfoundation import OAuth2ClientConfiguration
+    from okta_client.authfoundation.oauth2.client_authorization import ClientAssertionAuthorization
+    from okta_client.authfoundation.oauth2.jwt_bearer_claims import JWTBearerClaims
+    from okta_client.oauth2auth import CrossAppAccessFlow
+    from okta_client.oauth2auth import CrossAppAccessTarget
+except ImportError:
+    LocalKeyProvider = None  # type: ignore[assignment,misc]
+    OAuth2Client = None  # type: ignore[assignment,misc]
+    OAuth2ClientConfiguration = None  # type: ignore[assignment,misc]
+    ClientAssertionAuthorization = None  # type: ignore[assignment,misc]
+    JWTBearerClaims = None  # type: ignore[assignment,misc]
+    CrossAppAccessFlow = None  # type: ignore[assignment,misc]
+    CrossAppAccessTarget = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Environment / Runtime Parameter settings
+# ---------------------------------------------------------------------------
+
+
+class _OktaSettings(DataRobotAppFrameworkBaseSettings):
+    """Reads Okta credentials from env vars, Runtime Parameters, .env, or file_secrets.
+
+    Field names map to the reference application ``Config`` naming convention so
+    that the same Runtime Parameters work across both the application and the
+    DataRobot agent template.
+    """
+
+    principal_id: str | None = None
+    """Okta AI agent principal ID (``PRINCIPAL_ID``)."""
+
+    private_jwk: str | None = None
+    """Base64-encoded or raw-JSON private JWK (``PRIVATE_JWK``)."""
+
+
+def _get_default_principal_id() -> str | None:
+    return _OktaSettings().principal_id
+
+
+def _get_default_private_jwk() -> SecretStr | None:
+    if jwk := _OktaSettings().private_jwk:
+        return SecretStr(jwk)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+
+# ---------------------------------------------------------------------------
+# _CrossAppFlowParams — populated from the fetched AgentCard
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CrossAppFlowParams:
+    """Parameters parsed from the agent card for the Okta Cross App Access flow.
+
+    Populated by :meth:`OktaTokenExchangeAuthProvider.set_agent_card` from the
+    agent card's ``securitySchemes`` and RFC 8693 capability extension.
+    """
+
+    issuer: str
+    """Org-level authorization server issuer (``trusted_issuer`` from the RFC 8693
+    extension). Used as ``issuer`` in :class:`OAuth2ClientConfiguration` and as
+    the base for the JWT client assertion ``audience`` claim."""
+
+    target_issuer: str
+    """Custom authorization server base URL (agent token URL with ``/v1/token``
+    stripped). Passed to :class:`CrossAppAccessTarget` and used as the ``audience``
+    argument in ``CrossAppAccessFlow.start()``."""
+
+    id_jag_scopes: list[str]
+    """OAuth scopes for Step 1 (ID-JAG request). Defaults to ``["read_data"]``."""
+
+
+# ---------------------------------------------------------------------------
+# OktaTokenExchangeAuthProviderConfig
+# ---------------------------------------------------------------------------
+
+
+class OktaTokenExchangeAuthProviderConfig(
+    AuthProviderBaseConfig,
+    name="okta_token_exchange",
+):  # type: ignore[call-arg]
+    """Configuration for :class:`OktaTokenExchangeAuthProvider`.
+
+    Credential fields (``principal_id``, ``private_jwk``) are populated
+    automatically from environment variables / Runtime Parameters / ``.env`` /
+    ``file_secrets`` via :class:`_OktaSettings` and do **not** need to appear
+    in ``workflow.yaml``.
+
+    Override any field explicitly in the YAML when you need to supply a value
+    that is not in the environment (e.g. in unit tests).
+    """
+
+    okta_token_header: str = Field(
+        default="x-datarobot-okta-access-token",
+        description=(
+            "Name of the incoming request header that carries the caller's Okta access "
+            "token. Used for agent card discovery and as the subject token in Step 1. "
+            "Header names are matched case-insensitively."
+        ),
+    )
+    principal_id: str | None = Field(
+        default_factory=_get_default_principal_id,
+        description=(
+            "Okta AI agent principal ID (env: ``PRINCIPAL_ID``). Used as ``iss`` and "
+            "``sub`` claims in the JWT client assertion when "
+            "``token_endpoint_auth_method`` is ``private_key_jwt``."
+        ),
+    )
+    private_jwk: SecretStr | None = Field(
+        default_factory=_get_default_private_jwk,
+        description=(
+            "Base64-encoded private JWK or raw JSON string (env: ``PRIVATE_JWK``). "
+            "Used to sign JWT client assertions when ``token_endpoint_auth_method`` "
+            "is ``private_key_jwt``."
+        ),
+    )
+    id_jag_scopes: list[str] = Field(
+        default=["read_data"],
+        description=(
+            "OAuth scopes to request in Step 1 of the token exchange (ID-JAG request). "
+            "Defaults to ``['read_data']`` which matches Okta XAA reference implementations. "
+            "Override when the authorization server requires a different scope set."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# OktaTokenExchangeAuthProvider
+# ---------------------------------------------------------------------------
+
+
+class OktaTokenExchangeAuthProvider(
+    A2ADiscoveryAuthMixin,
+    AuthProviderBase[OktaTokenExchangeAuthProviderConfig],
+):
+    """Auth provider for Okta-authenticated A2A agent communication.
+
+    Implements :class:`~datarobot_genai.dragent.plugins.auth_a2a_client.A2ADiscoveryAuthMixin`
+    so that agent card discovery and A2A RPC calls use separate credentials:
+
+    * **Discovery** — forwards the incoming Okta bearer token from the request
+      context as ``Authorization: Bearer <token>``.
+    * **Call** — executes the two-step Okta XAA token exchange via the
+      ``okta-client-python`` SDK using parameters parsed from the agent card.
+    """
+
+    def __init__(self, config: OktaTokenExchangeAuthProviderConfig) -> None:
+        super().__init__(config)
+        self._flow_params: _CrossAppFlowParams | None = None
+
+    # ------------------------------------------------------------------
+    # A2ADiscoveryAuthMixin
+    # ------------------------------------------------------------------
+
+    async def authenticate_for_discovery(self, user_id: str | None = None) -> dict[str, str]:
+        """Return the incoming Okta token as ``Authorization: Bearer`` headers.
+
+        Reads the header named by :attr:`~OktaTokenExchangeAuthProviderConfig.okta_token_header`
+        from the current NAT request context (case-insensitive).
+
+        Raises
+        ------
+        RuntimeError
+            If the expected header is absent from the request context.
+        """
+        token = self._extract_okta_token()
+        logger.info(
+            "Forwarding Okta token from header '%s' for agent card discovery",
+            self.config.okta_token_header,
+        )
+        return {"Authorization": f"Bearer {token}"}
+
+    # ------------------------------------------------------------------
+    # Agent card injection (called by _AuthenticatedA2ABaseClient after discovery)
+    # ------------------------------------------------------------------
+
+    def set_agent_card(self, card: AgentCard) -> None:
+        """Parse the agent card and store :class:`_CrossAppFlowParams`.
+
+        Called by
+        :class:`~datarobot_genai.dragent.plugins.auth_a2a_client._AuthenticatedA2ABaseClient`
+        immediately after the card is resolved, before ``authenticate()`` is invoked.
+
+        Raises
+        ------
+        ValueError
+            If the card does not contain the expected security schemes or
+            RFC 8693 capability extension.
+        """
+        self._flow_params = _parse_cross_app_params(card, id_jag_scopes=self.config.id_jag_scopes)
+        logger.info(
+            "Agent card parsed: issuer=%s, target_issuer=%s",
+            self._flow_params.issuer,
+            self._flow_params.target_issuer,
+        )
+
+    # ------------------------------------------------------------------
+    # AuthProviderBase
+    # ------------------------------------------------------------------
+
+    async def authenticate(self, user_id: str | None = None, **kwargs: Any) -> AuthResult | None:
+        """Obtain a scoped agent token via the two-step Okta XAA token exchange.
+
+        Requires :meth:`set_agent_card` to have been called first.
+
+        Returns
+        -------
+        AuthResult
+            Contains a single :class:`~nat.data_models.authentication.BearerTokenCred`
+            with the final scoped agent token.
+        """
+        if self._flow_params is None:
+            raise RuntimeError(
+                "OktaTokenExchangeAuthProvider.authenticate() called before set_agent_card(). "
+                "Ensure the provider is used with authenticated_a2a_client."
+            )
+
+        if not self.config.principal_id:
+            raise ValueError("principal_id is required for the Okta cross-app access flow")
+
+        private_jwk = self._parse_private_jwk()
+        if not private_jwk:
+            raise ValueError("private_jwk is required for the Okta cross-app access flow")
+
+        access_token = self._extract_okta_token()
+        flow = self._build_cross_app_flow(private_jwk=private_jwk)
+
+        logger.info(
+            "Step 1: exchanging access token for ID-JAG (issuer=%s, user_id=%s)",
+            self._flow_params.issuer,
+            user_id,
+        )
+        await flow.start(token=access_token, audience=self._flow_params.target_issuer)
+
+        logger.info(
+            "Step 2: exchanging ID-JAG for scoped agent token (target=%s)",
+            self._flow_params.target_issuer,
+        )
+        token_result = await flow.resume()
+
+        logger.info("Cross-app access flow completed successfully")
+        return AuthResult(credentials=[BearerTokenCred(token=token_result.access_token)])
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _extract_okta_token(self) -> str:
+        """Extract the Okta access token from NAT request context headers."""
+        context_headers: dict[str, str] = Context.get().metadata.headers or {}
+        token = context_headers.get(self.config.okta_token_header.lower())
+        if not token:
+            raise RuntimeError(
+                f"Header '{self.config.okta_token_header}' not found in the request context. "
+                "The Okta access token must be forwarded with every agent call."
+            )
+        return token
+
+    def _parse_private_jwk(self) -> dict[str, Any] | None:
+        """Decode and parse the private JWK from config (supports base64 and raw JSON)."""
+        if not self.config.private_jwk:
+            return None
+        raw = self.config.private_jwk.get_secret_value()
+        # Try base64-decode first (new format)
+        try:
+            return json.loads(base64.b64decode(raw).decode())
+        except Exception:
+            pass
+        # Try direct JSON
+        try:
+            return json.loads(raw)
+        except Exception:
+            pass
+        raise ValueError(
+            "Could not parse private_jwk: expected base64-encoded JSON or raw JSON string."
+        )
+
+    def _build_cross_app_flow(self, private_jwk: dict[str, Any]) -> Any:
+        """Construct a :class:`CrossAppAccessFlow` from the Okta Client SDK.
+
+        Parameters
+        ----------
+        private_jwk:
+            Parsed private JWK dict used to sign JWT client assertions.
+        """
+        if CrossAppAccessFlow is None:
+            raise ImportError(
+                "okta-client-python is required for the Okta cross-app access flow. "
+                "Install it with: pip install datarobot-genai[auth-okta]"
+            )
+
+        assert self._flow_params is not None  # validated by authenticate() before this call
+
+        key_provider = LocalKeyProvider.from_jwk(private_jwk, algorithm="RS256")
+        token_endpoint = self._flow_params.issuer.rstrip("/") + "/oauth2/v1/token"
+
+        config = OAuth2ClientConfiguration(
+            issuer=self._flow_params.issuer,
+            scope=self._flow_params.id_jag_scopes,
+            client_authorization=ClientAssertionAuthorization(
+                assertion_claims=JWTBearerClaims(
+                    issuer=self.config.principal_id,
+                    subject=self.config.principal_id,
+                    audience=token_endpoint,
+                    expires_in=60,
+                ),
+                key_provider=key_provider,
+            ),
+        )
+
+        oauth_client = OAuth2Client(configuration=config)
+        target = CrossAppAccessTarget(issuer=self._flow_params.target_issuer)
+        return CrossAppAccessFlow(client=oauth_client, target=target)
+
+
+# ---------------------------------------------------------------------------
+# Agent card parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_cross_app_params(
+    card: AgentCard,
+    id_jag_scopes: list[str] | None = None,
+) -> _CrossAppFlowParams:
+    """Extract :class:`_CrossAppFlowParams` from a fetched :class:`AgentCard`.
+
+    Reads:
+    - ``securitySchemes["oauth2"].root.flows.client_credentials.token_url``
+    - ``capabilities.extensions[uri=RFC8693_GRANT_TYPE_URI].params``
+
+    All required RFC 8693 fields are validated to be present even though only
+    ``trusted_issuer`` is stored — this ensures the remote agent card is
+    well-formed before the flow begins.
+
+    Parameters
+    ----------
+    card:
+        Fetched agent card.
+    id_jag_scopes:
+        Scopes to request in Step 1.  When *None*, defaults to ``["read_data"]``.
+    """
+    agent_token_url, _ = _parse_security_schemes(card)
+    # Validate full RFC 8693 extension; only trusted_issuer is needed by the SDK.
+    trusted_issuer, *_ = _parse_rfc8693_extension(card)
+
+    # Custom-AS base URL: strip the /v1/token suffix from the token endpoint.
+    target_issuer = agent_token_url.rstrip("/").removesuffix("/v1/token")
+
+    return _CrossAppFlowParams(
+        issuer=trusted_issuer,
+        target_issuer=target_issuer,
+        id_jag_scopes=id_jag_scopes if id_jag_scopes is not None else ["read_data"],
+    )
+
+
+def _parse_security_schemes(card: AgentCard) -> tuple[str, list[str]]:
+    """Return ``(agent_token_url, scopes)`` from the agent card security schemes."""
+    if not card.security_schemes:
+        raise ValueError("Agent card has no securitySchemes — cannot extract token_url.")
+
+    oauth2 = card.security_schemes.get("oauth2")
+    if not oauth2:
+        raise ValueError("Agent card securitySchemes has no 'oauth2' entry.")
+
+    flows = getattr(oauth2.root, "flows", None)
+    if not flows:
+        raise ValueError("Agent card oauth2 security scheme has no flows.")
+
+    cc_flow = getattr(flows, "client_credentials", None)
+    if not cc_flow:
+        raise ValueError("Agent card oauth2 flows has no clientCredentials flow.")
+
+    token_url: str = str(cc_flow.token_url)
+    scopes: list[str] = list(cc_flow.scopes.keys()) if cc_flow.scopes else []
+
+    return token_url, scopes
+
+
+def _parse_rfc8693_extension(
+    card: AgentCard,
+) -> tuple[str, str, str, str, str]:
+    """Return RFC 8693 token-exchange fields from the agent card extension.
+
+    Tuple elements are ``trusted_issuer``, ``agent_audience``,
+    ``subject_token_type``, ``requested_token_type``,
+    ``token_endpoint_auth_method``.
+    """
+    extensions = (
+        card.capabilities.extensions if card.capabilities and card.capabilities.extensions else []
+    )
+    for ext in extensions:
+        if ext.uri == _RFC8693_GRANT_TYPE_URI:
+            params = ext.params or {}
+            constraints = params.get("subject_token_constraints", {})
+            exchange_req = params.get("token_exchange_request", {})
+
+            trusted_issuer = constraints.get("trusted_issuer")
+            agent_audience = exchange_req.get("audience")
+            subject_token_type = exchange_req.get("subject_token_type")
+            requested_token_type = exchange_req.get("requested_token_type")
+            token_endpoint_auth_method = exchange_req.get("token_endpoint_auth_method")
+
+            missing = [
+                name
+                for name, val in [
+                    ("subject_token_constraints.trusted_issuer", trusted_issuer),
+                    ("token_exchange_request.audience", agent_audience),
+                    ("token_exchange_request.subject_token_type", subject_token_type),
+                    ("token_exchange_request.requested_token_type", requested_token_type),
+                    (
+                        "token_exchange_request.token_endpoint_auth_method",
+                        token_endpoint_auth_method,
+                    ),
+                ]
+                if not val
+            ]
+            if missing:
+                raise ValueError(
+                    f"Agent card RFC 8693 extension is missing required fields: {missing}"
+                )
+
+            return (
+                trusted_issuer,
+                agent_audience,
+                subject_token_type,
+                requested_token_type,
+                token_endpoint_auth_method,
+            )  # type: ignore[return-value]
+
+    raise ValueError(
+        f"Agent card capabilities.extensions has no entry with uri='{_RFC8693_GRANT_TYPE_URI}'. "
+        "The remote agent must advertise the RFC 8693 token exchange extension."
+    )
+
+
+# ---------------------------------------------------------------------------
+# NAT registration
+# ---------------------------------------------------------------------------
+
+
+@register_auth_provider(config_type=OktaTokenExchangeAuthProviderConfig)
+async def okta_token_exchange_auth_provider(
+    config: OktaTokenExchangeAuthProviderConfig, builder: Builder
+) -> AsyncGenerator[OktaTokenExchangeAuthProvider, None]:
+    """NAT auth provider factory for Okta XAA token exchange."""
+    yield OktaTokenExchangeAuthProvider(config=config)

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -425,7 +425,7 @@ class OktaTokenExchangeAuthProvider(
         if CrossAppAccessFlow is None:
             raise ImportError(
                 "okta-client-python is required for the Okta cross-app access flow. "
-                "Install it with: pip install datarobot-genai[auth-okta]"
+                "Install it with: pip install datarobot-genai[auth]"
             )
 
         assert self._flow_params is not None  # validated by authenticate() before this call

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -124,7 +124,7 @@ def _get_default_private_jwk() -> SecretStr | None:
 # Constants
 # ---------------------------------------------------------------------------
 
-_RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
+_JWT_BEARER_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
 
 # ---------------------------------------------------------------------------
@@ -134,24 +134,57 @@ _RFC8693_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
 
 @dataclass
 class _CrossAppFlowParams:
-    """Parameters parsed from the agent card for the Okta Cross App Access flow.
+    """Full configuration context parsed from the agent card for the Okta XAA flow.
 
-    Populated by :meth:`OktaTokenExchangeAuthProvider.set_agent_card` from the
-    agent card's ``securitySchemes`` and RFC 8693 capability extension.
+    Populated by :meth:`OktaTokenExchangeAuthProvider.set_agent_card` from
+    the agent card's ``securitySchemes`` (OpenAPI layer) and JWT Bearer
+    ``capabilities.extensions`` (A2A layer).
+
+    Every field used by the Okta SDK during the two-step Cross-Application
+    Access flow is extracted here so that the authentication handler never
+    needs to hardcode or derive values at runtime.
     """
 
-    issuer: str
-    """Org-level authorization server issuer (``trusted_issuer`` from the RFC 8693
-    extension). Used as ``issuer`` in :class:`OAuth2ClientConfiguration` and as
-    the base for the JWT client assertion ``audience`` claim."""
+    token_url: str
+    """Token endpoint URL from
+    ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``.
+    Represents the resource AS token endpoint.  Stored for reference; the SDK
+    discovers the endpoint automatically from ``exchange_audience``."""
 
-    target_issuer: str
-    """Custom authorization server base URL (agent token URL with ``/v1/token``
-    stripped). Passed to :class:`CrossAppAccessTarget` and used as the ``audience``
-    argument in ``CrossAppAccessFlow.start()``."""
+    trusted_issuer: str
+    """**Originating** authorization server issuer
+    (``capabilities.extensions[].params.token_exchange.trusted_issuer``).
+    Passed to ``OAuth2ClientConfiguration(issuer=...)`` — this is the AS
+    that runs Step 1 (RFC 8693 token exchange) and validates the JWT client
+    assertion.  The assertion ``audience`` claim is derived as
+    ``trusted_issuer + "/oauth2/v1/token"``."""
+
+    exchange_audience: str
+    """**Resource** authorization server issuer
+    (``capabilities.extensions[].params.token_exchange.audience``).
+    Serves a dual role in the SDK:
+
+    * ``CrossAppAccessTarget(issuer=...)`` — structural config that tells
+      ``resume()`` which server to talk to for Step 2 (JWT bearer grant).
+    * ``flow.start(audience=...)`` — logical parameter that tells the
+      originating AS what audience to embed in the ID-JAG.
+
+    Per Okta SDK docs these are the same issuer URL in the common case."""
+
+    target_audience: str
+    """Final resource identifier for the agent being called
+    (``capabilities.extensions[].params.target_audience``).
+    A2A-level metadata; not passed to the Okta SDK directly."""
+
+    token_endpoint_auth_method: str
+    """Client authentication method
+    (``capabilities.extensions[].params.token_endpoint_auth_method``).
+    When ``"private_key_jwt"``, :class:`ClientAssertionAuthorization` with
+    :class:`LocalKeyProvider` is initialized for JWT client assertions."""
 
     id_jag_scopes: list[str]
-    """OAuth scopes for Step 1 (ID-JAG request). Defaults to ``["read_data"]``."""
+    """OAuth scopes for Step 1 (ID-JAG request). Defaults to ``["read_data"]``.
+    Sourced from the provider config, not the agent card."""
 
 
 # ---------------------------------------------------------------------------
@@ -269,13 +302,16 @@ class OktaTokenExchangeAuthProvider(
         ------
         ValueError
             If the card does not contain the expected security schemes or
-            RFC 8693 capability extension.
+            JWT Bearer capability extension.
         """
         self._flow_params = _parse_cross_app_params(card, id_jag_scopes=self.config.id_jag_scopes)
         logger.info(
-            "Agent card parsed: issuer=%s, target_issuer=%s",
-            self._flow_params.issuer,
-            self._flow_params.target_issuer,
+            "Agent card parsed: trusted_issuer=%s, exchange_audience=%s, "
+            "target_audience=%s, token_endpoint_auth_method=%s",
+            self._flow_params.trusted_issuer,
+            self._flow_params.exchange_audience,
+            self._flow_params.target_audience,
+            self._flow_params.token_endpoint_auth_method,
         )
 
     # ------------------------------------------------------------------
@@ -310,15 +346,17 @@ class OktaTokenExchangeAuthProvider(
         flow = self._build_cross_app_flow(private_jwk=private_jwk)
 
         logger.info(
-            "Step 1: exchanging access token for ID-JAG (issuer=%s, user_id=%s)",
-            self._flow_params.issuer,
+            "Step 1: exchanging access token for ID-JAG (trusted_issuer=%s, "
+            "exchange_audience=%s, user_id=%s)",
+            self._flow_params.trusted_issuer,
+            self._flow_params.exchange_audience,
             user_id,
         )
-        await flow.start(token=access_token, audience=self._flow_params.target_issuer)
+        await flow.start(token=access_token, audience=self._flow_params.exchange_audience)
 
         logger.info(
-            "Step 2: exchanging ID-JAG for scoped agent token (target=%s)",
-            self._flow_params.target_issuer,
+            "Step 2: exchanging ID-JAG for scoped agent token (target_audience=%s)",
+            self._flow_params.target_audience,
         )
         token_result = await flow.resume()
 
@@ -362,6 +400,23 @@ class OktaTokenExchangeAuthProvider(
     def _build_cross_app_flow(self, private_jwk: dict[str, Any]) -> Any:
         """Construct a :class:`CrossAppAccessFlow` from the Okta Client SDK.
 
+        Mapping from :attr:`_flow_params` (agent card) to SDK constructor args
+        follows Okta's ``target`` vs ``audience`` distinction:
+
+        * ``trusted_issuer`` → ``OAuth2ClientConfiguration(issuer=...)`` — the
+          **originating** authorization server that runs Step 1 (RFC 8693 token
+          exchange).  The JWT client assertion ``audience`` claim targets this
+          server's token endpoint (``trusted_issuer + "/oauth2/v1/token"``).
+        * ``token_endpoint_auth_method`` → when ``"private_key_jwt"``,
+          ``ClientAssertionAuthorization`` with ``LocalKeyProvider`` is used.
+        * ``exchange_audience`` → ``CrossAppAccessTarget(issuer=...)`` — the
+          **resource** authorization server that ``resume()`` talks to (Step 2).
+          The SDK uses its issuer to discover the token endpoint and rewrite the
+          client assertion ``aud`` claim for the JWT bearer exchange.
+        * ``exchange_audience`` is also the ``audience`` arg in
+          ``flow.start()`` — tells the originating AS what audience the ID-JAG
+          should carry so the resource AS will accept it.
+
         Parameters
         ----------
         private_jwk:
@@ -375,13 +430,11 @@ class OktaTokenExchangeAuthProvider(
 
         assert self._flow_params is not None  # validated by authenticate() before this call
 
-        key_provider = LocalKeyProvider.from_jwk(private_jwk, algorithm="RS256")
-        token_endpoint = self._flow_params.issuer.rstrip("/") + "/oauth2/v1/token"
-
-        config = OAuth2ClientConfiguration(
-            issuer=self._flow_params.issuer,
-            scope=self._flow_params.id_jag_scopes,
-            client_authorization=ClientAssertionAuthorization(
+        client_authorization = None
+        if self._flow_params.token_endpoint_auth_method == "private_key_jwt":
+            key_provider = LocalKeyProvider.from_jwk(private_jwk, algorithm="RS256")
+            token_endpoint = self._flow_params.trusted_issuer.rstrip("/") + "/oauth2/v1/token"
+            client_authorization = ClientAssertionAuthorization(
                 assertion_claims=JWTBearerClaims(
                     issuer=self.config.principal_id,
                     subject=self.config.principal_id,
@@ -389,11 +442,16 @@ class OktaTokenExchangeAuthProvider(
                     expires_in=60,
                 ),
                 key_provider=key_provider,
-            ),
+            )
+
+        config = OAuth2ClientConfiguration(
+            issuer=self._flow_params.trusted_issuer,
+            scope=self._flow_params.id_jag_scopes,
+            client_authorization=client_authorization,
         )
 
         oauth_client = OAuth2Client(configuration=config)
-        target = CrossAppAccessTarget(issuer=self._flow_params.target_issuer)
+        target = CrossAppAccessTarget(issuer=self._flow_params.exchange_audience)
         return CrossAppAccessFlow(client=oauth_client, target=target)
 
 
@@ -408,13 +466,14 @@ def _parse_cross_app_params(
 ) -> _CrossAppFlowParams:
     """Extract :class:`_CrossAppFlowParams` from a fetched :class:`AgentCard`.
 
-    Reads:
-    - ``securitySchemes["oauth2"].root.flows.client_credentials.token_url``
-    - ``capabilities.extensions[uri=RFC8693_GRANT_TYPE_URI].params``
+    Combines fields from two locations in the card:
 
-    All required RFC 8693 fields are validated to be present even though only
-    ``trusted_issuer`` is stored — this ensures the remote agent card is
-    well-formed before the flow begins.
+    * **OpenAPI layer** — ``securitySchemes.oauth2.flows.clientCredentials``
+      provides the ``tokenUrl`` (needed to initialize the ``OAuth2Client``).
+    * **Extension layer** — ``capabilities.extensions`` (JWT Bearer entry)
+      provides the remaining negotiation parameters: ``trusted_issuer``,
+      ``exchange_audience``, ``target_audience``, and
+      ``token_endpoint_auth_method``.
 
     Parameters
     ----------
@@ -423,16 +482,15 @@ def _parse_cross_app_params(
     id_jag_scopes:
         Scopes to request in Step 1.  When *None*, defaults to ``["read_data"]``.
     """
-    agent_token_url, _ = _parse_security_schemes(card)
-    # Validate full RFC 8693 extension; only trusted_issuer is needed by the SDK.
-    trusted_issuer, *_ = _parse_rfc8693_extension(card)
-
-    # Custom-AS base URL: strip the /v1/token suffix from the token endpoint.
-    target_issuer = agent_token_url.rstrip("/").removesuffix("/v1/token")
+    token_url, _ = _parse_security_schemes(card)
+    ext = _parse_cross_app_extension(card)
 
     return _CrossAppFlowParams(
-        issuer=trusted_issuer,
-        target_issuer=target_issuer,
+        token_url=token_url,
+        trusted_issuer=ext.trusted_issuer,
+        exchange_audience=ext.exchange_audience,
+        target_audience=ext.target_audience,
+        token_endpoint_auth_method=ext.token_endpoint_auth_method,
         id_jag_scopes=id_jag_scopes if id_jag_scopes is not None else ["read_data"],
     )
 
@@ -460,60 +518,85 @@ def _parse_security_schemes(card: AgentCard) -> tuple[str, list[str]]:
     return token_url, scopes
 
 
-def _parse_rfc8693_extension(
-    card: AgentCard,
-) -> tuple[str, str, str, str, str]:
-    """Return RFC 8693 token-exchange fields from the agent card extension.
+@dataclass
+class _CrossAppExtensionFields:
+    """Raw fields extracted from the JWT Bearer capability extension."""
 
-    Tuple elements are ``trusted_issuer``, ``agent_audience``,
-    ``subject_token_type``, ``requested_token_type``,
-    ``token_endpoint_auth_method``.
+    trusted_issuer: str
+    exchange_audience: str
+    target_audience: str
+    token_endpoint_auth_method: str
+
+
+def _parse_cross_app_extension(card: AgentCard) -> _CrossAppExtensionFields:
+    """Extract all Cross-Application Access fields from the JWT Bearer extension.
+
+    Reads the ``capabilities.extensions`` entry whose
+    ``uri == "urn:ietf:params:oauth:grant-type:jwt-bearer"`` and returns a
+    :class:`_CrossAppExtensionFields` containing every parameter required by
+    the Okta Cross-Application Access SDK:
+
+    - ``params.target_audience`` — final resource identifier.
+    - ``params.token_endpoint_auth_method`` — client auth method.
+    - ``params.token_exchange.trusted_issuer`` — org-level AS for the ID-JAG.
+    - ``params.token_exchange.audience`` — Step 1 AS destination for
+      ``flow.start(audience=...)``.
+    - ``params.token_request.grant_type`` — validated present for card
+      well-formedness but not returned (always
+      ``urn:ietf:params:oauth:grant-type:jwt-bearer``).
+
+    Returns
+    -------
+    _CrossAppExtensionFields
+        All extracted extension parameters needed to configure the SDK.
+
+    Raises
+    ------
+    ValueError
+        If the extension is absent or any required field is missing.
     """
     extensions = (
         card.capabilities.extensions if card.capabilities and card.capabilities.extensions else []
     )
     for ext in extensions:
-        if ext.uri == _RFC8693_GRANT_TYPE_URI:
+        if ext.uri == _JWT_BEARER_GRANT_TYPE_URI:
             params = ext.params or {}
-            constraints = params.get("subject_token_constraints", {})
-            exchange_req = params.get("token_exchange_request", {})
+            token_exchange = params.get("token_exchange") or {}
+            token_request = params.get("token_request") or {}
 
-            trusted_issuer = constraints.get("trusted_issuer")
-            agent_audience = exchange_req.get("audience")
-            subject_token_type = exchange_req.get("subject_token_type")
-            requested_token_type = exchange_req.get("requested_token_type")
-            token_endpoint_auth_method = exchange_req.get("token_endpoint_auth_method")
+            target_audience = params.get("target_audience")
+            token_endpoint_auth_method = params.get("token_endpoint_auth_method")
+            trusted_issuer = token_exchange.get("trusted_issuer")
+            exchange_audience = token_exchange.get("audience")
+            grant_type = token_request.get("grant_type")
 
             missing = [
                 name
                 for name, val in [
-                    ("subject_token_constraints.trusted_issuer", trusted_issuer),
-                    ("token_exchange_request.audience", agent_audience),
-                    ("token_exchange_request.subject_token_type", subject_token_type),
-                    ("token_exchange_request.requested_token_type", requested_token_type),
-                    (
-                        "token_exchange_request.token_endpoint_auth_method",
-                        token_endpoint_auth_method,
-                    ),
+                    ("target_audience", target_audience),
+                    ("token_endpoint_auth_method", token_endpoint_auth_method),
+                    ("token_exchange.trusted_issuer", trusted_issuer),
+                    ("token_exchange.audience", exchange_audience),
+                    ("token_request.grant_type", grant_type),
                 ]
                 if not val
             ]
             if missing:
                 raise ValueError(
-                    f"Agent card RFC 8693 extension is missing required fields: {missing}"
+                    f"Agent card Cross-Application Access extension is missing required "
+                    f"fields: {missing}"
                 )
 
-            return (
-                trusted_issuer,
-                agent_audience,
-                subject_token_type,
-                requested_token_type,
-                token_endpoint_auth_method,
-            )  # type: ignore[return-value]
+            return _CrossAppExtensionFields(
+                trusted_issuer=trusted_issuer,  # type: ignore[arg-type]
+                exchange_audience=exchange_audience,  # type: ignore[arg-type]
+                target_audience=target_audience,  # type: ignore[arg-type]
+                token_endpoint_auth_method=token_endpoint_auth_method,  # type: ignore[arg-type]
+            )
 
     raise ValueError(
-        f"Agent card capabilities.extensions has no entry with uri='{_RFC8693_GRANT_TYPE_URI}'. "
-        "The remote agent must advertise the RFC 8693 token exchange extension."
+        f"Agent card capabilities.extensions has no entry with uri='{_JWT_BEARER_GRANT_TYPE_URI}'. "
+        "The remote agent must advertise the Cross-Application Access extension."
     )
 
 

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -463,20 +463,20 @@ def _parse_cross_app_extension(card: AgentCard) -> _CrossAppExtensionFields:
             token_exchange = params.get("token_exchange") or {}
             token_request = params.get("token_request") or {}
 
-            target_audience = params.get("target_audience")
             token_endpoint_auth_method = params.get("token_endpoint_auth_method")
             trusted_issuer = token_exchange.get("trusted_issuer")
             exchange_audience = token_exchange.get("audience")
             grant_type = token_request.get("grant_type")
+            target_audience = token_request.get("audience")
 
             missing = [
                 name
                 for name, val in [
-                    ("target_audience", target_audience),
                     ("token_endpoint_auth_method", token_endpoint_auth_method),
                     ("token_exchange.trusted_issuer", trusted_issuer),
                     ("token_exchange.audience", exchange_audience),
                     ("token_request.grant_type", grant_type),
+                    ("token_request.audience", target_audience),
                 ]
                 if not val
             ]

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -134,57 +134,36 @@ _JWT_BEARER_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
 @dataclass
 class _CrossAppFlowParams:
-    """Full configuration context parsed from the agent card for the Okta XAA flow.
+    """Agent card parameters needed for the Okta XAA flow.
 
     Populated by :meth:`OktaTokenExchangeAuthProvider.set_agent_card` from
-    the agent card's ``securitySchemes`` (OpenAPI layer) and JWT Bearer
-    ``capabilities.extensions`` (A2A layer).
-
-    Every field used by the Okta SDK during the two-step Cross-Application
-    Access flow is extracted here so that the authentication handler never
-    needs to hardcode or derive values at runtime.
+    ``securitySchemes`` (OpenAPI layer) and ``capabilities.extensions`` (A2A layer).
     """
 
     token_url: str
-    """Token endpoint URL from
-    ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``.
-    Represents the resource AS token endpoint.  Stored for reference; the SDK
-    discovers the endpoint automatically from ``exchange_audience``."""
+    """From ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``.
+    Stored for reference; the SDK discovers the endpoint from ``exchange_audience``."""
 
     trusted_issuer: str
-    """**Originating** authorization server issuer
-    (``capabilities.extensions[].params.token_exchange.trusted_issuer``).
-    Passed to ``OAuth2ClientConfiguration(issuer=...)`` — this is the AS
-    that runs Step 1 (RFC 8693 token exchange) and validates the JWT client
-    assertion.  The assertion ``audience`` claim is derived as
-    ``trusted_issuer + "/oauth2/v1/token"``."""
+    """Org-level AS issuer (``token_exchange.trusted_issuer``); runs Step 1 (RFC 8693).
+    Passed to ``OAuth2ClientConfiguration(issuer=...)``.  JWT assertion ``aud`` is
+    derived as ``trusted_issuer + "/oauth2/v1/token"``."""
 
     exchange_audience: str
-    """**Resource** authorization server issuer
-    (``capabilities.extensions[].params.token_exchange.audience``).
-    Serves a dual role in the SDK:
-
-    * ``CrossAppAccessTarget(issuer=...)`` — structural config that tells
-      ``resume()`` which server to talk to for Step 2 (JWT bearer grant).
-    * ``flow.start(audience=...)`` — logical parameter that tells the
-      originating AS what audience to embed in the ID-JAG.
-
-    Per Okta SDK docs these are the same issuer URL in the common case."""
+    """Resource AS issuer (``token_exchange.audience``); dual role in the SDK:
+    ``CrossAppAccessTarget(issuer=...)`` for Step 2 and ``flow.start(audience=...)``
+    so the originating AS embeds the right audience in the ID-JAG."""
 
     target_audience: str
-    """Final resource identifier for the agent being called
-    (``capabilities.extensions[].params.target_audience``).
-    A2A-level metadata; not passed to the Okta SDK directly."""
+    """Final resource identifier for the agent (``params.target_audience``).
+    A2A metadata; not passed to the Okta SDK."""
 
     token_endpoint_auth_method: str
-    """Client authentication method
-    (``capabilities.extensions[].params.token_endpoint_auth_method``).
-    When ``"private_key_jwt"``, :class:`ClientAssertionAuthorization` with
-    :class:`LocalKeyProvider` is initialized for JWT client assertions."""
+    """Client auth method (``params.token_endpoint_auth_method``).
+    ``"private_key_jwt"`` triggers ``ClientAssertionAuthorization`` with ``LocalKeyProvider``."""
 
     id_jag_scopes: list[str]
-    """OAuth scopes for Step 1 (ID-JAG request). Defaults to ``["read_data"]``.
-    Sourced from the provider config, not the agent card."""
+    """Step 1 scopes; sourced from provider config, not the agent card."""
 
 
 # ---------------------------------------------------------------------------
@@ -198,45 +177,38 @@ class OktaTokenExchangeAuthProviderConfig(
 ):  # type: ignore[call-arg]
     """Configuration for :class:`OktaTokenExchangeAuthProvider`.
 
-    Credential fields (``principal_id``, ``private_jwk``) are populated
-    automatically from environment variables / Runtime Parameters / ``.env`` /
-    ``file_secrets`` via :class:`_OktaSettings` and do **not** need to appear
-    in ``workflow.yaml``.
-
-    Override any field explicitly in the YAML when you need to supply a value
-    that is not in the environment (e.g. in unit tests).
+    ``principal_id`` and ``private_jwk`` are auto-loaded from env vars /
+    Runtime Parameters / ``.env`` / ``file_secrets`` — no ``workflow.yaml``
+    entries needed for credentials.
     """
 
     okta_token_header: str = Field(
         default="x-datarobot-okta-access-token",
         description=(
-            "Name of the incoming request header that carries the caller's Okta access "
-            "token. Used for agent card discovery and as the subject token in Step 1. "
-            "Header names are matched case-insensitively."
+            "Incoming header carrying the caller's Okta access token. "
+            "Forwarded as Bearer for discovery; used as subject token in Step 1. "
+            "Matched case-insensitively."
         ),
     )
     principal_id: str | None = Field(
         default_factory=_get_default_principal_id,
         description=(
-            "Okta AI agent principal ID (env: ``PRINCIPAL_ID``). Used as ``iss`` and "
-            "``sub`` claims in the JWT client assertion when "
-            "``token_endpoint_auth_method`` is ``private_key_jwt``."
+            "Okta AI agent principal ID (env: ``PRINCIPAL_ID``). "
+            "Used as ``iss``/``sub`` in the JWT client assertion."
         ),
     )
     private_jwk: SecretStr | None = Field(
         default_factory=_get_default_private_jwk,
         description=(
-            "Base64-encoded private JWK or raw JSON string (env: ``PRIVATE_JWK``). "
-            "Used to sign JWT client assertions when ``token_endpoint_auth_method`` "
-            "is ``private_key_jwt``."
+            "Base64-encoded or raw-JSON private JWK (env: ``PRIVATE_JWK``). "
+            "Signs JWT client assertions."
         ),
     )
     id_jag_scopes: list[str] = Field(
         default=["read_data"],
         description=(
-            "OAuth scopes to request in Step 1 of the token exchange (ID-JAG request). "
-            "Defaults to ``['read_data']`` which matches Okta XAA reference implementations. "
-            "Override when the authorization server requires a different scope set."
+            "Scopes for the Step 1 ID-JAG request. ``['read_data']`` matches "
+            "Okta XAA reference implementations."
         ),
     )
 
@@ -250,15 +222,10 @@ class OktaTokenExchangeAuthProvider(
     A2ADiscoveryAuthMixin,
     AuthProviderBase[OktaTokenExchangeAuthProviderConfig],
 ):
-    """Auth provider for Okta-authenticated A2A agent communication.
+    """Auth provider for Okta XAA A2A calls.
 
-    Implements :class:`~datarobot_genai.dragent.plugins.auth_a2a_client.A2ADiscoveryAuthMixin`
-    so that agent card discovery and A2A RPC calls use separate credentials:
-
-    * **Discovery** — forwards the incoming Okta bearer token from the request
-      context as ``Authorization: Bearer <token>``.
-    * **Call** — executes the two-step Okta XAA token exchange via the
-      ``okta-client-python`` SDK using parameters parsed from the agent card.
+    * **Discovery** — forwards the incoming Okta bearer token as ``Authorization: Bearer``.
+    * **Call** — two-step XAA token exchange (RFC 8693 → RFC 7523) via ``okta-client-python``.
     """
 
     def __init__(self, config: OktaTokenExchangeAuthProviderConfig) -> None:
@@ -272,13 +239,7 @@ class OktaTokenExchangeAuthProvider(
     async def authenticate_for_discovery(self, user_id: str | None = None) -> dict[str, str]:
         """Return the incoming Okta token as ``Authorization: Bearer`` headers.
 
-        Reads the header named by :attr:`~OktaTokenExchangeAuthProviderConfig.okta_token_header`
-        from the current NAT request context (case-insensitive).
-
-        Raises
-        ------
-        RuntimeError
-            If the expected header is absent from the request context.
+        Raises ``RuntimeError`` if ``okta_token_header`` is absent from the request context.
         """
         token = self._extract_okta_token()
         logger.info(
@@ -294,15 +255,8 @@ class OktaTokenExchangeAuthProvider(
     def set_agent_card(self, card: AgentCard) -> None:
         """Parse the agent card and store :class:`_CrossAppFlowParams`.
 
-        Called by
-        :class:`~datarobot_genai.dragent.plugins.auth_a2a_client._AuthenticatedA2ABaseClient`
-        immediately after the card is resolved, before ``authenticate()`` is invoked.
-
-        Raises
-        ------
-        ValueError
-            If the card does not contain the expected security schemes or
-            JWT Bearer capability extension.
+        Called before ``authenticate()``.  Raises ``ValueError`` if security
+        schemes or the JWT Bearer capability extension are missing.
         """
         self._flow_params = _parse_cross_app_params(card, id_jag_scopes=self.config.id_jag_scopes)
         logger.info(
@@ -322,12 +276,6 @@ class OktaTokenExchangeAuthProvider(
         """Obtain a scoped agent token via the two-step Okta XAA token exchange.
 
         Requires :meth:`set_agent_card` to have been called first.
-
-        Returns
-        -------
-        AuthResult
-            Contains a single :class:`~nat.data_models.authentication.BearerTokenCred`
-            with the final scoped agent token.
         """
         if self._flow_params is None:
             raise RuntimeError(
@@ -398,29 +346,11 @@ class OktaTokenExchangeAuthProvider(
         )
 
     def _build_cross_app_flow(self, private_jwk: dict[str, Any]) -> Any:
-        """Construct a :class:`CrossAppAccessFlow` from the Okta Client SDK.
+        """Construct a :class:`CrossAppAccessFlow` from the Okta SDK.
 
-        Mapping from :attr:`_flow_params` (agent card) to SDK constructor args
-        follows Okta's ``target`` vs ``audience`` distinction:
-
-        * ``trusted_issuer`` → ``OAuth2ClientConfiguration(issuer=...)`` — the
-          **originating** authorization server that runs Step 1 (RFC 8693 token
-          exchange).  The JWT client assertion ``audience`` claim targets this
-          server's token endpoint (``trusted_issuer + "/oauth2/v1/token"``).
-        * ``token_endpoint_auth_method`` → when ``"private_key_jwt"``,
-          ``ClientAssertionAuthorization`` with ``LocalKeyProvider`` is used.
-        * ``exchange_audience`` → ``CrossAppAccessTarget(issuer=...)`` — the
-          **resource** authorization server that ``resume()`` talks to (Step 2).
-          The SDK uses its issuer to discover the token endpoint and rewrite the
-          client assertion ``aud`` claim for the JWT bearer exchange.
-        * ``exchange_audience`` is also the ``audience`` arg in
-          ``flow.start()`` — tells the originating AS what audience the ID-JAG
-          should carry so the resource AS will accept it.
-
-        Parameters
-        ----------
-        private_jwk:
-            Parsed private JWK dict used to sign JWT client assertions.
+        ``trusted_issuer`` → Step 1 AS (``OAuth2ClientConfiguration(issuer=...)``).
+        ``exchange_audience`` → Step 2 AS (``CrossAppAccessTarget(issuer=...)``) and
+        the ``audience`` arg for ``flow.start()``.
         """
         if CrossAppAccessFlow is None:
             raise ImportError(
@@ -466,21 +396,8 @@ def _parse_cross_app_params(
 ) -> _CrossAppFlowParams:
     """Extract :class:`_CrossAppFlowParams` from a fetched :class:`AgentCard`.
 
-    Combines fields from two locations in the card:
-
-    * **OpenAPI layer** — ``securitySchemes.oauth2.flows.clientCredentials``
-      provides the ``tokenUrl`` (needed to initialize the ``OAuth2Client``).
-    * **Extension layer** — ``capabilities.extensions`` (JWT Bearer entry)
-      provides the remaining negotiation parameters: ``trusted_issuer``,
-      ``exchange_audience``, ``target_audience``, and
-      ``token_endpoint_auth_method``.
-
-    Parameters
-    ----------
-    card:
-        Fetched agent card.
-    id_jag_scopes:
-        Scopes to request in Step 1.  When *None*, defaults to ``["read_data"]``.
+    Combines ``securitySchemes.oauth2.flows.clientCredentials`` (``tokenUrl``) and
+    ``capabilities.extensions`` (JWT Bearer entry) into a single params object.
     """
     token_url, _ = _parse_security_schemes(card)
     ext = _parse_cross_app_extension(card)
@@ -529,31 +446,12 @@ class _CrossAppExtensionFields:
 
 
 def _parse_cross_app_extension(card: AgentCard) -> _CrossAppExtensionFields:
-    """Extract all Cross-Application Access fields from the JWT Bearer extension.
+    """Extract Cross-Application Access fields from the JWT Bearer capability extension.
 
-    Reads the ``capabilities.extensions`` entry whose
-    ``uri == "urn:ietf:params:oauth:grant-type:jwt-bearer"`` and returns a
-    :class:`_CrossAppExtensionFields` containing every parameter required by
-    the Okta Cross-Application Access SDK:
+    Finds the extension with ``uri == _JWT_BEARER_GRANT_TYPE_URI`` and validates
+    required fields.  ``token_request.grant_type`` is validated but not returned.
 
-    - ``params.target_audience`` — final resource identifier.
-    - ``params.token_endpoint_auth_method`` — client auth method.
-    - ``params.token_exchange.trusted_issuer`` — org-level AS for the ID-JAG.
-    - ``params.token_exchange.audience`` — Step 1 AS destination for
-      ``flow.start(audience=...)``.
-    - ``params.token_request.grant_type`` — validated present for card
-      well-formedness but not returned (always
-      ``urn:ietf:params:oauth:grant-type:jwt-bearer``).
-
-    Returns
-    -------
-    _CrossAppExtensionFields
-        All extracted extension parameters needed to configure the SDK.
-
-    Raises
-    ------
-    ValueError
-        If the extension is absent or any required field is missing.
+    Raises ``ValueError`` if the extension is missing or any required field is absent.
     """
     extensions = (
         card.capabilities.extensions if card.capabilities and card.capabilities.extensions else []

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -14,7 +14,7 @@
 
 """Okta token exchange auth provider for A2A agent communication.
 
-Registered as ``_type: okta_token_exchange`` in workflow YAML.
+Registered as ``_type: okta_cross_app_access`` in workflow YAML.
 
 Discovery phase: forwards the incoming ``x-datarobot-okta-access-token`` header
 directly to the agent card endpoint as a Bearer token.
@@ -35,7 +35,7 @@ environment variables / Runtime Parameters / ``.env`` / ``file_secrets`` via
 
     authentication:
       okta_auth:
-        _type: okta_token_exchange
+        _type: okta_cross_app_access
 
     function_groups:
       remote_agent:
@@ -136,7 +136,7 @@ _JWT_BEARER_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 class _CrossAppFlowParams:
     """Agent card parameters needed for the Okta XAA flow.
 
-    Populated by :meth:`OktaTokenExchangeAuthProvider.set_agent_card` from
+    Populated by :meth:`OktaCrossApplicationAccessAuthProvider.set_agent_card` from
     ``securitySchemes`` (OpenAPI layer) and ``capabilities.extensions`` (A2A layer).
     """
 
@@ -167,15 +167,15 @@ class _CrossAppFlowParams:
 
 
 # ---------------------------------------------------------------------------
-# OktaTokenExchangeAuthProviderConfig
+# OktaCrossApplicationAccessAuthProviderConfig
 # ---------------------------------------------------------------------------
 
 
-class OktaTokenExchangeAuthProviderConfig(
+class OktaCrossApplicationAccessAuthProviderConfig(
     AuthProviderBaseConfig,
-    name="okta_token_exchange",
+    name="okta_cross_app_access",
 ):  # type: ignore[call-arg]
-    """Configuration for :class:`OktaTokenExchangeAuthProvider`.
+    """Configuration for :class:`OktaCrossApplicationAccessAuthProvider`.
 
     ``principal_id`` and ``private_jwk`` are auto-loaded from env vars /
     Runtime Parameters / ``.env`` / ``file_secrets`` — no ``workflow.yaml``
@@ -214,13 +214,13 @@ class OktaTokenExchangeAuthProviderConfig(
 
 
 # ---------------------------------------------------------------------------
-# OktaTokenExchangeAuthProvider
+# OktaCrossApplicationAccessAuthProvider
 # ---------------------------------------------------------------------------
 
 
-class OktaTokenExchangeAuthProvider(
+class OktaCrossApplicationAccessAuthProvider(
     A2ADiscoveryAuthMixin,
-    AuthProviderBase[OktaTokenExchangeAuthProviderConfig],
+    AuthProviderBase[OktaCrossApplicationAccessAuthProviderConfig],
 ):
     """Auth provider for Okta XAA A2A calls.
 
@@ -228,7 +228,7 @@ class OktaTokenExchangeAuthProvider(
     * **Call** — two-step XAA token exchange (RFC 8693 → RFC 7523) via ``okta-client-python``.
     """
 
-    def __init__(self, config: OktaTokenExchangeAuthProviderConfig) -> None:
+    def __init__(self, config: OktaCrossApplicationAccessAuthProviderConfig) -> None:
         super().__init__(config)
         self._flow_params: _CrossAppFlowParams | None = None
 
@@ -279,8 +279,9 @@ class OktaTokenExchangeAuthProvider(
         """
         if self._flow_params is None:
             raise RuntimeError(
-                "OktaTokenExchangeAuthProvider.authenticate() called before set_agent_card(). "
-                "Ensure the provider is used with authenticated_a2a_client."
+                "OktaCrossApplicationAccessAuthProvider.authenticate() called "
+                "before set_agent_card(). Ensure the provider is used with "
+                "authenticated_a2a_client."
             )
 
         if not self.config.principal_id:
@@ -503,9 +504,9 @@ def _parse_cross_app_extension(card: AgentCard) -> _CrossAppExtensionFields:
 # ---------------------------------------------------------------------------
 
 
-@register_auth_provider(config_type=OktaTokenExchangeAuthProviderConfig)
-async def okta_token_exchange_auth_provider(
-    config: OktaTokenExchangeAuthProviderConfig, builder: Builder
-) -> AsyncGenerator[OktaTokenExchangeAuthProvider, None]:
-    """NAT auth provider factory for Okta XAA token exchange."""
-    yield OktaTokenExchangeAuthProvider(config=config)
+@register_auth_provider(config_type=OktaCrossApplicationAccessAuthProviderConfig)
+async def okta_cross_app_access_auth_provider(
+    config: OktaCrossApplicationAccessAuthProviderConfig, builder: Builder
+) -> AsyncGenerator[OktaCrossApplicationAccessAuthProvider, None]:
+    """NAT auth provider factory for Okta Cross-Application Access."""
+    yield OktaCrossApplicationAccessAuthProvider(config=config)

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -28,17 +28,19 @@ from nat.data_models.config import GeneralConfig
 from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 
-from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_ROUTES
-from datarobot_genai.dragent.frontends.fastapi import (
-    OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE,
+from datarobot_genai.dragent.frontends.a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
+from datarobot_genai.dragent.frontends.a2a import RFC8693_GRANT_TYPE_URI
+from datarobot_genai.dragent.frontends.a2a import RFC8693_SECURITY_SCHEME_FLOW_REF
+from datarobot_genai.dragent.frontends.a2a import RFC8693_SECURITY_SCHEME_REF
+from datarobot_genai.dragent.frontends.a2a import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
+from datarobot_genai.dragent.frontends.a2a import (
+    PerUserCompatibleAgentExecutor as _PerUserCompatibleAgentExecutor,
 )
-from datarobot_genai.dragent.frontends.fastapi import RFC8693_GRANT_TYPE_URI
-from datarobot_genai.dragent.frontends.fastapi import RFC8693_SECURITY_SCHEME_FLOW_REF
-from datarobot_genai.dragent.frontends.fastapi import RFC8693_SECURITY_SCHEME_REF
-from datarobot_genai.dragent.frontends.fastapi import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
+from datarobot_genai.dragent.frontends.a2a import create_agent_card
+from datarobot_genai.dragent.frontends.a2a import get_a2a_endpoint_url
+from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_ROUTES
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
-from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
 from datarobot_genai.dragent.frontends.server_auth import OAuth2SubjectTokenConstraints
@@ -147,57 +149,45 @@ class TestDRAgentFastApiFrontEndPluginWorker:
         assert isinstance(worker.get_step_adaptor(), DRAgentNestedReasoningStepAdaptor)
 
     def test_get_a2a_endpoint_url_default(self, worker):
-        cfg = A2AFrontEndConfig(host="localhost", port=8000)
-        assert worker._get_a2a_endpoint_url(cfg) == "http://localhost:8000/a2a/"
+        assert get_a2a_endpoint_url("localhost", 8000) == "http://localhost:8000/a2a/"
 
-    def test_get_a2a_endpoint_url_deployment(self, worker):
-        cfg = A2AFrontEndConfig(host="localhost", port=8000)
-        env = {
-            "MLOPS_DEPLOYMENT_ID": "abc123",
-            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
-        }
+    @pytest.mark.parametrize(
+        "env,expected",
+        [
+            (
+                {
+                    "MLOPS_DEPLOYMENT_ID": "abc123",
+                    "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+                },
+                "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/",
+            ),
+            (
+                {
+                    "MLOPS_DEPLOYMENT_ID": "abc123",
+                    "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2/",
+                },
+                "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/",
+            ),
+            (
+                {
+                    "MLOPS_DEPLOYMENT_ID": "abc123",
+                    "DATAROBOT_PUBLIC_API_ENDPOINT": "https://public.datarobot.com/api/v2",
+                    "DATAROBOT_ENDPOINT": "https://internal.k8s.local/api/v2",
+                },
+                "https://public.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/",
+            ),
+        ],
+    )
+    def test_get_a2a_endpoint_url_deployment(self, worker, env, expected):
         with patch.dict(os.environ, env, clear=True):
-            url = worker._get_a2a_endpoint_url(cfg)
-        assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
-
-    def test_get_a2a_endpoint_url_deployment_strips_trailing_slash(self, worker):
-        cfg = A2AFrontEndConfig(host="localhost", port=8000)
-        env = {
-            "MLOPS_DEPLOYMENT_ID": "abc123",
-            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2/",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            url = worker._get_a2a_endpoint_url(cfg)
-        assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
-
-    def test_get_a2a_endpoint_url_deployment_prefers_public_api_endpoint(self, worker):
-        cfg = A2AFrontEndConfig(host="localhost", port=8000)
-        env = {
-            "MLOPS_DEPLOYMENT_ID": "abc123",
-            "DATAROBOT_PUBLIC_API_ENDPOINT": "https://public.datarobot.com/api/v2",
-            "DATAROBOT_ENDPOINT": "https://internal.k8s.local/api/v2",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            url = worker._get_a2a_endpoint_url(cfg)
-        assert url == "https://public.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
-
-    def test_get_a2a_endpoint_url_deployment_falls_back_to_endpoint(self, worker):
-        cfg = A2AFrontEndConfig(host="localhost", port=8000)
-        env = {
-            "MLOPS_DEPLOYMENT_ID": "abc123",
-            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            url = worker._get_a2a_endpoint_url(cfg)
-        assert url == "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/"
+            assert get_a2a_endpoint_url("localhost", 8000) == expected
 
     def test_get_a2a_endpoint_url_deployment_missing_endpoint_raises(self, worker):
-        cfg = A2AFrontEndConfig(host="localhost", port=8000)
         with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "abc123"}, clear=True):
             with pytest.raises(
                 ValueError, match="DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set"
             ):
-                worker._get_a2a_endpoint_url(cfg)
+                get_a2a_endpoint_url("localhost", 8000)
 
     async def test_add_routes_inherits_host_port_from_fastapi_config(
         self, dragent_worker, mock_builder, mock_a2a_worker
@@ -350,25 +340,20 @@ class TestPerUserCompatibleAgentExecutor:
 
 
 class TestCreateAgentCard:
-    async def test_default_skill_when_skills_empty(
-        self, dragent_worker_with_a2a, a2a_frontend_config
-    ):
-        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+    async def test_default_skill_when_skills_empty(self, a2a_frontend_config):
+        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[])
         assert len(card.skills) == 1
         assert card.skills[0].id == "call"
         assert card.skills[0].name == "My Agent"
         assert card.skills[0].description == "Does things"
 
-    async def test_configured_skills_used_when_present(
-        self, dragent_worker_with_a2a, a2a_frontend_config
-    ):
+    async def test_configured_skills_used_when_present(self, a2a_frontend_config):
         skill = AgentSkill(id="summarize", name="Summarize", description="Summarizes text", tags=[])
-        dragent_worker_with_a2a.front_end_config.a2a.skills = [skill]
-        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[skill])
         assert len(card.skills) == 1
         assert card.skills[0].id == "summarize"
 
-    async def test_agent_card_fields_from_frontend_config(self, dragent_worker_with_a2a):
+    async def test_agent_card_fields_from_frontend_config(self):
         cfg = A2AFrontEndConfig(
             name="My Agent",
             description="Does things",
@@ -376,32 +361,31 @@ class TestCreateAgentCard:
             host="localhost",
             port=9000,
         )
-        card = await dragent_worker_with_a2a._create_agent_card(cfg)
+        card = await create_agent_card(cfg, token_exchange=None, skills=[])
         assert card.name == "My Agent"
         assert card.description == "Does things"
         assert card.version == "2.0.0"
         assert card.url == "http://localhost:9000/a2a/"
 
     async def test_security_schemes_set_when_oauth_token_exchange_present(
-        self, dragent_worker_with_a2a, a2a_frontend_config
+        self, a2a_frontend_config
     ):
-        assert dragent_worker_with_a2a.front_end_config.a2a is not None
-        dragent_worker_with_a2a.front_end_config.a2a.oauth_token_exchange = (
-            OAuth2TokenExchangeConfig(
-                token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-                scopes=["blog:write"],
-                subject_token_constraints=OAuth2SubjectTokenConstraints(
-                    trusted_issuer="https://id-jag.internal.datarobot.com",
-                ),
-                token_exchange_request=OAuth2TokenExchangeRequest(
-                    audience="https://app.datarobot.com/dr_org_id/my_agent",
-                    subject_token_type="urn:ietf:params:oauth:token-type:jwt",
-                    requested_token_type="urn:ietf:params:oauth:token-type:access_token",
-                    token_endpoint_auth_method="private_key_jwt",
-                ),
-            )
+        token_exchange = OAuth2TokenExchangeConfig(
+            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+            scopes=["blog:write"],
+            subject_token_constraints=OAuth2SubjectTokenConstraints(
+                trusted_issuer="https://id-jag.internal.datarobot.com",
+            ),
+            token_exchange_request=OAuth2TokenExchangeRequest(
+                audience="https://app.datarobot.com/dr_org_id/my_agent",
+                subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+                requested_token_type="urn:ietf:params:oauth:token-type:access_token",
+                token_endpoint_auth_method="private_key_jwt",
+            ),
         )
-        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        card = await create_agent_card(
+            a2a_frontend_config, token_exchange=token_exchange, skills=[]
+        )
 
         assert "oauth2" in card.security_schemes
         oauth_scheme = card.security_schemes["oauth2"].root
@@ -438,15 +422,13 @@ class TestCreateAgentCard:
             },
         }
 
-    async def test_security_schemes_from_server_auth(
-        self, dragent_worker_with_a2a, a2a_frontend_config
-    ):
+    async def test_security_schemes_from_server_auth(self, a2a_frontend_config):
         a2a_frontend_config.server_auth = MagicMock(
             issuer_url="https://issuer.example.com",
             discovery_url=None,
             scopes=["read"],
         )
-        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[])
 
         oauth_scheme = card.security_schemes["oauth2"].root
         assert oauth_scheme.description == OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
@@ -463,9 +445,7 @@ class TestCreateAgentCard:
         assert oauth_scheme.flows.client_credentials is None
         assert card.security == [{"oauth2": ["read"]}]
 
-    async def test_both_server_auth_and_token_exchange(
-        self, dragent_worker_with_a2a, a2a_frontend_config
-    ):
+    async def test_both_server_auth_and_token_exchange(self, a2a_frontend_config):
         # server_auth → authorization_code flow
         a2a_frontend_config.server_auth = MagicMock(
             issuer_url="https://issuer.example.com",
@@ -474,24 +454,23 @@ class TestCreateAgentCard:
         )
 
         # oauth_token_exchange → client_credentials flow
-        assert dragent_worker_with_a2a.front_end_config.a2a is not None
-        dragent_worker_with_a2a.front_end_config.a2a.oauth_token_exchange = (
-            OAuth2TokenExchangeConfig(
-                token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-                scopes=["blog:write"],
-                subject_token_constraints=OAuth2SubjectTokenConstraints(
-                    trusted_issuer="https://id-jag.internal.datarobot.com",
-                ),
-                token_exchange_request=OAuth2TokenExchangeRequest(
-                    audience="https://app.datarobot.com/dr_org_id/my_agent",
-                    subject_token_type="urn:ietf:params:oauth:token-type:jwt",
-                    requested_token_type="urn:ietf:params:oauth:token-type:access_token",
-                    token_endpoint_auth_method="private_key_jwt",
-                ),
-            )
+        token_exchange = OAuth2TokenExchangeConfig(
+            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+            scopes=["blog:write"],
+            subject_token_constraints=OAuth2SubjectTokenConstraints(
+                trusted_issuer="https://id-jag.internal.datarobot.com",
+            ),
+            token_exchange_request=OAuth2TokenExchangeRequest(
+                audience="https://app.datarobot.com/dr_org_id/my_agent",
+                subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+                requested_token_type="urn:ietf:params:oauth:token-type:access_token",
+                token_endpoint_auth_method="private_key_jwt",
+            ),
         )
 
-        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+        card = await create_agent_card(
+            a2a_frontend_config, token_exchange=token_exchange, skills=[]
+        )
 
         # Single oauth2 scheme with both flows
         assert len(card.security_schemes) == 1
@@ -534,10 +513,8 @@ class TestCreateAgentCard:
             },
         }
 
-    async def test_no_security_when_server_auth_absent(
-        self, dragent_worker_with_a2a, a2a_frontend_config
-    ):
-        card = await dragent_worker_with_a2a._create_agent_card(a2a_frontend_config)
+    async def test_no_security_when_server_auth_absent(self, a2a_frontend_config):
+        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[])
         assert card.security_schemes is None
         assert card.security is None
 

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -369,9 +369,6 @@ class TestCreateAgentCard:
         self, a2a_frontend_config
     ):
         cross_app_access = CrossApplicationAccessConfig(
-            token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-            scopes=["blog:write"],
-            target_audience="https://app.datarobot.com/dr_org_id/my_agent_id",
             token_endpoint_auth_method="private_key_jwt",
             token_exchange=CrossAppTokenExchange(
                 trusted_issuer="https://your-org.oktapreview.com",
@@ -379,6 +376,9 @@ class TestCreateAgentCard:
             ),
             token_request=CrossAppTokenRequest(
                 grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
+                token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+                audience="https://app.datarobot.com/dr_org_id/my_agent_id",
+                scopes=["blog:write"],
             ),
         )
         card = await create_agent_card(
@@ -409,7 +409,6 @@ class TestCreateAgentCard:
                 "scheme": CROSS_APP_SECURITY_SCHEME_REF,
                 "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
             },
-            "target_audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             "token_endpoint_auth_method": "private_key_jwt",
             "token_exchange": {
                 "trusted_issuer": "https://your-org.oktapreview.com",
@@ -417,6 +416,7 @@ class TestCreateAgentCard:
             },
             "token_request": {
                 "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             },
         }
         # Verify OpenAPI/extension strict separation: token_url and scopes are NOT in params
@@ -456,9 +456,6 @@ class TestCreateAgentCard:
 
         # cross_application_access → client_credentials flow + JWT Bearer extension
         cross_app_access = CrossApplicationAccessConfig(
-            token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
-            scopes=["blog:write"],
-            target_audience="https://app.datarobot.com/dr_org_id/my_agent_id",
             token_endpoint_auth_method="private_key_jwt",
             token_exchange=CrossAppTokenExchange(
                 trusted_issuer="https://your-org.oktapreview.com",
@@ -466,6 +463,9 @@ class TestCreateAgentCard:
             ),
             token_request=CrossAppTokenRequest(
                 grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
+                token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+                audience="https://app.datarobot.com/dr_org_id/my_agent_id",
+                scopes=["blog:write"],
             ),
         )
 
@@ -503,7 +503,6 @@ class TestCreateAgentCard:
                 "scheme": CROSS_APP_SECURITY_SCHEME_REF,
                 "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
             },
-            "target_audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             "token_endpoint_auth_method": "private_key_jwt",
             "token_exchange": {
                 "trusted_issuer": "https://your-org.oktapreview.com",
@@ -511,6 +510,7 @@ class TestCreateAgentCard:
             },
             "token_request": {
                 "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             },
         }
         assert "token_url" not in ext.params
@@ -532,9 +532,6 @@ class TestDRAgentFastApiFrontEndConfig:
 
     def test_custom_a2a_fields(self):
         cross_app = CrossApplicationAccessConfig(
-            token_url="https://idp.example.com/oauth2/v1/token",
-            scopes=["agent:use"],
-            target_audience="api://my-agent",
             token_endpoint_auth_method="private_key_jwt",
             token_exchange=CrossAppTokenExchange(
                 trusted_issuer="https://id-jag.example.com",
@@ -542,6 +539,9 @@ class TestDRAgentFastApiFrontEndConfig:
             ),
             token_request=CrossAppTokenRequest(
                 grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
+                token_url="https://idp.example.com/oauth2/v1/token",
+                audience="api://my-agent",
+                scopes=["agent:use"],
             ),
         )
         config = DRAgentFastApiFrontEndConfig(

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -33,14 +33,12 @@ from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_FLOW
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_REF
 from datarobot_genai.dragent.frontends.a2a import JWT_BEARER_GRANT_TYPE_URI
 from datarobot_genai.dragent.frontends.a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
-from datarobot_genai.dragent.frontends.a2a import (
-    PerUserCompatibleAgentExecutor as _PerUserCompatibleAgentExecutor,
-)
 from datarobot_genai.dragent.frontends.a2a import create_agent_card
 from datarobot_genai.dragent.frontends.a2a import get_a2a_endpoint_url
 from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_ROUTES
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
+from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
 from datarobot_genai.dragent.frontends.server_auth import CrossApplicationAccessConfig

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -28,11 +28,11 @@ from nat.data_models.config import GeneralConfig
 from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 
+from datarobot_genai.dragent.frontends.a2a import CROSS_APP_EXTENSION_DESCRIPTION
+from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_FLOW_REF
+from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_REF
+from datarobot_genai.dragent.frontends.a2a import JWT_BEARER_GRANT_TYPE_URI
 from datarobot_genai.dragent.frontends.a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
-from datarobot_genai.dragent.frontends.a2a import RFC8693_GRANT_TYPE_URI
-from datarobot_genai.dragent.frontends.a2a import RFC8693_SECURITY_SCHEME_FLOW_REF
-from datarobot_genai.dragent.frontends.a2a import RFC8693_SECURITY_SCHEME_REF
-from datarobot_genai.dragent.frontends.a2a import RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
 from datarobot_genai.dragent.frontends.a2a import (
     PerUserCompatibleAgentExecutor as _PerUserCompatibleAgentExecutor,
 )
@@ -43,9 +43,9 @@ from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlug
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
-from datarobot_genai.dragent.frontends.server_auth import OAuth2SubjectTokenConstraints
-from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeConfig
-from datarobot_genai.dragent.frontends.server_auth import OAuth2TokenExchangeRequest
+from datarobot_genai.dragent.frontends.server_auth import CrossApplicationAccessConfig
+from datarobot_genai.dragent.frontends.server_auth import CrossAppTokenExchange
+from datarobot_genai.dragent.frontends.server_auth import CrossAppTokenRequest
 from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
 
 
@@ -341,7 +341,7 @@ class TestPerUserCompatibleAgentExecutor:
 
 class TestCreateAgentCard:
     async def test_default_skill_when_skills_empty(self, a2a_frontend_config):
-        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[])
+        card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
         assert len(card.skills) == 1
         assert card.skills[0].id == "call"
         assert card.skills[0].name == "My Agent"
@@ -349,7 +349,7 @@ class TestCreateAgentCard:
 
     async def test_configured_skills_used_when_present(self, a2a_frontend_config):
         skill = AgentSkill(id="summarize", name="Summarize", description="Summarizes text", tags=[])
-        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[skill])
+        card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[skill])
         assert len(card.skills) == 1
         assert card.skills[0].id == "summarize"
 
@@ -361,30 +361,30 @@ class TestCreateAgentCard:
             host="localhost",
             port=9000,
         )
-        card = await create_agent_card(cfg, token_exchange=None, skills=[])
+        card = await create_agent_card(cfg, cross_app_access=None, skills=[])
         assert card.name == "My Agent"
         assert card.description == "Does things"
         assert card.version == "2.0.0"
         assert card.url == "http://localhost:9000/a2a/"
 
-    async def test_security_schemes_set_when_oauth_token_exchange_present(
+    async def test_security_schemes_set_when_cross_application_access_present(
         self, a2a_frontend_config
     ):
-        token_exchange = OAuth2TokenExchangeConfig(
-            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+        cross_app_access = CrossApplicationAccessConfig(
+            token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
             scopes=["blog:write"],
-            subject_token_constraints=OAuth2SubjectTokenConstraints(
-                trusted_issuer="https://id-jag.internal.datarobot.com",
+            target_audience="https://app.datarobot.com/dr_org_id/my_agent_id",
+            token_endpoint_auth_method="private_key_jwt",
+            token_exchange=CrossAppTokenExchange(
+                trusted_issuer="https://your-org.oktapreview.com",
+                audience="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             ),
-            token_exchange_request=OAuth2TokenExchangeRequest(
-                audience="https://app.datarobot.com/dr_org_id/my_agent",
-                subject_token_type="urn:ietf:params:oauth:token-type:jwt",
-                requested_token_type="urn:ietf:params:oauth:token-type:access_token",
-                token_endpoint_auth_method="private_key_jwt",
+            token_request=CrossAppTokenRequest(
+                grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
             ),
         )
         card = await create_agent_card(
-            a2a_frontend_config, token_exchange=token_exchange, skills=[]
+            a2a_frontend_config, cross_app_access=cross_app_access, skills=[]
         )
 
         assert "oauth2" in card.security_schemes
@@ -395,32 +395,35 @@ class TestCreateAgentCard:
         # Only client_credentials flow, no authorization_code
         assert oauth_scheme.flows.authorization_code is None
         flow = oauth_scheme.flows.client_credentials
-        assert flow.token_url == "https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
+        assert flow.token_url == "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
         assert flow.scopes == {"blog:write": "Permission: blog:write"}
 
         assert card.security == [{"oauth2": ["blog:write"]}]
 
-        # RFC 8693 extension: ref + subject_token_constraints + token_exchange_request
+        # JWT Bearer extension: nested params — token_url/scopes must NOT appear here
         assert card.capabilities.extensions is not None
         assert len(card.capabilities.extensions) == 1
         ext = card.capabilities.extensions[0]
-        assert ext.uri == RFC8693_GRANT_TYPE_URI
-        assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
+        assert ext.uri == JWT_BEARER_GRANT_TYPE_URI
+        assert ext.description == CROSS_APP_EXTENSION_DESCRIPTION
         assert ext.params == {
             "ref": {
-                "scheme": RFC8693_SECURITY_SCHEME_REF,
-                "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
+                "scheme": CROSS_APP_SECURITY_SCHEME_REF,
+                "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
             },
-            "subject_token_constraints": {
-                "trusted_issuer": "https://id-jag.internal.datarobot.com",
+            "target_audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
+            "token_endpoint_auth_method": "private_key_jwt",
+            "token_exchange": {
+                "trusted_issuer": "https://your-org.oktapreview.com",
+                "audience": "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             },
-            "token_exchange_request": {
-                "audience": "https://app.datarobot.com/dr_org_id/my_agent",
-                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-                "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
-                "token_endpoint_auth_method": "private_key_jwt",
+            "token_request": {
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             },
         }
+        # Verify OpenAPI/extension strict separation: token_url and scopes are NOT in params
+        assert "token_url" not in ext.params
+        assert "scopes" not in ext.params
 
     async def test_security_schemes_from_server_auth(self, a2a_frontend_config):
         a2a_frontend_config.server_auth = MagicMock(
@@ -428,7 +431,7 @@ class TestCreateAgentCard:
             discovery_url=None,
             scopes=["read"],
         )
-        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[])
+        card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
 
         oauth_scheme = card.security_schemes["oauth2"].root
         assert oauth_scheme.description == OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
@@ -445,7 +448,7 @@ class TestCreateAgentCard:
         assert oauth_scheme.flows.client_credentials is None
         assert card.security == [{"oauth2": ["read"]}]
 
-    async def test_both_server_auth_and_token_exchange(self, a2a_frontend_config):
+    async def test_both_server_auth_and_cross_application_access(self, a2a_frontend_config):
         # server_auth → authorization_code flow
         a2a_frontend_config.server_auth = MagicMock(
             issuer_url="https://issuer.example.com",
@@ -453,23 +456,23 @@ class TestCreateAgentCard:
             scopes=["read"],
         )
 
-        # oauth_token_exchange → client_credentials flow
-        token_exchange = OAuth2TokenExchangeConfig(
-            token_url="https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+        # cross_application_access → client_credentials flow + JWT Bearer extension
+        cross_app_access = CrossApplicationAccessConfig(
+            token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
             scopes=["blog:write"],
-            subject_token_constraints=OAuth2SubjectTokenConstraints(
-                trusted_issuer="https://id-jag.internal.datarobot.com",
+            target_audience="https://app.datarobot.com/dr_org_id/my_agent_id",
+            token_endpoint_auth_method="private_key_jwt",
+            token_exchange=CrossAppTokenExchange(
+                trusted_issuer="https://your-org.oktapreview.com",
+                audience="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             ),
-            token_exchange_request=OAuth2TokenExchangeRequest(
-                audience="https://app.datarobot.com/dr_org_id/my_agent",
-                subject_token_type="urn:ietf:params:oauth:token-type:jwt",
-                requested_token_type="urn:ietf:params:oauth:token-type:access_token",
-                token_endpoint_auth_method="private_key_jwt",
+            token_request=CrossAppTokenRequest(
+                grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
             ),
         )
 
         card = await create_agent_card(
-            a2a_frontend_config, token_exchange=token_exchange, skills=[]
+            a2a_frontend_config, cross_app_access=cross_app_access, skills=[]
         )
 
         # Single oauth2 scheme with both flows
@@ -486,35 +489,37 @@ class TestCreateAgentCard:
         assert oauth_scheme.flows.client_credentials is not None
         assert (
             oauth_scheme.flows.client_credentials.token_url
-            == "https://datarobot.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
+            == "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token"
         )
 
         # Merged scopes (deduplicated)
         assert card.security == [{"oauth2": ["read", "blog:write"]}]
 
-        # RFC 8693 extension: nested params; scopes only under OpenAPI flows
+        # JWT Bearer extension: nested params; token_url/scopes only under OpenAPI flows
         assert card.capabilities.extensions is not None
         ext = card.capabilities.extensions[0]
-        assert ext.uri == RFC8693_GRANT_TYPE_URI
-        assert ext.description == RFC8693_TOKEN_EXCHANGE_EXTENSION_DESCRIPTION
+        assert ext.uri == JWT_BEARER_GRANT_TYPE_URI
+        assert ext.description == CROSS_APP_EXTENSION_DESCRIPTION
         assert ext.params == {
             "ref": {
-                "scheme": RFC8693_SECURITY_SCHEME_REF,
-                "flow": RFC8693_SECURITY_SCHEME_FLOW_REF,
+                "scheme": CROSS_APP_SECURITY_SCHEME_REF,
+                "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
             },
-            "subject_token_constraints": {
-                "trusted_issuer": "https://id-jag.internal.datarobot.com",
+            "target_audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
+            "token_endpoint_auth_method": "private_key_jwt",
+            "token_exchange": {
+                "trusted_issuer": "https://your-org.oktapreview.com",
+                "audience": "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             },
-            "token_exchange_request": {
-                "audience": "https://app.datarobot.com/dr_org_id/my_agent",
-                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-                "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
-                "token_endpoint_auth_method": "private_key_jwt",
+            "token_request": {
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             },
         }
+        assert "token_url" not in ext.params
+        assert "scopes" not in ext.params
 
     async def test_no_security_when_server_auth_absent(self, a2a_frontend_config):
-        card = await create_agent_card(a2a_frontend_config, token_exchange=None, skills=[])
+        card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
         assert card.security_schemes is None
         assert card.security is None
 
@@ -528,17 +533,17 @@ class TestDRAgentFastApiFrontEndConfig:
         assert config.a2a is None
 
     def test_custom_a2a_fields(self):
-        oauth = OAuth2TokenExchangeConfig(
+        cross_app = CrossApplicationAccessConfig(
             token_url="https://idp.example.com/oauth2/v1/token",
             scopes=["agent:use"],
-            subject_token_constraints=OAuth2SubjectTokenConstraints(
+            target_audience="api://my-agent",
+            token_endpoint_auth_method="private_key_jwt",
+            token_exchange=CrossAppTokenExchange(
                 trusted_issuer="https://id-jag.example.com",
+                audience="https://idp.example.com/oauth2/ausXXX",
             ),
-            token_exchange_request=OAuth2TokenExchangeRequest(
-                audience="api://my-agent",
-                subject_token_type="urn:ietf:params:oauth:token-type:jwt",
-                requested_token_type="urn:ietf:params:oauth:token-type:access_token",
-                token_endpoint_auth_method="private_key_jwt",
+            token_request=CrossAppTokenRequest(
+                grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
             ),
         )
         config = DRAgentFastApiFrontEndConfig(
@@ -548,13 +553,13 @@ class TestDRAgentFastApiFrontEndConfig:
                     description="Does things",
                     version="2.0.0",
                 ),
-                oauth_token_exchange=oauth,
+                cross_application_access=cross_app,
             )
         )
         assert config.a2a.server.name == "My Agent"
         assert config.a2a.server.description == "Does things"
         assert config.a2a.server.version == "2.0.0"
-        assert config.a2a.oauth_token_exchange == oauth
+        assert config.a2a.cross_application_access == cross_app
 
     def test_is_not_a2a_front_end_config(self):
         config = DRAgentFastApiFrontEndConfig()

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -23,6 +23,7 @@ from nat.data_models.authentication import BearerTokenCred
 from nat.data_models.authentication import HeaderCred
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 
+from datarobot_genai.dragent.plugins.auth_a2a_client import A2ADiscoveryAuthMixin
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientConfig
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientFunctionGroup
 from datarobot_genai.dragent.plugins.auth_a2a_client import _AuthenticatedA2ABaseClient
@@ -74,6 +75,21 @@ def bearer_auth_provider():
 
 
 @pytest.fixture
+def mixin_auth_provider():
+    """Auth provider that implements A2ADiscoveryAuthMixin."""
+
+    class _MockDiscoveryProvider(A2ADiscoveryAuthMixin):
+        authenticate_for_discovery = AsyncMock(
+            return_value={"Authorization": "Bearer discovery_token"}
+        )
+        authenticate = AsyncMock(
+            return_value=AuthResult(credentials=[BearerTokenCred(token="call_token")])
+        )
+
+    return _MockDiscoveryProvider()
+
+
+@pytest.fixture
 def patched_base_client_env():
     """Patch httpx, ClientFactory, and Context for _AuthenticatedA2ABaseClient tests."""
     with (
@@ -84,14 +100,12 @@ def patched_base_client_env():
         mock_httpx.AsyncClient.return_value = MagicMock(aclose=AsyncMock())
         mock_factory.return_value.create.return_value = MagicMock(aclose=AsyncMock())
         mock_ctx.get.return_value.user_id = "test-user"
-        yield mock_httpx
+        yield mock_httpx, mock_factory
 
 
 @pytest.fixture
 def patched_fg_env():
-    """Patch Context, _AuthenticatedA2ABaseClient,
-    and _register_functions for function group tests.
-    """
+    """Patch Context, _AuthenticatedA2ABaseClient, and _register_functions."""
     with (
         patch(f"{_MODULE}.Context") as mock_ctx,
         patch(f"{_MODULE}._AuthenticatedA2ABaseClient") as mock_cls,
@@ -120,6 +134,21 @@ class TestExtractAuthHeaders:
 
 
 # ---------------------------------------------------------------------------
+# Tests: A2ADiscoveryAuthMixin
+# ---------------------------------------------------------------------------
+
+
+class TestA2ADiscoveryAuthMixin:
+    def test_is_abstract(self):
+        """A2ADiscoveryAuthMixin cannot be instantiated without implementing the abstract method."""
+        with pytest.raises(TypeError):
+            A2ADiscoveryAuthMixin()  # type: ignore[abstract]
+
+    def test_concrete_subclass_is_recognised(self, mixin_auth_provider):
+        assert isinstance(mixin_auth_provider, A2ADiscoveryAuthMixin)
+
+
+# ---------------------------------------------------------------------------
 # Tests: AuthenticatedA2AClientConfig
 # ---------------------------------------------------------------------------
 
@@ -130,25 +159,101 @@ class TestAuthenticatedA2AClientConfig:
 
 
 # ---------------------------------------------------------------------------
-# Tests: _AuthenticatedA2ABaseClient
+# Tests: _AuthenticatedA2ABaseClient — _resolve_agent_card dispatch
 # ---------------------------------------------------------------------------
 
 
-class TestAuthenticatedA2ABaseClient:
-    async def test_injects_bearer_headers(self, bearer_auth_provider, patched_base_client_env):
+class TestAuthenticatedA2ABaseClientResolveCard:
+    """Unit-tests for the three-branch discovery-auth dispatch in _resolve_agent_card."""
+
+    @pytest.fixture
+    def patched_resolver_env(self):
+        """Patch A2ACardResolver and Context; yield (mock_resolver_cls, mock_ctx)."""
+        with (
+            patch(f"{_MODULE}.A2ACardResolver") as mock_resolver_cls,
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch(f"{_MODULE}.httpx") as mock_httpx,
+        ):
+            mock_httpx.AsyncClient.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+            mock_httpx.AsyncClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.Timeout = MagicMock()
+            mock_resolver_cls.return_value.get_agent_card = AsyncMock(return_value=MagicMock())
+            mock_ctx.get.return_value.user_id = "test-user"
+            yield mock_resolver_cls, mock_ctx, mock_httpx
+
+    async def test_no_provider_unauthenticated(self, patched_resolver_env):
+        """When no auth_provider is set, card is fetched with empty headers."""
+        _, _, mock_httpx = patched_resolver_env
+        client = _AuthenticatedA2ABaseClient(base_url=_AGENT_URL, auth_provider=None)
+        await client._resolve_agent_card()
+        _, httpx_kwargs = mock_httpx.AsyncClient.call_args
+        assert httpx_kwargs.get("headers", {}) == {}
+
+    async def test_plain_provider_calls_authenticate(
+        self, patched_resolver_env, bearer_auth_provider
+    ):
+        """Provider without mixin → authenticate() called, headers extracted."""
+        _, _, mock_httpx = patched_resolver_env
+        client = _AuthenticatedA2ABaseClient(
+            base_url=_AGENT_URL, auth_provider=bearer_auth_provider
+        )
+        await client._resolve_agent_card()
+        bearer_auth_provider.authenticate.assert_awaited_once()
+        _, httpx_kwargs = mock_httpx.AsyncClient.call_args
+        assert httpx_kwargs["headers"]["Authorization"] == "Bearer test_token"
+
+    async def test_mixin_provider_calls_authenticate_for_discovery(
+        self, patched_resolver_env, mixin_auth_provider
+    ):
+        """Provider with mixin → authenticate_for_discovery() called; authenticate() NOT called."""
+        _, _, mock_httpx = patched_resolver_env
+        client = _AuthenticatedA2ABaseClient(base_url=_AGENT_URL, auth_provider=mixin_auth_provider)
+        await client._resolve_agent_card()
+        mixin_auth_provider.authenticate_for_discovery.assert_awaited_once()
+        mixin_auth_provider.authenticate.assert_not_awaited()
+        _, httpx_kwargs = mock_httpx.AsyncClient.call_args
+        assert httpx_kwargs["headers"]["Authorization"] == "Bearer discovery_token"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _AuthenticatedA2ABaseClient — __aenter__ (call phase)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticatedA2ABaseClientCallPhase:
+    async def test_call_auth_uses_auth_interceptor(
+        self, bearer_auth_provider, patched_base_client_env
+    ):
+        """When auth_provider is set, AuthInterceptor is added for RPC calls."""
+        mock_httpx, mock_factory = patched_base_client_env
         client = _AuthenticatedA2ABaseClient(
             base_url=_AGENT_URL, auth_provider=bearer_auth_provider
         )
         with _skip_agent_card_resolution(client):
             async with client:
-                _, httpx_kwargs = patched_base_client_env.AsyncClient.call_args
-                assert httpx_kwargs["headers"]["Authorization"] == "Bearer test_token"
+                create_kw = mock_factory.return_value.create.call_args.kwargs
+                assert len(create_kw["interceptors"]) == 1
 
-    async def test_no_auth_uses_empty_headers(self, patched_base_client_env):
+    async def test_no_auth_empty_interceptors(self, patched_base_client_env):
+        """When no auth_provider, no interceptors are added."""
+        mock_httpx, mock_factory = patched_base_client_env
         client = _AuthenticatedA2ABaseClient(base_url=_AGENT_URL, auth_provider=None)
         with _skip_agent_card_resolution(client):
             async with client:
-                _, httpx_kwargs = patched_base_client_env.AsyncClient.call_args
+                create_kw = mock_factory.return_value.create.call_args.kwargs
+                assert create_kw.get("interceptors") == []
+
+    async def test_task_httpx_client_has_no_default_headers(
+        self, bearer_auth_provider, patched_base_client_env
+    ):
+        """The long-lived task httpx client carries no default auth headers."""
+        mock_httpx, _ = patched_base_client_env
+        client = _AuthenticatedA2ABaseClient(
+            base_url=_AGENT_URL, auth_provider=bearer_auth_provider
+        )
+        with _skip_agent_card_resolution(client):
+            async with client:
+                _, httpx_kwargs = mock_httpx.AsyncClient.call_args
                 assert httpx_kwargs.get("headers", {}) == {}
 
 

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -44,7 +44,10 @@ def _skip_agent_card_resolution(client):
     """Patch _resolve_agent_card to set a mock agent card without network access."""
 
     async def _set_mock_card():
-        client._agent_card = MagicMock()
+        mock_card = MagicMock()
+        # Ensure A2ACredentialService skips compatibility validation (no security schemes).
+        mock_card.security_schemes = None
+        client._agent_card = mock_card
 
     with patch.object(client, "_resolve_agent_card", side_effect=_set_mock_card):
         yield
@@ -79,9 +82,9 @@ def mixin_auth_provider():
     """Auth provider that implements A2ADiscoveryAuthMixin."""
 
     class _MockDiscoveryProvider(A2ADiscoveryAuthMixin):
-        authenticate_for_discovery = AsyncMock(
-            return_value={"Authorization": "Bearer discovery_token"}
-        )
+        async def authenticate_for_discovery(self, user_id=None):
+            return {"Authorization": "Bearer discovery_token"}
+
         authenticate = AsyncMock(
             return_value=AuthResult(credentials=[BearerTokenCred(token="call_token")])
         )
@@ -157,6 +160,10 @@ class TestAuthenticatedA2AClientConfig:
     def test_is_a2a_client_config(self, a2a_config):
         assert isinstance(a2a_config, A2AClientConfig)
 
+    def test_url_only_is_valid(self):
+        cfg = AuthenticatedA2AClientConfig(url=_AGENT_URL)
+        assert str(cfg.url).rstrip("/") == _AGENT_URL
+
 
 # ---------------------------------------------------------------------------
 # Tests: _AuthenticatedA2ABaseClient — _resolve_agent_card dispatch
@@ -164,7 +171,7 @@ class TestAuthenticatedA2AClientConfig:
 
 
 class TestAuthenticatedA2ABaseClientResolveCard:
-    """Unit-tests for the three-branch discovery-auth dispatch in _resolve_agent_card."""
+    """Unit-tests for the two-branch discovery-auth dispatch in _resolve_agent_card."""
 
     @pytest.fixture
     def patched_resolver_env(self):
@@ -209,7 +216,6 @@ class TestAuthenticatedA2ABaseClientResolveCard:
         _, _, mock_httpx = patched_resolver_env
         client = _AuthenticatedA2ABaseClient(base_url=_AGENT_URL, auth_provider=mixin_auth_provider)
         await client._resolve_agent_card()
-        mixin_auth_provider.authenticate_for_discovery.assert_awaited_once()
         mixin_auth_provider.authenticate.assert_not_awaited()
         _, httpx_kwargs = mock_httpx.AsyncClient.call_args
         assert httpx_kwargs["headers"]["Authorization"] == "Bearer discovery_token"

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -1,0 +1,257 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for OktaTokenExchangeAuthProvider and its agent-card parsing helpers."""
+
+import base64
+import json
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from a2a.types import AgentCapabilities
+from a2a.types import AgentCard
+from a2a.types import AgentExtension
+from a2a.types import ClientCredentialsOAuthFlow
+from a2a.types import OAuth2SecurityScheme
+from a2a.types import OAuthFlows
+from a2a.types import SecurityScheme
+from nat.data_models.authentication import BearerTokenCred
+
+from datarobot_genai.dragent.plugins.okta_a2a_auth import OktaTokenExchangeAuthProvider
+from datarobot_genai.dragent.plugins.okta_a2a_auth import OktaTokenExchangeAuthProviderConfig
+from datarobot_genai.dragent.plugins.okta_a2a_auth import _parse_cross_app_params
+
+_MODULE = "datarobot_genai.dragent.plugins.okta_a2a_auth"
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+_TRUSTED_ISSUER = "https://okta.example.com"
+_AGENT_TOKEN_URL = "https://okta.example.com/oauth2/ausYYY/v1/token"
+_AGENT_AUDIENCE = "https://api.agent.example.com"
+_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+_REQUESTED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag"
+_AUTH_METHOD = "private_key_jwt"
+
+# Derived: custom-AS base URL = agent token URL with /v1/token stripped
+_TARGET_ISSUER = "https://okta.example.com/oauth2/ausYYY"
+
+_FAKE_JWK = {
+    "kty": "RSA",
+    "kid": "test-kid",
+    "n": "abc",
+    "e": "AQAB",
+    "d": "def",
+    "p": "ghi",
+    "q": "jkl",
+    "dp": "mno",
+    "dq": "pqr",
+    "qi": "stu",
+}
+_FAKE_JWK_B64 = base64.b64encode(json.dumps(_FAKE_JWK).encode()).decode()
+
+
+def _make_agent_card() -> AgentCard:
+    """Build a minimal AgentCard that contains the RFC 8693 extension."""
+    cc_flow = ClientCredentialsOAuthFlow(
+        token_url=_AGENT_TOKEN_URL,
+        scopes={"read_data": "Read access"},
+    )
+    security_scheme = SecurityScheme(
+        root=OAuth2SecurityScheme(
+            type="oauth2",
+            flows=OAuthFlows(client_credentials=cc_flow),
+        )
+    )
+    extension = AgentExtension(
+        uri="urn:ietf:params:oauth:grant-type:token-exchange",
+        description="RFC 8693 two-step token exchange",
+        params={
+            "subject_token_constraints": {"trusted_issuer": _TRUSTED_ISSUER},
+            "token_exchange_request": {
+                "audience": _AGENT_AUDIENCE,
+                "subject_token_type": _SUBJECT_TOKEN_TYPE,
+                "requested_token_type": _REQUESTED_TOKEN_TYPE,
+                "token_endpoint_auth_method": _AUTH_METHOD,
+            },
+        },
+    )
+    return AgentCard(
+        name="Test Agent",
+        description="Test",
+        url="https://agent.example.com/",
+        version="1.0.0",
+        skills=[],
+        capabilities=AgentCapabilities(streaming=False, extensions=[extension]),
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        security_schemes={"oauth2": security_scheme},
+        security=[{"oauth2": ["read_data"]}],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: OktaTokenExchangeAuthProvider — discovery phase
+# ---------------------------------------------------------------------------
+
+
+class TestOktaTokenExchangeAuthProviderDiscovery:
+    @pytest.fixture
+    def provider(self):
+        return OktaTokenExchangeAuthProvider(config=OktaTokenExchangeAuthProviderConfig())
+
+    async def test_authenticate_for_discovery_returns_bearer(self, provider):
+        """authenticate_for_discovery() returns the Okta token as Authorization: Bearer."""
+        with patch(f"{_MODULE}.Context") as mock_ctx:
+            mock_ctx.get.return_value.metadata.headers = {
+                "x-datarobot-okta-access-token": "my-okta-token"
+            }
+            headers = await provider.authenticate_for_discovery()
+
+        assert headers == {"Authorization": "Bearer my-okta-token"}
+
+    async def test_authenticate_for_discovery_raises_when_header_missing(self, provider):
+        """authenticate_for_discovery() raises RuntimeError when header is absent."""
+        with patch(f"{_MODULE}.Context") as mock_ctx:
+            mock_ctx.get.return_value.metadata.headers = {}
+            with pytest.raises(RuntimeError, match="x-datarobot-okta-access-token"):
+                await provider.authenticate_for_discovery()
+
+
+# ---------------------------------------------------------------------------
+# Tests: OktaTokenExchangeAuthProvider — set_agent_card / param parsing
+# ---------------------------------------------------------------------------
+
+
+class TestOktaTokenExchangeAuthProviderSetAgentCard:
+    def test_set_agent_card_parses_params(self):
+        """set_agent_card() populates _CrossAppFlowParams from the agent card."""
+        provider = OktaTokenExchangeAuthProvider(config=OktaTokenExchangeAuthProviderConfig())
+
+        provider.set_agent_card(_make_agent_card())
+
+        params = provider._flow_params
+        assert params is not None
+        assert params.issuer == _TRUSTED_ISSUER
+        assert params.target_issuer == _TARGET_ISSUER
+        assert params.id_jag_scopes == ["read_data"]
+
+
+class TestParseCrossAppParams:
+    def test_parse_cross_app_params_happy_path(self):
+        """_parse_cross_app_params extracts issuer and target_issuer correctly."""
+        params = _parse_cross_app_params(_make_agent_card())
+
+        assert params.issuer == _TRUSTED_ISSUER
+        assert params.target_issuer == _TARGET_ISSUER
+        assert params.id_jag_scopes == ["read_data"]
+
+    def test_parse_cross_app_params_custom_scopes(self):
+        """_parse_cross_app_params uses caller-supplied scopes when provided."""
+        params = _parse_cross_app_params(_make_agent_card(), id_jag_scopes=["openid", "profile"])
+
+        assert params.id_jag_scopes == ["openid", "profile"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: OktaTokenExchangeAuthProvider — authenticate (call phase)
+# ---------------------------------------------------------------------------
+
+
+class TestOktaTokenExchangeAuthProviderAuthenticate:
+    @pytest.fixture
+    def provider_with_card(self):
+        config = OktaTokenExchangeAuthProviderConfig(
+            principal_id="principal_abc",
+            private_jwk=_FAKE_JWK_B64,
+        )
+        provider = OktaTokenExchangeAuthProvider(config=config)
+        provider.set_agent_card(_make_agent_card())
+        return provider
+
+    async def test_authenticate_returns_bearer_cred(self, provider_with_card):
+        """authenticate() calls start()/resume() and returns the final scoped token."""
+        mock_token_result = MagicMock(access_token="final-scoped-token")
+        mock_flow = MagicMock()
+        mock_flow.start = AsyncMock()
+        mock_flow.resume = AsyncMock(return_value=mock_token_result)
+
+        with (
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch.object(provider_with_card, "_build_cross_app_flow", return_value=mock_flow),
+        ):
+            mock_ctx.get.return_value.metadata.headers = {
+                "x-datarobot-okta-access-token": "incoming-okta-token"
+            }
+            result = await provider_with_card.authenticate(user_id="test-user")
+
+        assert result is not None
+        assert len(result.credentials) == 1
+        cred = result.credentials[0]
+        assert isinstance(cred, BearerTokenCred)
+        assert cred.token.get_secret_value() == "final-scoped-token"
+
+        mock_flow.start.assert_awaited_once_with(
+            token="incoming-okta-token",
+            audience=_TARGET_ISSUER,
+        )
+        mock_flow.resume.assert_awaited_once()
+
+    async def test_authenticate_raises_on_sdk_error(self, provider_with_card):
+        """authenticate() propagates exceptions from the SDK flow."""
+        mock_flow = MagicMock()
+        mock_flow.start = AsyncMock(side_effect=RuntimeError("token exchange failed"))
+
+        with (
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch.object(provider_with_card, "_build_cross_app_flow", return_value=mock_flow),
+        ):
+            mock_ctx.get.return_value.metadata.headers = {
+                "x-datarobot-okta-access-token": "bad-token"
+            }
+            with pytest.raises(RuntimeError, match="token exchange failed"):
+                await provider_with_card.authenticate()
+
+    async def test_authenticate_raises_before_set_agent_card(self):
+        """authenticate() raises RuntimeError if called before set_agent_card()."""
+        provider = OktaTokenExchangeAuthProvider(config=OktaTokenExchangeAuthProviderConfig())
+
+        with patch(f"{_MODULE}.Context") as mock_ctx:
+            mock_ctx.get.return_value.metadata.headers = {"x-datarobot-okta-access-token": "token"}
+            with pytest.raises(RuntimeError, match="set_agent_card"):
+                await provider.authenticate()
+
+    @pytest.mark.parametrize(
+        "principal_id,private_jwk_b64,match",
+        [
+            (None, _FAKE_JWK_B64, "principal_id"),
+            ("principal_abc", None, "private_jwk"),
+        ],
+    )
+    async def test_authenticate_raises_without_credentials(
+        self, principal_id, private_jwk_b64, match
+    ):
+        """authenticate() raises ValueError when a required credential is absent."""
+        config = OktaTokenExchangeAuthProviderConfig(
+            principal_id=principal_id,
+            private_jwk=private_jwk_b64,
+        )
+        provider = OktaTokenExchangeAuthProvider(config=config)
+        provider.set_agent_card(_make_agent_card())
+
+        with pytest.raises(ValueError, match=match):
+            await provider.authenticate()

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -42,10 +42,10 @@ _MODULE = "datarobot_genai.dragent.plugins.okta_a2a_auth"
 
 _TRUSTED_ISSUER = "https://okta.example.com"
 _AGENT_TOKEN_URL = "https://okta.example.com/oauth2/ausYYY/v1/token"
-_AGENT_AUDIENCE = "https://api.agent.example.com"
-_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
-_REQUESTED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag"
+_TARGET_AUDIENCE = "https://api.agent.example.com"
+_EXCHANGE_AUDIENCE = "https://okta.example.com/oauth2/ausYYY"
 _AUTH_METHOD = "private_key_jwt"
+_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
 # Derived: custom-AS base URL = agent token URL with /v1/token stripped
 _TARGET_ISSUER = "https://okta.example.com/oauth2/ausYYY"
@@ -66,7 +66,7 @@ _FAKE_JWK_B64 = base64.b64encode(json.dumps(_FAKE_JWK).encode()).decode()
 
 
 def _make_agent_card() -> AgentCard:
-    """Build a minimal AgentCard that contains the RFC 8693 extension."""
+    """Build a minimal AgentCard with the JWT Bearer Cross-Application Access extension."""
     cc_flow = ClientCredentialsOAuthFlow(
         token_url=_AGENT_TOKEN_URL,
         scopes={"read_data": "Read access"},
@@ -78,15 +78,22 @@ def _make_agent_card() -> AgentCard:
         )
     )
     extension = AgentExtension(
-        uri="urn:ietf:params:oauth:grant-type:token-exchange",
-        description="RFC 8693 two-step token exchange",
+        uri="urn:ietf:params:oauth:grant-type:jwt-bearer",
+        description=(
+            "Two-Step Cross-Application Access execution parameters. "
+            "Step 1: RFC 8693 Token Exchange prerequisite. "
+            "Step 2: RFC 7523 JWT Bearer Grant."
+        ),
         params={
-            "subject_token_constraints": {"trusted_issuer": _TRUSTED_ISSUER},
-            "token_exchange_request": {
-                "audience": _AGENT_AUDIENCE,
-                "subject_token_type": _SUBJECT_TOKEN_TYPE,
-                "requested_token_type": _REQUESTED_TOKEN_TYPE,
-                "token_endpoint_auth_method": _AUTH_METHOD,
+            "ref": {"scheme": "oauth2", "flow": "clientCredentials"},
+            "target_audience": _TARGET_AUDIENCE,
+            "token_endpoint_auth_method": _AUTH_METHOD,
+            "token_exchange": {
+                "trusted_issuer": _TRUSTED_ISSUER,
+                "audience": _EXCHANGE_AUDIENCE,
+            },
+            "token_request": {
+                "grant_type": _GRANT_TYPE,
             },
         },
     )
@@ -139,25 +146,31 @@ class TestOktaTokenExchangeAuthProviderDiscovery:
 
 class TestOktaTokenExchangeAuthProviderSetAgentCard:
     def test_set_agent_card_parses_params(self):
-        """set_agent_card() populates _CrossAppFlowParams from the agent card."""
+        """set_agent_card() populates _CrossAppFlowParams with all card fields."""
         provider = OktaTokenExchangeAuthProvider(config=OktaTokenExchangeAuthProviderConfig())
 
         provider.set_agent_card(_make_agent_card())
 
         params = provider._flow_params
         assert params is not None
-        assert params.issuer == _TRUSTED_ISSUER
-        assert params.target_issuer == _TARGET_ISSUER
+        assert params.token_url == _AGENT_TOKEN_URL
+        assert params.trusted_issuer == _TRUSTED_ISSUER
+        assert params.exchange_audience == _EXCHANGE_AUDIENCE
+        assert params.target_audience == _TARGET_AUDIENCE
+        assert params.token_endpoint_auth_method == _AUTH_METHOD
         assert params.id_jag_scopes == ["read_data"]
 
 
 class TestParseCrossAppParams:
     def test_parse_cross_app_params_happy_path(self):
-        """_parse_cross_app_params extracts issuer and target_issuer correctly."""
+        """_parse_cross_app_params extracts full configuration context from the card."""
         params = _parse_cross_app_params(_make_agent_card())
 
-        assert params.issuer == _TRUSTED_ISSUER
-        assert params.target_issuer == _TARGET_ISSUER
+        assert params.token_url == _AGENT_TOKEN_URL
+        assert params.trusted_issuer == _TRUSTED_ISSUER
+        assert params.exchange_audience == _EXCHANGE_AUDIENCE
+        assert params.target_audience == _TARGET_AUDIENCE
+        assert params.token_endpoint_auth_method == _AUTH_METHOD
         assert params.id_jag_scopes == ["read_data"]
 
     def test_parse_cross_app_params_custom_scopes(self):
@@ -207,7 +220,7 @@ class TestOktaTokenExchangeAuthProviderAuthenticate:
 
         mock_flow.start.assert_awaited_once_with(
             token="incoming-okta-token",
-            audience=_TARGET_ISSUER,
+            audience=_EXCHANGE_AUDIENCE,
         )
         mock_flow.resume.assert_awaited_once()
 
@@ -255,3 +268,138 @@ class TestOktaTokenExchangeAuthProviderAuthenticate:
 
         with pytest.raises(ValueError, match=match):
             await provider.authenticate()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: card parse → set_agent_card → authenticate → SDK wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCrossAppAccessEndToEnd:
+    """Mocked end-to-end happy path from raw AgentCard to final BearerTokenCred.
+
+    Mocks only the Okta SDK boundary (CrossAppAccessFlow, OAuth2Client, etc.)
+    and the NAT Context.  Everything else — card parsing, _CrossAppFlowParams
+    construction, _build_cross_app_flow wiring — runs as production code.
+
+    GIVEN an agent card with full Cross-Application Access extension,
+          a provider configured with principal_id + private_jwk,
+          and an incoming Okta access token in the request headers,
+    WHEN  set_agent_card() then authenticate() are called,
+    THEN  the Okta SDK is invoked with the correct parameters at every step
+          and a BearerTokenCred with the final scoped token is returned.
+    """
+
+    # -- Fixtures: pure setup, no logic in the test body --
+
+    @pytest.fixture
+    def agent_card(self):
+        """Full agent card matching the reference agentcard.json."""
+        return _make_agent_card()
+
+    @pytest.fixture
+    def provider_config(self):
+        return OktaTokenExchangeAuthProviderConfig(
+            principal_id="0oa_test_principal",
+            private_jwk=_FAKE_JWK_B64,
+        )
+
+    @pytest.fixture
+    def provider(self, provider_config, agent_card):
+        """Return provider with the agent card already parsed."""
+        p = OktaTokenExchangeAuthProvider(config=provider_config)
+        p.set_agent_card(agent_card)
+        return p
+
+    @pytest.fixture
+    def incoming_token(self):
+        return "user-okta-access-token-xyz"
+
+    @pytest.fixture
+    def mock_context(self, incoming_token):
+        with patch(f"{_MODULE}.Context") as ctx:
+            ctx.get.return_value.metadata.headers = {
+                "x-datarobot-okta-access-token": incoming_token,
+            }
+            yield ctx
+
+    @pytest.fixture
+    def mock_sdk(self):
+        """Patch all Okta SDK classes at the module level; yield a namespace."""
+        mock_flow_instance = MagicMock()
+        mock_flow_instance.start = AsyncMock()
+        mock_flow_instance.resume = AsyncMock(
+            return_value=MagicMock(access_token="final-scoped-agent-token")
+        )
+
+        with (
+            patch(f"{_MODULE}.LocalKeyProvider") as mock_key_provider_cls,
+            patch(f"{_MODULE}.OAuth2ClientConfiguration") as mock_config_cls,
+            patch(f"{_MODULE}.OAuth2Client") as mock_client_cls,
+            patch(f"{_MODULE}.ClientAssertionAuthorization") as mock_client_auth_cls,
+            patch(f"{_MODULE}.JWTBearerClaims") as mock_claims_cls,
+            patch(f"{_MODULE}.CrossAppAccessTarget") as mock_target_cls,
+            patch(
+                f"{_MODULE}.CrossAppAccessFlow", return_value=mock_flow_instance
+            ) as mock_flow_cls,
+        ):
+            yield {
+                "LocalKeyProvider": mock_key_provider_cls,
+                "OAuth2ClientConfiguration": mock_config_cls,
+                "OAuth2Client": mock_client_cls,
+                "ClientAssertionAuthorization": mock_client_auth_cls,
+                "JWTBearerClaims": mock_claims_cls,
+                "CrossAppAccessTarget": mock_target_cls,
+                "CrossAppAccessFlow": mock_flow_cls,
+                "flow": mock_flow_instance,
+            }
+
+    # -- The test --
+
+    async def test_happy_path_card_to_token(self, provider, incoming_token, mock_context, mock_sdk):
+        result = await provider.authenticate(user_id="test-user")
+
+        # -- Step 0: private_key_jwt → LocalKeyProvider initialized --
+        mock_sdk["LocalKeyProvider"].from_jwk.assert_called_once_with(_FAKE_JWK, algorithm="RS256")
+
+        # -- Step 0: JWT client assertion targets the originating AS token endpoint --
+        mock_sdk["JWTBearerClaims"].assert_called_once_with(
+            issuer="0oa_test_principal",
+            subject="0oa_test_principal",
+            audience=_TRUSTED_ISSUER.rstrip("/") + "/oauth2/v1/token",
+            expires_in=60,
+        )
+
+        # -- Step 0: OAuth2ClientConfiguration uses the originating AS (trusted_issuer) --
+        mock_sdk["OAuth2ClientConfiguration"].assert_called_once_with(
+            issuer=_TRUSTED_ISSUER,
+            scope=["read_data"],
+            client_authorization=mock_sdk["ClientAssertionAuthorization"].return_value,
+        )
+
+        # -- Step 0: CrossAppAccessTarget uses the resource AS (exchange_audience) --
+        mock_sdk["CrossAppAccessTarget"].assert_called_once_with(
+            issuer=_EXCHANGE_AUDIENCE,
+        )
+
+        # -- Step 0: CrossAppAccessFlow wired with client + target --
+        mock_sdk["CrossAppAccessFlow"].assert_called_once_with(
+            client=mock_sdk["OAuth2Client"].return_value,
+            target=mock_sdk["CrossAppAccessTarget"].return_value,
+        )
+
+        # -- Step 1: flow.start() exchanges the user token for an ID-JAG --
+        mock_sdk["flow"].start.assert_awaited_once_with(
+            token=incoming_token,
+            audience=_EXCHANGE_AUDIENCE,
+        )
+
+        # -- Step 2: flow.resume() exchanges the ID-JAG for the final token --
+        mock_sdk["flow"].resume.assert_awaited_once()
+
+        # -- Final result: BearerTokenCred with the scoped agent token --
+        assert result is not None
+        assert len(result.credentials) == 1
+        cred = result.credentials[0]
+        assert isinstance(cred, BearerTokenCred)
+        assert cred.token.get_secret_value() == "final-scoped-agent-token"

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -88,7 +88,6 @@ def _make_agent_card() -> AgentCard:
         ),
         params={
             "ref": {"scheme": "oauth2", "flow": "clientCredentials"},
-            "target_audience": _TARGET_AUDIENCE,
             "token_endpoint_auth_method": _AUTH_METHOD,
             "token_exchange": {
                 "trusted_issuer": _TRUSTED_ISSUER,
@@ -96,6 +95,7 @@ def _make_agent_card() -> AgentCard:
             },
             "token_request": {
                 "grant_type": _GRANT_TYPE,
+                "audience": _TARGET_AUDIENCE,
             },
         },
     )

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for OktaTokenExchangeAuthProvider and its agent-card parsing helpers."""
+"""Tests for OktaCrossApplicationAccessAuthProvider and its agent-card parsing helpers."""
 
 import base64
 import json
@@ -30,8 +30,10 @@ from a2a.types import OAuthFlows
 from a2a.types import SecurityScheme
 from nat.data_models.authentication import BearerTokenCred
 
-from datarobot_genai.dragent.plugins.okta_a2a_auth import OktaTokenExchangeAuthProvider
-from datarobot_genai.dragent.plugins.okta_a2a_auth import OktaTokenExchangeAuthProviderConfig
+from datarobot_genai.dragent.plugins.okta_a2a_auth import OktaCrossApplicationAccessAuthProvider
+from datarobot_genai.dragent.plugins.okta_a2a_auth import (
+    OktaCrossApplicationAccessAuthProviderConfig,
+)
 from datarobot_genai.dragent.plugins.okta_a2a_auth import _parse_cross_app_params
 
 _MODULE = "datarobot_genai.dragent.plugins.okta_a2a_auth"
@@ -112,14 +114,16 @@ def _make_agent_card() -> AgentCard:
 
 
 # ---------------------------------------------------------------------------
-# Tests: OktaTokenExchangeAuthProvider — discovery phase
+# Tests: OktaCrossApplicationAccessAuthProvider — discovery phase
 # ---------------------------------------------------------------------------
 
 
-class TestOktaTokenExchangeAuthProviderDiscovery:
+class TestOktaCrossApplicationAccessAuthProviderDiscovery:
     @pytest.fixture
     def provider(self):
-        return OktaTokenExchangeAuthProvider(config=OktaTokenExchangeAuthProviderConfig())
+        return OktaCrossApplicationAccessAuthProvider(
+            config=OktaCrossApplicationAccessAuthProviderConfig()
+        )
 
     async def test_authenticate_for_discovery_returns_bearer(self, provider):
         """authenticate_for_discovery() returns the Okta token as Authorization: Bearer."""
@@ -140,14 +144,16 @@ class TestOktaTokenExchangeAuthProviderDiscovery:
 
 
 # ---------------------------------------------------------------------------
-# Tests: OktaTokenExchangeAuthProvider — set_agent_card / param parsing
+# Tests: OktaCrossApplicationAccessAuthProvider — set_agent_card / param parsing
 # ---------------------------------------------------------------------------
 
 
-class TestOktaTokenExchangeAuthProviderSetAgentCard:
+class TestOktaCrossApplicationAccessAuthProviderSetAgentCard:
     def test_set_agent_card_parses_params(self):
         """set_agent_card() populates _CrossAppFlowParams with all card fields."""
-        provider = OktaTokenExchangeAuthProvider(config=OktaTokenExchangeAuthProviderConfig())
+        provider = OktaCrossApplicationAccessAuthProvider(
+            config=OktaCrossApplicationAccessAuthProviderConfig()
+        )
 
         provider.set_agent_card(_make_agent_card())
 
@@ -181,18 +187,18 @@ class TestParseCrossAppParams:
 
 
 # ---------------------------------------------------------------------------
-# Tests: OktaTokenExchangeAuthProvider — authenticate (call phase)
+# Tests: OktaCrossApplicationAccessAuthProvider — authenticate (call phase)
 # ---------------------------------------------------------------------------
 
 
-class TestOktaTokenExchangeAuthProviderAuthenticate:
+class TestOktaCrossApplicationAccessAuthProviderAuthenticate:
     @pytest.fixture
     def provider_with_card(self):
-        config = OktaTokenExchangeAuthProviderConfig(
+        config = OktaCrossApplicationAccessAuthProviderConfig(
             principal_id="principal_abc",
             private_jwk=_FAKE_JWK_B64,
         )
-        provider = OktaTokenExchangeAuthProvider(config=config)
+        provider = OktaCrossApplicationAccessAuthProvider(config=config)
         provider.set_agent_card(_make_agent_card())
         return provider
 
@@ -241,7 +247,9 @@ class TestOktaTokenExchangeAuthProviderAuthenticate:
 
     async def test_authenticate_raises_before_set_agent_card(self):
         """authenticate() raises RuntimeError if called before set_agent_card()."""
-        provider = OktaTokenExchangeAuthProvider(config=OktaTokenExchangeAuthProviderConfig())
+        provider = OktaCrossApplicationAccessAuthProvider(
+            config=OktaCrossApplicationAccessAuthProviderConfig()
+        )
 
         with patch(f"{_MODULE}.Context") as mock_ctx:
             mock_ctx.get.return_value.metadata.headers = {"x-datarobot-okta-access-token": "token"}
@@ -259,11 +267,11 @@ class TestOktaTokenExchangeAuthProviderAuthenticate:
         self, principal_id, private_jwk_b64, match
     ):
         """authenticate() raises ValueError when a required credential is absent."""
-        config = OktaTokenExchangeAuthProviderConfig(
+        config = OktaCrossApplicationAccessAuthProviderConfig(
             principal_id=principal_id,
             private_jwk=private_jwk_b64,
         )
-        provider = OktaTokenExchangeAuthProvider(config=config)
+        provider = OktaCrossApplicationAccessAuthProvider(config=config)
         provider.set_agent_card(_make_agent_card())
 
         with pytest.raises(ValueError, match=match):
@@ -299,7 +307,7 @@ class TestCrossAppAccessEndToEnd:
 
     @pytest.fixture
     def provider_config(self):
-        return OktaTokenExchangeAuthProviderConfig(
+        return OktaCrossApplicationAccessAuthProviderConfig(
             principal_id="0oa_test_principal",
             private_jwk=_FAKE_JWK_B64,
         )
@@ -307,7 +315,7 @@ class TestCrossAppAccessEndToEnd:
     @pytest.fixture
     def provider(self, provider_config, agent_card):
         """Return provider with the agent card already parsed."""
-        p = OktaTokenExchangeAuthProvider(config=provider_config)
+        p = OktaCrossApplicationAccessAuthProvider(config=provider_config)
         p.set_agent_card(agent_card)
         return p
 

--- a/tests/dragent/test_deployment_urls.py
+++ b/tests/dragent/test_deployment_urls.py
@@ -1,0 +1,125 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.dragent.deployment_urls import _DEFAULT_DATAROBOT_ENDPOINT
+from datarobot_genai.dragent.deployment_urls import build_deployment_a2a_url
+from datarobot_genai.dragent.deployment_urls import build_deployment_agent_card_url
+from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
+
+
+class TestBuildDeploymentA2aUrl:
+    @pytest.mark.parametrize(
+        "endpoint,dep_id,expected",
+        [
+            (
+                "https://app.datarobot.com/api/v2",
+                "abc123",
+                "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/",
+            ),
+            (
+                "https://app.datarobot.com/api/v2/",
+                "abc123",
+                "https://app.datarobot.com/api/v2/deployments/abc123/directAccess/a2a/",
+            ),
+            (
+                "https://acme.internal/api/v2",
+                "dep-999",
+                "https://acme.internal/api/v2/deployments/dep-999/directAccess/a2a/",
+            ),
+        ],
+    )
+    def test_builds_correct_url(self, endpoint, dep_id, expected):
+        assert build_deployment_a2a_url(endpoint, dep_id) == expected
+
+    @pytest.mark.parametrize("deployment_id", ["dep1", "abc-123", "0" * 24])
+    def test_deployment_id_appears_verbatim_in_path(self, deployment_id):
+        url = build_deployment_a2a_url("https://app.datarobot.com/api/v2", deployment_id)
+        assert f"/deployments/{deployment_id}/" in url
+
+
+class TestBuildDeploymentAgentCardUrl:
+    @pytest.mark.parametrize(
+        "endpoint,dep_id,expected",
+        [
+            (
+                "https://app.datarobot.com/api/v2",
+                "abc123",
+                "https://app.datarobot.com/api/v2/deployments/abc123/agentCard/",
+            ),
+            (
+                "https://app.datarobot.com/api/v2/",
+                "abc123",
+                "https://app.datarobot.com/api/v2/deployments/abc123/agentCard/",
+            ),
+            (
+                "https://acme.internal/api/v2",
+                "dep-999",
+                "https://acme.internal/api/v2/deployments/dep-999/agentCard/",
+            ),
+        ],
+    )
+    def test_builds_correct_url(self, endpoint, dep_id, expected):
+        assert build_deployment_agent_card_url(endpoint, dep_id) == expected
+
+
+class TestResolveDataRobotEndpoint:
+    def test_prefers_public_api_endpoint_over_endpoint(self):
+        env = {
+            "DATAROBOT_PUBLIC_API_ENDPOINT": "https://public.datarobot.com/api/v2",
+            "DATAROBOT_ENDPOINT": "https://internal.k8s.local/api/v2",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_datarobot_endpoint() == "https://public.datarobot.com/api/v2"
+
+    def test_falls_back_to_endpoint_when_public_absent(self):
+        env = {"DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2"}
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_datarobot_endpoint() == "https://app.datarobot.com/api/v2"
+
+    def test_returns_default_when_neither_set_and_require_false(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_datarobot_endpoint(require=False) == _DEFAULT_DATAROBOT_ENDPOINT
+
+    def test_raises_when_neither_set_and_require_true(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(
+                ValueError,
+                match="DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set",
+            ):
+                resolve_datarobot_endpoint(require=True)
+
+    def test_empty_string_env_var_is_ignored(self):
+        env = {
+            "DATAROBOT_PUBLIC_API_ENDPOINT": "",
+            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_datarobot_endpoint() == "https://app.datarobot.com/api/v2"
+
+
+class TestUrlConsistency:
+    def test_a2a_url_and_agent_card_url_share_deployment_path_prefix(self):
+        endpoint = "https://app.datarobot.com/api/v2"
+        dep_id = "abc123"
+        a2a = build_deployment_a2a_url(endpoint, dep_id)
+        card = build_deployment_agent_card_url(endpoint, dep_id)
+        expected_prefix = f"{endpoint}/deployments/{dep_id}/"
+        assert a2a.startswith(expected_prefix)
+        assert card.startswith(expected_prefix)
+        assert a2a != card

--- a/tests/nat/integration/test_a2a.py
+++ b/tests/nat/integration/test_a2a.py
@@ -97,6 +97,17 @@ def set_context_user_id() -> None:
     ContextState.get().user_id.set("integration-test-user")
 
 
+@pytest.fixture(autouse=True)
+def set_datarobot_api_token_for_agent_card(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a DataRobot API token for respx tests.
+
+    ``DataRobotAPIKeyAuthProvider`` does not implement ``A2ADiscoveryAuthMixin``,
+    so ``_resolve_agent_card`` falls back to calling ``authenticate()``, which
+    reads ``DATAROBOT_API_TOKEN`` from the environment.
+    """
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "integration-test-token")
+
+
 @pytest.fixture
 def mock_a2a_endpoints():
     """Intercept httpx calls with respx so no real A2A agent is needed.

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.33"
+version = "0.15.34"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1086,7 +1086,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -12,23 +12,6 @@ overrides = [
     { name = "crewai", extras = ["litellm"], specifier = ">=1.11.0" },
     { name = "litellm", specifier = ">=1.83.0,<2.0.0" },
     { name = "ragas", specifier = ">=0.3.8,<0.4.0" },
-]
-excludes = [
-    "build",
-    "diskcache",
-    "flask",
-    "kubernetes",
-    "lancedb",
-    "langchain-milvus",
-    "llama-index-cli",
-    "openpyxl",
-    "pymilvus",
-    "python-docx",
-    "pytube",
-    "scikit-network",
-    "stagehand",
-    "uv",
-    "youtube-transcript-api",
 ]
 
 [[package]]
@@ -539,6 +522,15 @@ wheels = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
@@ -564,6 +556,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/c5/f6ce561004db45f0b847c2cd9b19c67c6bf348a82018a48cb718be6b58b0/botocore-1.40.61-py3-none-any.whl", hash = "sha256:17ebae412692fd4824f99cde0f08d50126dc97954008e5ba2b522eb049238aa7", size = 14055973, upload-time = "2025-10-28T19:26:42.15Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -725,10 +731,12 @@ version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
+    { name = "build" },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "importlib-resources" },
     { name = "jsonschema" },
+    { name = "kubernetes" },
     { name = "mmh3" },
     { name = "numpy" },
     { name = "onnxruntime" },
@@ -881,8 +889,10 @@ dependencies = [
     { name = "json-repair" },
     { name = "json5" },
     { name = "jsonref" },
+    { name = "lancedb" },
     { name = "mcp" },
     { name = "openai" },
+    { name = "openpyxl" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -898,6 +908,7 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tomli" },
     { name = "tomli-w" },
+    { name = "uv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/17/508e239669b1d5349eb816fdc06800d34f1d9c95b0f0c780da78d58db3a3/crewai-1.14.1.tar.gz", hash = "sha256:7e1a22b41f673a2f157e802a258e948d22eb8fc5a2411add81efa4c0b295a3a8", size = 7793182, upload-time = "2026-04-08T17:57:51.537Z" }
 wheels = [
@@ -917,9 +928,14 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "crewai", extra = ["litellm"] },
     { name = "docker" },
+    { name = "lancedb" },
     { name = "pypdf" },
+    { name = "python-docx" },
+    { name = "pytube" },
     { name = "requests" },
+    { name = "stagehand" },
     { name = "tiktoken" },
+    { name = "youtube-transcript-api" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4c/b33d8aaedf1b0c059545ce642a2238e67f1d3c15c5f20fb659a5e4f511ae/crewai_tools-0.76.0.tar.gz", hash = "sha256:5511b21387ad5366564e04d2b3ef7f951d423d9550f880c92a11fec340c624f3", size = 1137089, upload-time = "2025-10-08T21:21:21.87Z" }
 wheels = [
@@ -1077,6 +1093,7 @@ source = { editable = "." }
 auth = [
     { name = "aiohttp" },
     { name = "datarobot", extra = ["auth"] },
+    { name = "okta-client-python" },
     { name = "pydantic" },
 ]
 core = [
@@ -1158,6 +1175,7 @@ drmcp = [
     { name = "datarobot-predict" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "okta-client-python" },
     { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -1185,6 +1203,7 @@ drtools = [
     { name = "datarobot", extra = ["auth"] },
     { name = "datarobot-predict" },
     { name = "httpx" },
+    { name = "okta-client-python" },
     { name = "perplexityai" },
     { name = "polars" },
     { name = "pyarrow" },
@@ -1372,6 +1391,9 @@ requires-dist = [
     { name = "nvidia-nat-mcp", marker = "extra == 'nat'", specifier = "==1.6.0" },
     { name = "nvidia-nat-opentelemetry", marker = "extra == 'dragent'", specifier = "==1.6.0" },
     { name = "nvidia-nat-opentelemetry", marker = "extra == 'nat'", specifier = "==1.6.0" },
+    { name = "okta-client-python", marker = "extra == 'auth'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "okta-client-python", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "okta-client-python", marker = "extra == 'drtools'", specifier = ">=0.2.0,<1.0.0" },
     { name = "openai", marker = "extra == 'core'", specifier = ">=2.0.0,<3.0.0" },
     { name = "openai", marker = "extra == 'crewai'", specifier = ">=2.0.0,<3.0.0" },
     { name = "openai", marker = "extra == 'dragent'", specifier = ">=2.0.0,<3.0.0" },
@@ -1557,6 +1579,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1572,6 +1606,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/04/d24f6e645ad82ba0ef092fa17d9ef7a21953781663648a01c9371d9e8e98/dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd", size = 30782, upload-time = "2022-11-28T23:32:33.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/69/1bcf70f81de1b4a9f21b3a62ec0c83bdff991c88d6cc2267d02408457e88/dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53", size = 25197, upload-time = "2022-11-28T23:32:31.219Z" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
@@ -1634,6 +1677,15 @@ wheels = [
 ]
 
 [[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1644,6 +1696,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -1781,6 +1842,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -2390,6 +2468,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2640,6 +2727,76 @@ wheels = [
 ]
 
 [[package]]
+name = "kubernetes"
+version = "35.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+]
+
+[[package]]
+name = "lance-namespace"
+version = "0.7.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace-urllib3-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/bf/1eaf33cda3ebb37b013463e061e1c7666c92c2cab8e0ad96b23c529effcb/lance_namespace-0.7.5.tar.gz", hash = "sha256:8dbcea18a8ed88af3a5444d6a46d2786dda3d6763e90ee59f65245f7d3ae8f43", size = 10688, upload-time = "2026-05-05T06:23:39.65Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/0e/624f202855ef8971e6b3b0a81aae4291e3218c9b71e06d681b96e797d576/lance_namespace-0.7.5-py3-none-any.whl", hash = "sha256:bb85e8f161e9ec76cc7fe9ba3484d1f0d61175c56b940b4e8a491f247290a77a", size = 12519, upload-time = "2026-05-05T06:23:35.52Z" },
+]
+
+[[package]]
+name = "lance-namespace-urllib3-client"
+version = "0.7.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/5f/8c1036ade66a7eda7c10da90dbbd9186e76992190ce5501cb96b15d00eff/lance_namespace_urllib3_client-0.7.5.tar.gz", hash = "sha256:a87fc8ea167886a38e57783f21d82ebbab8770798c522bf45beef9b13e3be1da", size = 195540, upload-time = "2026-05-05T06:23:36.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/15/025dff007b428bcd4323e0b4072c770c95d61f5ed1435a9a984b41032e92/lance_namespace_urllib3_client-0.7.5-py3-none-any.whl", hash = "sha256:cec5a3d8279b92088740a44cafb9ffc398f4e5a32d771f20baa0bfc91da41512", size = 324604, upload-time = "2026-05-05T06:23:38.522Z" },
+]
+
+[[package]]
+name = "lancedb"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "lance-namespace" },
+    { name = "numpy" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/1577778ad57dba0c55dc13d87230583e14541c82562483ecf8bb2f8e8a00/lancedb-0.30.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:be2a9a43a65c330ccfd08115afb26106cd8d16788522fe7693d3a1f4e01ad321", size = 41959907, upload-time = "2026-03-16T23:03:04.551Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ca/8c2a04ce499a2a97d1a0de2b7e84fa8166f988a9a495e1ada860110489c2/lancedb-0.30.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be6a4ba2a1799a426cbf2ba5ea2559a7389a569e9a31f2409d531ceb59d42f35", size = 43873070, upload-time = "2026-03-16T23:11:01.352Z" },
+    { url = "https://files.pythonhosted.org/packages/16/68/e01bf7837454a5ce9e2f6773905e07b09a949bc88136c0773c8166ed7729/lancedb-0.30.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a967ec05f9930770aeb077bc5579769b1bedf559fcd03a592d9644084625918", size = 46891197, upload-time = "2026-03-16T23:14:39.18Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d1/9085ad17abd98f3a180d7860df3190b2d76f99f533c76d7c7494cec4139d/lancedb-0.30.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:05c66f40f7d4f6f24208e786c40f84b87b1b8e55505305849dd3fed3b78431a3", size = 43877660, upload-time = "2026-03-16T23:11:00.837Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/69/504ee25c57c3f23c80276b5b7b5e4c0f98a5197a7e9e51d3c50500d2b53a/lancedb-0.30.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:bdcd27d98554ed11b6f345b14d1307b0e2332d5654767e9ee2e23d9b2d6513d1", size = 46932144, upload-time = "2026-03-16T23:15:00.474Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/85/d5550f22023e672af1945394f7a06a578fcab2980ecc6666acef3428a771/lancedb-0.30.0-cp39-abi3-win_amd64.whl", hash = "sha256:4751ff0446b90be4d4dccfe05f6c105f403a05f3b8531ab99eedc1c656aca950", size = 51121310, upload-time = "2026-03-16T23:43:23.89Z" },
+]
+
+[[package]]
 name = "langchain"
 version = "1.2.10"
 source = { registry = "https://pypi.org/simple" }
@@ -2767,6 +2924,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/36/0179462acf344ad18cf6d7190b7a6797e015386a3b4518fcd960bb831c61/langchain_mcp_adapters-0.1.14.tar.gz", hash = "sha256:36f8131d0b3b5ca28df03440be4dc2a3636e2f73e3e4a0a266d606ffaa12adda", size = 31119, upload-time = "2025-11-24T15:00:54.591Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/e0/eee23ea4d651d2b2dd5b1a5e1b7f66ee212940a595917a280663d5f745b9/langchain_mcp_adapters-0.1.14-py3-none-any.whl", hash = "sha256:b900d37d1a82261e408e663b7176a1a74cf0072e17ae9e4241c068093912394a", size = 21133, upload-time = "2025-11-24T15:00:53.569Z" },
+]
+
+[[package]]
+name = "langchain-milvus"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "pymilvus" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/21/ecce785a24e61ba2c0f6249a5a68b969ccc053342f933aeab31a3f885f5e/langchain_milvus-0.3.3.tar.gz", hash = "sha256:406c2d88da133741f5cc3e2fea4b36386182b35500205c70d003382ded210e41", size = 35577, upload-time = "2026-01-05T10:01:16.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/5d/6a0dac51ca2343332d5de9c79686d54f905d225b173a8e1b03ae6d35982a/langchain_milvus-0.3.3-py3-none-any.whl", hash = "sha256:6e12f15453372dd48836978faa4a149de79c721df3322229ad732a5e628e8e97", size = 38962, upload-time = "2026-01-05T10:01:15.186Z" },
 ]
 
 [[package]]
@@ -3005,6 +3175,7 @@ name = "llama-index"
 version = "0.14.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "llama-index-cli" },
     { name = "llama-index-core" },
     { name = "llama-index-embeddings-openai" },
     { name = "llama-index-indices-managed-llama-cloud" },
@@ -3016,6 +3187,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e5/43/440cbd852b9372fd392cc81f72df75f17d6dfbe93a427c5911a3400ea168/llama_index-0.14.16.tar.gz", hash = "sha256:266c9b066f2eaee584188bbdb440ed4fd9ad41694c6c9c55c5f15e55eb9dcbc2", size = 9048, upload-time = "2026-03-10T19:20:29.96Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/98/12ff971b3b5f4f82153adb7f5528a276f42aafcdd6193392c43998dd32de/llama_index-0.14.16-py3-none-any.whl", hash = "sha256:cb98fece42d485f52ca847d3d16af61984fdeb7f4c0793a069357ac6eb8293ce", size = 7847, upload-time = "2026-03-10T19:20:31.151Z" },
+]
+
+[[package]]
+name = "llama-index-cli"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llama-index-core" },
+    { name = "llama-index-embeddings-openai" },
+    { name = "llama-index-llms-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/66/90747a02fa9f4e9503da40259d18105f75a02b3f3b6b722faf0502d8b40d/llama_index_cli-0.5.5.tar.gz", hash = "sha256:a2de5a22f675f60908c8cd1fd873f132cf2bfdf3462fa79ef5fbe6b95727a30b", size = 24852, upload-time = "2026-03-04T23:00:55.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/ef/ca63ce9ae26de1c64fcf1876d67ee7996cecf6127f43a49c1e4a485d806c/llama_index_cli-0.5.5-py3-none-any.whl", hash = "sha256:ac041aa61c2e194266a07fea617500a063f389af7dd6ae02f8cd3f1f7644d06d", size = 28210, upload-time = "2026-03-04T23:00:54.696Z" },
 ]
 
 [[package]]
@@ -3299,6 +3484,72 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/52/dc9ef71a43eddb8f7b7f6d887feb4e04e61f07bb99359c4aa1dd112c715b/llama_parse-0.5.20.tar.gz", hash = "sha256:649e256431d3753025b9a320bb03b76849ce4b5a1121394c803df543e6c1006f", size = 16941, upload-time = "2025-01-22T21:04:22.226Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/7c/203b7ffc633b9c0823f0d0701e361e002b93bf4e493f4c494d4bd5934c0b/llama_parse-0.5.20-py3-none-any.whl", hash = "sha256:9617edb3428d3218ea01f1708f0b6105f3ffef142fedbeb8c98d50082c37e226", size = 16163, upload-time = "2025-01-22T21:04:20.751Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
 ]
 
 [[package]]
@@ -3946,6 +4197,7 @@ dependencies = [
     { name = "colorama" },
     { name = "expandvars" },
     { name = "fastapi" },
+    { name = "flask" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "jinja2" },
@@ -3964,6 +4216,7 @@ dependencies = [
     { name = "plotly" },
     { name = "pydantic" },
     { name = "pyjwt" },
+    { name = "pymilvus" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -4015,6 +4268,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-huggingface" },
     { name = "langchain-litellm" },
+    { name = "langchain-milvus" },
     { name = "langchain-nvidia-ai-endpoints" },
     { name = "langchain-openai" },
     { name = "langchain-tavily" },
@@ -4075,6 +4329,27 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/b4/54c29f536b498cfdfe00ebf4a52bdbc78db9af6b84c011c1c6ed4b647352/nvidia_nat_opentelemetry-1.6.0-py3-none-any.whl", hash = "sha256:5ae11e4acfc08e04bf3040a4cd69241f1c2c096b83061be15ee459d7c7c1b73d", size = 67843, upload-time = "2026-04-10T03:01:14.482Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "okta-client-python"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/b3/70389869c4fae298a271db9e746539cea6342ab288347a37ffcf505dac6a/okta_client_python-0.2.0.tar.gz", hash = "sha256:c5b82dac1ab93b366e34a0c57b265ec0c43afb7ef65499f2bed4021412baec5e", size = 111396, upload-time = "2026-03-11T05:17:23.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/2a/f5f52239a932ba5093a45e4b978be99ba0c440ced850b0555f7f826b2fcc/okta_client_python-0.2.0-py3-none-any.whl", hash = "sha256:2c8ccf8b8e04d14f35322937e16d48b933da7e180817cc3d4ae248d8025b7984", size = 101640, upload-time = "2026-03-11T05:17:21.098Z" },
 ]
 
 [[package]]
@@ -4161,6 +4436,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/32/c79bf8bd3ea5a00e492449b31ca600bbc2a8e88a301e42c872af925a156c/openinference_semantic_conventions-0.1.28.tar.gz", hash = "sha256:6388465174e8ab3f27ebc6a9e9bb2e1b804d30caefb57234e16db874da1c6a7b", size = 12893, upload-time = "2026-03-11T04:45:46.543Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/40/34b570462c3ce250277254bb0cca655eb39b64c0dffe63cd7751f103f8d6/openinference_semantic_conventions-0.1.28-py3-none-any.whl", hash = "sha256:a2fed5bb167aa56c1c7448cdb7a8d775f989339ba1f8b04a7b45d4f8388cccfb", size = 10522, upload-time = "2026-03-11T04:45:45.423Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -5324,6 +5611,25 @@ crypto = [
 ]
 
 [[package]]
+name = "pymilvus"
+version = "2.6.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "grpcio" },
+    { name = "orjson" },
+    { name = "pandas" },
+    { name = "protobuf" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/d7/c5d1381248a33975ccc864a0f980f93270ecc35354de8646c8a16443cccb/pymilvus-2.6.12.tar.gz", hash = "sha256:8323e990dc305e607fef525498eb779e42940a69e0691dde009cd02d48845f7a", size = 1584521, upload-time = "2026-04-09T07:49:11.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/5d/44b0fa94c91503381e6f12298277f84f8e7b0bb00715ab89fc273c4d681e/pymilvus-2.6.12-py3-none-any.whl", hash = "sha256:69051b8b62712f157b2b50aeb7bde7fd7cdb5940aac0122094eb3cd58bc20f0d", size = 315183, upload-time = "2026-04-09T07:49:09.013Z" },
+]
+
+[[package]]
 name = "pypdf"
 version = "6.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5377,6 +5683,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/78/cbaebba88e05e2dcda13ca203131b38d3640219f20ebb49676d26714861b/pypika-0.51.1.tar.gz", hash = "sha256:c30c7c1048fbf056fd3920c5a2b88b0c29dd190a9b2bee971fd17e4abe4d0ebe", size = 80919, upload-time = "2026-02-04T11:27:48.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/83/c77dfeed04022e8930b08eedca2b6e5efed256ab3321396fde90066efb65/pypika-0.51.1-py2.py3-none-any.whl", hash = "sha256:77985b4d7ce71b9905255bf12468cf598349e98837c037541cfc240e528aec46", size = 60585, upload-time = "2026-02-04T11:27:46.251Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]
@@ -5448,6 +5763,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5463,6 +5791,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pytube"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e7/16fec46c8d255c4bbc4b185d89c91dc92cdb802836570d8004d0db169c91/pytube-15.0.0.tar.gz", hash = "sha256:076052efe76f390dfa24b1194ff821d4e86c17d41cb5562f3a276a8bcbfc9d1d", size = 67229, upload-time = "2023-05-07T19:39:01.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/64/bcf8632ed2b7a36bbf84a0544885ffa1d0b4bcf25cc0903dba66ec5fdad9/pytube-15.0.0-py3-none-any.whl", hash = "sha256:07b9904749e213485780d7eb606e5e5b8e4341aa4dccf699160876da00e12d78", size = 57594, upload-time = "2023-05-07T19:38:59.191Z" },
 ]
 
 [[package]]
@@ -5561,6 +5898,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
     { name = "datasets" },
+    { name = "diskcache" },
     { name = "gitpython" },
     { name = "instructor" },
     { name = "langchain" },
@@ -5574,6 +5912,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "rich" },
+    { name = "scikit-network" },
     { name = "tiktoken" },
     { name = "tqdm" },
     { name = "typer" },
@@ -5696,6 +6035,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -5910,6 +6262,84 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-network"
+version = "0.33.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/6d/28b00fbef9ff7d8ba31861bf16705a1a74a1696fb65aab2a7c584f966bec/scikit_network-0.33.5.tar.gz", hash = "sha256:ae2149d9a280fdc4bbadd5f8a7b17c8af61c054bc3f834792bc61483e6783c12", size = 1784205, upload-time = "2025-11-19T09:45:14.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/ed/4a14f48ae7eceeb4bc2085c9467e7dda487b8728261a2556a3d2fdc99b0e/scikit_network-0.33.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:38a5a55f125b9ff574b085994e6374f783469faf1542d140c1630ad2c14127b9", size = 2854152, upload-time = "2025-11-19T09:44:43.049Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f9/71e225866bedaf6256ba3cd720c5bdbbe4828df7574d3c9cb741789b0f85/scikit_network-0.33.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d796382dd914ccaa7d3fb990e148f5f095817690f07119d614f4d5bd63b347e", size = 2840146, upload-time = "2025-11-19T09:44:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ac/ed64fbc2a21074aa399d3e527695f4d4bb35be3346b5e09edf0637d58080/scikit_network-0.33.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:406af38a07ee1d631b62616496013fc5d941fffb5221fdb9e9091b87352a3f0c", size = 8005762, upload-time = "2025-11-19T09:44:47.186Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8e/9631ea79d6144d746e9a73e79d392656ae0c1d2989b8183f4f13134ad253/scikit_network-0.33.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d001988f07abe03ef4d8189da148968ad520f8cb8666d9ecee0d51c277bd466", size = 8061688, upload-time = "2025-11-19T09:44:49.034Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d2/26d21c25245204ef0ac6dfd047e8b6181bdc40d486dd9daadaadfed1c0e6/scikit_network-0.33.5-cp311-cp311-win_amd64.whl", hash = "sha256:8b9338feb0b2bae0f32ddd77453125b4e6c2d365cfb1bb1334b016888466e42f", size = 2738782, upload-time = "2025-11-19T09:44:50.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/32/f092fca9a3ae256e0608ec6a4d8830023ea4ae478c2e27e94cf5802824f0/scikit_network-0.33.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ced625228be1632595d11adaf22d61d1d4c788909cd4d8c364e720b2814aac7f", size = 2874698, upload-time = "2025-11-19T09:44:52.765Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c7/5b2ce72f93b422af48a2b755fbcbab271bf980a6b46484f754d63978f1ff/scikit_network-0.33.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:808b625d28005c24b47cbdf65f780a3a355aa4080992e6b78f03434e873d06e6", size = 2854224, upload-time = "2025-11-19T09:44:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/86/02/974ae67f493ccf988108894e8a9dedfd00ca5113d2848e0b9fc2a4d18824/scikit_network-0.33.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9f2d98059cd79bdb935ff6a638f1c3a12b0b1cb7ace9e1d3fb35476eeeaabaa", size = 7924650, upload-time = "2025-11-19T09:44:57.704Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/34/b67e48e111916a6f09fe29a971a9716c14f78525e0ab7c46e6a6538cf2f6/scikit_network-0.33.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aac2d3bc14214f02dac300624f5ec2650af9a98b52f304d300f0ec2813a0e544", size = 8012322, upload-time = "2025-11-19T09:45:00.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a2/49293b53b837b3248d19fffd41a9fd73dcb2eeabbab890cc4c8aa237b545/scikit_network-0.33.5-cp312-cp312-win_amd64.whl", hash = "sha256:2866b16aed9ef25ba42cb2f2e44ef2ad079337f336ce48d0604b55fa4af87688", size = 2746491, upload-time = "2025-11-19T09:45:01.997Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/cd/0069244e970d27fa0ab0512394295a106605f00c271e85618182460d2c92/scikit_network-0.33.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:aa8b490a777e081dd6f69627a26b50cc4012f27fff683a1e4828819a88a5dcf2", size = 2862564, upload-time = "2025-11-19T09:45:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/51/37/85454864e50a65e528fe3b15eb3b41eb68b0c7f6d5c51c220b3198622ede/scikit_network-0.33.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3615d073ba9ae1ae30dda2de747474cd23c86cededa82b317471ee9f9bebd1b2", size = 2842521, upload-time = "2025-11-19T09:45:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b9/4023f35e430b51020f17b0f1d8933768cf1ed7cd1623cc089f5543048983/scikit_network-0.33.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2408d3f4c81256a3193d536aad4a6ffcfbb05d096abe6a9cc0b6b5e275df876d", size = 7871695, upload-time = "2025-11-19T09:45:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ec/e50755f7459130ba745c42c37665c5ae9a7c7e357f43400b5b8b966f902e/scikit_network-0.33.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:526490a1e0e8e49ad0f4cca193f581d60082a2fa8c9a825eb0b6936050b0d02b", size = 7968762, upload-time = "2025-11-19T09:45:10.347Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2a/616974a0adb9d04a791570e9371caaef14c54f8806b04dd59c80a7b60289/scikit_network-0.33.5-cp313-cp313-win_amd64.whl", hash = "sha256:722c15fcede5e07ac008354bbd6ef375e0f5bf1fd52bd40271775997be2fb715", size = 2742482, upload-time = "2025-11-19T09:45:12.843Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6046,6 +6476,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "stagehand"
+version = "3.19.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/f8/ccd2bb2758a4eaf0af3846e097ff206e0aa76c8d3b5aa2bded77fb47825e/stagehand-3.19.5.tar.gz", hash = "sha256:3cb8279ac82051e584b34d26e87dc764f0ccad766a01625198ca578eb35f0b6c", size = 281033, upload-time = "2026-04-03T20:21:09.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/6f/a47bad258bfafc193ebb8e0e8c440e8028c9ab28b54a333b46aa3c0cff53/stagehand-3.19.5-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:14f39a4f8d30d77c089166185c705f66aade25432b903a663a937b3747439c26", size = 34495874, upload-time = "2026-04-03T20:21:07.366Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f7/e39868903121f1a80ae6eda088383362cd2d3a578c04493a2f83c1aac1da/stagehand-3.19.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:80ed0d732cb9c3e952ad851e071dad5775a9ea88d2787c006289d61097fd2609", size = 33193535, upload-time = "2026-04-03T20:21:18.536Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/0b/35cb92bb53e9539c0147892dbd0a227b43bf0d8adcd0a8e867dc5f2bf7fd/stagehand-3.19.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:aa947a5f6241f5953ac238cd9b0ab72e0cb87f559f97e5ee875f83dbc0c351d1", size = 37273148, upload-time = "2026-04-03T20:21:11.939Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c7/dccf63cba1941b5710dc9968218e2883a937cf6534d644bb0c5222d3f40a/stagehand-3.19.5-py3-none-win_amd64.whl", hash = "sha256:e37bf630b99b4a9b7d95f151c56b296940db88b3049b68f0abb56f9e31cc6095", size = 30758357, upload-time = "2026-04-03T20:21:15.121Z" },
 ]
 
 [[package]]
@@ -6431,6 +6881,32 @@ wheels = [
 ]
 
 [[package]]
+name = "uv"
+version = "0.9.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a0/63cea38fe839fb89592728b91928ee6d15705f1376a7940fee5bbc77fea0/uv-0.9.30.tar.gz", hash = "sha256:03ebd4b22769e0a8d825fa09d038e31cbab5d3d48edf755971cb0cec7920ab95", size = 3846526, upload-time = "2026-02-04T21:45:37.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/3c/71be72f125f0035348b415468559cc3b335ec219376d17a3d242d2bd9b23/uv-0.9.30-py3-none-linux_armv6l.whl", hash = "sha256:a5467dddae1cd5f4e093f433c0f0d9a0df679b92696273485ec91bbb5a8620e6", size = 21927585, upload-time = "2026-02-04T21:46:14.935Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fd/8070b5423a77d4058d14e48a970aa075762bbff4c812dda3bb3171543e44/uv-0.9.30-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ec38ae29aa83a37c6e50331707eac8ecc90cf2b356d60ea6382a94de14973be", size = 21050392, upload-time = "2026-02-04T21:45:55.649Z" },
+    { url = "https://files.pythonhosted.org/packages/42/5f/3ccc9415ef62969ed01829572338ea7bdf4c5cf1ffb9edc1f8cb91b571f3/uv-0.9.30-py3-none-macosx_11_0_arm64.whl", hash = "sha256:777ecd117cf1d8d6bb07de8c9b7f6c5f3e802415b926cf059d3423699732eb8c", size = 19817085, upload-time = "2026-02-04T21:45:40.881Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3f/76b44e2a224f4c4a8816fc92686ef6d4c2656bc5fc9d4f673816162c994d/uv-0.9.30-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:93049ba3c41fa2cc38b467cb78ef61b2ddedca34b6be924a5481d7750c8111c6", size = 21620537, upload-time = "2026-02-04T21:45:47.846Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2a/50f7e8c6d532af8dd327f77bdc75ce4652322ac34f5e29f79a8e04ea3cc8/uv-0.9.30-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:f295604fee71224ebe2685a0f1f4ff7a45c77211a60bd57133a4a02056d7c775", size = 21550855, upload-time = "2026-02-04T21:46:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/10/f823d4af1125fae559194b356757dc7d4a8ac79d10d11db32c2d4c9e2f63/uv-0.9.30-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2faf84e1f3b6fc347a34c07f1291d11acf000b0dd537a61d541020f22b17ccd9", size = 21516576, upload-time = "2026-02-04T21:46:03.494Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f3/64b02db11f38226ed34458c7fbdb6f16b6d4fd951de24c3e51acf02b30f8/uv-0.9.30-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b3b3700ecf64a09a07fd04d10ec35f0973ec15595d38bbafaa0318252f7e31f", size = 22718097, upload-time = "2026-02-04T21:45:51.875Z" },
+    { url = "https://files.pythonhosted.org/packages/28/21/a48d1872260f04a68bb5177b0f62ddef62ab892d544ed1922f2d19fd2b00/uv-0.9.30-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b176fc2937937dd81820445cb7e7e2e3cd1009a003c512f55fa0ae10064c8a38", size = 24107844, upload-time = "2026-02-04T21:46:19.032Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c6/d7e5559bfe1ab7a215a7ad49c58c8a5701728f2473f7f436ef00b4664e88/uv-0.9.30-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:180e8070b8c438b9a3fb3fde8a37b365f85c3c06e17090f555dc68fdebd73333", size = 23685378, upload-time = "2026-02-04T21:46:07.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/bf/b937bbd50d14c6286e353fd4c7bdc09b75f6b3a26bd4e2f3357e99891f28/uv-0.9.30-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4125a9aa2a751e1589728f6365cfe204d1be41499148ead44b6180b7df576f27", size = 22848471, upload-time = "2026-02-04T21:45:18.728Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/57/12a67c569e69b71508ad669adad266221f0b1d374be88eaf60109f551354/uv-0.9.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4366dd740ac9ad3ec50a58868a955b032493bb7d7e6ed368289e6ced8bbc70f3", size = 22774258, upload-time = "2026-02-04T21:46:10.798Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b8/a26cc64685dddb9fb13f14c3dc1b12009f800083405f854f84eb8c86b494/uv-0.9.30-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:33e50f208e01a0c20b3c5f87d453356a5cbcfd68f19e47a28b274cd45618881c", size = 21699573, upload-time = "2026-02-04T21:45:44.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/995af0c5f0740f8acb30468e720269e720352df1d204e82c2d52d9a8c586/uv-0.9.30-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5e7a6fa7a3549ce893cf91fe4b06629e3e594fc1dca0a6050aba2ea08722e964", size = 22460799, upload-time = "2026-02-04T21:45:26.658Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0b/6affe815ecbaebf38b35d6230fbed2f44708c67d5dd5720f81f2ec8f96ff/uv-0.9.30-py3-none-musllinux_1_1_i686.whl", hash = "sha256:62d7e408d41e392b55ffa4cf9b07f7bbd8b04e0929258a42e19716c221ac0590", size = 22001777, upload-time = "2026-02-04T21:45:34.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b6/47a515171c891b0d29f8e90c8a1c0e233e4813c95a011799605cfe04c74c/uv-0.9.30-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6dc65c24f5b9cdc78300fa6631368d3106e260bbffa66fb1e831a318374da2df", size = 22968416, upload-time = "2026-02-04T21:45:22.863Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3a/c1df8615385138bb7c43342586431ca32b77466c5fb086ac0ed14ab6ca28/uv-0.9.30-py3-none-win32.whl", hash = "sha256:74e94c65d578657db94a753d41763d0364e5468ec0d368fb9ac8ddab0fb6e21f", size = 20889232, upload-time = "2026-02-04T21:46:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a8/e8761c8414a880d70223723946576069e042765475f73b4436d78b865dba/uv-0.9.30-py3-none-win_amd64.whl", hash = "sha256:88a2190810684830a1ba4bb1cf8fb06b0308988a1589559404259d295260891c", size = 23432208, upload-time = "2026-02-04T21:45:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e8/6f2ebab941ec559f97110bbbae1279cd0333d6bc352b55f6fa3fefb020d9/uv-0.9.30-py3-none-win_arm64.whl", hash = "sha256:7fde83a5b5ea027315223c33c30a1ab2f2186910b933d091a1b7652da879e230", size = 21887273, upload-time = "2026-02-04T21:45:59.787Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6569,6 +7045,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6607,6 +7092,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]
@@ -6815,6 +7312,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/68/8c5b36aa5178900b37387937bc2c2fe0e9505537f713495472dcf6f6fccc/yarl-1.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dd00607bffbf30250fe108065f07453ec124dbf223420f57f5e749b04295e090", size = 94932, upload-time = "2026-03-01T22:06:39.579Z" },
     { url = "https://files.pythonhosted.org/packages/c6/cc/d79ba8292f51f81f4dc533a8ccfb9fc6992cabf0998ed3245de7589dc07c/yarl-1.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ac09d42f48f80c9ee1635b2fcaa819496a44502737660d3c0f2ade7526d29144", size = 84786, upload-time = "2026-03-01T22:06:41.988Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "youtube-transcript-api"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
- Added Okta Cross-Application Access (XAA) support for A2A agent-to-agent calls via the new `okta_cross_app_access` auth provider.
- Server-side XAA parameters are declared in `workflow.yaml` under `cross_application_access` and published on the AgentCard: OpenAPI `clientCredentials` security scheme plus a JWT Bearer capability extension containing the two-step flow parameters (RFC 8693 → RFC 7523).
- Client-side: `OktaCrossApplicationAccessAuthProvider` reads the AgentCard extension at runtime, performs the two-step token exchange via `okta-client-python`, and requires only `PRINCIPAL_ID` / `PRIVATE_JWK` env vars.
- Added `okta-client-python` dependency into the `auth` extra.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces new authentication/token-exchange flows (RFC 8693 → RFC 7523) and changes how A2A client requests are authenticated (discovery vs call phase), which can break connectivity or weaken security if misconfigured.
> 
> **Overview**
> Adds first-class **Okta Cross-Application Access (XAA)** support for A2A by introducing a new `okta_cross_app_access` auth provider (backed by `okta-client-python`) and wiring it into NAT via a new `nat.plugins` entry point.
> 
> Refactors A2A server AgentCard creation into `dragent/frontends/a2a.py`, publishing Cross-App Access details as an OpenAPI `oauth2` `clientCredentials` flow plus a JWT Bearer capability extension, and renames server config from `oauth_token_exchange` to `cross_application_access`.
> 
> Updates the authenticated A2A client to split **agent-card discovery auth** from **RPC call auth** (new `A2ADiscoveryAuthMixin`, optional agent-card injection for providers), with expanded unit/integration tests and new shared deployment URL helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7960683b0367f3d8e96f4162a3d9768e9d70132b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->