### PR TITLE
NAT auto memory wrapper client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.41
+- Added a NAT `dr_mem0_memory` provider that adapts `datarobot-genai[memory]`'s Mem0 client to NAT's `MemoryEditor` interface for `auto_memory_agent`.
+- Documented Mem0 automatic-memory workflow configuration for NAT.
+
 ## 0.15.40
 - Simplified cross-application access `workflow.yaml` config: IETF URNs and auth method defaults are now injected by the AgentCard generator rather than declared by the developer.
 - Added `urn:datarobot:agent:identity:internal` and `urn:datarobot:agent:identity:external` AgentCard extensions, and an optional external URL override (`general.frontend.a2a.external.url`).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can also install:
 * `datarobot-genai[dragent]`&mdash;serve and orchestrate your agent with `DRAgent`.
 * `datarobot-genai[drtools]`&mdash;use the standard library of agentic tools DataRobot provides.
 * `datarobot-genai[drmcp]`&mdash;host a custom MCP server in DataRobot.
+* `datarobot-genai[memory]`&mdash;use the Mem0-backed memory client and NAT memory provider.
 
 ## Credentials
 You need a DataRobot account to use DataRobot-backed features. Export these environment variables:

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Each guide walks you through the **interfaces in the repo**: `workflow.yaml` key
 
 For shared **LLM routing** (gateway vs deployment vs NIM vs external), see [LLM configuration](llm.md).
 For native **primary/fallback failover** changes in an existing component, see [LLM provider fallback (router)](fallback.md).
+For NAT automatic memory with Mem0, see [nat/memory.md](nat/memory.md).
 
 **Note:** With NAT, you edit **`workflow.yaml`** as the contract. Host workflows with DRAgent for the supported path. You can still load the same YAML in process without DRAgent (legacy); target DRAgent for new work.
 

--- a/docs/nat/agent.md
+++ b/docs/nat/agent.md
@@ -39,6 +39,10 @@ Those names are what you list under **`workflow.tool_names`**.
 
 The example defines **`datarobot_mcp_auth`** so MCP requests carry the same kind of auth as the rest of the DataRobot stack. See [mcp.md](mcp.md).
 
+## `memory` — optional long-term memory
+
+Use **`_type: dr_mem0_memory`** under **`memory:`** when wrapping a NAT agent with **`workflow._type: auto_memory_agent`**. The workflow points at the memory entry by name with **`memory_name`**. See [memory.md](memory.md).
+
 ## `workflow` — the top-level runner
 
 This block picks **which agent pattern** runs and **which tools** are in play.

--- a/docs/nat/memory.md
+++ b/docs/nat/memory.md
@@ -1,0 +1,84 @@
+<!--
+  ~ Copyright 2026 DataRobot, Inc. and its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+# Mem0 memory in NAT workflows
+
+`datarobot-genai` includes a NAT `MemoryEditor` provider that adapts the DataRobot Mem0 client for NAT's `auto_memory_agent`. This avoids the upstream `nvidia-nat-mem0ai` plugin while still using NAT's standard `memory:` configuration.
+
+Install both the NAT and memory extras:
+
+```bash
+pip install "datarobot-genai[nat,memory]"
+```
+
+Set the Mem0 API key at runtime:
+
+```bash
+export MEM0_API_KEY=...
+```
+
+## Configure the memory provider
+
+```yaml
+memory:
+  mem0_memory:
+    _type: dr_mem0_memory
+    # Optional Mem0 organization/project routing:
+    # host: https://api.mem0.ai
+    # org_id: ...
+    # project_id: ...
+```
+
+**`mem0_memory`** is the local name you reference from the workflow. **`dr_mem0_memory`** is the DataRobot provider type registered by this package.
+
+## Wrap an agent with automatic memory
+
+```yaml
+functions:
+  nat_agent:
+    _type: per_user_tool_calling_agent
+    llm_name: datarobot_llm
+    tool_names:
+      - planner
+      - writer
+
+workflow:
+  _type: auto_memory_agent
+  inner_agent_name: nat_agent
+  memory_name: mem0_memory
+  llm_name: datarobot_llm
+  description: "Agent with automatic memory capture and retrieval."
+```
+
+NAT supplies the runtime `user_id` to the memory backend from the session user manager, `X-User-ID` header, or its local fallback. The provider forwards that `user_id` into Mem0 v2 search filters so memories remain isolated per user.
+
+## Optional search and add parameters
+
+Parameters under `search_params` are passed to `MemoryEditor.search()`, and parameters under `add_params` are passed to `MemoryEditor.add_items()`:
+
+```yaml
+workflow:
+  _type: auto_memory_agent
+  inner_agent_name: nat_agent
+  memory_name: mem0_memory
+  llm_name: datarobot_llm
+  search_params:
+    top_k: 5
+  add_params:
+    agent_id: blog_agent
+```
+
+The provider also supports `host`, `org_id`, and `project_id` on the memory config for Mem0 deployment routing.

--- a/docs/nat/memory.md
+++ b/docs/nat/memory.md
@@ -36,14 +36,15 @@ export MEM0_API_KEY=...
 memory:
   mem0_memory:
     _type: dr_mem0_memory
