### PR TITLE
[MODEL-22469] Imporve MCP lineage sync in user mcp server

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -92,7 +92,7 @@ tasks:
     desc: "Run DR MCP Library integration tests"
     cmds:
       - echo "Running DR MCP Library integration tests"
-      - DR_MCP_SERVER_URL=http://localhost:{{.PORT}}/mcp/ DR_MCP_SERVER_HTTP_URL=http://localhost:{{.PORT}}/ uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/integration/{{end}} -s -vv
+      - uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/integration/{{end}} -s -vv
     silent: true
 
   drmcp-acceptance:

--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -90,12 +90,7 @@ tasks:
 
   drmcp-integration:
     desc: "Run DR MCP Library integration tests"
-    vars:
-      PORT: 8652
     cmds:
-      - defer: |
-          echo "Stopping DR MCP Library MCP Server"
-          lsof -i :{{.PORT}} | grep LISTEN | awk '{print $2}' | xargs kill -9 2>/dev/null || true
       - echo "Running DR MCP Library integration tests"
       - DR_MCP_SERVER_URL=http://localhost:{{.PORT}}/mcp/ DR_MCP_SERVER_HTTP_URL=http://localhost:{{.PORT}}/ uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/integration/{{end}} -s -vv
     silent: true

--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -93,7 +93,6 @@ tasks:
     vars:
       PORT: 8652
     cmds:
-      - task: drmcp-test-dev-server-background
       - defer: |
           echo "Stopping DR MCP Library MCP Server"
           lsof -i :{{.PORT}} | grep LISTEN | awk '{print $2}' | xargs kill -9 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
 ## 0.15.31
-- Improved MCP lineage sync logic and make it always run during user MCP startup.
+- Improved MCP lineage sync logic and made it always run during user MCP startup.
 
 ## 0.15.30
 - Implemented pagination for predictive data MCP tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.31
+- Improved MCP lineage sync logic and make it always run during user MCP startup.
+
 ## 0.15.30
 - Implemented pagination for predictive data MCP tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -27,6 +27,9 @@ from fastmcp.resources import Resource
 from fastmcp.tools import Tool
 from starlette.middleware import Middleware
 
+from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
+from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
+from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drtools.core.auth import initialize_oauth_middleware
 from datarobot_genai.drtools.core.credentials import get_credentials
 
@@ -240,6 +243,16 @@ class DataRobotMCPServer:
             if self._config.mcp_server_register_dynamic_prompts_on_startup:
                 self._logger.info("Registering dynamic prompts from prompt management...")
                 asyncio.run(register_prompts_from_datarobot_prompt_management())
+
+            if FeatureFlag.is_mcp_tools_gallery_support_enabled():
+                try:
+                    linear_manager = LineageManager(self._mcp)
+                    asyncio.run(linear_manager.sync_mcp_tools())
+                    asyncio.run(linear_manager.sync_mcp_prompts())
+                    self._logger.info("Sync with MCP lineage")
+                except LRSEnvVarIsNotSetError as error:
+                    error_message = f"MCP item metadata is not sync. {str(error)}"
+                    self._logger.warning(error_message)
 
             # Execute pre-server start actions
             asyncio.run(self._lifecycle.pre_server_start(self._mcp))

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/register.py
@@ -23,10 +23,6 @@ from fastmcp.prompts.prompt import Prompt
 from pydantic import Field
 
 from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
-from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
-from datarobot_genai.drmcp.core.lineage.manager import LineageManager
-from datarobot_genai.drmcp.core.mcp_instance import mcp
 from datarobot_genai.drmcp.core.mcp_instance import register_prompt
 
 from .dr_lib import get_datarobot_prompt_template_versions
@@ -56,14 +52,6 @@ async def register_prompts_from_datarobot_prompt_management() -> None:
             await register_prompt_from_datarobot_prompt_management(prompt, latest_version)
         except DynamicPromptRegistrationError:
             pass
