### PR TITLE
[-] Emit one AG-UI text message per CrewAI agent step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.33
+- Fixed CrewAI AG-UI streaming so each agent role in a multi-agent crew emits its own assistant message with a unique `messageId`. Previously, `TEXT_MESSAGE_END` was missing at agent-role boundaries and a single `messageId` was reused across the whole run, collapsing every agent's output into one merged message.
+
 ## 0.15.32
 - Implemented pagination for predictive model MCP tool
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.32"
+version = "0.15.33"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.32"
+version = "0.15.33"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -402,9 +402,9 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                         )
                     except Exception as exc:
                         logger.warning("CrewAI memory retrieval failed: %s", exc)
-            message_id = str(uuid.uuid4())
             crew_output = await crew.kickoff_async(inputs=kickoff_inputs)
             current_agent_role = ""
+            message_id = str(uuid.uuid4())
 
             if isinstance(crew_output, CrewStreamingOutput):
                 reasoning_started = False
@@ -415,6 +415,37 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                     if chunk.agent_role != current_agent_role:
                         logger.info(f"[{chunk.agent_role}] Working on task: {chunk.task_name}")
                         if current_agent_role:
+                            # Close any open text/reasoning message scoped to the
+                            # outgoing step so each step gets its own AG-UI message
+                            # with a unique message_id.
+                            if text_started:
+                                yield (
+                                    TextMessageEndEvent(
+                                        type=EventType.TEXT_MESSAGE_END,
+                                        message_id=message_id,
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                text_started = False
+                            if reasoning_started:
+                                yield (
+                                    ReasoningMessageEndEvent(
+                                        type=EventType.REASONING_MESSAGE_END,
+                                        message_id=message_id,
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                yield (
+                                    ReasoningEndEvent(
+                                        type=EventType.REASONING_END,
+                                        message_id=message_id,
+                                    ),
+                                    None,
+                                    zero_metrics,
+                                )
+                                reasoning_started = False
                             yield (
                                 StepFinishedEvent(
                                     type=EventType.STEP_FINISHED,
@@ -423,6 +454,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                                 None,
                                 zero_metrics,
                             )
+                            message_id = str(uuid.uuid4())
                         yield (
                             StepStartedEvent(
                                 type=EventType.STEP_STARTED,

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -479,6 +479,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                                 ReasoningMessageStartEvent(
                                     type=EventType.REASONING_MESSAGE_START,
                                     message_id=message_id,
+                                    role="reasoning",
                                 ),
                                 None,
                                 zero_metrics,

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -22,6 +22,11 @@ from crewai.types.streaming import CrewStreamingOutput
 from crewai.types.streaming import StreamChunk
 from crewai.types.streaming import StreamChunkType
 import pytest
+from ag_ui.core import ReasoningEndEvent
+from ag_ui.core import ReasoningMessageContentEvent
+from ag_ui.core import ReasoningMessageEndEvent
+from ag_ui.core import ReasoningMessageStartEvent
+from ag_ui.core import ReasoningStartEvent
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
@@ -849,3 +854,102 @@ async def test_invoke_streaming_single_agent_role_uses_single_message(
     assert len(starts) == 1
     assert len(ends) == 1
     assert starts[0].message_id == ends[0].message_id
+
+
+async def test_invoke_streaming_closes_reasoning_message_at_step_boundary(
+    mock_ragas_event_listener, run_agent_input
+) -> None:
+    # GIVEN a streaming crew where the first agent emits a reasoning chunk and
+    # the second agent emits a normal text chunk. The agent_role transition
+    # must close REASONING_MESSAGE_END and REASONING_END for the outgoing step
+    # before STEP_FINISHED is emitted.
+    planner_chunk = _text_chunk("plan-thoughts", "Planner")
+    writer_chunk = _text_chunk("write-text", "Writer")
+    result = CrewOutput(raw="ignored")
+
+    captured: list[Any] = []
+
+    class _CapturingStreamingListener:
+        def __init__(self) -> None:
+            self.reasoning_event = False
+            self.step_event = False
+            captured.append(self)
+
+        def setup_listeners(self, _bus: Any) -> None:
+            pass
+
+    class _ReasoningTransitionStreamingOutput(CrewStreamingOutput):
+        def __init__(self) -> None:
+            super().__init__(async_iterator=self._iter())
+
+        @staticmethod
+        async def _iter():  # type: ignore[no-untyped-def]
+            captured[0].reasoning_event = True
+            yield planner_chunk
+            captured[0].reasoning_event = False
+            yield writer_chunk
+
+        @property
+        def result(self) -> CrewOutput:  # type: ignore[override]
+            return result
+
+    streaming = _ReasoningTransitionStreamingOutput()
+    agent = AgentForTest(api_base="https://x/", api_key="k", verbose=False)
+    agent._crew_for_test = CrewForTest(streaming)
+
+    # WHEN we collect the AG-UI event stream
+    with patch(
+        "datarobot_genai.crewai.agent.CrewAIStreamingEventListener",
+        _CapturingStreamingListener,
+    ):
+        events = [e async for (e, _, _) in agent.invoke(run_agent_input)]
+
+    # THEN the sequence is valid per the AG-UI verifier
+    validate_sequence(events)
+
+    # THEN the Planner emits exactly one reasoning lifecycle and the Writer
+    # emits exactly one text lifecycle
+    reasoning_starts = [e for e in events if isinstance(e, ReasoningStartEvent)]
+    reasoning_msg_starts = [e for e in events if isinstance(e, ReasoningMessageStartEvent)]
+    reasoning_contents = [e for e in events if isinstance(e, ReasoningMessageContentEvent)]
+    reasoning_msg_ends = [e for e in events if isinstance(e, ReasoningMessageEndEvent)]
+    reasoning_ends = [e for e in events if isinstance(e, ReasoningEndEvent)]
+    text_starts = [e for e in events if isinstance(e, TextMessageStartEvent)]
+    text_ends = [e for e in events if isinstance(e, TextMessageEndEvent)]
+    text_contents = [e for e in events if isinstance(e, TextMessageContentEvent)]
+    assert len(reasoning_starts) == 1
+    assert len(reasoning_msg_starts) == 1
+    assert len(reasoning_msg_ends) == 1
+    assert len(reasoning_ends) == 1
+    assert len(text_starts) == 1
+    assert len(text_ends) == 1
+
+    # THEN reasoning content is on the Planner's message_id and text content
+    # is on a fresh message_id (no cross-agent leakage)
+    planner_id = reasoning_starts[0].message_id
+    writer_id = text_starts[0].message_id
+    assert planner_id != writer_id
+    assert reasoning_msg_starts[0].message_id == planner_id
+    assert reasoning_msg_ends[0].message_id == planner_id
+    assert reasoning_ends[0].message_id == planner_id
+    assert [c.delta for c in reasoning_contents if c.message_id == planner_id] == ["plan-thoughts"]
+    assert text_ends[0].message_id == writer_id
+    assert [c.delta for c in text_contents if c.message_id == writer_id] == ["write-text"]
+
+    # THEN REASONING_MESSAGE_END and REASONING_END are emitted before
+    # STEP_FINISHED Planner, which is emitted before STEP_STARTED Writer
+    reasoning_msg_end_idx = events.index(reasoning_msg_ends[0])
+    reasoning_end_idx = events.index(reasoning_ends[0])
+    planner_step_finish_idx = next(
+        i
+        for i, e in enumerate(events)
+        if isinstance(e, StepFinishedEvent) and e.step_name == "Planner"
+    )
+    writer_step_start_idx = next(
+        i
+        for i, e in enumerate(events)
+        if isinstance(e, StepStartedEvent) and e.step_name == "Writer"
+    )
+    assert (
+        reasoning_msg_end_idx < reasoning_end_idx < planner_step_finish_idx < writer_step_start_idx
+    )

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -19,11 +19,18 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from crewai.types.streaming import CrewStreamingOutput
+from crewai.types.streaming import StreamChunk
+from crewai.types.streaming import StreamChunkType
 import pytest
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
+from ag_ui.core import StepFinishedEvent
+from ag_ui.core import StepStartedEvent
 from ag_ui.core import TextMessageChunkEvent
+from ag_ui.core import TextMessageContentEvent
+from ag_ui.core import TextMessageEndEvent
+from ag_ui.core import TextMessageStartEvent
 from ag_ui.core import UserMessage
 from crewai import CrewOutput
 from ragas import MultiTurnSample
@@ -31,6 +38,7 @@ from ragas.messages import AIMessage
 from ragas.messages import HumanMessage
 
 from datarobot_genai.core.agents.base import UsageMetrics
+from datarobot_genai.core.agents.verify import validate_sequence
 from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.crewai.agent import CrewAIAgent
 from datarobot_genai.crewai.agent import datarobot_agent_class_from_crew
@@ -724,3 +732,120 @@ async def test_invoke_does_not_store_memory_when_run_fails(
         }
     ]
     assert memory_client.store_calls == []
+
+
+# --- Streaming AG-UI message-lifecycle tests ---
+
+
+def _text_chunk(content: str, agent_role: str) -> StreamChunk:
+    return StreamChunk(
+        content=content,
+        chunk_type=StreamChunkType.TEXT,
+        agent_role=agent_role,
+        task_name=f"{agent_role}-task",
+    )
+
+
+class _FakeStreamingOutput(CrewStreamingOutput):
+    """CrewStreamingOutput double that yields a fixed chunk list and a result."""
+
+    def __init__(self, chunks: list[StreamChunk], result: CrewOutput) -> None:
+        super().__init__(async_iterator=self._iter(chunks))
+        self._fixed_result = result
+
+    @staticmethod
+    async def _iter(chunks: list[StreamChunk]):  # type: ignore[no-untyped-def]
+        for c in chunks:
+            yield c
+
+    @property
+    def result(self) -> CrewOutput:  # type: ignore[override]
+        return self._fixed_result
+
+
+async def test_invoke_streaming_emits_separate_messages_per_agent_role(
+    mock_ragas_event_listener, run_agent_input
+) -> None:
+    # GIVEN a streaming crew that emits chunks under two different agent roles
+    chunks = [
+        _text_chunk("plan-a", "Planner"),
+        _text_chunk("plan-b", "Planner"),
+        _text_chunk("write-a", "Writer"),
+        _text_chunk("write-b", "Writer"),
+    ]
+    result = CrewOutput(
+        raw="ignored",
+        token_usage=UsageMetrics(completion_tokens=1, prompt_tokens=2, total_tokens=3),
+    )
+    streaming = _FakeStreamingOutput(chunks, result)
+    agent = AgentForTest(api_base="https://x/", api_key="k", verbose=False)
+    agent._crew_for_test = CrewForTest(streaming)
+
+    # WHEN we collect the AG-UI event stream
+    events = [e async for (e, _, _) in agent.invoke(run_agent_input)]
+
+    # THEN the sequence is valid per the AG-UI verifier
+    validate_sequence(events)
+
+    # THEN each step gets its own TEXT_MESSAGE_START / _END pair
+    starts = [e for e in events if isinstance(e, TextMessageStartEvent)]
+    ends = [e for e in events if isinstance(e, TextMessageEndEvent)]
+    contents = [e for e in events if isinstance(e, TextMessageContentEvent)]
+    assert len(starts) == 2, "expected one TEXT_MESSAGE_START per agent role"
+    assert len(ends) == 2, "expected one TEXT_MESSAGE_END per agent role"
+
+    # THEN the two messages have distinct ids
+    assert starts[0].message_id != starts[1].message_id
+
+    # THEN content events are partitioned by message_id (no cross-agent leakage)
+    by_id: dict[str, list[str]] = {}
+    for c in contents:
+        by_id.setdefault(c.message_id, []).append(c.delta)
+    assert by_id[starts[0].message_id] == ["plan-a", "plan-b"]
+    assert by_id[starts[1].message_id] == ["write-a", "write-b"]
+
+    # THEN each step boundary is closed before the next one opens
+    step_started = [e for e in events if isinstance(e, StepStartedEvent)]
+    step_finished = [e for e in events if isinstance(e, StepFinishedEvent)]
+    assert [s.step_name for s in step_started] == ["Planner", "Writer"]
+    assert [s.step_name for s in step_finished] == ["Planner", "Writer"]
+
+    # THEN the Planner's TEXT_MESSAGE_END is emitted before STEP_FINISHED Planner,
+    # which is emitted before STEP_STARTED Writer.
+    planner_end_idx = events.index(ends[0])
+    planner_step_finish_idx = next(
+        i
+        for i, e in enumerate(events)
+        if isinstance(e, StepFinishedEvent) and e.step_name == "Planner"
+    )
+    writer_step_start_idx = next(
+        i
+        for i, e in enumerate(events)
+        if isinstance(e, StepStartedEvent) and e.step_name == "Writer"
+    )
+    assert planner_end_idx < planner_step_finish_idx < writer_step_start_idx
+
+
+async def test_invoke_streaming_single_agent_role_uses_single_message(
+    mock_ragas_event_listener, run_agent_input
+) -> None:
+    # GIVEN a streaming crew that only emits chunks for one agent role
+    chunks = [
+        _text_chunk("hello-", "Solo"),
+        _text_chunk("world", "Solo"),
+    ]
+    result = CrewOutput(raw="ignored")
+    streaming = _FakeStreamingOutput(chunks, result)
+    agent = AgentForTest(api_base="https://x/", api_key="k", verbose=False)
+    agent._crew_for_test = CrewForTest(streaming)
+
+    # WHEN we collect the AG-UI event stream
+    events = [e async for (e, _, _) in agent.invoke(run_agent_input)]
+
+    # THEN the sequence is valid and there is exactly one text message
+    validate_sequence(events)
+    starts = [e for e in events if isinstance(e, TextMessageStartEvent)]
+    ends = [e for e in events if isinstance(e, TextMessageEndEvent)]
+    assert len(starts) == 1
+    assert len(ends) == 1
+    assert starts[0].message_id == ends[0].message_id

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.32"
+version = "0.15.33"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
In the CrewAI -> AG-UI streaming adapter, message_id was created once per run and the text message was opened on the first chunk and closed only at run end. With multi-agent crews this collapsed every agent's output into a single assistant message: no TEXT_MESSAGE_END at the agent_role boundary, no new TEXT_MESSAGE_START for the next agent, and the same message_id reused across both. The verifier accepted it because verify.py does not correlate message lifecycle with step lifecycle.

On agent_role transitions the streaming loop now closes any open text/reasoning message under the outgoing step, emits STEP_FINISHED, rotates message_id, then emits STEP_STARTED for the new step. The existing per-chunk emission code re-opens a fresh message under the new id on the next text/reasoning chunk.

Adds two streaming tests: one drives chunks across two agent roles and asserts distinct message ids, no cross-agent content leakage, correct ordering (TEXT_MESSAGE_END before STEP_FINISHED before STEP_STARTED), and that validate_sequence passes; the other guards the single-agent path so it still produces exactly one message.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CrewAI streaming → AG-UI event lifecycle ordering and `message_id` rotation at step boundaries, which could affect downstream consumers expecting the previous (merged) message behavior. Added tests mitigate regressions but multi-agent streaming paths are inherently timing/ordering sensitive.
> 
> **Overview**
> Fixes CrewAI AG-UI streaming for multi-agent crews by **closing any open text/reasoning message at `agent_role` transitions**, emitting `STEP_FINISHED`, rotating to a new `message_id`, and then starting the next step—so each agent role produces its own assistant message instead of all output merging into one.
> 
> Adds focused streaming tests to verify per-role message separation (unique `message_id`s, no cross-agent content leakage) and correct event ordering, including closing reasoning lifecycles at step boundaries; bumps package version to `0.15.33` and updates the changelog/lockfiles accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3425dff34f7c72efe390aade7baa314206a99b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->