### PR TITLE
[BUZZOK-30695] A2A Agent Card support for external identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.40
+- Simplified XAA `workflow.yaml` config: IETF URNs and auth method defaults are now injected by the AgentCard generator rather than declared by the developer.
+- Added `urn:datarobot:agent:identity:internal` and `urn:datarobot:agent:identity:external` AgentCard extensions, and an optional external URL override (`general.frontend.a2a.external.url`).
+
 ## 0.15.39
 - Added documentation `docs/nat/a2a-auth.md` on how to configure various auth options for A2A agents.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.40
-- Simplified XAA `workflow.yaml` config: IETF URNs and auth method defaults are now injected by the AgentCard generator rather than declared by the developer.
+- Simplified cross-application access `workflow.yaml` config: IETF URNs and auth method defaults are now injected by the AgentCard generator rather than declared by the developer.
 - Added `urn:datarobot:agent:identity:internal` and `urn:datarobot:agent:identity:external` AgentCard extensions, and an optional external URL override (`general.frontend.a2a.external.url`).
 
 ## 0.15.39

--- a/docs/nat/a2a-auth.md
+++ b/docs/nat/a2a-auth.md
@@ -31,7 +31,7 @@ requirements in the agent card.
 
 ```bash
 # With Okta XAA support (adds okta-client-python)
-pip install "datarobot-genai[dragent,langgraph,auth]>=0.15.35"
+pip install "datarobot-genai[dragent,langgraph,auth]>=0.15.40"
 ```
 
 Replace `langgraph` with `crewai` or `llamaindex` depending on your framework.
@@ -140,20 +140,21 @@ general:
 
       # Server-side: advertise XAA requirements in the agent card
       cross_application_access:
-        token_endpoint_auth_method: "private_key_jwt"
-
         # Step 1: Token exchange to fetch the ID-JAG (RFC 8693)
         token_exchange:
-          trusted_issuer: "https://your-org.oktapreview.com"
-          audience: "https://your-org.oktapreview.com/oauth2/ausXXXXXXXXXXXXXXX"
-
+          trusted_issuer: "https://your-org.okta.com"
+          audience: "https://your-org.okta.com/oauth2/ausXXXXXXXXXXXXXXX"
         # Step 2: Execute the Final Grant (RFC 7523)
         token_request:
-          grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer"
-          token_url: "https://your-org.oktapreview.com/oauth2/ausXXXXXXXXXXXXXXX/v1/token"
+          token_url: "https://your-org.okta.com/oauth2/ausXXXXXXXXXXXXXXX/v1/token"
           audience: "https://app.datarobot.com/<org_id>/<agent_id>"
           scopes:
             - "blog:write"
+
+      # Optional: external identity and URL overrides published on the agent card
+      external:
+        id: "my-agent-id"       # Emitted as urn:datarobot:agent:identity:external
+        url: "https://my-agent-id.example.com/a2a/"  # Overrides the auto-generated card URL
 
 # Client-side: call a remote XAA-protected agent
 function_groups:
@@ -194,7 +195,7 @@ The XAA flow operates in two steps:
    granting access to the target agent with the requested scopes.
 
 Both steps authenticate the client using the same method
-(`token_endpoint_auth_method: private_key_jwt`), signing JWT client assertions
+(private key jwt), signing JWT client assertions
 with the private key from `PRIVATE_JWK`.
 
 ### Server-side configuration reference: `cross_application_access`
@@ -202,15 +203,28 @@ with the private key from `PRIVATE_JWK`.
 These fields are declared in the serving agent's `workflow.yaml` and published
 on the A2A agent card.
 