-
-    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_prompts()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
 
 
 async def register_prompt_from_datarobot_prompt_management(

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/register.py
@@ -20,10 +20,6 @@ from datarobot_genai.drmcp.core.clients import get_api_client
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.config import create_deployment_tool_config
 from datarobot_genai.drmcp.core.dynamic_tools.register import register_external_tool
 from datarobot_genai.drmcp.core.exceptions import DynamicToolRegistrationError
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
-from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
-from datarobot_genai.drmcp.core.lineage.manager import LineageManager
-from datarobot_genai.drmcp.core.mcp_instance import mcp
 
 logger = logging.getLogger(__name__)
 
@@ -43,14 +39,6 @@ async def register_tools_of_datarobot_deployments() -> None:
         except Exception as exc:
             logger.error(f"Unexpected error for deployment {deployment_id}: {exc}")
             pass
-
-    if FeatureFlag.is_mcp_tools_gallery_support_enabled():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_tools()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
 
 
 async def register_tool_of_datarobot_deployment(

--- a/tests/drmcp/unit/dynamic_prompts/test_register.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_register.py
@@ -14,8 +14,6 @@
 
 """Tests for external prompt registration."""
 
-from collections.abc import Iterator
-from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 from uuid import UUID
@@ -96,40 +94,6 @@ class TestToValidFunctionName:
 class TestRegisterPrompt:
     """Tests for register_prompt - happy path."""
 
-    @pytest.fixture
-    def module_under_test(self) -> str:
-        return "datarobot_genai.drmcp.core.dynamic_prompts.register"
-
-    @pytest.fixture
-    def mock_get_datarobot_prompt_templates(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.get_datarobot_prompt_templates") as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_get_datarobot_prompt_template_versions(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.get_datarobot_prompt_template_versions") as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_register_prompt_from_datarobot_prompt_management(
-        self, module_under_test: str
-    ) -> Iterator[AsyncMock]:
-        with patch(
-            f"{module_under_test}.register_prompt_from_datarobot_prompt_management",
-            new_callable=AsyncMock,
-        ) as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_mcp_server(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.mcp") as mock_mcp:
-            yield mock_mcp
-
-    @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
-        "mock_lineage_manager_init",
-        "mock_sync_mcp_prompts",
-    )
     @pytest.mark.asyncio
     async def test_register_prompt_from_datarobot_prompt_management(
         self,
@@ -143,11 +107,6 @@ class TestRegisterPrompt:
         assert "Dummy prompt name" in prompts, "`Dummy prompt name` is missing."
 
     @pytest.mark.asyncio
-    @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
-        "mock_lineage_manager_init",
-        "mock_sync_mcp_prompts",
-    )
     @patch("datarobot_genai.drmcp.core.dynamic_prompts.utils.uuid4")
     async def test_register_prompt_from_datarobot_prompt_management_duplicated_prompt_names(
         self,
@@ -163,35 +122,3 @@ class TestRegisterPrompt:
 
         assert "Dummy prompt name" in prompts, "`Dummy prompt name` is missing."
         assert "Dummy prompt name (f2bd)" in prompts, "`Dummy prompt name (f2bd)` is missing."
-
-    @pytest.mark.asyncio
-    async def test_sync_mcp_metadata_after_register_prompts(
-        self,
-        mock_get_datarobot_prompt_templates: Mock,
-        mock_get_datarobot_prompt_template_versions: Mock,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
-        mock_lineage_manager_init: Mock,
-        mock_sync_mcp_prompts: Mock,
-        mock_mcp_server: Mock,
-        mock_register_prompt_from_datarobot_prompt_management: AsyncMock,
-    ) -> None:
-        mock_prompt = Mock()
-        mock_get_datarobot_prompt_templates.return_value = [mock_prompt]
-        prompt_template_version = dr.genai.PromptTemplateVersion("adsf", version=1)
-        mock_get_datarobot_prompt_template_versions.return_value = {
-            mock_prompt.id: [prompt_template_version],
-        }
-
-        await register_prompts_from_datarobot_prompt_management()
-
-        mock_get_datarobot_prompt_templates.assert_called_once_with()
-        mock_get_datarobot_prompt_template_versions.assert_called_once_with(
-            prompt_template_ids=[mock_prompt.id],
-        )
-        mock_register_prompt_from_datarobot_prompt_management.assert_called_once_with(
-            mock_prompt,
-            prompt_template_version,
-        )
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
-        mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
-        mock_sync_mcp_prompts.assert_called_once_with()

--- a/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
+++ b/tests/drmcp/unit/dynamic_tools/test_deployment_register.py
@@ -11,52 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import Iterator
-from unittest.mock import AsyncMock
-from unittest.mock import Mock
 from unittest.mock import patch
-
-import datarobot as dr
-import pytest
 
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
     get_datarobot_tool_deployments,
 )
-from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
-    register_tools_of_datarobot_deployments,
-)
-
-
-@pytest.fixture
-def module_under_test() -> str:
-    return "datarobot_genai.drmcp.core.dynamic_tools.deployment.register"
-
-
-@pytest.fixture
-def mock_get_datarobot_tool_deployments(module_under_test: str) -> Iterator[Mock]:
-    with patch(f"{module_under_test}.get_datarobot_tool_deployments") as mock_func:
-        yield mock_func
-
-
-@pytest.fixture
-def mock_register_tool_of_datarobot_deployment(module_under_test: str) -> Iterator[AsyncMock]:
-    with patch(
-        f"{module_under_test}.register_tool_of_datarobot_deployment",
-        new_callable=AsyncMock,
-    ) as mock_func:
-        yield mock_func
-
-
-@pytest.fixture
-def mock_mcp_server(module_under_test: str) -> Iterator[Mock]:
-    with patch(f"{module_under_test}.mcp") as mock_mcp:
-        yield mock_mcp
-
-
-@pytest.fixture
-def mock_datarobot_deployment_get() -> Iterator[Mock]:
-    with patch.object(dr.Deployment, "get") as mock_func:
-        yield mock_func
 
 
 @patch("datarobot_genai.drmcp.core.dynamic_tools.deployment.register.get_api_client")
@@ -107,28 +66,3 @@ def test_get_datarobot_tool_deployments_filters_tags_correctly(mock_dr, mock_get
     )
 
     assert result == ["deployment_1", "deployment_5"]
-
-
-@pytest.mark.asyncio
-async def test_sync_mcp_metadata_after_register_tools(
-    mock_datarobot_deployment_get: Mock,
-    mock_is_mcp_tools_gallery_support_enabled: Mock,
-    mock_get_datarobot_tool_deployments: Mock,
-    mock_lineage_manager_init: Mock,
-    mock_sync_mcp_tools: Mock,
-    mock_mcp_server: Mock,
-    mock_register_tool_of_datarobot_deployment: AsyncMock,
-) -> None:
-    mock_deployment_id = Mock()
-    mock_get_datarobot_tool_deployments.return_value = [mock_deployment_id]
-
-    await register_tools_of_datarobot_deployments()
-
-    mock_get_datarobot_tool_deployments.assert_called_once_with()
-    mock_datarobot_deployment_get.assert_called_once_with(mock_deployment_id)
-    mock_register_tool_of_datarobot_deployment.assert_called_once_with(
-        mock_datarobot_deployment_get.return_value,
-    )
-    mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
-    mock_lineage_manager_init.assert_called_once_with(mock_mcp_server)
-    mock_sync_mcp_tools.assert_called_once_with()

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -14,6 +14,7 @@
 import asyncio
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
@@ -99,6 +100,7 @@ class TestDataRobotMCPServer:
     @pytest.mark.usefixtures(
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
+        "mock_sync_mcp_prompts",
         "mock_is_mcp_tools_gallery_support_enabled",
     )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
@@ -185,6 +187,10 @@ class TestDataRobotMCPServer:
         mock_get_config: MagicMock,
         mock_mcp: MagicMock,
         mock_config: MagicMock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
+        mock_lineage_manager_init: Mock,
+        mock_sync_mcp_prompts: AsyncMock,
+        mock_sync_mcp_tools: AsyncMock,
     ) -> None:
         """Test successful server run."""
         mock_get_config.return_value = mock_config
