### PR TITLE
[-] Fix NAT tool-call result correlation and ordering

### DIFF
--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.29"
+version = "0.15.30"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.29"
+version = "0.15.30"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -54,7 +54,6 @@ async def convert_chunks_to_agui_events(
     ``GeneratorExit`` (client disconnect), exits silently.
     """
     active_message_id: str | None = None
-    tool_call_message_id: str | None = None
     active_tool_calls: set[str] = set()
     seen_tool_calls: bool = False
     tool_index_map: dict[int, str] = {}
@@ -77,7 +76,6 @@ async def convert_chunks_to_agui_events(
                     for tc_id in active_tool_calls:
                         events.append(ToolCallEndEvent(tool_call_id=tc_id))
                     active_tool_calls.clear()
-                    tool_call_message_id = None
 
                 if active_message_id is None:
                     # After a tool call cycle, the LLM response is a new turn
@@ -97,11 +95,6 @@ async def convert_chunks_to_agui_events(
                     active_message_id = None
                 seen_tool_calls = True
 
-                # Create a dedicated message for tool calls so they don't
-                # merge with the preceding text message in storage.
-                if tool_call_message_id is None:
-                    tool_call_message_id = str(uuid.uuid4())
-
                 for tc in delta.tool_calls:
                     tc_id = tc.id or tool_index_map.get(tc.index)  # type: ignore[assignment]
                     if tc_id is None:
@@ -118,7 +111,6 @@ async def convert_chunks_to_agui_events(
                             ToolCallStartEvent(
                                 tool_call_id=tc_id,
                                 tool_call_name=tc.function.name if tc.function else "",
-                                parent_message_id=tool_call_message_id,
                             )
                         )
                     arguments = tc.function.arguments if tc.function else None

--- a/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
+++ b/src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py
@@ -26,24 +26,37 @@ using ``DRAgentNestedReasoningStepAdaptor.process_chunks()`` to produce
 ``DRAgentEventResponse`` with valid AG-UI event sequences.
 """
 
+import asyncio
+import logging
 import uuid
 from collections.abc import AsyncGenerator
 from collections.abc import Sequence
 from typing import Any
 
+from ag_ui.core import Event
+from ag_ui.core import ToolCallEndEvent
+from ag_ui.core import ToolCallResultEvent
+from ag_ui.core import ToolCallStartEvent
 from langchain_core.messages import BaseMessage
 from langgraph.pregel._messages import StreamMessagesHandler
 from langgraph.pregel._messages import _state_values
+from nat.builder.context import Context
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_per_user_function
 from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.api_server import ChatResponse
+from nat.data_models.intermediate_step import IntermediateStep
+from nat.data_models.intermediate_step import IntermediateStepType
 from nat.plugins.langchain.agent.tool_calling_agent.register import ToolCallAgentWorkflowConfig
 from nat.plugins.langchain.agent.tool_calling_agent.register import tool_calling_agent_workflow
+from nat.utils.type_converter import GlobalTypeConverter
 
+from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.stream_converter import convert_chunks_to_agui_events
+
+logger = logging.getLogger(__name__)
 
 # Workaround: prior assistant messages from chat history were leaking back into
 # the response stream as a single trailing mega-chunk after the new response.
@@ -98,6 +111,178 @@ class PerUserToolCallAgentWorkflowConfig(
     pass
 
 
+class _ToolCallResultBridge:
+    """Correlate NAT tool completions back to AG-UI tool-call events.
+
+    NAT's intermediate-step events do not carry the LLM's original
+    ``tool_call_id``. This bridge reconstructs that mapping from streamed
+    ``ToolCallStartEvent`` batches, then emits ``ToolCallResultEvent`` in
+    ``END -> RESULT`` order while suppressing duplicate end events.
+    """
+
+    def __init__(self) -> None:
+        self.pending_tool_call_ids_by_name: dict[str, list[str]] = {}
+        self.pending_invocation_uuids_by_name: dict[str, list[str]] = {}
+        self.pending_result_content_by_invocation_uuid: dict[str, str] = {}
+        self.tool_call_id_by_invocation_uuid: dict[str, str] = {}
+        self.ended_tool_call_ids: set[str] = set()
+        self.queued_responses: asyncio.Queue[DRAgentEventResponse] = asyncio.Queue()
+        self.zero_metrics = default_usage_metrics()
+
+    def _queue_result(self, tool_call_id: str, content: str) -> None:
+        self.queued_responses.put_nowait(
+            DRAgentEventResponse(
+                events=[
+                    ToolCallResultEvent(
+                        message_id=tool_call_id,
+                        tool_call_id=tool_call_id,
+                        content=content,
+                        role="tool",
+                    )
+                ],
+                usage_metrics=self.zero_metrics,
+            )
+        )
+
+    def _flush_buffered_result_for_tool_call_id(
+        self, invocation_uuid: str, tool_call_id: str
+    ) -> None:
+        content = self.pending_result_content_by_invocation_uuid.pop(invocation_uuid, None)
+        if content is not None:
+            self._queue_result(tool_call_id, content)
+            return
+        self.tool_call_id_by_invocation_uuid[invocation_uuid] = tool_call_id
+
+    def _bind_streamed_tool_call_start(self, tool_call_name: str, tool_call_id: str) -> None:
+        pending_invocations = self.pending_invocation_uuids_by_name.get(tool_call_name)
+        if pending_invocations:
+            invocation_uuid = pending_invocations.pop(0)
+            self._flush_buffered_result_for_tool_call_id(invocation_uuid, tool_call_id)
+            return
+
+        self.pending_tool_call_ids_by_name.setdefault(tool_call_name, []).append(tool_call_id)
+
+    def on_step(self, step: IntermediateStep) -> None:
+        """Capture tool completions from NAT's intermediate-step stream."""
+        payload = step.payload
+        tool_name = payload.name or ""
+
+        if payload.event_type in (
+            IntermediateStepType.TOOL_START,
+            IntermediateStepType.FUNCTION_START,
+        ):
+            pending_ids = self.pending_tool_call_ids_by_name.get(tool_name)
+            if pending_ids:
+                self._flush_buffered_result_for_tool_call_id(payload.UUID, pending_ids.pop(0))
+            else:
+                self.pending_invocation_uuids_by_name.setdefault(tool_name, []).append(payload.UUID)
+            return
+
+        if payload.event_type not in (
+            IntermediateStepType.TOOL_END,
+            IntermediateStepType.FUNCTION_END,
+        ):
+            return
+
+        output = getattr(payload.metadata, "tool_outputs", None)
+        if output is None and payload.data is not None:
+            output = getattr(payload.data, "output", None)
+
+        try:
+            content = GlobalTypeConverter.get().convert(output, str)
+        except Exception:
+            content = str(output) if output is not None else ""
+
+        tool_call_id = self.tool_call_id_by_invocation_uuid.pop(payload.UUID, None)
+        if tool_call_id is not None:
+            self._queue_result(tool_call_id, content)
+            return
+
+        pending_invocations = self.pending_invocation_uuids_by_name.get(tool_name)
+        if pending_invocations and payload.UUID in pending_invocations:
+            self.pending_result_content_by_invocation_uuid[payload.UUID] = content
+            return
+
+        # Fallback if the matching START happened before we subscribed.
+        pending_ids = self.pending_tool_call_ids_by_name.get(tool_name)
+        if pending_ids:
+            self._queue_result(pending_ids.pop(0), content)
+            return
+
+    def emit_queued_results(self) -> list[DRAgentEventResponse]:
+        """Emit any queued results, synthesizing END before RESULT if needed."""
+        responses: list[DRAgentEventResponse] = []
+
+        while not self.queued_responses.empty():
+            response = self.queued_responses.get_nowait()
+            prefix_events: list[Event] = []
+
+            for event in response.events:
+                if (
+                    isinstance(event, ToolCallResultEvent)
+                    and event.tool_call_id not in self.ended_tool_call_ids
+                ):
+                    prefix_events.append(ToolCallEndEvent(tool_call_id=event.tool_call_id))
+                    self.ended_tool_call_ids.add(event.tool_call_id)
+
+            if prefix_events:
+                responses.append(
+                    DRAgentEventResponse(
+                        events=prefix_events,
+                        usage_metrics=self.zero_metrics,
+                    )
+                )
+            responses.append(response)
+
+        return responses
+
+    def _filter_stream_events(self, events: list[Event]) -> list[Event]:
+        """Track start/end state and suppress duplicate END events."""
+        filtered_events: list[Event] = []
+
+        for event in events:
+            if isinstance(event, ToolCallStartEvent):
+                self._bind_streamed_tool_call_start(event.tool_call_name, event.tool_call_id)
+            elif isinstance(event, ToolCallEndEvent):
+                if event.tool_call_id in self.ended_tool_call_ids:
+                    continue
+                self.ended_tool_call_ids.add(event.tool_call_id)
+
+            filtered_events.append(event)
+
+        return filtered_events
+
+    def rewrite_response(self, response: DRAgentEventResponse) -> list[DRAgentEventResponse]:
+        """Insert queued results after the last END in a streamed batch."""
+        filtered_events = self._filter_stream_events(response.events)
+        if not filtered_events:
+            return self.emit_queued_results()
+
+        if filtered_events != response.events:
+            response = response.model_copy(update={"events": filtered_events})
+
+        last_end_index = next(
+            (
+                i
+                for i in range(len(filtered_events) - 1, -1, -1)
+                if isinstance(filtered_events[i], ToolCallEndEvent)
+            ),
+            None,
+        )
+
+        if last_end_index is None:
+            return [*self.emit_queued_results(), response]
+
+        split_index = last_end_index + 1
+        rewritten = [
+            response.model_copy(update={"events": filtered_events[:split_index]}),
+            *self.emit_queued_results(),
+        ]
+        if split_index < len(filtered_events):
+            rewritten.append(response.model_copy(update={"events": filtered_events[split_index:]}))
+        return rewritten
+
+
 async def _per_user_tool_calling_agent(
     config: PerUserToolCallAgentWorkflowConfig, builder: Any
 ) -> AsyncGenerator[Any, None]:
@@ -117,10 +302,31 @@ async def _per_user_tool_calling_agent(
         async def wrapped_stream(
             chat_request_or_message: ChatRequestOrMessage,
         ) -> AsyncGenerator[DRAgentEventResponse, None]:
-            async for event in convert_chunks_to_agui_events(
-                original_stream_fn(chat_request_or_message)
-            ):
-                yield event
+            bridge = _ToolCallResultBridge()
+
+            subscription = None
+            try:
+                subscription = Context.get().intermediate_step_manager.subscribe(
+                    on_next=bridge.on_step
+                )
+            except Exception as exc:
+                logger.warning("Failed to subscribe to intermediate steps: %s", exc)
+
+            try:
+                async for event in convert_chunks_to_agui_events(
+                    original_stream_fn(chat_request_or_message)
+                ):
+                    for rewritten in bridge.rewrite_response(event):
+                        yield rewritten
+
+                for rewritten in bridge.emit_queued_results():
+                    yield rewritten
+            finally:
+                if subscription is not None:
+                    try:
+                        subscription.unsubscribe()
+                    except Exception as exc:
+                        logger.warning("Failed to unsubscribe intermediate steps: %s", exc)
 
         yield FunctionInfo.create(
             single_fn=fn_info.single_fn,

--- a/tests/dragent/plugins/test_per_user_tool_calling_agent.py
+++ b/tests/dragent/plugins/test_per_user_tool_calling_agent.py
@@ -12,14 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from ag_ui.core import ToolCallEndEvent
+from ag_ui.core import ToolCallResultEvent
+from ag_ui.core import ToolCallStartEvent
 from nat.builder.function_info import FunctionInfo
+from nat.data_models.intermediate_step import IntermediateStepType
 from nat.plugins.langchain.agent.tool_calling_agent.register import ToolCallAgentWorkflowConfig
 
+from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.plugins.per_user_tool_calling_agent import (
     PerUserToolCallAgentWorkflowConfig,
 )
@@ -132,3 +138,193 @@ class TestPerUserToolCallingAgentWrapper:
             await gen.aclose()
 
             assert closed
+
+
+def _make_step(event_type, name, uuid_, output=None):
+    """Build a minimal IntermediateStep-shaped object for the bridge's _on_step."""
+    metadata = SimpleNamespace(tool_outputs=output)
+    payload = SimpleNamespace(
+        event_type=event_type,
+        UUID=uuid_,
+        name=name,
+        metadata=metadata,
+        data=None,
+    )
+    return SimpleNamespace(payload=payload)
+
+
+async def _drive_wrapped_stream(converter_events):
+    """Drive `_per_user_tool_calling_agent`'s wrapped_stream and return (subscriber, run).
+
+    `converter_events` is a list of either DRAgentEventResponse (yielded by the
+    fake converter) or callables (invoked between yields, given the captured
+    on_step subscriber). Returns (subscription_mock, output_responses).
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_converter(_chunks):
+        on_step = captured["on_step"]
+        for item in converter_events:
+            if callable(item):
+                item(on_step)
+            else:
+                yield item
+
+    subscription = MagicMock()
+    step_mgr = MagicMock()
+    step_mgr.subscribe.side_effect = lambda on_next, **_: (
+        (captured.setdefault("on_step", on_next) and subscription) or subscription
+    )
+    context = MagicMock()
+    context.intermediate_step_manager = step_mgr
+
+    original_fn_info = _make_fn_info(stream_fn=AsyncMock())
+
+    async def fake_gen(config, builder):
+        yield original_fn_info
+
+    with (
+        patch(
+            "datarobot_genai.dragent.plugins.per_user_tool_calling_agent"
+            ".tool_calling_agent_workflow"
+        ) as mock_workflow,
+        patch(
+            "datarobot_genai.dragent.plugins.per_user_tool_calling_agent"
+            ".convert_chunks_to_agui_events",
+            new=fake_converter,
+        ),
+        patch(
+            "datarobot_genai.dragent.plugins.per_user_tool_calling_agent.Context.get",
+            return_value=context,
+        ),
+    ):
+        mock_workflow.__wrapped__ = fake_gen
+        gen = _per_user_tool_calling_agent(MagicMock(), MagicMock())
+        fn_info = await gen.__anext__()
+        outputs: list[DRAgentEventResponse] = []
+        async for response in fn_info.stream_fn(MagicMock()):
+            outputs.append(response)
+        await gen.aclose()
+        return subscription, outputs
+
+
+def _flatten(outputs):
+    return [e for response in outputs for e in response.events]
+
+
+class TestSubscriberLifecycle:
+    @pytest.mark.asyncio
+    async def test_subscription_unsubscribed_on_stream_completion(self):
+        """The intermediate-step subscription is disposed when wrapped_stream exits."""
+        subscription, _ = await _drive_wrapped_stream([])
+        subscription.unsubscribe.assert_called_once()
+
+
+class TestToolCallResultBridge:
+    async def test_preserves_parallel_same_name_results_when_function_starts_arrive_first(self):
+        """Parallel same-name tools keep invocation order after late starts."""
+        zero = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        # GIVEN two same-name tool invocations whose NAT starts arrive before streamed tool starts
+        events = [
+            lambda on_step: on_step(_make_step(IntermediateStepType.FUNCTION_START, "foo", "u1")),
+            lambda on_step: on_step(_make_step(IntermediateStepType.FUNCTION_START, "foo", "u2")),
+            DRAgentEventResponse(
+                events=[
+                    ToolCallStartEvent(tool_call_id="tc1", tool_call_name="foo"),
+                    ToolCallStartEvent(tool_call_id="tc2", tool_call_name="foo"),
+                ],
+                usage_metrics=zero,
+            ),
+            lambda on_step: on_step(
+                _make_step(IntermediateStepType.FUNCTION_END, "foo", "u2", output="B")
+            ),
+            lambda on_step: on_step(
+                _make_step(IntermediateStepType.FUNCTION_END, "foo", "u1", output="A")
+            ),
+        ]
+
+        # WHEN the wrapped stream is drained
+        _, outputs = await _drive_wrapped_stream(events)
+        results = [event for event in _flatten(outputs) if isinstance(event, ToolCallResultEvent)]
+
+        # THEN each completion stays attached to the correct tool call id
+        assert [result.tool_call_id for result in results] == ["tc2", "tc1"]
+        assert [result.content for result in results] == ["B", "A"]
+
+    @pytest.mark.asyncio
+    async def test_synthesizes_end_before_queued_result_for_open_tool(self):
+        """If a tool completes before the converter emits END, the bridge synthesizes one."""
+        zero = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        # Sequence: TOOL_CALL_START(tc1) → fire FUNCTION_END for tc1 → next tool starts.
+        # The converter never emits a TOOL_CALL_END for tc1, so the bridge must synthesize one.
+        events = [
+            DRAgentEventResponse(
+                events=[ToolCallStartEvent(tool_call_id="tc1", tool_call_name="foo")],
+                usage_metrics=zero,
+            ),
+            lambda on_step: on_step(_make_step(IntermediateStepType.FUNCTION_START, "foo", "u1")),
+            lambda on_step: on_step(
+                _make_step(IntermediateStepType.FUNCTION_END, "foo", "u1", output="A")
+            ),
+            DRAgentEventResponse(
+                events=[ToolCallStartEvent(tool_call_id="tc2", tool_call_name="foo")],
+                usage_metrics=zero,
+            ),
+        ]
+        _, outputs = await _drive_wrapped_stream(events)
+        flat = _flatten(outputs)
+
+        types = [type(e).__name__ for e in flat]
+        assert types == [
+            "ToolCallStartEvent",
+            "ToolCallEndEvent",
+            "ToolCallResultEvent",
+            "ToolCallStartEvent",
+        ]
+        synthetic_end = flat[1]
+        result = flat[2]
+        assert isinstance(synthetic_end, ToolCallEndEvent)
+        assert synthetic_end.tool_call_id == "tc1"
+        assert isinstance(result, ToolCallResultEvent)
+        assert result.tool_call_id == "tc1"
+
+    @pytest.mark.asyncio
+    async def test_correlates_parallel_same_name_tools_via_invocation_uuid(self):
+        """Same-name parallel tools match results by step UUID, not FIFO completion order."""
+        zero = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        # Two starts for the same tool name, dispatch order tc1 then tc2.
+        # FUNCTION_START fires in dispatch order → invocation u1↔tc1, u2↔tc2.
+        # Tool tc2 completes first (u2), then tc1 (u1). Results must use the
+        # correct tc_ids despite the swapped completion order.
+        events = [
+            DRAgentEventResponse(
+                events=[
+                    ToolCallStartEvent(tool_call_id="tc1", tool_call_name="foo"),
+                    ToolCallStartEvent(tool_call_id="tc2", tool_call_name="foo"),
+                ],
+                usage_metrics=zero,
+            ),
+            lambda on_step: on_step(_make_step(IntermediateStepType.FUNCTION_START, "foo", "u1")),
+            lambda on_step: on_step(_make_step(IntermediateStepType.FUNCTION_START, "foo", "u2")),
+            lambda on_step: on_step(
+                _make_step(IntermediateStepType.FUNCTION_END, "foo", "u2", output="B")
+            ),
+            lambda on_step: on_step(
+                _make_step(IntermediateStepType.FUNCTION_END, "foo", "u1", output="A")
+            ),
+            DRAgentEventResponse(
+                events=[
+                    ToolCallEndEvent(tool_call_id="tc1"),
+                    ToolCallEndEvent(tool_call_id="tc2"),
+                ],
+                usage_metrics=zero,
+            ),
+        ]
+        _, outputs = await _drive_wrapped_stream(events)
+        results = [e for e in _flatten(outputs) if isinstance(e, ToolCallResultEvent)]
+
+        assert [r.tool_call_id for r in results] == ["tc2", "tc1"]
+        assert [r.content for r in results] == ["B", "A"]

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.29"
+version = "0.15.30"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

## NAT (per_user_tool_calling_agent)

### Why

Five real issues in [`src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py`](src/datarobot_genai/dragent/plugins/per_user_tool_calling_agent.py) and [`src/datarobot_genai/dragent/frontends/stream_converter.py`](src/datarobot_genai/dragent/frontends/stream_converter.py):

1. **Phantom `parent_message_id` on every `TOOL_CALL_START`.** The
   converter generated a fresh uuid that did not match any
   `TEXT_MESSAGE_START`. The UI rendered an empty parent bubble plus the
   tool card, which looked like a duplicated tool entry above the real
   one.
2. **No `TOOL_CALL_RESULT` emitted.** NAT signals tool completion through
   its intermediate-step bus (`FUNCTION_END`/`TOOL_END`), but the stream
   converter only sees the LLM-side `ChatResponseChunk`s. Without a
   bridge, tool cards never transitioned to "completed" in the UI.
3. **`RESULT` arriving before `END`.** Once `RESULT` events were bridged
   in, they could leak out before the converter's `TOOL_CALL_END`, because
   the converter batches `[ToolCallEndEvent, TextMessageStartEvent,
   TextMessageContentEvent]` together when text resumes after a tool call,
   and the drain ran before that batch yielded.
4. **Subscriber leak.** `Context.get().intermediate_step_manager.subscribe(...)`
   was added per request and never unsubscribed, so callbacks accumulated
   across runs and could emit stale `TOOL_CALL_RESULT` events later.
5. **Same-name parallel tool calls could cross results.** The original
   FIFO-by-name correlation popped the first pending `tool_call_id` for
   that name, so two parallel `search` invocations finishing in reverse
   order would deliver each other's results.

`validate_sequence` rejects state where `TOOL_CALL_RESULT` arrives without
an active tool call, and the UI rendering depends on every
`TOOL_CALL_START` having a matching `END` and `RESULT` keyed by the LLM's
`tool_call_id`.

### Example: planner -> writer per-user agent

Before:

```
RUN_STARTED
STEP_STARTED (per_user_tool_calling_agent)
  TEXT_MESSAGE_START (msg_X)
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_X)
  TOOL_CALL_START (planner, parent_message_id=phantom_uuid)   <- references no real message
  TOOL_CALL_ARGS * N
  CUSTOM FUNCTION_END (planner)                               <- no AG-UI RESULT emitted
  TEXT_MESSAGE_START (msg_X)                                  <- reused id, UI merges with prior text
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_X)
  TOOL_CALL_START (writer, parent_message_id=phantom_uuid_2)
  TOOL_CALL_ARGS * N
  CUSTOM FUNCTION_END (writer)
  TEXT_MESSAGE_START (msg_X)
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_X)
STEP_FINISHED
RUN_FINISHED
```

After:

```
RUN_STARTED
STEP_STARTED (per_user_tool_calling_agent)
  TEXT_MESSAGE_START (msg_1)
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_1)
  TOOL_CALL_START (planner)                                   <- no parent_message_id
  TOOL_CALL_ARGS * N
  TOOL_CALL_END (planner)
  TOOL_CALL_RESULT (planner)                                  <- END before RESULT
  TEXT_MESSAGE_START (msg_2)                                  <- fresh id resumes after tool
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_2)
  TOOL_CALL_START (writer)
  TOOL_CALL_ARGS * N
  TOOL_CALL_END (writer)
  TOOL_CALL_RESULT (writer)
  TEXT_MESSAGE_START (msg_3)
  TEXT_MESSAGE_CONTENT * N
  TEXT_MESSAGE_END (msg_3)
STEP_FINISHED
RUN_FINISHED
```

### What changed

- **Dropped phantom `parent_message_id`** from `ToolCallStartEvent` and
  removed the now-dead `tool_call_message_id` state from the converter.
- **Introduced `_ToolCallResultBridge`** that subscribes to NAT's
  intermediate-step bus and emits `TOOL_CALL_RESULT` for each
  `FUNCTION_END`/`TOOL_END` event.
- **Correlation is by step UUID, not by name + FIFO.** On
  `FUNCTION_START`/`TOOL_START`, the bridge pops the next pending
  `tool_call_id` for that tool name and binds it to the step's `UUID`; on
  `FUNCTION_END`/`TOOL_END`, it looks up the `tool_call_id` by `UUID`.
  Same-name parallel tools dispatched in order but finishing in any order
  now get the correct results.
- **Yielding splits at the last `ToolCallEndEvent` in each converter
  batch.** The head (through the END) is yielded first, then the queue is
  drained (so `RESULT` lands after `END`), then the tail is yielded. This
  makes the order `END -> RESULT -> next TEXT_MESSAGE_START` instead of
  `RESULT -> END -> next TEXT_MESSAGE_START`.
- **Synthetic `END` before `RESULT` for unclosed tools.** If NAT signals
  tool completion before the converter emits an `END` (chained tool calls
  without intervening text), the drain emits a synthesized
  `ToolCallEndEvent` for that `tool_call_id` first, then the queued
  `RESULT`. The converter's later `END` for the same id is filtered out to
  avoid duplicates.
- **Subscriber lifecycle fixed.** The `subscribe()` call captures the
  returned `Subscription`, and the wrapper calls `subscription.unsubscribe()`
  in a `finally` that wraps the whole stream body, so listeners do not
  accumulate across requests.

Three regression tests cover the new behavior: `unsubscribe()` is invoked
on stream completion, a synthetic `END` is emitted before a queued
`RESULT` for an open tool, and same-name parallel tools completing in
reverse order route results to the correct `tool_call_id`s.



## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NAT streaming glue code and tool-call event sequencing; mistakes could misorder or misattribute tool results in the UI, but changes are scoped and covered by new regression tests.
> 
> **Overview**
> Fixes per-user NAT streaming so **tool-call results are correlated to the correct `tool_call_id`**, including parallel same-name tool invocations, and ensures results are emitted in **`ToolCallEndEvent` → `ToolCallResultEvent`** order.
> 
> This introduces a `_ToolCallResultBridge` that subscribes to NAT intermediate-step events during streaming, rewrites/suppresses duplicate tool-call ENDs, and injects queued result events into the converted chunk stream; the stream converter is simplified by removing the extra tool-call parent message grouping.
> 
> Adds focused async tests covering subscription lifecycle, out-of-order starts/ends, and parallel same-name tool-call correlation, and bumps package version to `0.15.30` with corresponding lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb8a73dbc19d84962ad309edfbe4d6eefc394bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->