### PR TITLE
[-] Bump version to 0.15.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `okta-client-python` dependency into the `auth` extra.
 - Server-side config tag was renamed from `oauth_token_exchange` into `cross_application_access`.
 
-## 0.15.35
+## 0.15.36
 - Fixed AG-UI tool call lifecycle in dragent frontends.
 
 ## 0.15.34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.36
+- Fixed AG-UI tool call lifecycle in dragent frontends.
+
 ## 0.15.35
 - Added Okta Cross-Application Access (XAA) support for A2A agent-to-agent calls via the new `okta_cross_app_access` auth provider.
 - Server-side XAA parameters are declared in `workflow.yaml` under `cross_application_access` and published on the AgentCard: OpenAPI `clientCredentials` security scheme plus a JWT Bearer capability extension containing the two-step flow parameters (RFC 8693 → RFC 7523).
 - Client-side: `OktaCrossApplicationAccessAuthProvider` reads the AgentCard extension at runtime, performs the two-step token exchange via `okta-client-python`, and requires only `PRINCIPAL_ID` / `PRIVATE_JWK` env vars.
 - Added `okta-client-python` dependency into the `auth` extra.
 - Server-side config tag was renamed from `oauth_token_exchange` into `cross_application_access`.
-
-## 0.15.36
-- Fixed AG-UI tool call lifecycle in dragent frontends.
 
 ## 0.15.34
 - Fixed AG-UI event lifecycle in the LlamaIndex agent adapter: each agent step emits its own message bubble and a matching `STEP_FINISHED`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.35"
+version = "0.15.36"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1086,7 +1086,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.35"
+version = "0.15.36"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- PR #335 merged without bumping `pyproject.toml` past PR #321's `0.15.35`, so two changelog entries ended up under the same version.
- Bump `pyproject.toml` (and `uv.lock` workspace entry) to `0.15.36`.
- Move the AG-UI tool-call-lifecycle changelog entry from #335 under `## 0.15.36`.

## Test plan
- [ ] CI green (version-check-and-bump pre-commit passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: only updates version metadata and reorganizes a changelog entry, with no runtime code changes.
> 
> **Overview**
> Bumps the package version from `0.15.35` to `0.15.36` in `pyproject.toml` and the `uv.lock` workspace entry.
> 
> Reorders `CHANGELOG.md` to add a new `0.15.36` section and moves the “AG-UI tool call lifecycle” fix out of `0.15.35` so each release has a unique entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c70c738795ff09af6a1cdda12fba5d49bd41a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->