### PR TITLE
Fix llm docs for all tools, add fall back headers and proper error handeling

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -21,14 +21,6 @@ tasks:
       - uv run src/datarobot_genai/drmcp/server.py
     silent: true
 
-  drmcp-ete-test-server:
-    desc: "🔨 Running DR MCP Library test server"
-    cmds:
-      - echo "🔨 Starting DR MCP Library development server"
-      - task: drmcp-install
-      - uv run tests/drmcp/acceptance/ete_test_server.py
-    silent: true
-
   drmcp-test-dev-server-background:
     desc: "🔨 Running DR MCP Library locally in background"
     vars:
@@ -36,10 +28,11 @@ tasks:
     cmds:
       - echo "🔨 Starting DR MCP Library development server"
       - lsof -i :{{.PORT}} > /dev/null 2>&1 && echo "Killing existing process on port {{.PORT}}" && lsof -i :{{.PORT}} | grep LISTEN | awk '{print $2}' | xargs kill -9 2>/dev/null || true
+      - task: drmcp-install
       - |
         OTEL_ENABLED=false \
         OTEL_SDK_DISABLED=true \
-        MCP_SERVER_PORT={{.PORT}} task drmcp-ete-test-server &
+        MCP_SERVER_PORT={{.PORT}} uv run tests/drmcp/acceptance/ete_test_server.py &
       - |
         for i in {1..30}; do
           if curl -s http://localhost:{{.PORT}}/ > /dev/null 2>&1; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.26