-| Field | Section | Purpose |
-|-------|---------|---------|
-| `token_endpoint_auth_method` | root | How the client authenticates to token endpoints (e.g. `private_key_jwt`). |
-| `token_exchange.trusted_issuer` | Step 1 | Org-level Authorization Server issuer URL. |
-| `token_exchange.audience` | Step 1 | Resource AS base URL (where ID-JAG is fetched from). |
-| `token_request.grant_type` | Step 2 | Must be `urn:ietf:params:oauth:grant-type:jwt-bearer`. |
-| `token_request.token_url` | Step 2 | Token endpoint of the resource AS. |
-| `token_request.audience` | Step 2 | Final resource identifier for the agent. |
-| `token_request.scopes` | Step 2 | Scopes the caller must request (default: `["read_data"]`). |
+| Field | Required | Default | Purpose |
+|-------|----------|---------|---------|
+| `token_exchange.trusted_issuer` | Yes | — | Org-level Authorization Server issuer URL. |
+| `token_exchange.audience` | Yes | — | Resource AS base URL (where ID-JAG is fetched from). |
+| `token_request.token_url` | Yes | — | Token endpoint of the resource AS. |
+| `token_request.audience` | Yes | — | Final resource identifier for the agent. |
+| `token_request.scopes` | No | `["read_data"]` | Scopes the caller must request. |
+
+> **Note:** `grant_type` URNs are injected automatically by the generator — do not
+> set them in `workflow.yaml`. The agent card will always contain
+> `urn:ietf:params:oauth:grant-type:token-exchange` (Step 1) and
+> `urn:ietf:params:oauth:grant-type:jwt-bearer` (Step 2).
+
+### Server-side configuration reference: `external`
+
+Optional fields under `general.frontend.a2a.external` that control additional
+identity metadata and the agent card URL.
+
+| Field | Purpose |
+|-------|---------|
+| `external.id` | Catalog discovery identifier. Emitted as the `urn:datarobot:agent:identity:external` extension on the agent card. |
+| `external.url` | Overrides the auto-generated agent card endpoint URL. Used as-is — no normalization is applied. |
 
 ### Client-side configuration reference: `okta_cross_app_access`
 
@@ -234,22 +248,20 @@ published A2A agent card:
   `token_request.scopes`).
 - **`capabilities.extensions[]`** (URI: `urn:ietf:params:oauth:grant-type:jwt-bearer`)
   — Non-standard XAA parameters for SDK consumption:
-  `token_endpoint_auth_method`, `token_exchange.*`, and
-  `token_request.grant_type` / `token_request.audience`.
+  `token_endpoint_auth_method`, `token_exchange.*` (including hardcoded
+  `grant_type` and `requested_token_type` URNs), and `token_request.audience`.
+
+In addition, the agent card may include up to two identity extensions:
+
+- **`urn:datarobot:agent:identity:internal`** — Emitted automatically in deployed
+  environments (when `MLOPS_DEPLOYMENT_ID` is set). Carries `deployment_id` for
+  internal DataRobot routing. Not emitted in local development.
+- **`urn:datarobot:agent:identity:external`** — Emitted when `external.id` is
+  set in `workflow.yaml`. Carries the developer-supplied catalog identifier.
 
 This separation follows the A2A spec convention: standard OAuth fields belong
 in `securitySchemes`, while flow-specific parameters go in
 `capabilities.extensions`.
-
-## Choosing between the two methods
-
-| Criteria | DataRobot API key | Okta XAA |
-|----------|-------------------|----------|
-| Setup complexity | Minimal — one env var. | Moderate — Okta principal + key pair. |
-| Identity model | Service-level API token. | User-delegated federated identity. |
-| Token type | Static API key. | Short-lived scoped access token. |
-| Use case | Internal DataRobot agents. | Cross-organization / federated agents. |
-| Extra install | None. | `auth` extra required. |
 
 ## Troubleshooting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.39"
+version = "0.15.40"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -39,6 +39,7 @@ from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from datarobot_genai.dragent.deployment_urls import build_deployment_a2a_url
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
 
+from .register import DRAgentA2AExternalConfig
 from .server_auth import CrossApplicationAccessConfig
 
 logger = logging.getLogger(__name__)
@@ -58,14 +59,26 @@ OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
 # Extension URI for the RFC 7523 JWT Bearer Grant (outer grant type for the hybrid flow).
 JWT_BEARER_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
