### PR TITLE
[-] Fix AG-UI event lifecycle in LlamaIndex agent adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.34
+- Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step now emits its own `TEXT_MESSAGE_START`/`END`-bounded bubbles in chronological order with tool calls between them, the final step always emits a matching `STEP_FINISHED`, and `ToolCallResultEvent.message_id` anchors to the preceding text bubble per AG-UI spec.
+
 ## 0.15.33
 - Fixed CrewAI AG-UI streaming so each agent role in a multi-agent crew emits its own assistant message with a unique `messageId`. Previously, `TEXT_MESSAGE_END` was missing at agent-role boundaries and a single `messageId` was reused across the whole run, collapsing every agent's output into one merged message.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
 ## 0.15.34
-- Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step now emits its own `TEXT_MESSAGE_START`/`END`-bounded bubbles in chronological order with tool calls between them, the final step always emits a matching `STEP_FINISHED`, and `ToolCallResultEvent.message_id` anchors to the preceding text bubble per AG-UI spec.
+- Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step emits its own message bubble and a matching `STEP_FINISHED`.
 
 ## 0.15.33
-- Fixed CrewAI AG-UI streaming so each agent role in a multi-agent crew emits its own assistant message with a unique `messageId`. Previously, `TEXT_MESSAGE_END` was missing at agent-role boundaries and a single `messageId` was reused across the whole run, collapsing every agent's output into one merged message.
+- Fixed CrewAI AG-UI streaming so each agent role in a multi-agent crew emits its own assistant message with a unique `messageId`.
 
 ## 0.15.32
 - Implemented pagination for predictive model MCP tool

