### PR TITLE
[BUZZOK-30222] fix(langgraph/mcp): one bad MCP tool no longer aborts the agent run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.27
+- Fixed LangGraph MCP integration so a single failing MCP tool no longer aborts the entire agent run.
+
 ## 0.15.26
 - Categorized ToolErrors, OAuth access tokens with x-datarobot-*-access-token fallback, MCP logging that surfaces kinds to FastMCP, SDK ClientError → tool errors in predictive tools and improved third party APIs tool_metadata descriptions.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.26"
+version = "0.15.27"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.26"
+version = "0.15.27"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from langchain.tools import BaseTool
 from langchain_core.tools import StructuredTool
+from langchain_core.tools.base import ToolException
 from langchain_mcp_adapters.sessions import SSEConnection
 from langchain_mcp_adapters.sessions import StreamableHttpConnection
 from langchain_mcp_adapters.sessions import create_session
@@ -46,9 +47,17 @@ def _wrap_mcp_tool_for_langgraph(inner: BaseTool) -> BaseTool:
     async def _invoke_inner(**kwargs: Any) -> Any:
         # Call the inner tool's coroutine so we return (content, artifact), not the
         # formatted output that ainvoke() would return.
-        if getattr(inner, "coroutine", None) is not None:
-            return await inner.coroutine(**kwargs)
-        return await inner.ainvoke(kwargs)
+        try:
+            if getattr(inner, "coroutine", None) is not None:
+                return await inner.coroutine(**kwargs)
+            return await inner.ainvoke(kwargs)
+        except ToolException as exc:
+            logger.warning("MCP tool '%s' raised ToolException: %s", inner.name, exc)
+            error_content = f"Tool '{inner.name}' failed: {exc}"
+            response_format = getattr(inner, "response_format", "content_and_artifact")
+            if response_format == "content_and_artifact":
+                return error_content, None
+            return error_content
 
     class _MCPToolWrapper(StructuredTool):
         """Thin wrapper that adds 'runtime' to injected args for callback filtering."""

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.26"
+version = "0.15.27"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

When a single MCP tool failed inside a LangGraph agent, the entire agent run aborted: the AG-UI stream got stuck with a half-open tool call, the frontend rejected the run, and the user saw no follow-up assistant text. This PR makes the wrapper around `langchain_mcp_adapters` tools tolerate tool errors and report them as normal tool results so the LLM can recover and respond.

## The bug

Reproduced locally by asking a LangGraph + MCP agent to summarize a deployment that doesn't have a valid prediction history. The agent fans out three parallel tool calls in a single turn:

- `get_deployment_info` ✅
- `get_model_info_from_deployment` ✅
- `get_prediction_history` → DataRobot returns **HTTP 400 `Predictions results are not available for this deployment type`**

The 400 is converted by `langchain_mcp_adapters._convert_call_tool_result` into a `ToolException`. Two consequences:

1. **Workflow aborts on first tool failure.** `langgraph.prebuilt.tool_node._default_handle_tool_errors` only swallows `ToolInvocationError`; everything else (including `ToolException`) is re-raised, so one bad tool tears down the whole `tool_node` execution.
2. **Wire-protocol violation in the AG-UI stream.** `TOOL_CALL_START` + `TOOL_CALL_ARGS` are emitted for the failing tool, then never `TOOL_CALL_END` / `TOOL_CALL_RESULT`. The agent never gets to write a follow-up assistant message because the run died.

Frontend log:

```
AGUIError: Cannot send 'RUN_FINISHED' while tool calls are still active:
  toolu_vrtx_01LX1EA42Vd5tHkiN2mJyGih
```

Backend stack (truncated):

```
ToolException: Error in get_prediction_history: ClientError: 400 client error:
  {'message': 'Predictions results are not available for this deployment type.'}
  During task with name 'tools' and id '...'
  During task with name 'planner_node' and id '...'

ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  ...
nat.runtime.runner: ERROR    - Error running workflow:
  unhandled errors in a TaskGroup (1 sub-exception)
```

## The fix

`_wrap_mcp_tool_for_langgraph._invoke_inner` now catches `ToolException` and returns it as a tool-result content. The LLM sees `"Tool 'get_prediction_history' failed: <error>"` as a normal tool result on its next turn and can proceed (e.g., summarize what the other tools returned, or ask the user for clarification).

Two implementation details worth flagging in review:

- MCP tools use `response_format="content_and_artifact"`, so the return value must be a `(content, artifact)` two-tuple, not a bare string. langchain_core's response-format validator raises `ValueError` otherwise. The patch checks the format and returns `(error_content, None)` for `content_and_artifact`, falling back to a string for `content`-only tools.
- Only `ToolException` is caught. Other exceptions still propagate so they can be diagnosed normally — we're explicitly only converting "the upstream tool reported a failure" into "tool returned an error message".

The same pattern is **not** mirrored to `crewai/mcp.py`, `llama_index/mcp.py`, or `nat/datarobot_mcp_client.py`. None of them currently expose a wrap-point comparable to `_wrap_mcp_tool_for_langgraph`, and the immediate symptom only reproduces on the LangGraph stack. If users hit the same UX issue on CrewAI / LlamaIndex / NAT, those will need framework-specific fixes.

## After the fix

Same scenario, same 400 from the platform. The agent now:

- Streams `TOOL_CALL_END` + `TOOL_CALL_RESULT` for all three calls (including the failing one, with the error message as content).
- Emits a follow-up assistant text that summarizes the working tools' output and explains why prediction history wasn't available.
- AG-UI client accepts `RUN_FINISHED` cleanly. No frontend error, no stuck spinner.

## Verified locally

Repro'd the failure on `vertex_ai/claude-sonnet-4-5@20250929` against an Agentic Workflow deployment, applied the patch in the agent venv, restarted `task dev`, and re-ran the same prompt. The trailing assistant turn now appears in the UI and the SSE stream closes cleanly.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool execution error handling in the LangGraph MCP integration; while scoped to `ToolException`, it alters failure semantics and could mask issues or affect downstream prompting/tool result parsing.
> 
> **Overview**
> Prevents LangGraph agent runs from aborting when a single MCP tool call fails by catching `ToolException` inside the MCP tool wrapper and returning an error message as a normal tool result (respecting `response_format`, returning `(content, None)` for `content_and_artifact`).
> 
> Bumps the package version to `0.15.27` and updates `CHANGELOG.md` and lockfiles accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b108216c10463a1fd6ffb482a16935327e41b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->