-# Binding references linking the extension to the OpenAPI security scheme.
-CROSS_APP_SECURITY_SCHEME_REF = "oauth2"
-CROSS_APP_SECURITY_SCHEME_FLOW_REF = "clientCredentials"
+# IETF URNs injected by the generator into the token_exchange block.
+TOKEN_EXCHANGE_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:token-exchange"
+TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id-jag"
 
 CROSS_APP_EXTENSION_DESCRIPTION = (
     "Two-Step Cross-Application Access execution parameters. "
     "Step 1: RFC 8693 Token Exchange prerequisite. "
     "Step 2: RFC 7523 JWT Bearer Grant."
+)
+
+# Binding references linking the extension to the OpenAPI security scheme.
+CROSS_APP_SECURITY_SCHEME_REF = "oauth2"
+CROSS_APP_SECURITY_SCHEME_FLOW_REF = "clientCredentials"
+
+INTERNAL_IDENTITY_URI = "urn:datarobot:agent:identity:internal"
+INTERNAL_IDENTITY_DESCRIPTION = "Internal DataRobot routing and system identifiers."
+
+EXTERNAL_IDENTITY_URI = "urn:datarobot:agent:identity:external"
+EXTERNAL_IDENTITY_DESCRIPTION = (
+    "Customer-provided external agent identifiers for catalog discovery."
 )
 
 
@@ -158,7 +171,7 @@ def build_oauth_flow_from_cross_app_access(
 def build_cross_app_capability_extension(
     config: CrossApplicationAccessConfig,
 ) -> list[AgentExtension]:
-    """Build the JWT Bearer Grant extension entry for ``capabilities.extensions``.
+    """Build the Cross-Application Access extension entry for ``capabilities.extensions``.
 
     Only extension-bound fields go in ``params``; ``token_url`` and ``scopes``
     are intentionally omitted — they belong to OpenAPI ``securitySchemes``.
@@ -169,9 +182,13 @@ def build_cross_app_capability_extension(
             "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
         },
         "token_endpoint_auth_method": config.token_endpoint_auth_method,
-        "token_exchange": config.token_exchange.model_dump(),
+        "token_exchange": {
+            "grant_type": TOKEN_EXCHANGE_GRANT_TYPE_URI,
+            "requested_token_type": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
+            **config.token_exchange.model_dump(),
+        },
         "token_request": {
-            "grant_type": config.token_request.grant_type,
+            "grant_type": JWT_BEARER_GRANT_TYPE_URI,
             "audience": config.token_request.audience,
         },
     }
@@ -184,35 +201,79 @@ def build_cross_app_capability_extension(
     ]
 
 
+def build_internal_identity_extension() -> AgentExtension | None:
+    """Build the internal identity extension from MLOPS_DEPLOYMENT_ID, or None in local dev."""
+    deployment_id = os.getenv("MLOPS_DEPLOYMENT_ID", "")
+    if not deployment_id:
+        return None
+    return AgentExtension(
+        uri=INTERNAL_IDENTITY_URI,
+        description=INTERNAL_IDENTITY_DESCRIPTION,
+        required=True,
+        params={"deployment_id": deployment_id},
+    )
+
+
+def build_external_identity_extension(external_id: str) -> AgentExtension:
+    """Build the external identity extension for catalog discovery."""
+    return AgentExtension(
+        uri=EXTERNAL_IDENTITY_URI,
+        description=EXTERNAL_IDENTITY_DESCRIPTION,
+        required=False,
+        params={"id": external_id},
+    )
+
+
+def _collect_extensions(
+    cross_app_access: CrossApplicationAccessConfig | None,
+    external: DRAgentA2AExternalConfig | None,
+) -> list[AgentExtension] | None:
+    """Assemble all agent card extensions from the configured sources."""
+    extensions: list[AgentExtension] = []
+    if cross_app_access:
+        extensions.extend(build_cross_app_capability_extension(cross_app_access))
+    if internal := build_internal_identity_extension():
+        extensions.append(internal)
+    if external and external.id:
+        extensions.append(build_external_identity_extension(external.id))
+    return extensions or None
+
+
+def _resolve_url(
+    frontend_config: A2AFrontEndConfig,
+    external: DRAgentA2AExternalConfig | None,
+) -> str:
+    """Return the agent card URL, preferring ``external.url`` when provided."""
+    if external and external.url:
+        return external.url
+    return get_a2a_endpoint_url(frontend_config.host, frontend_config.port)
+
+
 async def build_security_schemes(
     frontend_config: A2AFrontEndConfig,
     cross_app_access: CrossApplicationAccessConfig | None,
 ) -> tuple[
     dict[str, SecurityScheme] | None,
     list[dict[str, list[str]]] | None,
-    list[AgentExtension] | None,
 ]:
     """Assemble A2A security schemes, merging up to two auth sources.
 
     * ``server_auth`` → authorization_code flow.
-    * ``cross_app_access`` → client_credentials flow + JWT Bearer capability extension.
+    * ``cross_app_access`` → client_credentials flow.
 
-    Returns ``(security_schemes, security_requirements, extensions)``, all ``None``
+    Returns ``(security_schemes, security_requirements)``, both ``None``
     when neither source is configured.
     """
     server_auth = frontend_config.server_auth
 
     if not server_auth and not cross_app_access:
