### PR TITLE
Improve predictive drtools for MCP agents: rich tool_metadata descriptions and fix predictive tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.24
+- Improved predictive drtools for MCP agents: rich tool_metadata descriptions, robust batch download polling and async-safe waits, safer CSV/JSON parsing for realtime predict, and more resilient deployment CSV validation (importance + whitespace/empty rows).
+
 ## 0.15.23
 - OAuth2 token exchange configuration now use a nested `subject_token_constraints` and `token_exchange_request`, with AgentCard extension.
 - 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.23"
+version = "0.15.24"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import re
 from typing import Any
 
 from pydantic import BaseModel
@@ -29,14 +30,64 @@ class ToolCallTestExpectations(BaseModel):
 
 
 class ETETestExpectations(BaseModel):
-    """Class to store test expectations for ETE tests."""
+    """Class to store test expectations for ETE tests.
+
+    By default ``allow_unexpected_tool_calls`` is True so models may call extra tools
+    (e.g. list_projects after an error, get_dataset_details after resolving an id).
+    Set it to False when a test must assert an exact tool-call count and order with
+    no additional calls.
+    """
 
     potential_no_tool_calls: bool = False
+    allow_unexpected_tool_calls: bool = True
     tool_calls_expected: list[ToolCallTestExpectations]
     llm_response_content_contains_expectations: list[str]
 
 
 SHOULD_NOT_BE_EMPTY = "SHOULD_NOT_BE_EMPTY"
+
+
+class _AnyNonemptyStringSentinel:
+    """Sentinel: expected param must be a non-blank string (e.g. job_id from a prior tool)."""
+
+
+ANY_NONEMPTY_STRING = _AnyNonemptyStringSentinel()
+
+
+def _truncate(text: str, max_len: int = 400) -> str:
+    """Return a single-line truncated representation for failure diagnostics."""
+    flattened = text.replace("\n", "\\n")
+    if len(flattened) <= max_len:
+        return flattened
+    return f"{flattened[:max_len]}...<truncated>"
+
+
+def _normalize_tool_name(tool_name: str, expected_tool_name: str | None = None) -> str:
+    """Normalize namespaced MCP tool names to their base function name.
+
+    Some environments expose tool names as `mcp_<server>_<tool_name>` while others expose
+    plain `<tool_name>`. Acceptance checks should compare logical tool names, not namespace.
+
+    When expected_tool_name is provided, match by suffix for namespaced MCP tools so server
+    names that include underscores do not break normalization.
+    """
+    if expected_tool_name:
+        if tool_name == expected_tool_name:
+            return tool_name
+        if tool_name.startswith("mcp_") and tool_name.endswith(f"_{expected_tool_name}"):
+            return expected_tool_name
+
+    # Some environments expose names as `<server>_mcp_<tool_name>`
+    # (e.g. `global_mcp_upload_dataset_to_ai_catalog`). Strip that server prefix.
+    if "_mcp_" in tool_name:
+        _, suffix = tool_name.split("_mcp_", 1)
+        if suffix:
+            # If expected_tool_name is provided, validate the suffix matches
+            if expected_tool_name is None or suffix == expected_tool_name:
+                return suffix
+
+    match = re.match(r"^mcp_[^_]+_(.+)$", tool_name)
+    return match.group(1) if match else tool_name
 
 
 def _extract_content_when_structured_empty(tool_result: str) -> dict[str, str] | None:
@@ -102,6 +153,15 @@ def _extract_structured_content(tool_result: str) -> Any:
     return result
 
 