-    api_key: ${MEM0_API_KEY}
+    # Optional explicit override; defaults from MEM0_API_KEY runtime settings.
+    # api_key: ${MEM0_API_KEY}
     # Optional Mem0 organization/project routing:
     # host: https://api.mem0.ai
     # org_id: ...
     # project_id: ...
 ```
 
-**`mem0_memory`** is the local name you reference from the workflow. **`dr_mem0_memory`** is the DataRobot provider type registered by this package. The provider requires `api_key` in the memory config; the example uses NAT's YAML environment interpolation so the library receives it as a config value.
+**`mem0_memory`** is the local name you reference from the workflow. **`dr_mem0_memory`** is the DataRobot provider type registered by this package. The provider reads `MEM0_API_KEY` through DataRobot app framework settings by default; use `api_key` only when you need an explicit workflow-level override.
 
 ## Wrap an agent with automatic memory
 

--- a/docs/nat/memory.md
+++ b/docs/nat/memory.md
@@ -36,13 +36,14 @@ export MEM0_API_KEY=...
 memory:
   mem0_memory:
     _type: dr_mem0_memory
+    api_key: ${MEM0_API_KEY}
     # Optional Mem0 organization/project routing:
     # host: https://api.mem0.ai
     # org_id: ...
     # project_id: ...
 ```
 
-**`mem0_memory`** is the local name you reference from the workflow. **`dr_mem0_memory`** is the DataRobot provider type registered by this package.
+**`mem0_memory`** is the local name you reference from the workflow. **`dr_mem0_memory`** is the DataRobot provider type registered by this package. The provider requires `api_key` in the memory config; the example uses NAT's YAML environment interpolation so the library receives it as a config value.
 
 ## Wrap an agent with automatic memory
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.38"
+version = "0.15.39"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.40"
+version = "0.15.41"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -25,6 +25,7 @@ datarobot_llm_providers = "datarobot_genai.nat.datarobot_llm_providers"
 datarobot_llm_clients = "datarobot_genai.nat.datarobot_llm_clients"
 datarobot_mcp_client = "datarobot_genai.nat.datarobot_mcp_client"
 datarobot_auth_provider = "datarobot_genai.nat.datarobot_auth_provider"
+datarobot_mem0_memory = "datarobot_genai.nat.datarobot_mem0_memory"
 
 [project.entry-points.'nat.front_ends']
 dragent = "datarobot_genai.dragent.frontends.register"

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -22,23 +22,17 @@ without relying on the upstream ``nvidia-nat-mem0ai`` plugin.
 from __future__ import annotations
 
 import asyncio
-import os
 from collections.abc import AsyncGenerator
 from typing import Any
 
 from nat.builder.builder import Builder
-from nat.builder.context import Context
 from nat.cli.register_workflow import register_memory
 from nat.data_models.memory import MemoryBaseConfig
 from nat.data_models.retry_mixin import RetryMixin
 from nat.memory.interfaces import MemoryEditor
 from nat.memory.models import MemoryItem
 from nat.utils.exception_handlers.automatic_retries import patch_with_retry
-
-# Some NAT/NAT-LangChain version combinations access Context.user_manager before it exists.
-# Add a default so user-id resolution can continue through headers and fallback behavior.
-if not hasattr(Context, "user_manager"):
-    setattr(Context, "user_manager", None)
+from pydantic import Field
 
 
 class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
@@ -48,6 +42,7 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
 ):
     """A NAT memory backend backed by ``datarobot-genai``'s Mem0 client."""
 
+    api_key: str = Field(description="Mem0 API key used by the memory backend.")
     host: str | None = None
     org_id: str | None = None
     project_id: str | None = None
@@ -146,13 +141,7 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str) -> Any:
 async def dr_mem0_memory_client(
     config: DRMem0MemoryClientConfig, builder: Builder
 ) -> AsyncGenerator[MemoryEditor]:
-    api_key = os.environ.get("MEM0_API_KEY")
-    if not api_key:
-        raise RuntimeError(
-            "Mem0 API key is not set. Please specify it in the environment variable 'MEM0_API_KEY'."
-        )
-
-    editor: MemoryEditor = DRMem0Editor(_create_mem0_client(config, api_key))
+    editor: MemoryEditor = DRMem0Editor(_create_mem0_client(config, config.api_key))
     if isinstance(config, RetryMixin):
         editor = patch_with_retry(
             editor,

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -56,21 +56,25 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         self._mem0 = client._memory
 
     async def add_items(self, items: list[MemoryItem], **kwargs: Any) -> None:
+        add_kwargs = dict(kwargs)
+        output_format = add_kwargs.pop("output_format", "v1.1")
+        configured_run_id = add_kwargs.pop("run_id", None)
+        configured_tags = add_kwargs.pop("tags", None)
+        configured_metadata = dict(add_kwargs.pop("metadata", None) or {})
+        add_kwargs.pop("user_id", None)
+
         coroutines = []
         for item in items:
-            metadata = dict(item.metadata or {})
-            run_id = metadata.pop("run_id", None)
-            coroutines.append(
-                self._mem0.add(
-                    item.conversation,
-                    user_id=item.user_id,
-                    run_id=run_id,
-                    tags=item.tags,
-                    metadata=metadata,
-                    output_format="v1.1",
-                    **kwargs,
-                )
-            )
+            metadata = configured_metadata | dict(item.metadata or {})
+            run_id = metadata.pop("run_id", configured_run_id)
+            item_kwargs = add_kwargs | {
+                "user_id": item.user_id,
+                "run_id": run_id,
+                "tags": item.tags or configured_tags or [],
+                "metadata": metadata,
+                "output_format": output_format,
+            }
+            coroutines.append(self._mem0.add(item.conversation, **item_kwargs))
 
         if coroutines:
             await asyncio.gather(*coroutines)
@@ -89,11 +93,12 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
             conditions.append({"metadata": metadata_filter})
 
         filters = kwargs.pop("filters", None) or {"AND": conditions}
+        output_format = kwargs.pop("output_format", "v1.1")
         result = await self._mem0.search(
             query,
             filters=filters,
             top_k=top_k,
-            output_format="v1.1",
+            output_format=output_format,
             **kwargs,
         )
 

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -25,6 +25,7 @@ import asyncio
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_memory
 from nat.data_models.memory import MemoryBaseConfig
@@ -35,6 +36,20 @@ from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 from pydantic import Field
 
 
+class Config(DataRobotAppFrameworkBaseSettings):
+    """
+    Finds variables in the priority order of: env
+    variables (including Runtime Parameters), .env, file_secrets, then
+    Pulumi output variables.
+    """
+
+    mem0_api_key: str | None = None
+
+
+def _get_default_mem0_api_key() -> str | None:
+    return Config().mem0_api_key
+
+
 class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
     MemoryBaseConfig,  # type: ignore[misc]
     RetryMixin,  # type: ignore[misc]
@@ -42,7 +57,10 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
 ):
     """A NAT memory backend backed by ``datarobot-genai``'s Mem0 client."""
 
