### PR TITLE
[-] fix(nat): stop chat history from leaking into stream as duplicate chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.24
-- Fixed NAT `per_user_tool_calling_agent` leaking prior assistant messages from chat history back into the response stream as a single trailing chunk. Patches langgraph's `StreamMessagesHandler.on_chain_start` to assign uuids to id-less input messages so the dedupe set tracks them correctly. Removable once NAT assigns ids to its `BaseMessage`s upstream.
+- Fixed NAT `per_user_tool_calling_agent` leaking prior assistant messages from chat history back into the response stream as a single trailing chunk.
 
 ## 0.15.23
 - OAuth2 token exchange configuration now use a nested `subject_token_constraints` and `token_exchange_request`, with AgentCard extension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.23
 - OAuth2 token exchange configuration now use a nested `subject_token_constraints` and `token_exchange_request`, with AgentCard extension.
--
+
 ## 0.15.22
 - Removed `posthog` and `qdrant-client` from `e2e-tests/pyproject.toml` exclude list to mirror the main pyproject.toml fix in 0.15.21; both are imported eagerly by upstream libs and excluding them would break e2e test collection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.24
+- Fixed NAT `per_user_tool_calling_agent` leaking prior assistant messages from chat history back into the response stream as a single trailing chunk. Patches langgraph's `StreamMessagesHandler.on_chain_start` to assign uuids to id-less input messages so the dedupe set tracks them correctly. Removable once NAT assigns ids to its `BaseMessage`s upstream.
+
 ## 0.15.23
 - OAuth2 token exchange configuration now use a nested `subject_token_constraints` and `token_exchange_request`, with AgentCard extension.
-- 
+-
 ## 0.15.22
 - Removed `posthog` and `qdrant-client` from `e2e-tests/pyproject.toml` exclude list to mirror the main pyproject.toml fix in 0.15.21; both are imported eagerly by upstream libs and excluding them would break e2e test collection.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.23"
+version = "0.15.24"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.23"
+version = "0.15.24"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
+++ b/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
@@ -26,9 +26,14 @@ using ``DRAgentNestedReasoningStepAdaptor.process_chunks()`` to produce
 ``DRAgentEventResponse`` with valid AG-UI event sequences.
 """
 
+import uuid
 from collections.abc import AsyncGenerator
+from collections.abc import Sequence
 from typing import Any
 
+from langchain_core.messages import BaseMessage
+from langgraph.pregel._messages import StreamMessagesHandler
+from langgraph.pregel._messages import _state_values
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_per_user_function
 from nat.data_models.api_server import ChatRequest
@@ -39,6 +44,49 @@ from nat.plugins.langchain.agent.tool_calling_agent.register import tool_calling
 
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.stream_converter import convert_chunks_to_agui_events
+
+# Workaround: prior assistant messages from chat history were leaking back into
+# the response stream as a single trailing mega-chunk after the new response.
+#
+# How that happens:
+#   1. NAT's `Message` data model has no `id` field, so when `_stream_fn`
+#      converts the request into BaseMessages via
+#      `trim_messages([m.model_dump() for m in chat.messages], ...)`, every
+#      BaseMessage handed to the graph has `id=None`.
+#   2. Langgraph's `StreamMessagesHandler` uses a `seen` set, keyed by
+#      `message.id`, to avoid emitting the same message twice. Its
+#      `on_chain_start` only records ids when `id is not None`, so id-less
+#      inputs are never added to `seen`.
+#   3. When `agent_node` returns, `on_chain_end` walks the new state and emits
+#      every BaseMessage not in `seen`. Prior history items (id=None) match
+#      that condition and get streamed to the client as if the model had just
+#      produced them, even though they were part of the conversation history.
+#
+# Fix: assign a uuid to every id-less input message before the original
+# `on_chain_start` runs, mirroring what `StreamMessagesHandler._emit` already
+# does for output messages. This makes the seen set track them correctly, so
+# `on_chain_end` no longer treats them as new output.
+#
+_original_on_chain_start = StreamMessagesHandler.on_chain_start
+
+
+def _patched_on_chain_start(
+    self: StreamMessagesHandler,
+    serialized: dict[str, Any],
+    inputs: dict[str, Any],
+    **kwargs: Any,
+) -> Any:
+    for value in _state_values(inputs):
+        if isinstance(value, BaseMessage) and value.id is None:
+            value.id = str(uuid.uuid4())
+        elif isinstance(value, Sequence) and not isinstance(value, str):
+            for item in value:
+                if isinstance(item, BaseMessage) and item.id is None:
+                    item.id = str(uuid.uuid4())
+    return _original_on_chain_start(self, serialized, inputs, **kwargs)
+
+
+StreamMessagesHandler.on_chain_start = _patched_on_chain_start  # type: ignore[method-assign]
 
 
 class PerUserToolCallAgentWorkflowConfig(

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.23"
+version = "0.15.24"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
NAT's per_user_tool_calling_agent was emitting prior assistant messages from chat history back to the client as a single trailing mega-chunk after the new response. Symptom on the wire was a TEXT_MESSAGE_CONTENT delta containing the verbatim text of an earlier turn, arriving right before TEXT_MESSAGE_END.

Root cause is a contract gap between NAT and langgraph: NAT's Message data model has no id field, so the BaseMessages handed to the graph all have id=None. Langgraph's
StreamMessagesHandler.on_chain_start only adds ids to its `seen` set when id is not None, so id-less inputs are never tracked. When the agent node finishes, on_chain_end walks the new state and emits every BaseMessage not in `seen`, which means prior history items get streamed as if the model had just produced them.

Patch wraps on_chain_start to assign a uuid to each id-less input message before the original handler runs, mirroring what StreamMessagesHandler._emit already does for output messages. The seen set then tracks history correctly and on_chain_end no longer treats it as new model output.

Removable once NAT assigns ids to its BaseMessages upstream.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global streaming behavior via a runtime monkey-patch of `StreamMessagesHandler`, so regressions could affect any LangGraph streaming in-process; the change is small and narrowly scoped to assigning missing ids.
> 
> **Overview**
> Prevents NAT `per_user_tool_calling_agent` streaming from emitting prior chat history messages as a trailing duplicate “mega-chunk”.
> 
> This monkey-patches LangGraph’s `StreamMessagesHandler.on_chain_start` to assign UUIDs to any id-less input `BaseMessage` instances (including those nested in sequences) so the handler’s `seen` tracking correctly suppresses re-emitting history on chain end.
> 
> Bumps package version to `0.15.24` and records the fix in `CHANGELOG.md` (lockfiles updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1f75b848c7f3a7563ab2b7e7884793864904a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->