### PR TITLE
[-] Fix AG-UI event ordering in CrewAI and LlamaIndex agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-
 ## 0.15.30
 - Implemented pagination for predictive data MCP tools
+- Fixed AG-UI event ordering in CrewAI and LlamaIndex agents so each agent step closes its open text/reasoning message before STEP_FINISHED, allocates a fresh message_id per step, and emits well-formed start/end pairs that pass the AG-UI sequence validator.
 
 ## 0.15.29
 - Added LangGraph human-in-the-loop (HITL) support and parameterization of LangGraph agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.31
+- Fixed AG-UI event ordering in CrewAI and LlamaIndex agents.
+
 ## 0.15.30
 - Implemented pagination for predictive data MCP tools
-- Fixed AG-UI event ordering in CrewAI and LlamaIndex agents so each agent step closes its open text/reasoning message before STEP_FINISHED, allocates a fresh message_id per step, and emits well-formed start/end pairs that pass the AG-UI sequence validator.
 
 ## 0.15.29
 - Added LangGraph human-in-the-loop (HITL) support and parameterization of LangGraph agent.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -415,6 +415,34 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                     if chunk.agent_role != current_agent_role:
                         logger.info(f"[{chunk.agent_role}] Working on task: {chunk.task_name}")
                         if current_agent_role:
