### PR TITLE
BUZZOK-29612 Using tools from `drtools` standalone

### DIFF
--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -54,6 +54,11 @@ except ImportError:
         """
         return None
 
+    class Middleware:  # type: ignore[no-redef]
+        """Stub base class when FastMCP is not installed."""
+
+        pass
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/datarobot_genai/drtools/core/clients/atlassian.py
+++ b/src/datarobot_genai/drtools/core/clients/atlassian.py
@@ -15,10 +15,12 @@
 """Atlassian API client utilities for OAuth and cloud ID management."""
 
 import logging
+import os
 from typing import Any
 from typing import Literal
 
 import httpx
+from dotenv import load_dotenv
 
 from datarobot_genai.drtools.core.auth import get_oauth_access_token_with_header_fallback
 from datarobot_genai.drtools.core.exceptions import ToolError
@@ -39,7 +41,10 @@ async def get_atlassian_access_token() -> str | ToolError:
     """
     Get Atlassian OAuth access token with error handling.
 
-    Uses DataRobot OBO when available; otherwise ``x-datarobot-atlassian-access-token``.
+    Resolution order:
+    1. ``ATLASSIAN_ACCESS_TOKEN`` environment variable (also loaded from ``.env``).
+    2. DataRobot OBO OAuth flow.
+    3. ``x-datarobot-atlassian-access-token`` request header.
 
     Returns
     -------