+def _param_leaf_matches(expected: Any, actual: Any) -> bool:
+    """Return whether ``actual`` satisfies the expected leaf constraint."""
+    if expected is ANY_NONEMPTY_STRING:
+        return isinstance(actual, str) and bool(str(actual).strip())
+    if isinstance(expected, str) and isinstance(actual, str):
+        return actual.strip() == expected.strip()
+    return actual == expected
+
+
 def _check_dict_params_match(
     expected: dict[str, Any],
     actual: dict[str, Any],
@@ -110,20 +170,21 @@ def _check_dict_params_match(
     """
     Recursively check if all keys in expected exist in actual with matching values.
     Extra keys in actual are ignored (subset/partial matching).
+
+    Use :data:`ANY_NONEMPTY_STRING` as an expected leaf when the value is any non-blank string
+    (e.g. IDs from a prior tool). String literals compare with leading/trailing whitespace stripped.
     """
     for key, value in expected.items():
         current_path = f"{path}.{key}" if path else key
         if key not in actual:
             return False
+        actual_v = actual[key]
         if isinstance(value, dict):
-            if not isinstance(actual[key], dict):
+            if not isinstance(actual_v, dict) or not _check_dict_params_match(
+                value, actual_v, current_path
+            ):
                 return False
-            if not _check_dict_params_match(value, actual[key], current_path):
-                return False
-        elif isinstance(value, str) and isinstance(actual[key], str):
-            if actual[key].strip() != value.strip():
-                return False
-        elif actual[key] != value:
+        elif not _param_leaf_matches(value, actual_v):
             return False
     return True
 
@@ -158,6 +219,38 @@ def _check_dict_has_keys(
     return True
 
 
+def _build_failure_diagnostics(
+    expected_calls: list[ToolCallTestExpectations],
+    response: LLMResponse,
+) -> str:
+    """Build a compact diagnostics section for assertion errors."""
+    expected_lines = [
+        f"#{idx + 1} {call.name} params={call.parameters}"
+        for idx, call in enumerate(expected_calls)
+    ]
+    actual_lines = []
+    for idx, tool_call in enumerate(response.tool_calls):
+        expected_name = expected_calls[idx].name if idx < len(expected_calls) else None
+        normalized_name = _normalize_tool_name(tool_call.tool_name, expected_name)
+        actual_lines.append(
+            f"#{idx + 1} raw={tool_call.tool_name} "
+            f"normalized={normalized_name} "
+            f"params={tool_call.parameters}"
+        )
+    result_lines = [
+        f"#{idx + 1} {_truncate(result)}" for idx, result in enumerate(response.tool_results)
+    ]
+    return (
+        "Diagnostics:\n"
+        f"Expected tool calls ({len(expected_calls)}):\n  "
+        + "\n  ".join(expected_lines or ["<none>"])
+        + f"\nActual tool calls ({len(response.tool_calls)}):\n  "
+        + "\n  ".join(actual_lines or ["<none>"])
+        + f"\nTool results ({len(response.tool_results)}):\n  "
+        + "\n  ".join(result_lines or ["<none>"])
+    )
+
+
 class ToolBaseE2E:
     """Base class for end-to-end tests."""
 
@@ -176,6 +269,8 @@ class ToolBaseE2E:
             prompt: The prompt to send to the LLM
             test_expectations: ETETestExpectations object containing test expectations with keys:
                 - tool_calls_expected: List of expected tool calls with their parameters and results
+                - allow_unexpected_tool_calls: Default True — expected calls must appear in order,
+                  with optional extra calls allowed. Set False for strict exact count.
                 - llm_response_content_contains_expectations: Expected content in the LLM response
             openai_llm_client: The OpenAI LLM client
             mcp_session: The test session
@@ -195,40 +290,89 @@ class ToolBaseE2E:
         if test_expectations.potential_no_tool_calls and len(response.tool_calls) == 0:
             pass
         else:
-            # Verify LLM decided to use tools
-            assert len(response.tool_calls) == len(test_expectations.tool_calls_expected), (
-                "LLM should have decided to call tools"
+            diagnostics = _build_failure_diagnostics(
+                test_expectations.tool_calls_expected,
+                response,
             )
 
-            for i, tool_call in enumerate(response.tool_calls):
-                assert tool_call.tool_name == test_expectations.tool_calls_expected[i].name, (
-                    f"Should have called {test_expectations.tool_calls_expected[i].name} tool, but "
-                    f"got: {tool_call.tool_name}"
+            expected_calls = test_expectations.tool_calls_expected
+            expected_actual_indices: list[tuple[int, int]] = []
+
+            # Verify LLM decided to use tools
+            if test_expectations.allow_unexpected_tool_calls:
+                assert len(response.tool_calls) >= len(expected_calls), (
+                    f"LLM should have decided to call tools\n{diagnostics}"
+                )
+                search_start = 0
+                for expected_idx, expected_call in enumerate(expected_calls):
+                    matched_actual_idx = None
+                    for actual_idx in range(search_start, len(response.tool_calls)):
+                        actual_call = response.tool_calls[actual_idx]
+                        actual_tool_name = _normalize_tool_name(
+                            actual_call.tool_name, expected_call.name
+                        )
+                        if actual_tool_name != expected_call.name:
+                            continue
+                        if not _check_dict_params_match(
+                            expected_call.parameters, actual_call.parameters
+                        ):
+                            continue
+                        matched_actual_idx = actual_idx
+                        break
+
+                    assert matched_actual_idx is not None, (
+                        f"Should have called {expected_call.name} tool with the correct "
+                        f"parameters. Expected (subset): {expected_call.parameters}\n"
+                        f"{diagnostics}"
+                    )
+                    expected_actual_indices.append((expected_idx, matched_actual_idx))
+                    search_start = matched_actual_idx + 1
+            else:
+                assert len(response.tool_calls) == len(expected_calls), (
+                    f"LLM should have decided to call tools\n{diagnostics}"
+                )
+                expected_actual_indices = [(i, i) for i in range(len(expected_calls))]
+
+            for expected_idx, actual_idx in expected_actual_indices:
+                tool_call = response.tool_calls[actual_idx]
+                expected_tool_name = expected_calls[expected_idx].name
+                actual_tool_name = _normalize_tool_name(tool_call.tool_name, expected_tool_name)
+
+                assert actual_tool_name == expected_tool_name, (
+                    f"Should have called {expected_tool_name} tool, but got: "
+                    f"{tool_call.tool_name}\n"
+                    f"{diagnostics}"
                 )
                 assert _check_dict_params_match(
-                    test_expectations.tool_calls_expected[i].parameters, tool_call.parameters
+                    expected_calls[expected_idx].parameters, tool_call.parameters
                 ), (
-                    f"Should have called {tool_call.tool_name} tool with the correct parameters. "
-                    f"Expected (subset): {test_expectations.tool_calls_expected[i].parameters}, "
-                    f"but got: {tool_call.parameters}"
+                    f"Should have called {expected_tool_name} tool with the correct parameters. "
+                    f"Expected (subset): {expected_calls[expected_idx].parameters}, "
+                    f"but got: {tool_call.parameters}\n"
+                    f"{diagnostics}"
                 )
-                if test_expectations.tool_calls_expected[i].result != SHOULD_NOT_BE_EMPTY:
-                    expected_result = test_expectations.tool_calls_expected[i].result
+                if expected_calls[expected_idx].result != SHOULD_NOT_BE_EMPTY:
+                    expected_result = expected_calls[expected_idx].result
                     if isinstance(expected_result, str):
-                        assert expected_result in response.tool_results[i], (
-                            f"Should have called {tool_call.tool_name} tool with the correct "
-                            f"result, but got: {response.tool_results[i]}"
+                        assert expected_result in response.tool_results[actual_idx], (
+                            f"Should have called {expected_tool_name} tool with the correct "
+                            f"result, but got: {response.tool_results[actual_idx]}\n"
+                            f"{diagnostics}"
                         )
                     else:
-                        actual_result = _extract_structured_content(response.tool_results[i])
+                        actual_result = _extract_structured_content(
+                            response.tool_results[actual_idx]
+                        )
                         if actual_result is None:
                             # Fallback: try to parse the entire tool result as JSON
                             try:
-                                actual_result = json.loads(response.tool_results[i])
+                                actual_result = json.loads(response.tool_results[actual_idx])
                             except json.JSONDecodeError:
                                 # If that fails, try to extract content part
-                                if "Content: " in response.tool_results[i]:
-                                    content_part = response.tool_results[i].split("Content: ", 1)[1]
+                                if "Content: " in response.tool_results[actual_idx]:
+                                    content_part = response.tool_results[actual_idx].split(
+                                        "Content: ", 1
+                                    )[1]
                                     if "\nStructured content: " in content_part:
                                         content_part = content_part.split(
                                             "\nStructured content: ", 1
@@ -238,16 +382,19 @@ class ToolBaseE2E:
                                     except json.JSONDecodeError:
                                         raise AssertionError(
                                             f"Could not parse tool result for "
-                                            f"{tool_call.tool_name}: {response.tool_results[i]}"
+                                            f"{expected_tool_name}: "
+                                            f"{response.tool_results[actual_idx]}"
                                         )
                         assert _check_dict_has_keys(expected_result, actual_result), (
-                            f"Should have called {tool_call.tool_name} tool with the correct "
-                            f"result structure, but got: {response.tool_results[i]}"
+                            f"Should have called {expected_tool_name} tool with the correct "
+                            f"result structure, but got: {response.tool_results[actual_idx]}\n"
+                            f"{diagnostics}"
                         )
                 else:
-                    assert len(response.tool_results[i]) > 0, (
-                        f"Should have called {tool_call.tool_name} tool with non-empty result, but "
-                        f"got: {response.tool_results[i]}"
+                    assert len(response.tool_results[actual_idx]) > 0, (
+                        f"Should have called {expected_tool_name} tool with non-empty result, but "
+                        f"got: {response.tool_results[actual_idx]}\n"
+                        f"{diagnostics}"
                     )
 
         # Verify LLM provided comprehensive response

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -42,25 +42,33 @@ def _serialize_datastore_params(params: Any) -> dict[str, Any]:
     return {}
 
 
-@tool_metadata(tags={"predictive", "data", "write", "upload", "catalog", "daria"})
+@tool_metadata(
+    tags={"predictive", "data", "write", "upload", "catalog", "daria"},
+    description=(
+        "[Catalog—register new data] Use when the user has file bytes or a public HTTPS URL "
+        "and needs a new AI Catalog dataset_id (nothing registered yet). Exactly one of "
+        "base64 file content or file_url. Returns dataset id, version id, and name for "
+        "Autopilot, scoring, or inspection. Not for listing existing items "
+        "(list_ai_catalog_items), not external DB browsing (list_datastores)."
+    ),
+)
 async def upload_dataset_to_ai_catalog(
     *,
     file_content_base64: Annotated[
         str,
-        (
-            "Base64-encoded file bytes (e.g. CSV). For remote clients; "
-            "mutually exclusive with file_url."
-        ),
+        "Base64-encoded file bytes (e.g. CSV). Mutually exclusive with file_url.",
     ]
     | None = None,
     dataset_filename: Annotated[
         str,
-        "Filename for base64 upload; include extension (e.g. data.csv).",
+        "Filename for base64 upload; include extension (e.g. sales.csv).",
     ] = "data.csv",
-    file_url: Annotated[str, "HTTPS URL of a dataset file to register in the catalog."]
+    file_url: Annotated[
+        str,
+        "Public HTTPS URL of the file to register. Mutually exclusive with file_content_base64.",
+    ]
     | None = None,
 ) -> dict[str, Any]:
-    """Upload a dataset to the DataRobot AI Catalog / Data Registry from bytes or URL."""
     if not file_content_base64 and not file_url:
         raise ToolError("Either file_content_base64 or file_url must be provided.")
     if file_content_base64 and file_url:
@@ -103,9 +111,16 @@ async def upload_dataset_to_ai_catalog(
     }
 
 
-@tool_metadata(tags={"predictive", "data", "read", "list", "catalog", "daria"})
+@tool_metadata(
+    tags={"predictive", "data", "read", "list", "catalog", "daria"},
+    description=(
+        "[Catalog—list datasets] Use when the user needs catalog datasets they already have "
+        "as id-to-name map. Read-only. Not project-attached datasets "
+        "(get_project_dataset_by_name), not modeling projects (list_projects). Follow with "
+        "get_dataset_details or scoring tools that take dataset_id."
+    ),
+)
 async def list_ai_catalog_items() -> dict[str, Any]:
-    """List all AI Catalog items (datasets) for the authenticated user."""
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
     datasets = client.Dataset.list()
@@ -122,14 +137,24 @@ async def list_ai_catalog_items() -> dict[str, Any]:
     }
 
 
-@tool_metadata(tags={"predictive", "data", "read", "dataset", "metadata", "daria"})
+@tool_metadata(
+    tags={"predictive", "data", "read", "dataset", "metadata", "daria"},
+    description=(
+        "[Catalog—one dataset metadata] Use when you already have catalog dataset_id and "
+        "need name, row count, timestamps, optional column list and sample rows. Read-only. "
+        "Lighter than full EDA (analyze_dataset / get_exploratory_insights); not datastore "
+        "SQL (query_datastore)."
+    ),
+)
 async def get_dataset_details(
     *,
-    dataset_id: Annotated[str, "The ID of the DataRobot dataset"] | None = None,
-    include_sample: Annotated[bool, "Whether to include sample rows"] = True,
-    sample_rows: Annotated[int, "Number of sample rows to return"] = 10,
+    dataset_id: Annotated[str, "AI Catalog dataset id (from list_ai_catalog_items or upload)."]
+    | None = None,
+    include_sample: Annotated[
+        bool, "If true, include columns and up to sample_rows example rows."
+    ] = True,
+    sample_rows: Annotated[int, "Max sample rows when include_sample is true."] = 10,
 ) -> dict[str, Any]:
-    """Get DataRobot dataset metadata and optional sample rows."""
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
@@ -154,9 +179,16 @@ async def get_dataset_details(
     return result
 
 
-@tool_metadata(tags={"predictive", "data", "read", "datastore", "list", "daria"})
+@tool_metadata(
+    tags={"predictive", "data", "read", "datastore", "list", "daria"},
+    description=(
+        "[Datastore—list connections] Use when the user works with saved external connections "
+        "(DB, warehouse, bucket, etc.) and needs datastore ids. Read-only. Not AI Catalog "
+        "datasets (list_ai_catalog_items), not modeling projects. Next step: browse_datastore "
+        "or query_datastore."
+    ),
+)
 async def list_datastores() -> dict[str, Any]:
-    """List available DataRobot data connections (datastores)."""
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
     datastores = client.DataStore.list()
@@ -175,16 +207,23 @@ async def list_datastores() -> dict[str, Any]:
     }
 
 
-@tool_metadata(tags={"predictive", "data", "read", "datastore", "browse", "daria"})
+@tool_metadata(
+    tags={"predictive", "data", "read", "datastore", "browse", "daria"},
+    description=(
+        "[Datastore—browse objects] Use after list_datastores when the user needs schemas, "
+        "tables, or folders inside one connection. Read-only; optional path, search filter, "
+        "pagination. Not SQL execution (query_datastore), not catalog dataset listing."
+    ),
+)
 async def browse_datastore(
     *,
-    datastore_id: Annotated[str, "The ID of the datastore to browse"] | None = None,
-    path: Annotated[str, "The path to browse within the datastore"] | None = None,
-    offset: Annotated[int, "Pagination offset"] = 0,
-    limit: Annotated[int, "Maximum number of items to return"] = 100,
-    search: Annotated[str, "Search filter for items"] | None = None,
+    datastore_id: Annotated[str, "Connection id from list_datastores."] | None = None,
+    path: Annotated[str, "Path within the connection (e.g. schema or folder); omit for root."]
+    | None = None,
+    offset: Annotated[int, "Pagination offset."] = 0,
+    limit: Annotated[int, "Max entries to return."] = 100,
+    search: Annotated[str, "Optional filter substring for object names."] | None = None,
 ) -> dict[str, Any]:
-    """Browse a DataRobot data connection to list catalogs, schemas, and tables."""
     if not datastore_id:
         raise ToolError("Datastore ID must be provided")
 
@@ -210,19 +249,20 @@ async def browse_datastore(
 
 
 @tool_metadata(
-    tags={"predictive", "data", "read", "write", "delete", "datastore", "query", "sql", "daria"}
+    tags={"predictive", "data", "read", "write", "delete", "datastore", "query", "sql", "daria"},
+    description=(
+        "[Datastore—run SQL] Use when the user wants to execute SQL (SELECT or DML) against "
+        "one saved external connection. Requires datastore_id from list_datastores; returns "
+        "rows, columns, and row count up to limit. Not DataRobot catalog inspection "
+        "(get_dataset_details), not browsing without SQL (browse_datastore)."
+    ),
 )
 async def query_datastore(
     *,
-    datastore_id: Annotated[str, "The ID of the datastore to query"] | None = None,
-    sql: Annotated[str, "The SQL query to execute"] | None = None,
-    limit: Annotated[int, "Maximum number of rows to return"] = 1000,
+    datastore_id: Annotated[str, "Connection id from list_datastores."] | None = None,
+    sql: Annotated[str, "SQL statement to run against that connection."] | None = None,
+    limit: Annotated[int, "Max rows returned from the query result."] = 1000,
 ) -> dict[str, Any]:
-    """Execute a SQL query against a DataRobot datastore connection.
-
-    Only data manipulation language queries (insert, update, and delete data)
-    are supported — no commits or rollbacks.
-    """
     if not datastore_id:
         raise ToolError("Datastore ID must be provided")
     if not sql:

--- a/src/datarobot_genai/drtools/predictive/deployment.py
+++ b/src/datarobot_genai/drtools/predictive/deployment.py
@@ -29,9 +29,16 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"predictive", "deployment", "read", "management", "list", "daria"})
+@tool_metadata(
+    tags={"predictive", "deployment", "read", "management", "list", "daria"},
+    description=(
+        "[Deploy—discover deployments] Use when the user needs their MLOps deployments as "
+        "id-to-label map. Read-only. Not modeling projects (list_projects), not logged "
+        "prediction rows (get_prediction_history), not scoring payloads "
+        "(predict_* / get_deployment_info)."
+    ),
+)
 async def list_deployments() -> dict[str, Any]:
-    """List all DataRobot deployments for the authenticated user."""
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
     deployments = client.Deployment.list()
@@ -41,12 +48,19 @@ async def list_deployments() -> dict[str, Any]:
     return {"deployments": deployments_dict}
 
 
-@tool_metadata(tags={"predictive", "deployment", "read", "model", "info", "daria"})
+@tool_metadata(
+    tags={"predictive", "deployment", "read", "model", "info", "daria"},
+    description=(
+        "[Deploy—model linkage] Use when the user wants the model record attached to a deployment "
+        "(model id, project linkage). Read-only and narrow. For input feature names, types, and "
+        "prediction contract, use get_deployment_info instead; for training leaderboard details, "
+        "use get_model_details with project_id + model_id."
+    ),
+)
 async def get_model_info_from_deployment(
     *,
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment"],
+    deployment_id: Annotated[str, "MLOps deployment id."],
 ) -> dict[str, Any]:
-    """Retrieve model info associated with a given deployment ID."""
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
     token = await get_datarobot_access_token()
@@ -55,14 +69,22 @@ async def get_model_info_from_deployment(
     return deployment.model
 
 
-@tool_metadata(tags={"predictive", "deployment", "write", "model", "create", "daria"})
+@tool_metadata(
+    tags={"predictive", "deployment", "write", "model", "create", "daria"},
+    description=(
+        "[Deploy—from leaderboard model] Use when the user wants a new live MLOps deployment "
+        "from an existing trained leaderboard model_id (from list_models / get_best_model). "
+        "Returns deployment id and label. Not batch or realtime scoring by itself, not custom "
+        "folder deploy (deploy_custom_model when enabled), not listing deployments "
+        "(list_deployments)."
+    ),
+)
 async def deploy_model(
     *,
-    model_id: Annotated[str, "The ID of the DataRobot model to deploy"],
-    label: Annotated[str, "The label/name for the deployment"],
-    description: Annotated[str, "Optional description for the deployment"] | None = None,
+    model_id: Annotated[str, "Trained model id from list_models / leaderboard."],
+    label: Annotated[str, "Human-readable deployment name shown in the UI."],
+    description: Annotated[str, "Optional longer description for operators."] | None = None,
 ) -> dict[str, Any]:
-    """Deploy a model by creating a new DataRobot deployment."""
     if not model_id:
         raise ToolError("Model ID must be provided")
     if not label:
@@ -107,10 +129,6 @@ async def deploy_custom_model(
     execution_environment_id: Annotated[str, "Optional execution environment ID"] | None = None,
     description: Annotated[str, "Optional description"] | None = None,
 ) -> dict[str, Any]:
-    """Deploy a custom inference model (e.g., .pkl) to DataRobot MLOps.
-
-    Requires a model file in the folder or model_file_path.
-    """
     if not model_folder:
         raise ToolError("model_folder must be provided")
     if not name:
@@ -163,16 +181,23 @@ async def deploy_custom_model(
     return out
 
 
-@tool_metadata(tags={"predictive", "deployment", "read", "predictions", "history", "daria"})
+@tool_metadata(
+    tags={"predictive", "deployment", "read", "predictions", "history", "daria"},
+    description=(
+        "[Deploy—prediction audit log] Use when the user asks for historical prediction rows "
+        "already logged for a deployment (monitoring, audit). Read-only pagination; does not run "
+        "new scores. For fresh scoring use predict_realtime, predict_by_ai_catalog, "
+        "predict_from_project_data, etc."
+    ),
+)
 async def get_prediction_history(
     *,
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment"],
-    limit: Annotated[int, "Maximum number of prediction rows to return"] = 100,
-    offset: Annotated[int, "Number of rows to skip for pagination"] = 0,
-    start_time: Annotated[str, "ISO 8601 start time filter"] | None = None,
-    end_time: Annotated[str, "ISO 8601 end time filter"] | None = None,
+    deployment_id: Annotated[str, "MLOps deployment id."],
+    limit: Annotated[int, "Max rows in this page."] = 100,
+    offset: Annotated[int, "Rows to skip (pagination)."] = 0,
+    start_time: Annotated[str, "Optional ISO 8601 lower bound on prediction time."] | None = None,
+    end_time: Annotated[str, "Optional ISO 8601 upper bound on prediction time."] | None = None,
 ) -> dict[str, Any]:
-    """Retrieve recent prediction results from a DataRobot deployment."""
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
 

--- a/src/datarobot_genai/drtools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drtools/predictive/deployment_info.py
@@ -32,8 +32,10 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 logger = logging.getLogger(__name__)
 
 
-def _feature_importance_value(feature: dict[str, Any]) -> float:
-    """Deployment features may have importance null; treat as 0 for comparisons and formatting."""
+def _feature_importance_value(feature: Any) -> float:
+    """Deployment features may have importance null or non-numeric; coerce for sort/compare."""
+    if not isinstance(feature, dict):
+        return 0.0
     imp = feature.get("importance")
     if imp is None:
         return 0.0
@@ -96,7 +98,7 @@ async def get_deployment_info(
         "model_type": model_type,
         "target": target,
         "target_type": target_type,
-        "features": sorted(features, key=lambda x: x.get("importance") or 0, reverse=True),
+        "features": sorted(features, key=_feature_importance_value, reverse=True),
         "total_features": len(features),
     }
 

--- a/src/datarobot_genai/drtools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drtools/predictive/deployment_info.py
@@ -32,15 +32,31 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"predictive", "deployment", "read", "info", "metadata", "daria"})
+def _feature_importance_value(feature: dict[str, Any]) -> float:
+    """Deployment features may have importance null; treat as 0 for comparisons and formatting."""
+    imp = feature.get("importance")
+    if imp is None:
+        return 0.0
+    try:
+        return float(imp)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@tool_metadata(
+    tags={"predictive", "deployment", "read", "info", "metadata", "daria"},
+    description=(
+        "[Deploy—scoring contract] Use first when building or validating payloads for a "
+        "deployment: target name/type, model family, all input features (name, type, "
+        "importance), plus time-series settings when relevant. Read-only. Narrower feature-only "
+        "view is get_deployment_features; model training diagnostics stay on the project "
+        "(get_model_details)."
+    ),
+)
 async def get_deployment_info(
     *,
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment"],
+    deployment_id: Annotated[str, "MLOps deployment id (from list_deployments or product UI)."],
 ) -> dict[str, Any]:
-    """
-    Retrieve information about the deployment, including the list of
-    features needed to make predictions on this deployment.
-    """
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
 
@@ -97,13 +113,20 @@ async def get_deployment_info(
     return result
 
 
-@tool_metadata(tags={"predictive", "deployment", "read", "template", "data"})
+@tool_metadata(
+    tags={"predictive", "deployment", "read", "template", "data"},
+    description=(
+        "[Deploy—sample prediction rows] Use when the user needs example rows with correct "
+        "column names and types for one deployment (placeholder values only). Read-only. "
+        "Pair with get_deployment_info for semantics; output is meant as a skeleton for "
+        "predict_realtime CSV/JSON, not for batch catalog jobs or project model scoring."
+    ),
+)
 async def generate_prediction_data_template(
     *,
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment"],
-    n_rows: Annotated[int, "Number of template rows to generate"] = 1,
+    deployment_id: Annotated[str, "MLOps deployment id."],
+    n_rows: Annotated[int, "How many identical-length template rows to generate (≥1)."] = 1,
 ) -> dict[str, Any]:
-    """Generate a template CSV with the correct structure for making predictions."""
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
     if n_rows is None or n_rows <= 0:
@@ -187,17 +210,34 @@ async def generate_prediction_data_template(
     return structured_content
 
 
-@tool_metadata(tags={"predictive", "deployment", "read", "validation", "data"})
+@tool_metadata(
+    tags={"predictive", "deployment", "read", "validation", "data"},
+    description=(
+        "[Deploy—validate CSV only] Use when the user has inline CSV text and wants a schema "
+        "check against one deployment before scoring (columns, basic types, time-series "
+        "datetime and series id columns). Does not score; returns valid/invalid plus "
+        "errors/warnings. Same csv_string shape as predict_realtime dataset when CSV; not for "
+        "catalog dataset_id flows or JSON-only payloads."
+    ),
+)
 async def validate_prediction_data(
     *,
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment"],
-    csv_string: Annotated[str, "CSV data as a string (same format as predict_realtime dataset)."],
+    deployment_id: Annotated[str, "MLOps deployment id."],
+    csv_string: Annotated[
+        str, "Single CSV document (header + rows), same shape as predict_realtime dataset."
+    ],
 ) -> dict[str, Any]:
-    """Validate whether inline CSV data is suitable for making predictions with a deployment."""
     if not csv_string or not csv_string.strip():
         raise ToolError("Argument validation error: 'csv_string' cannot be empty.")
 
-    df = pl.read_csv(io.StringIO(csv_string))
+    df = pl.read_csv(io.StringIO(csv_string.strip()))
+    # LLMs often paste CSV with indented headers; align names to deployment features.
+    df = df.rename({c: c.strip() for c in df.columns})
+    if df.height > 0 and df.width > 0:
+        row_nonempty = pl.any_horizontal(
+            [pl.col(c).cast(pl.Utf8).fill_null("").str.strip_chars() != "" for c in df.columns]
+        )
+        df = df.filter(row_nonempty)
 
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
@@ -222,10 +262,10 @@ async def validate_prediction_data(
 
         # Check if feature exists
         if feature_name not in data_columns:
-            if feature.get("importance", 0) > importance_threshold:
+            imp_val = _feature_importance_value(feature)
+            if imp_val > importance_threshold:
                 validation_report["warnings"].append(
-                    f"Missing important feature: {feature_name} (importance: "
-                    f"{feature.get('importance', 0):.2f})"
+                    f"Missing important feature: {feature_name} (importance: {imp_val:.2f})"
                 )
             else:
                 validation_report["warnings"].append(
@@ -311,12 +351,19 @@ async def validate_prediction_data(
     return validation_report
 
 
-@tool_metadata(tags={"predictive", "deployment", "read", "features", "info"})
+@tool_metadata(
+    tags={"predictive", "deployment", "read", "features", "info"},
+    description=(
+        "[Deploy—features slice] Use when you only need feature list, target summary, and "
+        "optional time_series_config for a deployment without the full scoring contract "
+        "narrative. Read-only; subset of get_deployment_info (which remains the default first "
+        "call for predict_realtime prep)."
+    ),
+)
 async def get_deployment_features(
     *,
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment"],
+    deployment_id: Annotated[str, "MLOps deployment id."],
 ) -> dict[str, Any]:
-    """Retrieve only the features list for a deployment, as JSON string."""
     if not deployment_id:
         raise ToolError("Deployment ID must be provided")
 

--- a/src/datarobot_genai/drtools/predictive/model.py
+++ b/src/datarobot_genai/drtools/predictive/model.py
@@ -77,14 +77,24 @@ class ModelEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
-@tool_metadata(tags={"predictive", "model", "read", "management", "info", "daria"})
+@tool_metadata(
+    tags={"predictive", "model", "read", "management", "info", "daria"},
+    description=(
+        "[Project—pick best model] Use when the user wants the top leaderboard model for one "
+        "modeling project, optionally ranked by a validation metric (e.g. AUC, LogLoss). "
+        "Read-only; returns project_id plus best model id, type, and metrics. Not for listing "
+        "every model (list_models), not deployment scoring metadata (get_deployment_info), "
+        "not full diagnostics (get_model_details)."
+    ),
+)
 async def get_best_model(
     *,
-    project_id: Annotated[str, "The DataRobot project ID"],
-    metric: Annotated[str, "The metric to use for best model selection (e.g., 'AUC', 'LogLoss')"]
+    project_id: Annotated[str, "DataRobot modeling project id."],
+    metric: Annotated[
+        str, "Optional leaderboard sort key (e.g. AUC, LogLoss); omit for default order."
+    ]
     | None = None,
 ) -> dict[str, Any]:
-    """Get the best model for a DataRobot project, optionally by a specific metric."""
     if not project_id:
         raise ToolError("Project ID must be provided")
 
@@ -134,14 +144,22 @@ async def get_best_model(
     }
 
 
-@tool_metadata(tags={"predictive", "model", "read", "scoring", "dataset"})
+@tool_metadata(
+    tags={"predictive", "model", "read", "scoring", "dataset"},
+    description=(
+        "[Project—model vs catalog] Use when the user wants to score an AI Catalog dataset with a "
+        "specific leaderboard model inside a modeling project (they give project_id, model_id, and "
+        "catalog dataset_id). This is not deployment batch scoring (see predict_by_ai_catalog) and "
+        "not inline CSV in chat (see predict_realtime). Starts an async project scoring job; "
+        "returns scoring_job_id and related dataset ids, not prediction rows."
+    ),
+)
 async def score_dataset_with_model(
     *,
-    project_id: Annotated[str, "The DataRobot project ID"],
-    model_id: Annotated[str, "The DataRobot model ID"],
-    dataset_id: Annotated[str, "AI Catalog dataset ID to score with this model"],
+    project_id: Annotated[str, "Modeling project that owns the model."],
+    model_id: Annotated[str, "Leaderboard model id from list_models."],
+    dataset_id: Annotated[str, "AI Catalog dataset id to score (tabular)."],
 ) -> dict[str, Any]:
-    """Score a dataset using a specific DataRobot model (async predict job)."""
     if not project_id:
         raise ToolError("Project ID must be provided")
     if not model_id:
@@ -167,12 +185,19 @@ async def score_dataset_with_model(
     }
 
 
-@tool_metadata(tags={"predictive", "model", "read", "management", "list", "daria"})
+@tool_metadata(
+    tags={"predictive", "model", "read", "management", "list", "daria"},
+    description=(
+        "[Project—list models] Use when the user needs every trained leaderboard model for a "
+        "project (ids, types, metrics). Read-only. Not the same as picking only the best model "
+        "(get_best_model). Follow with get_model_details, deploy_model, or "
+        "score_dataset_with_model using a chosen model_id."
+    ),
+)
 async def list_models(
     *,
-    project_id: Annotated[str, "The DataRobot project ID"],
+    project_id: Annotated[str, "DataRobot modeling project id."],
 ) -> dict[str, Any]:
-    """List all models in a project."""
     if not project_id:
         raise ToolError("Project ID must be provided")
 
@@ -187,15 +212,27 @@ async def list_models(
     }
 
 
-@tool_metadata(tags={"predictive", "model", "read", "details", "info", "daria"})
+@tool_metadata(
+    tags={"predictive", "model", "read", "details", "info", "daria"},
+    description=(
+        "[Project—model diagnostics] Use when the user asks for training-time detail on one "
+        "leaderboard model: target, project metric, validation metrics, optional feature impact "
+        "and ROC. Read-only. For MLOps deployment input columns and prediction contract, use "
+        "get_deployment_info instead. For ROC-only or lift-only charts with explicit source "
+        "fold, see get_model_roc_curve / get_model_lift_chart."
+    ),
+)
 async def get_model_details(
     *,
-    project_id: Annotated[str, "The DataRobot project ID"],
-    model_id: Annotated[str, "The DataRobot model ID"],
-    include_feature_impact: Annotated[bool, "Whether to include feature impact data"] = True,
-    include_roc_curve: Annotated[bool, "Whether to include ROC curve data"] = False,
+    project_id: Annotated[str, "DataRobot modeling project id."],
+    model_id: Annotated[str, "Leaderboard model id."],
+    include_feature_impact: Annotated[
+        bool, "If true, request or return per-feature impact."
+    ] = True,
+    include_roc_curve: Annotated[
+        bool, "If true, include validation ROC points (classification)."
+    ] = False,
 ) -> dict[str, Any]:
-    """Get detailed information about a DataRobot model, optionally with feature impact and ROC."""
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
     project = client.Project.get(project_id)
@@ -231,15 +268,26 @@ async def get_model_details(
     return {k: v for k, v in asdict(insights).items() if v is not None}
 
 
-@tool_metadata(tags={"predictive", "model", "read", "timeseries", "validation", "daria"})
+@tool_metadata(
+    tags={"predictive", "model", "read", "timeseries", "validation", "daria"},
+    description=(
+        "[Catalog—time series readiness] Use before starting time-series Autopilot: checks an "
+        "AI Catalog dataset for row count, parsable datetime column, target null rate, optional "
+        "multiseries id column. Read-only; returns ELIGIBLE or NOT_ELIGIBLE with reasons; does "
+        "not train. Not general EDA (get_exploratory_insights / analyze_dataset) and not "
+        "tabular-only Autopilot start (start_autopilot without TS-specific checks)."
+    ),
+)
 async def is_eligible_for_timeseries_training(
     *,
-    dataset_id: Annotated[str, "The ID of the DataRobot dataset to validate"],
-    datetime_column: Annotated[str, "The name of the datetime column"],
-    target_column: Annotated[str, "The name of the target column"],
-    series_id_column: Annotated[str, "The name of the series ID column"] | None = None,
+    dataset_id: Annotated[str, "AI Catalog dataset id."],
+    datetime_column: Annotated[str, "Column name with timestamps."],
+    target_column: Annotated[str, "Column name to forecast."],
+    series_id_column: Annotated[
+        str, "Multiseries: column distinguishing each series; omit for single series."
+    ]
+    | None = None,
 ) -> dict[str, Any]:
-    """Check if a dataset is eligible for DataRobot time series training."""
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
     if not datetime_column:

--- a/src/datarobot_genai/drtools/predictive/predict.py
+++ b/src/datarobot_genai/drtools/predictive/predict.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import io
 import logging
+import time
 from typing import Annotated
 from typing import Any
 
@@ -26,6 +28,13 @@ from datarobot_genai.drtools.core.constants import MAX_INLINE_SIZE
 from datarobot_genai.drtools.core.exceptions import ToolError
 
 logger = logging.getLogger(__name__)
+
+# After completion, links.download can lag (busy queues). SDK download() waits up to 120s for the
+# URL; we only poll status until the link appears—~30s balances real deployments vs giving up.
+_DOWNLOAD_LINK_MAX_ATTEMPTS = 60
+_DOWNLOAD_LINK_POLL_SEC = 0.5
+
+_TERMINAL_FAILURE_STATUSES = frozenset({"ERROR", "FAILED", "ABORTED"})
 
 
 def _batch_job_download_url(job: Any) -> str | None:
@@ -44,12 +53,36 @@ def _tool_error_with_batch_url(message: str, url: str | None) -> ToolError:
 
 def _handle_prediction_resource(job: Any, deployment_id: str, input_desc: str) -> dict[str, Any]:
     """Return batch job metadata and an authenticated download URL for scored CSV."""
-    status = job.get_status()
-    download_url = status.get("links", {}).get("download")
+    download_url: str | None = None
+    last_status: dict[str, Any] | None = None
+    for attempt in range(_DOWNLOAD_LINK_MAX_ATTEMPTS):
+        status = job.get_status()
+        last_status = status
+        st = status.get("status")
+        if st in _TERMINAL_FAILURE_STATUSES:
+            details = status.get("status_details", "")
+            logger.error("Batch job %s terminal status=%s details=%s", job.id, st, details)
+            raise ToolError(f"Batch prediction job failed: status={st!r} details={details!r}")
+        download_url = status.get("links", {}).get("download")
+        if download_url:
+            break
+        output_settings = (status.get("job_spec") or {}).get("output_settings") or {}
+        out_type = output_settings.get("type")
+        if out_type and out_type != "localFile":
+            raise ToolError(
+                "Batch job output is not local file streaming; there is no download URL for this "
+                f"output type ({out_type!r}). Use the configured sink (e.g. JDBC/S3) instead."
+            )
+        if attempt < _DOWNLOAD_LINK_MAX_ATTEMPTS - 1:
+            time.sleep(_DOWNLOAD_LINK_POLL_SEC)
     if not download_url:
+        st = (last_status or {}).get("status")
+        details = (last_status or {}).get("status_details", "")
         raise ToolError(
-            "Batch prediction finished but no download URL is available. "
-            "Confirm the job used local file streaming output (default batch output)."
+            "Batch prediction finished but no download URL appeared after polling. "
+            f"Last status={st!r} details={details!r}. "
+            "Confirm the job used local file (streaming) output, or retry later with the same "
+            "job_id."
         )
     return {
         "job_id": job.id,
@@ -65,27 +98,39 @@ def wait_for_preds_and_cache_results(
     job: Any, deployment_id: str, input_desc: str, timeout: int
 ) -> dict[str, Any]:
     job.wait_for_completion(timeout)
-    if job.status in ["ERROR", "FAILED", "ABORTED"]:
-        logger.error(f"Job failed with status {job.status}")
+    if job.status in _TERMINAL_FAILURE_STATUSES:
+        logger.error("Job failed with status %s", job.status)
         raise ToolError(f"Job failed with status {job.status}")
     return _handle_prediction_resource(job, deployment_id, input_desc)
 
 
-@tool_metadata(tags={"predictive", "prediction", "read", "scoring", "batch"})
-async def predict_by_ai_catalog(
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"],
-    dataset_id: Annotated[str, "The ID of the AI Catalog dataset to use for prediction"],
-    timeout: Annotated[int, "Timeout in seconds for the batch prediction job"] | None = 600,
+async def _wait_for_preds_and_cache_results_async(
+    job: Any, deployment_id: str, input_desc: str, timeout: int
 ) -> dict[str, Any]:
-    """
-    Make predictions using a DataRobot deployment and an AI Catalog dataset using the DataRobot
-    Python SDK.
-    Use this tool when asked to score data stored in AI Catalog by dataset id.
+    """Run blocking SDK wait in a thread pool so the MCP/async event loop is not stalled."""
+    return await asyncio.to_thread(
+        wait_for_preds_and_cache_results, job, deployment_id, input_desc, timeout
+    )
 
-    Returns prediction job details including job ID, deployment ID, and a DataRobot URL to download
-    scored results (batch local file streaming). Use get_batch_prediction_results with that job_id
-    to retrieve CSV using server credentials.
-    """
+
+@tool_metadata(
+    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    description=(
+        "[Predict—deployment + catalog dataset] Use when the user wants batch scoring of one AI "
+        "Catalog tabular dataset through an MLOps deployment (deployment_id + dataset_id). Waits "
+        "until the job finishes. Returns job_id and an authenticated download URL for scored CSV. "
+        "Not the same as scoring with a leaderboard model inside a project "
+        "(score_dataset_with_model), not scoring project holdout/validation partitions "
+        "(predict_from_project_data), and not inline pasted rows (predict_realtime). Use "
+        "get_batch_prediction_results for CSV text when small enough; for synchronous rows from "
+        "catalog data, consider predict_by_ai_catalog_rt."
+    ),
+)
+async def predict_by_ai_catalog(
+    deployment_id: Annotated[str, "MLOps deployment id."],
+    dataset_id: Annotated[str, "AI Catalog dataset id to score."],
+    timeout: Annotated[int, "Max seconds to wait for batch job completion."] | None = 600,
+) -> dict[str, Any]:
     if not deployment_id or not deployment_id.strip():
         raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
     if not dataset_id or not dataset_id.strip():
@@ -102,37 +147,39 @@ async def predict_by_ai_catalog(
         },
         output_settings=None,
     )
-    return wait_for_preds_and_cache_results(
+    return await _wait_for_preds_and_cache_results_async(
         job, deployment_id, f"Scoring dataset {dataset_id}.", timeout or 600
     )
 
 
-@tool_metadata(tags={"predictive", "prediction", "read", "scoring", "batch"})
+@tool_metadata(
+    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    description=(
+        "[Predict—deployment + project splits] Use when the user asks for batch predictions from a "
+        "deployment using data that already lives in the modeling project: training, holdout, "
+        "validation, or allBacktest partitions (pass partition, e.g. holdout). Optional catalog "
+        "dataset_id if they linked another dataset to the project. This is the right tool for "
+        "phrases like 'batch score the holdout' or 'predict on the training partition', not for "
+        "only a catalog dataset_id without project context, and not for inline CSV/JSON in the "
+        "message. Returns job_id and scored CSV download URL like predict_by_ai_catalog, not "
+        "inline rows."
+    ),
+)
 async def predict_from_project_data(
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"],
-    project_id: Annotated[str, "The ID of the DataRobot project to use for prediction"],
+    deployment_id: Annotated[str, "MLOps deployment id."],
+    project_id: Annotated[str, "DataRobot project id that supplies training/holdout data."],
     dataset_id: Annotated[
-        str, "The ID of the external dataset, usually stored in AI Catalog, to use for prediction"
+        str,
+        "Optional catalog dataset id for project-linked scoring (alternative to partition-only).",
     ]
     | None = None,
     partition: Annotated[
         str,
-        "The partition of the DataRobot dataset to use ('holdout', 'validation', 'allBacktest')",
+        "Project data split: holdout, validation, or allBacktest.",
     ]
     | None = None,
-    timeout: Annotated[int, "Timeout in seconds for the batch prediction job"] | None = 600,
+    timeout: Annotated[int, "Max seconds to wait for batch job completion."] | None = 600,
 ) -> dict[str, Any]:
-    """
-    Make predictions using a DataRobot deployment using the training data associated with the
-    project that created the deployment.
-    Use this tool to score holdout, validation, or allBacktest partitions of the training data.
-    Can request a specific partition of the data, or use an external dataset (with dataset_id)
-    stored in AI Catalog.
-
-    Returns prediction job details including job ID, deployment ID, and a DataRobot URL to download
-    scored results (batch local file streaming). Use get_batch_prediction_results with that job_id
-    to retrieve CSV using server credentials.
-    """
     if not deployment_id or not deployment_id.strip():
         raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
     if not project_id or not project_id.strip():
@@ -157,34 +204,29 @@ async def predict_from_project_data(
         intake_settings=intake_settings,  # type: ignore[arg-type]
         output_settings=None,
     )
-    return wait_for_preds_and_cache_results(
+    return await _wait_for_preds_and_cache_results_async(
         job, deployment_id, f"Scoring project {project_id}.", timeout or 600
     )
 
 
-@tool_metadata(tags={"predictive", "prediction", "read", "scoring", "batch"})
+@tool_metadata(
+    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    description=(
+        "[Predict—fetch batch CSV] Use after a batch job completed: returns scored CSV text "
+        "inline given job_id from predict_by_ai_catalog or predict_from_project_data. Only when "
+        "the file is under the inline size cap; otherwise use the job download URL from the "
+        "batch tool with authenticated fetch. Does not start scoring and does not apply to "
+        "score_dataset_with_model jobs (different API surface)."
+    ),
+)
 async def get_batch_prediction_results(
     job_id: Annotated[
         str,
-        (
-            "Batch prediction job_id from predict_by_ai_catalog, "
-            "predict_from_project_data, or related tools"
-        ),
+        "job_id returned by predict_by_ai_catalog or predict_from_project_data.",
     ],
-    download_timeout: Annotated[
-        int, "Seconds to wait for the download URL to become available"
-    ] = 120,
-    download_read_timeout: Annotated[
-        int, "HTTP read timeout in seconds for streaming the CSV"
-    ] = 660,
+    download_timeout: Annotated[int, "Seconds to wait for the download to become ready."] = 120,
+    download_read_timeout: Annotated[int, "Seconds allowed for streaming the CSV body."] = 660,
 ) -> dict[str, Any]:
-    """
-    Download scored CSV for a completed batch prediction job using the request DataRobot API token.
-
-    Use this after batch prediction tools return a job_id and url, when you want the CSV inline
-    without configuring a separate HTTP client. Output is limited to 1 MiB; for larger results,
-    download using the returned url with DataRobot API authentication.
-    """
     if not job_id or not job_id.strip():
         raise ToolError("Argument validation error: 'job_id' cannot be empty.")
 

--- a/src/datarobot_genai/drtools/predictive/predict_realtime.py
+++ b/src/datarobot_genai/drtools/predictive/predict_realtime.py
@@ -41,18 +41,21 @@ def _parse_datetime(value: str) -> datetime:
         return dateutil_parser.parse(str(value))
 
 
-@tool_metadata(tags={"predictive", "prediction", "realtime", "read", "scoring"})
+@tool_metadata(
+    tags={"predictive", "prediction", "realtime", "read", "scoring"},
+    description=(
+        "[Predict—deployment + catalog, synchronous rows] Use when the user already has an AI "
+        "Catalog dataset_id and wants realtime-style scoring through a deployment with rows "
+        "returned in one response (moderate size). Not for pasted inline CSV/JSON "
+        "(predict_realtime), not for async batch CSV download (predict_by_ai_catalog), not "
+        "project-partition batch (predict_from_project_data)."
+    ),
+)
 async def predict_by_ai_catalog_rt(
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"],
-    dataset_id: Annotated[str, "ID of an AI Catalog item to use as input data"],
-    timeout: Annotated[int, "Timeout in seconds for the prediction job"] | None = 600,
+    deployment_id: Annotated[str, "MLOps deployment id."],
+    dataset_id: Annotated[str, "AI Catalog dataset id (tabular)."],
+    timeout: Annotated[int, "Client wait cap in seconds."] | None = 600,
 ) -> dict[str, Any]:
-    """
-    Make real-time predictions using a DataRobot deployment and an AI Catalog dataset using the
-    datarobot-predict library.
-    Use this for fast results when your data is not huge (not gigabytes). Results must fit within
-    the configured inline size limit; otherwise use batch prediction tools for large outputs.
-    """
     if not deployment_id or not deployment_id.strip():
         raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
     if not dataset_id or not dataset_id.strip():
@@ -100,151 +103,118 @@ async def predict_by_ai_catalog_rt(
     return content
 
 
-@tool_metadata(tags={"predictive", "prediction", "realtime", "read", "scoring"})
+@tool_metadata(
+    tags={"predictive", "prediction", "realtime", "read", "scoring"},
+    description=(
+        "[Predict—inline rows now] Use when the user pastes or embeds prediction rows directly "
+        "in the conversation: a CSV snippet (header + rows) or a JSON array of row objects in "
+        "the dataset argument, plus deployment_id. Immediate synchronous scoring; results return "
+        "in the tool response. Do not use for catalog dataset_id only (use "
+        "predict_by_ai_catalog_rt or batch predict_by_ai_catalog), not for project holdout "
+        "batch jobs (predict_from_project_data), and not for leaderboard model scoring jobs "
+        "(score_dataset_with_model). Match feature columns to get_deployment_info. Time series: "
+        "forecast_point or forecast_range_start+end, plus series_id_column if multiseries. "
+        "validate_prediction_data can sanity-check CSV shape first."
+    ),
+)
 async def predict_realtime(
-    deployment_id: Annotated[str, "The ID of the DataRobot deployment to use for prediction"],
+    deployment_id: Annotated[str, "MLOps deployment id."],
     dataset: Annotated[
         str,
-        """CSV or JSON string representing the input data, e.g. "a,b\\na value,b value\\n".
-        For time series with forecast_point, include at least enough historical rows within the
-        feature derivation window.""",
+        (
+            "CSV (header row + data) or JSON array of row objects; columns must match deployment "
+            "inputs."
+        ),
     ],
     forecast_point: Annotated[
         str,
-        """Date to start forecasting from (e.g., '2024-06-01').
-        If provided, triggers time series FORECAST mode. Uses most recent date if None.""",
+        "Time series forecast anchor date (ISO). Omit for non-time-series or use range instead.",
     ]
     | None = None,
     forecast_range_start: Annotated[
         str,
-        """Start date for historical predictions (e.g., '2024-06-01').
-        Must be used with forecast_range_end for HISTORICAL mode.""",
+        "Time series historical window start (ISO); pair with forecast_range_end.",
     ]
     | None = None,
     forecast_range_end: Annotated[
         str,
-        """End date for historical predictions (e.g., '2024-06-07').
-        Must be used with forecast_range_start for HISTORICAL mode.""",
+        "Time series historical window end (ISO); pair with forecast_range_start.",
     ]
     | None = None,
     series_id_column: Annotated[
         str,
-        """Column name identifying different series (e.g., 'store_id', 'region').
-        Must exist in the input data.""",
+        "Multiseries: existing column that identifies each series (e.g. store_id).",
     ]
     | None = None,
     max_explanations: Annotated[
         int,
-        """Number of prediction explanations to return per prediction.
-        - 0: No explanations (default)
-        - Positive integer: Specific number of explanations
-        - 'all': All available explanations (SHAP only)
-        Note: For SHAP, 0 means all explanations; for XEMP, 0 means none.""",
+        "Explanation count: 0 none; >0 cap; some deployments treat 0 as 'all' for SHAP—see docs.",
     ]
     | None = 0,
     max_ngram_explanations: Annotated[
         int,
-        """Maximum number of text explanations per prediction.
-        Recommended: 'all' for text models. None disables text explanations.""",
+        "Text model: max text-segment explanations per row; omit to skip.",
     ]
     | None = None,
     threshold_high: Annotated[
         float,
-        """Only compute explanations for predictions above this threshold (0.0-1.0).
-        Useful for focusing explanations on high-confidence predictions.""",
+        "If set with explanations: only explain rows with prediction probability above this (0–1).",
     ]
     | None = None,
     threshold_low: Annotated[
         float,
-        """Only compute explanations for predictions below this threshold (0.0-1.0).
-        Useful for focusing explanations on low-confidence predictions.""",
+        "If set with explanations: only explain rows with prediction probability below this (0–1).",
     ]
     | None = None,
     passthrough_columns: Annotated[
         str,
-        """Input columns to include in output alongside predictions.
-        - 'all': Include all input columns
-        - 'column1,column2': Comma-separated list of specific columns
-        - None: No passthrough columns (default)""",
+        "'all' or comma-separated input column names to copy through to the output.",
     ]
     | None = None,
     explanation_algorithm: Annotated[
         str,
-        """Algorithm for computing explanations.
-        - 'shap': SHAP explanations (default for most models)
-        - 'xemp': XEMP explanations (faster, less accurate)
-        - None: Use deployment default""",
+        "Optional 'shap' or 'xemp'; omit to use deployment default.",
     ]
     | None = None,
     prediction_endpoint: Annotated[
         str,
-        """Override the prediction server endpoint URL.
-        Useful for custom prediction servers or Portable Prediction Server.""",
+        "Rare: override default prediction HTTP endpoint (e.g. dedicated inference host).",
     ]
     | None = None,
-    timeout: Annotated[int, "Timeout in seconds for the prediction job"] | None = 600,
+    timeout: Annotated[int, "Client wait cap in seconds."] | None = 600,
 ) -> dict[str, Any]:
-    r"""
-    Make real-time predictions using a DataRobot deployment and inline CSV or JSON data.
-
-    This is the unified prediction function that supports:
-    - Regular classification/regression predictions
-    - Time series forecasting with advanced parameters
-    - Prediction explanations (SHAP/XEMP)
-    - Text explanations for NLP models
-    - Custom thresholds and passthrough columns
-
-    For regular predictions: provide deployment_id and dataset (CSV or JSON string).
-    For time series: add forecast_point OR forecast_range_start/end.
-    For explanations: set max_explanations > 0 and optionally explanation_algorithm.
-    For text models: use max_ngram_explanations for text feature explanations.
-
-    When using this tool, always consider feature importance. For features with high importance,
-    try to infer or ask for a reasonable value, using frequent values or domain knowledge if
-    available.
-    For less important features, you may leave them blank.
-
-    Examples
-    --------
-        # Regular binary classification (CSV string)
-        predict_realtime(deployment_id="abc123", dataset="f1,f2\\n0,1\\n1,0")
-
-        # With SHAP explanations
-        predict_realtime(deployment_id="abc123", dataset="...",
-                        max_explanations=10, explanation_algorithm="shap")
-
-        # Time series forecasting
-        predict_realtime(deployment_id="abc123", dataset="...",
-                        forecast_point="2024-06-01")
-
-        # Multiseries time series
-        predict_realtime(deployment_id="abc123", dataset="...",
-                        forecast_point="2024-06-01", series_id_column="store_id")
-
-        # Historical time series predictions
-        predict_realtime(deployment_id="abc123", dataset="...",
-                        forecast_range_start="2024-06-01",
-                        forecast_range_end="2024-06-07")
-
-        # Text model with explanations and passthrough
-        predict_realtime(deployment_id="abc123", dataset="...",
-                        max_explanations="all", max_ngram_explanations="all",
-                        passthrough_columns="document_id,customer_id")
-    """
     if not deployment_id or not deployment_id.strip():
         raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
-    if not dataset or not dataset.strip():
+    ds = dataset.strip()
+    if not ds:
         raise ToolError("Argument validation error: 'dataset' cannot be empty.")
 
-    # Load input data from dataset string (CSV or JSON)
-    try:
-        pl_df = pl.read_csv(io.StringIO(dataset))
-    except Exception:
+    # JSON array of row objects must not go through read_csv first — Polars can "parse" a
+    # leading '[' as CSV and yield empty or wrong frames, which then produce API errors like
+    # "no data to predict on".
+    pl_df: pl.DataFrame
+    if ds.startswith("["):
         try:
-            data = json.loads(dataset)
-            pl_df = pl.DataFrame(data)
-        except Exception as e:
-            raise ValueError(f"Could not parse dataset string as CSV or JSON: {e}") from e
+            data = json.loads(ds)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Could not parse dataset string as JSON: {e}") from e
+        if not isinstance(data, list):
+            raise ValueError("JSON dataset must be an array of row objects.")
+        pl_df = pl.DataFrame(data)
+    else:
+        try:
+            pl_df = pl.read_csv(io.StringIO(ds))
+        except Exception:
+            try:
+                parsed = json.loads(ds)
+                if isinstance(parsed, list):
+                    pl_df = pl.DataFrame(parsed)
+                elif isinstance(parsed, dict):
+                    pl_df = pl.DataFrame([parsed])
+                else:
+                    raise ValueError("JSON dataset must be an array or object.")
+            except Exception as e:
+                raise ValueError(f"Could not parse dataset string as CSV or JSON: {e}") from e
 
     # Normalize column names: strip leading/trailing whitespace
     pl_df = pl_df.rename({c: c.strip() for c in pl_df.columns})

--- a/src/datarobot_genai/drtools/predictive/project.py
+++ b/src/datarobot_genai/drtools/predictive/project.py
@@ -24,9 +24,16 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"predictive", "project", "read", "management", "list"})
+@tool_metadata(
+    tags={"predictive", "project", "read", "management", "list"},
+    description=(
+        "[Project—discover ids] Use when the user needs their modeling projects as id-to-name "
+        "map (no single project_id yet). Read-only. Not for datasets inside one project "
+        "(get_project_dataset_by_name), not catalog datasets (list_ai_catalog_items), not "
+        "deployments (list_deployments)."
+    ),
+)
 async def list_projects() -> dict[str, Any]:
-    """List all DataRobot projects for the authenticated user."""
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
     projects = client.Project.list()
@@ -35,16 +42,22 @@ async def list_projects() -> dict[str, Any]:
     return projects
 
 
-@tool_metadata(tags={"predictive", "project", "read", "data", "info"})
+@tool_metadata(
+    tags={"predictive", "project", "read", "data", "info"},
+    description=(
+        "[Project—resolve dataset by name] Use when the user names or describes a dataset "
+        "already attached to a modeling project (e.g. 'get the holdout dataset', 'dataset named "
+        "X') and you need its dataset_id: pass project_id plus dataset_name as a case-insensitive "
+        "substring of the dataset display name. Read-only. Returns dataset_id and whether it is "
+        "the project source or a prediction upload. Not for listing all projects "
+        "(list_projects) or arbitrary catalog lookup."
+    ),
+)
 async def get_project_dataset_by_name(
     *,
-    project_id: Annotated[str, "The ID of the DataRobot project."],
-    dataset_name: Annotated[str, "The name of the dataset to find (e.g., 'training', 'holdout')."],
+    project_id: Annotated[str, "DataRobot modeling project id."],
+    dataset_name: Annotated[str, "Substring to match against dataset display names."],
 ) -> dict[str, Any]:
-    """Get a dataset ID by name for a given project.
-
-    The dataset ID and the dataset type (source or prediction) as a string, or an error message.
-    """
     if not project_id:
         raise ToolError("Project ID is required.")
     if not dataset_name:

--- a/src/datarobot_genai/drtools/predictive/training.py
+++ b/src/datarobot_genai/drtools/predictive/training.py
@@ -86,12 +86,20 @@ def _get_dataset_or_raise(client: Any, dataset_id: str) -> tuple[Any, pd.DataFra
         raise ToolError(f"Failed to retrieve dataset '{dataset_id}': {error_str}")
 
 
-@tool_metadata(tags={"predictive", "training", "read", "analysis", "dataset"})
+@tool_metadata(
+    tags={"predictive", "training", "read", "analysis", "dataset"},
+    description=(
+        "[Catalog—quick profile] Use for a fast structural overview of one AI Catalog dataset: "
+        "row/column counts, inferred kinds (numeric, categorical, datetime, text), missingness, "
+        "heuristic candidate targets. Read-only; does not train. Lighter than "
+        "get_exploratory_insights; does not rank ML use-case ideas (suggest_use_cases calls this "
+        "internally)."
+    ),
+)
 async def analyze_dataset(
     *,
-    dataset_id: Annotated[str, "The ID of the DataRobot dataset to analyze"],
+    dataset_id: Annotated[str, "AI Catalog dataset id."],
 ) -> dict[str, Any]:
-    """Analyze a dataset to understand its structure and potential use cases."""
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
@@ -136,12 +144,19 @@ async def analyze_dataset(
     return insights_dict
 
 
-@tool_metadata(tags={"predictive", "training", "read", "analysis", "usecase"})
+@tool_metadata(
+    tags={"predictive", "training", "read", "analysis", "usecase"},
+    description=(
+        "[Catalog—use-case ideas] Use when the user wants ranked ML problem suggestions from one "
+        "catalog dataset (name, suggested target, problem type, confidence). Read-only. Builds on "
+        "dataset profiling; not the same as starting Autopilot (start_autopilot) or deep EDA "
+        "(get_exploratory_insights)."
+    ),
+)
 async def suggest_use_cases(
     *,
-    dataset_id: Annotated[str, "The ID of the DataRobot dataset to analyze"],
+    dataset_id: Annotated[str, "AI Catalog dataset id."],
 ) -> dict[str, Any]:
-    """Analyze a dataset and suggest potential machine learning use cases."""
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
@@ -164,13 +179,23 @@ async def suggest_use_cases(
     return {"use_case_suggestions": suggestions}
 
 
-@tool_metadata(tags={"predictive", "training", "read", "analysis", "eda"})
+@tool_metadata(
+    tags={"predictive", "training", "read", "analysis", "eda"},
+    description=(
+        "[Catalog—deep EDA] Use when the user wants richer exploratory stats on one catalog "
+        "dataset: memory, per-column missingness, type groupings, optional target distribution "
+        "and numeric correlations. Read-only; does not train or upload data. Heavier than "
+        "analyze_dataset; not time-series eligibility (is_eligible_for_timeseries_training)."
+    ),
+)
 async def get_exploratory_insights(
     *,
-    dataset_id: Annotated[str, "The ID of the DataRobot dataset to analyze"],
-    target_col: Annotated[str, "Optional target column to focus EDA insights on"] | None = None,
+    dataset_id: Annotated[str, "AI Catalog dataset id."],
+    target_col: Annotated[
+        str, "If set, add target-centric stats (must be an existing column name)."
+    ]
+    | None = None,
 ) -> dict[str, Any]:
-    """Generate exploratory data insights for a dataset."""
     if not dataset_id:
         raise ToolError("Dataset ID must be provided")
 
@@ -461,43 +486,44 @@ def _analyze_target_for_use_cases(df: pd.DataFrame, target_col: str) -> list[Use
     return suggestions
 
 
-@tool_metadata(tags={"predictive", "training", "write", "autopilot", "model", "daria"})
+@tool_metadata(
+    tags={"predictive", "training", "write", "autopilot", "model", "daria"},
+    description=(
+        "[Project—start Autopilot] Use when the user wants to start or resume Autopilot for one "
+        "tabular target: new project from dataset_id or public dataset_url plus project_name, or "
+        "existing project via project_id. mode is quick, comprehensive, or manual. Returns "
+        "project_id and status—not finished leaderboard models yet. Not deployment creation "
+        "(deploy_model), not batch scoring (predict_*), not dataset upload "
+        "(upload_dataset_to_ai_catalog) unless they already registered data."
+    ),
+)
 async def start_autopilot(
     *,
-    target: Annotated[str, "Name of the target column for modeling"],
+    target: Annotated[str, "Column name in the training table to predict."],
     project_id: Annotated[
-        str, "Optional, the ID of the DataRobot project or a new project if no id is provided"
+        str, "Existing project id to resume; omit when creating from dataset_url or dataset_id."
     ]
     | None = None,
-    mode: Annotated[
-        str, "Optional, Autopilot mode ('quick', 'comprehensive', or 'manual')"
-    ] = "quick",
+    mode: Annotated[str, "Autopilot breadth: quick, comprehensive, or manual."] = "quick",
     dataset_url: Annotated[
         str,
-        """
-        Optional, The URL to the dataset to upload
-        (optional if dataset_id is provided) for a new project.
-        """,
+        "For new projects: public URL to tabular data (mutually exclusive with dataset_id).",
     ]
     | None = None,
     dataset_id: Annotated[
         str,
-        """
-        Optional, The ID of an existing dataset in AI Catalog
-        (optional if dataset_url is provided) for a new project.
-        """,
+        "For new projects: AI Catalog dataset id (mutually exclusive with dataset_url).",
     ]
     | None = None,
     project_name: Annotated[
-        str, "Optional, name for the project if no id is provided, creates a new project"
+        str, "New project display name when project_id is omitted."
     ] = "MCP Project",
     use_case_id: Annotated[
         str,
-        "Optional, ID of the use case to associate this project (required for next-gen platform)",
+        "Optional org use-case id; some tenants require it on new projects.",
     ]
     | None = None,
 ) -> dict[str, Any]:
-    """Start automated model training (Autopilot) for a project."""
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
 
@@ -539,20 +565,24 @@ async def start_autopilot(
         raise ToolError(f"Failed to start Autopilot: {str(e)}")
 
 
-@tool_metadata(tags={"prediction", "training", "read", "model", "evaluation"})
+@tool_metadata(
+    tags={"prediction", "training", "read", "model", "evaluation"},
+    description=(
+        "[Project—ROC only] Use when the user wants ROC curve points for one binary classification "
+        "leaderboard model; source is validation, holdout, or crossValidation. Read-only. Not "
+        "for regression-only models, not full model card (get_model_details), not deployment "
+        "monitoring (get_prediction_history)."
+    ),
+)
 async def get_model_roc_curve(
     *,
-    project_id: Annotated[str, "The ID of the DataRobot project"],
-    model_id: Annotated[str, "The ID of the model to analyze"],
+    project_id: Annotated[str, "DataRobot modeling project id."],
+    model_id: Annotated[str, "Leaderboard model id."],
     source: Annotated[
         str,
-        """
-        The source of the data to use for the ROC curve
-        ('validation' or 'holdout' or 'crossValidation')
-        """,
+        "Which data fold: validation, holdout, or crossValidation.",
     ] = "validation",
 ) -> dict[str, Any]:
-    """Get detailed ROC curve for a specific model."""
     if not project_id:
         raise ToolError("Project ID must be provided")
     if not model_id:
@@ -596,13 +626,20 @@ async def get_model_roc_curve(
         raise ToolError(f"Failed to get ROC curve: {str(e)}")
 
 
-@tool_metadata(tags={"predictive", "training", "read", "model", "evaluation"})
+@tool_metadata(
+    tags={"predictive", "training", "read", "model", "evaluation"},
+    description=(
+        "[Project—global feature impact] Use for training-time global feature impact on one "
+        "leaderboard model (may wait while impact is computed). Read-only. Not per-row SHAP from "
+        "live deployment predictions (those come from predict_realtime explanation flags), not "
+        "lift chart bins (get_model_lift_chart)."
+    ),
+)
 async def get_model_feature_impact(
     *,
-    project_id: Annotated[str, "The ID of the DataRobot project"],
-    model_id: Annotated[str, "The ID of the model to analyze"],
+    project_id: Annotated[str, "DataRobot modeling project id."],
+    model_id: Annotated[str, "Leaderboard model id."],
 ) -> dict[str, Any]:
-    """Get detailed feature impact for a specific model."""
     if not project_id:
         raise ToolError("Project ID must be provided")
     if not model_id:
@@ -619,20 +656,24 @@ async def get_model_feature_impact(
     return {"data": feature_impact}
 
 
-@tool_metadata(tags={"predictive", "training", "read", "model", "evaluation"})
+@tool_metadata(
+    tags={"predictive", "training", "read", "model", "evaluation"},
+    description=(
+        "[Project—lift chart] Use for lift chart bins on one classification leaderboard model "
+        "(actual vs predicted by score bucket); source is validation, holdout, or crossValidation. "
+        "Read-only. Not ROC points (get_model_roc_curve), not general model metrics dump "
+        "(get_model_details)."
+    ),
+)
 async def get_model_lift_chart(
     *,
-    project_id: Annotated[str, "The ID of the DataRobot project"],
-    model_id: Annotated[str, "The ID of the model to analyze"],
+    project_id: Annotated[str, "DataRobot modeling project id."],
+    model_id: Annotated[str, "Leaderboard model id."],
     source: Annotated[
         str,
-        """
-        The source of the data to use for the lift chart
-        ('validation' or 'holdout' or 'crossValidation')
-        """,
+        "Which data fold: validation, holdout, or crossValidation.",
     ] = "validation",
 ) -> dict[str, Any]:
-    """Get detailed lift chart for a specific model."""
     if not project_id:
         raise ToolError("Project ID must be provided")
     if not model_id:

--- a/tests/drmcp/acceptance/test_data.py
+++ b/tests/drmcp/acceptance/test_data.py
@@ -46,6 +46,11 @@ def expectations_for_upload_dataset_to_ai_catalog_success_from_base64() -> ETETe
             "dataset has been uploaded",
             "successfully",
             "uploaded",
+            "upload complete",
+            "dataset id",
+            "done",
+            "registered",
+            "ete_tiny.csv",
         ],
     )
 
@@ -67,6 +72,8 @@ def expectations_for_upload_dataset_to_ai_catalog_success_from_url() -> ETETestE
             "dataset has been uploaded",
             "successfully",
             "uploaded",
+            "upload complete",
+            "dataset id",
         ],
     )
 
@@ -128,9 +135,8 @@ class TestDataE2E(ToolBaseE2E):
         "prompt_template",
         [
             """
-        Upload a dataset to the DataRobot AI Catalog using the upload_dataset_to_ai_catalog tool.
-        Use file_content_base64 with this exact value (copy it character for character, no spaces
-        added or removed): {b64}
+        Register this file in the DataRobot AI Catalog from raw bytes: use file_content_base64 with
+        this exact value (copy it character for character, no spaces added or removed): {b64}
         Use dataset_filename exactly: ete_tiny.csv
         Do not use file_url or a local file path.
         """

--- a/tests/drmcp/acceptance/test_deployment_info.py
+++ b/tests/drmcp/acceptance/test_deployment_info.py
@@ -19,6 +19,8 @@ from typing import Any
 import pytest
 
 from datarobot_genai.drmcp.test_utils.mcp_utils_ete import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import ANY_NONEMPTY_STRING
+from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ETETestExpectations
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolBaseE2E
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectations
@@ -57,10 +59,7 @@ def expectations_for_generate_prediction_data_template_success(
         tool_calls_expected=[
             ToolCallTestExpectations(
                 name="generate_prediction_data_template",
-                parameters={
-                    "deployment_id": deployment_id,
-                    "n_rows": 5,
-                },
+                parameters={"deployment_id": deployment_id},
                 result={
                     "deployment_id": "",
                     "model_type": "",
@@ -116,15 +115,16 @@ def expectations_for_validate_prediction_data_inline_csv(
                 name="validate_prediction_data",
                 parameters={
                     "deployment_id": deployment_id,
-                    "csv_string": INLINE_CSV_FOR_VALIDATE,
+                    "csv_string": ANY_NONEMPTY_STRING,
                 },
-                result={"status": "valid"},
+                result=SHOULD_NOT_BE_EMPTY,
             ),
         ],
         llm_response_content_contains_expectations=[
             "valid",
             "validate",
             "deployment",
+            "csv",
         ],
     )
 
@@ -223,8 +223,8 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
         [
             """
             I have a DataRobot deployment with ID '{deployment_id}' for a text classification
-            model. Call validate_prediction_data with csv_string set to this exact multi-line
-            CSV (preserve newlines; do not add a file path):
+            model. Check whether this exact multi-line CSV is valid for scoring (preserve
+            newlines; do not add a file path):
 
             {csv_inline}
             """
@@ -301,9 +301,9 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
         [
             """
             DataRobot deployment_id is '{deployment_id}'.
-            Invoke the validate_prediction_data tool once. Pass csv_string as the empty string
-            (length zero: no spaces, no placeholder CSV). Pass only deployment_id and csv_string.
-            Do not use file paths. The purpose is to observe the tool error for empty csv_string.
+            Try to validate scoring data where the inline CSV body is completely empty: pass
+            csv_string as exactly an empty string (length zero, no spaces, no placeholder text).
+            Do not use file paths. We expect a clear validation or argument error for empty input.
             """
         ],
     )

--- a/tests/drmcp/acceptance/test_model.py
+++ b/tests/drmcp/acceptance/test_model.py
@@ -94,7 +94,13 @@ def expectations_for_score_dataset_with_model_success(
                 result=SHOULD_NOT_BE_EMPTY,
             ),
         ],
-        llm_response_content_contains_expectations=["Scoring job started"],
+        llm_response_content_contains_expectations=[
+            "scoring",
+            "job",
+            "started",
+            "dataset",
+            "project",
+        ],
     )
 
 
@@ -202,8 +208,8 @@ class TestModelE2E(ToolBaseE2E):
         [
             """
         I'm working on a machine learning project with ID '{project_id}' and I have a
-        DataRobot model with ID '{model_id}'. Score the AI Catalog dataset with dataset_id
-        '{dataset_id}' using score_dataset_with_model (use dataset_id, not a URL or file path).
+        DataRobot model with ID '{model_id}'. Please start scoring the AI Catalog dataset
+        '{dataset_id}' with that model (use the catalog dataset id, not a URL or local file).
         Can you help me score the dataset?
         """
         ],
@@ -239,8 +245,8 @@ class TestModelE2E(ToolBaseE2E):
         [
             """
         I'm working on a machine learning project with ID '{project_id}' but my model ID is
-        wrong: '{model_id}'. Please call score_dataset_with_model with dataset_id '{dataset_id}'
-        so we can see the error from the invalid model id.
+        wrong: '{model_id}'. Try to start scoring AI Catalog dataset '{dataset_id}' with that
+        model id so we can see the error from the invalid model id.
         """
         ],
     )

--- a/tests/drmcp/acceptance/test_predict.py
+++ b/tests/drmcp/acceptance/test_predict.py
@@ -18,6 +18,7 @@ from typing import Any
 import pytest
 
 from datarobot_genai.drmcp.test_utils.mcp_utils_ete import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import ANY_NONEMPTY_STRING
 from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ETETestExpectations
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolBaseE2E
@@ -64,6 +65,35 @@ def expectations_for_predict_from_project_data_success(
         ],
         llm_response_content_contains_expectations=[
             "prediction",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_batch_predict_then_get_batch_results_success(
+    deployment_id: str,
+    classification_predict_dataset: Any,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="predict_by_ai_catalog",
+                parameters={
+                    "deployment_id": deployment_id,
+                    "dataset_id": classification_predict_dataset["dataset_id"],
+                },
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+            ToolCallTestExpectations(
+                name="get_batch_prediction_results",
+                parameters={"job_id": ANY_NONEMPTY_STRING},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "prediction",
+            "job",
+            "result",
         ],
     )
 
@@ -135,8 +165,8 @@ class TestPredictE2E(ToolBaseE2E):
         [
             """
         The MCP server has no access to my laptop files. Deployment ID is '{deployment_id}'.
-        Run batch predictions with predict_by_ai_catalog using only dataset_id '{dataset_id}'
-        (AI Catalog). Do not use local file paths or batch intake from disk.
+        Run batch scoring using only the AI Catalog dataset id '{dataset_id}' as the input source.
+        Do not use local file paths or upload from this machine.
         """
         ],
     )
@@ -196,6 +226,44 @@ class TestPredictE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_predict_from_project_data_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    @pytest.mark.parametrize(
+        "prompt_template",
+        [
+            """
+        First, run batch scoring on DataRobot deployment '{deployment_id}' using AI Catalog
+        dataset '{dataset_id}'. When the first response includes a batch job identifier, use that
+        identifier in a follow-up step to fetch the scored CSV content (still within this
+        conversation). Summarize what you got back from the second step.
+        """
+        ],
+    )
+    async def test_batch_predict_then_get_batch_prediction_results(
+        self,
+        llm_client: Any,
+        expectations_for_batch_predict_then_get_batch_results_success: ETETestExpectations,
+        deployment_id: str,
+        classification_predict_dataset: Any,
+        prompt_template: str,
+    ) -> None:
+        prompt = prompt_template.format(
+            deployment_id=deployment_id,
+            dataset_id=classification_predict_dataset["dataset_id"],
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = (
+                frame.f_code.co_name
+                if frame
+                else "test_batch_predict_then_get_batch_prediction_results"
+            )
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_batch_predict_then_get_batch_results_success,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_predict_realtime.py
+++ b/tests/drmcp/acceptance/test_predict_realtime.py
@@ -18,6 +18,7 @@ from typing import Any
 import pytest
 
 from datarobot_genai.drmcp.test_utils.mcp_utils_ete import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import ANY_NONEMPTY_STRING
 from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ETETestExpectations
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolBaseE2E
@@ -79,6 +80,85 @@ def expectations_for_predict_realtime_dataset_string_success(
 
 
 @pytest.fixture(scope="session")
+def expectations_for_get_deployment_info_success(deployment_id: str) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="get_deployment_info",
+                parameters={"deployment_id": deployment_id},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "feature",
+            "deployment",
+            "target",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_get_deployment_features_success(deployment_id: str) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="get_deployment_features",
+                parameters={"deployment_id": deployment_id},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "feature",
+            "deployment",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_generate_prediction_data_template_success(
+    deployment_id: str,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="generate_prediction_data_template",
+                parameters={"deployment_id": deployment_id},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "template",
+            "column",
+            "feature",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_validate_prediction_data_success(
+    deployment_id: str,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="validate_prediction_data",
+                parameters={
+                    "deployment_id": deployment_id,
+                    "csv_string": INLINE_CSV_DATASET,
+                },
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "validation",
+            "deployment",
+            "column",
+            "row",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
 def expectations_for_predict_realtime_json_dataset_success(
     deployment_id: str,
 ) -> ETETestExpectations:
@@ -88,7 +168,7 @@ def expectations_for_predict_realtime_json_dataset_success(
                 name="predict_realtime",
                 parameters={
                     "deployment_id": deployment_id,
-                    "dataset": INLINE_JSON_DATASET,
+                    "dataset": ANY_NONEMPTY_STRING,
                 },
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -176,8 +256,8 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
         [
             """
         I have a DataRobot deployment with ID '{deployment_id}'.
-        Run predict_realtime using the dataset parameter only (inline JSON array, not a file path).
-        Use this exact JSON string as dataset (copy verbatim):
+        Run realtime scoring using the dataset argument only as an inline JSON array of row objects
+        (not a file path). Use this exact JSON string as dataset (copy verbatim):
 
         {dataset}
         """
@@ -202,6 +282,123 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
             await self._run_test_with_expectations(
                 prompt,
                 expectations_for_predict_realtime_json_dataset_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    @pytest.mark.parametrize(
+        "prompt_template",
+        [
+            """
+        For DataRobot deployment '{deployment_id}', look up what that deployment needs for
+        scoring: the prediction target and the input features. Summarize the target and roughly
+        how many features are required.
+        """
+        ],
+    )
+    async def test_get_deployment_info_success(
+        self,
+        llm_client: Any,
+        expectations_for_get_deployment_info_success: ETETestExpectations,
+        deployment_id: str,
+        prompt_template: str,
+    ) -> None:
+        prompt = prompt_template.format(deployment_id=deployment_id)
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_get_deployment_info_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_get_deployment_info_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    @pytest.mark.parametrize(
+        "prompt_template",
+        [
+            """
+        For deployment '{deployment_id}', list a few of the feature names the model expects
+        as inputs when scoring.
+        """
+        ],
+    )
+    async def test_get_deployment_features_success(
+        self,
+        llm_client: Any,
+        expectations_for_get_deployment_features_success: ETETestExpectations,
+        deployment_id: str,
+        prompt_template: str,
+    ) -> None:
+        prompt = prompt_template.format(deployment_id=deployment_id)
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_get_deployment_features_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_get_deployment_features_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    @pytest.mark.parametrize(
+        "prompt_template",
+        [
+            """
+        For deployment '{deployment_id}', produce about two sample rows that match the shape
+        needed for scoring, then describe the columns in those rows.
+        """
+        ],
+    )
+    async def test_generate_prediction_data_template_success(
+        self,
+        llm_client: Any,
+        expectations_for_generate_prediction_data_template_success: ETETestExpectations,
+        deployment_id: str,
+        prompt_template: str,
+    ) -> None:
+        prompt = prompt_template.format(deployment_id=deployment_id)
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = (
+                frame.f_code.co_name if frame else "test_generate_prediction_data_template_success"
+            )
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_generate_prediction_data_template_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    @pytest.mark.parametrize(
+        "prompt_template",
+        [
+            """
+        For deployment '{deployment_id}', check whether this inline CSV is acceptable for scoring.
+        Use this exact CSV text (verbatim, including header and newlines, no extra spaces):
+        {csv}
+        Summarize validation status and any warnings.
+        """
+        ],
+    )
+    async def test_validate_prediction_data_success(
+        self,
+        llm_client: Any,
+        expectations_for_validate_prediction_data_success: ETETestExpectations,
+        deployment_id: str,
+        prompt_template: str,
+    ) -> None:
+        prompt = prompt_template.format(deployment_id=deployment_id, csv=INLINE_CSV_DATASET)
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_validate_prediction_data_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_validate_prediction_data_success,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_projects.py
+++ b/tests/drmcp/acceptance/test_projects.py
@@ -126,10 +126,10 @@ def expectations_for_get_project_dataset_by_name_success_with_multiple_calls(
             ),
         ],
         llm_response_content_contains_expectations=[
-            classification_project_name,
-            classification_dataset_name,
+            classification_project_name.lower(),
+            classification_dataset_name.lower(),
             classification_dataset_id,
-            "Source",
+            "source",
         ],
     )
 

--- a/tests/drmcp/unit/predictive_tools/test_predict.py
+++ b/tests/drmcp/unit/predictive_tools/test_predict.py
@@ -207,6 +207,7 @@ async def test_predict_by_ai_catalog_missing_download_url(
             return_value="token",
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
+        patch("datarobot_genai.drtools.predictive.predict.time.sleep"),
     ):
         mock_dataset = MagicMock()
         mock_client = MagicMock()

--- a/tests/drmcp/unit/test_tool_base_ete.py
+++ b/tests/drmcp/unit/test_tool_base_ete.py
@@ -14,6 +14,7 @@
 
 """Unit tests for tool_base_ete.py module."""
 
+from datarobot_genai.drmcp.test_utils.tool_base_ete import ANY_NONEMPTY_STRING
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ETETestExpectations
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolBaseE2E
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectations
@@ -58,6 +59,7 @@ class TestETETestExpectations:
         assert len(expectations.tool_calls_expected) == 1
         assert expectations.tool_calls_expected[0].name == "tool1"
         assert expectations.potential_no_tool_calls is False
+        assert expectations.allow_unexpected_tool_calls is True
 
     def test_ete_test_expectations_with_potential_no_tool_calls(self) -> None:
         """Test ETETestExpectations with potential_no_tool_calls set."""
@@ -202,6 +204,15 @@ class TestCheckDictParamsMatch:
         actual = {"outer": "not_a_dict"}
 
         assert _check_dict_params_match(expected, actual) is False
+
+    def test_any_nonempty_string_accepts_nonblank(self) -> None:
+        expected = {"job_id": ANY_NONEMPTY_STRING}
+        assert _check_dict_params_match(expected, {"job_id": "abc-123"}) is True
+
+    def test_any_nonempty_string_rejects_blank(self) -> None:
+        expected = {"job_id": ANY_NONEMPTY_STRING}
+        assert _check_dict_params_match(expected, {"job_id": ""}) is False
+        assert _check_dict_params_match(expected, {"job_id": "   "}) is False
 
 
 class TestToolBaseE2E:

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.23"
+version = "0.15.24"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Improve predictive drtools for MCP agents: rich tool_metadata descriptions, robust batch download polling and async-safe waits, safer CSV/JSON parsing for realtime predict, and more resilient deployment CSV validation (importance + whitespace/empty rows).

`deployment_info:`

- `_feature_importance_value(): treats missing / non-numeric importance as 0.0 so comparisons and warning text do not break.
- validate_prediction_data: strip() on CSV input, strip column names, drop all-empty rows (helps LLM-pasted CSV).

`predict:`

- Polls job.get_status() for links.download (≈60 × 0.5s) so batch jobs that finish before the link appears still succeed.
- Explicit failure on terminal statuses ERROR / FAILED / ABORTED with details.
- asyncio.to_thread around wait_for_preds_and_cache_results so predict_by_ai_catalog and predict_from_project_data do not block the async event loop.

`predict_realtime:`

- JSON array inputs: if dataset starts with [, parse as JSON first (avoids Polars treating [ as CSV and yielding empty/wrong frames → “no data to predict on”).
- CSV path still tries read_csv, then JSON list/object fallback.
- Strip column names on the frame.
- Metadata + compressed parameter descriptions; large predict_realtime docstring removed.






<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core prediction and validation logic (batch polling/async waits, realtime payload parsing), which can change runtime behavior for scoring tools. Changes are localized and covered by updated unit/acceptance tests, but regressions would impact MCP agent scoring flows.
> 
> **Overview**
> Bumps version to `0.15.25` and expands `tool_metadata` descriptions across predictive tools to better steer MCP/LLM tool selection.
> 
> Hardens scoring flows: batch prediction now waits without blocking the async loop and polls for delayed `links.download` (with explicit terminal-failure handling), while `predict_realtime` parses JSON-first when input looks like a JSON array to avoid Polars CSV misparsing. Deployment CSV validation is made more resilient by stripping whitespace, dropping empty rows, and safely coercing feature importance.
> 
> ETE harness and tests are updated to be less brittle: tool name normalization for namespaced MCP tools, optional allowance for extra tool calls, improved failure diagnostics, and a new `ANY_NONEMPTY_STRING` sentinel to assert dynamic IDs (plus refreshed acceptance/unit tests including a batch-predict-then-download scenario).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5990e26d2cf843da0eb986df118fd99a5617d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->