-        return None, None, None
+        return None, None
 
     auth_code_flow, server_auth_scopes = (
         await build_oauth_flow_from_server_auth(server_auth) if server_auth else (None, [])
     )
     client_creds_flow, cross_app_scopes = (
         build_oauth_flow_from_cross_app_access(cross_app_access) if cross_app_access else (None, [])
-    )
-    extensions = (
-        build_cross_app_capability_extension(cross_app_access) if cross_app_access else None
     )
 
     all_scopes = list(dict.fromkeys(server_auth_scopes + cross_app_scopes))
@@ -228,7 +289,7 @@ async def build_security_schemes(
             )
         )
     }
-    return security_schemes, [{"oauth2": all_scopes}], extensions
+    return security_schemes, [{"oauth2": all_scopes}]
 
 
 # ---------------------------------------------------------------------------
@@ -240,15 +301,15 @@ async def create_agent_card(
     frontend_config: A2AFrontEndConfig,
     cross_app_access: CrossApplicationAccessConfig | None,
     skills: list[AgentSkill],
+    external: DRAgentA2AExternalConfig | None = None,
 ) -> AgentCard:
     """Build an :class:`~a2a.types.AgentCard` for a DataRobot-hosted A2A agent.
 
     When ``skills`` is empty, a single default skill is generated from
     ``frontend_config.name`` / ``frontend_config.description``.
     """
