### PR TITLE
Set user_id from context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.43
+- Fixed dragent A2A + per-user workflows when no Bearer JWT is present: `DRAgentAGUISessionManager.session` now forwards a preset `ContextState.user_id` (set from the A2A `context_id` by the FastAPI executor) into NAT’s explicit `user_id` argument. NAT 1.6+ otherwise replaced the context value with `None`, causing per-user workflows to fail in local dev and message-only A2A scenarios.
+
 ## 0.15.42
 - Added NAT middleware for DataRobot LLM guardrails (`datarobot_genai.nat.datarobot_moderation_middleware`), ported from the agent application recipe. The `dragent` extra includes `datarobot-moderations` (there is no separate `moderation` extra); import the middleware module in your NAT workflow registration so `@register_middleware` runs (same pattern as `import agent.datarobot_moderation_middleware` in app templates). Extended `DRAgentEventResponse` with optional `datarobot_moderations` for serialized pipeline metadata.
 - Declared `uv` `override-dependencies` for OpenTelemetry (`opentelemetry-api` / `sdk` / `instrumentation` and OTLP exporters at 1.39.x / 0.60b1) so `datarobot-moderations` can coexist with optional extras such as CrewAI when resolving `datarobot-genai[dragent]` together with other stacks.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.42"
+version = "0.15.43"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.42"
+version = "0.15.43"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -50,10 +50,11 @@ class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
     1. ``__init__`` accesses ``session_manager.workflow`` which raises ``ValueError``
        for per-user workflows.  We bypass it and log via ``config.workflow.type`` instead.
 
-    2. ``execute`` calls ``self.session_manager.session()`` with no ``user_id``, which
-       raises ``ValueError`` for per-user workflows.  We override it to pass the A2A
-       ``context_id`` as the ``user_id``, giving each conversation its own isolated
-       per-user workflow instance.
+    2. ``execute`` calls ``self.session_manager.session()`` with no ``user_id``. NAT 1.6+
+       would overwrite a preset ``ContextState.user_id`` with ``None``. We set the A2A
+       ``context_id`` on that context var before delegating; :class:`DRAgentAGUISessionManager`
+       merges it into the ``user_id`` argument so each conversation gets its own per-user
+       workflow instance without requiring a Bearer JWT.
     """
 
     def __init__(self, session_manager: SessionManager) -> None:
@@ -67,9 +68,8 @@ class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:  # type: ignore[override]
         # Inject the A2A context_id as user_id before delegating to the parent execute.
-        # The parent calls self.session_manager.session() with no user_id, which raises
-        # ValueError for per-user workflows.  Setting the context var here means the
-        # SessionManager's _get_user_id_from_context() will find it automatically.
+        # DRAgentAGUISessionManager.session copies this into the explicit user_id
+        # parameter because NAT 1.6+ session() replaces the context var with None.
         token = None
         if context.context_id:
             token = self.session_manager._context_state.user_id.set(context.context_id)

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -13,9 +13,19 @@
 # limitations under the License.
 
 import logging
+from collections.abc import AsyncIterator
+from collections.abc import Awaitable
+from collections.abc import Callable
+from contextlib import asynccontextmanager
 
 from fastapi import Request
+from nat.data_models.authentication import AuthenticatedContext
+from nat.data_models.authentication import AuthFlowType
+from nat.data_models.authentication import AuthProviderBaseConfig
+from nat.data_models.interactive import HumanResponse
+from nat.data_models.interactive import InteractionPrompt
 from nat.data_models.user_info import UserInfo
+from nat.runtime.session import Session
 from nat.runtime.session import SessionManager
 from nat.runtime.user_manager import UserManager
 from pydantic import BaseModel
@@ -65,6 +75,42 @@ _patch_user_manager()
 
 
 class DRAgentAGUISessionManager(SessionManager):
+    @asynccontextmanager
+    async def session(
+        self,
+        user_id: str | None = None,
+        http_connection: HTTPConnection | None = None,
+        user_message_id: str | None = None,
+        conversation_id: str | None = None,
+        user_input_callback: Callable[[InteractionPrompt], Awaitable[HumanResponse]] | None = None,
+        user_authentication_callback: Callable[
+            [AuthProviderBaseConfig, AuthFlowType], Awaitable[AuthenticatedContext | None]
+        ]
+        | None = None,
+    ) -> AsyncIterator[Session]:
+        """Bridge A2A and other callers that preset ``ContextState.user_id``.
+
+        NAT 1.6+ assigns ``self._context_state.user_id`` from the explicit ``user_id``
+        argument only. The A2A adapter calls ``session()`` with no arguments; our
+        executor sets ``context_id`` on the context var first, but the parent
+        ``session()`` would overwrite it with ``None``. Copy any preset non-empty
+        value into ``user_id`` before delegating so per-user workflows work without
+        a Bearer JWT (local dev / message-only A2A).
+        """
+        if user_id is None:
+            preset = self._context_state.user_id.get()
+            if preset:
+                user_id = preset
+        async with super().session(
+            user_id=user_id,
+            http_connection=http_connection,
+            user_message_id=user_message_id,
+            conversation_id=conversation_id,
+            user_input_callback=user_input_callback,
+            user_authentication_callback=user_authentication_callback,
+        ) as sess:
+            yield sess
+
     def get_workflow_input_schema(self) -> type[BaseModel]:
         """Get workflow input schema for OpenAPI documentation."""
         return DRAgentRunAgentInput

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import asynccontextmanager
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -61,6 +62,33 @@ class TestDRAgentAGUISessionManager:
     ):
         schema = session_manager.get_workflow_streaming_output_schema()
         assert schema is DRAgentEventResponse
+
+    @pytest.mark.asyncio
+    async def test_session_passes_preset_context_user_id_to_nat_session(self, session_manager):
+        """Regression guard for NAT 1.6 A2A + per-user workflows without Bearer JWT.
+
+        The A2A executor presets ``ContextState.user_id`` from ``context_id`` then calls
+        ``session()`` with no arguments. NAT's ``SessionManager.session`` used to replace
+        that context value with ``None``, triggering "user_id is required for per-user
+        workflow". DRAgent must forward the preset into the explicit ``user_id`` kwarg.
+        """
+        preset = "efeb8b83-ea1c-4d63-928b-aba9927520ee"
+        token = session_manager._context_state.user_id.set(preset)
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
+
+        try:
+            with patch.object(SessionManager, "session", fake_nat_session):
+                async with session_manager.session():
+                    pass
+        finally:
+            session_manager._context_state.user_id.reset(token)
+
+        assert captured.get("user_id") == preset
 
 
 class TestUserManagerPatch:

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.42"
+version = "0.15.43"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
See https://datarobot.slack.com/archives/C07DQSG302C/p1778253166435009
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Set user_id from context before initiating a session.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session creation/user identification plumbing for dragent A2A execution; mistakes could route requests to the wrong workflow instance or reintroduce per-user workflow failures, but the change is small and covered by a regression test.
> 
> **Overview**
> Fixes `dragent` A2A per-user workflows when no Bearer JWT is present by ensuring a preset `ContextState.user_id` (seeded from the A2A `context_id`) is forwarded into NAT’s explicit `user_id` parameter via an overridden `DRAgentAGUISessionManager.session()`.
> 
> Updates the A2A executor docs/behavior to rely on this bridge, adds a regression test for the NAT 1.6+ overwrite case, and bumps the package version to `0.15.43` (locks updated accordingly) with a changelog entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76690d7de7ec15a2acb5bd3b6b4ec23588f5693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->