### PR TITLE
[BUZZOK-30524] Move AG-UI validate_sequence into datarobot-genai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.28
+- Added `datarobot_genai.core.agents.verify` for validating AG-UI event streams against the protocol state machine. Re-enabled the previously skipped sequence checks in dragent e2e tests.
+
 ## 0.15.27
 - Fixed LangGraph MCP integration so a single failing MCP tool no longer aborts the entire agent run.
 

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -17,6 +17,7 @@ import os
 import httpx
 import pytest
 from ag_ui.core import EventType
+from datarobot_genai.core.agents.verify import validate_sequence
 
 from dragent_tests.helpers import AGENT
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS
@@ -57,9 +58,8 @@ def test_mcp_tool_is_called(http_client: httpx.Client) -> None:  # type: ignore[
     # THEN: a response is correct AG UI events
     mcp_ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # TODO (BUZZOK-30524): re-enable when merged upstream
-    # # THEN: a response is a valid AG-UI sequence
-    # validate_sequence(mcp_ag_ui_events)
+    # THEN: a response is a valid AG-UI sequence
+    validate_sequence(mcp_ag_ui_events)
 
     # THEN: the events contain tool call events (if framework supports tool calls)
     tool_types = {

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from datarobot_genai.core.agents.verify import validate_sequence
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
 from dragent_tests.helpers import AGENT
@@ -48,9 +49,8 @@ def test_generate_single(http_client: httpx.Client) -> None:
     # THEN: the response contains AG-UI events
     assert len(response_data.events) > 0
 
-    # TODO (BUZZOK-30524): re-enable when merged upstream
-    # # THEN: the events are a valid AG-UI sequence
-    # validate_sequence(response_data.events)
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(response_data.events)
 
     # THEN: there are events with text
     full_text = collect_text(response_data.events)

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from datarobot_genai.core.agents.verify import validate_sequence
 
 from dragent_tests.helpers import ALL_TEST_CASES
 from dragent_tests.helpers import GENERATE_STREAM_PATH
@@ -44,9 +45,8 @@ def test_generate_streaming(http_client: httpx.Client) -> None:
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_responses)
 
-    # TODO (BUZZOK-30524): re-enable when merged upstream
-    # # THEN: the events are a valid AG-UI sequence
-    # validate_sequence(ag_ui_events)
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(ag_ui_events)
 
     # THEN: there are events with text
     full_text = collect_text(ag_ui_events)

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import httpx
 import pytest
 from ag_ui.core import EventType