-    api_key: str = Field(description="Mem0 API key used by the memory backend.")
+    api_key: str | None = Field(
+        default_factory=_get_default_mem0_api_key,
+        description="Mem0 API key used by the memory backend.",
+    )
     host: str | None = None
     org_id: str | None = None
     project_id: str | None = None
@@ -126,7 +144,7 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
             await self._mem0.delete_all(user_id=kwargs.pop("user_id"))
 
 
-def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str) -> Any:
+def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:
     try:
         from datarobot_genai.core.memory.mem0client import Mem0Client
     except ImportError as exc:
@@ -147,6 +165,11 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str) -> Any:
 async def dr_mem0_memory_client(
     config: DRMem0MemoryClientConfig, builder: Builder
 ) -> AsyncGenerator[MemoryEditor]:
+    if not config.api_key:
+        raise RuntimeError(
+            "Mem0 API key is not set. Please configure memory.api_key or MEM0_API_KEY."
+        )
+
     editor: MemoryEditor = DRMem0Editor(_create_mem0_client(config, config.api_key))
     if isinstance(config, RetryMixin):
         editor = patch_with_retry(

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -1,0 +1,164 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NAT memory provider backed by DataRobot's Mem0 client.
+
+This provider wires ``datarobot-genai[memory]`` into NAT's ``MemoryEditor``
+interface so ``auto_memory_agent`` can store and retrieve long-term memory
+without relying on the upstream ``nvidia-nat-mem0ai`` plugin.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from nat.builder.builder import Builder
+from nat.builder.context import Context
+from nat.cli.register_workflow import register_memory
+from nat.data_models.memory import MemoryBaseConfig
+from nat.data_models.retry_mixin import RetryMixin
+from nat.memory.interfaces import MemoryEditor
+from nat.memory.models import MemoryItem
+from nat.utils.exception_handlers.automatic_retries import patch_with_retry
+
+# Some NAT/NAT-LangChain version combinations access Context.user_manager before it exists.
+# Add a default so user-id resolution can continue through headers and fallback behavior.
+if not hasattr(Context, "user_manager"):
+    setattr(Context, "user_manager", None)
+
+
+class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
+    MemoryBaseConfig,  # type: ignore[misc]
+    RetryMixin,  # type: ignore[misc]
+    name="dr_mem0_memory",
+):
+    """A NAT memory backend backed by ``datarobot-genai``'s Mem0 client."""
+
+    host: str | None = None
+    org_id: str | None = None
+    project_id: str | None = None
+
+
+class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
+    """Adapt ``Mem0Client`` to NAT's ``MemoryEditor`` interface."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        self._mem0 = client._memory
+
+    async def add_items(self, items: list[MemoryItem], **kwargs: Any) -> None:
+        coroutines = []
+        for item in items:
+            metadata = dict(item.metadata or {})
+            run_id = metadata.pop("run_id", None)
+            coroutines.append(
+                self._mem0.add(
+                    item.conversation,
+                    user_id=item.user_id,
+                    run_id=run_id,
+                    tags=item.tags,
+                    metadata=metadata,
+                    output_format="v1.1",
+                    **kwargs,
+                )
+            )
+
+        if coroutines:
+            await asyncio.gather(*coroutines)
+
+    async def search(self, query: str, top_k: int = 5, **kwargs: Any) -> list[MemoryItem]:
+        # Mem0's v2 search endpoint expects filters instead of top-level user/run/app ids.
+        user_id = kwargs.pop("user_id")
+        conditions: list[dict[str, Any]] = [{"user_id": user_id}]
+        for key in ("run_id", "agent_id", "app_id"):
+            value = kwargs.pop(key, None)
+            if value:
+                conditions.append({key: value})
+
+        metadata_filter = kwargs.pop("metadata", None)
+        if metadata_filter:
+            conditions.append({"metadata": metadata_filter})
+
+        filters = kwargs.pop("filters", None) or {"AND": conditions}
+        result = await self._mem0.search(
+            query,
+            filters=filters,
+            top_k=top_k,
+            output_format="v1.1",
+            **kwargs,
+        )
+
+        memories: list[MemoryItem] = []
+        for raw_result in result.get("results", []) or []:
+            if not isinstance(raw_result, dict):
+                continue
+            item_meta = raw_result.get("metadata") or {}
+            memories.append(
+                MemoryItem(
+                    conversation=raw_result.get("input") or [],
+                    user_id=user_id,
+                    memory=raw_result.get("memory"),
+                    tags=raw_result.get("categories") or [],
+                    metadata=item_meta,
+                )
+            )
+        return memories
+
+    async def remove_items(self, **kwargs: Any) -> None:
+        if "memory_id" in kwargs:
+            await self._mem0.delete(kwargs.pop("memory_id"))
+        elif "user_id" in kwargs:
+            await self._mem0.delete_all(user_id=kwargs.pop("user_id"))
+
+
+def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str) -> Any:
+    try:
+        from datarobot_genai.core.memory.mem0client import Mem0Client
+    except ImportError as exc:
+        raise RuntimeError(
+            "The DataRobot Mem0 NAT memory provider requires the memory extra. "
+            'Install it with `pip install "datarobot-genai[nat,memory]"`.'
+        ) from exc
+
+    return Mem0Client(
+        api_key=api_key,
+        host=config.host,
+        org_id=config.org_id,
+        project_id=config.project_id,
+    )
+
+
+@register_memory(config_type=DRMem0MemoryClientConfig)
+async def dr_mem0_memory_client(
+    config: DRMem0MemoryClientConfig, builder: Builder
+) -> AsyncGenerator[MemoryEditor]:
+    api_key = os.environ.get("MEM0_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Mem0 API key is not set. Please specify it in the environment variable 'MEM0_API_KEY'."
+        )
+
+    editor: MemoryEditor = DRMem0Editor(_create_mem0_client(config, api_key))
+    if isinstance(config, RetryMixin):
+        editor = patch_with_retry(
+            editor,
+            retries=config.num_retries,
+            retry_codes=config.retry_on_status_codes,
+            retry_on_messages=config.retry_on_errors,
+        )
+
+    yield editor

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -69,11 +69,12 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
             run_id = metadata.pop("run_id", configured_run_id)
             item_kwargs = add_kwargs | {
                 "user_id": item.user_id,
-                "run_id": run_id,
                 "tags": item.tags or configured_tags or [],
                 "metadata": metadata,
                 "output_format": output_format,
             }
+            if run_id:
+                item_kwargs["run_id"] = run_id
             coroutines.append(self._mem0.add(item.conversation, **item_kwargs))
 
         if coroutines:

--- a/tests/nat/integration/.env.sample
+++ b/tests/nat/integration/.env.sample
@@ -5,3 +5,5 @@ DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
 DATAROBOT_API_TOKEN=
 SESSION_SECRET_KEY=
 MCP_DEPLOYMENT_ID=
+# Optional: enables the real Mem0 auto-memory integration test.
+MEM0_API_KEY=

--- a/tests/nat/integration/.env.sample
+++ b/tests/nat/integration/.env.sample
@@ -5,5 +5,4 @@ DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
 DATAROBOT_API_TOKEN=
 SESSION_SECRET_KEY=
 MCP_DEPLOYMENT_ID=
-# Optional: enables the real Mem0 auto-memory integration test.
 MEM0_API_KEY=

--- a/tests/nat/integration/README.md
+++ b/tests/nat/integration/README.md
@@ -5,4 +5,5 @@ These tests exercise NAT end-to-end using the legacy integration path (the way N
 ## Run
 
 1. Copy values from `.env.sample` into your root `.env` file.
-2. Run `task test-nat-integration`.
+2. Set `MEM0_API_KEY` to run the real Mem0 auto-memory wrapper test. Without it, that test is skipped.
+3. Run `task test-nat-integration`.

--- a/tests/nat/integration/README.md
+++ b/tests/nat/integration/README.md
@@ -5,5 +5,4 @@ These tests exercise NAT end-to-end using the legacy integration path (the way N
 ## Run
 
 1. Copy values from `.env.sample` into your root `.env` file.
-2. Set `MEM0_API_KEY` to run the real Mem0 auto-memory wrapper test. Without it, that test is skipped.
-3. Run `task test-nat-integration`.
+2. Run `task test-nat-integration`.

--- a/tests/nat/integration/test_auto_memory.py
+++ b/tests/nat/integration/test_auto_memory.py
@@ -63,26 +63,23 @@ async def auto_memory_probe_agent(
     )
 
 
-class StaticUserManager:
-    def __init__(self, user_id: str) -> None:
-        self._user_id = user_id
-
-    def get_id(self) -> str:
-        return self._user_id
+@pytest.fixture
+def mem0_api_key() -> str:
+    api_key = os.environ.get("MEM0_API_KEY")
+    if not api_key:
+        pytest.skip("requires MEM0_API_KEY for real Mem0 integration")
+    return api_key
 
 
 @pytest.fixture
-async def workflow_with_memory() -> AsyncGenerator[SessionManager, None]:
+async def workflow_with_memory(mem0_api_key: str) -> AsyncGenerator[SessionManager, None]:
     async with load_workflow(WORKFLOW_WITH_MEMORY_PATH) as workflow:
         yield workflow
 
 
-@pytest.mark.skipif(
-    not os.environ.get("MEM0_API_KEY"),
-    reason="requires MEM0_API_KEY for real Mem0 integration",
-)
 async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
     workflow_with_memory: SessionManager,
+    mem0_api_key: str,
 ) -> None:
     # GIVEN a workflow.yaml with a real Mem0-backed NAT memory provider and auto-memory wrapper.
     test_id = uuid.uuid4().hex
@@ -92,7 +89,7 @@ async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
     recall_message = "What is my NAT auto-memory integration secret code?"
 
     async def run_memory_workflow(message: str) -> str:
-        async with workflow_with_memory.session(user_manager=StaticUserManager(user_id)) as session:
+        async with workflow_with_memory.session(user_id=user_id) as session:
             async with session.run(message) as runner:
                 return await runner.result(to_type=str)
 
@@ -112,4 +109,4 @@ async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
                 f"Mem0 did not return expected memory text. Last response: {last_response!r}"
             )
     finally:
-        await Mem0Client()._memory.delete_all(user_id=user_id)
+        await Mem0Client(api_key=mem0_api_key)._memory.delete_all(user_id=user_id)

--- a/tests/nat/integration/test_auto_memory.py
+++ b/tests/nat/integration/test_auto_memory.py
@@ -1,0 +1,115 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import uuid
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import pytest
+from nat.builder.builder import Builder
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.api_server import ChatRequest
+from nat.data_models.function import FunctionBaseConfig
+from nat.runtime.session import SessionManager
+
+import datarobot_genai.nat.datarobot_mem0_memory  # noqa: F401
+from datarobot_genai.core.memory.mem0client import Mem0Client
+from datarobot_genai.nat.helpers import load_workflow
+
+WORKFLOW_WITH_MEMORY_PATH = Path(__file__).parent / "workflow_with_memory.yaml"
+
+
+class AutoMemoryProbeAgentConfig(  # type: ignore[call-arg]
+    FunctionBaseConfig,
+    name="auto_memory_probe_agent",
+):
+    """Probe function used by the auto-memory integration test."""
+
+
+async def _auto_memory_probe_agent(chat_request: ChatRequest) -> str:
+    system_messages = [
+        message.content
+        for message in chat_request.messages
+        if "system" in str(message.role).lower()
+    ]
+    return "\n".join(system_messages) or "NO_MEMORY_CONTEXT"
+
+
+@register_function(
+    config_type=AutoMemoryProbeAgentConfig,
+    framework_wrappers=[LLMFrameworkEnum.LANGCHAIN],
+)
+async def auto_memory_probe_agent(
+    config: AutoMemoryProbeAgentConfig, builder: Builder
+) -> AsyncGenerator[FunctionInfo, None]:
+    yield FunctionInfo.from_fn(
+        _auto_memory_probe_agent,
+        description="Returns memory context injected by NAT's auto-memory wrapper.",
+    )
+
+
+class StaticUserManager:
+    def __init__(self, user_id: str) -> None:
+        self._user_id = user_id
+
+    def get_id(self) -> str:
+        return self._user_id
+
+
+@pytest.fixture
+async def workflow_with_memory() -> AsyncGenerator[SessionManager, None]:
+    async with load_workflow(WORKFLOW_WITH_MEMORY_PATH) as workflow:
+        yield workflow
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MEM0_API_KEY"),
+    reason="requires MEM0_API_KEY for real Mem0 integration",
+)
+async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
+    workflow_with_memory: SessionManager,
+) -> None:
+    # GIVEN a workflow.yaml with a real Mem0-backed NAT memory provider and auto-memory wrapper.
+    test_id = uuid.uuid4().hex
+    user_id = f"nat-auto-memory-{test_id}"
+    secret_code = f"DRMEM-{test_id}"
+    first_message = f"My NAT auto-memory integration secret code is {secret_code}."
+    recall_message = "What is my NAT auto-memory integration secret code?"
+
+    async def run_memory_workflow(message: str) -> str:
+        async with workflow_with_memory.session(user_manager=StaticUserManager(user_id)) as session:
+            async with session.run(message) as runner:
+                return await runner.result(to_type=str)
+
+    try:
+        # WHEN the wrapped workflow sees one message to store.
+        await run_memory_workflow(first_message)
+
+        # THEN a later turn retrieves the real Mem0 memory and injects it as context.
+        last_response = ""
+        for _ in range(10):
+            last_response = await run_memory_workflow(recall_message)
+            if secret_code in last_response:
+                break
+            await asyncio.sleep(2)
+        else:
+            pytest.fail(
+                f"Mem0 did not return expected memory text. Last response: {last_response!r}"
+            )
+    finally:
+        await Mem0Client()._memory.delete_all(user_id=user_id)

--- a/tests/nat/integration/test_auto_memory.py
+++ b/tests/nat/integration/test_auto_memory.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import asyncio
-import os
 import uuid
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import pytest
 from nat.builder.builder import Builder
+from nat.builder.context import Context
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
@@ -29,9 +29,22 @@ from nat.runtime.session import SessionManager
 
 import datarobot_genai.nat.datarobot_mem0_memory  # noqa: F401
 from datarobot_genai.core.memory.mem0client import Mem0Client
+from datarobot_genai.nat.datarobot_mem0_memory import Config as Mem0Settings
 from datarobot_genai.nat.helpers import load_workflow
 
 WORKFLOW_WITH_MEMORY_PATH = Path(__file__).parent / "workflow_with_memory.yaml"
+
+
+class ContextUserManager:
+    def __init__(self, context: Context) -> None:
+        self._context = context
+
+    def get_id(self) -> str | None:
+        return self._context.user_id
+
+
+def get_context_user_manager(context: Context) -> ContextUserManager:
+    return ContextUserManager(context)
 
 
 class AutoMemoryProbeAgentConfig(  # type: ignore[call-arg]
@@ -65,10 +78,20 @@ async def auto_memory_probe_agent(
 
 @pytest.fixture
 def mem0_api_key() -> str:
-    api_key = os.environ.get("MEM0_API_KEY")
+    api_key = Mem0Settings().mem0_api_key
     if not api_key:
         pytest.skip("requires MEM0_API_KEY for real Mem0 integration")
     return api_key
+
+
+@pytest.fixture(autouse=True)
+def context_user_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        Context,
+        "user_manager",
+        property(get_context_user_manager),
+        raising=False,
+    )
 
 
 @pytest.fixture

--- a/tests/nat/integration/workflow_with_memory.yaml
+++ b/tests/nat/integration/workflow_with_memory.yaml
@@ -14,6 +14,7 @@
 memory:
   mem0_memory:
     _type: dr_mem0_memory
+    api_key: ${MEM0_API_KEY}
 
 functions:
   probe_agent:

--- a/tests/nat/integration/workflow_with_memory.yaml
+++ b/tests/nat/integration/workflow_with_memory.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+memory:
+  mem0_memory:
+    _type: dr_mem0_memory
+
+functions:
+  probe_agent:
+    _type: auto_memory_probe_agent
+
+workflow:
+  _type: auto_memory_agent
+  llm_name: unused_for_probe_agent
+  description: "Auto-memory wrapper integration probe."
+  inner_agent_name: probe_agent
+  memory_name: mem0_memory
+  save_ai_messages_to_memory: false
+  search_params:
+    top_k: 5
+  add_params:
+    async_mode: false

--- a/tests/nat/integration/workflow_with_memory.yaml
+++ b/tests/nat/integration/workflow_with_memory.yaml
@@ -14,7 +14,6 @@
 memory:
   mem0_memory:
     _type: dr_mem0_memory
-    api_key: ${MEM0_API_KEY}
 
 functions:
   probe_agent:

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import pytest
 from nat.memory.models import MemoryItem
+from pydantic import ValidationError
 
 from datarobot_genai.nat import datarobot_mem0_memory
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
@@ -164,8 +165,8 @@ async def test_remove_items_deletes_by_memory_id_or_user_id() -> None:
     assert mem0.delete_all_calls == [{"user_id": "user-123"}]
 
 
-async def test_registered_memory_client_uses_env_config_and_retry(monkeypatch: Any) -> None:
-    # GIVEN a configured NAT memory provider and MEM0_API_KEY.
+async def test_registered_memory_client_uses_config_api_key_and_retry(monkeypatch: Any) -> None:
+    # GIVEN a configured NAT memory provider with an explicit Mem0 API key.
     created_clients: list[dict[str, Any]] = []
     patched_editors: list[dict[str, Any]] = []
 
@@ -177,11 +178,11 @@ async def test_registered_memory_client_uses_env_config_and_retry(monkeypatch: A
         patched_editors.append({"editor": editor, "kwargs": kwargs})
         return editor
 
-    monkeypatch.setenv("MEM0_API_KEY", "secret-key")
     monkeypatch.setattr(datarobot_mem0_memory, "_create_mem0_client", fake_create_mem0_client)
     monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", fake_patch_with_retry)
 
     config = DRMem0MemoryClientConfig(
+        api_key="secret-key",
         host="https://mem0.example.com",
         org_id="org-123",
         project_id="project-123",
@@ -189,7 +190,7 @@ async def test_registered_memory_client_uses_env_config_and_retry(monkeypatch: A
 
     # WHEN NAT builds the memory client.
     async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
-        # THEN it creates a DRMem0Editor with the env key and retry wrapper.
+        # THEN it creates a DRMem0Editor with the configured key and retry wrapper.
         assert isinstance(editor, DRMem0Editor)
 
     assert created_clients == [{"config": config, "api_key": "secret-key"}]
@@ -205,13 +206,7 @@ async def test_registered_memory_client_uses_env_config_and_retry(monkeypatch: A
     ]
 
 
-async def test_registered_memory_client_requires_mem0_api_key(monkeypatch: Any) -> None:
-    # GIVEN no MEM0_API_KEY in the environment.
-    monkeypatch.delenv("MEM0_API_KEY", raising=False)
-
-    # WHEN NAT builds the memory client, THEN it raises a clear configuration error.
-    with pytest.raises(RuntimeError, match="Mem0 API key is not set"):
-        async with datarobot_mem0_memory.dr_mem0_memory_client(
-            DRMem0MemoryClientConfig(), object()
-        ):
-            pass
+def test_memory_client_config_requires_api_key() -> None:
+    # GIVEN no api_key in the memory config, WHEN the config is validated, THEN it fails.
+    with pytest.raises(ValidationError, match="api_key"):
+        DRMem0MemoryClientConfig()

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -1,0 +1,217 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from nat.memory.models import MemoryItem
+
+from datarobot_genai.nat import datarobot_mem0_memory
+from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
+from datarobot_genai.nat.datarobot_mem0_memory import DRMem0MemoryClientConfig
+
+
+class FakeMem0Api:
+    def __init__(self) -> None:
+        self.add_calls: list[dict[str, Any]] = []
+        self.search_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[str] = []
+        self.delete_all_calls: list[dict[str, Any]] = []
+        self.search_result: dict[str, Any] = {"results": []}
+
+    async def add(self, conversation: list[dict[str, str]], **kwargs: Any) -> None:
+        self.add_calls.append({"conversation": conversation, "kwargs": kwargs})
+
+    async def search(self, query: str, **kwargs: Any) -> dict[str, Any]:
+        self.search_calls.append({"query": query, "kwargs": kwargs})
+        return self.search_result
+
+    async def delete(self, memory_id: str) -> None:
+        self.delete_calls.append(memory_id)
+
+    async def delete_all(self, **kwargs: Any) -> None:
+        self.delete_all_calls.append(kwargs)
+
+
+class FakeMem0Client:
+    def __init__(self, mem0: FakeMem0Api | None = None) -> None:
+        self._memory = mem0 or FakeMem0Api()
+
+
+async def test_add_items_forwards_nat_memory_items_to_mem0() -> None:
+    # GIVEN a NAT MemoryItem with runtime user id and metadata.
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember Python"}],
+        user_id="user-123",
+        tags=["preference"],
+        metadata={"run_id": "run-456", "thread_id": "thread-789"},
+    )
+
+    # WHEN the editor stores it.
+    await editor.add_items([item], agent_id="agent-abc")
+
+    # THEN the underlying Mem0 client receives NAT's user id and v1.1 payload shape.
+    assert mem0.add_calls == [
+        {
+            "conversation": [{"role": "user", "content": "remember Python"}],
+            "kwargs": {
+                "user_id": "user-123",
+                "run_id": "run-456",
+                "tags": ["preference"],
+                "metadata": {"thread_id": "thread-789"},
+                "output_format": "v1.1",
+                "agent_id": "agent-abc",
+            },
+        }
+    ]
+
+
+async def test_search_builds_mem0_v2_filters_from_nat_kwargs() -> None:
+    # GIVEN a Mem0 search result and NAT auto-memory user/run/app parameters.
+    mem0 = FakeMem0Api()
+    mem0.search_result = {
+        "results": [
+            {
+                "input": [{"role": "user", "content": "I prefer Python"}],
+                "memory": "User prefers Python.",
+                "categories": ["preference"],
+                "metadata": {"thread_id": "thread-789"},
+            }
+        ]
+    }
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+
+    # WHEN the editor searches memory.
+    memories = await editor.search(
+        "language",
+        top_k=2,
+        user_id="user-123",
+        run_id="run-456",
+        app_id="app-abc",
+        metadata={"thread_id": "thread-789"},
+        threshold=0.75,
+    )
+
+    # THEN the search uses Mem0 v2 filters and returns NAT MemoryItems.
+    assert mem0.search_calls == [
+        {
+            "query": "language",
+            "kwargs": {
+                "filters": {
+                    "AND": [
+                        {"user_id": "user-123"},
+                        {"run_id": "run-456"},
+                        {"app_id": "app-abc"},
+                        {"metadata": {"thread_id": "thread-789"}},
+                    ]
+                },
+                "top_k": 2,
+                "output_format": "v1.1",
+                "threshold": 0.75,
+            },
+        }
+    ]
+    assert memories == [
+        MemoryItem(
+            conversation=[{"role": "user", "content": "I prefer Python"}],
+            user_id="user-123",
+            memory="User prefers Python.",
+            tags=["preference"],
+            metadata={"thread_id": "thread-789"},
+        )
+    ]
+
+
+async def test_search_honors_explicit_filters() -> None:
+    # GIVEN caller-provided Mem0 filters.
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+    filters = {"AND": [{"user_id": "user-123"}, {"agent_id": "agent-abc"}]}
+
+    # WHEN the editor searches with explicit filters.
+    await editor.search("question", user_id="user-123", filters=filters)
+
+    # THEN those filters are forwarded without rebuilding them.
+    assert mem0.search_calls[0]["kwargs"]["filters"] == filters
+
+
+async def test_remove_items_deletes_by_memory_id_or_user_id() -> None:
+    # GIVEN a Mem0-backed editor.
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+
+    # WHEN deleting a single memory and then all memories for a user.
+    await editor.remove_items(memory_id="memory-123")
+    await editor.remove_items(user_id="user-123")
+
+    # THEN the corresponding Mem0 delete APIs are used.
+    assert mem0.delete_calls == ["memory-123"]
+    assert mem0.delete_all_calls == [{"user_id": "user-123"}]
+
+
+async def test_registered_memory_client_uses_env_config_and_retry(monkeypatch: Any) -> None:
+    # GIVEN a configured NAT memory provider and MEM0_API_KEY.
+    created_clients: list[dict[str, Any]] = []
+    patched_editors: list[dict[str, Any]] = []
+
+    def fake_create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str) -> FakeMem0Client:
+        created_clients.append({"config": config, "api_key": api_key})
+        return FakeMem0Client()
+
+    def fake_patch_with_retry(editor: Any, **kwargs: Any) -> Any:
+        patched_editors.append({"editor": editor, "kwargs": kwargs})
+        return editor
+
+    monkeypatch.setenv("MEM0_API_KEY", "secret-key")
+    monkeypatch.setattr(datarobot_mem0_memory, "_create_mem0_client", fake_create_mem0_client)
+    monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", fake_patch_with_retry)
+
+    config = DRMem0MemoryClientConfig(
+        host="https://mem0.example.com",
+        org_id="org-123",
+        project_id="project-123",
+    )
+
+    # WHEN NAT builds the memory client.
+    async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
+        # THEN it creates a DRMem0Editor with the env key and retry wrapper.
+        assert isinstance(editor, DRMem0Editor)
+
+    assert created_clients == [{"config": config, "api_key": "secret-key"}]
+    assert patched_editors == [
+        {
+            "editor": editor,
+            "kwargs": {
+                "retries": config.num_retries,
+                "retry_codes": config.retry_on_status_codes,
+                "retry_on_messages": config.retry_on_errors,
+            },
+        }
+    ]
+
+
+async def test_registered_memory_client_requires_mem0_api_key(monkeypatch: Any) -> None:
+    # GIVEN no MEM0_API_KEY in the environment.
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+
+    # WHEN NAT builds the memory client, THEN it raises a clear configuration error.
+    with pytest.raises(RuntimeError, match="Mem0 API key is not set"):
+        async with datarobot_mem0_memory.dr_mem0_memory_client(
+            DRMem0MemoryClientConfig(), object()
+        ):
+            pass

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -82,6 +82,44 @@ async def test_add_items_forwards_nat_memory_items_to_mem0() -> None:
     ]
 
 
+async def test_add_items_resolves_conflicting_add_params() -> None:
+    # GIVEN add_params that overlap with NAT MemoryItem fields.
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember TypeScript"}],
+        user_id="item-user",
+        tags=["item-tag"],
+        metadata={"run_id": "item-run", "thread_id": "item-thread"},
+    )
+
+    # WHEN the editor stores it with conflicting backend-specific kwargs.
+    await editor.add_items(
+        [item],
+        user_id="configured-user",
+        run_id="configured-run",
+        tags=["configured-tag"],
+        metadata={"thread_id": "configured-thread", "source": "workflow"},
+        output_format="custom-format",
+        async_mode=False,
+    )
+
+    # THEN the Mem0 call has no duplicate kwargs and preserves NAT item identity.
+    assert mem0.add_calls == [
+        {
+            "conversation": [{"role": "user", "content": "remember TypeScript"}],
+            "kwargs": {
+                "user_id": "item-user",
+                "run_id": "item-run",
+                "tags": ["item-tag"],
+                "metadata": {"thread_id": "item-thread", "source": "workflow"},
+                "output_format": "custom-format",
+                "async_mode": False,
+            },
+        }
+    ]
+
+
 async def test_search_builds_mem0_v2_filters_from_nat_kwargs() -> None:
     # GIVEN a Mem0 search result and NAT auto-memory user/run/app parameters.
     mem0 = FakeMem0Api()
@@ -105,6 +143,7 @@ async def test_search_builds_mem0_v2_filters_from_nat_kwargs() -> None:
         run_id="run-456",
         app_id="app-abc",
         metadata={"thread_id": "thread-789"},
+        output_format="custom-format",
         threshold=0.75,
     )
 
@@ -122,7 +161,7 @@ async def test_search_builds_mem0_v2_filters_from_nat_kwargs() -> None:
                     ]
                 },
                 "top_k": 2,
-                "output_format": "v1.1",
+                "output_format": "custom-format",
                 "threshold": 0.75,
             },
         }

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -18,9 +18,9 @@ from typing import Any
 
 import pytest
 from nat.memory.models import MemoryItem
-from pydantic import ValidationError
 
 from datarobot_genai.nat import datarobot_mem0_memory
+from datarobot_genai.nat.datarobot_mem0_memory import Config
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0MemoryClientConfig
 
@@ -209,7 +209,9 @@ async def test_registered_memory_client_uses_config_api_key_and_retry(monkeypatc
     created_clients: list[dict[str, Any]] = []
     patched_editors: list[dict[str, Any]] = []
 
-    def fake_create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str) -> FakeMem0Client:
+    def fake_create_mem0_client(
+        config: DRMem0MemoryClientConfig, api_key: str | None
+    ) -> FakeMem0Client:
         created_clients.append({"config": config, "api_key": api_key})
         return FakeMem0Client()
 
@@ -245,7 +247,25 @@ async def test_registered_memory_client_uses_config_api_key_and_retry(monkeypatc
     ]
 
 
-def test_memory_client_config_requires_api_key() -> None:
-    # GIVEN no api_key in the memory config, WHEN the config is validated, THEN it fails.
-    with pytest.raises(ValidationError, match="api_key"):
-        DRMem0MemoryClientConfig()
+def test_memory_client_config_uses_settings_mem0_api_key(monkeypatch: Any) -> None:
+    # GIVEN MEM0_API_KEY is available from DataRobot app framework settings.
+    monkeypatch.setenv("MEM0_API_KEY", "settings-key")
+
+    # WHEN the NAT memory config is created without an explicit api_key.
+    config = DRMem0MemoryClientConfig()
+
+    # THEN the api_key defaults from the settings config.
+    assert Config().mem0_api_key == "settings-key"
+    assert config.api_key == "settings-key"
+
+
+async def test_registered_memory_client_requires_api_key(monkeypatch: Any) -> None:
+    # GIVEN neither memory.api_key nor MEM0_API_KEY is configured.
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+
+    # WHEN NAT builds the memory client, THEN it raises a clear configuration error.
+    with pytest.raises(RuntimeError, match="MEM0_API_KEY"):
+        async with datarobot_mem0_memory.dr_mem0_memory_client(
+            DRMem0MemoryClientConfig(api_key=None), object()
+        ):
+            pass

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.40"
+version = "0.15.41"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
NAT Auto Memory wrapper is being used in all agent workflows.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new NAT plugin that persists and retrieves user-scoped long-term memory via Mem0; risk is mainly around new external API integration and correctness of filter/metadata mapping, but changes are largely additive with tests.
> 
> **Overview**
> Adds a new NAT memory provider (`dr_mem0_memory`) that adapts `datarobot-genai[memory]`’s `Mem0Client` to NAT’s `MemoryEditor` interface, enabling `workflow._type: auto_memory_agent` to store/search/delete memories using Mem0 (including user-scoped v2 search filters and optional retry wrapping).
> 
> Registers the provider as a NAT plugin, documents how to configure it in `workflow.yaml`, and bumps the package version to `0.15.41`. Adds unit + integration coverage (real Mem0 round-trip behind `MEM0_API_KEY`) and updates sample env/config/docs to include the new memory workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 800cc37fee3222e36cc724c174d841bff22b4da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->