### PR TITLE
[BUZZOK-29046]Update BaseAgent parameters and standardize other agents inits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.31
+- `BaseAgent` accepts an optional `model` identifier. CrewAI, LangGraph, and LlamaIndex agents now use explicit named `__init__` parameters (instead of forwarding arbitrary kwargs).
+
 ## 0.15.30
 - Implemented pagination for predictive data MCP tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
 ## 0.15.35
-- `BaseAgent` accepts an optional `model` identifier. CrewAI, LangGraph, and LlamaIndex agents now use explicit named `__init__` parameters (instead of forwarding arbitrary kwargs). Possible breaking change moving away from `kwargs` to named parameters.
+- Added an optional `model` identifier to `BaseAgent`. Updated CrewAI, LangGraph, and LlamaIndex agents to use explicit named `__init__` parameters (instead of forwarding arbitrary kwargs). Possible breaking change moving away from `kwargs` to named parameters.
 
 ## 0.15.34
 - Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step emits its own message bubble and a matching `STEP_FINISHED`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
-## 0.15.34
-- `BaseAgent` accepts an optional `model` identifier. CrewAI, LangGraph, and LlamaIndex agents now use explicit named `__init__` parameters (instead of forwarding arbitrary kwargs).
+## 0.15.35
+- `BaseAgent` accepts an optional `model` identifier. CrewAI, LangGraph, and LlamaIndex agents now use explicit named `__init__` parameters (instead of forwarding arbitrary kwargs). Possible breaking change moving away from `kwargs` to named parameters.
 
 ## 0.15.33
 - Fixed CrewAI AG-UI streaming so each agent role in a multi-agent crew emits its own assistant message with a unique `messageId`. Previously, `TEXT_MESSAGE_END` was missing at agent-role boundaries and a single `messageId` was reused across the whole run, collapsing every agent's output into one merged message.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -53,6 +53,7 @@ class BaseAgent(Generic[TTool], abc.ABC):
       - api_key: DataRobot API token
       - api_base: Endpoint for DataRobot, normalized for LLM Gateway usage
       - llm: Framework-specific LLM client (constructed outside the agent and passed in)
+      - model: Optional model identifier string (e.g. LiteLLM / deployment model name)
       - timeout: Request timeout
       - verbose: Verbosity flag
       - forwarded_headers: Forwarded headers for the agent
@@ -71,6 +72,7 @@ class BaseAgent(Generic[TTool], abc.ABC):
         forwarded_headers: dict[str, str] | None = None,
         max_history_messages: int | None = None,
         memory_client: BaseMemoryClient | None = None,
+        model: str | None = None,
     ) -> None:
         self.api_key = api_key or os.environ.get("DATAROBOT_API_TOKEN")
         self.api_base = (
@@ -81,6 +83,7 @@ class BaseAgent(Generic[TTool], abc.ABC):
         self.set_timeout(timeout)
         self.set_verbose(verbose)
         self.set_memory_client(memory_client)
+        self.set_model(model)
         self._forwarded_headers: dict[str, str] = forwarded_headers or {}
         self._identity_header: dict[str, str] = prepare_identity_header(self._forwarded_headers)
         self._max_history_messages = max_history_messages
@@ -91,6 +94,13 @@ class BaseAgent(Generic[TTool], abc.ABC):
     @property
     def llm(self) -> Any | None:
         return self._llm
+
+    def set_model(self, model: str | None) -> None:
+        self._model = model
+
+    @property
+    def model(self) -> str | None:
+        return self._model
 
     def set_timeout(self, timeout: int) -> None:
         self._timeout = timeout

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -60,6 +60,7 @@ from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
+from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.crewai.ragas_events import CrewAIRagasEventListener
 from datarobot_genai.crewai.streaming_events import CrewAIStreamingEventListener
 
@@ -78,8 +79,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
     Subclasses should define the ``agents`` and ``tasks`` properties
     and may override ``crew`` to customize the workflow construction.
 
-    Optional keyword arguments may be passed to :meth:`__init__` after
-    ``BaseAgent`` parameters:
+    Framework-specific parameters:
 
     - ``roles``, ``goals``, ``backstories``: sequences with length
       ``len(agents)`` for CrewAI identity; omitted or ``None`` leaves agents
@@ -89,18 +89,41 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
       to the corresponding ``set_*`` methods; omitted or ``None`` skips.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        roles = kwargs.pop("roles", None)
-        goals = kwargs.pop("goals", None)
-        backstories = kwargs.pop("backstories", None)
-        max_iter = kwargs.pop("max_iter", None)
-        max_rpm = kwargs.pop("max_rpm", None)
-        max_execution_time = kwargs.pop("max_execution_time", None)
-        allow_delegation = kwargs.pop("allow_delegation", None)
-        max_retry_limit = kwargs.pop("max_retry_limit", None)
-        reasoning = kwargs.pop("reasoning", None)
-        max_reasoning_attempts = kwargs.pop("max_reasoning_attempts", None)
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        llm: Any | None = None,
+        tools: list[BaseTool] | None = None,
+        verbose: bool = True,
+        timeout: int = 90,
+        forwarded_headers: dict[str, str] | None = None,
+        max_history_messages: int | None = None,
+        memory_client: BaseMemoryClient | None = None,
+        model: str | None = None,
+        roles: Sequence[str] | None = None,
+        goals: Sequence[str] | None = None,
+        backstories: Sequence[str] | None = None,
+        max_iter: int | None = None,
+        max_rpm: int | None = None,
+        max_execution_time: int | None = None,
+        allow_delegation: bool | None = None,
+        max_retry_limit: int | None = None,
+        reasoning: bool | None = None,
+        max_reasoning_attempts: int | None = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            api_base=api_base,
+            llm=llm,
+            tools=tools,
+            verbose=verbose,
+            timeout=timeout,
+            forwarded_headers=forwarded_headers,
+            max_history_messages=max_history_messages,
+            memory_client=memory_client,
+            model=model,
+        )
         if roles is not None:
             self.set_roles(roles)
         if goals is not None:
@@ -607,8 +630,8 @@ def datarobot_agent_class_from_crew(
         configurations (e.g. ``{topic}``). Include a ``"chat_history"`` key
         with an empty string value to opt into automatic history injection.
 
-    The returned class accepts optional ``roles``, ``goals``, and ``backstories``
-    keyword arguments on instantiation (see :class:`CrewAIAgent`).
+    The returned class accepts the same parameters as :class:`CrewAIAgent`
+    (including optional ``roles``, ``goals``, and ``backstories``).
 
     Returns
     -------
@@ -620,11 +643,50 @@ def datarobot_agent_class_from_crew(
     class DataRobotAgent(CrewAIAgent):
         def __init__(
             self,
-            *args: Any,
-            **kwargs: Any,
+            api_key: str | None = None,
+            api_base: str | None = None,
+            llm: Any | None = None,
+            tools: list[BaseTool] | None = None,
+            verbose: bool = True,
+            timeout: int = 90,
+            forwarded_headers: dict[str, str] | None = None,
+            max_history_messages: int | None = None,
+            memory_client: BaseMemoryClient | None = None,
+            model: str | None = None,
+            roles: Sequence[str] | None = None,
+            goals: Sequence[str] | None = None,
+            backstories: Sequence[str] | None = None,
+            max_iter: int | None = None,
+            max_rpm: int | None = None,
+            max_execution_time: int | None = None,
+            allow_delegation: bool | None = None,
+            max_retry_limit: int | None = None,
+            reasoning: bool | None = None,
+            max_reasoning_attempts: int | None = None,
         ) -> None:
             self._original_agent_tools = {agent: agent.tools for agent in agents}
-            super().__init__(*args, **kwargs)
+            super().__init__(
+                api_key=api_key,
+                api_base=api_base,
+                llm=llm,
+                tools=tools,
+                verbose=verbose,
+                timeout=timeout,
+                forwarded_headers=forwarded_headers,
+                max_history_messages=max_history_messages,
+                memory_client=memory_client,
+                model=model,
+                roles=roles,
+                goals=goals,
+                backstories=backstories,
+                max_iter=max_iter,
+                max_rpm=max_rpm,
+                max_execution_time=max_execution_time,
+                allow_delegation=allow_delegation,
+                max_retry_limit=max_retry_limit,
+                reasoning=reasoning,
+                max_reasoning_attempts=max_reasoning_attempts,
+            )
 
         def set_tools(self, tools: list[BaseTool]) -> None:
             super().set_tools(tools)

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -81,12 +81,21 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
     Framework-specific parameters:
 
-    - ``roles``, ``goals``, ``backstories``: sequences with length
-      ``len(agents)`` for CrewAI identity; omitted or ``None`` leaves agents
-      unchanged.
-    - ``max_iter``, ``max_rpm``, ``max_execution_time``, ``allow_delegation``,
-      ``max_retry_limit``, ``reasoning``, ``max_reasoning_attempts``: forwarded
-      to the corresponding ``set_*`` methods; omitted or ``None`` skips.
+    - ``roles``: One role string per crew agent (length ``len(agents)``); sets
+      each agent's ``role``.
+    - ``goals``: One goal string per agent; sets each agent's ``goal``.
+    - ``backstories``: One backstory string per agent; sets each agent's
+      ``backstory``.
+    - ``max_iter``: Upper bound on iterations (tool / act loops) per agent.
+    - ``max_rpm``: Requests-per-minute limit per agent.
+    - ``max_execution_time``: Wall-clock seconds cap per agent (only applied
+      when not ``None``).
+    - ``allow_delegation``: Whether agents may delegate work to other crew
+      members.
+    - ``max_retry_limit``: Retries per agent after recoverable failures.
+    - ``reasoning``: Turns CrewAI structured reasoning on or off per agent.
+    - ``max_reasoning_attempts``: Maximum reasoning passes per agent (only
+      applied when not ``None``).
     """
 
     def __init__(

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -339,7 +339,7 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
                 # LangGraph expects a RunnableConfig, but our config is a plain dict.
                 # Cast to Any to avoid leaking LangGraph internals into this interface.
                 config=cast(Any, self.build_langgraph_runnable_config(run_agent_input)),
-                debug=self.debug,
+                debug=self.debug or self.verbose,
                 # Streaming updates and messages from all the nodes
                 stream_mode=["updates", "messages"],
                 subgraphs=True,

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -50,6 +50,7 @@ from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
+from datarobot_genai.core.memory.base import BaseMemoryClient
 
 if TYPE_CHECKING:
     from ragas import MultiTurnSample
@@ -89,30 +90,63 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
     History is opt-in: prior turns are only injected when the prompt template
     declares and uses a `{chat_history}` input variable. If the template does
     not use `{chat_history}`, no chat history is passed to the model.
+
+    Framework-specific parameters:
+
+    - ``checkpointer``: checkpoint store for ``interrupt()`` and thread resume.
+    - ``interrupt_before`` / ``interrupt_after``: compile-time interrupt node lists.
+    - ``debug``: forwarded to ``StateGraph.compile(debug=...)``.
+    - ``name``: optional name for the compiled graph.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Forward ``*args`` / ``**kwargs`` to :class:`BaseAgent` after setting LangGraph fields.
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        llm: Any | None = None,
+        tools: list[BaseTool] | None = None,
+        verbose: bool = True,
+        timeout: int = 90,
+        forwarded_headers: dict[str, str] | None = None,
+        max_history_messages: int | None = None,
+        memory_client: BaseMemoryClient | None = None,
+        model: str | None = None,
+        checkpointer: Any | None = None,
+        interrupt_before: Any | None = None,
+        interrupt_after: Any | None = None,
+        debug: bool = False,
+        name: str | None = None,
+    ) -> None:
+        """Initialize the agent and LangGraph compile settings.
 
-        The following keyword arguments are handled here and are not passed to
-        :meth:`BaseAgent.__init__`: ``checkpointer``, ``interrupt_before``,
-        ``interrupt_after``, ``debug``, ``name``.
+        LangGraph-only parameters:
 
         - ``checkpointer``: forwarded to ``compile(...)``. Required for ``interrupt()``
           resume across requests; without it, pending-interrupt detection is a no-op.
           Pair with a stable ``RunAgentInput.thread_id`` from the caller.
         - ``interrupt_before`` / ``interrupt_after``: passed to
           :meth:`langgraph.graph.state.StateGraph.compile`.
-        - ``debug``: if provided, passed to ``compile(debug=...)``; for ``astream``,
-          when omitted, ``debug`` follows ``verbose`` (previous behavior).
+        - ``debug``: passed to ``compile(debug=...)``; for ``astream``, when this is
+          false, ``debug`` follows ``verbose`` (previous behavior).
         - ``name``: optional graph name for ``compile(name=...)``.
         """
-        self.checkpointer = kwargs.pop("checkpointer", None)
-        self.interrupt_before = kwargs.pop("interrupt_before", None)
-        self.interrupt_after = kwargs.pop("interrupt_after", None)
-        self.debug = kwargs.pop("debug", False)
-        self.name = kwargs.pop("name", None)
-        super().__init__(*args, **kwargs)
+        self.checkpointer = checkpointer
+        self.interrupt_before = interrupt_before
+        self.interrupt_after = interrupt_after
+        self.debug = debug
+        self.name = name
+        super().__init__(
+            api_key=api_key,
+            api_base=api_base,
+            llm=llm,
+            tools=tools,
+            verbose=verbose,
+            timeout=timeout,
+            forwarded_headers=forwarded_headers,
+            max_history_messages=max_history_messages,
+            memory_client=memory_client,
+            model=model,
+        )
 
     @property
     @abc.abstractmethod
@@ -305,7 +339,7 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
                 # LangGraph expects a RunnableConfig, but our config is a plain dict.
                 # Cast to Any to avoid leaking LangGraph internals into this interface.
                 config=cast(Any, self.build_langgraph_runnable_config(run_agent_input)),
-                debug=self.verbose,
+                debug=self.debug,
                 # Streaming updates and messages from all the nodes
                 stream_mode=["updates", "messages"],
                 subgraphs=True,

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -117,19 +117,6 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
         debug: bool = False,
         name: str | None = None,
     ) -> None:
-        """Initialize the agent and LangGraph compile settings.
-
-        LangGraph-only parameters:
-
-        - ``checkpointer``: forwarded to ``compile(...)``. Required for ``interrupt()``
-          resume across requests; without it, pending-interrupt detection is a no-op.
-          Pair with a stable ``RunAgentInput.thread_id`` from the caller.
-        - ``interrupt_before`` / ``interrupt_after``: passed to
-          :meth:`langgraph.graph.state.StateGraph.compile`.
-        - ``debug``: passed to ``compile(debug=...)``; for ``astream``, when this is
-          false, ``debug`` follows ``verbose`` (previous behavior).
-        - ``name``: optional graph name for ``compile(name=...)``.
-        """
         self.checkpointer = checkpointer
         self.interrupt_before = interrupt_before
         self.interrupt_after = interrupt_after

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -73,7 +73,13 @@ class DataRobotLiteLLM(LiteLLM):
 
 
 class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
-    """Abstract base agent for LlamaIndex workflows."""
+    """Abstract base agent for LlamaIndex workflows.
+
+    Framework-specific parameters:
+
+    - ``allow_parallel_tool_calls``: when true (default), LlamaIndex workflow
+      agents that support it may issue parallel tool calls
+    """
 
     def __init__(
         self,
@@ -86,6 +92,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         forwarded_headers: dict[str, str] | None = None,
         max_history_messages: int | None = None,
         memory_client: BaseMemoryClient | None = None,
+        model: str | None = None,
         allow_parallel_tool_calls: bool = True,
     ) -> None:
         super().__init__(
@@ -98,6 +105,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
             forwarded_headers=forwarded_headers,
             max_history_messages=max_history_messages,
             memory_client=memory_client,
+            model=model,
         )
         self.allow_parallel_tool_calls = allow_parallel_tool_calls
 
@@ -446,6 +454,7 @@ def datarobot_agent_class_from_llamaindex(
             forwarded_headers: dict[str, str] | None = None,
             max_history_messages: int | None = None,
             memory_client: BaseMemoryClient | None = None,
+            model: str | None = None,
             allow_parallel_tool_calls: bool = True,
         ) -> None:
             super().__init__(
@@ -458,6 +467,7 @@ def datarobot_agent_class_from_llamaindex(
                 forwarded_headers=forwarded_headers,
                 max_history_messages=max_history_messages,
                 memory_client=memory_client,
+                model=model,
                 allow_parallel_tool_calls=allow_parallel_tool_calls,
             )
             for agent in agents:

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -141,6 +141,16 @@ def test_base_agent_llm_optional() -> None:
     assert agent.llm is llm
 
 
+def test_base_agent_model_optional() -> None:
+    assert SimpleAgent().model is None
+
+    agent = SimpleAgent(model="datarobot/azure-openai-gpt-4")
+    assert agent.model == "datarobot/azure-openai-gpt-4"
+
+    agent.set_model(None)
+    assert agent.model is None
+
+
 def test_base_agent_timeout_default() -> None:
     assert SimpleAgent().timeout == 90
 

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -147,13 +147,13 @@ def mock_ragas_event_listener() -> ListenerForTest:
 
 
 class AgentForTest(CrewAIAgent):
-    def __init__(self, crew_output: CrewOutput | None = None, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, crew_output: CrewOutput | None = None, **kwargs: Any) -> None:
         crew_kw = kwargs.pop("crew", None)
         self.crew_output = crew_output
         self._crew_for_test: Any = crew_kw if crew_kw is not None else CrewForTest(crew_output)
         self._agents_for_test: list[MagicMock] = [_mock_crewai_agent(), _mock_crewai_agent()]
         self._tasks_for_test: list[MagicMock] = [MagicMock(), MagicMock()]
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     @property
     def agents(self) -> list[Any]:

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
- Added `model` to base agent list of parameters
- Updated the other agents to be uniform in how parameters are declared (named parameters instead of kwargs)
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public constructor signatures for `CrewAIAgent`, `LangGraphAgent`, and `LlamaIndexAgent` by removing generic `*args/**kwargs` forwarding, which can break downstream instantiation code relying on extra kwargs or positional args.
> 
> **Overview**
> Bumps version to `0.15.37` and documents a **potential breaking change** in agent initialization.
> 
> Adds an optional `model` field to `BaseAgent` (with `set_model`/`model` accessors) and threads it through CrewAI, LangGraph, and LlamaIndex agent constructors.
> 
> Standardizes framework agent `__init__` methods to **explicit named parameters** instead of forwarding arbitrary `*args/**kwargs`, and tweaks LangGraph streaming to use `debug=self.debug or self.verbose`. Tests are updated to cover the new `model` parameter and the revised CrewAI test agent initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a024e6ae5352376dfb45c1d6b8c2079cdbf8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->