--- a/README.md
+++ b/README.md
@@ -98,11 +98,9 @@ These are explicitly excluded via `[tool.uv] exclude-dependencies` in `pyproject
 | `langchain-milvus` | `nvidia-nat-langchain` | Milvus vector DB adapter; not used |
 | `llama-index-cli` | `llama-index` | CLI tool; not needed at runtime |
 | `openpyxl` | `crewai-tools` | Excel parser; not used |
-| `posthog` | `mem0ai` | Analytics/telemetry; not used |
 | `pymilvus` | `langchain-milvus` | Milvus client; not used |
 | `python-docx` | `crewai-tools` | Word doc parser; not used |
 | `pytube` | `crewai-tools` | YouTube downloader; not used |
-| `qdrant-client` | `mem0ai` | Optional vector DB backend; not used |
 | `scikit-network` | `ragas` | Graph analysis library; not used |
 | `stagehand` | `crewai-tools` | Playwright web automation; not used |
 | `uv` | `crewai` | Package manager bundled as a runtime dep; not needed |

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.33"
+version = "0.15.34"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.33"
+version = "0.15.34"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -154,13 +154,49 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         current_agent_name: str | None = None
         message_id = str(uuid.uuid4())
         text_started = False
-        agent: str | None = None
+        any_text_emitted = False
+        # Id of the most recently opened text bubble in the current step. Used
+        # to anchor TOOL_CALL_RESULT.message_id to the assistant message that
+        # contained the tool call (per AG-UI spec). Resets on step transition.
+        last_text_message_id: str | None = None
 
         async for event in handler.stream_events():
             events.append(event)
+
+            # Detect agent transition first so the first delta of a new agent
+            # is attributed to the new agent's text bubble, not the previous one.
+            new_agent = getattr(event, "current_agent_name", None)
+            if new_agent is not None and new_agent != current_agent_name:
+                # Close any open text message from the outgoing agent so each
+                # step's text commits as its own AG-UI message.
+                if text_started:
+                    yield (
+                        TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),
+                        None,
+                        usage_metrics,
+                    )
+                    text_started = False
+                if current_agent_name is not None:
+                    yield (
+                        StepFinishedEvent(
+                            type=EventType.STEP_FINISHED, step_name=current_agent_name
+                        ),
+                        None,
+                        usage_metrics,
+                    )
+                yield (
+                    StepStartedEvent(type=EventType.STEP_STARTED, step_name=new_agent),
+                    None,
+                    usage_metrics,
+                )
+                current_agent_name = new_agent
+                # Fresh id for the new step; anchor for tool results resets too.
+                message_id = str(uuid.uuid4())
+                last_text_message_id = None
+                logger.info(f"Agent: {current_agent_name}")
+
             # Best-effort extraction of incremental text from LlamaIndex events
             delta: str | None = None
-
             try:
                 if hasattr(event, "delta") and isinstance(getattr(event, "delta"), str):
                     delta = getattr(event, "delta")
@@ -181,6 +217,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                         usage_metrics,
                     )
                     text_started = True
+                    any_text_emitted = True
+                    last_text_message_id = message_id
                 yield (
                     TextMessageContentEvent(
                         type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=delta
@@ -189,31 +227,13 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
 
-                # Agent switch banner if available on event
-            if hasattr(event, "current_agent_name"):
-                agent = getattr(event, "current_agent_name", None)
-                if agent is not None and agent != current_agent_name:
-                    if current_agent_name is not None:
-                        yield (
-                            StepFinishedEvent(step_name=current_agent_name),
-                            None,
-                            usage_metrics,
-                        )
-
-                    yield (
-                        StepStartedEvent(step_name=agent),
-                        None,
-                        usage_metrics,
-                    )
-                    current_agent_name = agent
-                    agent = None
-                    logger.info(f"Agent: {current_agent_name}")
-
             event_type = type(event).__name__
             if event_type == "AgentInput" and hasattr(event, "input"):
                 logger.info(f"Input: {getattr(event, 'input')}")
             elif event_type == "AgentOutput":
-                # Output content
+                # When no deltas streamed for this turn, attach the full response
+                # content to the current step's open text message. Step transition
+                # or end-of-run closes it.
                 resp = getattr(event, "response", None)
                 if resp is not None and hasattr(resp, "content") and getattr(resp, "content"):
                     content_str = str(getattr(resp, "content"))
@@ -227,6 +247,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                             usage_metrics,
                         )
                         text_started = True
+                        any_text_emitted = True
+                        last_text_message_id = message_id
                         yield (
                             TextMessageContentEvent(
                                 type=EventType.TEXT_MESSAGE_CONTENT,
@@ -270,7 +292,10 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 yield (
                     ToolCallResultEvent(
                         type=EventType.TOOL_CALL_RESULT,
-                        message_id=message_id,
+                        # Anchor to the assistant text bubble that initiated the
+                        # tool call. Falls back to the step's current id when
+                        # the step never emitted text (tool-only turn).
+                        message_id=last_text_message_id or message_id,
                         tool_call_id=tid,
                         content=json.dumps(tout, default=str),
                         role="tool",
@@ -279,6 +304,19 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
             elif event_type == "ToolCall":
+                # Close the open text message before the tool widget commits so
+                # the tool renders chronologically below the preceding text and
+                # the next text run starts a fresh bubble. ToolCallResult below
+                # uses the regenerated message_id, which matches the upcoming
+                # text bubble (or stays unreferenced if no more text follows).
+                if text_started:
+                    yield (
+                        TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),
+                        None,
+                        usage_metrics,
+                    )
+                    text_started = False
+                    message_id = str(uuid.uuid4())
                 tname = getattr(event, "tool_name", None)
                 tkwargs = getattr(event, "tool_kwargs", None)
                 tid = getattr(event, "tool_id", None)
@@ -303,14 +341,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
 
-        if agent is not None:
-            yield (
-                StepFinishedEvent(step_name=agent),
-                None,
-                usage_metrics,
-            )
-            agent = None
-
+        # Close any text message still open from the final agent before the
+        # step is finished so the message commits inside its step boundaries.
         if text_started:
             yield (
                 TextMessageEndEvent(
@@ -320,6 +352,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 None,
                 usage_metrics,
             )
+            text_started = False
+            message_id = str(uuid.uuid4())
 
         # After streaming completes, build final interactions and finish chunk
         # Extract state from workflow context (supports sync/async get or attribute)
@@ -338,7 +372,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
         # Use subclass-defined response extraction as final fallback when no text was streamed
         fallback_text = self.extract_response_text(state, events)
-        if not text_started and fallback_text:
+        if not any_text_emitted and fallback_text:
             yield (
                 TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id),
                 None,
@@ -361,7 +395,16 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 None,
                 usage_metrics,
             )
-            text_started = True
+            message_id = str(uuid.uuid4())
+
+        # Close the final agent's step. Each STEP_STARTED needs a matching
+        # STEP_FINISHED; without this, the UI shows the last step as still running.
+        if current_agent_name is not None:
+            yield (
+                StepFinishedEvent(type=EventType.STEP_FINISHED, step_name=current_agent_name),
+                None,
+                usage_metrics,
+            )
 
         pipeline_interactions = self.create_pipeline_interactions_from_events(events)
         if uses_memory:

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -155,10 +155,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         message_id = str(uuid.uuid4())
         text_started = False
         any_text_emitted = False
-        # Id of the most recently opened text bubble in the current step. Used
-        # to anchor TOOL_CALL_RESULT.message_id to the assistant message that
-        # contained the tool call (per AG-UI spec). Resets on step transition.
-        last_text_message_id: str | None = None
 
         async for event in handler.stream_events():
             events.append(event)
@@ -190,9 +186,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
                 current_agent_name = new_agent
-                # Fresh id for the new step; anchor for tool results resets too.
+                # Fresh id for the new step's first text bubble.
                 message_id = str(uuid.uuid4())
-                last_text_message_id = None
                 logger.info(f"Agent: {current_agent_name}")
 
             # Best-effort extraction of incremental text from LlamaIndex events
@@ -218,7 +213,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     )
                     text_started = True
                     any_text_emitted = True
-                    last_text_message_id = message_id
                 yield (
                     TextMessageContentEvent(
                         type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=delta
@@ -248,7 +242,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                         )
                         text_started = True
                         any_text_emitted = True
-                        last_text_message_id = message_id
                         yield (
                             TextMessageContentEvent(
                                 type=EventType.TEXT_MESSAGE_CONTENT,
@@ -292,10 +285,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                 yield (
                     ToolCallResultEvent(
                         type=EventType.TOOL_CALL_RESULT,
-                        # Anchor to the assistant text bubble that initiated the
-                        # tool call. Falls back to the step's current id when
-                        # the step never emitted text (tool-only turn).
-                        message_id=last_text_message_id or message_id,
+                        message_id=tid,
                         tool_call_id=tid,
                         content=json.dumps(tout, default=str),
                         role="tool",
@@ -304,11 +294,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     usage_metrics,
                 )
             elif event_type == "ToolCall":
-                # Close the open text message before the tool widget commits so
-                # the tool renders chronologically below the preceding text and
-                # the next text run starts a fresh bubble. ToolCallResult below
-                # uses the regenerated message_id, which matches the upcoming
-                # text bubble (or stays unreferenced if no more text follows).
+                # Close any open text message so the tool widget renders below
+                # the preceding text and the next text run starts a fresh bubble.
                 if text_started:
                     yield (
                         TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -46,6 +46,7 @@ from llama_index.core.tools import ToolOutput
 from llama_index.core.tools import ToolSelection
 from ragas import MultiTurnSample
 
+from datarobot_genai.core.agents.verify import validate_sequence
 from datarobot_genai.core.memory.base import BaseMemoryClient
 from datarobot_genai.llama_index.agent import DataRobotLiteLLM
 from datarobot_genai.llama_index.agent import LlamaIndexAgent
@@ -362,6 +363,9 @@ async def test_llama_index_agent_invoke(
     # THEN: the events follow AG-UI lifecycle pattern
     ag_events, pipeline_interactions, usage = zip(*events)
 
+    # THEN: the sequence is valid per the AG-UI verifier
+    validate_sequence(ag_events)
+
     # THEN: first event is RunStartedEvent
     assert isinstance(ag_events[0], RunStartedEvent)
 
@@ -454,6 +458,7 @@ async def test_invoke_agent_output_with_dict_tool_calls(
     events_out = [e async for e in agent.invoke(run_agent_input)]
     ag_events, pipeline, _ = zip(*events_out)
 
+    validate_sequence(ag_events)
     assert isinstance(ag_events[-1], RunFinishedEvent)
     content = [e for e in ag_events if isinstance(e, TextMessageContentEvent)]
     assert [e.delta for e in content] == ["hey"]
@@ -502,6 +507,7 @@ async def test_invoke_tool_result_message_id_is_distinct_from_text_bubbles(
     events_out = [e async for e in agent.invoke(run_agent_input)]
     ag_events, _, _ = zip(*events_out)
 
+    validate_sequence(ag_events)
     text_starts = [e for e in ag_events if isinstance(e, TextMessageStartEvent)]
     tool_results = [e for e in ag_events if isinstance(e, ToolCallResultEvent)]
     assert len(text_starts) == 2
@@ -530,6 +536,7 @@ async def test_invoke_agent_stream_multiple_agents(
     events_out = [e async for e in agent.invoke(run_agent_input)]
     ag_events, _, _ = zip(*events_out)
 
+    validate_sequence(ag_events)
     content = [e for e in ag_events if isinstance(e, TextMessageContentEvent)]
     assert [e.delta for e in content] == ["one", " two"]
     assert any(isinstance(e, TextMessageStartEvent) for e in ag_events)

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -28,6 +28,9 @@ from ag_ui.core import SystemMessage as AgSystemMessage
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import TextMessageStartEvent
+from ag_ui.core import ToolCallEndEvent
+from ag_ui.core import ToolCallResultEvent
+from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import UserMessage
 from llama_index.core.agent.workflow import AgentInput
 from llama_index.core.agent.workflow import AgentOutput
@@ -362,15 +365,47 @@ async def test_llama_index_agent_invoke(
     # THEN: first event is RunStartedEvent
     assert isinstance(ag_events[0], RunStartedEvent)
 
-    # THEN: text message events contain the expected deltas (after step / lifecycle events)
+    # THEN: each agent step gets its own text message (Agent 1 streamed text,
+    # then Agent 2 streamed text after the tool call) with distinct message ids.
     text_starts = [e for e in ag_events if isinstance(e, TextMessageStartEvent)]
-    assert len(text_starts) == 1
+    text_ends = [e for e in ag_events if isinstance(e, TextMessageEndEvent)]
+    assert len(text_starts) == 2
+    assert len(text_ends) == 2
+    assert text_starts[0].message_id != text_starts[1].message_id
+    assert text_starts[0].message_id == text_ends[0].message_id
+    assert text_starts[1].message_id == text_ends[1].message_id
+
     content_events = [e for e in ag_events if isinstance(e, TextMessageContentEvent)]
     assert [e.delta for e in content_events] == ["Hello ", "World\n", "Hello ", "World Again\n"]
 
-    # THEN: TextMessageEnd is present
-    end_events = [e for e in ag_events if isinstance(e, TextMessageEndEvent)]
-    assert len(end_events) == 1
+    # THEN: each STEP_STARTED has a matching STEP_FINISHED for the same agent
+    step_started = [e for e in ag_events if isinstance(e, StepStartedEvent)]
+    step_finished = [e for e in ag_events if isinstance(e, StepFinishedEvent)]
+    assert [e.step_name for e in step_started] == ["Agent 1", "Agent 2"]
+    assert [e.step_name for e in step_finished] == ["Agent 1", "Agent 2"]
+
+    # THEN: text messages live inside their step boundaries (END before STEP_FINISHED)
+    indexed = list(enumerate(ag_events))
+    end_idx = [i for i, e in indexed if isinstance(e, TextMessageEndEvent)]
+    finish_idx = [i for i, e in indexed if isinstance(e, StepFinishedEvent)]
+    assert end_idx[0] < finish_idx[0]
+    assert end_idx[1] < finish_idx[1]
+
+    # THEN: the tool call sits between the two agents' text messages
+    tool_start_idx = next(i for i, e in indexed if isinstance(e, ToolCallStartEvent))
+    tool_end_idx = next(i for i, e in indexed if isinstance(e, ToolCallEndEvent))
+    text_start_idx_1 = next(
+        i
+        for i, e in indexed
+        if isinstance(e, TextMessageStartEvent) and e.message_id == text_starts[1].message_id
+    )
+    assert end_idx[0] < tool_start_idx < tool_end_idx < text_start_idx_1
+
+    # THEN: the tool call result references the surrounding step's text message id,
+    # so the UI can anchor the tool call to the assistant message it came from.
+    tool_results = [e for e in ag_events if isinstance(e, ToolCallResultEvent)]
+    assert len(tool_results) == 1
+    assert tool_results[0].message_id == text_starts[1].message_id
 
     # THEN: last event is RunFinishedEvent with pipeline interactions
     assert isinstance(ag_events[-1], RunFinishedEvent)
@@ -421,6 +456,58 @@ async def test_invoke_agent_output_with_dict_tool_calls(
     content = [e for e in ag_events if isinstance(e, TextMessageContentEvent)]
     assert [e.delta for e in content] == ["hey"]
     assert pipeline[-1] is not None
+
+
+async def test_invoke_tool_result_anchors_to_preceding_text_bubble(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Text -> tool -> text within one step: tool_result.message_id must match
+    the preceding text bubble (the assistant message that initiated the call),
+    not the following one.
+    """
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentInput(
+                input=[ChatMessage(content="go", role=MessageRole.USER)],
+                current_agent_name="A",
+            ),
+            AgentStream(delta="thinking ", response="", current_agent_name="A"),
+            AgentStream(delta="aloud", response="", current_agent_name="A"),
+            AgentOutput(
+                response=ChatMessage(content="thinking aloud", role=MessageRole.ASSISTANT),
+                current_agent_name="A",
+                tool_calls=[ToolSelection(tool_name="t", tool_kwargs={}, tool_id="t1")],
+            ),
+            ToolCall(tool_name="t", tool_kwargs={}, tool_id="t1"),
+            ToolCallResult(
+                tool_name="t",
+                tool_kwargs={},
+                tool_id="t1",
+                tool_output=ToolOutput(
+                    tool_name="t",
+                    content="ok",
+                    raw_input={},
+                    raw_output="ok",
+                    is_error=False,
+                ),
+                return_direct=False,
+            ),
+            AgentStream(delta="after tool", response="", current_agent_name="A"),
+        ],
+        state="S",
+    )
+    agent = MyLlamaAgent(workflow)
+    events_out = [e async for e in agent.invoke(run_agent_input)]
+    ag_events, _, _ = zip(*events_out)
+
+    text_starts = [e for e in ag_events if isinstance(e, TextMessageStartEvent)]
+    tool_results = [e for e in ag_events if isinstance(e, ToolCallResultEvent)]
+    assert len(text_starts) == 2
+    assert len(tool_results) == 1
+    # Tool result references the bubble that came BEFORE it, not the next one.
+    assert tool_results[0].message_id == text_starts[0].message_id
+    assert tool_results[0].message_id != text_starts[1].message_id
 
 
 async def test_invoke_agent_stream_multiple_agents(

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -401,11 +401,13 @@ async def test_llama_index_agent_invoke(
     )
     assert end_idx[0] < tool_start_idx < tool_end_idx < text_start_idx_1
 
-    # THEN: the tool call result references the surrounding step's text message id,
-    # so the UI can anchor the tool call to the assistant message it came from.
+    # THEN: the tool call result has its own unique message_id (the tool_call_id),
+    # independent of any text bubble.
     tool_results = [e for e in ag_events if isinstance(e, ToolCallResultEvent)]
     assert len(tool_results) == 1
-    assert tool_results[0].message_id == text_starts[1].message_id
+    assert tool_results[0].message_id == tool_results[0].tool_call_id
+    assert tool_results[0].message_id != text_starts[0].message_id
+    assert tool_results[0].message_id != text_starts[1].message_id
 
     # THEN: last event is RunFinishedEvent with pipeline interactions
     assert isinstance(ag_events[-1], RunFinishedEvent)
@@ -458,12 +460,11 @@ async def test_invoke_agent_output_with_dict_tool_calls(
     assert pipeline[-1] is not None
 
 
-async def test_invoke_tool_result_anchors_to_preceding_text_bubble(
+async def test_invoke_tool_result_message_id_is_distinct_from_text_bubbles(
     run_agent_input: RunAgentInput,
 ) -> None:
-    """Text -> tool -> text within one step: tool_result.message_id must match
-    the preceding text bubble (the assistant message that initiated the call),
-    not the following one.
+    """Text -> tool -> text within one step: tool_result.message_id is the
+    tool_call_id and does not collide with either surrounding text bubble.
     """
     workflow = Workflow(
         events=[
@@ -505,9 +506,11 @@ async def test_invoke_tool_result_anchors_to_preceding_text_bubble(
     tool_results = [e for e in ag_events if isinstance(e, ToolCallResultEvent)]
     assert len(text_starts) == 2
     assert len(tool_results) == 1
-    # Tool result references the bubble that came BEFORE it, not the next one.
-    assert tool_results[0].message_id == text_starts[0].message_id
+    assert tool_results[0].message_id == tool_results[0].tool_call_id == "t1"
+    assert tool_results[0].message_id != text_starts[0].message_id
     assert tool_results[0].message_id != text_starts[1].message_id
+    # The two text bubbles within the step still have distinct ids.
+    assert text_starts[0].message_id != text_starts[1].message_id
 
 
 async def test_invoke_agent_stream_multiple_agents(

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.33"
+version = "0.15.34"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Each agent step now emits its own TEXT_MESSAGE_START/END-bounded bubble with tool calls between them in chronological order. The final step's STEP_FINISHED is now reliably emitted, fixing the "step stuck running" UI bug. ToolCallResultEvent.message_id anchors to the preceding text bubble per AG-UI spec, so server replay and other AG-UI consumers can trace tool results back to the assistant message that initiated them.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ordering/IDs of streamed AG-UI events from the LlamaIndex adapter, which can affect downstream UI rendering and replay logic, but is limited to event translation (no auth/data persistence changes).
> 
> **Overview**
> Fixes the LlamaIndex agent AG-UI stream so **each agent step cleanly brackets its own text bubble**: agent transitions now end any open `TEXT_MESSAGE_*`, emit `STEP_FINISHED` for the prior agent, then `STEP_STARTED` for the new agent with a fresh `message_id`.
> 
> Tool calls now **close the current text bubble before rendering tool widgets**, and `ToolCallResultEvent.message_id` is set to the `tool_call_id` to avoid collisions with assistant message bubbles; the final step now reliably emits a matching `STEP_FINISHED` to prevent “stuck running” UI states. Tests were tightened to validate sequences via `validate_sequence()` and assert step/text/tool ordering, and the package version was bumped to `0.15.34` (including lockfiles/changelog).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78db5dbbd9ec6ec155255c1aa12aa92c119aaf17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->