+                            if text_started:
+                                yield (
+                                    TextMessageEndEvent(
+                                        type=EventType.TEXT_MESSAGE_END,
+                                        message_id=message_id,
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                text_started = False
+                            if reasoning_started:
+                                yield (
+                                    ReasoningMessageEndEvent(
+                                        type=EventType.REASONING_MESSAGE_END,
+                                        message_id=message_id,
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                yield (
+                                    ReasoningEndEvent(
+                                        type=EventType.REASONING_END,
+                                        message_id=message_id,
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                reasoning_started = False
                             yield (
                                 StepFinishedEvent(
                                     type=EventType.STEP_FINISHED,
@@ -423,6 +451,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                                 None,
                                 zero_metrics,
                             )
+                            message_id = str(uuid.uuid4())
                         yield (
                             StepStartedEvent(
                                 type=EventType.STEP_STARTED,

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -464,6 +464,16 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
                     if streaming_event_listener.reasoning_event:
                         if not reasoning_started:
+                            if text_started:
+                                yield (
+                                    TextMessageEndEvent(
+                                        type=EventType.TEXT_MESSAGE_END,
+                                        message_id=message_id,
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                text_started = False
                             yield (
                                 ReasoningStartEvent(
                                     type=EventType.REASONING_START,

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -476,6 +476,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                                 ReasoningMessageStartEvent(
                                     type=EventType.REASONING_MESSAGE_START,
                                     message_id=message_id,
+                                    role="reasoning",
                                 ),
                                 None,
                                 zero_metrics,

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -54,6 +54,7 @@ async def convert_chunks_to_agui_events(
     ``GeneratorExit`` (client disconnect), exits silently.
     """
     active_message_id: str | None = None
+    tool_call_message_id: str | None = None
     active_tool_calls: set[str] = set()
     seen_tool_calls: bool = False
     tool_index_map: dict[int, str] = {}
@@ -76,6 +77,7 @@ async def convert_chunks_to_agui_events(
                     for tc_id in active_tool_calls:
                         events.append(ToolCallEndEvent(tool_call_id=tc_id))
                     active_tool_calls.clear()
+                    tool_call_message_id = None
 
                 if active_message_id is None:
                     # After a tool call cycle, the LLM response is a new turn
@@ -95,6 +97,11 @@ async def convert_chunks_to_agui_events(
                     active_message_id = None
                 seen_tool_calls = True
 
+                # Create a dedicated message for tool calls so they don't
+                # merge with the preceding text message in storage.
+                if tool_call_message_id is None:
+                    tool_call_message_id = str(uuid.uuid4())
+
                 for tc in delta.tool_calls:
                     tc_id = tc.id or tool_index_map.get(tc.index)  # type: ignore[assignment]
                     if tc_id is None:
@@ -111,6 +118,7 @@ async def convert_chunks_to_agui_events(
                             ToolCallStartEvent(
                                 tool_call_id=tc_id,
                                 tool_call_name=tc.function.name if tc.function else "",
+                                parent_message_id=tool_call_message_id,
                             )
                         )
                     arguments = tc.function.arguments if tc.function else None

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -54,7 +54,6 @@ async def convert_chunks_to_agui_events(
     ``GeneratorExit`` (client disconnect), exits silently.
     """
     active_message_id: str | None = None
-    tool_call_message_id: str | None = None
     active_tool_calls: set[str] = set()
     seen_tool_calls: bool = False
     tool_index_map: dict[int, str] = {}
@@ -77,7 +76,6 @@ async def convert_chunks_to_agui_events(
                     for tc_id in active_tool_calls:
                         events.append(ToolCallEndEvent(tool_call_id=tc_id))
                     active_tool_calls.clear()
-                    tool_call_message_id = None
 
                 if active_message_id is None:
                     # After a tool call cycle, the LLM response is a new turn
@@ -97,11 +95,6 @@ async def convert_chunks_to_agui_events(
                     active_message_id = None
                 seen_tool_calls = True
 
-                # Create a dedicated message for tool calls so they don't
-                # merge with the preceding text message in storage.
-                if tool_call_message_id is None:
-                    tool_call_message_id = str(uuid.uuid4())
-
                 for tc in delta.tool_calls:
                     tc_id = tc.id or tool_index_map.get(tc.index)  # type: ignore[assignment]
                     if tc_id is None:
@@ -118,7 +111,6 @@ async def convert_chunks_to_agui_events(
                             ToolCallStartEvent(
                                 tool_call_id=tc_id,
                                 tool_call_name=tc.function.name if tc.function else "",
-                                parent_message_id=tool_call_message_id,
                             )
                         )
                     arguments = tc.function.arguments if tc.function else None

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -284,7 +284,11 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 yield (
                     ToolCallResultEvent(
                         type=EventType.TOOL_CALL_RESULT,
-                        message_id=message_id,
+                        # Tie the result to its tool card via tool_call_id rather
+                        # than the prior assistant text's id, so UIs that group
+                        # tool results by message_id don't overwrite the
+                        # assistant bubble with the tool's confirmation string.
+                        message_id=tid,
                         tool_call_id=tid,
                         content=json.dumps(tout, default=str),
                         role="tool",
@@ -292,6 +296,18 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     None,
                     usage_metrics,
                 )
+                # Close any open text/reasoning before regenerating message_id so
+                # the next text block opens with a fresh id (mirrors ToolCall).
+                if text_started:
+                    yield (
+                        TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=message_id,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
+                    text_started = False
                 message_id = str(uuid.uuid4())
             elif event_type == "ToolCall":
                 tname = getattr(event, "tool_name", None)

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -184,7 +184,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     )
                     message_id = str(uuid.uuid4())
                     current_message_has_text = False
-                    last_step_text = None
 
                 yield (
                     StepStartedEvent(step_name=next_agent),

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -154,7 +154,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         current_agent_name: str | None = None
         message_id = str(uuid.uuid4())
         text_started = False
-        any_text_emitted = False
+        current_message_has_text = False
 
         async for event in handler.stream_events():
             events.append(event)
@@ -179,6 +179,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                         usage_metrics,
                     )
                     message_id = str(uuid.uuid4())
+                    current_message_has_text = False
 
                 yield (
                     StepStartedEvent(step_name=next_agent),
@@ -218,7 +219,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     None,
                     usage_metrics,
                 )
-                any_text_emitted = True
+                current_message_has_text = True
 
             event_type = type(event).__name__
             if event_type == "AgentInput" and hasattr(event, "input"):
@@ -247,7 +248,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                             None,
                             usage_metrics,
                         )
-                        any_text_emitted = True
+                        current_message_has_text = True
                 # Planned tool calls
                 tcalls = getattr(event, "tool_calls", None)
                 if isinstance(tcalls, list) and tcalls:
@@ -309,6 +310,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
                 message_id = str(uuid.uuid4())
+                current_message_has_text = False
             elif event_type == "ToolCall":
                 tname = getattr(event, "tool_name", None)
                 tkwargs = getattr(event, "tool_kwargs", None)
@@ -372,7 +374,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
         # Use subclass-defined response extraction as final fallback when no text was streamed
         fallback_text = self.extract_response_text(state, events)
-        if not any_text_emitted and fallback_text:
+        if not current_message_has_text and fallback_text:
             yield (
                 TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id),
                 None,

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -155,6 +155,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         message_id = str(uuid.uuid4())
         text_started = False
         current_message_has_text = False
+        current_text_chunks: list[str] = []
+        last_step_text: str | None = None
 
         async for event in handler.stream_events():
             events.append(event)
@@ -164,6 +166,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
             if next_agent is not None and next_agent != current_agent_name:
                 if current_agent_name is not None:
                     if text_started:
+                        last_step_text = "".join(current_text_chunks)
+                        current_text_chunks = []
                         yield (
                             TextMessageEndEvent(
                                 type=EventType.TEXT_MESSAGE_END,
@@ -180,6 +184,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     )
                     message_id = str(uuid.uuid4())
                     current_message_has_text = False
+                    last_step_text = None
 
                 yield (
                     StepStartedEvent(step_name=next_agent),
@@ -204,6 +209,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
             if delta:
                 if not text_started:
+                    current_text_chunks = []
                     yield (
                         TextMessageStartEvent(
                             type=EventType.TEXT_MESSAGE_START, message_id=message_id
@@ -219,6 +225,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     None,
                     usage_metrics,
                 )
+                current_text_chunks.append(delta)
                 current_message_has_text = True
 
             event_type = type(event).__name__
@@ -231,6 +238,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     content_str = str(getattr(resp, "content"))
                     logger.info(f"Output: {content_str}")
                     if not text_started:
+                        current_text_chunks = []
                         yield (
                             TextMessageStartEvent(
                                 type=EventType.TEXT_MESSAGE_START, message_id=message_id
@@ -248,6 +256,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                             None,
                             usage_metrics,
                         )
+                        current_text_chunks.append(content_str)
                         current_message_has_text = True
                 # Planned tool calls
                 tcalls = getattr(event, "tool_calls", None)
@@ -277,6 +286,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 # closed it), close it before emitting tool events so they
                 # never sit inside an open text message. Mirrors ToolCall.
                 if text_started:
+                    last_step_text = "".join(current_text_chunks)
+                    current_text_chunks = []
                     yield (
                         TextMessageEndEvent(
                             type=EventType.TEXT_MESSAGE_END,
@@ -310,6 +321,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
                 message_id = str(uuid.uuid4())
+                current_message_has_text = False
             elif event_type == "ToolCall":
                 tname = getattr(event, "tool_name", None)
                 tkwargs = getattr(event, "tool_kwargs", None)
@@ -317,6 +329,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 logger.info(f"Calling Tool: {tname}")
                 logger.debug(f"With arguments: {tkwargs}")
                 if text_started:
+                    last_step_text = "".join(current_text_chunks)
+                    current_text_chunks = []
                     yield (
                         TextMessageEndEvent(
                             type=EventType.TEXT_MESSAGE_END,
@@ -346,6 +360,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 )
 
         if text_started:
+            last_step_text = "".join(current_text_chunks)
+            current_text_chunks = []
             yield (
                 TextMessageEndEvent(
                     type=EventType.TEXT_MESSAGE_END,
@@ -373,7 +389,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
         # Use subclass-defined response extraction as final fallback when no text was streamed
         fallback_text = self.extract_response_text(state, events)
-        if not current_message_has_text and fallback_text:
+        if not current_message_has_text and fallback_text and fallback_text != last_step_text:
             yield (
                 TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id),
                 None,
@@ -397,6 +413,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 usage_metrics,
             )
             text_started = False
+            last_step_text = fallback_text
 
         if current_agent_name is not None:
             yield (

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -155,10 +155,39 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         message_id = str(uuid.uuid4())
         text_started = False
         any_text_emitted = False
-        agent: str | None = None
 
         async for event in handler.stream_events():
             events.append(event)
+
+            # Resolve agent ownership before emitting any text from this event.
+            next_agent = getattr(event, "current_agent_name", None)
+            if next_agent is not None and next_agent != current_agent_name:
+                if current_agent_name is not None:
+                    if text_started:
+                        yield (
+                            TextMessageEndEvent(
+                                type=EventType.TEXT_MESSAGE_END,
+                                message_id=message_id,
+                            ),
+                            None,
+                            usage_metrics,
+                        )
+                        text_started = False
+                    yield (
+                        StepFinishedEvent(step_name=current_agent_name),
+                        None,
+                        usage_metrics,
+                    )
+                    message_id = str(uuid.uuid4())
+
+                yield (
+                    StepStartedEvent(step_name=next_agent),
+                    None,
+                    usage_metrics,
+                )
+                current_agent_name = next_agent
+                logger.info(f"Agent: {current_agent_name}")
+
             # Best-effort extraction of incremental text from LlamaIndex events
             delta: str | None = None
 
@@ -190,37 +219,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
                 any_text_emitted = True
-
-                # Agent switch banner if available on event
-            if hasattr(event, "current_agent_name"):
-                agent = getattr(event, "current_agent_name", None)
-                if agent is not None and agent != current_agent_name:
-                    if current_agent_name is not None:
-                        if text_started:
-                            yield (
-                                TextMessageEndEvent(
-                                    type=EventType.TEXT_MESSAGE_END,
-                                    message_id=message_id,
-                                ),
-                                None,
-                                usage_metrics,
-                            )
-                            text_started = False
-                        yield (
-                            StepFinishedEvent(step_name=current_agent_name),
-                            None,
-                            usage_metrics,
-                        )
-                        message_id = str(uuid.uuid4())
-
-                    yield (
-                        StepStartedEvent(step_name=agent),
-                        None,
-                        usage_metrics,
-                    )
-                    current_agent_name = agent
-                    agent = None
-                    logger.info(f"Agent: {current_agent_name}")
 
             event_type = type(event).__name__
             if event_type == "AgentInput" and hasattr(event, "input"):

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -273,6 +273,20 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 logger.info(f"Tool Result: {tname}")
                 logger.debug(f"Arguments: {tkwargs}")
                 logger.debug(f"Output: {tout}")
+                # Safety net: if a text message is somehow still open (e.g. a
+                # ToolCallResult arrives without a preceding ToolCall having
+                # closed it), close it before emitting tool events so they
+                # never sit inside an open text message. Mirrors ToolCall.
+                if text_started:
+                    yield (
+                        TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=message_id,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
+                    text_started = False
                 yield (
                     ToolCallEndEvent(
                         type=EventType.TOOL_CALL_END,
@@ -296,18 +310,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     None,
                     usage_metrics,
                 )
-                # Close any open text/reasoning before regenerating message_id so
-                # the next text block opens with a fresh id (mirrors ToolCall).
-                if text_started:
-                    yield (
-                        TextMessageEndEvent(
-                            type=EventType.TEXT_MESSAGE_END,
-                            message_id=message_id,
-                        ),
-                        None,
-                        usage_metrics,
-                    )
-                    text_started = False
                 message_id = str(uuid.uuid4())
             elif event_type == "ToolCall":
                 tname = getattr(event, "tool_name", None)

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -355,13 +355,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
             )
             text_started = False
 
-        if current_agent_name is not None:
-            yield (
-                StepFinishedEvent(step_name=current_agent_name),
-                None,
-                usage_metrics,
-            )
-
         # After streaming completes, build final interactions and finish chunk
         # Extract state from workflow context (supports sync/async get or attribute)
         state = None
@@ -402,7 +395,14 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 None,
                 usage_metrics,
             )
-            text_started = True
+            text_started = False
+
+        if current_agent_name is not None:
+            yield (
+                StepFinishedEvent(step_name=current_agent_name),
+                None,
+                usage_metrics,
+            )
 
         pipeline_interactions = self.create_pipeline_interactions_from_events(events)
         if uses_memory:

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -154,6 +154,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         current_agent_name: str | None = None
         message_id = str(uuid.uuid4())
         text_started = False
+        any_text_emitted = False
         agent: str | None = None
 
         async for event in handler.stream_events():
@@ -188,17 +189,29 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     None,
                     usage_metrics,
                 )
+                any_text_emitted = True
 
                 # Agent switch banner if available on event
             if hasattr(event, "current_agent_name"):
                 agent = getattr(event, "current_agent_name", None)
                 if agent is not None and agent != current_agent_name:
                     if current_agent_name is not None:
+                        if text_started:
+                            yield (
+                                TextMessageEndEvent(
+                                    type=EventType.TEXT_MESSAGE_END,
+                                    message_id=message_id,
+                                ),
+                                None,
+                                usage_metrics,
+                            )
+                            text_started = False
                         yield (
                             StepFinishedEvent(step_name=current_agent_name),
                             None,
                             usage_metrics,
                         )
+                        message_id = str(uuid.uuid4())
 
                     yield (
                         StepStartedEvent(step_name=agent),
@@ -236,6 +249,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                             None,
                             usage_metrics,
                         )
+                        any_text_emitted = True
                 # Planned tool calls
                 tcalls = getattr(event, "tool_calls", None)
                 if isinstance(tcalls, list) and tcalls:
@@ -278,12 +292,23 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     None,
                     usage_metrics,
                 )
+                message_id = str(uuid.uuid4())
             elif event_type == "ToolCall":
                 tname = getattr(event, "tool_name", None)
                 tkwargs = getattr(event, "tool_kwargs", None)
                 tid = getattr(event, "tool_id", None)
                 logger.info(f"Calling Tool: {tname}")
                 logger.debug(f"With arguments: {tkwargs}")
+                if text_started:
+                    yield (
+                        TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=message_id,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
+                    text_started = False
                 yield (
                     ToolCallStartEvent(
                         type=EventType.TOOL_CALL_START,
@@ -303,20 +328,20 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
 
-        if agent is not None:
-            yield (
-                StepFinishedEvent(step_name=agent),
-                None,
-                usage_metrics,
-            )
-            agent = None
-
         if text_started:
             yield (
                 TextMessageEndEvent(
                     type=EventType.TEXT_MESSAGE_END,
                     message_id=message_id,
                 ),
+                None,
+                usage_metrics,
+            )
+            text_started = False
+
+        if current_agent_name is not None:
+            yield (
+                StepFinishedEvent(step_name=current_agent_name),
                 None,
                 usage_metrics,
             )
@@ -338,7 +363,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
         # Use subclass-defined response extraction as final fallback when no text was streamed
         fallback_text = self.extract_response_text(state, events)
-        if not text_started and fallback_text:
+        if not any_text_emitted and fallback_text:
             yield (
                 TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id),
                 None,

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -310,7 +310,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
                 message_id = str(uuid.uuid4())
-                current_message_has_text = False
             elif event_type == "ToolCall":
                 tname = getattr(event, "tool_name", None)
                 tkwargs = getattr(event, "tool_kwargs", None)

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -24,6 +24,7 @@ from crewai.types.streaming import StreamChunk
 from crewai.types.streaming import StreamChunkType
 import pytest
 from ag_ui.core import ReasoningEndEvent
+from ag_ui.core import ReasoningMessageContentEvent
 from ag_ui.core import ReasoningMessageEndEvent
 from ag_ui.core import ReasoningMessageStartEvent
 from ag_ui.core import RunAgentInput
@@ -457,6 +458,67 @@ async def test_invoke_streaming_closes_reasoning_before_finishing_step(
     )
     assert reasoning_message_end_idx < reasoning_end_idx < planner_step_finished_idx
     assert planner_step_finished_idx < writer_step_started_idx
+
+
+async def test_invoke_streaming_closes_text_before_same_step_reasoning_starts(
+    run_agent_input, mock_ragas_event_listener
+) -> None:
+    streaming_listener = StreamingListenerForTest()
+
+    async def stream_chunks() -> AsyncGenerator[StreamChunk, None]:
+        yield StreamChunk(
+            content="answer",
+            chunk_type=StreamChunkType.TEXT,
+            task_name="plan",
+            agent_role="Planner",
+        )
+        streaming_listener.reasoning_event = True
+        yield StreamChunk(
+            content="think",
+            chunk_type=StreamChunkType.TEXT,
+            task_name="plan",
+            agent_role="Planner",
+        )
+
+    # GIVEN a streamed CrewAI run that switches from text to reasoning in one step
+    streaming_output = FakeStreamingOutput(async_iterator=stream_chunks())
+    agent = AgentForTest(
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        crew=StreamingCrewForTest(streaming_output),
+    )
+
+    with patch(
+        "datarobot_genai.crewai.agent.CrewAIStreamingEventListener",
+        return_value=streaming_listener,
+    ):
+        # WHEN invoking the agent
+        events_out = [event async for event in agent.invoke(run_agent_input)]
+
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the text lifecycle closes before reasoning starts
+    text_start_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, TextMessageStartEvent)
+    )
+    text_end_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, TextMessageEndEvent)
+    )
+    reasoning_start_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, ReasoningMessageStartEvent)
+    )
+    reasoning_content_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, ReasoningMessageContentEvent)
+    )
+    assert text_start_idx < text_end_idx < reasoning_start_idx < reasoning_content_idx
+
+    planner_step_finished_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepFinishedEvent) and event.step_name == "Planner"
+    )
+    assert reasoning_content_idx < planner_step_finished_idx
 
 
 async def test_invoke_does_not_include_chat_history_by_default(

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -14,16 +14,27 @@
 
 # ruff: noqa: I001
 from collections.abc import AsyncGenerator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from crewai.types.streaming import CrewStreamingOutput
+from crewai.types.streaming import StreamChunk
+from crewai.types.streaming import StreamChunkType
 import pytest
+from ag_ui.core import ReasoningEndEvent
+from ag_ui.core import ReasoningMessageEndEvent
+from ag_ui.core import ReasoningMessageStartEvent
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
+from ag_ui.core import StepFinishedEvent
+from ag_ui.core import StepStartedEvent
 from ag_ui.core import TextMessageChunkEvent
+from ag_ui.core import TextMessageContentEvent
+from ag_ui.core import TextMessageEndEvent
+from ag_ui.core import TextMessageStartEvent
 from ag_ui.core import UserMessage
 from crewai import CrewOutput
 from ragas import MultiTurnSample
@@ -31,6 +42,7 @@ from ragas.messages import AIMessage
 from ragas.messages import HumanMessage
 
 from datarobot_genai.core.agents.base import UsageMetrics
+from datarobot_genai.core.agents.verify import validate_sequence
 from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.crewai.agent import CrewAIAgent
 from datarobot_genai.crewai.agent import datarobot_agent_class_from_crew
@@ -66,6 +78,41 @@ class ListenerForTest:
 
     def setup_listeners(self, crewai_event_bus: Any) -> None:
         self.called_setup = True
+
+
+class FakeStreamingOutput(CrewStreamingOutput):
+    def __init__(
+        self,
+        *,
+        async_iterator: AsyncGenerator[StreamChunk, None],
+        token_usage: Any | None = None,
+    ) -> None:
+        super().__init__(async_iterator=async_iterator)
+        self._forced_result = SimpleNamespace(
+            token_usage=token_usage
+            or SimpleNamespace(completion_tokens=1, prompt_tokens=2, total_tokens=3)
+        )
+
+    @property
+    def result(self) -> Any:
+        return self._forced_result
+
+
+class StreamingCrewForTest:
+    def __init__(self, output: CrewStreamingOutput) -> None:
+        self.output = output
+        self.verbose = True
+
+    async def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewStreamingOutput:  # type: ignore[override]
+        return self.output
+
+
+class StreamingListenerForTest:
+    def __init__(self) -> None:
+        self.reasoning_event = False
+
+    def setup_listeners(self, crewai_event_bus: Any) -> None:
+        return None
 
 
 class FakeMemoryClient(BaseMemoryClient):
@@ -266,6 +313,150 @@ async def test_invoke(run_agent_input, mock_ragas_event_listener) -> None:
 
     # THEN usage is the expected usage
     assert usage == {"completion_tokens": 1, "prompt_tokens": 2, "total_tokens": 3}
+
+
+async def test_invoke_streaming_starts_fresh_text_message_per_step(
+    run_agent_input, mock_ragas_event_listener
+) -> None:
+    async def stream_chunks() -> AsyncGenerator[StreamChunk, None]:
+        yield StreamChunk(
+            content="plan",
+            chunk_type=StreamChunkType.TEXT,
+            task_name="plan",
+            agent_role="Planner",
+        )
+        yield StreamChunk(
+            content="write",
+            chunk_type=StreamChunkType.TEXT,
+            task_name="write",
+            agent_role="Writer",
+        )
+
+    # GIVEN a streamed CrewAI run that switches agent roles between text chunks
+    streaming_output = FakeStreamingOutput(async_iterator=stream_chunks())
+    agent = AgentForTest(
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        crew=StreamingCrewForTest(streaming_output),
+    )
+    streaming_listener = StreamingListenerForTest()
+
+    with patch(
+        "datarobot_genai.crewai.agent.CrewAIStreamingEventListener",
+        return_value=streaming_listener,
+    ):
+        # WHEN invoking the agent
+        events_out = [event async for event in agent.invoke(run_agent_input)]
+
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the AG-UI event sequence remains valid
+    validate_sequence(list(ag_events))
+
+    # THEN each step gets its own text message lifecycle with a distinct id
+    text_starts = [event for event in ag_events if isinstance(event, TextMessageStartEvent)]
+    text_contents = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
+    text_ends = [event for event in ag_events if isinstance(event, TextMessageEndEvent)]
+    assert [event.delta for event in text_contents] == ["plan", "write"]
+    assert len(text_starts) == 2
+    assert len(text_ends) == 2
+    assert len({event.message_id for event in text_starts}) == 2
+    assert {event.message_id for event in text_starts} == {event.message_id for event in text_ends}
+
+    # THEN the first text message closes before Planner finishes
+    planner_text_end_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, TextMessageEndEvent)
+    )
+    planner_step_finished_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepFinishedEvent) and event.step_name == "Planner"
+    )
+    writer_step_started_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepStartedEvent) and event.step_name == "Writer"
+    )
+    writer_text_start_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, TextMessageStartEvent)
+        and event.message_id == text_contents[1].message_id
+    )
+    assert planner_text_end_idx < planner_step_finished_idx < writer_step_started_idx
+    assert writer_step_started_idx < writer_text_start_idx
+
+
+async def test_invoke_streaming_closes_reasoning_before_finishing_step(
+    run_agent_input, mock_ragas_event_listener
+) -> None:
+    streaming_listener = StreamingListenerForTest()
+
+    async def stream_chunks() -> AsyncGenerator[StreamChunk, None]:
+        streaming_listener.reasoning_event = True
+        yield StreamChunk(
+            content="think",
+            chunk_type=StreamChunkType.TEXT,
+            task_name="plan",
+            agent_role="Planner",
+        )
+        streaming_listener.reasoning_event = False
+        yield StreamChunk(
+            content="answer",
+            chunk_type=StreamChunkType.TEXT,
+            task_name="write",
+            agent_role="Writer",
+        )
+
+    # GIVEN a streamed CrewAI run that exits reasoning mode while switching steps
+    streaming_output = FakeStreamingOutput(async_iterator=stream_chunks())
+    agent = AgentForTest(
+        api_base="https://x/",
+        api_key="k",
+        verbose=False,
+        crew=StreamingCrewForTest(streaming_output),
+    )
+
+    with patch(
+        "datarobot_genai.crewai.agent.CrewAIStreamingEventListener",
+        return_value=streaming_listener,
+    ):
+        # WHEN invoking the agent
+        events_out = [event async for event in agent.invoke(run_agent_input)]
+
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the AG-UI event sequence remains valid
+    validate_sequence(list(ag_events))
+
+    # THEN the planner reasoning lifecycle closes before Planner finishes
+    reasoning_start = next(
+        event for event in ag_events if isinstance(event, ReasoningMessageStartEvent)
+    )
+    writer_text_start = next(
+        event for event in ag_events if isinstance(event, TextMessageStartEvent)
+    )
+    assert reasoning_start.message_id != writer_text_start.message_id
+
+    reasoning_message_end_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, ReasoningMessageEndEvent)
+    )
+    reasoning_end_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, ReasoningEndEvent)
+    )
+    planner_step_finished_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepFinishedEvent) and event.step_name == "Planner"
+    )
+    writer_step_started_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepStartedEvent) and event.step_name == "Writer"
+    )
+    assert reasoning_message_end_idx < reasoning_end_idx < planner_step_finished_idx
+    assert planner_step_finished_idx < writer_step_started_idx
 
 
 async def test_invoke_does_not_include_chat_history_by_default(

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -576,10 +576,10 @@ async def test_invoke_fallback_text_not_suppressed_by_prior_step_text(
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 
-async def test_invoke_does_not_emit_fallback_after_tool_when_step_already_streamed_text(
+async def test_invoke_emits_fallback_after_tool_when_final_answer_is_new(
     run_agent_input: RunAgentInput,
 ) -> None:
-    """Fallback text does not duplicate content after a tool result in the same step."""
+    """Fallback text still emits after a tool when it is a new final answer."""
     workflow = Workflow(
         events=[
             AgentWorkflowStartEvent(),
@@ -619,7 +619,127 @@ async def test_invoke_does_not_emit_fallback_after_tool_when_step_already_stream
     events_out = [e async for e in agent.invoke(run_agent_input)]
     ag_events, _, _ = zip(*events_out)
 
-    # THEN fallback text is not emitted again for the same step
+    # THEN the final fallback answer is emitted as a fresh message after the tool result
+    content = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
+    assert [event.delta for event in content] == ["prefix", "FINAL:6"]
+
+    text_starts = [event for event in ag_events if isinstance(event, TextMessageStartEvent)]
+    text_ends = [event for event in ag_events if isinstance(event, TextMessageEndEvent)]
+    assert len(text_starts) == 2
+    assert len(text_ends) == 2
+    assert text_starts[0].message_id == text_ends[0].message_id == content[0].message_id
+    assert text_starts[1].message_id == text_ends[1].message_id == content[1].message_id
+    assert isinstance(ag_events[-1], RunFinishedEvent)
+
+
+async def test_invoke_suppresses_duplicate_fallback_after_tool_when_text_matches(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Fallback text is skipped when it would only repeat the pre-tool assistant message."""
+
+    class SameFallbackAgent(MyLlamaAgent):
+        def extract_response_text(self, result_state: Any, events: list[Any]) -> str:
+            return "prefix"
+
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentInput(
+                input=[ChatMessage(content="{'input': 'use tool'}", role=MessageRole.USER)],
+                current_agent_name="Agent1",
+            ),
+            AgentStream(delta="prefix", response="", current_agent_name="Agent1"),
+            AgentOutput(
+                response=ChatMessage(content="prefix", role=MessageRole.ASSISTANT),
+                current_agent_name="Agent1",
+                tool_calls=[
+                    ToolSelection(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1")
+                ],
+            ),
+            ToolCall(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1"),
+            ToolCallResult(
+                tool_name="tool1",
+                tool_kwargs={"a": 1},
+                tool_id="tool1",
+                tool_output=ToolOutput(
+                    tool_name="tool1",
+                    content="tool result",
+                    raw_input={"a": 1},
+                    raw_output="tool result",
+                    is_error=False,
+                ),
+                return_direct=False,
+            ),
+        ],
+        state="FINAL",
+    )
+    agent = SameFallbackAgent(workflow)
+
+    # GIVEN a fallback extractor that would only repeat the already streamed text
+    # WHEN the step ends after a tool result
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the duplicate fallback message is suppressed
+    content = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
+    assert [event.delta for event in content] == ["prefix"]
+
+    text_starts = [event for event in ag_events if isinstance(event, TextMessageStartEvent)]
+    text_ends = [event for event in ag_events if isinstance(event, TextMessageEndEvent)]
+    assert len(text_starts) == 1
+    assert len(text_ends) == 1
+    assert text_starts[0].message_id == text_ends[0].message_id == content[0].message_id
+    assert isinstance(ag_events[-1], RunFinishedEvent)
+
+
+async def test_invoke_suppresses_duplicate_fallback_after_tool_when_agent_output_matches(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Fallback text is skipped when it repeats AgentOutput-only text from the same step."""
+
+    class SameFallbackAgent(MyLlamaAgent):
+        def extract_response_text(self, result_state: Any, events: list[Any]) -> str:
+            return "prefix"
+
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentInput(
+                input=[ChatMessage(content="{'input': 'use tool'}", role=MessageRole.USER)],
+                current_agent_name="Agent1",
+            ),
+            AgentOutput(
+                response=ChatMessage(content="prefix", role=MessageRole.ASSISTANT),
+                current_agent_name="Agent1",
+                tool_calls=[
+                    ToolSelection(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1")
+                ],
+            ),
+            ToolCall(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1"),
+            ToolCallResult(
+                tool_name="tool1",
+                tool_kwargs={"a": 1},
+                tool_id="tool1",
+                tool_output=ToolOutput(
+                    tool_name="tool1",
+                    content="tool result",
+                    raw_input={"a": 1},
+                    raw_output="tool result",
+                    is_error=False,
+                ),
+                return_direct=False,
+            ),
+        ],
+        state="FINAL",
+    )
+    agent = SameFallbackAgent(workflow)
+
+    # GIVEN assistant text emitted only through AgentOutput before the tool call
+    # WHEN fallback would repeat that same text after the tool result
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the duplicate fallback message is suppressed
     content = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
     assert [event.delta for event in content] == ["prefix"]
 

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -581,6 +581,66 @@ async def test_invoke_fallback_text_not_suppressed_by_prior_step_text(
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 
+async def test_invoke_does_not_repeat_prior_step_text_in_silent_final_step(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Fallback text is suppressed when it would only repeat the prior step's output."""
+
+    class EventEchoAgent(MyLlamaAgent):
+        def extract_response_text(self, result_state: Any, events: list[Any]) -> str:
+            for event in reversed(events):
+                response = getattr(event, "response", None)
+                if response is not None and getattr(response, "content", None):
+                    return str(response.content)
+                delta = getattr(event, "delta", None)
+                if isinstance(delta, str) and delta:
+                    return delta
+            return ""
+
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentStream(delta="outline", response="", current_agent_name="Planner"),
+            AgentInput(
+                input=[ChatMessage(content="{'input': 'write answer'}", role=MessageRole.USER)],
+                current_agent_name="Writer",
+            ),
+        ],
+        state="FINAL",
+    )
+    agent = EventEchoAgent(workflow)
+
+    # GIVEN a prior step already emitted the only assistant text
+    # WHEN the final step is silent and fallback extraction looks at prior events
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the previous step's text is not re-emitted inside the silent final step
+    content = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
+    assert [event.delta for event in content] == ["outline"]
+
+    writer_step_started_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepStartedEvent) and event.step_name == "Writer"
+    )
+    writer_step_finished_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepFinishedEvent) and event.step_name == "Writer"
+    )
+    writer_text_events = [
+        event
+        for event in ag_events[writer_step_started_idx + 1 : writer_step_finished_idx]
+        if isinstance(
+            event,
+            TextMessageStartEvent | TextMessageContentEvent | TextMessageEndEvent,
+        )
+    ]
+    assert writer_text_events == []
+    assert isinstance(ag_events[-1], RunFinishedEvent)
+
+
 async def test_invoke_emits_fallback_after_tool_when_final_answer_is_new(
     run_agent_input: RunAgentInput,
 ) -> None:

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -520,6 +520,62 @@ async def test_invoke_fallback_text_stays_within_active_step(
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 
+async def test_invoke_fallback_text_not_suppressed_by_prior_step_text(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Fallback text still emits for the active step after earlier streamed text."""
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentStream(delta="outline", response="", current_agent_name="Planner"),
+            AgentInput(
+                input=[ChatMessage(content="{'input': 'write answer'}", role=MessageRole.USER)],
+                current_agent_name="Writer",
+            ),
+        ],
+        state="FINAL",
+    )
+    agent = MyLlamaAgent(workflow)
+
+    # GIVEN a prior step already streamed text
+    # WHEN the active step relies on fallback extraction for its final answer
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the fallback text still appears within the active step
+    content = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
+    assert [event.delta for event in content] == ["outline", "FINAL:3"]
+
+    writer_step_started_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepStartedEvent) and event.step_name == "Writer"
+    )
+    fallback_text_start_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, TextMessageStartEvent) and event.message_id == content[1].message_id
+    )
+    fallback_text_end_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, TextMessageEndEvent) and event.message_id == content[1].message_id
+    )
+    writer_step_finished_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepFinishedEvent) and event.step_name == "Writer"
+    )
+
+    assert (
+        writer_step_started_idx
+        < fallback_text_start_idx
+        < fallback_text_end_idx
+        < writer_step_finished_idx
+    )
+    assert isinstance(ag_events[-1], RunFinishedEvent)
+
+
 async def test_invoke_replaces_chat_history_placeholder() -> None:
     """invoke() replaces {chat_history} inside the raw user prompt."""
     workflow = CapturingWorkflow(events=[], state="S")

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -362,15 +362,17 @@ async def test_llama_index_agent_invoke(
     # THEN: first event is RunStartedEvent
     assert isinstance(ag_events[0], RunStartedEvent)
 
-    # THEN: text message events contain the expected deltas (after step / lifecycle events)
+    # THEN: each agent step has its own text message (start/end pair) with a unique id
     text_starts = [e for e in ag_events if isinstance(e, TextMessageStartEvent)]
-    assert len(text_starts) == 1
+    assert len(text_starts) == 2
     content_events = [e for e in ag_events if isinstance(e, TextMessageContentEvent)]
     assert [e.delta for e in content_events] == ["Hello ", "World\n", "Hello ", "World Again\n"]
 
-    # THEN: TextMessageEnd is present
+    # THEN: each TextMessageStart has a matching TextMessageEnd with the same id
     end_events = [e for e in ag_events if isinstance(e, TextMessageEndEvent)]
-    assert len(end_events) == 1
+    assert len(end_events) == 2
+    assert {e.message_id for e in text_starts} == {e.message_id for e in end_events}
+    assert len({e.message_id for e in text_starts}) == 2
 
     # THEN: last event is RunFinishedEvent with pipeline interactions
     assert isinstance(ag_events[-1], RunFinishedEvent)

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -576,6 +576,61 @@ async def test_invoke_fallback_text_not_suppressed_by_prior_step_text(
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 
+async def test_invoke_does_not_emit_fallback_after_tool_when_step_already_streamed_text(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Fallback text does not duplicate content after a tool result in the same step."""
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentInput(
+                input=[ChatMessage(content="{'input': 'use tool'}", role=MessageRole.USER)],
+                current_agent_name="Agent1",
+            ),
+            AgentStream(delta="prefix", response="", current_agent_name="Agent1"),
+            AgentOutput(
+                response=ChatMessage(content="prefix", role=MessageRole.ASSISTANT),
+                current_agent_name="Agent1",
+                tool_calls=[
+                    ToolSelection(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1")
+                ],
+            ),
+            ToolCall(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1"),
+            ToolCallResult(
+                tool_name="tool1",
+                tool_kwargs={"a": 1},
+                tool_id="tool1",
+                tool_output=ToolOutput(
+                    tool_name="tool1",
+                    content="tool result",
+                    raw_input={"a": 1},
+                    raw_output="tool result",
+                    is_error=False,
+                ),
+                return_direct=False,
+            ),
+        ],
+        state="FINAL",
+    )
+    agent = MyLlamaAgent(workflow)
+
+    # GIVEN a step that already streamed assistant text before a tool call
+    # WHEN the step ends without any additional text after the tool result
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN fallback text is not emitted again for the same step
+    content = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
+    assert [event.delta for event in content] == ["prefix"]
+
+    text_starts = [event for event in ag_events if isinstance(event, TextMessageStartEvent)]
+    text_ends = [event for event in ag_events if isinstance(event, TextMessageEndEvent)]
+    assert len(text_starts) == 1
+    assert len(text_ends) == 1
+    assert text_starts[0].message_id == text_ends[0].message_id == content[0].message_id
+    assert isinstance(ag_events[-1], RunFinishedEvent)
+
+
 async def test_invoke_replaces_chat_history_placeholder() -> None:
     """invoke() replaces {chat_history} inside the raw user prompt."""
     workflow = CapturingWorkflow(events=[], state="S")

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -22,6 +22,7 @@ from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
+from ag_ui.core import StepFinishedEvent
 from ag_ui.core import StepStartedEvent
 from ag_ui.core import SystemMessage as AgSystemMessage
 from ag_ui.core import TextMessageContentEvent
@@ -471,6 +472,51 @@ async def test_invoke_agent_stream_multiple_agents(
     assert text_starts[1].message_id == content[1].message_id
 
     # THEN the run still completes cleanly
+    assert isinstance(ag_events[-1], RunFinishedEvent)
+
+
+async def test_invoke_fallback_text_stays_within_active_step(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Fallback text is emitted before the active step is finished."""
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentInput(
+                input=[ChatMessage(content="{'input': 'say hello'}", role=MessageRole.USER)],
+                current_agent_name="Agent1",
+            ),
+        ],
+        state="FINAL",
+    )
+    agent = MyLlamaAgent(workflow)
+
+    # GIVEN a workflow that assigns agent ownership but streams no text
+    # WHEN invoking the agent
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the fallback text lifecycle stays inside the active step
+    step_started_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, StepStartedEvent)
+    )
+    text_start_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, TextMessageStartEvent)
+    )
+    text_content_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, TextMessageContentEvent)
+    )
+    text_end_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, TextMessageEndEvent)
+    )
+    step_finished_idx = next(
+        i for i, event in enumerate(ag_events) if isinstance(event, StepFinishedEvent)
+    )
+
+    assert step_started_idx < text_start_idx < text_content_idx < text_end_idx < step_finished_idx
+
+    content = next(event for event in ag_events if isinstance(event, TextMessageContentEvent))
+    assert content.delta == "FINAL:2"
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -28,6 +28,10 @@ from ag_ui.core import SystemMessage as AgSystemMessage
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import TextMessageStartEvent
+from ag_ui.core import ToolCallArgsEvent
+from ag_ui.core import ToolCallEndEvent
+from ag_ui.core import ToolCallResultEvent
+from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import UserMessage
 from llama_index.core.agent.workflow import AgentInput
 from llama_index.core.agent.workflow import AgentOutput
@@ -43,6 +47,7 @@ from llama_index.core.tools import ToolOutput
 from llama_index.core.tools import ToolSelection
 from ragas import MultiTurnSample
 
+from datarobot_genai.core.agents.verify import validate_sequence
 from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.llama_index.agent import DataRobotLiteLLM
 from datarobot_genai.llama_index.agent import LlamaIndexAgent
@@ -629,6 +634,89 @@ async def test_invoke_emits_fallback_after_tool_when_final_answer_is_new(
     assert len(text_ends) == 2
     assert text_starts[0].message_id == text_ends[0].message_id == content[0].message_id
     assert text_starts[1].message_id == text_ends[1].message_id == content[1].message_id
+    assert isinstance(ag_events[-1], RunFinishedEvent)
+
+
+async def test_invoke_tool_result_uses_tool_call_id_and_post_tool_text_gets_new_message(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Tool result stays tied to the tool call while post-tool text starts a fresh message."""
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentInput(
+                input=[ChatMessage(content="{'input': 'use tool'}", role=MessageRole.USER)],
+                current_agent_name="Agent1",
+            ),
+            AgentStream(delta="prefix", response="", current_agent_name="Agent1"),
+            AgentOutput(
+                response=ChatMessage(content="prefix", role=MessageRole.ASSISTANT),
+                current_agent_name="Agent1",
+                tool_calls=[
+                    ToolSelection(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1")
+                ],
+            ),
+            ToolCall(tool_name="tool1", tool_kwargs={"a": 1}, tool_id="tool1"),
+            ToolCallResult(
+                tool_name="tool1",
+                tool_kwargs={"a": 1},
+                tool_id="tool1",
+                tool_output=ToolOutput(
+                    tool_name="tool1",
+                    content="tool result",
+                    raw_input={"a": 1},
+                    raw_output="tool result",
+                    is_error=False,
+                ),
+                return_direct=False,
+            ),
+            AgentStream(delta="suffix", response="", current_agent_name="Agent1"),
+        ],
+        state="FINAL",
+    )
+    agent = MyLlamaAgent(workflow)
+
+    # GIVEN a step that streams text, runs a tool, then streams more text
+    # WHEN invoking the agent
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    # THEN the AG-UI event sequence remains valid
+    validate_sequence(list(ag_events))
+
+    # THEN the tool-result event is keyed by the tool call id
+    tool_start = next(event for event in ag_events if isinstance(event, ToolCallStartEvent))
+    tool_args = next(event for event in ag_events if isinstance(event, ToolCallArgsEvent))
+    tool_end = next(event for event in ag_events if isinstance(event, ToolCallEndEvent))
+    tool_result = next(event for event in ag_events if isinstance(event, ToolCallResultEvent))
+    assert tool_start.tool_call_id == "tool1"
+    assert tool_args.tool_call_id == "tool1"
+    assert tool_end.tool_call_id == "tool1"
+    assert tool_result.tool_call_id == "tool1"
+    assert tool_result.message_id == "tool1"
+
+    # THEN post-tool assistant text opens a new message instead of reusing the tool id
+    content = [event for event in ag_events if isinstance(event, TextMessageContentEvent)]
+    assert [event.delta for event in content] == ["prefix", "suffix"]
+    text_starts = [event for event in ag_events if isinstance(event, TextMessageStartEvent)]
+    assert len(text_starts) == 2
+    assert text_starts[0].message_id == content[0].message_id
+    assert text_starts[1].message_id == content[1].message_id
+    assert text_starts[1].message_id != tool_result.message_id
+
+    prefix_text_end_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, TextMessageEndEvent) and event.message_id == content[0].message_id
+    )
+    tool_start_idx = next(i for i, event in enumerate(ag_events) if event == tool_start)
+    tool_result_idx = next(i for i, event in enumerate(ag_events) if event == tool_result)
+    suffix_text_start_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, TextMessageStartEvent) and event.message_id == content[1].message_id
+    )
+    assert prefix_text_end_idx < tool_start_idx < tool_result_idx < suffix_text_start_idx
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -22,7 +22,6 @@ from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
-from ag_ui.core import StepFinishedEvent
 from ag_ui.core import StepStartedEvent
 from ag_ui.core import SystemMessage as AgSystemMessage
 from ag_ui.core import TextMessageContentEvent
@@ -428,7 +427,7 @@ async def test_invoke_agent_output_with_dict_tool_calls(
 async def test_invoke_agent_stream_multiple_agents(
     run_agent_input: RunAgentInput,
 ) -> None:
-    """Multi-agent stream yields text, step events, and completes."""
+    """Multi-agent stream starts a fresh text message when agent ownership changes."""
     workflow = Workflow(
         events=[
             AgentWorkflowStartEvent(),
@@ -439,21 +438,39 @@ async def test_invoke_agent_stream_multiple_agents(
     )
     agent = MyLlamaAgent(workflow)
 
+    # GIVEN a stream that switches agents between incremental text chunks
+    # WHEN invoking the agent
     events_out = [e async for e in agent.invoke(run_agent_input)]
     ag_events, _, _ = zip(*events_out)
 
+    # THEN the streamed text deltas are preserved
     content = [e for e in ag_events if isinstance(e, TextMessageContentEvent)]
     assert [e.delta for e in content] == ["one", " two"]
-    assert any(isinstance(e, TextMessageStartEvent) for e in ag_events)
-    assert any(isinstance(e, TextMessageEndEvent) for e in ag_events)
 
-    step_started = [e for e in ag_events if isinstance(e, StepStartedEvent)]
-    step_finished = [e for e in ag_events if isinstance(e, StepFinishedEvent)]
-    if step_started:
-        assert {e.step_name for e in step_started} <= {"Agent1", "Agent2"}
-    if step_finished:
-        assert {e.step_name for e in step_finished} <= {"Agent1", "Agent2"}
+    # THEN each agent step gets its own text message lifecycle
+    text_starts = [e for e in ag_events if isinstance(e, TextMessageStartEvent)]
+    text_ends = [e for e in ag_events if isinstance(e, TextMessageEndEvent)]
+    assert len(text_starts) == 2
+    assert len(text_ends) == 2
+    assert {e.message_id for e in text_starts} == {e.message_id for e in text_ends}
+    assert len({e.message_id for e in text_starts}) == 2
 
+    # THEN the second agent's step starts before its text message opens
+    second_step_started_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, StepStartedEvent) and event.step_name == "Agent2"
+    )
+    second_text_start_idx = next(i for i, event in enumerate(ag_events) if event == text_starts[1])
+    second_text_content_idx = next(
+        i
+        for i, event in enumerate(ag_events)
+        if isinstance(event, TextMessageContentEvent) and event.delta == " two"
+    )
+    assert second_step_started_idx < second_text_start_idx < second_text_content_idx
+    assert text_starts[1].message_id == content[1].message_id
+
+    # THEN the run still completes cleanly
     assert isinstance(ag_events[-1], RunFinishedEvent)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## CrewAI

### Why

Two real ordering bugs in [`src/datarobot_genai/crewai/agent.py`](src/datarobot_genai/crewai/agent.py):

1. **Single `message_id` for the whole run.** It was created once before
   the streaming loop and reused for every agent role. The `Planner` text
   and the `Writer` text were stored as one continuous assistant message in
   the client.
2. **`STEP_FINISHED` fires while the text message is still open.** On agent
   role change, the loop emitted `STEP_FINISHED (prev role)` and
   `STEP_STARTED (new role)` without first emitting `TEXT_MESSAGE_END`. The
   single `TEXT_MESSAGE_END` only fired at the very end of the run, which
   means the closing event escaped its step entirely.

`validate_sequence` rejects this because:

- Two `TEXT_MESSAGE_START` are required for two distinct messages, but only
  one is ever emitted.
- A `STEP_FINISHED` cannot be emitted while a `TEXT_MESSAGE_START` is open.

### Example: Planner -> Writer crew

Before:

```
RUN_STARTED
STEP_STARTED (Planner)
  TEXT_MESSAGE_START (msg_X)
  TEXT_MESSAGE_CONTENT * N            (planner output)
STEP_FINISHED (Planner)               <- text still open
STEP_STARTED (Writer)
  TEXT_MESSAGE_CONTENT * N            (writer continues into msg_X)
STEP_FINISHED (Writer)
TEXT_MESSAGE_END (msg_X)              <- closing event lives outside both steps
RUN_FINISHED
```

After:

```
RUN_STARTED
STEP_STARTED (Planner)
  TEXT_MESSAGE_START (msg_A)
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_A)            <- closes inside its step
STEP_FINISHED (Planner)
STEP_STARTED (Writer)
  TEXT_MESSAGE_START (msg_B)          <- fresh id per step
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_B)
STEP_FINISHED (Writer)
RUN_FINISHED
```

### What changed

On agent role change, before emitting `STEP_FINISHED` for the previous role
the loop now closes any open `text_started` or `reasoning_started` message,
emits the step boundary, then allocates a fresh `message_id` for the next
step. Same cleanup runs at end-of-stream so the final message closes before
the final `STEP_FINISHED`.

## LlamaIndex

### Why

Three layered ordering bugs in [`src/datarobot_genai/llama_index/agent.py`](src/datarobot_genai/llama_index/agent.py):

1. **Single `message_id` reused across agents and across tool boundaries.**
   Created once before the stream loop and never regenerated, so the
   `planner_agent` and `writer_agent` text appeared as one assistant
   message, and any text resuming after a tool call was glued onto the same
   message.
2. **Tool calls fire inside open text messages.** `TOOL_CALL_START`,
   `TOOL_CALL_ARGS`, `TOOL_CALL_END`, and `TOOL_CALL_RESULT` were all
   emitted while a `TEXT_MESSAGE_START` was still open. AG-UI expects tool
   calls between text messages, not nested inside one.
3. **End-of-stream order is reversed.** The cleanup logic emitted
   `STEP_FINISHED` before `TEXT_MESSAGE_END`, and used a per-iteration
   scratch variable instead of `current_agent_name` for the final step
   close. The fallback response path then re-fired even after streaming had
   already completed.

### Example: planner_agent -> tool -> writer_agent

Before:

```
RUN_STARTED
STEP_STARTED (planner_agent)
  TEXT_MESSAGE_START (msg_X)
  TEXT_MESSAGE_CONTENT * N            (planner explains plan)
  TOOL_CALL_START / ARGS / END        <- nested inside an open text message
  TOOL_CALL_RESULT (msg_X)
  TEXT_MESSAGE_CONTENT * N            (planner continues, still msg_X)
  TOOL_CALL_START / ARGS / END        (handoff tool)
  TOOL_CALL_RESULT (msg_X)
STEP_FINISHED (planner_agent)         <- text still open
STEP_STARTED (writer_agent)
  TEXT_MESSAGE_CONTENT * N            (writer continues into msg_X)
STEP_FINISHED (writer_agent)
TEXT_MESSAGE_END (msg_X)              <- escapes the writer step
RUN_FINISHED
```

After:

```
RUN_STARTED
STEP_STARTED (planner_agent)
  TEXT_MESSAGE_START (msg_1)
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_1)            <- closes before the tool runs
  TOOL_CALL_START / ARGS / END
  TOOL_CALL_RESULT (msg_1)
  TEXT_MESSAGE_START (msg_2)          <- fresh id resumes after tool
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_2)
  TOOL_CALL_START / ARGS / END
  TOOL_CALL_RESULT (msg_2)
STEP_FINISHED (planner_agent)
STEP_STARTED (writer_agent)
  TEXT_MESSAGE_START (msg_3)
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_3)
STEP_FINISHED (writer_agent)
RUN_FINISHED
```

### What changed

- On agent role change: close any open text/reasoning message, emit
  `STEP_FINISHED`, regenerate `message_id`, then emit `STEP_STARTED`.
- Around tool calls: close any open text before emitting `TOOL_CALL_START`,
  and regenerate `message_id` after `TOOL_CALL_RESULT` so post-tool text
  becomes a new assistant message.
- End-of-stream: close text before closing the step, and use
  `current_agent_name` so the final `STEP_FINISHED` always fires for the
  last active agent.
- Added an `any_text_emitted` flag so the response-extraction fallback only
  fires when the stream produced no text at all, not whenever the current
  message happens to be closed.

The existing test asserts each agent step now produces its own
start/content/end pair with a distinct `message_id`, matching the AG-UI
sequence validator.




<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming event emission for two agent frameworks (steps/text/reasoning/tool-call boundaries), which can affect client rendering and downstream protocol validation, though covered by new/expanded sequence tests.
> 
> **Overview**
> Fixes AG-UI streaming event ordering for **CrewAI** and **LlamaIndex** agents by ensuring step boundaries don’t occur while text/reasoning messages are open and by generating fresh `message_id`s when agent ownership changes.
> 
> In `LlamaIndexAgent`, tool calls are now emitted outside open text messages, tool results are keyed by `tool_call_id` (not assistant `message_id`), post-tool text starts a new message, and fallback response emission is gated to avoid repeating prior step output; tests were expanded substantially to validate sequences via `validate_sequence`.
> 
> Bumps package version to `0.15.31` (and lockfiles) and adds a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bfc57e75235283f9cbd1a33ed0e13ff49e93f75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->