### PR TITLE
[-] Fix LangGraph streaming for list-form AIMessage.content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.43
+- Fixed LangGraph agent streaming when the underlying LLM emits reasoning content. List-form `AIMessage.content` is now collapsed to its text portion via `message.text` before streaming the AG-UI delta and before passing the trace to ragas, instead of being str-coerced into the OpenAI `delta.content` field.
+
 ## 0.15.42
 - Added NAT middleware for DataRobot LLM guardrails (`datarobot_genai.nat.datarobot_moderation_middleware`), ported from the agent application recipe. The `dragent` extra includes `datarobot-moderations` (there is no separate `moderation` extra); import the middleware module in your NAT workflow registration so `@register_middleware` runs (same pattern as `import agent.datarobot_moderation_middleware` in app templates). Extended `DRAgentEventResponse` with optional `datarobot_moderations` for serialized pipeline metadata.
 - Declared `uv` `override-dependencies` for OpenTelemetry (`opentelemetry-api` / `sdk` / `instrumentation` and OTLP exporters at 1.39.x / 0.60b1) so `datarobot-moderations` can coexist with optional extras such as CrewAI when resolving `datarobot-genai[dragent]` together with other stacks.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.42"
+version = "0.15.43"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.42"
+version = "0.15.43"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -418,38 +418,43 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
                                     None,
                                     usage_metrics,
                                 )