@@ -54,11 +59,24 @@ async def get_atlassian_access_token() -> str | ToolError:
         # Use token
         ```
     """
-    return await get_oauth_access_token_with_header_fallback(
-        "atlassian",
-        display_name="Atlassian",
-        access_token_header_segment="atlassian",
-    )
+    load_dotenv(override=False)
+    env_token = os.environ.get("ATLASSIAN_ACCESS_TOKEN", "").strip()
+    username = os.environ.get("ATLASSIAN_API_USERNAME", "").strip()
+    base_url = os.environ.get("ATLASSIAN_API_BASE_URL", "").strip()
+    
+    if (env_token and username and base_url):    
+        logger.info("Using Atlassian access token from environment variable.")
+        return {
+            "username": username,
+            "token": env_token,
+            "base_url": base_url.rstrip("/"),
+        } 
+    else:
+        return await get_oauth_access_token_with_header_fallback(
+            "atlassian",
+            display_name="Atlassian",
+            access_token_header_segment="atlassian",
+        )
 
 
 def _find_resource_by_service(

--- a/src/datarobot_genai/drtools/core/clients/confluence.py
+++ b/src/datarobot_genai/drtools/core/clients/confluence.py
@@ -122,10 +122,21 @@ class ConfluenceClient:
         Args:
             access_token: OAuth access token for Atlassian API
         """
+        self._base_url_override: str | None = None
+        if isinstance(access_token, dict):
+            import base64
+            credentials = base64.b64encode(
+                f"{access_token['username']}:{access_token['token']}".encode()
+            ).decode()
+            auth_header = f"Basic {credentials}"
+            self._base_url_override = access_token["base_url"]
+        else:
+            auth_header = f"Bearer {access_token}"
+        
         self.access_token = access_token
         self._client = httpx.AsyncClient(
             headers={
-                "Authorization": f"Bearer {access_token}",
+                "Authorization": auth_header,
                 "Accept": "application/json",
                 "Content-Type": "application/json",
             },
@@ -153,6 +164,13 @@ class ConfluenceClient:
 
         self._cloud_id = await get_atlassian_cloud_id(self._client, service_type="confluence")
         return self._cloud_id
+
+    async def _get_api_base(self) -> str:
+        """Return the base URL for Confluence REST API calls."""
+        if self._base_url_override:
+            return f"{self._base_url_override}/wiki/rest/api"
+        cloud_id = await self._get_cloud_id()
+        return f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api"
 
     def _parse_response(self, data: dict) -> ConfluencePage:
         """Parse API response into ConfluencePage."""
@@ -194,8 +212,8 @@ class ConfluenceClient:
             ConfluenceError: If page is not found
             httpx.HTTPStatusError: If the API request fails
         """
-        cloud_id = await self._get_cloud_id()
-        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/content/{page_id}"
+        api_base = await self._get_api_base()
+        url = f"{api_base}/content/{page_id}"
 
         response = await self._client.get(url, params={"expand": self.EXPAND_FIELDS})
 
@@ -222,8 +240,8 @@ class ConfluenceClient:
             ConfluenceError: If the page is not found
             httpx.HTTPStatusError: If the API request fails
         """
-        cloud_id = await self._get_cloud_id()
-        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/content"
+        api_base = await self._get_api_base()
+        url = f"{api_base}/content"
 
         response = await self._client.get(
             url,
@@ -290,8 +308,8 @@ class ConfluenceClient:
                             permission denied, or invalid content
             httpx.HTTPStatusError: If the API request fails with unexpected status
         """
-        cloud_id = await self._get_cloud_id()
-        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/content"
+        api_base = await self._get_api_base()
+        url = f"{api_base}/content"
 
         payload: dict[str, Any] = {
             "type": "page",
@@ -370,8 +388,8 @@ class ConfluenceClient:
                             or rate limited (429)
             httpx.HTTPStatusError: If the API request fails with unexpected status
         """
-        cloud_id = await self._get_cloud_id()
-        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/content/{page_id}"
+        api_base = await self._get_api_base()
+        url = f"{api_base}/content/{page_id}"
 
         try:
             current_page = await self.get_page_by_id(page_id)
@@ -463,8 +481,8 @@ class ConfluenceClient:
             ConfluenceError: If page not found, permission denied, or invalid content
             httpx.HTTPStatusError: If the API request fails with unexpected status
         """
-        cloud_id = await self._get_cloud_id()
-        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/content"
+        api_base = await self._get_api_base()
+        url = f"{api_base}/content"
 
         payload: dict[str, Any] = {
             "type": "comment",
@@ -521,8 +539,8 @@ class ConfluenceClient:
         ------
             ConfluenceError: If the API request fails (400, 403, 429)
         """
-        cloud_id = await self._get_cloud_id()
-        url = f"{ATLASSIAN_API_BASE}/ex/confluence/{cloud_id}/wiki/rest/api/search"
+        api_base = await self._get_api_base()
+        url = f"{api_base}/search"
 
         response = await self._client.get(
             url,

--- a/src/datarobot_genai/drtools/core/clients/jira.py
+++ b/src/datarobot_genai/drtools/core/clients/jira.py
@@ -80,17 +80,30 @@ class JiraClient:
     At the moment of creating this client, official Jira SDK is not supporting async.
     """
 
-    def __init__(self, access_token: str) -> None:
+    def __init__(self, access_token: str | dict[str, str]) -> None:
         """
         Initialize Jira client with access token.
 
         Args:
-            access_token: OAuth access token for Atlassian API
+            access_token: OAuth access token string, or a dict with
+                ``username``, ``token``, and ``base_url`` keys for Basic Auth
+                (API token flow).
         """
+        self._base_url_override: str | None = None
+        if isinstance(access_token, dict):
+            import base64
+            credentials = base64.b64encode(
+                f"{access_token['username']}:{access_token['token']}".encode()
+            ).decode()
+            auth_header = f"Basic {credentials}"
+            self._base_url_override = access_token["base_url"]
+        else:
+            auth_header = f"Bearer {access_token}"
+
         self.access_token = access_token
         self._client = httpx.AsyncClient(
             headers={
-                "Authorization": f"Bearer {access_token}",
+                "Authorization": auth_header,
                 "Accept": "application/json",
                 "Content-Type": "application/json",
             },
@@ -121,6 +134,8 @@ class JiraClient:
 
     async def _get_full_url(self, path: str) -> str:
         """Return URL for Jira API."""
+        if self._base_url_override:
+            return f"{self._base_url_override}/rest/api/3/{path}"
         cloud_id = await self._get_cloud_id()
         return f"{ATLASSIAN_API_BASE}/ex/jira/{cloud_id}/rest/api/3/{path}"
 

--- a/src/datarobot_genai/drtools/core/clients/tavily.py
+++ b/src/datarobot_genai/drtools/core/clients/tavily.py
@@ -15,9 +15,11 @@
 """Tavily API Client and utilities for API key authentication."""
 
 import logging
+import os
 from typing import Any
 from typing import Literal
 
+from dotenv import load_dotenv
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -38,7 +40,11 @@ CHUNKS_PER_SOURCE_DEFAULT: int = 1
 
 async def get_tavily_access_token() -> str:
     """
-    Get Tavily API key from HTTP headers.
+    Get Tavily API key.
+
+    Resolution order:
+    1. ``TAVILY_API_KEY`` environment variable (also loaded from ``.env``).
+    2. ``x-tavily-api-key`` request header.
 
     Returns
     -------
@@ -46,14 +52,20 @@ async def get_tavily_access_token() -> str:
 
     Raises
     ------
-        ToolError: If API key is not found in headers
+        ToolError: If API key is not found
     """
+    load_dotenv(override=False)
+    env_key = os.environ.get("TAVILY_API_KEY", "").strip()
+    if env_key:
+        logger.info("Using Tavily API key from environment variable.")
+        return env_key
     if api_key := get_api_key_from_headers("x-tavily-api-key"):
         return api_key
 
-    logger.warning("Tavily API key not found in headers")
+    logger.warning("Tavily API key not found in environment or headers")
     raise ToolError(
-        "Tavily API key not found in headers. Please provide it via 'x-tavily-api-key' header.",
+        "Tavily API key not found. Set TAVILY_API_KEY in .env or pass it via "
+        "'x-tavily-api-key' header.",
         kind=ToolErrorKind.AUTHENTICATION,
     )
 


### PR DESCRIPTION
# RATIONALE
IN PROGRESS
simplifying usage of tools without MCP where is possible. Docs will be provided later

## CHANGES
static creds usage for:
Tavily
<img width="1241" height="991" alt="Screenshot 2026-05-08 at 14 32 21" src="https://github.com/user-attachments/assets/5c78a6f2-a275-4e78-8b15-2a51f3a44f9c" />

confluence 
<img width="1240" height="1071" alt="Screenshot 2026-05-07 at 13 19 49" src="https://github.com/user-attachments/assets/a6d0dd55-0e26-4d39-9234-dba40915d4dd" />

jira
<img width="752" height="983" alt="Screenshot 2026-05-07 at 12 33 30" src="https://github.com/user-attachments/assets/227d1b9a-d870-4206-97e7-57868a9bdbed" />

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cbd18d37598bb04ebf3c3696aae2912c385cd946. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->