-    security_schemes, security, extensions = await build_security_schemes(
-        frontend_config, cross_app_access
-    )
+    security_schemes, security = await build_security_schemes(frontend_config, cross_app_access)
+    extensions = _collect_extensions(cross_app_access, external)
 
     resolved_skills = skills or [
         AgentSkill(
@@ -260,10 +321,12 @@ async def create_agent_card(
         )
     ]
 
+    url = _resolve_url(frontend_config, external)
+
     return AgentCard(
         name=frontend_config.name,
         description=frontend_config.description,
-        url=get_a2a_endpoint_url(frontend_config.host, frontend_config.port),
+        url=url,
         version=frontend_config.version,
         default_input_modes=frontend_config.default_input_modes,
         default_output_modes=frontend_config.default_output_modes,

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -124,11 +124,13 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             else None
         )
         skills = self.front_end_config.a2a.skills if self.front_end_config.a2a else []
+        external = self.front_end_config.a2a.external if self.front_end_config.a2a else None
 
         agent_card = await create_agent_card(
             frontend_config=self._a2a_worker.front_end_config,
             cross_app_access=cross_app_access,
             skills=skills,
+            external=external,
         )
         session_manager = await DRAgentAGUISessionManager.create(
             config=self._config,

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -44,6 +44,13 @@ logging_handler_setup()
 warnings.filterwarnings("ignore", message=".*stream_options is not default parameter.*")
 
 
+class DRAgentA2AExternalConfig(BaseModel):
+    """Customer-provided external identity and URL override for the agent card."""
+
+    id: str | None = Field(default=None, description="External agent identifier for catalog discovery.")
+    url: str | None = Field(default=None, description="Custom external URL override for the agent card endpoint.")
+
+
 class DRAgentA2AConfig(BaseModel):
     """DR-owned wrapper around NAT's A2AFrontEndConfig with optional skill definitions."""
 
@@ -59,6 +66,10 @@ class DRAgentA2AConfig(BaseModel):
         default=[],
         description="Skills to advertise in the A2A agent card. "
         "If empty, a single default skill is generated from the agent name and description.",
+    )
+    external: DRAgentA2AExternalConfig | None = Field(
+        default=None,
+        description="External identity and URL override for the agent card.",
     )
 
 

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -47,8 +47,12 @@ warnings.filterwarnings("ignore", message=".*stream_options is not default param
 class DRAgentA2AExternalConfig(BaseModel):
     """Customer-provided external identity and URL override for the agent card."""
 
-    id: str | None = Field(default=None, description="External agent identifier for catalog discovery.")
-    url: str | None = Field(default=None, description="Custom external URL override for the agent card endpoint.")
+    id: str | None = Field(
+        default=None, description="External agent identifier for catalog discovery."
+    )
+    url: str | None = Field(
+        default=None, description="Custom external URL override for the agent card endpoint."
+    )
 
 
 class DRAgentA2AConfig(BaseModel):

--- a/src/datarobot_genai/dragent/frontends/server_auth.py
+++ b/src/datarobot_genai/dragent/frontends/server_auth.py
@@ -14,9 +14,17 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 from nat.data_models.authentication import AuthProviderBaseConfig
 from pydantic import BaseModel
 from pydantic import Field
+
+
+class TokenEndpointAuthMethod(StrEnum):
+    """Supported ``token_endpoint_auth_method`` values for Cross-Application Access."""
+
+    PRIVATE_KEY_JWT = "private_key_jwt"
 
 
 class CrossAppTokenExchange(BaseModel):
@@ -36,9 +44,6 @@ class CrossAppTokenExchange(BaseModel):
 class CrossAppTokenRequest(BaseModel):
     """Step 2 parameters: RFC 7523 JWT Bearer Grant to obtain the final access token."""
 
-    grant_type: str = Field(
-        description="Must be ``urn:ietf:params:oauth:grant-type:jwt-bearer`` (RFC 7523).",
-    )
     token_url: str = Field(
         description=(
             "Token endpoint of the resource AS. "
@@ -71,11 +76,9 @@ class CrossApplicationAccessConfig(AuthProviderBaseConfig):
     All other fields → ``capabilities.extensions.params`` only.
     """
 
-    token_endpoint_auth_method: str = Field(
-        description=(
-            "Client auth method (e.g. ``private_key_jwt``). "
-            "Published in ``capabilities.extensions[].params``."
-        ),
+    token_endpoint_auth_method: TokenEndpointAuthMethod = Field(
+        default=TokenEndpointAuthMethod.PRIVATE_KEY_JWT,
+        description="Client auth method. Published in ``capabilities.extensions[].params``.",
     )
     token_exchange: CrossAppTokenExchange = Field(
         description="RFC 8693 Token Exchange parameters (Step 1: ID-JAG prerequisite).",

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -530,7 +530,8 @@ class TestCreateAgentCard:
 
     async def test_internal_identity_extension_when_deployment_id_set(self, a2a_frontend_config):
         """GIVEN MLOPS_DEPLOYMENT_ID is set WHEN create_agent_card is called THEN the internal
-        identity extension is present with the deployment_id."""
+        identity extension is present with the deployment_id.
+        """
         env = {
             "MLOPS_DEPLOYMENT_ID": "dep-abc123",
             "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
@@ -547,7 +548,8 @@ class TestCreateAgentCard:
 
     async def test_no_internal_identity_extension_in_local_dev(self, a2a_frontend_config):
         """GIVEN MLOPS_DEPLOYMENT_ID is not set WHEN create_agent_card is called THEN the
-        internal identity extension is absent."""
+        internal identity extension is absent.
+        """
         with patch.dict(os.environ, {}, clear=True):
             card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
 
@@ -556,7 +558,8 @@ class TestCreateAgentCard:
 
     async def test_external_identity_extension_when_external_id_set(self, a2a_frontend_config):
         """GIVEN external.id is provided WHEN create_agent_card is called THEN the external
-        identity extension is present with the correct id."""
+        identity extension is present with the correct id.
+        """
         external = DRAgentA2AExternalConfig(id="catalog-id-xyz")
         card = await create_agent_card(
             a2a_frontend_config, cross_app_access=None, skills=[], external=external
@@ -571,7 +574,8 @@ class TestCreateAgentCard:
 
     async def test_no_external_identity_extension_when_external_absent(self, a2a_frontend_config):
         """GIVEN external is None WHEN create_agent_card is called THEN no external identity
-        extension is present."""
+        extension is present.
+        """
         card = await create_agent_card(
             a2a_frontend_config, cross_app_access=None, skills=[], external=None
         )
@@ -581,7 +585,8 @@ class TestCreateAgentCard:
 
     async def test_external_url_overrides_agent_card_url(self, a2a_frontend_config):
         """GIVEN external.url is set WHEN create_agent_card is called THEN the agent card url
-        uses the external URL exactly as provided."""
+        uses the external URL exactly as provided.
+        """
         external = DRAgentA2AExternalConfig(url="https://custom.example.com/agent/")
         card = await create_agent_card(
             a2a_frontend_config, cross_app_access=None, skills=[], external=external
@@ -591,7 +596,8 @@ class TestCreateAgentCard:
 
     async def test_external_url_used_as_provided(self, a2a_frontend_config):
         """GIVEN external.url is set without a trailing slash WHEN create_agent_card is called
-        THEN the url is used exactly as provided, without modification."""
+        THEN the url is used exactly as provided, without modification.
+        """
         external = DRAgentA2AExternalConfig(url="https://custom.example.com/agent")
         card = await create_agent_card(
             a2a_frontend_config, cross_app_access=None, skills=[], external=external
@@ -601,7 +607,8 @@ class TestCreateAgentCard:
 
     async def test_all_extensions_combined(self, a2a_frontend_config):
         """GIVEN cross_app_access, MLOPS_DEPLOYMENT_ID, and external.id are all set WHEN
-        create_agent_card is called THEN all three extensions are present."""
+        create_agent_card is called THEN all three extensions are present.
+        """
         cross_app_access = CrossApplicationAccessConfig(
             token_endpoint_auth_method="private_key_jwt",
             token_exchange=CrossAppTokenExchange(

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -31,8 +31,12 @@ from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_EXTENSION_DESCRIPTION
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_FLOW_REF
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_REF
+from datarobot_genai.dragent.frontends.a2a import EXTERNAL_IDENTITY_URI
+from datarobot_genai.dragent.frontends.a2a import INTERNAL_IDENTITY_URI
 from datarobot_genai.dragent.frontends.a2a import JWT_BEARER_GRANT_TYPE_URI
 from datarobot_genai.dragent.frontends.a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
+from datarobot_genai.dragent.frontends.a2a import TOKEN_EXCHANGE_GRANT_TYPE_URI
+from datarobot_genai.dragent.frontends.a2a import TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE
 from datarobot_genai.dragent.frontends.a2a import create_agent_card
 from datarobot_genai.dragent.frontends.a2a import get_a2a_endpoint_url
 from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_ROUTES
@@ -40,6 +44,7 @@ from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlug
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
+from datarobot_genai.dragent.frontends.register import DRAgentA2AExternalConfig
 from datarobot_genai.dragent.frontends.register import DRAgentFastApiFrontEndConfig
 from datarobot_genai.dragent.frontends.server_auth import CrossApplicationAccessConfig
 from datarobot_genai.dragent.frontends.server_auth import CrossAppTokenExchange
@@ -375,7 +380,6 @@ class TestCreateAgentCard:
                 audience="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             ),
             token_request=CrossAppTokenRequest(
-                grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
                 token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
                 audience="https://app.datarobot.com/dr_org_id/my_agent_id",
                 scopes=["blog:write"],
@@ -411,11 +415,13 @@ class TestCreateAgentCard:
             },
             "token_endpoint_auth_method": "private_key_jwt",
             "token_exchange": {
+                "grant_type": TOKEN_EXCHANGE_GRANT_TYPE_URI,
+                "requested_token_type": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
                 "trusted_issuer": "https://your-org.oktapreview.com",
                 "audience": "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             },
             "token_request": {
-                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "grant_type": JWT_BEARER_GRANT_TYPE_URI,
                 "audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             },
         }
@@ -462,7 +468,6 @@ class TestCreateAgentCard:
                 audience="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             ),
             token_request=CrossAppTokenRequest(
-                grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
                 token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
                 audience="https://app.datarobot.com/dr_org_id/my_agent_id",
                 scopes=["blog:write"],
@@ -493,7 +498,7 @@ class TestCreateAgentCard:
         # Merged scopes (deduplicated)
         assert card.security == [{"oauth2": ["read", "blog:write"]}]
 
-        # JWT Bearer extension: nested params; token_url/scopes only under OpenAPI flows
+        # Cross-app extension: nested params; token_url/scopes only under OpenAPI flows
         assert card.capabilities.extensions is not None
         ext = card.capabilities.extensions[0]
         assert ext.uri == JWT_BEARER_GRANT_TYPE_URI
@@ -505,11 +510,13 @@ class TestCreateAgentCard:
             },
             "token_endpoint_auth_method": "private_key_jwt",
             "token_exchange": {
+                "grant_type": TOKEN_EXCHANGE_GRANT_TYPE_URI,
+                "requested_token_type": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
                 "trusted_issuer": "https://your-org.oktapreview.com",
                 "audience": "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             },
             "token_request": {
-                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "grant_type": JWT_BEARER_GRANT_TYPE_URI,
                 "audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             },
         }
@@ -520,6 +527,110 @@ class TestCreateAgentCard:
         card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
         assert card.security_schemes is None
         assert card.security is None
+
+    async def test_internal_identity_extension_when_deployment_id_set(self, a2a_frontend_config):
+        """GIVEN MLOPS_DEPLOYMENT_ID is set WHEN create_agent_card is called THEN the internal
+        identity extension is present with the deployment_id."""
+        env = {
+            "MLOPS_DEPLOYMENT_ID": "dep-abc123",
+            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+        }
+        with patch.dict(os.environ, env):
+            card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
+
+        assert card.capabilities.extensions is not None
+        uris = [ext.uri for ext in card.capabilities.extensions]
+        assert INTERNAL_IDENTITY_URI in uris
+        internal = next(e for e in card.capabilities.extensions if e.uri == INTERNAL_IDENTITY_URI)
+        assert internal.required is True
+        assert internal.params == {"deployment_id": "dep-abc123"}
+
+    async def test_no_internal_identity_extension_in_local_dev(self, a2a_frontend_config):
+        """GIVEN MLOPS_DEPLOYMENT_ID is not set WHEN create_agent_card is called THEN the
+        internal identity extension is absent."""
+        with patch.dict(os.environ, {}, clear=True):
+            card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
+
+        extensions = card.capabilities.extensions or []
+        assert not any(e.uri == INTERNAL_IDENTITY_URI for e in extensions)
+
+    async def test_external_identity_extension_when_external_id_set(self, a2a_frontend_config):
+        """GIVEN external.id is provided WHEN create_agent_card is called THEN the external
+        identity extension is present with the correct id."""
+        external = DRAgentA2AExternalConfig(id="catalog-id-xyz")
+        card = await create_agent_card(
+            a2a_frontend_config, cross_app_access=None, skills=[], external=external
+        )
+
+        assert card.capabilities.extensions is not None
+        uris = [ext.uri for ext in card.capabilities.extensions]
+        assert EXTERNAL_IDENTITY_URI in uris
+        ext = next(e for e in card.capabilities.extensions if e.uri == EXTERNAL_IDENTITY_URI)
+        assert ext.required is False
+        assert ext.params == {"id": "catalog-id-xyz"}
+
+    async def test_no_external_identity_extension_when_external_absent(self, a2a_frontend_config):
+        """GIVEN external is None WHEN create_agent_card is called THEN no external identity
+        extension is present."""
+        card = await create_agent_card(
+            a2a_frontend_config, cross_app_access=None, skills=[], external=None
+        )
+
+        extensions = card.capabilities.extensions or []
+        assert not any(e.uri == EXTERNAL_IDENTITY_URI for e in extensions)
+
+    async def test_external_url_overrides_agent_card_url(self, a2a_frontend_config):
+        """GIVEN external.url is set WHEN create_agent_card is called THEN the agent card url
+        uses the external URL exactly as provided."""
+        external = DRAgentA2AExternalConfig(url="https://custom.example.com/agent/")
+        card = await create_agent_card(
+            a2a_frontend_config, cross_app_access=None, skills=[], external=external
+        )
+
+        assert card.url == "https://custom.example.com/agent/"
+
+    async def test_external_url_used_as_provided(self, a2a_frontend_config):
+        """GIVEN external.url is set without a trailing slash WHEN create_agent_card is called
+        THEN the url is used exactly as provided, without modification."""
+        external = DRAgentA2AExternalConfig(url="https://custom.example.com/agent")
+        card = await create_agent_card(
+            a2a_frontend_config, cross_app_access=None, skills=[], external=external
+        )
+
+        assert card.url == "https://custom.example.com/agent"
+
+    async def test_all_extensions_combined(self, a2a_frontend_config):
+        """GIVEN cross_app_access, MLOPS_DEPLOYMENT_ID, and external.id are all set WHEN
+        create_agent_card is called THEN all three extensions are present."""
+        cross_app_access = CrossApplicationAccessConfig(
+            token_endpoint_auth_method="private_key_jwt",
+            token_exchange=CrossAppTokenExchange(
+                trusted_issuer="https://your-org.oktapreview.com",
+                audience="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
+            ),
+            token_request=CrossAppTokenRequest(
+                token_url="https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7/v1/token",
+                audience="https://app.datarobot.com/dr_org_id/my_agent_id",
+            ),
+        )
+        external = DRAgentA2AExternalConfig(id="catalog-id-combined")
+        env = {
+            "MLOPS_DEPLOYMENT_ID": "dep-combined",
+            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+        }
+        with patch.dict(os.environ, env):
+            card = await create_agent_card(
+                a2a_frontend_config,
+                cross_app_access=cross_app_access,
+                skills=[],
+                external=external,
+            )
+
+        assert card.capabilities.extensions is not None
+        uris = [ext.uri for ext in card.capabilities.extensions]
+        assert JWT_BEARER_GRANT_TYPE_URI in uris
+        assert INTERNAL_IDENTITY_URI in uris
+        assert EXTERNAL_IDENTITY_URI in uris
 
 
 class TestDRAgentFastApiFrontEndConfig:
@@ -538,7 +649,6 @@ class TestDRAgentFastApiFrontEndConfig:
                 audience="https://idp.example.com/oauth2/ausXXX",
             ),
             token_request=CrossAppTokenRequest(
-                grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer",
                 token_url="https://idp.example.com/oauth2/v1/token",
                 audience="api://my-agent",
                 scopes=["agent:use"],
@@ -566,6 +676,18 @@ class TestDRAgentFastApiFrontEndConfig:
     def test_a2a_enables_endpoints(self):
         config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=A2AFrontEndConfig()))
         assert config.a2a is not None
+
+    def test_a2a_external_config_optional(self):
+        config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=A2AFrontEndConfig()))
+        assert config.a2a.external is None
+
+    def test_a2a_with_external_config(self):
+        external = DRAgentA2AExternalConfig(id="ext-id-123", url="https://external.example.com/")
+        config = DRAgentFastApiFrontEndConfig(
+            a2a=DRAgentA2AConfig(server=A2AFrontEndConfig(), external=external)
+        )
+        assert config.a2a.external.id == "ext-id-123"
+        assert config.a2a.external.url == "https://external.example.com/"
 
 
 class TestDRAgentFastApiFrontEndPluginWorkerCleanup:

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -90,6 +90,8 @@ def _make_agent_card() -> AgentCard:
             "ref": {"scheme": "oauth2", "flow": "clientCredentials"},
             "token_endpoint_auth_method": _AUTH_METHOD,
             "token_exchange": {
+                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                "requested_token_type": "urn:ietf:params:oauth:token-type:id-jag",
                 "trusted_issuer": _TRUSTED_ISSUER,
                 "audience": _EXCHANGE_AUDIENCE,
             },

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.39"
+version = "0.15.40"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.38"
+version = "0.15.39"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Simplifies Cross-Application Access configuration in `workflow.yaml` by auto-generating static values, instead of requiring user to manually type them. This simplifies the setup and lowers the risk of errors due to typos.

Adds two new AgentCard extensions: `urn:datarobot:agent:identity:internal` and `urn:datarobot:agent:identity:external`. Supports an optional `external` configuration block with `id` for identity and `url` for the AgentCard endpoint override.

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches A2A agent-card generation and Okta cross-application access metadata, so mistakes could break agent discovery/auth flows, but changes are scoped and covered by updated unit tests/docs.
> 
> **Overview**
> AgentCard generation for A2A now **injects fixed OAuth/XAA URNs and defaults** (token-exchange `grant_type`/`requested_token_type`, JWT bearer `grant_type`, and default `token_endpoint_auth_method`) so `workflow.yaml` no longer needs to specify these static values.
> 
> Adds optional `general.frontend.a2a.external` config to publish an **external identity extension** (`urn:datarobot:agent:identity:external`) and to **override the agent card `url`** as provided. Also emits an **internal identity extension** (`urn:datarobot:agent:identity:internal`) in deployments when `MLOPS_DEPLOYMENT_ID` is set.
> 
> Bumps version to `0.15.40`, updates A2A auth docs/examples accordingly, and extends tests to validate new extensions, URL override behavior, and the injected URN fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502f04be80532ec32cc442c65a1e4addaa99aa74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->