### PR TITLE
[-] Fix AG-UI tool call lifecycle in nat dragent frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
 ## 0.15.35
-- Fixed AG-UI tool call lifecycle in dragent frontends: tool calls now thread under the assistant message that issued them, `TOOL_CALL_END` and `TOOL_CALL_RESULT` fire at actual tool completion, and nested NAT `FUNCTION_*` events no longer leak as duplicate `CustomEvent`s.
+- Fixed AG-UI tool call lifecycle in dragent frontends: tool calls now thread under the assistant message that issued them, `TOOL_CALL_END` and `TOOL_CALL_RESULT` fire at actual tool completion, parallel same-name calls correlate by NAT `payload.UUID` so out-of-order completions bind to the correct `tool_call_id`, and nested NAT `FUNCTION_*` events no longer leak as duplicate `CustomEvent`s.
 
 ## 0.15.34
 - Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step emits its own message bubble and a matching `STEP_FINISHED`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
 ## 0.15.35
-- Fixed AG-UI tool call lifecycle in dragent frontends: tool calls now thread under the assistant message that issued them, `TOOL_CALL_END` and `TOOL_CALL_RESULT` fire at actual tool completion, parallel same-name calls correlate by NAT `payload.UUID` so out-of-order completions bind to the correct `tool_call_id`, and nested NAT `FUNCTION_*` events no longer leak as duplicate `CustomEvent`s.
+- Fixed AG-UI tool call lifecycle in dragent frontends.
 
 ## 0.15.34
 - Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step emits its own message bubble and a matching `STEP_FINISHED`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.15.35
+- Fixed AG-UI tool call lifecycle in dragent frontends: tool calls now thread under the assistant message that issued them, `TOOL_CALL_END` and `TOOL_CALL_RESULT` fire at actual tool completion, and nested NAT `FUNCTION_*` events no longer leak as duplicate `CustomEvent`s.
+
 ## 0.15.34
 - Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step emits its own message bubble and a matching `STEP_FINISHED`.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/step_adaptor.py
+++ b/src/datarobot_genai/dragent/frontends/step_adaptor.py
@@ -91,12 +91,9 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
 
             if step.event_category == IntermediateStepCategory.WORKFLOW:
                 result = self._handle_workflow(payload, ancestry)
-            # Fall through to custom for unhandled non-function events.
-            # Function events are intentionally suppressed when
-            # _handle_function returns None: falling through would emit a
-            # CustomEvent whose value.data.output carries the entire run's
-            # event stream, which the dragent UI rendered as a duplicate
-            # message thread on top of the live stream.
+            # FUNCTION events are suppressed when _handle_function returns
+            # None; falling through leaks the entire run's event stream as
+            # a CustomEvent (data.output carries it).
             elif result is None and step.event_category != IntermediateStepCategory.FUNCTION:
                 result = self._handle_custom(payload, ancestry)
 
@@ -293,23 +290,20 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
     def _handle_function(
         self, payload: IntermediateStepPayload, ancestry: InvocationNode
     ) -> ResponseSerializable | None:
-        # Track function nesting so _handle_llm can distinguish primary text
-        # from nested reasoning.
+        # Just track the function level so we can handle nested functions correctly
         if payload.event_type == IntermediateStepType.FUNCTION_START:
             self.function_level += 1
         elif payload.event_type == IntermediateStepType.FUNCTION_END:
             self.function_level -= 1
-            # When the parent agent dispatched this function as a tool, NAT
-            # may only fire FUNCTION_START/END (no TOOL_*). Pop the pending
-            # tool_call_id published by the converter on ToolCallStartEvent
-            # and emit End + Result so AG-UI clients close the call.
+            # Sub-agents dispatched as tools fire only FUNCTION_*, no TOOL_*.
+            # Close the LLM-issued tool call here so the UI doesn't hang.
             tool_call_id = pop_tool_call(payload.name)
             if tool_call_id is not None:
                 output = ""
                 if payload.data is not None and getattr(payload.data, "output", None) is not None:
                     output = str(payload.data.output)