-                    elif message.content:
-                        # Its a text message
-                        # Handle the start and end of the text message
-                        if message.id != current_message_id:
-                            if current_message_id:
+                    else:
+                        # AIMessage.text strips reasoning/thinking blocks and
+                        # joins any remaining text-typed blocks; only user-visible
+                        # text is streamed as message deltas.
+                        text_delta = message.text
+                        if text_delta:
+                            # Its a text message
+                            # Handle the start and end of the text message
+                            if message.id != current_message_id:
+                                if current_message_id:
+                                    yield (
+                                        TextMessageEndEvent(
+                                            type=EventType.TEXT_MESSAGE_END,
+                                            message_id=current_message_id,
+                                        ),
+                                        None,
+                                        usage_metrics,
+                                    )
+                                current_message_id = str(message.id or "")
                                 yield (
-                                    TextMessageEndEvent(
-                                        type=EventType.TEXT_MESSAGE_END,
+                                    TextMessageStartEvent(
+                                        type=EventType.TEXT_MESSAGE_START,
                                         message_id=current_message_id,
+                                        role="assistant",
                                     ),
                                     None,
                                     usage_metrics,
                                 )
-                            current_message_id = str(message.id or "")
                             yield (
-                                TextMessageStartEvent(
-                                    type=EventType.TEXT_MESSAGE_START,
+                                TextMessageContentEvent(
+                                    type=EventType.TEXT_MESSAGE_CONTENT,
                                     message_id=current_message_id,
-                                    role="assistant",
+                                    delta=text_delta,
                                 ),
                                 None,
                                 usage_metrics,
                             )
-                        yield (
-                            TextMessageContentEvent(
-                                type=EventType.TEXT_MESSAGE_CONTENT,
-                                message_id=current_message_id,
-                                delta=str(message.content),
-                            ),
-                            None,
-                            usage_metrics,
-                        )
                 else:
                     raise ValueError(f"Invalid message event: {message_event}")
             elif mode == "updates":
@@ -572,7 +577,14 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
             for _, v in e.items():
                 if v is not None:
                     messages.extend(v.get("messages", []))
-        messages = [m for m in messages if not isinstance(m, ToolMessage)]
+        # Ragas only accepts string content. Models that emit reasoning return
+        # AIMessage.content as a list of content blocks; collapse them to plain
+        # text via .text (drops thinking blocks) before handing the list off.
+        messages = [
+            m if isinstance(m.content, str) else m.model_copy(update={"content": m.text})
+            for m in messages
+            if not isinstance(m, ToolMessage)
+        ]
         # Lazy import to reduce memory overhead when ragas is not used
         from ragas import MultiTurnSample
         from ragas.integrations.langgraph import convert_to_ragas_messages

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -760,3 +760,150 @@ def test_create_pipeline_interactions_from_events_filters_tool_messages() -> Non
     # ToolMessage filtered out; order preserved
     msgs = sample.user_input
     assert len(msgs) == 2
+
+
+class ThinkingBlockLangGraphAgent(LangGraphAgent):
+    """Agent whose graph stream emits AIMessageChunks with list-form content
+    (Anthropic-style thinking blocks alongside text).
+    """
+
+    @cached_property
+    def workflow(self) -> StateGraph[MessagesState]:
+        async def mock_stream_generator():
+            yield (
+                "agent",
+                "messages",
+                (
+                    AIMessageChunk(
+                        content=[
+                            {"type": "thinking", "thinking": "The user is asking..."},
+                        ],
+                        id="111",
+                    ),
+                    {},
+                ),
+            )
+            yield (
+                "agent",
+                "messages",
+                (
+                    AIMessageChunk(
+                        content=[
+                            {"type": "thinking", "thinking": " let me search."},
+                            {"type": "text", "text": "I am an assistant."},
+                        ],
+                        id="111",
+                    ),
+                    {},
+                ),
+            )
+            yield (
+                "agent",
+                "messages",
+                (
+                    AIMessageChunk(
+                        content=[
+                            {"type": "text", "text": " Nice to meet you."},
+                        ],
+                        id="111",
+                    ),
+                    {},
+                ),
+            )
+            yield (
+                "agent",
+                "updates",
+                {
+                    "agent": {
+                        "usage": {
+                            "total_tokens": 10,
+                            "prompt_tokens": 5,
+                            "completion_tokens": 5,
+                        },
+                        "messages": [
+                            HumanMessage(content="who are you?"),
+                            AIMessage(
+                                content=[
+                                    {"type": "thinking", "thinking": "..."},
+                                    {
+                                        "type": "text",
+                                        "text": "I am an assistant. Nice to meet you.",
+                                    },
+                                ],
+                                id="111",
+                            ),
+                        ],
+                    }
+                },
+            )
+
+        mock_graph_stream = Mock(astream=Mock(return_value=mock_stream_generator()))
+        mock_state_graph = Mock(compile=Mock(return_value=mock_graph_stream))
+        return mock_state_graph
+
+    @property
+    def prompt_template(self) -> ChatPromptTemplate:
+        return ChatPromptTemplate.from_messages(
+            [
+                {"role": "system", "content": "You are an assistant about {topic}."},
+                {"role": "user", "content": "Hi, tell me about {topic}."},
+            ]
+        )
+
+    @property
+    def langgraph_config(self) -> dict[str, Any]:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_extracts_text_from_thinking_block_content(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """When the model emits AIMessageChunks with list-form content (thinking
+    blocks + text), the streamed TextMessageContent deltas must contain only
+    the text portion, not the Python repr of the content list.
+    """
+    agent = ThinkingBlockLangGraphAgent()
+
+    events: list[BaseEvent] = []
+    async for response_event, _, _ in agent.invoke(run_agent_input):
+        if isinstance(response_event, BaseEvent):
+            events.append(response_event)
+
+    text_deltas = [e.delta for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT]
+    # Thinking-only chunks should not produce any visible delta.
+    # Mixed and text-only chunks should produce only the text portion.
+    assert text_deltas == ["I am an assistant.", " Nice to meet you."]
+    # No delta should ever contain the dict repr of a thinking block.
+    for delta in text_deltas:
+        assert "thinking" not in delta
+        assert "{'type'" not in delta
+
+
+def test_create_pipeline_interactions_from_events_handles_list_content_with_thinking() -> None:
+    """AIMessage content can be a list of content blocks (thinking + text) when
+    the underlying model emits reasoning. ragas's converter only accepts string
+    content, so the agent must normalize list-form content before handing it
+    over.
+    """
+    human = HumanMessage(content="who are you?")
+    ai = AIMessage(
+        content=[
+            {"type": "thinking", "thinking": "The user is asking..."},
+            {"type": "thinking", "thinking": " let me search."},
+            {"type": "text", "text": "I am an assistant."},
+            {"type": "text", "text": " Nice to meet you."},
+        ],
+        id="111",
+    )
+    events: list[dict[str, Any]] = [
+        {"node1": {"messages": [human]}},
+        {"node2": {"messages": [ai]}},
+    ]
+
+    sample = LangGraphAgent.create_pipeline_interactions_from_events(events)
+    assert sample is not None
+    msgs = sample.user_input
+    assert len(msgs) == 2
+    # The AIMessage should have been normalized to plain text, with thinking blocks dropped.
+    assert msgs[1].content == "I am an assistant. Nice to meet you."

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.42"
+version = "0.15.43"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
When the underlying LLM emits reasoning content (e.g. Claude with extended thinking), AIMessageChunk.content is a list of content blocks rather than a plain string. The previous str(message.content) coercion produced Python repr like "[{'type': 'thinking', 'thinking': 'The'}]" in the OpenAI delta.content stream. Use AIMessage.text to drop thinking blocks and join text-typed blocks, and apply the same normalization before handing traces to ragas.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LangGraph agent streaming and trace normalization logic, which can affect user-visible deltas and downstream Ragas evaluation when models emit list-form (thinking/text) content.
> 
> **Overview**
> Fixes LangGraph AG-UI streaming for models that emit *reasoning/thinking* blocks by switching text delta generation from `str(message.content)` to `AIMessageChunk.text`, preventing Python-repr artifacts and skipping thinking-only chunks.
> 
> Normalizes LangGraph event traces before sending to Ragas by collapsing any non-string `AIMessage.content` into plain text (via `.text`) and dropping tool messages, and adds targeted tests plus a version bump to `0.15.43`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 705012a7b98eaf6d1f1afa5ed95cafdd15350975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->