+from datarobot_genai.core.agents.verify import validate_sequence
 
 from dragent_tests.helpers import AGENT
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS
@@ -62,9 +63,8 @@ def test_generate_objectid_tool_is_called(http_client: httpx.Client) -> None:  #
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # TODO (BUZZOK-30524): re-enable when merged upstream
-    # # THEN: the events are a valid AG-UI sequence
-    # validate_sequence(ag_ui_events)
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(ag_ui_events)
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}
     tool_types = {
@@ -125,9 +125,8 @@ def test_calculator_tool_is_called(http_client: httpx.Client) -> None:  # type: 
     # THEN: the response contains AG-UI events
     ag_ui_events = collect_ag_ui_events(sse_events)
 
-    # TODO (BUZZOK-30524): re-enable when merged upstream
-    # # THEN: the events are a valid AG-UI sequence
-    # validate_sequence(ag_ui_events)
+    # THEN: the events are a valid AG-UI sequence
+    validate_sequence(ag_ui_events)
 
     # THEN: there are events with tool call
     event_types = {e.type for e in ag_ui_events}

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.27"
+version = "0.15.28"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.27"
+version = "0.15.28"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/agents/verify.py
+++ b/src/datarobot_genai/core/agents/verify.py
@@ -1,0 +1,357 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Event sequence validation for the AG-UI protocol.
+
+Validates that event streams conform to the AG-UI protocol state machine rules.
+
+TODO (BUZZOK-30605): remove this module once `ag_ui.verify` is published upstream
+and switch consumers back to `from ag_ui.verify import validate_sequence`.
+Tracking upstream: https://github.com/ag-ui-protocol/ag-ui/issues/1327 and
+https://github.com/ag-ui-protocol/ag-ui/pull/1322.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from collections.abc import Iterator
+
+from ag_ui.core import BaseEvent
+from ag_ui.core import EventType
+
+logger = logging.getLogger(__name__)
+
+
+class EventSequenceError(Exception):
+    """Raised when an event violates AG-UI protocol sequence rules."""
+
+    pass
+
+
+class EventSequenceValidator:
+    """Stateful validator that enforces AG-UI protocol event ordering rules.
+
+    Tracks the state machine across calls to validate_event(), allowing both
+    batch and streaming validation patterns.
+    """
+
+    def __init__(self, debug: bool = False) -> None:
+        self._debug = debug
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset all state for a new validation session."""
+        self._active_messages: set[str] = set()
+        self._active_tool_calls: set[str] = set()
+        self._active_steps: set[str] = set()
+        self._active_reasoning_messages: set[str] = set()
+        self._active_thinking_step: bool = False
+        self._active_thinking_step_message: bool = False
+        self._run_started: bool = False
+        self._run_finished: bool = False
+        self._run_error: bool = False
+        self._first_event_received: bool = False
+
+    def _reset_run_state(self) -> None:
+        """Reset state for a new run (called on RUN_STARTED after RUN_FINISHED)."""
+        self._active_messages.clear()
+        self._active_tool_calls.clear()
+        self._active_steps.clear()
+        self._active_reasoning_messages.clear()
+        self._active_thinking_step = False
+        self._active_thinking_step_message = False
+        self._run_finished = False
+        self._run_error = False
+        self._run_started = True
+
+    def validate_event(self, event: BaseEvent) -> None:
+        """Validate a single event against the current state machine.
+
+        Parameters
+        ----------
+        event : BaseEvent
+            The event to validate.
+
+        Raises
+        ------
+        EventSequenceError
+            If the event violates protocol sequence rules.
+        """
+        event_type = event.type
+
+        if self._debug:
+            logger.debug("[VERIFY]: %s", event.model_dump_json(by_alias=True, exclude_none=True))
+
+        # Global pre-check 1: run errored
+        if self._run_error:
+            raise EventSequenceError(
+                f"Cannot send event type '{event_type.value}': The run has already "
+                f"errored with 'RUN_ERROR'. No further events can be sent."
+            )
+
+        # Global pre-check 2: run finished
+        if self._run_finished and event_type not in (
+            EventType.RUN_STARTED,
+            EventType.RUN_ERROR,
+        ):
+            raise EventSequenceError(
+                f"Cannot send event type '{event_type.value}': The run has already "
+                f"finished with 'RUN_FINISHED'. Start a new run with 'RUN_STARTED'."
+            )
+
+        # Global pre-check 3: first event
+        if not self._first_event_received:
+            self._first_event_received = True
+            if event_type not in (EventType.RUN_STARTED, EventType.RUN_ERROR):
+                raise EventSequenceError("First event must be 'RUN_STARTED'.")
+        elif event_type == EventType.RUN_STARTED:
+            if self._run_started and not self._run_finished:
+                raise EventSequenceError(
+                    "Cannot send 'RUN_STARTED' while a run is still active. "
+                    "The previous run must be finished with 'RUN_FINISHED' before "
+                    "starting a new run."
+                )
+            if self._run_finished:
+                self._reset_run_state()
+
+        # Per-event validation
+        if event_type == EventType.RUN_STARTED:
+            self._run_started = True
+
+        elif event_type == EventType.RUN_FINISHED:
+            if self._active_steps:
+                names = ", ".join(sorted(self._active_steps))
+                raise EventSequenceError(
+                    f"Cannot send 'RUN_FINISHED' while steps are still active: {names}"
+                )
+            if self._active_messages:
+                ids = ", ".join(sorted(self._active_messages))
+                raise EventSequenceError(
+                    f"Cannot send 'RUN_FINISHED' while text messages are still active: {ids}"
+                )
+            if self._active_tool_calls:
+                ids = ", ".join(sorted(self._active_tool_calls))
+                raise EventSequenceError(
+                    f"Cannot send 'RUN_FINISHED' while tool calls are still active: {ids}"
+                )
+            self._run_finished = True
+
+        elif event_type == EventType.RUN_ERROR:
+            self._run_error = True
+
+        # Text message lifecycle
+        elif event_type == EventType.TEXT_MESSAGE_START:
+            message_id = event.message_id  # type: ignore[attr-defined]
+            if message_id in self._active_messages:
+                raise EventSequenceError(
+                    f"Cannot send 'TEXT_MESSAGE_START' event: A text message with "
+                    f"ID '{message_id}' is already in progress. Complete it with "
+                    f"'TEXT_MESSAGE_END' first."
+                )
+            self._active_messages.add(message_id)
+
+        elif event_type == EventType.TEXT_MESSAGE_CONTENT:
+            message_id = event.message_id  # type: ignore[attr-defined]
+            if message_id not in self._active_messages:
+                raise EventSequenceError(
+                    f"Cannot send 'TEXT_MESSAGE_CONTENT' event: No active text message "
+                    f"found with ID '{message_id}'. Start a text message with "
+                    f"'TEXT_MESSAGE_START' first."
+                )
+
+        elif event_type == EventType.TEXT_MESSAGE_END:
+            message_id = event.message_id  # type: ignore[attr-defined]
+            if message_id not in self._active_messages:
+                raise EventSequenceError(
+                    f"Cannot send 'TEXT_MESSAGE_END' event: No active text message "
+                    f"found with ID '{message_id}'. A 'TEXT_MESSAGE_START' event must "
+                    f"be sent first."
+                )
+            self._active_messages.discard(message_id)
+
+        # Tool call lifecycle
+        elif event_type == EventType.TOOL_CALL_START:
+            tool_call_id = event.tool_call_id  # type: ignore[attr-defined]
+            if tool_call_id in self._active_tool_calls:
+                raise EventSequenceError(
+                    f"Cannot send 'TOOL_CALL_START' event: A tool call with "
+                    f"ID '{tool_call_id}' is already in progress. Complete it with "
+                    f"'TOOL_CALL_END' first."
+                )
+            self._active_tool_calls.add(tool_call_id)
+
+        elif event_type == EventType.TOOL_CALL_ARGS:
+            tool_call_id = event.tool_call_id  # type: ignore[attr-defined]
+            if tool_call_id not in self._active_tool_calls:
+                raise EventSequenceError(
+                    f"Cannot send 'TOOL_CALL_ARGS' event: No active tool call found "
+                    f"with ID '{tool_call_id}'. Start a tool call with "
+                    f"'TOOL_CALL_START' first."
+                )
+
+        elif event_type == EventType.TOOL_CALL_END:
+            tool_call_id = event.tool_call_id  # type: ignore[attr-defined]
+            if tool_call_id not in self._active_tool_calls:
+                raise EventSequenceError(
+                    f"Cannot send 'TOOL_CALL_END' event: No active tool call found "
+                    f"with ID '{tool_call_id}'. A 'TOOL_CALL_START' event must be "
+                    f"sent first."
+                )
+            self._active_tool_calls.discard(tool_call_id)
+
+        # Step lifecycle
+        elif event_type == EventType.STEP_STARTED:
+            step_name = event.step_name  # type: ignore[attr-defined]
+            if step_name in self._active_steps:
+                raise EventSequenceError(
+                    f"Step \"{step_name}\" is already active for 'STEP_STARTED'."
+                )
+            self._active_steps.add(step_name)
+
+        elif event_type == EventType.STEP_FINISHED:
+            step_name = event.step_name  # type: ignore[attr-defined]
+            if step_name not in self._active_steps:
+                raise EventSequenceError(
+                    f"Cannot send 'STEP_FINISHED' for step \"{step_name}\" that was not started."
+                )
+            self._active_steps.discard(step_name)
+
+        # Thinking lifecycle
+        elif event_type == EventType.THINKING_START:
+            if self._active_thinking_step:
+                raise EventSequenceError(
+                    "Cannot send 'THINKING_START' event: A thinking step is already "
+                    "in progress. End it with 'THINKING_END' first."
+                )
+            self._active_thinking_step = True
+
+        elif event_type == EventType.THINKING_END:
+            if not self._active_thinking_step:
+                raise EventSequenceError(
+                    "Cannot send 'THINKING_END' event: No active thinking step found. "
+                    "A 'THINKING_START' event must be sent first."
+                )
+            self._active_thinking_step = False
+
+        elif event_type == EventType.THINKING_TEXT_MESSAGE_START:
+            if not self._active_thinking_step:
+                raise EventSequenceError(
+                    "Cannot send 'THINKING_TEXT_MESSAGE_START' event: A thinking step "
+                    "is not in progress. Create one with 'THINKING_START' first."
+                )
+            if self._active_thinking_step_message:
+                raise EventSequenceError(
+                    "Cannot send 'THINKING_TEXT_MESSAGE_START' event: A thinking "
+                    "message is already in progress. Complete it with "
+                    "'THINKING_TEXT_MESSAGE_END' first."
+                )
+            self._active_thinking_step_message = True
+
+        elif event_type == EventType.THINKING_TEXT_MESSAGE_CONTENT:
+            if not self._active_thinking_step_message:
+                raise EventSequenceError(
+                    "Cannot send 'THINKING_TEXT_MESSAGE_CONTENT' event: No active "
+                    "thinking message found. Start a message with "
+                    "'THINKING_TEXT_MESSAGE_START' first."
+                )
+
+        elif event_type == EventType.THINKING_TEXT_MESSAGE_END:
+            if not self._active_thinking_step_message:
+                raise EventSequenceError(
+                    "Cannot send 'THINKING_TEXT_MESSAGE_END' event: No active thinking "
+                    "message found. A 'THINKING_TEXT_MESSAGE_START' event must be "
+                    "sent first."
+                )
+            self._active_thinking_step_message = False
+
+        # Reasoning message lifecycle
+        elif event_type == EventType.REASONING_MESSAGE_START:
+            message_id = event.message_id  # type: ignore[attr-defined]
+            if message_id in self._active_reasoning_messages:
+                raise EventSequenceError(
+                    f"Cannot send 'REASONING_MESSAGE_START' event: A reasoning message "
+                    f"with ID '{message_id}' is already in progress. Complete it with "
+                    f"'REASONING_MESSAGE_END' first."
+                )
+            self._active_reasoning_messages.add(message_id)
+
+        elif event_type == EventType.REASONING_MESSAGE_CONTENT:
+            message_id = event.message_id  # type: ignore[attr-defined]
+            if message_id not in self._active_reasoning_messages:
+                raise EventSequenceError(
+                    f"Cannot send 'REASONING_MESSAGE_CONTENT' event: No active "
+                    f"reasoning message found with ID '{message_id}'. Start a "
+                    f"reasoning message with 'REASONING_MESSAGE_START' first."
+                )
+
+        elif event_type == EventType.REASONING_MESSAGE_END:
+            message_id = event.message_id  # type: ignore[attr-defined]
+            if message_id not in self._active_reasoning_messages:
+                raise EventSequenceError(
+                    f"Cannot send 'REASONING_MESSAGE_END' event: No active reasoning "
+                    f"message found with ID '{message_id}'. A 'REASONING_MESSAGE_START' "
+                    f"event must be sent first."
+                )
+            self._active_reasoning_messages.discard(message_id)
+
+        # All other event types pass through without validation
+
+
+def validate_sequence(events: Iterable[BaseEvent], debug: bool = False) -> None:
+    """Validate a sequence of events against AG-UI protocol rules.
+
+    Parameters
+    ----------
+    events : Iterable[BaseEvent]
+        The events to validate.
+    debug : bool
+        If True, log each event via this module's logger.
+
+    Raises
+    ------
+    EventSequenceError
+        On the first protocol violation encountered.
+    """
+    validator = EventSequenceValidator(debug=debug)
+    for event in events:
+        validator.validate_event(event)
+
+
+def verify_events(events: Iterable[BaseEvent], debug: bool = False) -> Iterator[BaseEvent]:
+    """Validate and yield events one at a time.
+
+    Acts as a pass-through iterator that raises on the first protocol violation.
+
+    Parameters
+    ----------
+    events : Iterable[BaseEvent]
+        The events to validate and yield.
+    debug : bool
+        If True, log each event via this module's logger.
+
+    Yields
+    ------
+    BaseEvent
+        Each event after successful validation.
+
+    Raises
+    ------
+    EventSequenceError
+        On the first protocol violation encountered.
+    """
+    validator = EventSequenceValidator(debug=debug)
+    for event in events:
+        validator.validate_event(event)
+        yield event

--- a/tests/core/agents/test_verify.py
+++ b/tests/core/agents/test_verify.py
@@ -1,0 +1,792 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for :mod:`datarobot_genai.core.agents.verify`."""
+
+from __future__ import annotations
+
+import unittest
+
+from ag_ui.core.events import CustomEvent
+from ag_ui.core.events import MessagesSnapshotEvent
+from ag_ui.core.events import RawEvent
+from ag_ui.core.events import ReasoningEndEvent
+from ag_ui.core.events import ReasoningMessageChunkEvent
+from ag_ui.core.events import ReasoningMessageContentEvent
+from ag_ui.core.events import ReasoningMessageEndEvent
+from ag_ui.core.events import ReasoningMessageStartEvent
+from ag_ui.core.events import ReasoningStartEvent
+from ag_ui.core.events import RunErrorEvent
+from ag_ui.core.events import RunFinishedEvent
+from ag_ui.core.events import RunStartedEvent
+from ag_ui.core.events import StateDeltaEvent
+from ag_ui.core.events import StateSnapshotEvent
+from ag_ui.core.events import StepFinishedEvent
+from ag_ui.core.events import StepStartedEvent
+from ag_ui.core.events import TextMessageChunkEvent
+from ag_ui.core.events import TextMessageContentEvent
+from ag_ui.core.events import TextMessageEndEvent
+from ag_ui.core.events import TextMessageStartEvent
+from ag_ui.core.events import ThinkingEndEvent
+from ag_ui.core.events import ThinkingStartEvent
+from ag_ui.core.events import ThinkingTextMessageContentEvent
+from ag_ui.core.events import ThinkingTextMessageEndEvent
+from ag_ui.core.events import ThinkingTextMessageStartEvent
+from ag_ui.core.events import ToolCallArgsEvent
+from ag_ui.core.events import ToolCallChunkEvent
+from ag_ui.core.events import ToolCallEndEvent
+from ag_ui.core.events import ToolCallResultEvent
+from ag_ui.core.events import ToolCallStartEvent
+
+from datarobot_genai.core.agents.verify import EventSequenceError
+from datarobot_genai.core.agents.verify import EventSequenceValidator
+from datarobot_genai.core.agents.verify import validate_sequence
+from datarobot_genai.core.agents.verify import verify_events
+
+
+def _run_started(thread_id="t1", run_id="r1"):
+    return RunStartedEvent(thread_id=thread_id, run_id=run_id)
+
+
+def _run_finished(thread_id="t1", run_id="r1"):
+    return RunFinishedEvent(thread_id=thread_id, run_id=run_id)
+
+
+def _run_error(message="error"):
+    return RunErrorEvent(message=message)
+
+
+class TestRunLifecycle(unittest.TestCase):
+    """Test run lifecycle validation rules."""
+
+    def test_valid_run_lifecycle(self):
+        validate_sequence([_run_started(), _run_finished()])
+
+    def test_first_event_must_be_run_started_or_run_error(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    TextMessageStartEvent(message_id="m1", role="assistant"),
+                ]
+            )
+
+    def test_run_error_as_first_event(self):
+        validate_sequence([_run_error()])
+
+    def test_no_events_after_run_error(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    _run_error(),
+                    _run_finished(),
+                ]
+            )
+
+    def test_no_events_after_run_finished_except_run_started(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    _run_finished(),
+                    TextMessageStartEvent(message_id="m1", role="assistant"),
+                ]
+            )
+
+    def test_cannot_start_run_while_active(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    _run_started(),
+                ]
+            )
+
+    def test_run_error_allowed_after_run_finished(self):
+        validate_sequence(
+            [
+                _run_started(),
+                _run_finished(),
+                _run_error(),
+            ]
+        )
+
+    def test_multiple_sequential_runs(self):
+        validate_sequence(
+            [
+                _run_started(run_id="r1"),
+                _run_finished(run_id="r1"),
+                _run_started(run_id="r2"),
+                _run_finished(run_id="r2"),
+            ]
+        )
+
+
+class TestTextMessageLifecycle(unittest.TestCase):
+    """Test text message lifecycle validation rules."""
+
+    def test_valid_message_lifecycle(self):
+        validate_sequence(
+            [
+                _run_started(),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="hello"),
+                TextMessageEndEvent(message_id="m1"),
+                _run_finished(),
+            ]
+        )
+
+    def test_duplicate_message_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    TextMessageStartEvent(message_id="m1", role="assistant"),
+                    TextMessageStartEvent(message_id="m1", role="assistant"),
+                ]
+            )
+
+    def test_content_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    TextMessageContentEvent(message_id="m1", delta="hello"),
+                ]
+            )
+
+    def test_end_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    TextMessageEndEvent(message_id="m1"),
+                ]
+            )
+
+    def test_concurrent_messages_different_ids(self):
+        validate_sequence(
+            [
+                _run_started(),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageStartEvent(message_id="m2", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="hello"),
+                TextMessageContentEvent(message_id="m2", delta="world"),
+                TextMessageEndEvent(message_id="m1"),
+                TextMessageEndEvent(message_id="m2"),
+                _run_finished(),
+            ]
+        )
+
+    def test_content_after_end(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    TextMessageStartEvent(message_id="m1", role="assistant"),
+                    TextMessageEndEvent(message_id="m1"),
+                    TextMessageContentEvent(message_id="m1", delta="hello"),
+                ]
+            )
+
+    def test_chunk_events_always_allowed(self):
+        validate_sequence(
+            [
+                _run_started(),
+                TextMessageChunkEvent(message_id="m1", role="assistant", delta="hello"),
+                _run_finished(),
+            ]
+        )
+
+    def test_multiple_sequential_messages(self):
+        validate_sequence(
+            [
+                _run_started(),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="first"),
+                TextMessageEndEvent(message_id="m1"),
+                TextMessageStartEvent(message_id="m2", role="assistant"),
+                TextMessageContentEvent(message_id="m2", delta="second"),
+                TextMessageEndEvent(message_id="m2"),
+                _run_finished(),
+            ]
+        )
+
+    def test_tool_call_during_text_message(self):
+        """Tool calls can start while a text message is active."""
+        validate_sequence(
+            [
+                _run_started(),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="searching..."),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallArgsEvent(tool_call_id="tc1", delta='{"q": "test"}'),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                TextMessageContentEvent(message_id="m1", delta="done"),
+                TextMessageEndEvent(message_id="m1"),
+                _run_finished(),
+            ]
+        )
+
+    def test_pass_through_events_inside_text_message(self):
+        """RAW, CUSTOM, STATE_SNAPSHOT, STATE_DELTA, MESSAGES_SNAPSHOT allowed inside messages."""
+        validate_sequence(
+            [
+                _run_started(),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                RawEvent(event={"data": "raw"}),
+                CustomEvent(name="custom", value=1),
+                StateSnapshotEvent(snapshot={"key": "val"}),
+                StateDeltaEvent(delta=[{"op": "replace", "path": "/k", "value": "v"}]),
+                MessagesSnapshotEvent(messages=[]),
+                TextMessageContentEvent(message_id="m1", delta="hello"),
+                TextMessageEndEvent(message_id="m1"),
+                _run_finished(),
+            ]
+        )
+
+
+class TestToolCallLifecycle(unittest.TestCase):
+    """Test tool call lifecycle validation rules."""
+
+    def test_valid_tool_call_lifecycle(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallArgsEvent(tool_call_id="tc1", delta='{"q": "test"}'),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                _run_finished(),
+            ]
+        )
+
+    def test_duplicate_tool_call_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                    ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ]
+            )
+
+    def test_args_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ToolCallArgsEvent(tool_call_id="tc1", delta="{}"),
+                ]
+            )
+
+    def test_end_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ToolCallEndEvent(tool_call_id="tc1"),
+                ]
+            )
+
+    def test_concurrent_tool_calls(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallStartEvent(tool_call_id="tc2", tool_call_name="fetch"),
+                ToolCallArgsEvent(tool_call_id="tc1", delta='{"q": "a"}'),
+                ToolCallArgsEvent(tool_call_id="tc2", delta='{"url": "b"}'),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                ToolCallEndEvent(tool_call_id="tc2"),
+                _run_finished(),
+            ]
+        )
+
+    def test_chunk_and_result_events_always_allowed(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ToolCallChunkEvent(tool_call_id="tc1", delta="hello"),
+                ToolCallResultEvent(message_id="msg1", tool_call_id="tc1", content="result"),
+                _run_finished(),
+            ]
+        )
+
+    def test_multiple_sequential_tool_calls(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                ToolCallStartEvent(tool_call_id="tc2", tool_call_name="fetch"),
+                ToolCallEndEvent(tool_call_id="tc2"),
+                _run_finished(),
+            ]
+        )
+
+    def test_text_message_during_tool_call(self):
+        """Text messages can start while a tool call is active."""
+        validate_sequence(
+            [
+                _run_started(),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallArgsEvent(tool_call_id="tc1", delta='{"q": "test"}'),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="searching"),
+                TextMessageEndEvent(message_id="m1"),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                _run_finished(),
+            ]
+        )
+
+    def test_pass_through_events_inside_tool_call(self):
+        """RAW, CUSTOM, STATE_SNAPSHOT, STATE_DELTA, MESSAGES_SNAPSHOT allowed inside tool calls."""
+        validate_sequence(
+            [
+                _run_started(),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                RawEvent(event={"data": "raw"}),
+                CustomEvent(name="custom", value=1),
+                StateSnapshotEvent(snapshot={"key": "val"}),
+                StateDeltaEvent(delta=[{"op": "replace", "path": "/k", "value": "v"}]),
+                MessagesSnapshotEvent(messages=[]),
+                ToolCallArgsEvent(tool_call_id="tc1", delta="{}"),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                _run_finished(),
+            ]
+        )
+
+
+class TestStepLifecycle(unittest.TestCase):
+    """Test step lifecycle validation rules."""
+
+    def test_valid_step_lifecycle(self):
+        validate_sequence(
+            [
+                _run_started(),
+                StepStartedEvent(step_name="step1"),
+                StepFinishedEvent(step_name="step1"),
+                _run_finished(),
+            ]
+        )
+
+    def test_duplicate_step_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    StepStartedEvent(step_name="step1"),
+                    StepStartedEvent(step_name="step1"),
+                ]
+            )
+
+    def test_finish_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    StepFinishedEvent(step_name="step1"),
+                ]
+            )
+
+    def test_concurrent_steps(self):
+        validate_sequence(
+            [
+                _run_started(),
+                StepStartedEvent(step_name="step1"),
+                StepStartedEvent(step_name="step2"),
+                StepFinishedEvent(step_name="step1"),
+                StepFinishedEvent(step_name="step2"),
+                _run_finished(),
+            ]
+        )
+
+
+class TestThinkingLifecycle(unittest.TestCase):
+    """Test thinking lifecycle validation rules."""
+
+    def test_valid_thinking_lifecycle(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ThinkingStartEvent(),
+                ThinkingTextMessageStartEvent(),
+                ThinkingTextMessageContentEvent(delta="thinking..."),
+                ThinkingTextMessageEndEvent(),
+                ThinkingEndEvent(),
+                _run_finished(),
+            ]
+        )
+
+    def test_duplicate_thinking_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ThinkingStartEvent(),
+                    ThinkingStartEvent(),
+                ]
+            )
+
+    def test_thinking_end_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ThinkingEndEvent(),
+                ]
+            )
+
+    def test_thinking_message_without_thinking_step(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ThinkingTextMessageStartEvent(),
+                ]
+            )
+
+    def test_duplicate_thinking_message_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ThinkingStartEvent(),
+                    ThinkingTextMessageStartEvent(),
+                    ThinkingTextMessageStartEvent(),
+                ]
+            )
+
+    def test_thinking_message_content_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ThinkingStartEvent(),
+                    ThinkingTextMessageContentEvent(delta="hello"),
+                ]
+            )
+
+    def test_thinking_message_end_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ThinkingStartEvent(),
+                    ThinkingTextMessageEndEvent(),
+                ]
+            )
+
+
+class TestReasoningMessageLifecycle(unittest.TestCase):
+    """Test reasoning message lifecycle validation rules."""
+
+    def test_valid_reasoning_message_lifecycle(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ReasoningStartEvent(message_id="r1"),
+                ReasoningMessageStartEvent(message_id="rm1", role="reasoning"),
+                ReasoningMessageContentEvent(message_id="rm1", delta="thinking..."),
+                ReasoningMessageEndEvent(message_id="rm1"),
+                ReasoningEndEvent(message_id="r1"),
+                _run_finished(),
+            ]
+        )
+
+    def test_duplicate_reasoning_message_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ReasoningMessageStartEvent(message_id="rm1", role="reasoning"),
+                    ReasoningMessageStartEvent(message_id="rm1", role="reasoning"),
+                ]
+            )
+
+    def test_reasoning_content_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ReasoningMessageContentEvent(message_id="rm1", delta="hello"),
+                ]
+            )
+
+    def test_reasoning_end_without_start(self):
+        with self.assertRaises(EventSequenceError):
+            validate_sequence(
+                [
+                    _run_started(),
+                    ReasoningMessageEndEvent(message_id="rm1"),
+                ]
+            )
+
+    def test_concurrent_reasoning_messages(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ReasoningMessageStartEvent(message_id="rm1", role="reasoning"),
+                ReasoningMessageStartEvent(message_id="rm2", role="reasoning"),
+                ReasoningMessageContentEvent(message_id="rm1", delta="a"),
+                ReasoningMessageContentEvent(message_id="rm2", delta="b"),
+                ReasoningMessageEndEvent(message_id="rm1"),
+                ReasoningMessageEndEvent(message_id="rm2"),
+                _run_finished(),
+            ]
+        )
+
+    def test_chunk_events_always_allowed(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ReasoningMessageChunkEvent(message_id="rm1", delta="hello"),
+                _run_finished(),
+            ]
+        )
+
+
+class TestRunFinishedGuards(unittest.TestCase):
+    """Test that RUN_FINISHED is blocked when resources are still active."""
+
+    def test_unfinished_step_blocks_run_finished(self):
+        with self.assertRaises(EventSequenceError) as ctx:
+            validate_sequence(
+                [
+                    _run_started(),
+                    StepStartedEvent(step_name="step1"),
+                    _run_finished(),
+                ]
+            )
+        self.assertIn("step1", str(ctx.exception))
+
+    def test_unfinished_message_blocks_run_finished(self):
+        with self.assertRaises(EventSequenceError) as ctx:
+            validate_sequence(
+                [
+                    _run_started(),
+                    TextMessageStartEvent(message_id="m1", role="assistant"),
+                    _run_finished(),
+                ]
+            )
+        self.assertIn("m1", str(ctx.exception))
+
+    def test_unfinished_tool_call_blocks_run_finished(self):
+        with self.assertRaises(EventSequenceError) as ctx:
+            validate_sequence(
+                [
+                    _run_started(),
+                    ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                    _run_finished(),
+                ]
+            )
+        self.assertIn("tc1", str(ctx.exception))
+
+    def test_active_reasoning_does_not_block_run_finished(self):
+        """Reasoning messages intentionally do not block RUN_FINISHED."""
+        validate_sequence(
+            [
+                _run_started(),
+                ReasoningMessageStartEvent(message_id="rm1", role="reasoning"),
+                _run_finished(),
+            ]
+        )
+
+
+class TestPassThroughEvents(unittest.TestCase):
+    """Test that events without lifecycle rules always pass through."""
+
+    def test_state_snapshot(self):
+        validate_sequence(
+            [
+                _run_started(),
+                StateSnapshotEvent(snapshot={"key": "value"}),
+                _run_finished(),
+            ]
+        )
+
+    def test_state_delta(self):
+        validate_sequence(
+            [
+                _run_started(),
+                StateDeltaEvent(delta=[{"op": "replace", "path": "/key", "value": "v"}]),
+                _run_finished(),
+            ]
+        )
+
+    def test_custom_event(self):
+        validate_sequence(
+            [
+                _run_started(),
+                CustomEvent(name="my_event", value={"data": 123}),
+                _run_finished(),
+            ]
+        )
+
+    def test_raw_event(self):
+        validate_sequence(
+            [
+                _run_started(),
+                RawEvent(event={"arbitrary": "data"}),
+                _run_finished(),
+            ]
+        )
+
+    def test_reasoning_start_end_pass_through(self):
+        validate_sequence(
+            [
+                _run_started(),
+                ReasoningStartEvent(message_id="r1"),
+                ReasoningEndEvent(message_id="r1"),
+                _run_finished(),
+            ]
+        )
+
+
+class TestVerifyEventsIterator(unittest.TestCase):
+    """Test the verify_events streaming iterator."""
+
+    def test_yields_valid_events(self):
+        events = [
+            _run_started(),
+            TextMessageStartEvent(message_id="m1", role="assistant"),
+            TextMessageContentEvent(message_id="m1", delta="hello"),
+            TextMessageEndEvent(message_id="m1"),
+            _run_finished(),
+        ]
+        result = list(verify_events(events))
+        self.assertEqual(len(result), 5)
+
+    def test_raises_mid_stream(self):
+        events = [
+            _run_started(),
+            TextMessageContentEvent(message_id="m1", delta="no start"),
+        ]
+        iterator = verify_events(events)
+        next(iterator)  # RUN_STARTED should pass
+        with self.assertRaises(EventSequenceError):
+            next(iterator)  # TEXT_MESSAGE_CONTENT without start should fail
+
+    def test_partial_consumption(self):
+        """Events before the violation should have been yielded."""
+        events = [
+            _run_started(),
+            TextMessageStartEvent(message_id="m1", role="assistant"),
+            TextMessageContentEvent(message_id="m1", delta="hello"),
+            TextMessageContentEvent(message_id="bad", delta="no start"),
+        ]
+        collected = []
+        with self.assertRaises(EventSequenceError):
+            for event in verify_events(events):
+                collected.append(event)
+        self.assertEqual(len(collected), 3)
+
+
+class TestValidatorReset(unittest.TestCase):
+    """Test the validator reset functionality."""
+
+    def test_reset_allows_reuse(self):
+        validator = EventSequenceValidator()
+        validator.validate_event(_run_started())
+        validator.validate_event(_run_finished())
+
+        validator.reset()
+
+        # Should work again after reset
+        validator.validate_event(_run_started())
+        validator.validate_event(_run_finished())
+
+
+class TestComplexSequences(unittest.TestCase):
+    """Test complex event sequences combining multiple lifecycles."""
+
+    def test_full_agent_interaction(self):
+        """Simulate a complete agent interaction with steps, messages, and tool calls."""
+        validate_sequence(
+            [
+                _run_started(),
+                StepStartedEvent(step_name="planning"),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="Let me search for that."),
+                TextMessageEndEvent(message_id="m1"),
+                StepFinishedEvent(step_name="planning"),
+                StepStartedEvent(step_name="execution"),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallArgsEvent(tool_call_id="tc1", delta='{"query": "test"}'),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                TextMessageStartEvent(message_id="m2", role="assistant"),
+                TextMessageContentEvent(message_id="m2", delta="Here are the results."),
+                TextMessageEndEvent(message_id="m2"),
+                StepFinishedEvent(step_name="execution"),
+                _run_finished(),
+            ]
+        )
+
+    def test_empty_sequence(self):
+        """An empty sequence should be valid."""
+        validate_sequence([])
+
+    def test_complex_concurrent_scenario(self):
+        """Many overlapping messages, tool calls, and steps in one run."""
+        validate_sequence(
+            [
+                _run_started(),
+                StepStartedEvent(step_name="plan"),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="I'll search"),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallArgsEvent(tool_call_id="tc1", delta='{"q": "a"}'),
+                TextMessageStartEvent(message_id="m2", role="assistant"),
+                TextMessageContentEvent(message_id="m2", delta="Also fetching"),
+                ToolCallStartEvent(tool_call_id="tc2", tool_call_name="fetch"),
+                ToolCallArgsEvent(tool_call_id="tc2", delta='{"url": "b"}'),
+                StateSnapshotEvent(snapshot={"progress": 50}),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                TextMessageEndEvent(message_id="m1"),
+                ToolCallEndEvent(tool_call_id="tc2"),
+                TextMessageEndEvent(message_id="m2"),
+                StepFinishedEvent(step_name="plan"),
+                _run_finished(),
+            ]
+        )
+
+    def test_multiple_runs_complex(self):
+        """Complex scenario with multiple runs and various event types."""
+        validate_sequence(
+            [
+                _run_started(run_id="r1"),
+                StepStartedEvent(step_name="step1"),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="hello"),
+                TextMessageEndEvent(message_id="m1"),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                StepFinishedEvent(step_name="step1"),
+                _run_finished(run_id="r1"),
+                # Second run reuses all IDs
+                _run_started(run_id="r2"),
+                StepStartedEvent(step_name="step1"),
+                TextMessageStartEvent(message_id="m1", role="assistant"),
+                TextMessageContentEvent(message_id="m1", delta="world"),
+                TextMessageEndEvent(message_id="m1"),
+                ToolCallStartEvent(tool_call_id="tc1", tool_call_name="search"),
+                ToolCallEndEvent(tool_call_id="tc1"),
+                StepFinishedEvent(step_name="step1"),
+                _run_finished(run_id="r2"),
+            ]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.27"
+version = "0.15.28"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Adds `datarobot_genai.core.agents.verify` (validate_sequence, verify_events, EventSequenceValidator, EventSequenceError) so e2e tests no longer depend on a private ag-ui branch.

Re-enables the previously skipped AG-UI sequence checks in the dragent e2e tests (test_mcp, test_single_response, test_streaming, test_tools) and points them at the new module.

The module carries a TODO (BUZZOK-30605) to be removed once `ag_ui.verify` lands upstream.

code source: https://github.com/ag-ui-protocol/ag-ui/compare/main...cavitcakir:ag-ui:feat/python-validate-sequence

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new protocol-validation logic that may fail tests/runs if it diverges from upstream AG‑UI expectations or if event streams contain previously-unvalidated ordering quirks.
> 
> **Overview**
> Introduces `datarobot_genai.core.agents.verify`, an in-repo AG‑UI event stream validator (`EventSequenceValidator`, `validate_sequence`, `verify_events`, `EventSequenceError`) that enforces protocol ordering (run lifecycle, steps, text messages, tool calls, thinking, and reasoning message sequencing).
> 
> Re-enables AG‑UI sequence validation assertions in dragent E2E tests by switching them to call the new `validate_sequence` helper, and adds a comprehensive unit test suite for the validator. Bumps package version to `0.15.28` (including lockfiles) and documents the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2772bc4c718e27d47cb74c10e445453a0f491a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->