-                # End must precede Result; reversing them leaves the UI
-                # stuck in "args streaming" state.
+                # End before Result; reversed order strands the UI in
+                # "args streaming".
                 return DRAgentEventResponse(
                     events=[
                         ToolCallEndEvent(tool_call_id=tool_call_id),

--- a/src/datarobot_genai/dragent/frontends/step_adaptor.py
+++ b/src/datarobot_genai/dragent/frontends/step_adaptor.py
@@ -92,9 +92,7 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
 
             if step.event_category == IntermediateStepCategory.WORKFLOW:
                 result = self._handle_workflow(payload, ancestry)
-            # FUNCTION events are suppressed when _handle_function returns
-            # None; falling through leaks the entire run's event stream as
-            # a CustomEvent (data.output carries it).
+            # FUNCTION fall-through leaks the run as a CustomEvent.
             elif result is None and step.event_category != IntermediateStepCategory.FUNCTION:
                 result = self._handle_custom(payload, ancestry)
 
@@ -294,21 +292,16 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
         # Just track the function level so we can handle nested functions correctly
         if payload.event_type == IntermediateStepType.FUNCTION_START:
             self.function_level += 1
-            # Bind by name in dispatch order; ``FUNCTION_END`` looks up by
-            # ``payload.UUID`` so parallel same-name calls completing out
-            # of order still correlate correctly.
             bind_tool_call(payload.name, payload.UUID)
         elif payload.event_type == IntermediateStepType.FUNCTION_END:
             self.function_level -= 1
             # Sub-agents dispatched as tools fire only FUNCTION_*, no TOOL_*.
-            # Close the LLM-issued tool call here so the UI doesn't hang.
             tool_call_id = pop_tool_call(payload.UUID)
             if tool_call_id is not None:
                 output = ""
                 if payload.data is not None and getattr(payload.data, "output", None) is not None:
-                    output = str(payload.data.output)
-                # End before Result; reversed order strands the UI in
-                # "args streaming".
+                    output = json.dumps(payload.data.output, default=str)
+                # End before Result; reversed order strands the UI in args streaming.
                 return DRAgentEventResponse(
                     events=[
                         ToolCallEndEvent(tool_call_id=tool_call_id),

--- a/src/datarobot_genai/dragent/frontends/step_adaptor.py
+++ b/src/datarobot_genai/dragent/frontends/step_adaptor.py
@@ -46,6 +46,7 @@ from nat.front_ends.fastapi.step_adaptor import StepAdaptor
 from nat.retriever.models import GlobalTypeConverter
 
 from .response import DRAgentEventResponse
+from .tool_call_registry import bind_tool_call
 from .tool_call_registry import pop_tool_call
 
 logger = logging.getLogger(__name__)
@@ -293,11 +294,15 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
         # Just track the function level so we can handle nested functions correctly
         if payload.event_type == IntermediateStepType.FUNCTION_START:
             self.function_level += 1
+            # Bind by name in dispatch order; ``FUNCTION_END`` looks up by
+            # ``payload.UUID`` so parallel same-name calls completing out
+            # of order still correlate correctly.
+            bind_tool_call(payload.name, payload.UUID)
         elif payload.event_type == IntermediateStepType.FUNCTION_END:
             self.function_level -= 1
             # Sub-agents dispatched as tools fire only FUNCTION_*, no TOOL_*.
             # Close the LLM-issued tool call here so the UI doesn't hang.
-            tool_call_id = pop_tool_call(payload.name)
+            tool_call_id = pop_tool_call(payload.UUID)
             if tool_call_id is not None:
                 output = ""
                 if payload.data is not None and getattr(payload.data, "output", None) is not None:

--- a/src/datarobot_genai/dragent/frontends/step_adaptor.py
+++ b/src/datarobot_genai/dragent/frontends/step_adaptor.py
@@ -46,6 +46,7 @@ from nat.front_ends.fastapi.step_adaptor import StepAdaptor
 from nat.retriever.models import GlobalTypeConverter
 
 from .response import DRAgentEventResponse
+from .tool_call_registry import pop_tool_call
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +91,13 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
 
             if step.event_category == IntermediateStepCategory.WORKFLOW:
                 result = self._handle_workflow(payload, ancestry)
-            # If we have not handle it yet, handle it as custom
-            if result is None:
+            # Fall through to custom for unhandled non-function events.
+            # Function events are intentionally suppressed when
+            # _handle_function returns None: falling through would emit a
+            # CustomEvent whose value.data.output carries the entire run's
+            # event stream, which the dragent UI rendered as a duplicate
+            # message thread on top of the live stream.
+            elif result is None and step.event_category != IntermediateStepCategory.FUNCTION:
                 result = self._handle_custom(payload, ancestry)
 
         except Exception as e:
@@ -287,11 +293,34 @@ class DRAgentNestedReasoningStepAdaptor(StepAdaptor):
     def _handle_function(
         self, payload: IntermediateStepPayload, ancestry: InvocationNode
     ) -> ResponseSerializable | None:
-        # Just track the function level so we can handle nested functions correctly
+        # Track function nesting so _handle_llm can distinguish primary text
+        # from nested reasoning.
         if payload.event_type == IntermediateStepType.FUNCTION_START:
             self.function_level += 1
         elif payload.event_type == IntermediateStepType.FUNCTION_END:
             self.function_level -= 1
+            # When the parent agent dispatched this function as a tool, NAT
+            # may only fire FUNCTION_START/END (no TOOL_*). Pop the pending
+            # tool_call_id published by the converter on ToolCallStartEvent
+            # and emit End + Result so AG-UI clients close the call.
+            tool_call_id = pop_tool_call(payload.name)
+            if tool_call_id is not None:
+                output = ""
+                if payload.data is not None and getattr(payload.data, "output", None) is not None:
+                    output = str(payload.data.output)
+                # End must precede Result; reversing them leaves the UI
+                # stuck in "args streaming" state.
+                return DRAgentEventResponse(
+                    events=[
+                        ToolCallEndEvent(tool_call_id=tool_call_id),
+                        ToolCallResultEvent(
+                            message_id=tool_call_id,
+                            tool_call_id=tool_call_id,
+                            content=output,
+                            role="tool",
+                        ),
+                    ]
+                )
         else:
             raise self._unknown_step_type(payload)
 

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -54,9 +54,8 @@ async def convert_chunks_to_agui_events(
     ``GeneratorExit`` (client disconnect), exits silently.
     """
     active_message_id: str | None = None
-    # parent_message_id of subsequent tool calls; threads them under the
-    # assistant message that issued them. A synthetic uuid here renders
-    # an orphan message stub in the UI.
+    # parent_message_id for subsequent tool calls; a synthetic uuid here
+    # renders an orphan message stub in the UI.
     last_text_message_id: str | None = None
     active_tool_calls: set[str] = set()
     seen_tool_calls: bool = False
@@ -73,8 +72,7 @@ async def convert_chunks_to_agui_events(
             events: list[Event] = []
 
             if delta and delta.content:
-                # Step adaptor owns ToolCallEnd at FUNCTION_END / TOOL_END;
-                # emitting End here would fire after Result and strand the UI.
+                # Step adaptor owns ToolCallEnd at FUNCTION_END / TOOL_END.
                 active_tool_calls.clear()
 
                 if active_message_id is None:
@@ -116,8 +114,7 @@ async def convert_chunks_to_agui_events(
                                 parent_message_id=last_text_message_id or "",
                             )
                         )
-                        # Hand the LLM-issued id to the step adaptor; it
-                        # binds ToolCallResult to it on FUNCTION_END.
+                        # Hand the LLM-issued id to the step adaptor.
                         if tool_name:
                             register_tool_call(tool_name, tc_id)
                     arguments = tc.function.arguments if tc.function else None
@@ -136,9 +133,6 @@ async def convert_chunks_to_agui_events(
     # Emit end/error events after the stream completes (normally or on error).
     # Errors are surfaced to the AG-UI client via RunErrorEvent rather than
     # propagated as exceptions, so NAT's streaming infrastructure stays stable.
-    # The step adaptor owns ``ToolCallEndEvent`` at ``FUNCTION_END``; on stream
-    # error, ``RunErrorEvent`` is the terminal event for the run, so any
-    # in-flight tool call is implicitly closed by the client.
     end: list[Event] = []
     if active_message_id is not None:
         end.append(TextMessageEndEvent(message_id=active_message_id))

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -57,7 +57,6 @@ async def convert_chunks_to_agui_events(
     # parent_message_id for subsequent tool calls; a synthetic uuid here
     # renders an orphan message stub in the UI.
     last_text_message_id: str | None = None
-    active_tool_calls: set[str] = set()
     seen_tool_calls: bool = False
     tool_index_map: dict[int, str] = {}
     zero = default_usage_metrics()
@@ -72,8 +71,9 @@ async def convert_chunks_to_agui_events(
             events: list[Event] = []
 
             if delta and delta.content:
+                # Reset per-turn index tracking; the next round's index 0 is a new tool call.
                 # Step adaptor owns ToolCallEnd at FUNCTION_END / TOOL_END.
-                active_tool_calls.clear()
+                tool_index_map.clear()
 
                 if active_message_id is None:
                     # After a tool call cycle, the LLM response is a new turn
@@ -102,9 +102,8 @@ async def convert_chunks_to_agui_events(
                             tc.index,
                         )
                         continue
-                    is_new = tc.id is not None and tc_id not in active_tool_calls
+                    is_new = tc.id is not None and tc.index not in tool_index_map
                     if is_new:
-                        active_tool_calls.add(tc_id)
                         tool_index_map[tc.index] = tc_id
                         tool_name = tc.function.name if tc.function else ""
                         events.append(

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -40,6 +40,7 @@ from nat.data_models.api_server import ChatResponseChunk
 from datarobot_genai.core.agents import default_usage_metrics
 
 from .response import DRAgentEventResponse
+from .tool_call_registry import register_tool_call
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,12 @@ async def convert_chunks_to_agui_events(
     ``GeneratorExit`` (client disconnect), exits silently.
     """
     active_message_id: str | None = None
-    tool_call_message_id: str | None = None
+    # The most recently ended assistant text message id. Tool calls reference
+    # it as parent_message_id so the AG-UI client can thread them under the
+    # assistant message that issued them. Without this, tool calls reference
+    # a phantom uuid and the UI renders a synthetic message stub on top of
+    # the real text message (duplicate-card bug).
+    last_text_message_id: str | None = None
     active_tool_calls: set[str] = set()
     seen_tool_calls: bool = False
     tool_index_map: dict[int, str] = {}
@@ -70,14 +76,12 @@ async def convert_chunks_to_agui_events(
             events: list[Event] = []
 
             if delta and delta.content:
-                # Close any active tool calls before resuming text.
-                # The LLM may stream: text -> tool_call -> (execute) -> more text.
-                # AG-UI expects sequential blocks, not interleaved.
-                if active_tool_calls:
-                    for tc_id in active_tool_calls:
-                        events.append(ToolCallEndEvent(tool_call_id=tc_id))
-                    active_tool_calls.clear()
-                    tool_call_message_id = None
+                # Tool calls are closed by the step adaptor when their
+                # FUNCTION_END / TOOL_END fires (which happens before text
+                # resumes). Emitting End here would duplicate that and, more
+                # importantly, fire End AFTER Result — which leaves the UI
+                # stuck in "args streaming" state. Just drop the bookkeeping.
+                active_tool_calls.clear()
 
                 if active_message_id is None:
                     # After a tool call cycle, the LLM response is a new turn
@@ -91,16 +95,14 @@ async def convert_chunks_to_agui_events(
                 )
 
             if delta and delta.tool_calls:
-                # Close any active text message before starting tool calls.
+                # Close any active text message before starting tool calls,
+                # but remember its id so tool calls can reference it as their
+                # parent assistant message.
                 if active_message_id is not None:
                     events.append(TextMessageEndEvent(message_id=active_message_id))
+                    last_text_message_id = active_message_id
                     active_message_id = None
                 seen_tool_calls = True
-
-                # Create a dedicated message for tool calls so they don't
-                # merge with the preceding text message in storage.
-                if tool_call_message_id is None:
-                    tool_call_message_id = str(uuid.uuid4())
 
                 for tc in delta.tool_calls:
                     tc_id = tc.id or tool_index_map.get(tc.index)  # type: ignore[assignment]
@@ -114,13 +116,19 @@ async def convert_chunks_to_agui_events(
                     if is_new:
                         active_tool_calls.add(tc_id)
                         tool_index_map[tc.index] = tc_id
+                        tool_name = tc.function.name if tc.function else ""
                         events.append(
                             ToolCallStartEvent(
                                 tool_call_id=tc_id,
-                                tool_call_name=tc.function.name if tc.function else "",
-                                parent_message_id=tool_call_message_id,
+                                tool_call_name=tool_name,
+                                parent_message_id=last_text_message_id,
                             )
                         )
+                        # Publish (name → tool_call_id) so the step adaptor can
+                        # bind ToolCallResult to this LLM-issued id when the
+                        # subagent/tool completes.
+                        if tool_name:
+                            register_tool_call(tool_name, tc_id)
                     arguments = tc.function.arguments if tc.function else None
                     if arguments:
                         events.append(ToolCallArgsEvent(tool_call_id=tc_id, delta=arguments))

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -33,7 +33,6 @@ from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import TextMessageStartEvent
 from ag_ui.core import ToolCallArgsEvent
-from ag_ui.core import ToolCallEndEvent
 from ag_ui.core import ToolCallStartEvent
 from nat.data_models.api_server import ChatResponseChunk
 
@@ -137,11 +136,12 @@ async def convert_chunks_to_agui_events(
     # Emit end/error events after the stream completes (normally or on error).
     # Errors are surfaced to the AG-UI client via RunErrorEvent rather than
     # propagated as exceptions, so NAT's streaming infrastructure stays stable.
+    # The step adaptor owns ``ToolCallEndEvent`` at ``FUNCTION_END``; on stream
+    # error, ``RunErrorEvent`` is the terminal event for the run, so any
+    # in-flight tool call is implicitly closed by the client.
     end: list[Event] = []
     if active_message_id is not None:
         end.append(TextMessageEndEvent(message_id=active_message_id))
-    for tc_id in active_tool_calls:
-        end.append(ToolCallEndEvent(tool_call_id=tc_id))
     if error is not None:
         end.append(RunErrorEvent(message=str(error), code="STREAM_ERROR"))
     if end:

--- a/src/datarobot_genai/dragent/frontends/stream_converter.py
+++ b/src/datarobot_genai/dragent/frontends/stream_converter.py
@@ -55,11 +55,9 @@ async def convert_chunks_to_agui_events(
     ``GeneratorExit`` (client disconnect), exits silently.
     """
     active_message_id: str | None = None
-    # The most recently ended assistant text message id. Tool calls reference
-    # it as parent_message_id so the AG-UI client can thread them under the
-    # assistant message that issued them. Without this, tool calls reference
-    # a phantom uuid and the UI renders a synthetic message stub on top of
-    # the real text message (duplicate-card bug).
+    # parent_message_id of subsequent tool calls; threads them under the
+    # assistant message that issued them. A synthetic uuid here renders
+    # an orphan message stub in the UI.
     last_text_message_id: str | None = None
     active_tool_calls: set[str] = set()
     seen_tool_calls: bool = False
@@ -76,11 +74,8 @@ async def convert_chunks_to_agui_events(
             events: list[Event] = []
 
             if delta and delta.content:
-                # Tool calls are closed by the step adaptor when their
-                # FUNCTION_END / TOOL_END fires (which happens before text
-                # resumes). Emitting End here would duplicate that and, more
-                # importantly, fire End AFTER Result — which leaves the UI
-                # stuck in "args streaming" state. Just drop the bookkeeping.
+                # Step adaptor owns ToolCallEnd at FUNCTION_END / TOOL_END;
+                # emitting End here would fire after Result and strand the UI.
                 active_tool_calls.clear()
 
                 if active_message_id is None:
@@ -95,9 +90,7 @@ async def convert_chunks_to_agui_events(
                 )
 
             if delta and delta.tool_calls:
-                # Close any active text message before starting tool calls,
-                # but remember its id so tool calls can reference it as their
-                # parent assistant message.
+                # Close any active text message before starting tool calls.
                 if active_message_id is not None:
                     events.append(TextMessageEndEvent(message_id=active_message_id))
                     last_text_message_id = active_message_id
@@ -121,12 +114,11 @@ async def convert_chunks_to_agui_events(
                             ToolCallStartEvent(
                                 tool_call_id=tc_id,
                                 tool_call_name=tool_name,
-                                parent_message_id=last_text_message_id,
+                                parent_message_id=last_text_message_id or "",
                             )
                         )
-                        # Publish (name → tool_call_id) so the step adaptor can
-                        # bind ToolCallResult to this LLM-issued id when the
-                        # subagent/tool completes.
+                        # Hand the LLM-issued id to the step adaptor; it
+                        # binds ToolCallResult to it on FUNCTION_END.
                         if tool_name:
                             register_tool_call(tool_name, tc_id)
                     arguments = tc.function.arguments if tc.function else None

--- a/src/datarobot_genai/dragent/frontends/tool_call_registry.py
+++ b/src/datarobot_genai/dragent/frontends/tool_call_registry.py
@@ -14,11 +14,10 @@
 
 """Per-run handoff of LLM-issued ``tool_call_id`` from converter to adaptor.
 
-LLM stream and NAT intermediate steps see different ids for the same call.
 Two-phase correlation tolerates parallel same-name calls completing out of
-order: ``register`` (converter) appends to a FIFO keyed by name; ``bind``
-(adaptor, ``FUNCTION_START``) pops the head into a UUID-keyed map; ``pop``
-(adaptor, ``FUNCTION_END``) drains by UUID.
+order: ``register`` (converter) appends to a per-name FIFO; ``bind`` (adaptor,
+``FUNCTION_START``) pops the head into a UUID-keyed map; ``pop`` (adaptor,
+``FUNCTION_END``) drains by UUID.
 """
 
 from __future__ import annotations
@@ -26,7 +25,6 @@ from __future__ import annotations
 from collections import deque
 from contextvars import ContextVar
 
-# (pending: name -> FIFO of tc_ids, bound: nat_uuid -> tc_id)
 _state: ContextVar[tuple[dict[str, deque[str]], dict[str, str]]] = ContextVar("dragent_tc")
 
 

--- a/src/datarobot_genai/dragent/frontends/tool_call_registry.py
+++ b/src/datarobot_genai/dragent/frontends/tool_call_registry.py
@@ -1,0 +1,60 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-run handoff of LLM-issued ``tool_call_id`` from converter to adaptor.
+
+The outer LLM stream sees ``tool_call_id`` values from the upstream provider
+(``toolu_…`` / ``call_…``); the intermediate-step stream sees only the NAT
+``payload.UUID``. To emit ``ToolCallResultEvent`` bound to the LLM's id we
+publish ids by name in ``ToolCallStartEvent`` and pop them by name in
+``FUNCTION_END``. FIFO order assumes serial completion per name; parallel
+same-name calls finishing out of dispatch order would correlate incorrectly.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from contextvars import ContextVar
+
+_pending: ContextVar[dict[str, deque[str]] | None] = ContextVar(
+    "dragent_tool_call_pending", default=None
+)
+
+
+def register_tool_call(name: str, tool_call_id: str) -> None:
+    """Record ``tool_call_id`` for the next ``FUNCTION_END`` of ``name``."""
+    pending = _pending.get()
+    if pending is None:
+        pending = {}
+        _pending.set(pending)
+    pending.setdefault(name, deque()).append(tool_call_id)
+
+
+def pop_tool_call(name: str) -> str | None:
+    """Pop the next pending ``tool_call_id`` for ``name``, or ``None``."""
+    pending = _pending.get()
+    if pending is None:
+        return None
+    queue = pending.get(name)
+    if not queue:
+        return None
+    tool_call_id = queue.popleft()
+    if not queue:
+        pending.pop(name, None)
+    return tool_call_id
+
+
+def reset() -> None:
+    """Clear pending state for the current context. For tests."""
+    _pending.set({})

--- a/src/datarobot_genai/dragent/frontends/tool_call_registry.py
+++ b/src/datarobot_genai/dragent/frontends/tool_call_registry.py
@@ -14,12 +14,10 @@
 
 """Per-run handoff of LLM-issued ``tool_call_id`` from converter to adaptor.
 
-The outer LLM stream sees ``tool_call_id`` values from the upstream provider
-(``toolu_…`` / ``call_…``); the intermediate-step stream sees only the NAT
-``payload.UUID``. To emit ``ToolCallResultEvent`` bound to the LLM's id we
-publish ids by name in ``ToolCallStartEvent`` and pop them by name in
-``FUNCTION_END``. FIFO order assumes serial completion per name; parallel
-same-name calls finishing out of dispatch order would correlate incorrectly.
+The LLM stream and the intermediate-step stream see different ids for the
+same call (provider id vs. NAT ``payload.UUID``); ``ToolCallResult`` must
+bind to the LLM's id. FIFO by name; parallel same-name calls finishing
+out of dispatch order would correlate incorrectly.
 """
 
 from __future__ import annotations

--- a/src/datarobot_genai/dragent/frontends/tool_call_registry.py
+++ b/src/datarobot_genai/dragent/frontends/tool_call_registry.py
@@ -14,10 +14,11 @@
 
 """Per-run handoff of LLM-issued ``tool_call_id`` from converter to adaptor.
 
-The LLM stream and the intermediate-step stream see different ids for the
-same call (provider id vs. NAT ``payload.UUID``); ``ToolCallResult`` must
-bind to the LLM's id. FIFO by name; parallel same-name calls finishing
-out of dispatch order would correlate incorrectly.
+LLM stream and NAT intermediate steps see different ids for the same call.
+Two-phase correlation tolerates parallel same-name calls completing out of
+order: ``register`` (converter) appends to a FIFO keyed by name; ``bind``
+(adaptor, ``FUNCTION_START``) pops the head into a UUID-keyed map; ``pop``
+(adaptor, ``FUNCTION_END``) drains by UUID.
 """
 
 from __future__ import annotations
@@ -25,34 +26,36 @@ from __future__ import annotations
 from collections import deque
 from contextvars import ContextVar
 
-_pending: ContextVar[dict[str, deque[str]] | None] = ContextVar(
-    "dragent_tool_call_pending", default=None
-)
+# (pending: name -> FIFO of tc_ids, bound: nat_uuid -> tc_id)
+_state: ContextVar[tuple[dict[str, deque[str]], dict[str, str]]] = ContextVar("dragent_tc")
+
+
+def _get() -> tuple[dict[str, deque[str]], dict[str, str]]:
+    try:
+        return _state.get()
+    except LookupError:
+        s: tuple[dict[str, deque[str]], dict[str, str]] = ({}, {})
+        _state.set(s)
+        return s
 
 
 def register_tool_call(name: str, tool_call_id: str) -> None:
-    """Record ``tool_call_id`` for the next ``FUNCTION_END`` of ``name``."""
-    pending = _pending.get()
-    if pending is None:
-        pending = {}
-        _pending.set(pending)
+    pending, _ = _get()
     pending.setdefault(name, deque()).append(tool_call_id)
 
 
-def pop_tool_call(name: str) -> str | None:
-    """Pop the next pending ``tool_call_id`` for ``name``, or ``None``."""
-    pending = _pending.get()
-    if pending is None:
-        return None
+def bind_tool_call(name: str, nat_uuid: str) -> str | None:
+    pending, bound = _get()
     queue = pending.get(name)
     if not queue:
         return None
-    tool_call_id = queue.popleft()
-    if not queue:
-        pending.pop(name, None)
-    return tool_call_id
+    bound[nat_uuid] = tc_id = queue.popleft()
+    return tc_id
+
+
+def pop_tool_call(nat_uuid: str) -> str | None:
+    return _get()[1].pop(nat_uuid, None)
 
 
 def reset() -> None:
-    """Clear pending state for the current context. For tests."""
-    _pending.set({})
+    _state.set(({}, {}))

--- a/tests/dragent/frontends/test_step_adaptor.py
+++ b/tests/dragent/frontends/test_step_adaptor.py
@@ -665,8 +665,6 @@ def test_step_adaptor_processes_nested_reasoning_steps(
     actual_responses = []
     for step in intermediate_steps_for_nested_reasoning:
         result = step_adaptor.process(step)
-        # FUNCTION_START / unmatched FUNCTION_END are suppressed by
-        # returning None so they don't fall through to _handle_custom.
         if result is None:
             continue
         assert isinstance(result, DRAgentEventResponse)

--- a/tests/dragent/frontends/test_step_adaptor.py
+++ b/tests/dragent/frontends/test_step_adaptor.py
@@ -15,7 +15,6 @@
 import json
 import uuid
 from types import SimpleNamespace
-from unittest import mock
 
 import pytest
 from ag_ui.core import CustomEvent
@@ -48,6 +47,15 @@ from nat.data_models.step_adaptor import StepAdaptorMode
 
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.step_adaptor import DRAgentNestedReasoningStepAdaptor
+from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
+from datarobot_genai.dragent.frontends.tool_call_registry import reset as reset_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    reset_registry()
+    yield
+    reset_registry()
 
 
 @pytest.fixture
@@ -124,7 +132,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 StepStartedEvent(step_name="tool_calling_agent"),
             ]
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[TextMessageStartEvent(message_id=intermediate_steps_ids["agent_message_id"])],
             model="vertex_ai/claude-3-5-haiku@20241022",
@@ -156,7 +163,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallStartEvent(
@@ -169,7 +175,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ReasoningStartEvent(message_id=intermediate_steps_ids["planner_message_id"]),
@@ -195,7 +200,6 @@ def expected_responses(intermediate_steps_ids, payloads):
             ],
             model="claude-3-5-haiku@20241022",
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(tool_call_id=intermediate_steps_ids["planner_tool_call_id"]),
@@ -219,7 +223,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_START", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ReasoningStartEvent(message_id=intermediate_steps_ids["writer_message_id"]),
@@ -245,7 +248,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 "total_tokens": 700,
             },
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(tool_call_id=intermediate_steps_ids["writer_tool_call_id"]),
@@ -257,7 +259,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 ToolCallEndEvent(
@@ -271,7 +272,6 @@ def expected_responses(intermediate_steps_ids, payloads):
                 ),
             ]
         ),
-        DRAgentEventResponse(events=[CustomEvent(name="FUNCTION_END", value=mock.ANY)]),
         DRAgentEventResponse(
             events=[
                 StepFinishedEvent(step_name="tool_calling_agent"),
@@ -665,7 +665,10 @@ def test_step_adaptor_processes_nested_reasoning_steps(
     actual_responses = []
     for step in intermediate_steps_for_nested_reasoning:
         result = step_adaptor.process(step)
-        assert result is not None
+        # FUNCTION_START / unmatched FUNCTION_END are suppressed by
+        # returning None so they don't fall through to _handle_custom.
+        if result is None:
+            continue
         assert isinstance(result, DRAgentEventResponse)
         actual_responses.append(result)
 
@@ -774,3 +777,81 @@ class TestHandleToolArgsEncoding:
         response = step_adaptor.process(step)
         args_event = next(e for e in response.events if isinstance(e, ToolCallArgsEvent))
         assert args_event.delta == "{}"
+
+
+class TestFunctionToolCorrelation:
+    """When the parent agent dispatches a function as a tool but NAT does not
+    fire ``TOOL_*`` events, the step adaptor pops the LLM's ``tool_call_id``
+    (published by the converter on ``ToolCallStartEvent``) at ``FUNCTION_END``
+    and emits ``ToolCallEndEvent`` + ``ToolCallResultEvent``.
+    """
+
+    @staticmethod
+    def _function_step(
+        event_type: IntermediateStepType,
+        name: str,
+        output: object | None,
+    ) -> IntermediateStep:
+        return IntermediateStep(
+            parent_id="agent",
+            function_ancestry=InvocationNode(
+                function_id="agent",
+                function_name="agent",
+                parent_id=None,
+                parent_name=None,
+            ),
+            payload=IntermediateStepPayload(
+                event_type=event_type,
+                name=name,
+                UUID=str(uuid.uuid4()),
+                data=StreamEventData(input=None, output=output),
+            ),
+        )
+
+    def test_function_end_emits_end_then_result_when_matched(
+        self, step_adaptor: DRAgentNestedReasoningStepAdaptor
+    ) -> None:
+        llm_tool_call_id = "toolu_vrtx_planner"
+        register_tool_call("planner", llm_tool_call_id)
+
+        start = step_adaptor.process(
+            self._function_step(IntermediateStepType.FUNCTION_START, "planner", output=None)
+        )
+        end = step_adaptor.process(
+            self._function_step(
+                IntermediateStepType.FUNCTION_END, "planner", output="planner output"
+            )
+        )
+
+        # End must precede Result; reversing them leaves the UI stuck in
+        # "args streaming" state.
+        assert start is None
+        assert len(end.events) == 2
+        assert isinstance(end.events[0], ToolCallEndEvent)
+        assert end.events[0].tool_call_id == llm_tool_call_id
+        assert isinstance(end.events[1], ToolCallResultEvent)
+        assert end.events[1].tool_call_id == llm_tool_call_id
+        assert end.events[1].message_id == llm_tool_call_id
+        assert end.events[1].content == "planner output"
+        assert end.events[1].role == "tool"
+
+    def test_function_end_returns_none_when_unmatched(
+        self, step_adaptor: DRAgentNestedReasoningStepAdaptor
+    ) -> None:
+        # FUNCTION_END for a function not dispatched as a tool returns None.
+        # The legacy CustomEvent fall-through leaked the entire run's event
+        # stream via value.data.output, rendered as a duplicate thread.
+        response = step_adaptor.process(
+            self._function_step(IntermediateStepType.FUNCTION_END, "untracked", output="ignored")
+        )
+
+        assert response is None
+
+    def test_function_start_returns_none(
+        self, step_adaptor: DRAgentNestedReasoningStepAdaptor
+    ) -> None:
+        response = step_adaptor.process(
+            self._function_step(IntermediateStepType.FUNCTION_START, "untracked", output=None)
+        )
+
+        assert response is None

--- a/tests/dragent/frontends/test_step_adaptor.py
+++ b/tests/dragent/frontends/test_step_adaptor.py
@@ -779,9 +779,10 @@ class TestHandleToolArgsEncoding:
 
 class TestFunctionToolCorrelation:
     """When the parent agent dispatches a function as a tool but NAT does not
-    fire ``TOOL_*`` events, the step adaptor pops the LLM's ``tool_call_id``
-    (published by the converter on ``ToolCallStartEvent``) at ``FUNCTION_END``
-    and emits ``ToolCallEndEvent`` + ``ToolCallResultEvent``.
+    fire ``TOOL_*`` events, the step adaptor binds the LLM's ``tool_call_id``
+    (published by the converter on ``ToolCallStartEvent``) to the NAT
+    ``payload.UUID`` at ``FUNCTION_START`` and emits ``ToolCallEndEvent`` +
+    ``ToolCallResultEvent`` keyed by that UUID at ``FUNCTION_END``.
     """
 
     @staticmethod
@@ -789,6 +790,7 @@ class TestFunctionToolCorrelation:
         event_type: IntermediateStepType,
         name: str,
         output: object | None,
+        nat_uuid: str | None = None,
     ) -> IntermediateStep:
         return IntermediateStep(
             parent_id="agent",
@@ -801,7 +803,7 @@ class TestFunctionToolCorrelation:
             payload=IntermediateStepPayload(
                 event_type=event_type,
                 name=name,
-                UUID=str(uuid.uuid4()),
+                UUID=nat_uuid if nat_uuid is not None else str(uuid.uuid4()),
                 data=StreamEventData(input=None, output=output),
             ),
         )
@@ -810,14 +812,20 @@ class TestFunctionToolCorrelation:
         self, step_adaptor: DRAgentNestedReasoningStepAdaptor
     ) -> None:
         llm_tool_call_id = "toolu_vrtx_planner"
+        nat_uuid = "nat-planner-1"
         register_tool_call("planner", llm_tool_call_id)
 
         start = step_adaptor.process(
-            self._function_step(IntermediateStepType.FUNCTION_START, "planner", output=None)
+            self._function_step(
+                IntermediateStepType.FUNCTION_START, "planner", output=None, nat_uuid=nat_uuid
+            )
         )
         end = step_adaptor.process(
             self._function_step(
-                IntermediateStepType.FUNCTION_END, "planner", output="planner output"
+                IntermediateStepType.FUNCTION_END,
+                "planner",
+                output="planner output",
+                nat_uuid=nat_uuid,
             )
         )
 
@@ -832,6 +840,51 @@ class TestFunctionToolCorrelation:
         assert end.events[1].message_id == llm_tool_call_id
         assert end.events[1].content == "planner output"
         assert end.events[1].role == "tool"
+
+    def test_parallel_same_name_calls_correlate_by_uuid(
+        self, step_adaptor: DRAgentNestedReasoningStepAdaptor
+    ) -> None:
+        # The LLM dispatches two parallel calls to the same tool. NAT fires
+        # FUNCTION_START in dispatch order but FUNCTION_END can arrive in
+        # any order. Each result must bind to the matching LLM tool_call_id.
+        register_tool_call("search", "tc-A")
+        register_tool_call("search", "tc-B")
+
+        step_adaptor.process(
+            self._function_step(
+                IntermediateStepType.FUNCTION_START, "search", output=None, nat_uuid="nat-A"
+            )
+        )
+        step_adaptor.process(
+            self._function_step(
+                IntermediateStepType.FUNCTION_START, "search", output=None, nat_uuid="nat-B"
+            )
+        )
+
+        # Second dispatch finishes first.
+        end_b = step_adaptor.process(
+            self._function_step(
+                IntermediateStepType.FUNCTION_END,
+                "search",
+                output="result B",
+                nat_uuid="nat-B",
+            )
+        )
+        end_a = step_adaptor.process(
+            self._function_step(
+                IntermediateStepType.FUNCTION_END,
+                "search",
+                output="result A",
+                nat_uuid="nat-A",
+            )
+        )
+
+        assert end_b.events[0].tool_call_id == "tc-B"
+        assert end_b.events[1].tool_call_id == "tc-B"
+        assert end_b.events[1].content == "result B"
+        assert end_a.events[0].tool_call_id == "tc-A"
+        assert end_a.events[1].tool_call_id == "tc-A"
+        assert end_a.events[1].content == "result A"
 
     def test_function_end_returns_none_when_unmatched(
         self, step_adaptor: DRAgentNestedReasoningStepAdaptor

--- a/tests/dragent/frontends/test_step_adaptor.py
+++ b/tests/dragent/frontends/test_step_adaptor.py
@@ -778,12 +778,7 @@ class TestHandleToolArgsEncoding:
 
 
 class TestFunctionToolCorrelation:
-    """When the parent agent dispatches a function as a tool but NAT does not
-    fire ``TOOL_*`` events, the step adaptor binds the LLM's ``tool_call_id``
-    (published by the converter on ``ToolCallStartEvent``) to the NAT
-    ``payload.UUID`` at ``FUNCTION_START`` and emits ``ToolCallEndEvent`` +
-    ``ToolCallResultEvent`` keyed by that UUID at ``FUNCTION_END``.
-    """
+    """Sub-agents-as-tools fire only FUNCTION_*; adaptor closes via the registry."""
 
     @staticmethod
     def _function_step(
@@ -829,8 +824,7 @@ class TestFunctionToolCorrelation:
             )
         )
 
-        # End must precede Result; reversing them leaves the UI stuck in
-        # "args streaming" state.
+        # End before Result; reversed order strands the UI in args streaming.
         assert start is None
         assert len(end.events) == 2
         assert isinstance(end.events[0], ToolCallEndEvent)
@@ -838,15 +832,12 @@ class TestFunctionToolCorrelation:
         assert isinstance(end.events[1], ToolCallResultEvent)
         assert end.events[1].tool_call_id == llm_tool_call_id
         assert end.events[1].message_id == llm_tool_call_id
-        assert end.events[1].content == "planner output"
+        assert end.events[1].content == '"planner output"'
         assert end.events[1].role == "tool"
 
     def test_parallel_same_name_calls_correlate_by_uuid(
         self, step_adaptor: DRAgentNestedReasoningStepAdaptor
     ) -> None:
-        # The LLM dispatches two parallel calls to the same tool. NAT fires
-        # FUNCTION_START in dispatch order but FUNCTION_END can arrive in
-        # any order. Each result must bind to the matching LLM tool_call_id.
         register_tool_call("search", "tc-A")
         register_tool_call("search", "tc-B")
 
@@ -881,17 +872,15 @@ class TestFunctionToolCorrelation:
 
         assert end_b.events[0].tool_call_id == "tc-B"
         assert end_b.events[1].tool_call_id == "tc-B"
-        assert end_b.events[1].content == "result B"
+        assert end_b.events[1].content == '"result B"'
         assert end_a.events[0].tool_call_id == "tc-A"
         assert end_a.events[1].tool_call_id == "tc-A"
-        assert end_a.events[1].content == "result A"
+        assert end_a.events[1].content == '"result A"'
 
     def test_function_end_returns_none_when_unmatched(
         self, step_adaptor: DRAgentNestedReasoningStepAdaptor
     ) -> None:
-        # FUNCTION_END for a function not dispatched as a tool returns None.
-        # The legacy CustomEvent fall-through leaked the entire run's event
-        # stream via value.data.output, rendered as a duplicate thread.
+        # Legacy CustomEvent fall-through leaked the run via value.data.output.
         response = step_adaptor.process(
             self._function_step(IntermediateStepType.FUNCTION_END, "untracked", output="ignored")
         )

--- a/tests/dragent/frontends/test_stream_converter.py
+++ b/tests/dragent/frontends/test_stream_converter.py
@@ -30,6 +30,7 @@ from nat.data_models.api_server import ChoiceDeltaToolCall
 from nat.data_models.api_server import ChoiceDeltaToolCallFunction
 
 from datarobot_genai.dragent.frontends.stream_converter import convert_chunks_to_agui_events
+from datarobot_genai.dragent.frontends.tool_call_registry import bind_tool_call
 from datarobot_genai.dragent.frontends.tool_call_registry import pop_tool_call
 from datarobot_genai.dragent.frontends.tool_call_registry import reset as reset_registry
 
@@ -298,7 +299,9 @@ class TestToolCallRegistry:
         )
         await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
 
-        # The step adaptor pops the registered id by tool name on
-        # FUNCTION_END to bind ToolCallResult to the same id the LLM exposed.
-        assert pop_tool_call("planner") == "tc-1"
-        assert pop_tool_call("planner") is None
+        # The step adaptor binds by name on FUNCTION_START to the NAT UUID,
+        # then pops by NAT UUID on FUNCTION_END to bind ToolCallResult to
+        # the same id the LLM exposed.
+        assert bind_tool_call("planner", "nat-uuid-1") == "tc-1"
+        assert pop_tool_call("nat-uuid-1") == "tc-1"
+        assert bind_tool_call("planner", "nat-uuid-2") is None

--- a/tests/dragent/frontends/test_stream_converter.py
+++ b/tests/dragent/frontends/test_stream_converter.py
@@ -169,6 +169,44 @@ class TestToolCall:
         assert args_events[1].tool_call_id == "tc-1"
 
     @pytest.mark.asyncio
+    async def test_tool_call_after_text_threads_under_text_message_id(self):
+        text = _make_chunk(content="Let me check.", chunk_id="msg-1")
+        tool_call = _make_chunk(
+            tool_calls=[
+                ChoiceDeltaToolCall(
+                    index=0,
+                    id="tc-1",
+                    function=ChoiceDeltaToolCallFunction(name="search", arguments="{}"),
+                )
+            ]
+        )
+        responses = await _collect(convert_chunks_to_agui_events(_async_iter(text, tool_call)))
+        events = _flat_events(responses)
+
+        start = next(e for e in events if isinstance(e, ToolCallStartEvent))
+        assert start.parent_message_id == "msg-1"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_with_no_preceding_text_uses_empty_parent(self):
+        # When the LLM emits tool calls without any preceding text message,
+        # parent_message_id falls back to "" (matching langgraph adapter
+        # convention) rather than None or a phantom uuid.
+        chunk = _make_chunk(
+            tool_calls=[
+                ChoiceDeltaToolCall(
+                    index=0,
+                    id="tc-1",
+                    function=ChoiceDeltaToolCallFunction(name="search", arguments="{}"),
+                )
+            ]
+        )
+        responses = await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
+        events = _flat_events(responses)
+
+        start = next(e for e in events if isinstance(e, ToolCallStartEvent))
+        assert start.parent_message_id == ""
+
+    @pytest.mark.asyncio
     async def test_multiple_parallel_tool_calls(self):
         chunk = _make_chunk(
             tool_calls=[

--- a/tests/dragent/frontends/test_stream_converter.py
+++ b/tests/dragent/frontends/test_stream_converter.py
@@ -133,8 +133,6 @@ class TestToolCall:
         responses = await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
         events = _flat_events(responses)
 
-        # Step adaptor owns ToolCallEnd at FUNCTION_END; converter only
-        # emits Start + Args.
         assert len(events) == 2
         assert isinstance(events[0], ToolCallStartEvent)
         assert events[0].tool_call_id == "tc-1"
@@ -190,9 +188,7 @@ class TestToolCall:
 
     @pytest.mark.asyncio
     async def test_tool_call_with_no_preceding_text_uses_empty_parent(self):
-        # When the LLM emits tool calls without any preceding text message,
-        # parent_message_id falls back to "" (matching langgraph adapter
-        # convention) rather than None or a phantom uuid.
+        # Falls back to "" (langgraph convention), not a phantom uuid.
         chunk = _make_chunk(
             tool_calls=[
                 ChoiceDeltaToolCall(
@@ -227,8 +223,6 @@ class TestToolCall:
         responses = await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
         events = _flat_events(responses)
 
-        # Step adaptor closes each tool call at FUNCTION_END; converter
-        # only emits Start (and Args).
         start_events = [e for e in events if isinstance(e, ToolCallStartEvent)]
         end_events = [e for e in events if isinstance(e, ToolCallEndEvent)]
         assert len(start_events) == 2
@@ -286,9 +280,7 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_stream_ending_with_active_tool_calls_emits_no_end(self):
-        # The step adaptor closes tool calls at FUNCTION_END. The converter
-        # must not emit a duplicate ToolCallEndEvent in its post-loop, which
-        # would fire a second End for the same tool_call_id.
+        # Adaptor owns End; a post-loop End here would duplicate it.
         chunk = _make_chunk(
             tool_calls=[
                 ChoiceDeltaToolCall(
@@ -305,9 +297,7 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_stream_error_after_tool_call_emits_no_tool_call_end(self):
-        # On stream error mid-tool-call, RunErrorEvent terminates the run
-        # for the client; emitting ToolCallEndEvent here would duplicate the
-        # adaptor's End if the tool actually ran before the error.
+        # RunErrorEvent is terminal for the run; client closes any in-flight call.
         async def _failing_gen():
             yield _make_chunk(
                 tool_calls=[
@@ -344,9 +334,6 @@ class TestToolCallRegistry:
         )
         await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
 
-        # The step adaptor binds by name on FUNCTION_START to the NAT UUID,
-        # then pops by NAT UUID on FUNCTION_END to bind ToolCallResult to
-        # the same id the LLM exposed.
         assert bind_tool_call("planner", "nat-uuid-1") == "tc-1"
         assert pop_tool_call("nat-uuid-1") == "tc-1"
         assert bind_tool_call("planner", "nat-uuid-2") is None

--- a/tests/dragent/frontends/test_stream_converter.py
+++ b/tests/dragent/frontends/test_stream_converter.py
@@ -30,6 +30,16 @@ from nat.data_models.api_server import ChoiceDeltaToolCall
 from nat.data_models.api_server import ChoiceDeltaToolCallFunction
 
 from datarobot_genai.dragent.frontends.stream_converter import convert_chunks_to_agui_events
+from datarobot_genai.dragent.frontends.tool_call_registry import pop_tool_call
+from datarobot_genai.dragent.frontends.tool_call_registry import reset as reset_registry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
 
 # --- Helpers ---
 
@@ -231,3 +241,26 @@ class TestErrorHandling:
         gen = convert_chunks_to_agui_events(_slow_gen())
         await gen.__anext__()
         await gen.aclose()
+
+
+# --- Registry integration ---
+
+
+class TestToolCallRegistry:
+    @pytest.mark.asyncio
+    async def test_tool_call_start_publishes_to_registry(self):
+        chunk = _make_chunk(
+            tool_calls=[
+                ChoiceDeltaToolCall(
+                    index=0,
+                    id="tc-1",
+                    function=ChoiceDeltaToolCallFunction(name="planner", arguments="{}"),
+                )
+            ]
+        )
+        await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
+
+        # The step adaptor pops the registered id by tool name on
+        # FUNCTION_END to bind ToolCallResult to the same id the LLM exposed.
+        assert pop_tool_call("planner") == "tc-1"
+        assert pop_tool_call("planner") is None

--- a/tests/dragent/frontends/test_stream_converter.py
+++ b/tests/dragent/frontends/test_stream_converter.py
@@ -133,13 +133,14 @@ class TestToolCall:
         responses = await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
         events = _flat_events(responses)
 
-        assert len(events) == 3
+        # Step adaptor owns ToolCallEnd at FUNCTION_END; converter only
+        # emits Start + Args.
+        assert len(events) == 2
         assert isinstance(events[0], ToolCallStartEvent)
         assert events[0].tool_call_id == "tc-1"
         assert events[0].tool_call_name == "get_weather"
         assert isinstance(events[1], ToolCallArgsEvent)
         assert events[1].delta == '{"loc":'
-        assert isinstance(events[2], ToolCallEndEvent)
 
     @pytest.mark.asyncio
     async def test_tool_call_followup_chunks_use_index_lookup(self):
@@ -226,11 +227,13 @@ class TestToolCall:
         responses = await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
         events = _flat_events(responses)
 
+        # Step adaptor closes each tool call at FUNCTION_END; converter
+        # only emits Start (and Args).
         start_events = [e for e in events if isinstance(e, ToolCallStartEvent)]
         end_events = [e for e in events if isinstance(e, ToolCallEndEvent)]
         assert len(start_events) == 2
         assert {e.tool_call_id for e in start_events} == {"tc-1", "tc-2"}
-        assert len(end_events) == 2
+        assert end_events == []
 
 
 # --- Edge cases ---
@@ -280,6 +283,48 @@ class TestErrorHandling:
         gen = convert_chunks_to_agui_events(_slow_gen())
         await gen.__anext__()
         await gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_stream_ending_with_active_tool_calls_emits_no_end(self):
+        # The step adaptor closes tool calls at FUNCTION_END. The converter
+        # must not emit a duplicate ToolCallEndEvent in its post-loop, which
+        # would fire a second End for the same tool_call_id.
+        chunk = _make_chunk(
+            tool_calls=[
+                ChoiceDeltaToolCall(
+                    index=0,
+                    id="tc-1",
+                    function=ChoiceDeltaToolCallFunction(name="search", arguments="{}"),
+                )
+            ]
+        )
+        responses = await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
+        events = _flat_events(responses)
+
+        assert [e for e in events if isinstance(e, ToolCallEndEvent)] == []
+
+    @pytest.mark.asyncio
+    async def test_stream_error_after_tool_call_emits_no_tool_call_end(self):
+        # On stream error mid-tool-call, RunErrorEvent terminates the run
+        # for the client; emitting ToolCallEndEvent here would duplicate the
+        # adaptor's End if the tool actually ran before the error.
+        async def _failing_gen():
+            yield _make_chunk(
+                tool_calls=[
+                    ChoiceDeltaToolCall(
+                        index=0,
+                        id="tc-1",
+                        function=ChoiceDeltaToolCallFunction(name="search", arguments="{}"),
+                    )
+                ]
+            )
+            raise RuntimeError("boom")
+
+        responses = await _collect(convert_chunks_to_agui_events(_failing_gen()))
+        events = _flat_events(responses)
+
+        assert [e for e in events if isinstance(e, ToolCallEndEvent)] == []
+        assert any(isinstance(e, RunErrorEvent) for e in events)
 
 
 # --- Registry integration ---

--- a/tests/dragent/frontends/test_tool_call_registry.py
+++ b/tests/dragent/frontends/test_tool_call_registry.py
@@ -16,6 +16,7 @@ from collections.abc import Iterator
 
 import pytest
 
+from datarobot_genai.dragent.frontends.tool_call_registry import bind_tool_call
 from datarobot_genai.dragent.frontends.tool_call_registry import pop_tool_call
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
 from datarobot_genai.dragent.frontends.tool_call_registry import reset
@@ -29,33 +30,60 @@ def _reset_registry() -> Iterator[None]:
 
 
 def test_pop_returns_none_when_nothing_registered() -> None:
-    assert pop_tool_call("missing") is None
+    assert pop_tool_call("nat-uuid-missing") is None
 
 
-def test_register_then_pop_round_trip() -> None:
+def test_bind_returns_none_when_no_pending_for_name() -> None:
+    # Internal NAT functions that were not dispatched as a tool by the LLM
+    # arrive with a name that has no registered tool_call_id.
+    assert bind_tool_call("internal-helper", "nat-uuid-1") is None
+
+
+def test_register_then_bind_then_pop_round_trip() -> None:
     register_tool_call("planner", "tc-1")
-    assert pop_tool_call("planner") == "tc-1"
-    assert pop_tool_call("planner") is None
+
+    assert bind_tool_call("planner", "nat-uuid-1") == "tc-1"
+    assert pop_tool_call("nat-uuid-1") == "tc-1"
+    assert pop_tool_call("nat-uuid-1") is None
 
 
-def test_pops_in_fifo_order_per_name() -> None:
+def test_binds_in_dispatch_order_per_name() -> None:
+    # The LLM dispatches two same-name calls; FUNCTION_START fires for each
+    # in dispatch order, so registering and binding must pair them as
+    # tc-1->nat-1 and tc-2->nat-2 regardless of completion order.
     register_tool_call("planner", "tc-1")
     register_tool_call("planner", "tc-2")
 
-    assert pop_tool_call("planner") == "tc-1"
-    assert pop_tool_call("planner") == "tc-2"
-    assert pop_tool_call("planner") is None
+    assert bind_tool_call("planner", "nat-1") == "tc-1"
+    assert bind_tool_call("planner", "nat-2") == "tc-2"
+    assert bind_tool_call("planner", "nat-3") is None
+
+
+def test_pop_by_uuid_tolerates_out_of_order_completion() -> None:
+    register_tool_call("planner", "tc-1")
+    register_tool_call("planner", "tc-2")
+    bind_tool_call("planner", "nat-1")
+    bind_tool_call("planner", "nat-2")
+
+    # Second dispatch finishes first.
+    assert pop_tool_call("nat-2") == "tc-2"
+    assert pop_tool_call("nat-1") == "tc-1"
 
 
 def test_isolates_per_name() -> None:
     register_tool_call("planner", "tc-1")
     register_tool_call("writer", "tc-2")
 
-    assert pop_tool_call("writer") == "tc-2"
-    assert pop_tool_call("planner") == "tc-1"
+    assert bind_tool_call("writer", "nat-w") == "tc-2"
+    assert bind_tool_call("planner", "nat-p") == "tc-1"
+    assert pop_tool_call("nat-p") == "tc-1"
+    assert pop_tool_call("nat-w") == "tc-2"
 
 
 def test_reset_clears_pending() -> None:
     register_tool_call("planner", "tc-1")
+    bind_tool_call("planner", "nat-1")
     reset()
-    assert pop_tool_call("planner") is None
+
+    assert pop_tool_call("nat-1") is None
+    assert bind_tool_call("planner", "nat-1") is None

--- a/tests/dragent/frontends/test_tool_call_registry.py
+++ b/tests/dragent/frontends/test_tool_call_registry.py
@@ -34,8 +34,6 @@ def test_pop_returns_none_when_nothing_registered() -> None:
 
 
 def test_bind_returns_none_when_no_pending_for_name() -> None:
-    # Internal NAT functions that were not dispatched as a tool by the LLM
-    # arrive with a name that has no registered tool_call_id.
     assert bind_tool_call("internal-helper", "nat-uuid-1") is None
 
 
@@ -48,9 +46,6 @@ def test_register_then_bind_then_pop_round_trip() -> None:
 
 
 def test_binds_in_dispatch_order_per_name() -> None:
-    # The LLM dispatches two same-name calls; FUNCTION_START fires for each
-    # in dispatch order, so registering and binding must pair them as
-    # tc-1->nat-1 and tc-2->nat-2 regardless of completion order.
     register_tool_call("planner", "tc-1")
     register_tool_call("planner", "tc-2")
 
@@ -65,7 +60,6 @@ def test_pop_by_uuid_tolerates_out_of_order_completion() -> None:
     bind_tool_call("planner", "nat-1")
     bind_tool_call("planner", "nat-2")
 
-    # Second dispatch finishes first.
     assert pop_tool_call("nat-2") == "tc-2"
     assert pop_tool_call("nat-1") == "tc-1"
 

--- a/tests/dragent/frontends/test_tool_call_registry.py
+++ b/tests/dragent/frontends/test_tool_call_registry.py
@@ -1,0 +1,61 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+
+import pytest
+
+from datarobot_genai.dragent.frontends.tool_call_registry import pop_tool_call
+from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
+from datarobot_genai.dragent.frontends.tool_call_registry import reset
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    reset()
+    yield
+    reset()
+
+
+def test_pop_returns_none_when_nothing_registered() -> None:
+    assert pop_tool_call("missing") is None
+
+
+def test_register_then_pop_round_trip() -> None:
+    register_tool_call("planner", "tc-1")
+    assert pop_tool_call("planner") == "tc-1"
+    assert pop_tool_call("planner") is None
+
+
+def test_pops_in_fifo_order_per_name() -> None:
+    register_tool_call("planner", "tc-1")
+    register_tool_call("planner", "tc-2")
+
+    assert pop_tool_call("planner") == "tc-1"
+    assert pop_tool_call("planner") == "tc-2"
+    assert pop_tool_call("planner") is None
+
+
+def test_isolates_per_name() -> None:
+    register_tool_call("planner", "tc-1")
+    register_tool_call("writer", "tc-2")
+
+    assert pop_tool_call("writer") == "tc-2"
+    assert pop_tool_call("planner") == "tc-1"
+
+
+def test_reset_clears_pending() -> None:
+    register_tool_call("planner", "tc-1")
+    reset()
+    assert pop_tool_call("planner") is None

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.34"
+version = "0.15.35"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Five issues in the event stream

## 1. `parent_message_id` on `TOOL_CALL_START` points to phantom UUIDs

- Planner: `parentMessageId: "f4a1be50-716b-4495-b055-f807546a7f1b"`
- Writer: `parentMessageId: "000f4b97-1827-4146-913c-825fb2e9d3f2"`

Neither id appears anywhere else in the stream as a message id. The preceding assistant text messages were `89b09756...` and `15a386a3...`. Tool calls reference message ids that were never started, so clients render an orphan message stub.

## 2. No `TOOL_CALL_RESULT` events anywhere in the run

Every `TOOL_CALL_START` has a matching `TOOL_CALL_END`, but the stream contains zero `TOOL_CALL_RESULT` events. The tool output exists (it's in `FUNCTION_END.data.output`) but is never surfaced as a Result event, so clients can't bind the output to the call and the call card stays in a running state.

## 3. `TOOL_CALL_END` fires after the tool has already completed

For planner, the order is:

```
FUNCTION_START (planner)
FUNCTION_END   (planner)   ← tool already finished, output present
Heartbeat
TOOL_CALL_END  (planner)   ← fired only when LLM text resumes
```

`TOOL_CALL_END` is bound to LLM-stream text resumption, not to actual tool completion. The lifecycle is misaligned with reality.

## 4. Outer `<workflow>` `FUNCTION_END` carries the entire serialized run as a `CustomEvent`

The final `CUSTOM FUNCTION_END` event has `name: "<workflow>"` and `data.output` containing the full event list of the run (it's the bulk of the bytes in this trace). This payload is shipped to clients as a `CustomEvent`, duplicating the entire stream.

## 5. Every nested `FUNCTION_START` / `FUNCTION_END` is emitted as a `CustomEvent`

`<workflow>`, `planner`, and `writer` each fire `CUSTOM FUNCTION_START` and `CUSTOM FUNCTION_END` events that carry internal NAT lifecycle data. These leak as `CustomEvents` on the wire even though they have no AG-UI semantics — pure noise that clients have to filter.


<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts streaming event ordering and tool-call completion semantics in the dragent frontend; bugs here can strand UIs or mis-associate tool results across parallel calls.
> 
> **Overview**
> Fixes AG-UI tool-call lifecycle in the `dragent` NAT frontend by **correlating LLM tool-call IDs with actual tool completion** and emitting `ToolCallEndEvent`/`ToolCallResultEvent` only when the underlying tool/function finishes.
> 
> Adds a per-run `tool_call_registry` to hand off LLM-issued `tool_call_id`s from `stream_converter` to `step_adaptor`, threads tool calls under the last assistant text message (avoiding orphan tool messages), and stops leaking unhandled `FUNCTION_*` steps as `CustomEvent`s. Updates/extends unit tests to cover registry behavior, parent message threading, and out-of-order parallel tool completion; bumps version to `0.15.35`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ad73b08ecc9e2f8f8fa5f76b46fcda061b4a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->