### PR TITLE
[MODEL-23297] Implement Pagination on Predictive Model Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.32
+- Implemented pagination for predictive model MCP tool
+
 ## 0.15.31
 - Improved MCP lineage sync logic and made it always run during user MCP startup.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.30"
+version = "0.15.32"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.31"
+version = "0.15.32"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -99,6 +99,10 @@ class StubProject:
         """Stub get_models (matches real API: no arguments)."""
         return self._models
 
+    def get_model_records(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> list:
+        """Stub paginated model list (matches ``Project.get_model_records`` slice semantics)."""
+        return self._models[offset : offset + limit]
+
     def upload_dataset_from_catalog(self, dataset_id: str, **kwargs: Any) -> Any:
         """Stub ``Project.upload_dataset_from_catalog`` (used by score_dataset_with_model)."""
         return SimpleNamespace(id=f"prediction_dataset_for_{dataset_id}")

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -29,27 +29,11 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.core.utils import is_valid_url
 from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drtools.predictive.utils import DR_PREDICTIVE_API_PAGINATION_MAX
+from datarobot_genai.drtools.predictive.utils import _clamp_limit
+from datarobot_genai.drtools.predictive.utils import _merge_pagination_metadata
 
 logger = logging.getLogger(__name__)
-
-# Max page / batch size for predictive `data` tools
-DR_PREDICTIVE_API_PAGINATION_MAX = 100
-
-
-def _clamp_limit(limit: int) -> tuple[int, str | None]:
-    """Clamp page size to [1, DR_PREDICTIVE_API_PAGINATION_MAX] and an optional user-facing note."""
-    m = DR_PREDICTIVE_API_PAGINATION_MAX
-    if limit < 1:
-        return (
-            m,
-            f"Limit must be at least 1. The maximum limit of {m} was applied.",
-        )
-    if limit > m:
-        return (
-            m,
-            f"Limit cannot exceed {m}. The maximum limit of {m} was applied.",
-        )
-    return (limit, None)
 
 
 def _serialize_datastore_params(params: Any) -> dict[str, Any]:
@@ -64,32 +48,6 @@ def _serialize_datastore_params(params: Any) -> dict[str, Any]:
         if isinstance(payload, dict):
             return payload
     return {}
-
-
-def _merge_pagination_metadata(
-    final_results: dict[str, Any],
-    api_response: dict[str, Any] | list,
-    message: str | None = None,
-    *,
-    offset: int | None = None,
-    limit: int | None = None,
-) -> dict[str, Any]:
-    """Add offset/limit echo and DataRobot list pagination (next, previous, total) when present."""
-    if offset is not None:
-        final_results["offset"] = offset
-    if limit is not None:
-        final_results["limit"] = limit
-    if message is not None:
-        final_results["note"] = message
-    if isinstance(api_response, dict):
-        for key in ("next", "previous"):
-            if key in api_response and api_response[key] is not None:
-                final_results[key] = api_response[key]
-        for total_key in ("total_count", "total"):
-            if total_key in api_response and api_response[total_key] is not None:
-                final_results["total_count"] = api_response[total_key]
-                break
-    return final_results
 
 
 @tool_metadata(

--- a/src/datarobot_genai/drtools/predictive/model.py
+++ b/src/datarobot_genai/drtools/predictive/model.py
@@ -29,6 +29,9 @@ from datarobot_genai.drtools.core.clients.datarobot import get_datarobot_access_
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drtools.predictive.utils import DR_PREDICTIVE_API_PAGINATION_MAX
+from datarobot_genai.drtools.predictive.utils import _clamp_limit
+from datarobot_genai.drtools.predictive.utils import _merge_pagination_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -197,18 +200,37 @@ async def score_dataset_with_model(
 @tool_metadata(
     tags={"predictive", "model", "read", "management", "list", "daria"},
     description=(
-        "[Project—list models] Use when the user needs every trained leaderboard model for a "
-        "project (ids, types, metrics). Read-only. Not the same as picking only the best model "
-        "(get_best_model). Follow with get_model_details, deploy_model, or "
-        "score_dataset_with_model using a chosen model_id."
+        "[Project—list models] Use when the user needs trained leaderboard models for a "
+        "project (ids, types, metrics), with optional offset/limit pagination. Read-only. Not "
+        "the same as picking only the best model (get_best_model). When may_have_more is true, "
+        "call again with offset increased by the prior limit. Follow with get_model_details, "
+        "deploy_model, or score_dataset_with_model using a chosen model_id."
     ),
 )
 async def list_models(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
+    offset: Annotated[
+        int | None,
+        (
+            "Skip this many leaderboard models (0-based). "
+            "Example: next page after limit=50 uses offset=50."
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        (
+            "Max models to return in this call (default 100). Use with offset to page. "
+            "Values above 100 are clamped; use offset to continue."
+        ),
+    ] = DR_PREDICTIVE_API_PAGINATION_MAX,
 ) -> dict[str, Any]:
     if not project_id:
         raise ToolError("Project ID must be provided", kind=ToolErrorKind.VALIDATION)
+    if offset is not None and offset < 0:
+        raise ToolError("offset must be non-negative", kind=ToolErrorKind.VALIDATION)
+
+    limit, message = _clamp_limit(limit)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
@@ -216,12 +238,22 @@ async def list_models(
         project = client.Project.get(project_id)
     except ClientError as e:
         raise_tool_error_for_client_error(e)
-    models = project.get_models()
+    iterate_offset = 0 if offset is None else offset
+    models = project.get_model_records(limit=limit, offset=iterate_offset)
 
-    return {
+    final_results: dict[str, Any] = {
         "project_id": project_id,
         "models": [model_to_dict(model) for model in models],
+        "count": len(models),
+        "may_have_more": len(models) == limit,
     }
+    return _merge_pagination_metadata(
+        final_results=final_results,
+        api_response={},
+        message=message,
+        offset=offset,
+        limit=limit,
+    )
 
 
 @tool_metadata(

--- a/src/datarobot_genai/drtools/predictive/utils.py
+++ b/src/datarobot_genai/drtools/predictive/utils.py
@@ -1,0 +1,61 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+# Max page / batch size for predictive tools
+DR_PREDICTIVE_API_PAGINATION_MAX = 100
+
+
+def _clamp_limit(limit: int) -> tuple[int, str | None]:
+    """Clamp page size to [1, DR_PREDICTIVE_API_PAGINATION_MAX] and an optional user-facing note."""
+    if limit < 1:
+        return (
+            DR_PREDICTIVE_API_PAGINATION_MAX,
+            f"""Limit must be at least 1. The maximum limit of """
+            f"""{DR_PREDICTIVE_API_PAGINATION_MAX} was applied.""",
+        )
+    if limit > DR_PREDICTIVE_API_PAGINATION_MAX:
+        return (
+            DR_PREDICTIVE_API_PAGINATION_MAX,
+            f"""Limit cannot exceed {DR_PREDICTIVE_API_PAGINATION_MAX}. """
+            f"""The maximum limit of {DR_PREDICTIVE_API_PAGINATION_MAX} was applied.""",
+        )
+    return (limit, None)
+
+
+def _merge_pagination_metadata(
+    final_results: dict[str, Any],
+    api_response: dict[str, Any] | list,
+    message: str | None = None,
+    *,
+    offset: int | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Add offset/limit echo and DataRobot list pagination (next, previous, total) when present."""
+    if offset is not None:
+        final_results["offset"] = offset
+    if limit is not None:
+        final_results["limit"] = limit
+    if message is not None:
+        final_results["note"] = message
+    if isinstance(api_response, dict):
+        for key in ("next", "previous"):
+            if key in api_response and api_response[key] is not None:
+                final_results[key] = api_response[key]
+        for total_key in ("total_count", "total"):
+            if total_key in api_response and api_response[total_key] is not None:
+                final_results["total_count"] = api_response[total_key]
+                break
+    return final_results

--- a/tests/drmcp/unit/predictive_tools/test_model.py
+++ b/tests/drmcp/unit/predictive_tools/test_model.py
@@ -118,6 +118,68 @@ async def test_get_best_model_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_models_success() -> None:
+    mock_client = MagicMock()
+    mock_project = MagicMock()
+    mock_model1 = MagicMock(id="m1", model_type="XGBoost", metrics={"AUC": {"validation": 0.9}})
+    mock_model2 = MagicMock(
+        id="m2", model_type="Random Forest", metrics={"AUC": {"validation": 0.8}}
+    )
+    mock_project.get_model_records.return_value = [mock_model1, mock_model2]
+    mock_client.Project.get.return_value = mock_project
+    p1, p2 = _patch_model_client(mock_client)
+    with p1, p2 as mock_drc:
+        mock_drc.return_value.get_client.return_value = mock_client
+        result = await model.list_models(project_id="pid")
+    mock_project.get_model_records.assert_called_once_with(limit=100, offset=0)
+    assert result["project_id"] == "pid"
+    assert result["count"] == 2
+    assert len(result["models"]) == 2
+    assert result["models"][0]["id"] == "m1"
+    assert result["may_have_more"] is False
+    assert result["limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_list_models_pagination_offset_limit() -> None:
+    mock_client = MagicMock()
+    mock_project = MagicMock()
+    mock_project.get_model_records.return_value = []
+    mock_client.Project.get.return_value = mock_project
+    p1, p2 = _patch_model_client(mock_client)
+    with p1, p2 as mock_drc:
+        mock_drc.return_value.get_client.return_value = mock_client
+        result = await model.list_models(project_id="pid", offset=25, limit=10)
+    mock_project.get_model_records.assert_called_once_with(limit=10, offset=25)
+    assert result["offset"] == 25
+    assert result["limit"] == 10
+    assert result["count"] == 0
+    assert result["may_have_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_models_negative_offset() -> None:
+    with pytest.raises(ToolError, match="offset must be non-negative"):
+        await model.list_models(project_id="pid", offset=-1)
+
+
+@pytest.mark.asyncio
+async def test_list_models_clamp_limit_applies_note() -> None:
+    mock_client = MagicMock()
+    mock_project = MagicMock()
+    mock_project.get_model_records.return_value = [MagicMock(id="m1", model_type="T", metrics={})]
+    mock_client.Project.get.return_value = mock_project
+    p1, p2 = _patch_model_client(mock_client)
+    with p1, p2 as mock_drc:
+        mock_drc.return_value.get_client.return_value = mock_client
+        result = await model.list_models(project_id="pid", limit=500)
+    mock_project.get_model_records.assert_called_once_with(limit=100, offset=0)
+    assert result["limit"] == 100
+    assert "note" in result
+    assert "100" in result["note"]
+
+
+@pytest.mark.asyncio
 async def test_score_dataset_with_model_success() -> None:
     mock_client = MagicMock()
     mock_project = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.31"
+version = "0.15.32"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Implements pagination for predictive model MCP tools.
Refactors pagination utils functions.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `list_models` predictive tool contract by adding `offset`/`limit` handling and switching to paginated SDK calls, which could affect downstream tool consumers and model listing completeness. Refactors shared pagination helpers into a new module used by multiple predictive tools, so regressions would impact other paginated endpoints too.
> 
> **Overview**
> Implements offset/limit pagination for the predictive `list_models` tool, including validation, limit clamping, and response metadata (`count`, `may_have_more`, plus echoed pagination fields/notes).
> 
> Refactors predictive pagination helpers by moving `DR_PREDICTIVE_API_PAGINATION_MAX`, `_clamp_limit`, and `_merge_pagination_metadata` into a new shared `predictive/utils.py`, updates data/model tools to import it, and extends test stubs + unit tests to cover the new paginated model listing behavior.
> 
> Bumps version to `0.15.32` and updates the changelog/lockfiles accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4711d17bcc0457638bc67d375abf74c6a3f7b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->