@@ -209,6 +215,18 @@ class TestDataRobotMCPServer:
         # Verify tools were listed
         mock_mcp.list_tools.assert_called_once()
 
+        # Check MCP lineage
+        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
+        mock_lineage_manager_init.assert_called_once_with(mock_mcp)
+        mock_sync_mcp_prompts.assert_called_once_with()
+        mock_sync_mcp_tools.assert_called_once_with()
+
+    @pytest.mark.usefixtures(
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+        "mock_sync_mcp_prompts",
+        "mock_is_mcp_tools_gallery_support_enabled",
+    )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_credentials")
@@ -237,6 +255,12 @@ class TestDataRobotMCPServer:
         with pytest.raises(Exception, match="Server failed to start"):
             server.run()
 
+    @pytest.mark.usefixtures(
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_tools",
+        "mock_sync_mcp_prompts",
+        "mock_is_mcp_tools_gallery_support_enabled",
+    )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_credentials")

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.31"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
With the existing implementation, MCP lineage will be sync after dynamic tools/prompts are loaded/registered. However, the dynamic tool/prompts loading/registration is optional. This PR updated MCP lineage logic and make it always run during user MCP server start up.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP server startup behavior to always attempt lineage sync (behind a feature flag), which could affect startup time and error handling if lineage configuration is missing. Also alters the integration test task to no longer start/stop a local dev server, potentially reducing test coverage for server-backed integration tests.
> 
> **Overview**
> Ensures MCP lineage metadata is synced during `DataRobotMCPServer.run()` startup (behind `FeatureFlag.is_mcp_tools_gallery_support_enabled()`), independent of whether dynamic tools/prompts registration is enabled; missing lineage env vars now only log a warning.
> 
> Removes the post-registration lineage sync calls from dynamic tool/prompt registration helpers and updates unit tests to assert lineage sync occurs at server startup instead. Bumps version to `0.15.31` and updates the changelog; simplifies `drmcp-integration` Taskfile to run tests without managing a background server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2809aa1ec6dd34115e41edbd1f45a7777d2730ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->