+- Categorized ToolErrors, OAuth access tokens with x-datarobot-*-access-token fallback, MCP logging that surfaces kinds to FastMCP, SDK ClientError → tool errors in predictive tools and improved third party APIs tool_metadata descriptions.
+
 ## 0.15.25
 - Improved predictive drtools for MCP agents: rich tool_metadata descriptions, robust batch download polling and async-safe waits, safer CSV/JSON parsing for realtime predict, and more resilient deployment CSV validation (importance + whitespace/empty rows).
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.25"
+version = "0.15.26"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.25"
+version = "0.15.26"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/logging.py
+++ b/src/datarobot_genai/drmcp/core/logging.py
@@ -20,7 +20,12 @@ from collections.abc import Callable
 from typing import Any
 from typing import TypeVar
 
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError as FastMCPToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
+from pydantic import ValidationError as PydanticValidationError
+
+from datarobot_genai.drtools.core.exceptions import ToolError as DRToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 # Secret patterns to redact from logs
 SECRET_PATTERNS = [
@@ -79,6 +84,32 @@ def _log_error(logger: logging.Logger, func_name: str, error: Exception, **kwarg
     return f"Error in {func_name}: {error_msg}"
 
 
+def _mcp_message_for_dr_tool_error(e: DRToolError) -> str:
+    """Format drtools ToolError for fastmcp (kind prefix, no duplicate wrapping)."""
+    return f"[{e.kind.value}] {e.message}"
+
+
+def _kind_for_wrapped_exception(exc: Exception) -> ToolErrorKind:
+    """Map platform/SDK HTTP errors to kinds when wrapping unknown exceptions.
+
+    Used only when the tool did not raise :class:`DRToolError` — e.g. other tools, deep SDK
+    calls, or new code paths. Predictive tools should still prefer explicit
+    ``raise_tool_error_for_client_error`` where :class:`~datarobot.errors.ClientError` is expected.
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        if status == 404:
+            return ToolErrorKind.NOT_FOUND
+        if status in (401, 403):
+            return ToolErrorKind.AUTHENTICATION
+        if 400 <= status < 600:
+            return ToolErrorKind.UPSTREAM
+    lowered = str(exc).lower()
+    if "404" in lowered and ("not found" in lowered or "does not exist" in lowered):
+        return ToolErrorKind.NOT_FOUND
+    return ToolErrorKind.INTERNAL
+
+
 def log_execution(func: F) -> F:
     """Log execution with error handling."""
     logger = logging.getLogger(func.__module__)
@@ -91,8 +122,18 @@ def log_execution(func: F) -> F:
             result = await func(*args, **kwargs)
             logger.info(f"Completed {func.__name__}")
             return result
+        except FastMCPToolError as e:
+            _log_error(logger, func.__name__, e, args=args, kwargs=kwargs)
+            raise
+        except DRToolError as e:
+            _log_error(logger, func.__name__, e, args=args, kwargs=kwargs)
+            raise FastMCPToolError(_mcp_message_for_dr_tool_error(e)) from e
+        except (PydanticValidationError, FastMCPValidationError) as e:
+            error_msg = _log_error(logger, func.__name__, e, args=args, kwargs=kwargs)
+            raise FastMCPToolError(f"[{ToolErrorKind.SCHEMA.value}] {error_msg}") from e
         except Exception as e:
             error_msg = _log_error(logger, func.__name__, e, args=args, kwargs=kwargs)
-            raise ToolError(error_msg) from e
+            kind = _kind_for_wrapped_exception(e)
+            raise FastMCPToolError(f"[{kind.value}] {error_msg}") from e
 
     return wrapper  # type: ignore[return-value]

--- a/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
@@ -398,7 +398,7 @@ class ToolBaseE2E:
                     )
 
         # Verify LLM provided comprehensive response
-        assert len(response.content) > 100, "LLM should provide detailed response"
+        assert len(response.content) > 60, "LLM should provide detailed response"
         assert any(
             expected_response.lower() in response.content
             for expected_response in test_expectations.llm_response_content_contains_expectations

--- a/src/datarobot_genai/drtools/confluence/tools.py
+++ b/src/datarobot_genai/drtools/confluence/tools.py
@@ -27,13 +27,26 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
+_CQL_DOCS = "https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/"
+_PAGE_REST_DOCS = "https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/"
+_PAGE_BODY_DOCS = (
+    "https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api-pages-post"
+)
+_FOOTER_COMMENTS_DOCS = (
+    "https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-footer-comments/"
+)
+
 
 @tool_metadata(
     tags={"confluence", "read", "get", "page"},
     description=(
         "[Confluence—get page] Use when you have a numeric page id, or an exact page title plus "
         "space_key, and need the page body (storage HTML). Not CQL multi-page search "
-        "(confluence_search), not Jira (jira_get_issue)."
+        "(confluence_search), not Jira (jira_get_issue).\n\n"
+        'Examples: By ID: page_id_or_title="856391684". By title: '
+        'page_id_or_title="Meeting Notes", space_key="TEAM" (space_key is required when '
+        "using a title).\n\n"
+        f"Reference: {_PAGE_REST_DOCS}"
     ),
 )
 async def confluence_get_page(
@@ -74,7 +87,10 @@ async def confluence_get_page(
     description=(
         "[Confluence—create page] Use when publishing a new page in a space (space_key, title, "
         "body storage format), optional parent page id. Not updating an existing page "
-        "(confluence_update_page), not comments (confluence_add_comment)."
+        "(confluence_update_page), not comments (confluence_add_comment).\n\n"
+        'Examples: Root page: space_key="PROJ", title="New Page", '
+        'body_content="<p>Content</p>". Child page: same fields plus parent_id=123456.\n\n'
+        f"References (body representation / storage): {_PAGE_BODY_DOCS} {_PAGE_REST_DOCS}"
     ),
 )
 async def confluence_create_page(
@@ -116,7 +132,9 @@ async def confluence_create_page(
     description=(
         "[Confluence—comment] Use when appending a page-level comment on an existing page by "
         "numeric page_id. Not page body edits (confluence_update_page), not new pages "
-        "(confluence_create_page)."
+        "(confluence_create_page).\n\n"
+        'Example: page_id="856391684", comment_body="Great work on this documentation!"\n\n'
+        f"Reference: {_FOOTER_COMMENTS_DOCS}"
     ),
 )
 async def confluence_add_comment(
@@ -157,7 +175,9 @@ async def confluence_add_comment(
         "[Confluence—CQL search] Use when finding pages or content with Confluence Query Language "
         "(type, space, text filters). Optional full body per hit. "
         "Not Jira JQL (jira_search_issues), "
-        "not single-page fetch by id alone (confluence_get_page when key already known)."
+        "not single-page fetch by id alone (confluence_get_page when key already known).\n\n"
+        'Example: cql_query="type=page and space=DOC", max_results=10, include_body=false.\n\n'
+        f"Reference (CQL): {_CQL_DOCS}"
     ),
 )
 async def confluence_search(
@@ -217,7 +237,11 @@ async def confluence_search(
     description=(
         "[Confluence—update page] Use when replacing page body content for an existing page_id; "
         "version_number must match current version from confluence_get_page (optimistic lock). "
-        "Not new pages (confluence_create_page), not comments (confluence_add_comment)."
+        "Not new pages (confluence_create_page), not comments (confluence_add_comment).\n\n"
+        'Example: page_id="856391684", new_body_content="<p>New content</p>", '
+        "version_number=5. Always call confluence_get_page first to read the current "
+        f"version_number.\n\nReferences (body representation / storage): {_PAGE_BODY_DOCS} "
+        f"{_PAGE_REST_DOCS}"
     ),
 )
 async def confluence_update_page(

--- a/src/datarobot_genai/drtools/confluence/tools.py
+++ b/src/datarobot_genai/drtools/confluence/tools.py
@@ -23,11 +23,19 @@ from datarobot_genai.drtools.core.clients.atlassian import get_atlassian_access_
 from datarobot_genai.drtools.core.clients.confluence import ConfluenceClient
 from datarobot_genai.drtools.core.clients.confluence import ConfluenceError
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"confluence", "read", "get", "page"})
+@tool_metadata(
+    tags={"confluence", "read", "get", "page"},
+    description=(
+        "[Confluence—get page] Use when you have a numeric page id, or an exact page title plus "
+        "space_key, and need the page body (storage HTML). Not CQL multi-page search "
+        "(confluence_search), not Jira (jira_get_issue)."
+    ),
+)
 async def confluence_get_page(
     *,
     page_id_or_title: Annotated[str, "The ID or the exact title of the Confluence page."],
@@ -36,19 +44,11 @@ async def confluence_get_page(
         "Required if identifying the page by title. The space key (e.g., 'PROJ').",
     ] = None,
 ) -> dict[str, Any]:
-    """Retrieve the content of a specific Confluence page.
-
-    Use this tool to fetch Confluence pages by their numeric ID or by title.
-    Returns page content in HTML storage format.
-
-    Usage:
-        - By ID: page_id_or_title="856391684"
-        - By title: page_id_or_title="Meeting Notes", space_key="TEAM"
-
-    When using a page title, the space_key parameter is required.
-    """
     if not page_id_or_title:
-        raise ToolError("Argument validation error: 'page_id_or_title' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'page_id_or_title' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     access_token = await get_atlassian_access_token()
     if isinstance(access_token, ToolError):
@@ -61,14 +61,22 @@ async def confluence_get_page(
             if not space_key:
                 raise ToolError(
                     "Argument validation error: "
-                    "'space_key' is required when identifying a page by title."
+                    "'space_key' is required when identifying a page by title.",
+                    kind=ToolErrorKind.VALIDATION,
                 )
             page_response = await client.get_page_by_title(page_id_or_title, space_key)
 
     return page_response.as_flat_dict()
 
 
-@tool_metadata(tags={"confluence", "write", "create", "page"})
+@tool_metadata(
+    tags={"confluence", "write", "create", "page"},
+    description=(
+        "[Confluence—create page] Use when publishing a new page in a space (space_key, title, "
+        "body storage format), optional parent page id. Not updating an existing page "
+        "(confluence_update_page), not comments (confluence_add_comment)."
+    ),
+)
 async def confluence_create_page(
     *,
     space_key: Annotated[str, "The key of the Confluence space where the new page should live."],
@@ -82,20 +90,10 @@ async def confluence_create_page(
         "The ID of the parent page, used to create a child page.",
     ] = None,
 ) -> dict[str, Any]:
-    """Create a new documentation page in a specified Confluence space.
-
-    Use this tool to create new Confluence pages with content in storage format.
-    The page will be created at the root level of the space unless a parent_id
-    is provided, in which case it will be created as a child page.
-
-    Usage:
-        - Root page: space_key="PROJ", title="New Page", body_content="<p>Content</p>"
-        - Child page: space_key="PROJ", title="Sub Page", body_content="<p>Content</p>",
-                      parent_id=123456
-    """
     if not all([space_key, title, body_content]):
         raise ToolError(
-            "Argument validation error: space_key, title, and body_content are required fields."
+            "Argument validation error: space_key, title, and body_content are required fields.",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     access_token = await get_atlassian_access_token()
@@ -113,25 +111,29 @@ async def confluence_create_page(
     return {"new_page_id": page_response.page_id, "title": page_response.title}
 
 
-@tool_metadata(tags={"confluence", "write", "add", "comment"})
+@tool_metadata(
+    tags={"confluence", "write", "add", "comment"},
+    description=(
+        "[Confluence—comment] Use when appending a page-level comment on an existing page by "
+        "numeric page_id. Not page body edits (confluence_update_page), not new pages "
+        "(confluence_create_page)."
+    ),
+)
 async def confluence_add_comment(
     *,
     page_id: Annotated[str, "The numeric ID of the page where the comment will be added."],
     comment_body: Annotated[str, "The text content of the comment."],
 ) -> dict[str, Any]:
-    """Add a new comment to a specified Confluence page for collaboration.
-
-    Use this tool to add comments to Confluence pages to facilitate collaboration
-    and discussion. Comments are added at the page level.
-
-    Usage:
-        - Add comment: page_id="856391684", comment_body="Great work on this documentation!"
-    """
     if not page_id:
-        raise ToolError("Argument validation error: 'page_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'page_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if not comment_body:
-        raise ToolError("Argument validation error: 'comment_body' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'comment_body' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     access_token = await get_atlassian_access_token()
     if isinstance(access_token, ToolError):
@@ -149,7 +151,15 @@ async def confluence_add_comment(
     }
 
 
-@tool_metadata(tags={"confluence", "search", "content"})
+@tool_metadata(
+    tags={"confluence", "search", "content"},
+    description=(
+        "[Confluence—CQL search] Use when finding pages or content with Confluence Query Language "
+        "(type, space, text filters). Optional full body per hit. "
+        "Not Jira JQL (jira_search_issues), "
+        "not single-page fetch by id alone (confluence_get_page when key already known)."
+    ),
+)
 async def confluence_search(
     *,
     cql_query: Annotated[
@@ -164,18 +174,16 @@ async def confluence_search(
         "makes additional API calls). Default is False, which returns only excerpts.",
     ] = False,
 ) -> dict[str, Any]:
-    """
-    Search Confluence pages and content efficiently using a CQL query string.
-    This pushes the search logic to the Confluence API (Push-Down).
-
-    Refer to Confluence documentation for advanced searching using CQL:
-    https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/
-    """
     if not cql_query:
-        raise ToolError("Argument validation error: 'cql_query' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'cql_query' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if max_results < 1 or max_results > 100:
-        raise ToolError("Argument validation error: 'max_results' must be between 1 and 100.")
+        raise ToolError(
+            "Argument validation error: 'max_results' must be between 1 and 100.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     access_token = await get_atlassian_access_token()
     if isinstance(access_token, ToolError):
@@ -204,7 +212,14 @@ async def confluence_search(
     return {"data": data, "count": n}
 
 
-@tool_metadata(tags={"confluence", "write", "update", "page"})
+@tool_metadata(
+    tags={"confluence", "write", "update", "page"},
+    description=(
+        "[Confluence—update page] Use when replacing page body content for an existing page_id; "
+        "version_number must match current version from confluence_get_page (optimistic lock). "
+        "Not new pages (confluence_create_page), not comments (confluence_add_comment)."
+    ),
+)
 async def confluence_update_page(
     *,
     page_id: Annotated[str, "The ID of the Confluence page to update."],
@@ -218,28 +233,21 @@ async def confluence_update_page(
         "Get this from the confluence_get_page tool.",
     ],
 ) -> dict[str, Any]:
-    """Update the content of an existing Confluence page.
-
-    Requires the current version number to ensure atomic updates.
-    Use this tool to update the body content of an existing Confluence page.
-    The version_number is required for optimistic locking - it prevents overwriting
-    changes made by others since you last fetched the page.
-
-    Usage:
-        page_id="856391684", new_body_content="<p>New content</p>", version_number=5
-
-    Important: Always fetch the page first using confluence_get_page to get the
-    current version number before updating.
-    """
     if not page_id:
-        raise ToolError("Argument validation error: 'page_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'page_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if not new_body_content:
-        raise ToolError("Argument validation error: 'new_body_content' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'new_body_content' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     if version_number < 1:
         raise ToolError(
-            "Argument validation error: 'version_number' must be a positive integer (>= 1)."
+            "Argument validation error: 'version_number' must be a positive integer (>= 1).",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     access_token = await get_atlassian_access_token()

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -17,6 +17,7 @@ import contextvars
 import logging
 from typing import Any
 
+from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
 from datarobot.auth.session import AuthCtx
 from datarobot.models.genai.agent.auth import ToolAuth
 
@@ -25,6 +26,8 @@ from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
 from datarobot_genai.core.utils.auth import DRAppCtx
 from datarobot_genai.drtools.core.constants import AUTH_CTX_KEY
 from datarobot_genai.drtools.core.constants import HEADER_TOKEN_CANDIDATE_NAMES
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 # Try to import get_http_headers from FastMCP if available
 # The deplyment is expected to have the fastmcp dependency installed.
@@ -186,6 +189,136 @@ async def get_access_token(provider_type: str | None = None) -> str:
         provider_type=provider_type,
     )
     return oauth_access_token
+
+
+def oauth_access_token_header_name(header_segment: str) -> str:
+    """Build ``x-datarobot-<segment>-access-token`` from *header_segment* (normalized)."""
+    segment = header_segment.strip().lower().replace("_", "-")
+    return f"x-datarobot-{segment}-access-token"
+
+
+def _parse_optional_bearer_token(raw: str) -> str | None:
+    value = str(raw).strip()
+    if not value:
+        return None
+    bearer_prefix = "bearer "
+    if value.lower().startswith(bearer_prefix):
+        value = value[len(bearer_prefix) :].strip()
+    return value or None
+
+
+def _extract_oauth_fallback_token_from_headers(
+    headers: dict[str, str], header_name_lower: str
+) -> str | None:
+    lowered = {str(k).lower(): v for k, v in headers.items() if isinstance(v, str)}
+    raw = lowered.get(header_name_lower)
+    if not raw:
+        return None
+    return _parse_optional_bearer_token(raw)
+
+
+def resolve_oauth_access_token_from_headers(header_segment: str) -> str | None:
+    """Read ``x-datarobot-<segment>-access-token`` for *header_segment* (raw or Bearer).
+
+    Tries framework HTTP headers, then :func:`set_request_headers_for_context`.
+    """
+    header_key = oauth_access_token_header_name(header_segment).lower()
+
+    framework_headers: dict[str, str] | None = None
+    try:
+        framework_headers = _get_http_headers()
+    except Exception:
+        pass
+
+    if framework_headers:
+        if token := _extract_oauth_fallback_token_from_headers(framework_headers, header_key):
+            logger.debug(
+                "OAuth fallback token (segment %r) resolved from framework headers.",
+                header_segment,
+            )
+            return token
+
+    ctx_headers = _request_headers_ctx.get()
+    if ctx_headers:
+        if token := _extract_oauth_fallback_token_from_headers(ctx_headers, header_key):
+            logger.debug(
+                "OAuth fallback token (segment %r) resolved from request-headers context.",
+                header_segment,
+            )
+            return token
+
+    return None
+
+
+async def get_oauth_access_token_with_header_fallback(
+    provider_type: str,
+    *,
+    display_name: str,
+    access_token_header_segment: str,
+) -> str | ToolError:
+    """Resolve an OAuth access token via OBO, or from the header for *access_token_header_segment*.
+
+    *provider_type* is passed to :func:`get_access_token`. *access_token_header_segment* builds
+    ``x-datarobot-<segment>-access-token`` (normalized: lower case, ``_`` → ``-``).
+    """
+    pt = provider_type.strip()
+    oauth_exc: BaseException | None = None
+    try:
+        access_token = await get_access_token(pt)
+        if access_token:
+            return access_token
+        logger.debug("OAuth returned empty token; checking header fallback for %s.", pt)
+    except OAuthServiceClientErr as e:
+        oauth_exc = e
+        logger.info(
+            "OAuth token not available for %s (%s); checking header fallback.",
+            pt,
+            e,
+            exc_info=True,
+        )
+    except RuntimeError as e:
+        oauth_exc = e
+        logger.info("No OAuth auth context for %s (%s); checking header fallback.", pt, e)
+    except Exception as e:
+        oauth_exc = e
+        logger.warning(
+            "Unexpected error obtaining OAuth token for %s; checking header fallback: %s",
+            pt,
+            e,
+            exc_info=True,
+        )
+
+    if header_token := resolve_oauth_access_token_from_headers(access_token_header_segment):
+        return header_token
+
+    header = oauth_access_token_header_name(access_token_header_segment)
+    if isinstance(oauth_exc, OAuthServiceClientErr):
+        logger.error("OAuth client error (no header fallback): %s", oauth_exc, exc_info=True)
+        return ToolError(
+            f"Could not obtain access token for {display_name}. Complete the OAuth flow or pass "
+            f"an access token via the {header} header.",
+            kind=ToolErrorKind.AUTHENTICATION,
+        )
+    if isinstance(oauth_exc, RuntimeError):
+        return ToolError(
+            f"No OAuth context for {display_name} and no access token in request headers. "
+            f"Complete the OAuth flow or pass a token via {header}.",
+            kind=ToolErrorKind.AUTHENTICATION,
+        )
+    if oauth_exc is not None:
+        logger.error(
+            "Unexpected error obtaining access token for %s: %s", pt, oauth_exc, exc_info=True
+        )
+        return ToolError(
+            f"An unexpected error occurred while obtaining access token for {display_name}.",
+            kind=ToolErrorKind.INTERNAL,
+        )
+
+    return ToolError(
+        f"Received empty access token for {display_name}. Complete the OAuth flow or pass an "
+        f"access token via the {header} header.",
+        kind=ToolErrorKind.AUTHENTICATION,
+    )
 
 
 def initialize_oauth_middleware(mcp: Any) -> None:

--- a/src/datarobot_genai/drtools/core/clients/atlassian.py
+++ b/src/datarobot_genai/drtools/core/clients/atlassian.py
@@ -19,9 +19,8 @@ from typing import Any
 from typing import Literal
 
 import httpx
-from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
 
-from datarobot_genai.drtools.core.auth import get_access_token
+from datarobot_genai.drtools.core.auth import get_oauth_access_token_with_header_fallback
 from datarobot_genai.drtools.core.exceptions import ToolError
 
 logger = logging.getLogger(__name__)
@@ -40,6 +39,8 @@ async def get_atlassian_access_token() -> str | ToolError:
     """
     Get Atlassian OAuth access token with error handling.
 
+    Uses DataRobot OBO when available; otherwise ``x-datarobot-atlassian-access-token``.
+
     Returns
     -------
         Access token string on success, ToolError on failure
@@ -53,21 +54,11 @@ async def get_atlassian_access_token() -> str | ToolError:
         # Use token
         ```
     """
-    try:
-        access_token = await get_access_token("atlassian")
-        if not access_token:
-            logger.warning("Empty access token received")
-            return ToolError("Received empty access token. Please complete the OAuth flow.")
-        return access_token
-    except OAuthServiceClientErr as e:
-        logger.error(f"OAuth client error: {e}", exc_info=True)
-        return ToolError(
-            "Could not obtain access token for Atlassian. Make sure the OAuth "
-            "permission was granted for the application to act on your behalf."
-        )
-    except Exception as e:
-        logger.error(f"Unexpected error obtaining access token: {e}", exc_info=True)
-        return ToolError("An unexpected error occurred while obtaining access token for Atlassian.")
+    return await get_oauth_access_token_with_header_fallback(
+        "atlassian",
+        display_name="Atlassian",
+        access_token_header_segment="atlassian",
+    )
 
 
 def _find_resource_by_service(

--- a/src/datarobot_genai/drtools/core/clients/datarobot.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot.py
@@ -23,6 +23,7 @@ from datarobot.context import Context as DRContext
 from datarobot_genai.drtools.core.auth import resolve_token_from_headers
 from datarobot_genai.drtools.core.credentials import get_credentials
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,8 @@ async def get_datarobot_access_token() -> str:
         logger.warning("DataRobot API token not found in headers")
         raise ToolError(
             "DataRobot API token not found in headers. "
-            "Please provide it via 'Authorization' (Bearer), 'x-datarobot-api-token' headers."
+            "Please provide it via 'Authorization' (Bearer), 'x-datarobot-api-token' headers.",
+            kind=ToolErrorKind.AUTHENTICATION,
         )
     return token
 

--- a/src/datarobot_genai/drtools/core/clients/gdrive.py
+++ b/src/datarobot_genai/drtools/core/clients/gdrive.py
@@ -23,13 +23,12 @@ from typing import Any
 from typing import Literal
 
 import httpx
-from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 from pypdf import PdfReader
 
-from datarobot_genai.drtools.core.auth import get_access_token
+from datarobot_genai.drtools.core.auth import get_oauth_access_token_with_header_fallback
 from datarobot_genai.drtools.core.exceptions import ToolError
 
 logger = logging.getLogger(__name__)
@@ -80,6 +79,8 @@ async def get_gdrive_access_token() -> str | ToolError:
     """
     Get Google Drive OAuth access token with error handling.
 
+    Uses DataRobot OBO when available; otherwise ``x-datarobot-google-drive-access-token``.
+
     Returns
     -------
         Access token string on success, ToolError on failure
@@ -93,21 +94,11 @@ async def get_gdrive_access_token() -> str | ToolError:
         # Use token
         ```
     """
-    try:
-        access_token = await get_access_token("google")
-        if not access_token:
-            logger.warning("Empty access token received")
-            return ToolError("Received empty access token. Please complete the OAuth flow.")
-        return access_token
-    except OAuthServiceClientErr as e:
-        logger.error(f"OAuth client error: {e}", exc_info=True)
-        return ToolError(
-            "Could not obtain access token for Google. Make sure the OAuth "
-            "permission was granted for the application to act on your behalf."
-        )
-    except Exception as e:
-        logger.error(f"Unexpected error obtaining access token: {e}", exc_info=True)
-        return ToolError("An unexpected error occurred while obtaining access token for Google.")
+    return await get_oauth_access_token_with_header_fallback(
+        "google",
+        display_name="Google",
+        access_token_header_segment="google-drive",
+    )
 
 
 class GoogleDriveError(Exception):

--- a/src/datarobot_genai/drtools/core/clients/microsoft_graph.py
+++ b/src/datarobot_genai/drtools/core/clients/microsoft_graph.py
@@ -20,11 +20,10 @@ from typing import Literal
 from urllib.parse import quote
 
 import httpx
-from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
 from pydantic import BaseModel
 from pydantic import Field
 
-from datarobot_genai.drtools.core.auth import get_access_token
+from datarobot_genai.drtools.core.auth import get_oauth_access_token_with_header_fallback
 from datarobot_genai.drtools.core.exceptions import ToolError
 
 logger = logging.getLogger(__name__)
@@ -36,6 +35,8 @@ MAX_SEARCH_RESULTS = 250
 async def get_microsoft_graph_access_token() -> str | ToolError:
     """
     Get Microsoft Graph OAuth access token with error handling.
+
+    Uses DataRobot OBO when available; otherwise ``x-datarobot-microsoft-graph-access-token``.
 
     Returns
     -------
@@ -50,22 +51,11 @@ async def get_microsoft_graph_access_token() -> str | ToolError:
         # Use token
         ```
     """
-    try:
-        access_token = await get_access_token("microsoft")
-        if not access_token:
-            logger.warning("Empty access token received")
-            return ToolError("Received empty access token. Please complete the OAuth flow.")
-        return access_token
-    except OAuthServiceClientErr as e:
-        logger.error(f"OAuth client error: {e}", exc_info=True)
-        return ToolError(
-            "Could not obtain access token for Microsoft. Make sure the OAuth "
-            "permission was granted for the application to act on your behalf."
-        )
-    except Exception as e:
-        error_msg = str(e)
-        logger.error(f"Unexpected error obtaining access token: {error_msg}", exc_info=True)
-        return ToolError("An unexpected error occurred while obtaining access token for Microsoft.")
+    return await get_oauth_access_token_with_header_fallback(
+        "microsoft",
+        display_name="Microsoft",
+        access_token_header_segment="microsoft-graph",
+    )
 
 
 class MicrosoftGraphError(Exception):

--- a/src/datarobot_genai/drtools/core/clients/perplexity.py
+++ b/src/datarobot_genai/drtools/core/clients/perplexity.py
@@ -29,6 +29,7 @@ from pydantic import Field
 
 from datarobot_genai.drtools.core.auth import get_api_key_from_headers
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
@@ -68,11 +69,15 @@ async def get_perplexity_access_token() -> str | ToolError:
         logger.warning("Perplexity API key not found in headers.")
         return ToolError(
             "Perplexity API key not found in headers. "
-            "Please provide it via 'x-perplexity-api-key' header."
+            "Please provide it via 'x-perplexity-api-key' header.",
+            kind=ToolErrorKind.AUTHENTICATION,
         )
     except Exception as e:
         logger.error(f"Unexpected error obtaining Perplexity API key: {e}.", exc_info=e)
-        return ToolError("An unexpected error occurred while obtaining Perplexity API key.")
+        return ToolError(
+            "An unexpected error occurred while obtaining Perplexity API key.",
+            kind=ToolErrorKind.INTERNAL,
+        )
 
 
 class PerplexityError(Exception):

--- a/src/datarobot_genai/drtools/core/clients/tavily.py
+++ b/src/datarobot_genai/drtools/core/clients/tavily.py
@@ -25,6 +25,7 @@ from tavily import AsyncTavilyClient
 
 from datarobot_genai.drtools.core.auth import get_api_key_from_headers
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,8 @@ async def get_tavily_access_token() -> str:
 
     logger.warning("Tavily API key not found in headers")
     raise ToolError(
-        "Tavily API key not found in headers. Please provide it via 'x-tavily-api-key' header."
+        "Tavily API key not found in headers. Please provide it via 'x-tavily-api-key' header.",
+        kind=ToolErrorKind.AUTHENTICATION,
     )
 
 

--- a/src/datarobot_genai/drtools/core/exceptions.py
+++ b/src/datarobot_genai/drtools/core/exceptions.py
@@ -14,6 +14,23 @@
 
 """Custom exceptions for DataRobot tools."""
 
+from enum import StrEnum
+
+
+class ToolErrorKind(StrEnum):
+    """High-level category for tool failures (logging and MCP-friendly).
+
+    ``SCHEMA`` — tool call arguments do not match the tool input schema (MCP/JSON shape, types,
+    required fields). Use ``VALIDATION`` for domain rules enforced inside the tool body.
+    """
+
+    SCHEMA = "schema"
+    VALIDATION = "validation"
+    AUTHENTICATION = "authentication"
+    NOT_FOUND = "not_found"
+    UPSTREAM = "upstream"
+    INTERNAL = "internal"
+
 
 class ToolError(Exception):
     """Drop-in replacement for fastmcp.exceptions.ToolError.
@@ -30,27 +47,31 @@ class ToolError(Exception):
     Attributes
     ----------
         message: The error message to be displayed to the user.
+        kind: Semantic category of the failure (defaults to INTERNAL). Use ``ToolErrorKind.SCHEMA``
+            when MCP tool-call JSON or types do not match the declared input schema.
         args: Tuple containing the error message (for compatibility with base Exception).
 
     Examples
     --------
         >>> raise ToolError("Failed to create deployment: No prediction servers available")
-        >>> raise ToolError(f"Job failed with status {job.status}")
+        >>> raise ToolError(f"Job failed with status {job.status}", kind=ToolErrorKind.UPSTREAM)
         >>> try:
         ...     risky_operation()
         ... except ValueError as e:
-        ...     raise ToolError(f"Invalid input: {e}")
+        ...     raise ToolError(f"Invalid input: {e}", kind=ToolErrorKind.VALIDATION)
+        >>> raise ToolError("Arguments do not match tool schema", kind=ToolErrorKind.SCHEMA)
     """
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, *, kind: ToolErrorKind = ToolErrorKind.INTERNAL) -> None:
         """Initialize the ToolError with a descriptive message.
 
         Args:
             message: A clear, user-friendly description of what went wrong.
-                    This message will be displayed to the end user.
+                This message will be displayed to the end user.
+            kind: Category used for routing, metrics, and MCP error strings.
         """
         self.message = message
-        # Call parent constructor with message to ensure args[0] is set
+        self.kind = kind
         super().__init__(message)
 
     def __str__(self) -> str:
@@ -59,4 +80,4 @@ class ToolError(Exception):
 
     def __repr__(self) -> str:
         """Return a string representation of the exception."""
-        return f"{self.__class__.__name__}({self.message!r})"
+        return f"{self.__class__.__name__}({self.message!r}, kind={self.kind!r})"

--- a/src/datarobot_genai/drtools/core/utils.py
+++ b/src/datarobot_genai/drtools/core/utils.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from .constants import MAX_INLINE_SIZE
 from .exceptions import ToolError
+from .exceptions import ToolErrorKind
 
 
 def is_valid_url(url: str) -> bool:
@@ -47,5 +48,6 @@ def predictions_result_response(df: Any, show_explanations: bool = False) -> Pre
         f"Prediction CSV is {encoded_len} bytes, which exceeds the inline limit "
         f"of {MAX_INLINE_SIZE} bytes. "
         "Use batch prediction (for example predict_by_ai_catalog) for large outputs, "
-        "or reduce rows or explanations."
+        "or reduce rows or explanations.",
+        kind=ToolErrorKind.VALIDATION,
     )

--- a/src/datarobot_genai/drtools/dr_docs/tools.py
+++ b/src/datarobot_genai/drtools/dr_docs/tools.py
@@ -45,11 +45,20 @@ from datarobot_genai.drtools.core.clients.dr_docs import MAX_RESULTS_DEFAULT
 from datarobot_genai.drtools.core.clients.dr_docs import fetch_page_content
 from datarobot_genai.drtools.core.clients.dr_docs import search_docs
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"datarobot", "docs", "documentation", "search"})
+@tool_metadata(
+    tags={"dr_docs", "datarobot", "docs", "documentation", "search"},
+    description=(
+        "[DR docs—search] Use when the user asks about DataRobot agentic AI product behavior, "
+        "setup, or APIs covered on the public agentic-AI documentation site. Returns page titles "
+        "and URLs (then fetch_datarobot_doc_page for full text). Not Confluence, not general web "
+        "(tavily_search / perplexity_search)."
+    ),
+)
 async def search_datarobot_agentic_docs(
     *,
     query: Annotated[
@@ -63,26 +72,10 @@ async def search_datarobot_agentic_docs(
         f"Maximum number of documentation pages to return (allowable values: 1 to {MAX_RESULTS}).",
     ] = MAX_RESULTS_DEFAULT,
 ) -> dict[str, Any]:
-    """
-    Search the DataRobot agentic-AI documentation for relevant pages.
-
-    This tool searches through the DataRobot agentic-AI documentation at
-    https://docs.datarobot.com/en/docs/agentic-ai/ to find pages relevant
-    to your query. It returns page titles, URLs, and page contents.
-
-    No API keys are required — the tool indexes the public documentation
-    site using TF-IDF over real page titles and page text.
-
-    Usage:
-        - Find MCP info: search_datarobot_agentic_docs(query="MCP server setup")
-        - Find agent tools: search_datarobot_agentic_docs(query="agentic tools")
-        - Broad search: search_datarobot_agentic_docs(query="authentication", max_results=10)
-
-    Note:
-        - The index covers only https://docs.datarobot.com/en/docs/agentic-ai/ (~28 pages).
-    """
     if not query or not query.strip():
-        raise ToolError("Argument validation error: 'query' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'query' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     results = await search_docs(query=query, max_results=max_results)
 
@@ -108,7 +101,14 @@ async def search_datarobot_agentic_docs(
     return flat
 
 
-@tool_metadata(tags={"datarobot", "docs", "documentation", "fetch", "read"})
+@tool_metadata(
+    tags={"dr_docs", "datarobot", "docs", "documentation", "fetch", "read"},
+    description=(
+        "[DR docs—fetch page] Use when you already have a full docs.datarobot.com English docs URL "
+        "(e.g. from search results) and need the page body as text. Not keyword search across the "
+        "agentic docs index (search_datarobot_agentic_docs)."
+    ),
+)
 async def fetch_datarobot_doc_page(
     *,
     url: Annotated[
@@ -117,22 +117,10 @@ async def fetch_datarobot_doc_page(
         "Must be a URL from docs.datarobot.com/en/docs/.",
     ],
 ) -> dict[str, Any]:
-    """
-    Fetch and extract the text content of a specific DataRobot documentation page.
-
-    Use this tool to retrieve the full content of a relevant documentation page. The content is
-    extracted as clean text, suitable for reading and analysis.
-
-    Usage:
-        - Fetch a page: fetch_datarobot_doc_page(
-            url="https://docs.datarobot.com/en/docs/mlops/deployment/index.html"
-          )
-
-    Note:
-        - Only works with English DataRobot documentation URLs (e.g. docs.datarobot.com/en/docs/).
-    """
     if not url or not url.strip():
-        raise ToolError("Argument validation error: 'url' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'url' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     result = await fetch_page_content(url=url)
     return result

--- a/src/datarobot_genai/drtools/gdrive/tools.py
+++ b/src/datarobot_genai/drtools/gdrive/tools.py
@@ -31,13 +31,23 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
+_DRIVE_SEARCH_DOCS = "https://developers.google.com/drive/api/guides/search-files"
+_DRIVE_EXPORT_DOCS = "https://developers.google.com/workspace/drive/api/guides/ref-export-formats"
+_DRIVE_CREATE_DOCS = "https://developers.google.com/drive/api/guides/create-file"
+_DRIVE_FILES_UPDATE_DOCS = "https://developers.google.com/drive/api/reference/rest/v3/files/update"
+_DRIVE_PERMISSIONS_DOCS = "https://developers.google.com/drive/api/guides/manage-sharing"
+
 
 @tool_metadata(
     tags={"gdrive", "google", "list", "search", "files", "find", "contents"},
     description=(
         "[GDrive—find files] Use when the user needs Google Drive file names and ids with "
         "optional folder scope, Drive query string, and pagination. Not file body text "
-        "(gdrive_read_content), not SharePoint (microsoft_graph_search_content)."
+        "(gdrive_read_content), not SharePoint (microsoft_graph_search_content).\n\n"
+        f"limit must be >= page_size and a multiple of page_size (page_size max {MAX_PAGE_SIZE}, "
+        f"limit max {LIMIT}). Examples: page_size=10, limit=50; page_size=3, limit=3; "
+        "page_size=12, limit=36.\n\n"
+        f"Reference: {_DRIVE_SEARCH_DOCS}"
     ),
 )
 async def gdrive_find_contents(
@@ -97,7 +107,14 @@ async def gdrive_find_contents(
     description=(
         "[GDrive—read file] Use when you have a Drive file_id (from gdrive_find_contents) and need "
         "exported text or markdown for Workspace types. Not listing files, not binary media "
-        "download."
+        "download.\n\n"
+        'Examples: gdrive_read_content(file_id="1ABC123def456"); '
+        'gdrive_read_content(file_id="1ABC...", target_format="text/plain"). '
+        "Discover file_id with gdrive_find_contents first.\n\n"
+        "Defaults: Google Docs -> text/markdown; Sheets -> text/csv; Slides -> text/plain; "
+        "PDF -> text/plain; other text as-is. Binary files are not supported; large exports "
+        "may fail.\n\n"
+        f"Reference (export MIME types): {_DRIVE_EXPORT_DOCS}"
     ),
 )
 async def gdrive_read_content(
@@ -131,7 +148,11 @@ async def gdrive_read_content(
     description=(
         "[GDrive—create file] Use when creating a new Drive file or folder from name + MIME type, "
         "optional parent folder and initial text. Not search (gdrive_find_contents), not "
-        "metadata-only updates (gdrive_update_metadata)."
+        "metadata-only updates (gdrive_update_metadata).\n\n"
+        'Examples: gdrive_create_file(name="report.txt", mime_type="text/plain"); '
+        "Google Doc with initial_content; folder with mime_type "
+        "application/vnd.google-apps.folder; file in folder via parent_id.\n\n"
+        f"Reference: {_DRIVE_CREATE_DOCS}"
     ),
 )
 async def gdrive_create_file(
@@ -179,7 +200,10 @@ async def gdrive_create_file(
     enabled=False,
     description=(
         "[GDrive—metadata] Use when renaming, starring, or trashing an existing file by id. "
-        "Not reading content (gdrive_read_content), not ACL changes (gdrive_manage_access)."
+        "Not reading content (gdrive_read_content), not ACL changes (gdrive_manage_access).\n\n"
+        "Examples: new_name only; starred=True/False; trash=True/restore False; combine fields. "
+        "At least one of new_name, starred, or trash is required.\n\n"
+        f"Reference: {_DRIVE_FILES_UPDATE_DOCS}"
     ),
 )
 async def gdrive_update_metadata(
@@ -227,7 +251,10 @@ async def gdrive_update_metadata(
     enabled=False,
     description=(
         "[GDrive—permissions] Use when adding, changing, or removing sharing on a file by id "
-        "(email or permission id). Not rename/trash (gdrive_update_metadata), not read content."
+        "(email or permission id). Not rename/trash (gdrive_update_metadata), not read content.\n\n"
+        'Examples: action="add", role="reader", email_address="user@example.com"; '
+        'action="update" with permission_id; action="remove" with permission_id.\n\n'
+        f"Reference: {_DRIVE_PERMISSIONS_DOCS}"
     ),
 )
 async def gdrive_manage_access(

--- a/src/datarobot_genai/drtools/gdrive/tools.py
+++ b/src/datarobot_genai/drtools/gdrive/tools.py
@@ -27,11 +27,19 @@ from datarobot_genai.drtools.core.clients.gdrive import SUPPORTED_FIELDS_STR
 from datarobot_genai.drtools.core.clients.gdrive import GoogleDriveClient
 from datarobot_genai.drtools.core.clients.gdrive import get_gdrive_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"google", "gdrive", "list", "search", "files", "find", "contents"})
+@tool_metadata(
+    tags={"gdrive", "google", "list", "search", "files", "find", "contents"},
+    description=(
+        "[GDrive—find files] Use when the user needs Google Drive file names and ids with "
+        "optional folder scope, Drive query string, and pagination. Not file body text "
+        "(gdrive_read_content), not SharePoint (microsoft_graph_search_content)."
+    ),
+)
 async def gdrive_find_contents(
     *,
     page_size: Annotated[
@@ -60,18 +68,6 @@ async def gdrive_find_contents(
         f"Default = {SUPPORTED_FIELDS_STR}",
     ] = None,
 ) -> dict[str, Any]:
-    """
-    Search or list files in the user's Google Drive with pagination and filtering support.
-    Use this tool to discover GDrive file names and IDs for use with other tools.
-
-    Limit must be bigger than or equal to page size and it must be multiplication of page size.
-
-    Examples
-    --------
-        - page size = 10 limit = 50
-        - page size = 3 limit = 3
-        - page size = 12 limit = 36
-    """
     access_token = await get_gdrive_access_token()
     if isinstance(access_token, ToolError):
         raise access_token
@@ -96,7 +92,14 @@ async def gdrive_find_contents(
     }
 
 
-@tool_metadata(tags={"google", "gdrive", "read", "content", "file", "download"})
+@tool_metadata(
+    tags={"gdrive", "google", "read", "content", "file", "download"},
+    description=(
+        "[GDrive—read file] Use when you have a Drive file_id (from gdrive_find_contents) and need "
+        "exported text or markdown for Workspace types. Not listing files, not binary media "
+        "download."
+    ),
+)
 async def gdrive_read_content(
     *,
     file_id: Annotated[str, "The ID of the file to read."],
@@ -107,29 +110,10 @@ async def gdrive_read_content(
         "If not specified, uses sensible defaults. Has no effect on regular files.",
     ] = None,
 ) -> dict[str, Any]:
-    """
-    Retrieve the content of a specific Google drive file by its ID.
-
-    Usage:
-        - Basic: gdrive_read_content(file_id="1ABC123def456")
-        - Custom format: gdrive_read_content(file_id="1ABC...", target_format="text/plain")
-        - First use gdrive_find_contents to discover file IDs
-
-    Supported conversions (defaults):
-        - Google Docs -> Markdown (text/markdown)
-        - Google Sheets -> CSV (text/csv)
-        - Google Slides -> Plain text (text/plain)
-        - PDF files -> Extracted text (text/plain)
-        - Other text files -> Downloaded as-is
-
-    Note: Binary files (images, videos, etc.) are not supported and will return an error.
-    Large Google Workspace files (>10MB) may fail to export due to API limits.
-
-    Refer to Google Drive export formats documentation:
-    https://developers.google.com/workspace/drive/api/guides/ref-export-formats
-    """
     if not file_id or not file_id.strip():
-        raise ToolError("Argument validation error: 'file_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'file_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     access_token = await get_gdrive_access_token()
     if isinstance(access_token, ToolError):
@@ -141,7 +125,15 @@ async def gdrive_read_content(
     return file_content.as_flat_dict()
 
 
-@tool_metadata(tags={"google", "gdrive", "create", "write", "file", "folder"}, enabled=False)
+@tool_metadata(
+    tags={"gdrive", "google", "create", "write", "file", "folder"},
+    enabled=False,
+    description=(
+        "[GDrive—create file] Use when creating a new Drive file or folder from name + MIME type, "
+        "optional parent folder and initial text. Not search (gdrive_find_contents), not "
+        "metadata-only updates (gdrive_update_metadata)."
+    ),
+)
 async def gdrive_create_file(
     *,
     name: Annotated[str, "The name for the new file or folder."],
@@ -157,44 +149,15 @@ async def gdrive_create_file(
         str | None, "Text content to populate the new file, if applicable."
     ] = None,
 ) -> dict[str, Any]:
-    """
-    Create a new file or folder in Google Drive.
-
-    This tool is essential for an AI agent to generate new output (like reports or
-    documentation) directly into the Drive structure.
-
-    Usage:
-        - Create empty file: gdrive_create_file(name="report.txt", mime_type="text/plain")
-        - Create Google Doc: gdrive_create_file(
-            name="My Report",
-            mime_type="application/vnd.google-apps.document",
-            initial_content="# Report Title"
-          )
-        - Create folder: gdrive_create_file(
-            name="Reports",
-            mime_type="application/vnd.google-apps.folder"
-          )
-        - Create in subfolder: gdrive_create_file(
-            name="file.txt",
-            mime_type="text/plain",
-            parent_id="folder_id_here",
-            initial_content="File content"
-          )
-
-    Supported MIME types:
-        - text/plain: Plain text file
-        - application/vnd.google-apps.document: Google Doc (content auto-converted)
-        - application/vnd.google-apps.spreadsheet: Google Sheet (CSV content works best)
-        - application/vnd.google-apps.folder: Folder (initial_content is ignored)
-
-    Note: For Google Workspace files, the Drive API automatically converts plain text
-    content to the appropriate format.
-    """
     if not name or not name.strip():
-        raise ToolError("Argument validation error: 'name' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'name' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if not mime_type or not mime_type.strip():
-        raise ToolError("Argument validation error: 'mime_type' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'mime_type' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     access_token = await get_gdrive_access_token()
     if isinstance(access_token, ToolError):
@@ -212,7 +175,12 @@ async def gdrive_create_file(
 
 
 @tool_metadata(
-    tags={"google", "gdrive", "update", "metadata", "rename", "star", "trash"}, enabled=False
+    tags={"gdrive", "google", "update", "metadata", "rename", "star", "trash"},
+    enabled=False,
+    description=(
+        "[GDrive—metadata] Use when renaming, starring, or trashing an existing file by id. "
+        "Not reading content (gdrive_read_content), not ACL changes (gdrive_manage_access)."
+    ),
 )
 async def gdrive_update_metadata(
     *,
@@ -221,39 +189,23 @@ async def gdrive_update_metadata(
     starred: Annotated[bool | None, "Set to True to star the file or False to unstar it."] = None,
     trash: Annotated[bool | None, "Set to True to trash the file or False to restore it."] = None,
 ) -> dict[str, Any]:
-    """
-    Update non-content metadata fields of a Google Drive file or folder.
-
-    This tool allows you to:
-    - Rename files and folders by setting new_name
-    - Star or unstar files (per-user preference) with starred
-    - Move files to trash or restore them with trash
-
-    Usage:
-        - Rename: gdrive_update_metadata(file_id="1ABC...", new_name="New Name.txt")
-        - Star: gdrive_update_metadata(file_id="1ABC...", starred=True)
-        - Unstar: gdrive_update_metadata(file_id="1ABC...", starred=False)
-        - Trash: gdrive_update_metadata(file_id="1ABC...", trash=True)
-        - Restore: gdrive_update_metadata(file_id="1ABC...", trash=False)
-        - Multiple: gdrive_update_metadata(file_id="1ABC...", new_name="New.txt", starred=True)
-
-    Note:
-        - At least one of new_name, starred, or trash must be provided.
-        - Starring is per-user: starring a shared file only affects your view.
-        - Trashing a folder trashes all contents recursively.
-        - Trashing requires permissions (owner for My Drive, organizer for Shared Drives).
-    """
     if not file_id or not file_id.strip():
-        raise ToolError("Argument validation error: 'file_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'file_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if new_name is None and starred is None and trash is None:
         raise ToolError(
             "Argument validation error: at least one of 'new_name', 'starred', or 'trash' "
-            "must be provided."
+            "must be provided.",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     if new_name is not None and not new_name.strip():
-        raise ToolError("Argument validation error: 'new_name' cannot be empty or whitespace.")
+        raise ToolError(
+            "Argument validation error: 'new_name' cannot be empty or whitespace.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     access_token = await get_gdrive_access_token()
     if isinstance(access_token, ToolError):
@@ -270,14 +222,26 @@ async def gdrive_update_metadata(
     return updated_file.as_flat_dict()
 
 
-@tool_metadata(tags={"google", "gdrive", "manage", "access", "acl"}, enabled=False)
+@tool_metadata(
+    tags={"gdrive", "google", "manage", "access", "acl"},
+    enabled=False,
+    description=(
+        "[GDrive—permissions] Use when adding, changing, or removing sharing on a file by id "
+        "(email or permission id). Not rename/trash (gdrive_update_metadata), not read content."
+    ),
+)
 async def gdrive_manage_access(
     *,
     file_id: Annotated[str, "The ID of the file or folder."],
-    action: Annotated[Literal["add", "update", "remove"], "The operation to perform."],
+    action: Annotated[
+        Literal["add", "update", "remove"],
+        "Pass exactly one of these strings: 'add', 'update', 'remove'.",
+    ],
     role: Annotated[
         Literal["reader", "commenter", "writer", "fileOrganizer", "organizer", "owner"] | None,
-        "The access level.",
+        "Required for 'add' and 'update' (omit for 'remove'). Pass exactly one of these strings "
+        "(camelCase as shown): 'reader', 'commenter', 'writer', 'fileOrganizer', 'organizer', "
+        "'owner'.",
     ] = None,
     email_address: Annotated[
         str | None, "The email of the user or group (required for 'add')."
@@ -289,40 +253,26 @@ async def gdrive_manage_access(
         bool, "Whether to transfer ownership (only for 'update' to 'owner' role)."
     ] = False,
 ) -> dict[str, Any]:
-    """
-    Consolidated tool for sharing files and managing permissions.
-    Pushes all logic to the Google Drive API permissions resource (create, update, delete).
-
-    Usage:
-        - Add role: gdrive_manage_access(
-            file_id="SomeFileId",
-            action="add",
-            role="reader",
-            email_address="dummy@user.com"
-          )
-        - Update role: gdrive_manage_access(
-            file_id="SomeFileId",
-            action="update",
-            role="reader",
-            permission_id="SomePermissionId"
-          )
-        - Remove permission: gdrive_manage_access(
-            file_id="SomeFileId",
-            action="remove",
-            permission_id="SomePermissionId"
-          )
-    """
     if not file_id or not file_id.strip():
-        raise ToolError("Argument validation error: 'file_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'file_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if action == "add" and not email_address:
-        raise ToolError("'email_address' is required for action 'add'.")
+        raise ToolError(
+            "'email_address' is required for action 'add'.", kind=ToolErrorKind.VALIDATION
+        )
 
     if action in ("update", "remove") and not permission_id:
-        raise ToolError("'permission_id' is required for action 'update' or 'remove'.")
+        raise ToolError(
+            "'permission_id' is required for action 'update' or 'remove'.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     if action != "remove" and not role:
-        raise ToolError("'role' is required for action 'add' or 'update'.")
+        raise ToolError(
+            "'role' is required for action 'add' or 'update'.", kind=ToolErrorKind.VALIDATION
+        )
 
     access_token = await get_gdrive_access_token()
     if isinstance(access_token, ToolError):

--- a/src/datarobot_genai/drtools/jira/tools.py
+++ b/src/datarobot_genai/drtools/jira/tools.py
@@ -20,11 +20,19 @@ from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.atlassian import get_atlassian_access_token
 from datarobot_genai.drtools.core.clients.jira import JiraClient
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"jira", "search", "issues"})
+@tool_metadata(
+    tags={"jira", "search", "issues"},
+    description=(
+        "[Jira—search issues] Use when filtering many issues with JQL (project, status, text, "
+        "dates, assignee, etc.). Returns matching issues as summaries. Not one known issue key "
+        "(jira_get_issue), not Confluence (confluence_search)."
+    ),
+)
 async def jira_search_issues(
     *,
     jql_query: Annotated[
@@ -32,17 +40,10 @@ async def jira_search_issues(
     ],
     max_results: Annotated[int, "Maximum number of issues to return. Default is 50."] = 50,
 ) -> dict[str, Any]:
-    """
-    Search for Jira issues using a powerful JQL query string.
-
-    Refer to JQL documentation for advanced query construction:
-    JQL functions: https://support.atlassian.com/jira-service-management-cloud/docs/jql-functions/
-    JQL fields: https://support.atlassian.com/jira-service-management-cloud/docs/jql-fields/
-    JQL keywords: https://support.atlassian.com/jira-service-management-cloud/docs/use-advanced-search-with-jira-query-language-jql/
-    JQL operators: https://support.atlassian.com/jira-service-management-cloud/docs/jql-operators/
-    """
     if not jql_query:
-        raise ToolError("Argument validation error: 'jql_query' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'jql_query' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     access_token = await get_atlassian_access_token()
     if isinstance(access_token, ToolError):
@@ -57,13 +58,20 @@ async def jira_search_issues(
     }
 
 
-@tool_metadata(tags={"jira", "read", "get", "issue"})
+@tool_metadata(
+    tags={"jira", "read", "get", "issue"},
+    description=(
+        "[Jira—get issue] Use when you already have an issue key (e.g. PROJ-123) and need full "
+        "fields and current values. Read-only. Not JQL multi-issue search (jira_search_issues)."
+    ),
+)
 async def jira_get_issue(
     *, issue_key: Annotated[str, "The key (ID) of the Jira issue to retrieve, e.g., 'PROJ-123'."]
 ) -> dict[str, Any]:
-    """Retrieve all fields and details for a single Jira issue by its key."""
     if not issue_key:
-        raise ToolError("Argument validation error: 'issue_key' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'issue_key' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     access_token = await get_atlassian_access_token()
     if isinstance(access_token, ToolError):
@@ -75,7 +83,14 @@ async def jira_get_issue(
     return issue.as_flat_dict()
 
 
-@tool_metadata(tags={"jira", "create", "add", "issue"})
+@tool_metadata(
+    tags={"jira", "create", "add", "issue"},
+    description=(
+        "[Jira—create issue] Use when opening a new work item: project key, summary, and issue "
+        "type name (Task/Bug/Story as configured). Optional description. Not status moves "
+        "(jira_transition_issue), not field patches on existing issues (jira_update_issue)."
+    ),
+)
 async def jira_create_issue(
     *,
     project_key: Annotated[str, "The key of the project where the issue should be created."],
@@ -83,10 +98,10 @@ async def jira_create_issue(
     issue_type: Annotated[str, "The type of issue to create (e.g., 'Task', 'Bug', 'Story')."],
     description: Annotated[str | None, "Detailed description of the issue."] = None,
 ) -> dict[str, Any]:
-    """Create a new Jira issue with mandatory project, summary, and type information."""
     if not all([project_key, summary, issue_type]):
         raise ToolError(
-            "Argument validation error: project_key, summary, and issue_type are required fields."
+            "Argument validation error: project_key, summary, and issue_type are required fields.",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     access_token = await get_atlassian_access_token()
@@ -102,9 +117,10 @@ async def jira_create_issue(
             issue_type_id = issue_types[issue_type]
         except KeyError:
             possible_issue_types = ",".join(issue_types)
-            raise ToolError(
+            msg = (
                 f"Unexpected issue type `{issue_type}`. Possible values are {possible_issue_types}."
             )
+            raise ToolError(msg, kind=ToolErrorKind.VALIDATION)
 
     async with JiraClient(access_token) as client:
         issue_key = await client.create_jira_issue(
@@ -117,7 +133,14 @@ async def jira_create_issue(
     return {"newIssueKey": issue_key, "projectKey": project_key}
 
 
-@tool_metadata(tags={"jira", "update", "edit", "issue"})
+@tool_metadata(
+    tags={"jira", "update", "edit", "issue"},
+    description=(
+        "[Jira—update fields] Use when changing field values on an existing issue (summary, "
+        "description, custom fields) by key; values must match Jira field formats. Not workflow "
+        "status changes (jira_transition_issue), not create (jira_create_issue)."
+    ),
+)
 async def jira_update_issue(
     *,
     issue_key: Annotated[str, "The key (ID) of the Jira issue to retrieve, e.g., 'PROJ-123'."],
@@ -126,34 +149,14 @@ async def jira_update_issue(
         "A dictionary of field names and their new values (e.g., {'summary': 'New content'}).",
     ],
 ) -> dict[str, Any]:
-    """
-    Modify descriptive fields or custom fields on an existing Jira issue using its key.
-    If you want to update issue status you should use `jira_transition_issue` tool instead.
-
-    Some fields needs very specific schema to allow update.
-    You should follow jira rest api guidance.
-    Good example is description field:
-        "description": {
-            "type": "text",
-            "version": 1,
-            "text": [
-                {
-                    "type": "paragraph",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "[HERE YOU PUT REAL DESCRIPTION]"
-                        }
-                    ]
-                }
-            ]
-        }
-    """
     if not issue_key:
-        raise ToolError("Argument validation error: 'issue_key' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'issue_key' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
     if not fields_to_update or not isinstance(fields_to_update, dict):
         raise ToolError(
-            "Argument validation error: 'fields_to_update' must be a non-empty dictionary."
+            "Argument validation error: 'fields_to_update' must be a non-empty dictionary.",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     access_token = await get_atlassian_access_token()
@@ -168,7 +171,14 @@ async def jira_update_issue(
     return {"updatedIssueKey": issue_key, "fields": updated_fields}
 
 
-@tool_metadata(tags={"jira", "update", "transition", "issue"})
+@tool_metadata(
+    tags={"jira", "update", "transition", "issue"},
+    description=(
+        "[Jira—transition status] Use when moving an existing issue along its workflow by exact "
+        "transition name (e.g. 'In Progress'). Not arbitrary field edits (jira_update_issue), "
+        "not new issues (jira_create_issue)."
+    ),
+)
 async def jira_transition_issue(
     *,
     issue_key: Annotated[str, "The key (ID) of the Jira issue to transition, e.g. 'PROJ-123'."],
@@ -176,12 +186,11 @@ async def jira_transition_issue(
         str, "The exact name of the target status/transition (e.g., 'In Progress')."
     ],
 ) -> dict[str, Any]:
-    """
-    Move a Jira issue through its defined workflow to a new status.
-    This leverages Jira's workflow engine directly.
-    """
     if not all([issue_key, transition_name]):
-        raise ToolError("Argument validation error: issue_key and transition name/ID are required.")
+        raise ToolError(
+            "Argument validation error: issue_key and transition name/ID are required.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     access_token = await get_atlassian_access_token()
     if isinstance(access_token, ToolError):
@@ -196,7 +205,8 @@ async def jira_transition_issue(
             available_transitions_str = ",".join(available_transitions)
             raise ToolError(
                 f"Unexpected transition name `{transition_name}`. "
-                f"Possible values are {available_transitions_str}."
+                f"Possible values are {available_transitions_str}.",
+                kind=ToolErrorKind.VALIDATION,
             )
 
     async with JiraClient(access_token) as client:

--- a/src/datarobot_genai/drtools/jira/tools.py
+++ b/src/datarobot_genai/drtools/jira/tools.py
@@ -24,13 +24,25 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
+_JQL_FUNCTIONS = "https://support.atlassian.com/jira-service-management-cloud/docs/jql-functions/"
+_JQL_FIELDS = "https://support.atlassian.com/jira-service-management-cloud/docs/jql-fields/"
+_JQL_KEYWORDS = (
+    "https://support.atlassian.com/jira-service-management-cloud/docs/"
+    "use-advanced-search-with-jira-query-language-jql/"
+)
+_JQL_OPERATORS = "https://support.atlassian.com/jira-service-management-cloud/docs/jql-operators/"
+_JIRA_ISSUES_REST = "https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/"
+
 
 @tool_metadata(
     tags={"jira", "search", "issues"},
     description=(
         "[Jira—search issues] Use when filtering many issues with JQL (project, status, text, "
         "dates, assignee, etc.). Returns matching issues as summaries. Not one known issue key "
-        "(jira_get_issue), not Confluence (confluence_search)."
+        "(jira_get_issue), not Confluence (confluence_search).\n\n"
+        'Example: jql_query="project = PROJ AND status = Open", max_results=50.\n\n'
+        "JQL references: "
+        f"{_JQL_FUNCTIONS} {_JQL_FIELDS} {_JQL_KEYWORDS} {_JQL_OPERATORS}"
     ),
 )
 async def jira_search_issues(
@@ -62,7 +74,8 @@ async def jira_search_issues(
     tags={"jira", "read", "get", "issue"},
     description=(
         "[Jira—get issue] Use when you already have an issue key (e.g. PROJ-123) and need full "
-        "fields and current values. Read-only. Not JQL multi-issue search (jira_search_issues)."
+        "fields and current values. Read-only. Not JQL multi-issue search (jira_search_issues).\n\n"
+        f'Example: issue_key="PROJ-123".\n\nReference: {_JIRA_ISSUES_REST}'
     ),
 )
 async def jira_get_issue(
@@ -88,7 +101,10 @@ async def jira_get_issue(
     description=(
         "[Jira—create issue] Use when opening a new work item: project key, summary, and issue "
         "type name (Task/Bug/Story as configured). Optional description. Not status moves "
-        "(jira_transition_issue), not field patches on existing issues (jira_update_issue)."
+        "(jira_transition_issue), not field patches on existing issues (jira_update_issue).\n\n"
+        'Example: project_key="PROJ", summary="Fix login", issue_type="Bug", '
+        'description="Steps...".\n\n'
+        f"Reference: {_JIRA_ISSUES_REST}"
     ),
 )
 async def jira_create_issue(
@@ -138,7 +154,11 @@ async def jira_create_issue(
     description=(
         "[Jira—update fields] Use when changing field values on an existing issue (summary, "
         "description, custom fields) by key; values must match Jira field formats. Not workflow "
-        "status changes (jira_transition_issue), not create (jira_create_issue)."
+        "status changes (jira_transition_issue), not create (jira_create_issue).\n\n"
+        "Example fields_to_update for description (ADF-style JSON): "
+        '{"description": {"type": "text", "version": 1, "text": [{"type": "paragraph", '
+        '"content": [{"type": "text", "text": "<your text>"}]}]}}\n\n'
+        f"Reference: {_JIRA_ISSUES_REST}"
     ),
 )
 async def jira_update_issue(
@@ -176,7 +196,10 @@ async def jira_update_issue(
     description=(
         "[Jira—transition status] Use when moving an existing issue along its workflow by exact "
         "transition name (e.g. 'In Progress'). Not arbitrary field edits (jira_update_issue), "
-        "not new issues (jira_create_issue)."
+        "not new issues (jira_create_issue).\n\n"
+        'Example: issue_key="PROJ-123", transition_name="In Progress" (names come from '
+        "the workflow; use the exact label returned for the issue).\n\n"
+        f"Reference: {_JIRA_ISSUES_REST}"
     ),
 )
 async def jira_transition_issue(

--- a/src/datarobot_genai/drtools/microsoft_graph/tools.py
+++ b/src/datarobot_genai/drtools/microsoft_graph/tools.py
@@ -24,22 +24,26 @@ from datarobot_genai.drtools.core.clients.microsoft_graph import MicrosoftGraphC
 from datarobot_genai.drtools.core.clients.microsoft_graph import get_microsoft_graph_access_token
 from datarobot_genai.drtools.core.clients.microsoft_graph import validate_site_url
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
 @tool_metadata(
     tags={
+        "microsoft_graph",
         "microsoft",
-        "graph api",
         "sharepoint",
-        "drive",
-        "list",
+        "onedrive",
         "search",
         "files",
-        "find",
-        "contents",
-    }
+    },
+    description=(
+        "[M365—search files] Use when the user needs SharePoint or OneDrive files and list items "
+        "by keywords plus optional KQL filters, paginated. Scope with site_url or site_id when "
+        "they named a site. Not Google Drive (gdrive_find_contents), not Jira issues, not "
+        "Confluence pages, not downloading file contents."
+    ),
 )
 async def microsoft_graph_search_content(
     *,
@@ -68,9 +72,8 @@ async def microsoft_graph_search_content(
     ] = 250,
     entity_types: Annotated[
         list[str] | None,
-        "Optional list of entity types to search. Valid values: 'driveItem', 'listItem', "
-        "'site', 'list', 'drive'. Default: ['driveItem', 'listItem']. "
-        "Multiple types can be specified.",
+        "Optional. Each list entry must be exactly one of these strings: 'driveItem', "
+        "'listItem', 'site', 'list', 'drive'. Omit to default to ['driveItem', 'listItem'].",
     ] = None,
     filters: Annotated[
         list[str] | None,
@@ -89,49 +92,17 @@ async def microsoft_graph_search_content(
         "specific regions.",
     ] = None,
 ) -> dict[str, Any]:
-    """
-    Search for SharePoint and OneDrive content using Microsoft Graph Search API.
-
-    Search Scope:
-    - When site_url or site_id is provided: searches within the specified SharePoint site
-    - When neither is provided: searches across all accessible SharePoint sites and OneDrive
-
-    Supported Entity Types:
-    - driveItem: Files and folders in document libraries and OneDrive
-    - listItem: Items in SharePoint lists
-    - site: SharePoint sites
-    - list: SharePoint lists
-    - drive: Document libraries/drives
-
-    Filtering:
-    - Filters use KQL (Keyword Query Language) syntax
-    - Multiple filters are combined with AND operators
-    - Examples: ['fileType:docx', 'size>1000', 'lastModifiedTime>2024-01-01']
-    - Filters are applied in addition to the search query
-
-    Pagination:
-    - Controlled via from_offset (zero-based index) and size parameters
-    - Maximum size per request: 250 results
-    - To paginate: increment from_offset by size value for each subsequent page
-    - Example pagination sequence:
-      * Page 1: from_offset=0, size=250 (returns results 0-249)
-      * Page 2: from_offset=250, size=250 (returns results 250-499)
-      * Page 3: from_offset=500, size=250 (returns results 500-749)
-
-    API Reference:
-    - Endpoint: POST /search/query
-    - Documentation: https://learn.microsoft.com/en-us/graph/api/search-query
-    - Search concepts: https://learn.microsoft.com/en-us/graph/search-concept-files
-
-    """
     if not search_query:
-        raise ToolError("Argument validation error: 'search_query' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'search_query' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     # Validate site_url if provided
     if site_url:
         validation_error = validate_site_url(site_url)
         if validation_error:
-            raise ToolError(validation_error)
+            raise ToolError(validation_error, kind=ToolErrorKind.VALIDATION)
 
     access_token = await get_microsoft_graph_access_token()
     if isinstance(access_token, ToolError):
@@ -177,37 +148,44 @@ async def microsoft_graph_search_content(
     }
 
 
-@tool_metadata(tags={"microsoft", "graph api", "sharepoint", "onedrive", "share"}, enabled=False)
+@tool_metadata(
+    tags={"microsoft_graph", "sharepoint", "onedrive", "share"},
+    enabled=False,
+    description=(
+        "[M365—share item] Use when inviting people to an existing SharePoint/OneDrive file or "
+        "folder by file id and document library id. Not search (microsoft_graph_search_content), "
+        "not create file."
+    ),
+)
 async def microsoft_graph_share_item(
     *,
     file_id: Annotated[str, "The ID of the file or folder to share."],
     document_library_id: Annotated[str, "The ID of the document library containing the item."],
     recipient_emails: Annotated[list[str], "A list of email addresses to invite."],
-    role: Annotated[Literal["read", "write"], "The role to assign: 'read' or 'write'."] = "read",
+    role: Annotated[
+        Literal["read", "write"],
+        "Pass exactly one of these strings: 'read', 'write'. Omit to default to 'read'.",
+    ] = "read",
     send_invitation: Annotated[
         bool, "Flag determining if recipients should be notified. Default False"
     ] = False,
 ) -> dict[str, Any]:
-    """
-    Share a SharePoint or Onedrive file or folder with one or more users.
-    It works with internal users or existing guest users in the
-    tenant. It does NOT create new guest accounts and does NOT use the tenant-level
-    /invitations endpoint.
-
-    Microsoft Graph API is treating OneDrive and SharePoint resources as driveItem.
-
-    API Reference:
-    - DriveItem Resource Type: https://learn.microsoft.com/en-us/graph/api/resources/driveitem
-    - API Documentation: https://learn.microsoft.com/en-us/graph/api/driveitem-invite
-    """
     if not file_id or not file_id.strip():
-        raise ToolError("Argument validation error: 'file_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'file_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if not document_library_id or not document_library_id.strip():
-        raise ToolError("Argument validation error: 'document_library_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'document_library_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     if not recipient_emails:
-        raise ToolError("Argument validation error: you must provide at least one 'recipient'.")
+        raise ToolError(
+            "Argument validation error: you must provide at least one 'recipient'.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     access_token = await get_microsoft_graph_access_token()
     if isinstance(access_token, ToolError):
@@ -232,17 +210,13 @@ async def microsoft_graph_share_item(
 
 
 @tool_metadata(
-    tags={
-        "microsoft",
-        "graph api",
-        "sharepoint",
-        "onedrive",
-        "document library",
-        "create",
-        "file",
-        "write",
-    },
+    tags={"microsoft_graph", "sharepoint", "onedrive", "create", "file", "write"},
     enabled=False,
+    description=(
+        "[M365—create text file] Use when the user wants a new plain-text file in personal "
+        "OneDrive or a SharePoint library (library id from search). Not metadata updates "
+        "(microsoft_update_metadata), not sharing (microsoft_graph_share_item)."
+    ),
 )
 async def microsoft_create_file(
     *,
@@ -257,23 +231,10 @@ async def microsoft_create_file(
         "ID of the parent folder. Defaults to 'root' (root of the drive).",
     ] = "root",
 ) -> dict[str, Any]:
-    """
-    Create a new text file in SharePoint or OneDrive.
-
-    **Personal OneDrive:** Just provide file_name and content_text.
-    The file saves to your personal OneDrive root folder.
-
-    **SharePoint:** Provide document_library_id to save to a specific
-    SharePoint site. Get the ID from microsoft_graph_search_content
-    results ('documentLibraryId' field).
-
-    **Conflict Resolution:** If a file with the same name exists,
-    it will be automatically renamed (e.g., 'report (1).txt').
-    """
     if not file_name or not file_name.strip():
-        raise ToolError("Error: file_name is required.")
+        raise ToolError("Error: file_name is required.", kind=ToolErrorKind.VALIDATION)
     if not content_text:
-        raise ToolError("Error: content_text is required.")
+        raise ToolError("Error: content_text is required.", kind=ToolErrorKind.VALIDATION)
 
     access_token = await get_microsoft_graph_access_token()
     if isinstance(access_token, ToolError):
@@ -309,17 +270,13 @@ async def microsoft_create_file(
 
 
 @tool_metadata(
-    tags={
-        "microsoft",
-        "graph api",
-        "sharepoint",
-        "onedrive",
-        "metadata",
-        "update",
-        "fields",
-        "compliance",
-    },
+    tags={"microsoft_graph", "sharepoint", "onedrive", "metadata", "update"},
     enabled=False,
+    description=(
+        "[M365—update metadata] Use when renaming or updating list/drive item fields: either "
+        "SharePoint list context (site_id + list_id) or a drive item (document_library_id). "
+        "Not file body edits, not search, not sharing."
+    ),
 )
 async def microsoft_update_metadata(
     *,
@@ -344,29 +301,13 @@ async def microsoft_update_metadata(
         "Cannot be used together with site_id and list_id.",
     ] = None,
 ) -> dict[str, Any]:
-    """
-    Update metadata on a SharePoint list item or OneDrive/SharePoint drive item.
-
-    **SharePoint List Items:** Provide site_id and list_id to update custom
-    column values on a list item. All custom columns can be updated.
-
-    **OneDrive/Drive Items:** Provide document_library_id to update drive item
-    properties. Only 'name' and 'description' fields can be updated.
-
-    **Context Requirements:**
-    - For SharePoint list items: Both site_id AND list_id are required
-    - For OneDrive/drive items: document_library_id is required
-    - Cannot specify both contexts simultaneously
-
-    **Examples:**
-    - SharePoint list item: Update a 'Status' column to 'Approved'
-    - Drive item: Rename a file or update its description
-
-    """
     if not item_id or not item_id.strip():
-        raise ToolError("Error: item_id is required.")
+        raise ToolError("Error: item_id is required.", kind=ToolErrorKind.VALIDATION)
     if not fields_to_update:
-        raise ToolError("Error: fields_to_update is required and cannot be empty.")
+        raise ToolError(
+            "Error: fields_to_update is required and cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     # Validate context parameters
     has_sharepoint_context = site_id is not None and list_id is not None
@@ -375,19 +316,22 @@ async def microsoft_update_metadata(
 
     if has_partial_sharepoint_context:
         raise ToolError(
-            "Error: For SharePoint list items, both site_id and list_id must be provided."
+            "Error: For SharePoint list items, both site_id and list_id must be provided.",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     if has_sharepoint_context and has_drive_context:
         raise ToolError(
             "Error: Cannot specify both SharePoint (site_id + list_id) and OneDrive "
-            "(document_library_id) context. Choose one."
+            "(document_library_id) context. Choose one.",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     if not has_sharepoint_context and not has_drive_context:
         raise ToolError(
             "Error: Must specify either SharePoint context (site_id + list_id) or "
-            "OneDrive context (document_library_id)."
+            "OneDrive context (document_library_id).",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     access_token = await get_microsoft_graph_access_token()

--- a/src/datarobot_genai/drtools/microsoft_graph/tools.py
+++ b/src/datarobot_genai/drtools/microsoft_graph/tools.py
@@ -28,6 +28,16 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
+_MS_SEARCH_QUERY = "https://learn.microsoft.com/en-us/graph/api/search-query"
+_MS_SEARCH_FILES = "https://learn.microsoft.com/en-us/graph/search-concept-files"
+_MS_KQL = (
+    "https://learn.microsoft.com/en-us/sharepoint/dev/general-development/"
+    "keyword-query-language-kql-syntax-reference"
+)
+_MS_DRIVEITEM = "https://learn.microsoft.com/en-us/graph/api/resources/driveitem"
+_MS_DRIVEITEM_INVITE = "https://learn.microsoft.com/en-us/graph/api/driveitem-invite"
+_MS_DRIVEITEM_PATCH = "https://learn.microsoft.com/en-us/graph/api/driveitem-update"
+
 
 @tool_metadata(
     tags={
@@ -42,7 +52,12 @@ logger = logging.getLogger(__name__)
         "[M365—search files] Use when the user needs SharePoint or OneDrive files and list items "
         "by keywords plus optional KQL filters, paginated. Scope with site_url or site_id when "
         "they named a site. Not Google Drive (gdrive_find_contents), not Jira issues, not "
-        "Confluence pages, not downloading file contents."
+        "Confluence pages, not downloading file contents.\n\n"
+        "Scope: with site_url/site_id -> that site; without -> tenant-wide accessible content. "
+        "Entity types include driveItem, listItem, site, list, drive. "
+        "Filters: KQL list e.g. ['fileType:docx', 'size>1000']. "
+        "Pagination: size max 250; page 1 from_offset=0, page 2 from_offset=250, etc.\n\n"
+        f"References: {_MS_SEARCH_QUERY} {_MS_SEARCH_FILES} {_MS_KQL}"
     ),
 )
 async def microsoft_graph_search_content(
@@ -154,7 +169,10 @@ async def microsoft_graph_search_content(
     description=(
         "[M365—share item] Use when inviting people to an existing SharePoint/OneDrive file or "
         "folder by file id and document library id. Not search (microsoft_graph_search_content), "
-        "not create file."
+        "not create file.\n\n"
+        "Internal or existing guest users only; does not create new guests via /invitations. "
+        "Graph treats OneDrive and SharePoint items as driveItem.\n\n"
+        f"References: {_MS_DRIVEITEM} {_MS_DRIVEITEM_INVITE}"
     ),
 )
 async def microsoft_graph_share_item(
@@ -215,7 +233,11 @@ async def microsoft_graph_share_item(
     description=(
         "[M365—create text file] Use when the user wants a new plain-text file in personal "
         "OneDrive or a SharePoint library (library id from search). Not metadata updates "
-        "(microsoft_update_metadata), not sharing (microsoft_graph_share_item)."
+        "(microsoft_update_metadata), not sharing (microsoft_graph_share_item).\n\n"
+        "Personal OneDrive: file_name + content_text only (saves to root). SharePoint: set "
+        "document_library_id from microsoft_graph_search_content (documentLibraryId). "
+        "Duplicate names are auto-renamed (e.g. report (1).txt).\n\n"
+        f"References: {_MS_DRIVEITEM} {_MS_DRIVEITEM_PATCH}"
     ),
 )
 async def microsoft_create_file(
@@ -275,7 +297,11 @@ async def microsoft_create_file(
     description=(
         "[M365—update metadata] Use when renaming or updating list/drive item fields: either "
         "SharePoint list context (site_id + list_id) or a drive item (document_library_id). "
-        "Not file body edits, not search, not sharing."
+        "Not file body edits, not search, not sharing.\n\n"
+        "List items: both site_id and list_id; custom columns in fields_to_update. "
+        "Drive items: document_library_id; only name and/or description in fields_to_update. "
+        "Do not mix list and drive contexts.\n\n"
+        f"References: {_MS_DRIVEITEM} {_MS_DRIVEITEM_PATCH}"
     ),
 )
 async def microsoft_update_metadata(

--- a/src/datarobot_genai/drtools/perplexity/tools.py
+++ b/src/datarobot_genai/drtools/perplexity/tools.py
@@ -33,6 +33,9 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
+_PPLX_SEARCH_GUIDE = "https://docs.perplexity.ai/guides/search"
+_PPLX_STRUCTURED = "https://docs.perplexity.ai/guides/structured-outputs"
+
 
 @tool_metadata(
     tags={"perplexity", "web", "search", "websearch", "daria"},
@@ -40,7 +43,11 @@ logger = logging.getLogger(__name__)
         "[Perplexity—web search] Use when the user needs ranked web sources/snippets for a "
         "question or multi-part research (string or list of sub-queries), with optional domain "
         "allow/deny and recency. Not long-form single narrative answers (perplexity_think), not "
-        "DataRobot docs (search_datarobot_agentic_docs), not raw URL extraction (tavily_extract)."
+        "DataRobot docs (search_datarobot_agentic_docs), not raw URL extraction "
+        "(tavily_extract).\n\n"
+        f"query may be a string or up to {MAX_QUERIES} strings; tune max_results (1-{MAX_RESULTS}) "
+        f"and max_tokens_per_page (1-{MAX_TOKENS_PER_PAGE}).\n\n"
+        f"Reference: {_PPLX_SEARCH_GUIDE}"
     ),
 )
 async def perplexity_search(
@@ -160,7 +167,10 @@ async def perplexity_search(
         "citations: fast Q&A, deeper reasoning, or long research report (set model to one of "
         "the string literals on the parameter), "
         "optionally JSON-shaped output via schema. Not primarily for ranked URL lists "
-        "(perplexity_search), not internal DR docs."
+        "(perplexity_search), not internal DR docs.\n\n"
+        "Models: sonar (fast), sonar-reasoning-pro (complex logic), sonar-deep-research (reports). "
+        "Pass json_schema for structured extraction.\n\n"
+        f"Reference: {_PPLX_STRUCTURED}"
     ),
 )
 async def perplexity_think(

--- a/src/datarobot_genai/drtools/perplexity/tools.py
+++ b/src/datarobot_genai/drtools/perplexity/tools.py
@@ -29,11 +29,20 @@ from datarobot_genai.drtools.core.clients.perplexity import MAX_TOKENS_PER_PAGE_
 from datarobot_genai.drtools.core.clients.perplexity import PerplexityClient
 from datarobot_genai.drtools.core.clients.perplexity import get_perplexity_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"perplexity", "web", "search", "websearch", "daria"})
+@tool_metadata(
+    tags={"perplexity", "web", "search", "websearch", "daria"},
+    description=(
+        "[Perplexity—web search] Use when the user needs ranked web sources/snippets for a "
+        "question or multi-part research (string or list of sub-queries), with optional domain "
+        "allow/deny and recency. Not long-form single narrative answers (perplexity_think), not "
+        "DataRobot docs (search_datarobot_agentic_docs), not raw URL extraction (tavily_extract)."
+    ),
+)
 async def perplexity_search(
     *,
     query: Annotated[
@@ -48,7 +57,9 @@ async def perplexity_search(
         f"to allowlist or denylist (prefix with '-').",
     ] = None,
     recency: Annotated[
-        Literal["day", "week", "month", "year"] | None, "Filter results by time period."
+        Literal["day", "week", "month", "year"] | None,
+        "Optional. Pass exactly one of these strings or omit: 'day', 'week', 'month', 'year' "
+        "to filter by recency.",
     ] = None,
     max_results: Annotated[
         int, f"Number of ranked results to return (1-{MAX_RESULTS})."
@@ -59,43 +70,63 @@ async def perplexity_search(
         f"(default {MAX_TOKENS_PER_PAGE_DEFAULT}).",
     ] = MAX_TOKENS_PER_PAGE_DEFAULT,
 ) -> dict[str, Any]:
-    """Perplexity web search tool combining multi-query research and content extraction control."""
     # Check if query is empty or None
     if not query:
-        raise ToolError("Argument validation error: query cannot be empty.")
+        raise ToolError(
+            "Argument validation error: query cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     # Handle string queries
     if isinstance(query, str):
         if not query.strip():
-            raise ToolError("Argument validation error: query cannot be empty or whitespace only.")
+            raise ToolError(
+                "Argument validation error: query cannot be empty or whitespace only.",
+                kind=ToolErrorKind.VALIDATION,
+            )
     # Handle list queries
     elif isinstance(query, list):
         if not query:  # Empty list
-            raise ToolError("Argument validation error: query list cannot be empty.")
+            raise ToolError(
+                "Argument validation error: query list cannot be empty.",
+                kind=ToolErrorKind.VALIDATION,
+            )
         if len(query) > MAX_QUERIES:
             raise ToolError(
-                f"Argument validation error: query list cannot be bigger than {MAX_QUERIES}."
+                f"Argument validation error: query list cannot be bigger than {MAX_QUERIES}.",
+                kind=ToolErrorKind.VALIDATION,
             )
         if not all(q.strip() for q in query):
-            raise ToolError("Argument validation error: query cannot contain empty strings.")
+            raise ToolError(
+                "Argument validation error: query cannot contain empty strings.",
+                kind=ToolErrorKind.VALIDATION,
+            )
     if search_domain_filter and len(search_domain_filter) > MAX_SEARCH_DOMAIN_FILTER:
         raise ToolError(
             f"Argument validation error: "
-            f"maximum number of search domain filters is {MAX_SEARCH_DOMAIN_FILTER}."
+            f"maximum number of search domain filters is {MAX_SEARCH_DOMAIN_FILTER}.",
+            kind=ToolErrorKind.VALIDATION,
         )
     if max_results <= 0:
-        raise ToolError("Argument validation error: max_results must be greater than 0.")
+        raise ToolError(
+            "Argument validation error: max_results must be greater than 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if max_results > MAX_RESULTS:
         raise ToolError(
             f"Argument validation error: "
-            f"max_results must be smaller than or equal to {MAX_RESULTS}."
+            f"max_results must be smaller than or equal to {MAX_RESULTS}.",
+            kind=ToolErrorKind.VALIDATION,
         )
     if max_tokens_per_page <= 0:
-        raise ToolError("Argument validation error: max_tokens_per_page must be greater than 0.")
+        raise ToolError(
+            "Argument validation error: max_tokens_per_page must be greater than 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if max_tokens_per_page > MAX_TOKENS_PER_PAGE:
         raise ToolError(
             f"Argument validation error: "
-            f"max_tokens_per_page must be smaller than or equal to {MAX_TOKENS_PER_PAGE}."
+            f"max_tokens_per_page must be smaller than or equal to {MAX_TOKENS_PER_PAGE}.",
+            kind=ToolErrorKind.VALIDATION,
         )
 
     access_token = await get_perplexity_access_token()
@@ -122,31 +153,33 @@ async def perplexity_search(
     }
 
 
-@tool_metadata(tags={"perplexity", "think", "research", "answer", "daria"})
+@tool_metadata(
+    tags={"perplexity", "think", "research", "answer", "daria"},
+    description=(
+        "[Perplexity—answer / reason] Use when the user wants a model-authored reply with "
+        "citations: fast Q&A, deeper reasoning, or long research report (set model to one of "
+        "the string literals on the parameter), "
+        "optionally JSON-shaped output via schema. Not primarily for ranked URL lists "
+        "(perplexity_search), not internal DR docs."
+    ),
+)
 async def perplexity_think(
     *,
     prompt: Annotated[str, "The research prompt or instruction."],
     model: Annotated[
         Literal["sonar", "sonar-reasoning-pro", "sonar-deep-research"],
-        "Select capability: "
-        "'sonar' (fast ask), "
-        "'sonar-reasoning-pro' (complex logic),"
-        "'sonar-deep-research' (comprehensive reports).",
+        "Pass exactly one of these strings (hyphens as shown): 'sonar', "
+        "'sonar-reasoning-pro', 'sonar-deep-research'. Fast Q&A vs deeper reasoning vs long "
+        "research; omit to default to 'sonar'.",
     ] = "sonar",
     json_schema: Annotated[
         dict | None, "Optional JSON Schema to enforce structured output for data extraction."
     ] = None,
 ) -> dict[str, Any]:
-    """Conversational AI for reasoning, research, and structured data extraction.
-    Deep Research: Use the sonar-deep-research model for thorough reports
-        and multi-step investigation.
-    Reasoning: Use sonar-reasoning-pro for complex analytical tasks.
-    Structured Extraction: Use the response_format parameter with a JSON Schema
-        to ensure machine-readable data
-    Documentation: https://docs.perplexity.ai/guides/structured-outputs .
-    """
     if not prompt or not prompt.strip():
-        raise ToolError("Argument validation error: prompt cannot be empty.")
+        raise ToolError(
+            "Argument validation error: prompt cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     access_token = await get_perplexity_access_token()
     if isinstance(access_token, ToolError):

--- a/src/datarobot_genai/drtools/predictive/client_exceptions.py
+++ b/src/datarobot_genai/drtools/predictive/client_exceptions.py
@@ -1,0 +1,30 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for DataRobot SDK HTTP errors in predictive tools."""
+
+from typing import NoReturn
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+
+
+def raise_tool_error_for_client_error(exc: ClientError) -> NoReturn:
+    """Raise :class:`ToolError` from SDK text: 404 → ``NOT_FOUND``, else ``UPSTREAM``."""
+    sc = getattr(exc, "status_code", None)
+    msg = f"DataRobot API error ({sc}): {exc}"
+    kind = ToolErrorKind.NOT_FOUND if sc == 404 else ToolErrorKind.UPSTREAM
+    raise ToolError(msg, kind=kind) from exc

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -19,11 +19,15 @@ import logging
 from typing import Annotated
 from typing import Any
 
+from datarobot.errors import ClientError
+
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.core.utils import is_valid_url
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +74,15 @@ async def upload_dataset_to_ai_catalog(
     | None = None,
 ) -> dict[str, Any]:
     if not file_content_base64 and not file_url:
-        raise ToolError("Either file_content_base64 or file_url must be provided.")
+        raise ToolError(
+            "Either file_content_base64 or file_url must be provided.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if file_content_base64 and file_url:
-        raise ToolError("Please provide either file_content_base64 or file_url, not both.")
+        raise ToolError(
+            "Please provide either file_content_base64 or file_url, not both.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -80,13 +90,18 @@ async def upload_dataset_to_ai_catalog(
     if file_content_base64 is not None:
         raw_b64 = file_content_base64.strip()
         if not raw_b64:
-            raise ToolError("Argument validation error: 'file_content_base64' cannot be empty.")
+            raise ToolError(
+                "Argument validation error: 'file_content_base64' cannot be empty.",
+                kind=ToolErrorKind.VALIDATION,
+            )
         try:
             raw = base64.b64decode(raw_b64)
         except binascii.Error as e:
-            raise ToolError("Invalid base64 in file_content_base64.") from e
+            raise ToolError(
+                "Invalid base64 in file_content_base64.", kind=ToolErrorKind.VALIDATION
+            ) from e
         if not raw:
-            raise ToolError("Decoded file content is empty.")
+            raise ToolError("Decoded file content is empty.", kind=ToolErrorKind.VALIDATION)
         fname = (
             dataset_filename.strip()
             if dataset_filename and dataset_filename.strip()
@@ -98,11 +113,11 @@ async def upload_dataset_to_ai_catalog(
     else:
         if file_url is None or not is_valid_url(file_url):
             logger.error("Invalid file URL: %s", file_url)
-            raise ToolError(f"Invalid file URL: {file_url}")
+            raise ToolError(f"Invalid file URL: {file_url}", kind=ToolErrorKind.VALIDATION)
         catalog_item = client.Dataset.create_from_url(file_url)
 
     if not catalog_item:
-        raise ToolError("Failed to upload dataset.")
+        raise ToolError("Failed to upload dataset.", kind=ToolErrorKind.UPSTREAM)
 
     return {
         "dataset_id": catalog_item.id,
@@ -156,11 +171,14 @@ async def get_dataset_details(
     sample_rows: Annotated[int, "Max sample rows when include_sample is true."] = 10,
 ) -> dict[str, Any]:
     if not dataset_id:
-        raise ToolError("Dataset ID must be provided")
+        raise ToolError("Dataset ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    dataset = client.Dataset.get(dataset_id)
+    try:
+        dataset = client.Dataset.get(dataset_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     result: dict = {
         "id": dataset.id,
@@ -225,7 +243,7 @@ async def browse_datastore(
     search: Annotated[str, "Optional filter substring for object names."] | None = None,
 ) -> dict[str, Any]:
     if not datastore_id:
-        raise ToolError("Datastore ID must be provided")
+        raise ToolError("Datastore ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
@@ -236,7 +254,10 @@ async def browse_datastore(
         params["path"] = path
     if search:
         params["search"] = search
-    response = rest_client.get(f"externalDataDrivers/{datastore_id}/tables/", params=params)
+    try:
+        response = rest_client.get(f"externalDataDrivers/{datastore_id}/tables/", params=params)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     data = response.json()
     items = data.get("data", data) if isinstance(data, dict) else data
 
@@ -264,16 +285,19 @@ async def query_datastore(
     limit: Annotated[int, "Max rows returned from the query result."] = 1000,
 ) -> dict[str, Any]:
     if not datastore_id:
-        raise ToolError("Datastore ID must be provided")
+        raise ToolError("Datastore ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not sql:
-        raise ToolError("SQL query must be provided")
+        raise ToolError("SQL query must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
     rest_client = dr_module.client.get_client()
 
     payload = {"query": sql, "limit": limit}
-    response = rest_client.post(f"externalDataDrivers/{datastore_id}/execute/", json=payload)
+    try:
+        response = rest_client.post(f"externalDataDrivers/{datastore_id}/execute/", json=payload)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     data = response.json()
 
     return {

--- a/src/datarobot_genai/drtools/predictive/deployment.py
+++ b/src/datarobot_genai/drtools/predictive/deployment.py
@@ -17,6 +17,8 @@ import os
 from typing import Annotated
 from typing import Any
 
+from datarobot.errors import ClientError
+
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
@@ -25,6 +27,8 @@ from datarobot_genai.drtools.core.deployment_utils import REQUIRED_FILES
 from datarobot_genai.drtools.core.deployment_utils import deploy_custom_model_impl
 from datarobot_genai.drtools.core.deployment_utils import find_model_file_in_folder
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -62,10 +66,13 @@ async def get_model_info_from_deployment(
     deployment_id: Annotated[str, "MLOps deployment id."],
 ) -> dict[str, Any]:
     if not deployment_id:
-        raise ToolError("Deployment ID must be provided")
+        raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    deployment = client.Deployment.get(deployment_id)
+    try:
+        deployment = client.Deployment.get(deployment_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     return deployment.model
 
 
@@ -86,21 +93,26 @@ async def deploy_model(
     description: Annotated[str, "Optional longer description for operators."] | None = None,
 ) -> dict[str, Any]:
     if not model_id:
-        raise ToolError("Model ID must be provided")
+        raise ToolError("Model ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not label:
-        raise ToolError("Model label must be provided")
+        raise ToolError("Model label must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
     prediction_servers = client.PredictionServer.list()
     if not prediction_servers:
-        raise ToolError("No prediction servers available for deployment.")
-    deployment = client.Deployment.create_from_learning_model(
-        model_id=model_id,
-        label=label,
-        description=description,
-        default_prediction_server_id=prediction_servers[0].id,
-    )
+        raise ToolError(
+            "No prediction servers available for deployment.", kind=ToolErrorKind.UPSTREAM
+        )
+    try:
+        deployment = client.Deployment.create_from_learning_model(
+            model_id=model_id,
+            label=label,
+            description=description,
+            default_prediction_server_id=prediction_servers[0].id,
+        )
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     return {
         "deployment_id": deployment.id,
         "label": label,
@@ -115,7 +127,11 @@ async def deploy_custom_model(
         str, "Path to directory with custom.py, requirements.txt, and optionally a model file"
     ],
     name: Annotated[str, "Single name used for both custom model and deployment"],
-    target_type: Annotated[str, "Target type: binary, regression, or multiclass"],
+    target_type: Annotated[
+        str,
+        "Pass exactly one of these strings: 'binary', 'regression', 'multiclass' "
+        "(DataRobot target type).",
+    ],
     target_name: Annotated[str, "Target column name"],
     model_file_path: Annotated[
         str,
@@ -130,20 +146,22 @@ async def deploy_custom_model(
     description: Annotated[str, "Optional description"] | None = None,
 ) -> dict[str, Any]:
     if not model_folder:
-        raise ToolError("model_folder must be provided")
+        raise ToolError("model_folder must be provided", kind=ToolErrorKind.VALIDATION)
     if not name:
-        raise ToolError("name must be provided")
+        raise ToolError("name must be provided", kind=ToolErrorKind.VALIDATION)
     if not target_type:
-        raise ToolError("target_type must be provided")
+        raise ToolError("target_type must be provided", kind=ToolErrorKind.VALIDATION)
     if not target_name:
-        raise ToolError("target_name must be provided")
+        raise ToolError("target_name must be provided", kind=ToolErrorKind.VALIDATION)
 
     model_folder = os.path.abspath(model_folder)
     if not os.path.isdir(model_folder):
-        raise ToolError(f"model_folder is not a directory: {model_folder}")
+        raise ToolError(
+            f"model_folder is not a directory: {model_folder}", kind=ToolErrorKind.VALIDATION
+        )
     for f in REQUIRED_FILES:
         if not os.path.isfile(os.path.join(model_folder, f)):
-            raise ToolError(f"model_folder must contain {f}")
+            raise ToolError(f"model_folder must contain {f}", kind=ToolErrorKind.VALIDATION)
     resolved_path: str | None = None
     if model_file_path:
         p = (
@@ -154,13 +172,14 @@ async def deploy_custom_model(
         if os.path.isfile(p):
             resolved_path = p
         else:
-            raise ToolError(f"model_file_path does not exist: {p}")
+            raise ToolError(f"model_file_path does not exist: {p}", kind=ToolErrorKind.VALIDATION)
     if resolved_path is None:
         resolved_path = find_model_file_in_folder(model_folder)
     if resolved_path is None:
         raise ToolError(
             f"No model file ({', '.join(MODEL_EXTENSIONS)}) found in {model_folder}. "
-            "Add a model file to the folder or pass model_file_path."
+            "Add a model file to the folder or pass model_file_path.",
+            kind=ToolErrorKind.VALIDATION,
         )
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -199,7 +218,7 @@ async def get_prediction_history(
     end_time: Annotated[str, "Optional ISO 8601 upper bound on prediction time."] | None = None,
 ) -> dict[str, Any]:
     if not deployment_id:
-        raise ToolError("Deployment ID must be provided")
+        raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
@@ -211,7 +230,10 @@ async def get_prediction_history(
     if end_time:
         params["endTime"] = end_time
 
-    response = rest_client.get(f"deployments/{deployment_id}/predictionResults/", params=params)
+    try:
+        response = rest_client.get(f"deployments/{deployment_id}/predictionResults/", params=params)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     data = response.json()
     rows = data.get("data", [])
     next_page = data.get("next")

--- a/src/datarobot_genai/drtools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drtools/predictive/deployment_info.py
@@ -23,11 +23,14 @@ from typing import Annotated
 from typing import Any
 
 import polars as pl
+from datarobot.errors import ClientError
 
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -60,11 +63,14 @@ async def get_deployment_info(
     deployment_id: Annotated[str, "MLOps deployment id (from list_deployments or product UI)."],
 ) -> dict[str, Any]:
     if not deployment_id:
-        raise ToolError("Deployment ID must be provided")
+        raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    deployment = client.Deployment.get(deployment_id)
+    try:
+        deployment = client.Deployment.get(deployment_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     # get features from the deployment
     features_raw = deployment.get_features()
@@ -86,11 +92,15 @@ async def get_deployment_info(
         target = ""
         target_type = ""
     else:
-        project = client.Project.get(deployment.model["project_id"])
-        model = client.Model.get(project=project, model_id=deployment.model["id"])
+        try:
+            dr_project = client.Project.get(deployment.model["project_id"])
+            model = client.Model.get(project=dr_project, model_id=deployment.model["id"])
+        except ClientError as e:
+            raise_tool_error_for_client_error(e)
+        project = dr_project
         model_type = model.model_type
-        target = project.target
-        target_type = project.target_type
+        target = dr_project.target
+        target_type = dr_project.target_type
 
     # Add model metadata
     result = {
@@ -130,7 +140,7 @@ async def generate_prediction_data_template(
     n_rows: Annotated[int, "How many identical-length template rows to generate (≥1)."] = 1,
 ) -> dict[str, Any]:
     if not deployment_id:
-        raise ToolError("Deployment ID must be provided")
+        raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
     if n_rows is None or n_rows <= 0:
         n_rows = 1
 
@@ -138,7 +148,9 @@ async def generate_prediction_data_template(
     features_info = await get_deployment_features(deployment_id=deployment_id)
     # Check if we got a valid result
     if not isinstance(features_info, dict) or "features" not in features_info:
-        raise ToolError(f"Invalid feature information received: {features_info}")
+        raise ToolError(
+            f"Invalid feature information received: {features_info}", kind=ToolErrorKind.INTERNAL
+        )
 
     # Create template data
     template_data: dict[str, list[Any]] = {}
@@ -230,7 +242,10 @@ async def validate_prediction_data(
     ],
 ) -> dict[str, Any]:
     if not csv_string or not csv_string.strip():
-        raise ToolError("Argument validation error: 'csv_string' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'csv_string' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     df = pl.read_csv(io.StringIO(csv_string.strip()))
     # LLMs often paste CSV with indented headers; align names to deployment features.
@@ -242,7 +257,7 @@ async def validate_prediction_data(
         df = df.filter(row_nonempty)
 
     if not deployment_id:
-        raise ToolError("Deployment ID must be provided")
+        raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
     # Get deployment features
     features_info = await get_deployment_features(deployment_id=deployment_id)
 
@@ -367,7 +382,7 @@ async def get_deployment_features(
     deployment_id: Annotated[str, "MLOps deployment id."],
 ) -> dict[str, Any]:
     if not deployment_id:
-        raise ToolError("Deployment ID must be provided")
+        raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     info = await get_deployment_info(deployment_id=deployment_id)
     # Only keep features, time_series_config, and total_features

--- a/src/datarobot_genai/drtools/predictive/model.py
+++ b/src/datarobot_genai/drtools/predictive/model.py
@@ -20,12 +20,15 @@ from typing import Annotated
 from typing import Any
 
 import polars as pl
+from datarobot.errors import ClientError
 from datarobot.models.model import Model
 
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -96,17 +99,20 @@ async def get_best_model(
     | None = None,
 ) -> dict[str, Any]:
     if not project_id:
-        raise ToolError("Project ID must be provided")
+        raise ToolError("Project ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
+    try:
+        project = client.Project.get(project_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     if not project:
-        raise ToolError(f"Project with ID {project_id} not found.")
+        raise ToolError(f"Project with ID {project_id} not found.", kind=ToolErrorKind.NOT_FOUND)
 
     leaderboard = project.get_models()
     if not leaderboard:
-        raise ToolError("No models found for this project.")
+        raise ToolError("No models found for this project.", kind=ToolErrorKind.NOT_FOUND)
 
     if metric:
         reverse_sort = metric.upper() in [
@@ -161,19 +167,22 @@ async def score_dataset_with_model(
     dataset_id: Annotated[str, "AI Catalog dataset id to score (tabular)."],
 ) -> dict[str, Any]:
     if not project_id:
-        raise ToolError("Project ID must be provided")
+        raise ToolError("Project ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not model_id:
-        raise ToolError("Model ID must be provided")
+        raise ToolError("Model ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not dataset_id or not dataset_id.strip():
-        raise ToolError("Dataset ID must be provided")
+        raise ToolError("Dataset ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
-    dr_model = client.Model.get(project, model_id)
-    catalog_dataset = client.Dataset.get(dataset_id)
-    prediction_dataset = project.upload_dataset_from_catalog(dataset_id=catalog_dataset.id)
-    job = dr_model.request_predictions(dataset_id=prediction_dataset.id)
+    try:
+        project = client.Project.get(project_id)
+        dr_model = client.Model.get(project, model_id)
+        catalog_dataset = client.Dataset.get(dataset_id)
+        prediction_dataset = project.upload_dataset_from_catalog(dataset_id=catalog_dataset.id)
+        job = dr_model.request_predictions(dataset_id=prediction_dataset.id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     return {
         "message": "Scoring job started",
@@ -199,11 +208,14 @@ async def list_models(
     project_id: Annotated[str, "DataRobot modeling project id."],
 ) -> dict[str, Any]:
     if not project_id:
-        raise ToolError("Project ID must be provided")
+        raise ToolError("Project ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
+    try:
+        project = client.Project.get(project_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     models = project.get_models()
 
     return {
@@ -235,8 +247,11 @@ async def get_model_details(
 ) -> dict[str, Any]:
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
-    model = client.Model.get(project=project, model_id=model_id)
+    try:
+        project = client.Project.get(project_id)
+        model = client.Model.get(project=project, model_id=model_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     insights = ModelInsights(
         model_id=model_id,
@@ -289,15 +304,18 @@ async def is_eligible_for_timeseries_training(
     | None = None,
 ) -> dict[str, Any]:
     if not dataset_id:
-        raise ToolError("Dataset ID must be provided")
+        raise ToolError("Dataset ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not datetime_column:
-        raise ToolError("Datetime column must be provided")
+        raise ToolError("Datetime column must be provided", kind=ToolErrorKind.VALIDATION)
     if not target_column:
-        raise ToolError("Target column must be provided")
+        raise ToolError("Target column must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    dataset = client.Dataset.get(dataset_id)
+    try:
+        dataset = client.Dataset.get(dataset_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     errors: list[str] = []
     infos: list[str] = []
@@ -306,7 +324,7 @@ async def is_eligible_for_timeseries_training(
         pandas_df = dataset.get_as_dataframe()
         df = pl.from_pandas(pandas_df)
     except Exception as exc:
-        raise ToolError(f"Could not load dataset: {exc}")
+        raise ToolError(f"Could not load dataset: {exc}", kind=ToolErrorKind.UPSTREAM)
 
     row_count = df.height
     infos.append(f"Row count: {row_count}")

--- a/src/datarobot_genai/drtools/predictive/predict.py
+++ b/src/datarobot_genai/drtools/predictive/predict.py
@@ -20,12 +20,15 @@ from typing import Annotated
 from typing import Any
 
 import datarobot as dr
+from datarobot.errors import ClientError
 
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.constants import MAX_INLINE_SIZE
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +50,8 @@ def _batch_job_download_url(job: Any) -> str | None:
 
 def _tool_error_with_batch_url(message: str, url: str | None) -> ToolError:
     if url:
-        return ToolError(f"{message} url: {url}")
-    return ToolError(message)
+        return ToolError(f"{message} url: {url}", kind=ToolErrorKind.UPSTREAM)
+    return ToolError(message, kind=ToolErrorKind.UPSTREAM)
 
 
 def _handle_prediction_resource(job: Any, deployment_id: str, input_desc: str) -> dict[str, Any]:
@@ -62,7 +65,10 @@ def _handle_prediction_resource(job: Any, deployment_id: str, input_desc: str) -
         if st in _TERMINAL_FAILURE_STATUSES:
             details = status.get("status_details", "")
             logger.error("Batch job %s terminal status=%s details=%s", job.id, st, details)
-            raise ToolError(f"Batch prediction job failed: status={st!r} details={details!r}")
+            raise ToolError(
+                f"Batch prediction job failed: status={st!r} details={details!r}",
+                kind=ToolErrorKind.UPSTREAM,
+            )
         download_url = status.get("links", {}).get("download")
         if download_url:
             break
@@ -71,7 +77,8 @@ def _handle_prediction_resource(job: Any, deployment_id: str, input_desc: str) -
         if out_type and out_type != "localFile":
             raise ToolError(
                 "Batch job output is not local file streaming; there is no download URL for this "
-                f"output type ({out_type!r}). Use the configured sink (e.g. JDBC/S3) instead."
+                f"output type ({out_type!r}). Use the configured sink (e.g. JDBC/S3) instead.",
+                kind=ToolErrorKind.UPSTREAM,
             )
         if attempt < _DOWNLOAD_LINK_MAX_ATTEMPTS - 1:
             time.sleep(_DOWNLOAD_LINK_POLL_SEC)
@@ -82,7 +89,8 @@ def _handle_prediction_resource(job: Any, deployment_id: str, input_desc: str) -
             "Batch prediction finished but no download URL appeared after polling. "
             f"Last status={st!r} details={details!r}. "
             "Confirm the job used local file (streaming) output, or retry later with the same "
-            "job_id."
+            "job_id.",
+            kind=ToolErrorKind.UPSTREAM,
         )
     return {
         "job_id": job.id,
@@ -100,7 +108,7 @@ def wait_for_preds_and_cache_results(
     job.wait_for_completion(timeout)
     if job.status in _TERMINAL_FAILURE_STATUSES:
         logger.error("Job failed with status %s", job.status)
-        raise ToolError(f"Job failed with status {job.status}")
+        raise ToolError(f"Job failed with status {job.status}", kind=ToolErrorKind.UPSTREAM)
     return _handle_prediction_resource(job, deployment_id, input_desc)
 
 
@@ -127,26 +135,36 @@ async def _wait_for_preds_and_cache_results_async(
     ),
 )
 async def predict_by_ai_catalog(
+    *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     dataset_id: Annotated[str, "AI Catalog dataset id to score."],
     timeout: Annotated[int, "Max seconds to wait for batch job completion."] | None = 600,
 ) -> dict[str, Any]:
     if not deployment_id or not deployment_id.strip():
-        raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'deployment_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if not dataset_id or not dataset_id.strip():
-        raise ToolError("Argument validation error: 'dataset_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'dataset_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    dataset = client.Dataset.get(dataset_id)
-    job = dr.BatchPredictionJob.score(
-        deployment=deployment_id,
-        intake_settings={  # type: ignore[arg-type]
-            "type": "dataset",
-            "dataset": dataset,
-        },
-        output_settings=None,
-    )
+    try:
+        dataset = client.Dataset.get(dataset_id)
+        job = dr.BatchPredictionJob.score(
+            deployment=deployment_id,
+            intake_settings={  # type: ignore[arg-type]
+                "type": "dataset",
+                "dataset": dataset,
+            },
+            output_settings=None,
+        )
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     return await _wait_for_preds_and_cache_results_async(
         job, deployment_id, f"Scoring dataset {dataset_id}.", timeout or 600
     )
@@ -166,6 +184,7 @@ async def predict_by_ai_catalog(
     ),
 )
 async def predict_from_project_data(
+    *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     project_id: Annotated[str, "DataRobot project id that supplies training/holdout data."],
     dataset_id: Annotated[
@@ -181,13 +200,24 @@ async def predict_from_project_data(
     timeout: Annotated[int, "Max seconds to wait for batch job completion."] | None = 600,
 ) -> dict[str, Any]:
     if not deployment_id or not deployment_id.strip():
-        raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'deployment_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if not project_id or not project_id.strip():
-        raise ToolError("Argument validation error: 'project_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'project_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if dataset_id is not None and (not dataset_id or not dataset_id.strip()):
-        raise ToolError("Argument validation error: 'dataset_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'dataset_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if partition is not None and (not partition or not partition.strip()):
-        raise ToolError("Argument validation error: 'partition' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'partition' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     token = await get_datarobot_access_token()
     DataRobotClient(token).get_client()
@@ -199,11 +229,14 @@ async def predict_from_project_data(
         intake_settings["partition"] = partition
     if dataset_id:
         intake_settings["dataset_id"] = dataset_id
-    job = dr.BatchPredictionJob.score(
-        deployment=deployment_id,
-        intake_settings=intake_settings,  # type: ignore[arg-type]
-        output_settings=None,
-    )
+    try:
+        job = dr.BatchPredictionJob.score(
+            deployment=deployment_id,
+            intake_settings=intake_settings,  # type: ignore[arg-type]
+            output_settings=None,
+        )
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     return await _wait_for_preds_and_cache_results_async(
         job, deployment_id, f"Scoring project {project_id}.", timeout or 600
     )
@@ -220,6 +253,7 @@ async def predict_from_project_data(
     ),
 )
 async def get_batch_prediction_results(
+    *,
     job_id: Annotated[
         str,
         "job_id returned by predict_by_ai_catalog or predict_from_project_data.",
@@ -228,11 +262,16 @@ async def get_batch_prediction_results(
     download_read_timeout: Annotated[int, "Seconds allowed for streaming the CSV body."] = 660,
 ) -> dict[str, Any]:
     if not job_id or not job_id.strip():
-        raise ToolError("Argument validation error: 'job_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'job_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     token = await get_datarobot_access_token()
     DataRobotClient(token).get_client()
-    job = dr.BatchPredictionJob.get(job_id.strip())
+    try:
+        job = dr.BatchPredictionJob.get(job_id.strip())
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     download_url = _batch_job_download_url(job)
     buf = io.BytesIO()
     try:

--- a/src/datarobot_genai/drtools/predictive/predict_realtime.py
+++ b/src/datarobot_genai/drtools/predictive/predict_realtime.py
@@ -20,6 +20,7 @@ from typing import Annotated
 from typing import Any
 
 import polars as pl
+from datarobot.errors import ClientError
 from datarobot_predict import TimeSeriesType
 from datarobot_predict.deployment import predict as dr_predict
 from dateutil import parser as dateutil_parser
@@ -28,7 +29,9 @@ from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.core.utils import predictions_result_response
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -52,18 +55,28 @@ def _parse_datetime(value: str) -> datetime:
     ),
 )
 async def predict_by_ai_catalog_rt(
+    *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     dataset_id: Annotated[str, "AI Catalog dataset id (tabular)."],
     timeout: Annotated[int, "Client wait cap in seconds."] | None = 600,
 ) -> dict[str, Any]:
     if not deployment_id or not deployment_id.strip():
-        raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'deployment_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     if not dataset_id or not dataset_id.strip():
-        raise ToolError("Argument validation error: 'dataset_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'dataset_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    dataset = client.Dataset.get(dataset_id)
+    try:
+        dataset = client.Dataset.get(dataset_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     # 1. Preferred: built-in DataFrame helper (newer SDKs)
     if hasattr(dataset, "get_as_dataframe"):
@@ -89,7 +102,10 @@ async def predict_by_ai_catalog_rt(
         url = dataset.url
         df = pl.read_csv(url).to_pandas()
 
-    deployment = client.Deployment.get(deployment_id=deployment_id)
+    try:
+        deployment = client.Deployment.get(deployment_id=deployment_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     result = dr_predict(deployment, df, timeout=timeout or 600)
     predictions = result.dataframe
     prediction_results = predictions_result_response(predictions, show_explanations=True)
@@ -118,6 +134,7 @@ async def predict_by_ai_catalog_rt(
     ),
 )
 async def predict_realtime(
+    *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     dataset: Annotated[
         str,
@@ -184,10 +201,15 @@ async def predict_realtime(
     timeout: Annotated[int, "Client wait cap in seconds."] | None = 600,
 ) -> dict[str, Any]:
     if not deployment_id or not deployment_id.strip():
-        raise ToolError("Argument validation error: 'deployment_id' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'deployment_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     ds = dataset.strip()
     if not ds:
-        raise ToolError("Argument validation error: 'dataset' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'dataset' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     # JSON array of row objects must not go through read_csv first — Polars can "parse" a
     # leading '[' as CSV and yield empty or wrong frames, which then produce API errors like
@@ -224,7 +246,10 @@ async def predict_realtime(
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    deployment = client.Deployment.get(deployment_id=deployment_id)
+    try:
+        deployment = client.Deployment.get(deployment_id=deployment_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     # Check if this is a time series prediction or regular prediction
     is_time_series = bool(forecast_point or (forecast_range_start and forecast_range_end))

--- a/src/datarobot_genai/drtools/predictive/project.py
+++ b/src/datarobot_genai/drtools/predictive/project.py
@@ -16,10 +16,14 @@ import logging
 from typing import Annotated
 from typing import Any
 
+from datarobot.errors import ClientError
+
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +63,16 @@ async def get_project_dataset_by_name(
     dataset_name: Annotated[str, "Substring to match against dataset display names."],
 ) -> dict[str, Any]:
     if not project_id:
-        raise ToolError("Project ID is required.")
+        raise ToolError("Project ID is required.", kind=ToolErrorKind.VALIDATION)
     if not dataset_name:
-        raise ToolError("Dataset name is required.")
+        raise ToolError("Dataset name is required.", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
+    try:
+        project = client.Project.get(project_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     all_datasets = []
     source_dataset = project.get_dataset()
     if source_dataset:
@@ -80,5 +87,6 @@ async def get_project_dataset_by_name(
                 "dataset_type": ds["type"],
             }
     raise ToolError(
-        f"Dataset with name containing '{dataset_name}' not found in project {project_id}."
+        f"Dataset with name containing '{dataset_name}' not found in project {project_id}.",
+        kind=ToolErrorKind.NOT_FOUND,
     )

--- a/src/datarobot_genai/drtools/predictive/training.py
+++ b/src/datarobot_genai/drtools/predictive/training.py
@@ -21,11 +21,14 @@ from typing import Annotated
 from typing import Any
 
 import pandas as pd
+from datarobot.errors import ClientError
 
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
 
@@ -74,16 +77,21 @@ def _get_dataset_or_raise(client: Any, dataset_id: str) -> tuple[Any, pd.DataFra
     try:
         dataset = client.Dataset.get(dataset_id)
         return dataset, dataset.get_as_dataframe()
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     except Exception as e:
         error_str = str(e)
         # Check if it's a 404 error (dataset not found)
         if "404" in error_str or "Not Found" in error_str:
             raise ToolError(
                 f"Dataset '{dataset_id}' not found. Please verify the dataset ID exists "
-                "and you have access to it."
+                "and you have access to it.",
+                kind=ToolErrorKind.NOT_FOUND,
             )
         # For other errors, provide context
-        raise ToolError(f"Failed to retrieve dataset '{dataset_id}': {error_str}")
+        raise ToolError(
+            f"Failed to retrieve dataset '{dataset_id}': {error_str}", kind=ToolErrorKind.UPSTREAM
+        )
 
 
 @tool_metadata(
@@ -101,7 +109,7 @@ async def analyze_dataset(
     dataset_id: Annotated[str, "AI Catalog dataset id."],
 ) -> dict[str, Any]:
     if not dataset_id:
-        raise ToolError("Dataset ID must be provided")
+        raise ToolError("Dataset ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -158,7 +166,7 @@ async def suggest_use_cases(
     dataset_id: Annotated[str, "AI Catalog dataset id."],
 ) -> dict[str, Any]:
     if not dataset_id:
-        raise ToolError("Dataset ID must be provided")
+        raise ToolError("Dataset ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -197,7 +205,7 @@ async def get_exploratory_insights(
     | None = None,
 ) -> dict[str, Any]:
     if not dataset_id:
-        raise ToolError("Dataset ID must be provided")
+        raise ToolError("Dataset ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -491,7 +499,8 @@ def _analyze_target_for_use_cases(df: pd.DataFrame, target_col: str) -> list[Use
     description=(
         "[Project—start Autopilot] Use when the user wants to start or resume Autopilot for one "
         "tabular target: new project from dataset_id or public dataset_url plus project_name, or "
-        "existing project via project_id. mode is quick, comprehensive, or manual. Returns "
+        "existing project via project_id. mode must be string 'quick', 'comprehensive', or "
+        "'manual' (default 'quick'). Returns "
         "project_id and status—not finished leaderboard models yet. Not deployment creation "
         "(deploy_model), not batch scoring (predict_*), not dataset upload "
         "(upload_dataset_to_ai_catalog) unless they already registered data."
@@ -504,7 +513,11 @@ async def start_autopilot(
         str, "Existing project id to resume; omit when creating from dataset_url or dataset_id."
     ]
     | None = None,
-    mode: Annotated[str, "Autopilot breadth: quick, comprehensive, or manual."] = "quick",
+    mode: Annotated[
+        str,
+        "Pass exactly one of these strings: 'quick', 'comprehensive', 'manual'. "
+        "Omit to default to 'quick'.",
+    ] = "quick",
     dataset_url: Annotated[
         str,
         "For new projects: public URL to tabular data (mutually exclusive with dataset_id).",
@@ -529,23 +542,34 @@ async def start_autopilot(
 
     if not project_id:
         if not dataset_url and not dataset_id:
-            raise ToolError("Either dataset_url or dataset_id must be provided")
+            raise ToolError(
+                "Either dataset_url or dataset_id must be provided", kind=ToolErrorKind.VALIDATION
+            )
         if dataset_url and dataset_id:
-            raise ToolError("Please provide either dataset_url or dataset_id, not both")
+            raise ToolError(
+                "Please provide either dataset_url or dataset_id, not both",
+                kind=ToolErrorKind.VALIDATION,
+            )
 
         if dataset_url:
             dataset = client.Dataset.create_from_url(dataset_url)
         else:
-            dataset = client.Dataset.get(dataset_id)
+            try:
+                dataset = client.Dataset.get(dataset_id)
+            except ClientError as e:
+                raise_tool_error_for_client_error(e)
 
         project = client.Project.create_from_dataset(
             dataset.id, project_name=project_name, use_case=use_case_id
         )
     else:
-        project = client.Project.get(project_id)
+        try:
+            project = client.Project.get(project_id)
+        except ClientError as e:
+            raise_tool_error_for_client_error(e)
 
     if not target:
-        raise ToolError("Target variable must be specified")
+        raise ToolError("Target variable must be specified", kind=ToolErrorKind.VALIDATION)
 
     try:
         # Start modeling
@@ -562,14 +586,15 @@ async def start_autopilot(
         return result
 
     except Exception as e:
-        raise ToolError(f"Failed to start Autopilot: {str(e)}")
+        raise ToolError(f"Failed to start Autopilot: {str(e)}", kind=ToolErrorKind.UPSTREAM)
 
 
 @tool_metadata(
     tags={"prediction", "training", "read", "model", "evaluation"},
     description=(
         "[Project—ROC only] Use when the user wants ROC curve points for one binary classification "
-        "leaderboard model; source is validation, holdout, or crossValidation. Read-only. Not "
+        "leaderboard model; source must be string 'validation', 'holdout', or 'crossValidation'. "
+        "Read-only. Not "
         "for regression-only models, not full model card (get_model_details), not deployment "
         "monitoring (get_prediction_history)."
     ),
@@ -580,18 +605,22 @@ async def get_model_roc_curve(
     model_id: Annotated[str, "Leaderboard model id."],
     source: Annotated[
         str,
-        "Which data fold: validation, holdout, or crossValidation.",
+        "Pass exactly one of these strings (camelCase as shown): 'validation', 'holdout', "
+        "'crossValidation'. Omit to default to 'validation'.",
     ] = "validation",
 ) -> dict[str, Any]:
     if not project_id:
-        raise ToolError("Project ID must be provided")
+        raise ToolError("Project ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not model_id:
-        raise ToolError("Model ID must be provided")
+        raise ToolError("Model ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
-    model = client.Model.get(project=project, model_id=model_id)
+    try:
+        project = client.Project.get(project_id)
+        model = client.Model.get(project=project, model_id=model_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     try:
         roc_curve = model.get_roc_curve(source=source)
@@ -623,7 +652,7 @@ async def get_model_roc_curve(
 
         return {"data": roc_data}
     except Exception as e:
-        raise ToolError(f"Failed to get ROC curve: {str(e)}")
+        raise ToolError(f"Failed to get ROC curve: {str(e)}", kind=ToolErrorKind.UPSTREAM)
 
 
 @tool_metadata(
@@ -641,14 +670,17 @@ async def get_model_feature_impact(
     model_id: Annotated[str, "Leaderboard model id."],
 ) -> dict[str, Any]:
     if not project_id:
-        raise ToolError("Project ID must be provided")
+        raise ToolError("Project ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not model_id:
-        raise ToolError("Model ID must be provided")
+        raise ToolError("Model ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
-    model = client.Model.get(project=project, model_id=model_id)
+    try:
+        project = client.Project.get(project_id)
+        model = client.Model.get(project=project, model_id=model_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
     # Get feature impact
     model.request_feature_impact()
     feature_impact = model.get_or_request_feature_impact()
@@ -660,8 +692,9 @@ async def get_model_feature_impact(
     tags={"predictive", "training", "read", "model", "evaluation"},
     description=(
         "[Project—lift chart] Use for lift chart bins on one classification leaderboard model "
-        "(actual vs predicted by score bucket); source is validation, holdout, or crossValidation. "
-        "Read-only. Not ROC points (get_model_roc_curve), not general model metrics dump "
+        "(actual vs predicted by score bucket); source must be 'validation', 'holdout', or "
+        "'crossValidation'. Read-only. Not ROC points (get_model_roc_curve), not general model "
+        "metrics dump "
         "(get_model_details)."
     ),
 )
@@ -671,18 +704,22 @@ async def get_model_lift_chart(
     model_id: Annotated[str, "Leaderboard model id."],
     source: Annotated[
         str,
-        "Which data fold: validation, holdout, or crossValidation.",
+        "Pass exactly one of these strings (camelCase as shown): 'validation', 'holdout', "
+        "'crossValidation'. Omit to default to 'validation'.",
     ] = "validation",
 ) -> dict[str, Any]:
     if not project_id:
-        raise ToolError("Project ID must be provided")
+        raise ToolError("Project ID must be provided", kind=ToolErrorKind.VALIDATION)
     if not model_id:
-        raise ToolError("Model ID must be provided")
+        raise ToolError("Model ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    project = client.Project.get(project_id)
-    model = client.Model.get(project=project, model_id=model_id)
+    try:
+        project = client.Project.get(project_id)
+        model = client.Model.get(project=project, model_id=model_id)
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
 
     # Get lift chart
     lift_chart = model.get_lift_chart(source=source)

--- a/src/datarobot_genai/drtools/tavily/tools.py
+++ b/src/datarobot_genai/drtools/tavily/tools.py
@@ -27,23 +27,33 @@ from datarobot_genai.drtools.core.clients.tavily import MAX_RESULTS_DEFAULT
 from datarobot_genai.drtools.core.clients.tavily import TavilyClient
 from datarobot_genai.drtools.core.clients.tavily import get_tavily_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"tavily", "search", "web", "websearch"})
+@tool_metadata(
+    tags={"tavily", "search", "web", "websearch"},
+    description=(
+        "[Tavily—web search] Use when the user needs fresh facts from the public web by keyword "
+        "(optional topic string: 'general', 'news', or 'finance'). Returns ranked snippets and "
+        "optional short answer. "
+        "Not for reading full pages when you already have URLs (tavily_extract), not site link "
+        "discovery (tavily_map), not multi-page site harvest (tavily_crawl)."
+    ),
+)
 async def tavily_search(
     *,
     query: Annotated[str, "The search query to execute."],
     topic: Annotated[
         Literal["general", "news", "finance"],
-        "The category of search. Use 'general' for broad web search, "
-        "'news' for recent news articles, or 'finance' for financial information.",
+        "Pass exactly one of these strings (not a type or enum name): 'general', 'news', "
+        "'finance'. Broad web vs news vs finance search; omit to default to 'general'.",
     ] = "general",
     search_depth: Annotated[
         Literal["basic", "advanced"],
-        "The depth of search. 'basic' is faster and cheaper, "
-        "'advanced' provides more comprehensive results.",
+        "Pass exactly one of these strings: 'basic', 'advanced'. Faster/cheaper vs deeper "
+        "coverage; omit to default to 'basic'.",
     ] = "basic",
     max_results: Annotated[
         int,
@@ -51,8 +61,8 @@ async def tavily_search(
     ] = MAX_RESULTS_DEFAULT,
     time_range: Annotated[
         Literal["day", "week", "month", "year"] | None,
-        "Filter results by time range. Use 'day' for last 24 hours, "
-        "'week' for last 7 days, 'month' for last 30 days, or 'year' for last year.",
+        "Optional. Pass exactly one of these strings or omit: 'day', 'week', 'month', 'year' "
+        "(last 24h / 7d / 30d / year).",
     ] = None,
     include_images: Annotated[
         bool,
@@ -72,30 +82,10 @@ async def tavily_search(
         "Whether to include an AI-generated answer summarizing the search results.",
     ] = False,
 ) -> dict[str, Any]:
-    """
-    Perform a real-time web search using Tavily API.
-
-    Tavily is optimized for AI agents and provides clean, relevant search results
-    suitable for LLM consumption. Use this tool to search the web for current
-    information, news, financial data, or general knowledge.
-
-    Usage:
-        - Basic search: tavily_search(query="Python best practices 2026")
-        - News search: tavily_search(query="AI regulations", topic="news", time_range="week")
-        - Financial search: tavily_search(query="AAPL stock analysis", topic="finance")
-        - Comprehensive search: tavily_search(
-            query="climate change solutions",
-            search_depth="advanced",
-            max_results=10,
-            include_answer=True
-          )
-
-    Note:
-        - Advanced search depth consumes more API credits but provides better results
-        - Time range filtering is useful for finding recent information
-    """
     if not query or not query.strip():
-        raise ToolError("Argument validation error: 'query' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'query' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     api_key = await get_tavily_access_token()
 
@@ -115,7 +105,14 @@ async def tavily_search(
     return response.as_flat_dict(include_images=include_images, include_answer=include_answer)
 
 
-@tool_metadata(tags={"extract", "tavily", "web", "content"})
+@tool_metadata(
+    tags={"tavily", "extract", "web", "content"},
+    description=(
+        "[Tavily—read URLs] Use when you already have one or more page URLs and need cleaned "
+        "body text or reranked chunks (optional query for relevance). Not broad keyword web "
+        "search (tavily_search), not crawling an entire site (tavily_crawl)."
+    ),
+)
 async def tavily_extract(
     *,
     urls: Annotated[
@@ -132,45 +129,36 @@ async def tavily_extract(
     ] = 3,
     format: Annotated[
         Literal["markdown", "text"],
-        "Format of extracted content. Markdown is usually more ergonomic for LLMs.",
+        "Pass exactly one of these strings: 'markdown', 'text'. Omit to default to 'markdown'.",
     ] = "markdown",
     extract_depth: Annotated[
         Literal["basic", "advanced"],
-        "Depth of extraction; 'advanced' handles complex tables and embedded content.",
+        "Pass exactly one of these strings: 'basic', 'advanced'. Omit to default to 'basic'; "
+        "'advanced' handles complex tables and embedded content.",
     ] = "basic",
 ) -> dict[str, Any]:
-    """
-    Extract content from web pages using Tavily Extract API.
-
-    Use this tool to retrieve and parse content from one or more URLs. The extracted
-    content is cleaned and formatted for LLM consumption.
-
-    Usage:
-        - Single URL: tavily_extract(urls="https://example.com/article")
-        - Multiple URLs: tavily_extract(urls=["url1", "url2"])
-        - With relevance query: tavily_extract(urls="url", query="auth setup", chunks_per_source=5)
-        - Advanced: tavily_extract(urls="url", extract_depth="advanced")
-
-    Limits (configurable in client):
-        - Maximum 20 URLs per request
-        - chunks_per_source: 1-5 (default 3)
-        - timeout: 1.0-60.0 seconds (default 30.0)
-
-    Note:
-        - Advanced depth handles complex content but may be slower
-    """
     if isinstance(urls, str):
         if not urls or not urls.strip():
-            raise ToolError("Argument validation error: 'urls' cannot be empty.")
+            raise ToolError(
+                "Argument validation error: 'urls' cannot be empty.", kind=ToolErrorKind.VALIDATION
+            )
     elif isinstance(urls, list):
         if not urls:
-            raise ToolError("Argument validation error: 'urls' list cannot be empty.")
+            raise ToolError(
+                "Argument validation error: 'urls' list cannot be empty.",
+                kind=ToolErrorKind.VALIDATION,
+            )
         for url in urls:
             if not url or not url.strip():
-                raise ToolError("Argument validation error: URLs in list cannot be empty.")
+                raise ToolError(
+                    "Argument validation error: URLs in list cannot be empty.",
+                    kind=ToolErrorKind.VALIDATION,
+                )
 
     if query is not None and (not query or not query.strip()):
-        raise ToolError("Argument validation error: 'query' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'query' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     api_key = await get_tavily_access_token()
 
@@ -186,7 +174,15 @@ async def tavily_extract(
     return response.as_flat_dict()
 
 
-@tool_metadata(tags={"map", "tavily", "discovery"})
+@tool_metadata(
+    tags={"tavily", "map", "discovery"},
+    description=(
+        "[Tavily—site map] Use when you need a structured list of links under one root URL "
+        "(find sections or docs paths before reading). Optional instructions steer which branches "
+        "matter. Not keyword web search (tavily_search), not full page text (tavily_extract), "
+        "not deep multi-hop crawl (tavily_crawl)."
+    ),
+)
 async def tavily_map(
     *,
     url: Annotated[str, "The root URL to begin mapping."],
@@ -198,15 +194,16 @@ async def tavily_map(
         bool, "Whether to include credit usage information in the response."
     ] = False,
 ) -> dict[str, Any]:
-    """
-    Generate a structured map of a website to discover relevant sub-pages.
-    API documentation: https://docs.tavily.com/documentation/api-reference/endpoint/map .
-    """
     if not url or not url.strip():
-        raise ToolError("Argument validation error: 'url' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'url' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if instructions is not None and (not instructions or not instructions.strip()):
-        raise ToolError("Argument validation error: 'instructions' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'instructions' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     api_key = await get_tavily_access_token()
 
@@ -218,7 +215,15 @@ async def tavily_map(
     return response.as_flat_dict()
 
 
-@tool_metadata(tags={"crawl", "tavily", "web", "rag"})
+@tool_metadata(
+    tags={"tavily", "crawl", "web", "rag"},
+    description=(
+        "[Tavily—site crawl] Use when you need many related pages from one site guided by "
+        "natural-language instructions (breadth/depth limits). Not single-URL read "
+        "(tavily_extract), not link-only outline (tavily_map), not global keyword search "
+        "(tavily_search)."
+    ),
+)
 async def tavily_crawl(
     *,
     url: Annotated[str, "The root URL to begin the traversal."],
@@ -234,38 +239,16 @@ async def tavily_crawl(
     ] = None,
     include_images: Annotated[bool, "Include images found during crawl."] = False,
 ) -> dict[str, Any]:
-    """
-    Crawl a website using Tavily Crawl API for Crawl-to-RAG workflows.
-
-    Use this tool to explore an entire site and retrieve relevant content based on
-    natural language instructions. Ideal for building knowledge bases, extracting
-    documentation, or gathering structured content from websites.
-
-    Usage:
-        - Basic crawl: tavily_crawl(url="https://docs.example.com")
-        - With instructions: tavily_crawl(
-            url="https://docs.example.com",
-            instructions="Find all API documentation pages"
-          )
-        - Deep crawl: tavily_crawl(url="https://example.com", max_depth=3, limit=100)
-        - Exclude paths: tavily_crawl(
-            url="https://example.com",
-            exclude_paths=["/blog/.*", "/archive/.*"]
-          )
-
-    Limits:
-        - limit: 1-500 (default 20)
-        - max_depth: 1-5 (default 1)
-
-    Note:
-        - Higher limits and depths consume more API credits
-        - Use instructions to filter for relevant content and reduce noise
-    """
     if not url or not url.strip():
-        raise ToolError("Argument validation error: 'url' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'url' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     if instructions is not None and (not instructions or not instructions.strip()):
-        raise ToolError("Argument validation error: 'instructions' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'instructions' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     api_key = await get_tavily_access_token()
 

--- a/src/datarobot_genai/drtools/tavily/tools.py
+++ b/src/datarobot_genai/drtools/tavily/tools.py
@@ -31,6 +31,11 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
+_TAVILY_SEARCH_API = "https://docs.tavily.com/documentation/api-reference/endpoint/search"
+_TAVILY_EXTRACT_API = "https://docs.tavily.com/documentation/api-reference/endpoint/extract"
+_TAVILY_MAP_API = "https://docs.tavily.com/documentation/api-reference/endpoint/map"
+_TAVILY_CRAWL_API = "https://docs.tavily.com/documentation/api-reference/endpoint/crawl"
+
 
 @tool_metadata(
     tags={"tavily", "search", "web", "websearch"},
@@ -39,7 +44,11 @@ logger = logging.getLogger(__name__)
         "(optional topic string: 'general', 'news', or 'finance'). Returns ranked snippets and "
         "optional short answer. "
         "Not for reading full pages when you already have URLs (tavily_extract), not site link "
-        "discovery (tavily_map), not multi-page site harvest (tavily_crawl)."
+        "discovery (tavily_map), not multi-page site harvest (tavily_crawl).\n\n"
+        'Examples: tavily_search(query="Python best practices 2026"); '
+        'topic="news", time_range="week"; topic="finance"; search_depth="advanced", '
+        "include_answer=True. Advanced depth uses more credits.\n\n"
+        f"Reference: {_TAVILY_SEARCH_API}"
     ),
 )
 async def tavily_search(
@@ -110,7 +119,10 @@ async def tavily_search(
     description=(
         "[Tavily—read URLs] Use when you already have one or more page URLs and need cleaned "
         "body text or reranked chunks (optional query for relevance). Not broad keyword web "
-        "search (tavily_search), not crawling an entire site (tavily_crawl)."
+        "search (tavily_search), not crawling an entire site (tavily_crawl).\n\n"
+        'Examples: single url string; list of urls; tavily_extract(urls="...", query="...", '
+        'chunks_per_source=5); extract_depth="advanced". Up to 20 URLs; chunks_per_source 1-5.\n\n'
+        f"Reference: {_TAVILY_EXTRACT_API}"
     ),
 )
 async def tavily_extract(
@@ -180,7 +192,9 @@ async def tavily_extract(
         "[Tavily—site map] Use when you need a structured list of links under one root URL "
         "(find sections or docs paths before reading). Optional instructions steer which branches "
         "matter. Not keyword web search (tavily_search), not full page text (tavily_extract), "
-        "not deep multi-hop crawl (tavily_crawl)."
+        "not deep multi-hop crawl (tavily_crawl).\n\n"
+        'Example: tavily_map(url="https://docs.example.com", instructions="API sections").\n\n'
+        f"Reference: {_TAVILY_MAP_API}"
     ),
 )
 async def tavily_map(
@@ -221,7 +235,10 @@ async def tavily_map(
         "[Tavily—site crawl] Use when you need many related pages from one site guided by "
         "natural-language instructions (breadth/depth limits). Not single-URL read "
         "(tavily_extract), not link-only outline (tavily_map), not global keyword search "
-        "(tavily_search)."
+        "(tavily_search).\n\n"
+        "Examples: basic crawl on docs root; instructions to filter topics; max_depth and limit "
+        "up to API max; exclude_paths regex list. Higher depth/limit uses more credits.\n\n"
+        f"Reference: {_TAVILY_CRAWL_API}"
     ),
 )
 async def tavily_crawl(

--- a/src/datarobot_genai/drtools/use_case/tools.py
+++ b/src/datarobot_genai/drtools/use_case/tools.py
@@ -22,23 +22,33 @@ from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_token
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
 
-@tool_metadata(tags={"use_case", "read", "list", "daria"})
+@tool_metadata(
+    tags={"use_case", "read", "list", "daria"},
+    description=(
+        "[Use case—list] Use when the user needs DataRobot use cases (workspace bundles) as "
+        "id+name, optionally filtered by name search. Read-only. Not assets inside a known case "
+        "(list_use_case_assets), not modeling project ids (list_projects), not deployments alone "
+        "(list_deployments)."
+    ),
+)
 async def list_use_cases(
     *,
     search: Annotated[str | None, "Optional search filter for use case names"] = None,
     limit: Annotated[int, "Maximum number of use cases to return"] = 100,
 ) -> dict[str, Any]:
-    """List DataRobot use cases with optional search filter."""
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()
     rest_client = dr_module.client.get_client()
 
     if search is not None and (not search or not search.strip()):
-        raise ToolError("Argument validation error: 'search' cannot be empty.")
+        raise ToolError(
+            "Argument validation error: 'search' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
 
     params: dict = {"limit": limit}
     if search:
@@ -52,28 +62,42 @@ async def list_use_cases(
     }
 
 
-@tool_metadata(tags={"use_case", "read", "assets", "daria"})
+@tool_metadata(
+    tags={"use_case", "read", "assets", "daria"},
+    description=(
+        "[Use case—assets] Use when you have one or more use_case_id values and need what is "
+        "linked: datasets, deployments, and experiments as id+name per case. Read-only. Not "
+        "discovering use case ids (list_use_cases), not Jira/Confluence content."
+    ),
+)
 async def list_use_case_assets(
     *,
     use_case_id: Annotated[str | None, "The ID of a single DataRobot use case"] = None,
     use_case_ids: Annotated[list[str] | None, "List of use case IDs to fetch assets for"] = None,
 ) -> dict[str, Any]:
-    """List datasets, deployments, and experiments belonging to one or more use cases."""
     ids: list[str] = []
     if use_case_ids is not None:
         if not use_case_ids:
-            raise ToolError("use_case_ids must not be empty.")
+            raise ToolError("use_case_ids must not be empty.", kind=ToolErrorKind.VALIDATION)
         # Validate each ID in the list
         for uc_id in use_case_ids:
             if not uc_id or not uc_id.strip():
-                raise ToolError("Argument validation error: use_case IDs in list cannot be empty.")
+                raise ToolError(
+                    "Argument validation error: use_case IDs in list cannot be empty.",
+                    kind=ToolErrorKind.VALIDATION,
+                )
         ids = use_case_ids
     elif use_case_id:
         if not use_case_id or not use_case_id.strip():
-            raise ToolError("Argument validation error: 'use_case_id' cannot be empty.")
+            raise ToolError(
+                "Argument validation error: 'use_case_id' cannot be empty.",
+                kind=ToolErrorKind.VALIDATION,
+            )
         ids = [use_case_id]
     else:
-        raise ToolError("Either use_case_id or use_case_ids must be provided.")
+        raise ToolError(
+            "Either use_case_id or use_case_ids must be provided.", kind=ToolErrorKind.VALIDATION
+        )
 
     token = await get_datarobot_access_token()
     dr_module = DataRobotClient(token).get_client()

--- a/tests/drmcp/acceptance/test_deployment.py
+++ b/tests/drmcp/acceptance/test_deployment.py
@@ -67,11 +67,7 @@ def expectations_for_get_model_info_from_deployment_failure(
             ToolCallTestExpectations(
                 name="get_model_info_from_deployment",
                 parameters={"deployment_id": nonexistent_deployment_id},
-                result=(
-                    "Error in "
-                    "get_model_info_from_deployment: ClientError: 404 client error: "
-                    "{'message': 'Not Found'}"
-                ),
+                result="[not_found] DataRobot API error (404):",
             ),
         ],
         llm_response_content_contains_expectations=[

--- a/tests/drmcp/acceptance/test_model.py
+++ b/tests/drmcp/acceptance/test_model.py
@@ -59,10 +59,7 @@ def expectations_for_get_best_model_failure(
             ToolCallTestExpectations(
                 name="get_best_model",
                 parameters={"project_id": nonexistent_project_id},
-                result=(
-                    "Error in get_best_model: "
-                    "ClientError: 404 client error: {'message': 'Not Found'}"
-                ),
+                result="[not_found] DataRobot API error (404):",
             ),
         ],
         llm_response_content_contains_expectations=[
@@ -119,11 +116,7 @@ def expectations_for_score_dataset_with_model_failure(
                     "model_id": nonexistent_model_id,
                     "dataset_id": classification_predict_dataset["dataset_id"],
                 },
-                result=(
-                    "Error in score_dataset_with_model: "
-                    "ClientError: 404 client error: "
-                    "{'message': 'Not Found'}"
-                ),
+                result="[not_found] DataRobot API error (404):",
             ),
         ],
         llm_response_content_contains_expectations=[

--- a/tests/drmcp/integration/test_model.py
+++ b/tests/drmcp/integration/test_model.py
@@ -97,9 +97,9 @@ class TestMCPToolsIntegration:
                 if hasattr(result.content[0], "text")
                 else str(result.content[0])
             )
-            # Stub returns "not found"; real API returns ClientError 404
-            assert "Error in get_best_model" in result_text
-            assert "nonexistent_project" in result_text or "Not Found" in result_text
+            # Stub returns not_found; real API returns ClientError 404
+            assert "nonexistent_project" in result_text
+            assert "not found" in result_text.lower() or "not_found" in result_text.lower()
 
             # 5 Test metric-based sorting of models
             result = await session.call_tool(

--- a/tests/drmcp/integration/test_predict_realtime.py
+++ b/tests/drmcp/integration/test_predict_realtime.py
@@ -194,7 +194,7 @@ class TestMCPRealtimePredictToolsIntegration:
             assert result.isError
             assert (
                 result.content[0].text  # type: ignore[union-attr]
-                == "Error in predict_realtime: "
+                == "[internal] Error in predict_realtime: "
                 "ValueError: series_id_column 'invalid_column' not found in input data."
             )
 

--- a/tests/drmcp/integration/test_use_case.py
+++ b/tests/drmcp/integration/test_use_case.py
@@ -160,4 +160,5 @@ class TestMCPUseCaseToolsIntegration:
                 if hasattr(result.content[0], "text")
                 else str(result.content[0])
             )
-            assert "use case" in error_text.lower() or "error" in error_text.lower()
+            lowered = error_text.lower()
+            assert "use_case_id" in lowered or "use case" in lowered or "validation" in lowered

--- a/tests/drmcp/unit/predictive_tools/test_deployment.py
+++ b/tests/drmcp/unit/predictive_tools/test_deployment.py
@@ -21,10 +21,12 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from datarobot.errors import ClientError
 from dotenv import load_dotenv
 
 from datarobot_genai.drtools.core.deployment_utils import deploy_custom_model_impl
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.predictive import deployment
 
 
@@ -105,7 +107,11 @@ async def test_get_model_info_from_deployment_success() -> None:
 @pytest.mark.asyncio
 async def test_get_model_info_from_deployment_not_found() -> None:
     mock_client = MagicMock()
-    mock_client.Deployment.get.side_effect = Exception("404 client error: {'message': 'Not Found'}")
+    mock_client.Deployment.get.side_effect = ClientError(
+        "404 client error: {'message': 'Not Found'}",
+        status_code=404,
+        json={"message": "Not Found"},
+    )
     with (
         patch(
             "datarobot_genai.drtools.predictive.deployment.get_datarobot_access_token",
@@ -115,9 +121,10 @@ async def test_get_model_info_from_deployment_not_found() -> None:
         patch("datarobot_genai.drtools.predictive.deployment.DataRobotClient") as mock_drc,
     ):
         mock_drc.return_value.get_client.return_value = mock_client
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ToolError) as exc_info:
             await deployment.get_model_info_from_deployment(deployment_id="dep_id")
-        assert "404 client error: {'message': 'Not Found'}" == str(exc_info.value)
+        assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+        assert "404" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/predictive_tools/test_model.py
+++ b/tests/drmcp/unit/predictive_tools/test_model.py
@@ -20,8 +20,10 @@ from unittest.mock import patch
 
 import polars as pl
 import pytest
+from datarobot.errors import ClientError
 
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.predictive import model
 from datarobot_genai.drtools.predictive.model import ModelEncoder
 from datarobot_genai.drtools.predictive.model import model_to_dict
@@ -87,6 +89,23 @@ async def test_get_best_model_project_not_found() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_best_model_project_client_error_404() -> None:
+    mock_client = MagicMock()
+    mock_client.Project.get.side_effect = ClientError(
+        "404 client error: {'message': 'Not Found'}",
+        status_code=404,
+        json={"message": "Not Found"},
+    )
+    p1, p2 = _patch_model_client(mock_client)
+    with p1, p2 as mock_drc:
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError) as exc_info:
+            await model.get_best_model(project_id="missing-proj", metric="AUC")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+    assert "404" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_get_best_model_error() -> None:
     with patch(
         "datarobot_genai.drtools.predictive.model.get_datarobot_access_token",
@@ -147,20 +166,22 @@ async def test_score_dataset_with_model_empty_dataset_id() -> None:
 async def test_score_dataset_with_model_project_not_found() -> None:
     project_id = "pid"
     mock_client = MagicMock()
-    exception_message = (
-        "404 client error: {'message': 'Project with ID " + project_id + " does not exist'}"
+    mock_client.Project.get.side_effect = ClientError(
+        "404 client error: {'message': 'Not Found'}",
+        status_code=404,
+        json={"message": "Not Found"},
     )
-    mock_client.Project.get.side_effect = Exception(exception_message)
     p1, p2 = _patch_model_client(mock_client)
     with p1, p2 as mock_drc:
         mock_drc.return_value.get_client.return_value = mock_client
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ToolError) as exc_info:
             await model.score_dataset_with_model(
                 project_id=project_id,
                 model_id="mid",
                 dataset_id="dsid",
             )
-    assert exception_message == str(exc_info.value)
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+    assert "not found" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio
@@ -169,18 +190,41 @@ async def test_score_dataset_with_model_model_not_found() -> None:
     mock_project = MagicMock()
     mock_project.get_models.return_value = []
     mock_client.Project.get.return_value = mock_project
-    exception_message = "404 client error: {'message': 'Leaderboard Item Not Found'}"
-    mock_client.Model.get.side_effect = Exception(exception_message)
+    mock_client.Model.get.side_effect = ClientError(
+        "404 client error: {'message': 'Leaderboard Item Not Found'}",
+        status_code=404,
+        json={"message": "Leaderboard Item Not Found"},
+    )
     p1, p2 = _patch_model_client(mock_client)
     with p1, p2 as mock_drc:
         mock_drc.return_value.get_client.return_value = mock_client
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ToolError) as exc_info:
             await model.score_dataset_with_model(
                 project_id="pid",
                 model_id="mid",
                 dataset_id="dsid",
             )
-    assert exception_message == str(exc_info.value)
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_score_dataset_with_model_client_error_non_404_is_upstream() -> None:
+    mock_client = MagicMock()
+    mock_client.Project.get.side_effect = ClientError(
+        "503: service unavailable",
+        status_code=503,
+        json={},
+    )
+    p1, p2 = _patch_model_client(mock_client)
+    with p1, p2 as mock_drc:
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError) as exc_info:
+            await model.score_dataset_with_model(
+                project_id="pid",
+                model_id="mid",
+                dataset_id="dsid",
+            )
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/predictive_tools/test_predict.py
+++ b/tests/drmcp/unit/predictive_tools/test_predict.py
@@ -62,7 +62,9 @@ async def test_predict_by_ai_catalog(
         mock_client = MagicMock()
         mock_client.Dataset.get.return_value = mock_dataset
         mock_drc.return_value.get_client.return_value = mock_client
-        result = await predict.predict_by_ai_catalog("dep", "dsid", 5)
+        result = await predict.predict_by_ai_catalog(
+            deployment_id="dep", dataset_id="dsid", timeout=5
+        )
         patch_predict_dependencies["mock_batch_job"].score.assert_called_once_with(
             deployment="dep",
             intake_settings={"type": "dataset", "dataset": mock_dataset},
@@ -90,7 +92,13 @@ async def test_predict_from_project_data(
         mock_drc.return_value.get_client.return_value = MagicMock()
         mock_job = _completed_job()
         patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
-        result = await predict.predict_from_project_data("dep", "pid", "dsid", "holdout", 5)
+        result = await predict.predict_from_project_data(
+            deployment_id="dep",
+            project_id="pid",
+            dataset_id="dsid",
+            partition="holdout",
+            timeout=5,
+        )
         patch_predict_dependencies["mock_batch_job"].score.assert_called_once_with(
             deployment="dep",
             intake_settings={
@@ -132,7 +140,7 @@ async def test_predict_by_ai_catalog_timeout(
         mock_drc.return_value.get_client.return_value = mock_client
         patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
         with pytest.raises(dr.errors.AsyncTimeoutError) as exc_info:
-            await predict.predict_by_ai_catalog("dep", "dsid", 1)
+            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=1)
     assert "Job did not complete within the timeout period." == str(exc_info.value)
 
 
@@ -160,7 +168,7 @@ async def test_predict_by_ai_catalog_failure_error(
         mock_drc.return_value.get_client.return_value = mock_client
         patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
         with pytest.raises(dr.errors.AsyncFailureError) as exc_info:
-            await predict.predict_by_ai_catalog("dep", "dsid", 1)
+            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=1)
     assert "Job failed for some reason." == str(exc_info.value)
 
 
@@ -188,7 +196,7 @@ async def test_predict_by_ai_catalog_unsuccessful_error(
         mock_drc.return_value.get_client.return_value = mock_client
         patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
         with pytest.raises(dr.errors.AsyncProcessUnsuccessfulError) as exc_info:
-            await predict.predict_by_ai_catalog("dep", "dsid", 1)
+            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=1)
     assert "Job was unsuccessful." == str(exc_info.value)
 
 
@@ -215,7 +223,7 @@ async def test_predict_by_ai_catalog_missing_download_url(
         mock_drc.return_value.get_client.return_value = mock_client
         patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
         with pytest.raises(ToolError, match="no download URL"):
-            await predict.predict_by_ai_catalog("dep", "dsid", 600)
+            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=600)
 
 
 @pytest.mark.asyncio
@@ -240,7 +248,7 @@ async def test_get_batch_prediction_results_success() -> None:
         ),
     ):
         mock_drc.return_value.get_client.return_value = MagicMock()
-        result = await predict.get_batch_prediction_results("abc123")
+        result = await predict.get_batch_prediction_results(job_id="abc123")
     assert result["job_id"] == "abc123"
     assert result["mime_type"] == "text/csv"
     assert result["data"] == "x,y\n1,2\n"
@@ -251,7 +259,7 @@ async def test_get_batch_prediction_results_success() -> None:
 @pytest.mark.asyncio
 async def test_get_batch_prediction_results_empty_job_id() -> None:
     with pytest.raises(ToolError, match="job_id"):
-        await predict.get_batch_prediction_results("   ")
+        await predict.get_batch_prediction_results(job_id="   ")
 
 
 @pytest.mark.asyncio
@@ -278,7 +286,7 @@ async def test_get_batch_prediction_results_too_large() -> None:
     ):
         mock_drc.return_value.get_client.return_value = MagicMock()
         with pytest.raises(ToolError, match="exceeding the inline limit") as exc:
-            await predict.get_batch_prediction_results("jid")
+            await predict.get_batch_prediction_results(job_id="jid")
         assert "https://example.com/batch/dl" in str(exc.value)
 
 
@@ -302,5 +310,5 @@ async def test_get_batch_prediction_results_download_runtime_error() -> None:
     ):
         mock_drc.return_value.get_client.return_value = MagicMock()
         with pytest.raises(ToolError, match="queue full") as exc:
-            await predict.get_batch_prediction_results("jid")
+            await predict.get_batch_prediction_results(job_id="jid")
         assert "https://example.com/batch/dl2" in str(exc.value)

--- a/tests/drmcp/unit/predictive_tools/test_predict_realtime.py
+++ b/tests/drmcp/unit/predictive_tools/test_predict_realtime.py
@@ -646,7 +646,9 @@ class TestPredictByAiCatalogRt:
         mock_predictions_result_response.return_value = {"type": "inline", "data": "test_data"}
 
         # Call function
-        result = await predict_by_ai_catalog_rt("deployment123", "dataset123")
+        result = await predict_by_ai_catalog_rt(
+            deployment_id="deployment123", dataset_id="dataset123"
+        )
 
         # Verify calls
         mock_client.Dataset.get.assert_called_once_with("dataset123")
@@ -704,7 +706,9 @@ class TestPredictByAiCatalogRt:
         mock_predictions_result_response.return_value = {"type": "inline", "data": "test_data"}
 
         # Call function
-        result = await predict_by_ai_catalog_rt("deployment123", "dataset123")
+        result = await predict_by_ai_catalog_rt(
+            deployment_id="deployment123", dataset_id="dataset123"
+        )
 
         # Verify calls
         mock_client.Dataset.get.assert_called_once_with("dataset123")
@@ -762,7 +766,9 @@ class TestPredictByAiCatalogRt:
 
         mock_predictions_result_response.return_value = {"type": "inline", "data": "test_data"}
 
-        result = await predict_by_ai_catalog_rt("deployment123", "dataset123")
+        result = await predict_by_ai_catalog_rt(
+            deployment_id="deployment123", dataset_id="dataset123"
+        )
 
         # Verify calls
         mock_client.Dataset.get.assert_called_once_with("dataset123")
@@ -823,7 +829,9 @@ class TestPredictByAiCatalogRt:
         mock_predictions_result_response.return_value = {"type": "inline", "data": "test_data"}
 
         # Call function
-        result = await predict_by_ai_catalog_rt("deployment123", "dataset123")
+        result = await predict_by_ai_catalog_rt(
+            deployment_id="deployment123", dataset_id="dataset123"
+        )
 
         # Verify calls
         mock_client.Dataset.get.assert_called_once_with("dataset123")
@@ -885,7 +893,9 @@ class TestPredictByAiCatalogRt:
         mock_predictions_result_response.return_value = {"type": "inline", "data": "test_data"}
 
         # Call function
-        result = await predict_by_ai_catalog_rt("deployment123", "dataset123")
+        result = await predict_by_ai_catalog_rt(
+            deployment_id="deployment123", dataset_id="dataset123"
+        )
 
         # Verify calls
         mock_client.Dataset.get.assert_called_once_with("dataset123")

--- a/tests/drmcp/unit/test_logging.py
+++ b/tests/drmcp/unit/test_logging.py
@@ -1,0 +1,123 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastmcp.exceptions import ToolError as FastMCPToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
+from pydantic import TypeAdapter
+
+from datarobot_genai.drmcp.core.logging import log_execution
+from datarobot_genai.drtools.core.exceptions import ToolError as DRToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+
+
+@pytest.mark.asyncio
+async def test_log_execution_wraps_dr_tool_error_with_kind_prefix() -> None:
+    @log_execution
+    async def failing_tool() -> None:
+        raise DRToolError("bad input", kind=ToolErrorKind.VALIDATION)
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await failing_tool()
+    assert str(exc_info.value) == "[validation] bad input"
+
+
+@pytest.mark.asyncio
+async def test_log_execution_passes_through_fastmcp_tool_error() -> None:
+    @log_execution
+    async def raises_fm() -> None:
+        raise FastMCPToolError("already formatted")
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await raises_fm()
+    assert str(exc_info.value) == "already formatted"
+
+
+@pytest.mark.asyncio
+async def test_log_execution_wraps_pydantic_validation_as_schema() -> None:
+    @log_execution
+    async def pydantic_fail() -> None:
+        TypeAdapter(int).validate_python("not-an-int")
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await pydantic_fail()
+    assert str(exc_info.value).startswith("[schema]")
+
+
+@pytest.mark.asyncio
+async def test_log_execution_wraps_fastmcp_validation_as_schema() -> None:
+    @log_execution
+    async def fm_validation_fail() -> None:
+        raise FastMCPValidationError("invalid tool parameters")
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await fm_validation_fail()
+    assert str(exc_info.value).startswith("[schema]")
+
+
+@pytest.mark.asyncio
+async def test_log_execution_wraps_404_like_exception_as_not_found() -> None:
+    @log_execution
+    async def raises_404_style() -> None:
+        raise Exception("404 client error: {'message': 'Not Found'}")
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await raises_404_style()
+    assert str(exc_info.value).startswith("[not_found]")
+
+
+@pytest.mark.asyncio
+async def test_log_execution_wraps_generic_exception_as_internal() -> None:
+    @log_execution
+    async def boom() -> None:
+        raise ValueError("nope")
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await boom()
+    assert "[internal]" in str(exc_info.value)
+    assert "boom" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_log_execution_wraps_exception_with_status_code_as_upstream() -> None:
+    class HttpishError(Exception):
+        status_code = 502
+
+        def __str__(self) -> str:
+            return "bad gateway"
+
+    @log_execution
+    async def upstream() -> None:
+        raise HttpishError()
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await upstream()
+    assert str(exc_info.value).startswith("[upstream]")
+
+
+@pytest.mark.asyncio
+async def test_log_execution_wraps_exception_with_403_as_authentication() -> None:
+    class ForbiddenError(Exception):
+        status_code = 403
+
+        def __str__(self) -> str:
+            return "forbidden"
+
+    @log_execution
+    async def forbidden() -> None:
+        raise ForbiddenError()
+
+    with pytest.raises(FastMCPToolError) as exc_info:
+        await forbidden()
+    assert str(exc_info.value).startswith("[authentication]")

--- a/tests/drmcp/unit/test_oauth_access_token_header_fallback.py
+++ b/tests/drmcp/unit/test_oauth_access_token_header_fallback.py
@@ -1,0 +1,209 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for OAuth access-token header fallback helpers in drtools.core.auth."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
+
+from datarobot_genai.drtools.core.auth import get_oauth_access_token_with_header_fallback
+from datarobot_genai.drtools.core.auth import oauth_access_token_header_name
+from datarobot_genai.drtools.core.auth import resolve_oauth_access_token_from_headers
+from datarobot_genai.drtools.core.auth import set_request_headers_for_context
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+
+
+@pytest.fixture(autouse=True)
+def clear_request_headers_ctx() -> None:
+    """Avoid leaking request header context between tests."""
+    yield
+    set_request_headers_for_context({})
+
+
+class TestOauthAccessTokenHeaderName:
+    def test_segment_lowercase_and_hyphens(self) -> None:
+        assert (
+            oauth_access_token_header_name("google-drive")
+            == "x-datarobot-google-drive-access-token"
+        )
+
+    def test_underscores_normalized(self) -> None:
+        assert (
+            oauth_access_token_header_name("microsoft_graph")
+            == "x-datarobot-microsoft-graph-access-token"
+        )
+
+    def test_whitespace_trimmed(self) -> None:
+        assert (
+            oauth_access_token_header_name("  Atlassian  ") == "x-datarobot-atlassian-access-token"
+        )
+
+
+class TestResolveOauthAccessTokenFromHeaders:
+    def test_reads_from_framework_headers(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth._get_http_headers",
+            return_value={"x-datarobot-google-drive-access-token": "tok-from-fw"},
+        ):
+            assert resolve_oauth_access_token_from_headers("google-drive") == "tok-from-fw"
+
+    def test_bearer_prefix_stripped(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth._get_http_headers",
+            return_value={"x-datarobot-google-drive-access-token": "Bearer abc.def"},
+        ):
+            assert resolve_oauth_access_token_from_headers("google-drive") == "abc.def"
+
+    def test_mixed_case_header_key(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth._get_http_headers",
+            return_value={"X-DataRobot-Google-Drive-Access-Token": "plain"},
+        ):
+            assert resolve_oauth_access_token_from_headers("google-drive") == "plain"
+
+    def test_framework_headers_take_priority_over_context(self) -> None:
+        set_request_headers_for_context(
+            {"x-datarobot-google-drive-access-token": "from-ctx"},
+        )
+        with patch(
+            "datarobot_genai.drtools.core.auth._get_http_headers",
+            return_value={"x-datarobot-google-drive-access-token": "from-fw"},
+        ):
+            assert resolve_oauth_access_token_from_headers("google-drive") == "from-fw"
+
+    def test_falls_back_to_request_headers_context(self) -> None:
+        with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value={}):
+            set_request_headers_for_context(
+                {"x-datarobot-microsoft-graph-access-token": "ctx-token"},
+            )
+            assert resolve_oauth_access_token_from_headers("microsoft-graph") == "ctx-token"
+
+    def test_returns_none_when_missing(self) -> None:
+        with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value={}):
+            set_request_headers_for_context({})
+            assert resolve_oauth_access_token_from_headers("google-drive") is None
+
+    def test_get_http_headers_exception_falls_back_to_context(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth._get_http_headers",
+            side_effect=RuntimeError("no http"),
+        ):
+            set_request_headers_for_context(
+                {"x-datarobot-atlassian-access-token": "atlas"},
+            )
+            assert resolve_oauth_access_token_from_headers("atlassian") == "atlas"
+
+
+class TestGetOauthAccessTokenWithHeaderFallback:
+    @pytest.mark.asyncio
+    async def test_returns_obo_token_when_oauth_succeeds(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            return_value="obo-secret",
+        ):
+            out = await get_oauth_access_token_with_header_fallback(
+                "google",
+                display_name="Google",
+                access_token_header_segment="google-drive",
+            )
+        assert out == "obo-secret"
+
+    @pytest.mark.asyncio
+    async def test_returns_header_token_when_runtime_error(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no context"),
+        ):
+            set_request_headers_for_context(
+                {"x-datarobot-google-drive-access-token": "fallback"},
+            )
+            out = await get_oauth_access_token_with_header_fallback(
+                "google",
+                display_name="Google",
+                access_token_header_segment="google-drive",
+            )
+        assert out == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_returns_header_token_when_oauth_service_client_err(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            side_effect=OAuthServiceClientErr("not granted"),
+        ):
+            with patch(
+                "datarobot_genai.drtools.core.auth._get_http_headers",
+                return_value={"x-datarobot-google-drive-access-token": "hdr"},
+            ):
+                out = await get_oauth_access_token_with_header_fallback(
+                    "google",
+                    display_name="Google",
+                    access_token_header_segment="google-drive",
+                )
+        assert out == "hdr"
+
+    @pytest.mark.asyncio
+    async def test_returns_header_when_oauth_returns_empty_string(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            return_value="",
+        ):
+            set_request_headers_for_context(
+                {"x-datarobot-atlassian-access-token": "atok"},
+            )
+            out = await get_oauth_access_token_with_header_fallback(
+                "atlassian",
+                display_name="Atlassian",
+                access_token_header_segment="atlassian",
+            )
+        assert out == "atok"
+
+    @pytest.mark.asyncio
+    async def test_tool_error_when_oauth_fails_and_no_header(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            side_effect=OAuthServiceClientErr("denied"),
+        ):
+            with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value={}):
+                out = await get_oauth_access_token_with_header_fallback(
+                    "microsoft",
+                    display_name="Microsoft",
+                    access_token_header_segment="microsoft-graph",
+                )
+        assert isinstance(out, ToolError)
+        assert out.kind == ToolErrorKind.AUTHENTICATION
+        assert "x-datarobot-microsoft-graph-access-token" in str(out)
+
+    @pytest.mark.asyncio
+    async def test_tool_error_internal_on_unexpected_exception(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            side_effect=ValueError("boom"),
+        ):
+            out = await get_oauth_access_token_with_header_fallback(
+                "google",
+                display_name="Google",
+                access_token_header_segment="google-drive",
+            )
+        assert isinstance(out, ToolError)
+        assert out.kind == ToolErrorKind.INTERNAL

--- a/tests/drmcp/unit/tool_clients/test_atlassian.py
+++ b/tests/drmcp/unit/tool_clients/test_atlassian.py
@@ -22,23 +22,31 @@ import httpx
 import pytest
 from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
 
+from datarobot_genai.drtools.core.auth import set_request_headers_for_context
 from datarobot_genai.drtools.core.clients.atlassian import ATLASSIAN_API_BASE
 from datarobot_genai.drtools.core.clients.atlassian import OAUTH_ACCESSIBLE_RESOURCES_PATH
 from datarobot_genai.drtools.core.clients.atlassian import _find_first_resource_with_id
 from datarobot_genai.drtools.core.clients.atlassian import _find_resource_by_service
 from datarobot_genai.drtools.core.clients.atlassian import get_atlassian_access_token
 from datarobot_genai.drtools.core.clients.atlassian import get_atlassian_cloud_id
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 
 class TestGetAtlassianAccessToken:
     """Test get_atlassian_access_token function."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_header_ctx(self) -> None:
+        yield
+        set_request_headers_for_context({})
 
     @pytest.mark.asyncio
     async def test_get_access_token_success(self) -> None:
         """Test successful access token retrieval."""
         mock_token = "test_access_token_123"
         with patch(
-            "datarobot_genai.drtools.core.clients.atlassian.get_access_token",
+            "datarobot_genai.drtools.core.auth.get_access_token",
             new_callable=AsyncMock,
             return_value=mock_token,
         ):
@@ -48,41 +56,61 @@ class TestGetAtlassianAccessToken:
 
     @pytest.mark.asyncio
     async def test_get_access_token_empty_token(self) -> None:
-        """Test handling of empty access token."""
+        """Test handling of empty access token without header fallback."""
         with patch(
-            "datarobot_genai.drtools.core.clients.atlassian.get_access_token",
+            "datarobot_genai.drtools.core.auth.get_access_token",
             new_callable=AsyncMock,
             return_value="",
         ):
-            result = await get_atlassian_access_token()
-            assert True  # Fixed: Functions now raise ToolError instead of returning it
-            assert "empty access token" in str(result).lower()
+            with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value={}):
+                result = await get_atlassian_access_token()
+        assert isinstance(result, ToolError)
+        assert result.kind == ToolErrorKind.AUTHENTICATION
+        assert "empty access token" in str(result).lower()
+        assert "x-datarobot-atlassian-access-token" in str(result)
 
     @pytest.mark.asyncio
     async def test_get_access_token_oauth_error(self) -> None:
-        """Test handling of OAuthServiceClientErr."""
+        """Test handling of OAuthServiceClientErr without header fallback."""
         oauth_error = OAuthServiceClientErr("OAuth error occurred")
         with patch(
-            "datarobot_genai.drtools.core.clients.atlassian.get_access_token",
+            "datarobot_genai.drtools.core.auth.get_access_token",
             new_callable=AsyncMock,
             side_effect=oauth_error,
         ):
-            result = await get_atlassian_access_token()
-            assert True  # Fixed: Functions now raise ToolError instead of returning it
-            assert "Could not obtain access token" in str(result)
+            with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value={}):
+                result = await get_atlassian_access_token()
+        assert isinstance(result, ToolError)
+        assert "Could not obtain access token" in str(result)
+        assert "x-datarobot-atlassian-access-token" in str(result)
 
     @pytest.mark.asyncio
     async def test_get_access_token_unexpected_error(self) -> None:
         """Test handling of unexpected exceptions."""
         unexpected_error = ValueError("Unexpected error")
         with patch(
-            "datarobot_genai.drtools.core.clients.atlassian.get_access_token",
+            "datarobot_genai.drtools.core.auth.get_access_token",
             new_callable=AsyncMock,
             side_effect=unexpected_error,
         ):
             result = await get_atlassian_access_token()
-            assert True  # Fixed: Functions now raise ToolError instead of returning it
-            assert "unexpected error" in str(result).lower()
+        assert isinstance(result, ToolError)
+        assert result.kind == ToolErrorKind.INTERNAL
+        assert "unexpected error" in str(result).lower()
+
+    @pytest.mark.asyncio
+    async def test_header_fallback_when_oauth_raises(self) -> None:
+        """OBO failure is satisfied by x-datarobot-atlassian-access-token."""
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no auth ctx"),
+        ):
+            set_request_headers_for_context(
+                {"x-datarobot-atlassian-access-token": "from-header"},
+            )
+            result = await get_atlassian_access_token()
+        assert result == "from-header"
 
 
 class TestFindResourceByService:

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.25"
+version = "0.15.26"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The branch introduces categorized ToolErrors, OAuth access tokens with x-datarobot-*-access-token fallback, MCP logging that surfaces kinds to FastMCP, SDK ClientError → tool errors in predictive tools

1. Typed tool errors

Added ToolErrorKind (schema, validation, authentication, not_found, upstream, internal).
ToolError now takes optional kind= (default INTERNAL)

2. OAuth + header fallback

Helpers to build/read x-datarobot-<segment>-access-token (normalised segment).
get_oauth_access_token_with_header_fallback: try normal OBO get_access_token, on failure / empty read token from headers; return structured ToolError (AUTHENTICATION / INTERNAL) with messages that mention the header name.

3. HTTP clients (atlassian, gdrive, microsoft_graph, perplexity, tavily, small tweaks in datarobot)

Token acquisition switched to the shared fallback helper with the right header segment / display name (same pattern as Atlassian: OBO first, then header).

4. MCP logging (drmcp/core/logging.py)

log_execution: distinguish FastMCP vs drtools ToolError; convert drtools errors to FastMCP with [kind] message; map Pydantic / FastMCP validation to [schema]; for other exceptions, infer ToolErrorKind from status_code or message (404-ish) before wrapping in FastMCP ToolError.

5. Improved llm doc description for all the 3rd party tools (confluence, dr_docs, gdrive, jira, microsoft_graph, perplexity, tavily, use_case)

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared error propagation and auth/token acquisition paths used across many tools, so misclassification or header fallback behavior could change client-visible errors. Logic is mostly additive but spans multiple integrations and predictive scoring flows.
> 
> **Overview**
> Adds **typed tool failures** via `ToolErrorKind` and extends `ToolError` to carry a `kind`, then updates `drmcp` logging to surface errors to FastMCP as `[kind] ...`, including schema/validation mapping and best-effort kind inference for unexpected exceptions.
> 
> Introduces OAuth token resolution with **`x-datarobot-<segment>-access-token` header fallback** (raw or `Bearer`) and switches Atlassian/Google Drive/Microsoft Graph clients to use it; several API-key/token missing cases now return `AUTHENTICATION`-kind errors.
> 
> Updates many tools (Confluence/Jira/GDrive/Microsoft Graph/Perplexity/Tavily/DR docs/Use cases) with richer `tool_metadata` descriptions and more explicit validation errors, and refactors predictive tools to catch DataRobot SDK `ClientError` and raise consistent `ToolError` kinds (notably `NOT_FOUND` vs `UPSTREAM`). Tests are adjusted to assert the new error strings/kinds, the package version is bumped to `0.15.26`, and the local task runner no longer relies on a separate ETE server task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f0f13f32e65a9b08e1231ac27a070aa733db7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->