### PR TITLE
Fix prediction tools blocking call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.44
+- `drtools/predictive/predict.py`: **Submit-and-poll batch workflow** — `predict_by_ai_catalog` and `predict_from_project_data` return immediately after submit (removed `timeout` and server-side `wait_for_completion` plus download-link polling); responses include `job_id`, `batch_job_status`, optional early `url`, and a `note` for follow-up instead of only completed-job metadata. **New tool `get_batch_prediction_job_status`** (`job_id`) returns status, optional download `url`, and progress fields without fetching CSV. **`get_batch_prediction_results`** is documented and used after polling for completion; passes `download_timeout` / `download_read_timeout` through to the SDK download. **`BatchPredictionJob.score` / `get`** use the same configured SDK client as `Dataset.get`.
+- `drtools/predictive/training.py` (`get_exploratory_insights`): optional `feature_col` plus `include_feature_histogram` add a DataRobot catalog API-backed column profile (allFeaturesDetails statistics and optional feature histogram) alongside existing EDA output; helpers resolve catalog `DatasetFeature` rows by name and serialize them for the tool response.
+- `drtools/predictive/predict_realtime.py`: clarified `predict_by_ai_catalog_rt` tool metadata so async batch scoring is described as submit-and-poll via `predict_by_ai_catalog` and `get_batch_prediction_job_status`.
+
 ## 0.15.43
 - Fixed dragent A2A + per-user workflows when no Bearer JWT is present: `DRAgentAGUISessionManager.session` now forwards a preset `ContextState.user_id` (set from the A2A `context_id` by the FastAPI executor) into NAT’s explicit `user_id` argument. NAT 1.6+ otherwise replaced the context value with `None`, causing per-user workflows to fail in local dev and message-only A2A scenarios.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.43"
+version = "0.15.44"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.43"
+version = "0.15.44"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -24,6 +24,12 @@ STUB_PROJECT_ID = "test_project_123"
 # Dataset id used by test_create_dr_client(); use for integration tests with stubs.
 STUB_DATASET_ID = "stub_dataset_id"
 
+# Catalog dataset id from ``classification_predict_dataset`` when using stub token (conftest).
+STUB_PREDICT_CATALOG_DATASET_ID = "stub_predict_dataset_id"
+
+# Batch prediction job id returned by stub ``BatchPredictionJob.score`` / ``get``.
+STUB_BATCH_PREDICTION_JOB_ID = "stub_batch_prediction_job_id"
+
 # Use case id used by test_create_dr_client(); use for integration tests with stubs.
 STUB_USE_CASE_ID = "stub_use_case_id"
 
@@ -135,6 +141,40 @@ class StubDeployment:
         return MagicMock()
 
 
+class StubCatalogDatasetFeature:
+    """Stand-in for SDK ``DatasetFeature`` (catalog / allFeaturesDetails) in stub tests."""
+
+    def __init__(self, name: str, feature_type: str = "Categorical", **kwargs: Any) -> None:
+        self.name = name
+        self.feature_type = feature_type
+        self.unique_count = kwargs.get("unique_count", 5)
+        self.na_count = kwargs.get("na_count", 0)
+        self.date_format = kwargs.get("date_format")
+        self.min = kwargs.get("min")
+        self.max = kwargs.get("max")
+        self.mean = kwargs.get("mean")
+        self.median = kwargs.get("median")
+        self.std_dev = kwargs.get("std_dev")
+        self.low_information = kwargs.get("low_information", False)
+        self.time_series_eligible = kwargs.get("time_series_eligible", False)
+        self.time_series_eligibility_reason = kwargs.get("time_series_eligibility_reason", "")
+        self.time_step = kwargs.get("time_step")
+        self.time_unit = kwargs.get("time_unit")
+        self.target_leakage = kwargs.get("target_leakage", "FALSE")
+        self.target_leakage_reason = kwargs.get("target_leakage_reason")
+
+    def get_histogram(self, bin_limit: int | None = None, key_name: str | None = None) -> Any:
+        return SimpleNamespace(
+            plot=[
+                {
+                    "label": "stub-bin",
+                    "count": max(1, int(self.unique_count or 1)),
+                    "target": None,
+                }
+            ]
+        )
+
+
 class StubDataset:
     """Stub DataRobot dataset object."""
 
@@ -148,6 +188,55 @@ class StubDataset:
         self.name = name
         self.created_at = "2025-01-01T00:00:00Z"
         self.row_count = row_count
+
+    def get_details(self) -> Any:
+        """Stub ``Dataset.get_details`` (catalog extended profile flag)."""
+        return SimpleNamespace(data_persisted=True)
+
+    def _stub_catalog_features(self) -> list[StubCatalogDatasetFeature]:
+        """Feature names align with ``get_as_dataframe`` (date, sales, store_id)."""
+        rc = self.row_count
+        return [
+            StubCatalogDatasetFeature(
+                "date",
+                "Categorical",
+                unique_count=rc,
+                na_count=0,
+                time_series_eligible=True,
+                time_series_eligibility_reason="suitable",
+            ),
+            StubCatalogDatasetFeature(
+                "sales",
+                "Float",
+                unique_count=min(100, max(1, rc)),
+                na_count=0,
+                min=100.0,
+                max=1000.0,
+                mean=550.0,
+                median=520.0,
+                std_dev=100.0,
+            ),
+            StubCatalogDatasetFeature(
+                "store_id",
+                "Categorical",
+                unique_count=min(5, max(1, rc)),
+                na_count=0,
+            ),
+        ]
+
+    def iterate_all_features(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+        order_by: str | None = None,
+    ) -> Any:
+        """Stub ``Dataset.iterate_all_features`` for catalog API-backed EDA in tools."""
+        features = self._stub_catalog_features()
+        if offset:
+            features = features[offset:]
+        if limit is not None:
+            features = features[:limit]
+        return iter(features)
 
     def get_as_dataframe(self) -> Any:
         """Return a stub pandas DataFrame suitable for time-series eligibility checks.
@@ -198,6 +287,40 @@ class StubUseCase:
         return [StubProject("test_project_123")]
 
 
+class StubBatchJob:
+    """Stub batch prediction job (submit, status poll, download) for MCP integration tests."""
+
+    def __init__(self, job_id: str = STUB_BATCH_PREDICTION_JOB_ID) -> None:
+        self.id = job_id
+
+    def get_status(self) -> dict[str, Any]:
+        return {
+            "status": "COMPLETED",
+            "links": {"download": "https://stub.app.example/api/v2/batchPredictions/download"},
+            "percentage_completed": 100.0,
+            "elapsed_time_sec": 0,
+            "status_details": "",
+            "job_spec": {"output_settings": {"type": "localFile"}},
+        }
+
+    def download(self, buf: Any, timeout: int = 120, read_timeout: int = 660) -> None:
+        _ = (timeout, read_timeout)
+        buf.write(b"text_review,sentiment_PREDICTION\nstub,positive\n")
+
+
+class StubBatchPredictionJobAPI:
+    """Subset of ``datarobot.BatchPredictionJob`` used by predictive batch tools."""
+
+    @staticmethod
+    def score(*args: Any, **kwargs: Any) -> StubBatchJob:
+        _ = (args, kwargs)
+        return StubBatchJob(STUB_BATCH_PREDICTION_JOB_ID)
+
+    @staticmethod
+    def get(job_id: str) -> StubBatchJob:
+        return StubBatchJob(job_id.strip())
+
+
 class StubDataStore:
     """Stub DataRobot datastore object."""
 
@@ -229,6 +352,7 @@ class StubDRClient:
         self.DataStore = MagicMock()
         self.UseCase = MagicMock()
         self.client = MagicMock()
+        self.BatchPredictionJob = StubBatchPredictionJobAPI()
         self.stub_rest_get: Any = None
         self.stub_rest_post: Any = None
 
@@ -298,7 +422,7 @@ def test_create_dr_client() -> StubDRClient:
     stub_dataset = StubDataset(STUB_DATASET_ID, name="stub_dataset.csv", row_count=200)
 
     def get_dataset(dataset_id: str) -> StubDataset:
-        if dataset_id == STUB_DATASET_ID:
+        if dataset_id in (STUB_DATASET_ID, STUB_PREDICT_CATALOG_DATASET_ID):
             return stub_dataset
         raise Exception(f"404 client error: {{'message': 'Dataset {dataset_id} not found'}}")
 

--- a/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
@@ -17,6 +17,7 @@ import re
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from .clients.base import LLMResponse
 
@@ -25,8 +26,19 @@ class ToolCallTestExpectations(BaseModel):
     """Class to store tool call information."""
 
     name: str
+    acceptable_tool_names: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Logical tool names treated as equivalent for this step (same parameters/result "
+            "checks). Example: get_deployment_features vs get_deployment_info for deployment "
+            "scoring metadata."
+        ),
+    )
     parameters: dict[str, Any]
     result: str | dict[str, Any]
+
+    def allowed_tool_names(self) -> set[str]:
+        return {self.name, *self.acceptable_tool_names}
 
 
 class ETETestExpectations(BaseModel):
@@ -219,15 +231,27 @@ def _check_dict_has_keys(
     return True
 
 
+def _canonical_tool_name_for_expectation(
+    raw_tool_name: str, expected_call: ToolCallTestExpectations
+) -> str | None:
+    """Return which allowed logical name ``raw_tool_name`` matches, or None."""
+    for cand in expected_call.allowed_tool_names():
+        if _normalize_tool_name(raw_tool_name, cand) == cand:
+            return cand
+    return None
+
+
 def _build_failure_diagnostics(
     expected_calls: list[ToolCallTestExpectations],
     response: LLMResponse,
 ) -> str:
     """Build a compact diagnostics section for assertion errors."""
-    expected_lines = [
-        f"#{idx + 1} {call.name} params={call.parameters}"
-        for idx, call in enumerate(expected_calls)
-    ]
+    expected_lines = []
+    for idx, call in enumerate(expected_calls):
+        alt = ""
+        if call.acceptable_tool_names:
+            alt = f" (or {', '.join(call.acceptable_tool_names)})"
+        expected_lines.append(f"#{idx + 1} {call.name}{alt} params={call.parameters}")
     actual_lines = []
     for idx, tool_call in enumerate(response.tool_calls):
         expected_name = expected_calls[idx].name if idx < len(expected_calls) else None
@@ -308,10 +332,10 @@ class ToolBaseE2E:
                     matched_actual_idx = None
                     for actual_idx in range(search_start, len(response.tool_calls)):
                         actual_call = response.tool_calls[actual_idx]
-                        actual_tool_name = _normalize_tool_name(
-                            actual_call.tool_name, expected_call.name
+                        canonical = _canonical_tool_name_for_expectation(
+                            actual_call.tool_name, expected_call
                         )
-                        if actual_tool_name != expected_call.name:
+                        if canonical is None:
                             continue
                         if not _check_dict_params_match(
                             expected_call.parameters, actual_call.parameters
@@ -320,8 +344,9 @@ class ToolBaseE2E:
                         matched_actual_idx = actual_idx
                         break
 
+                    allowed = ", ".join(sorted(expected_call.allowed_tool_names()))
                     assert matched_actual_idx is not None, (
-                        f"Should have called {expected_call.name} tool with the correct "
+                        f"Should have called one of [{allowed}] with the correct "
                         f"parameters. Expected (subset): {expected_call.parameters}\n"
                         f"{diagnostics}"
                     )
@@ -335,27 +360,25 @@ class ToolBaseE2E:
 
             for expected_idx, actual_idx in expected_actual_indices:
                 tool_call = response.tool_calls[actual_idx]
-                expected_tool_name = expected_calls[expected_idx].name
-                actual_tool_name = _normalize_tool_name(tool_call.tool_name, expected_tool_name)
-
-                assert actual_tool_name == expected_tool_name, (
-                    f"Should have called {expected_tool_name} tool, but got: "
-                    f"{tool_call.tool_name}\n"
+                expected_call = expected_calls[expected_idx]
+                canonical = _canonical_tool_name_for_expectation(tool_call.tool_name, expected_call)
+                assert canonical is not None, (
+                    f"Should have called one of {sorted(expected_call.allowed_tool_names())}, "
+                    f"but got: {tool_call.tool_name}\n"
                     f"{diagnostics}"
                 )
-                assert _check_dict_params_match(
-                    expected_calls[expected_idx].parameters, tool_call.parameters
-                ), (
-                    f"Should have called {expected_tool_name} tool with the correct parameters. "
-                    f"Expected (subset): {expected_calls[expected_idx].parameters}, "
+
+                assert _check_dict_params_match(expected_call.parameters, tool_call.parameters), (
+                    f"Should have called {canonical} tool with the correct parameters. "
+                    f"Expected (subset): {expected_call.parameters}, "
                     f"but got: {tool_call.parameters}\n"
                     f"{diagnostics}"
                 )
-                if expected_calls[expected_idx].result != SHOULD_NOT_BE_EMPTY:
-                    expected_result = expected_calls[expected_idx].result
+                if expected_call.result != SHOULD_NOT_BE_EMPTY:
+                    expected_result = expected_call.result
                     if isinstance(expected_result, str):
                         assert expected_result in response.tool_results[actual_idx], (
-                            f"Should have called {expected_tool_name} tool with the correct "
+                            f"Should have called {canonical} tool with the correct "
                             f"result, but got: {response.tool_results[actual_idx]}\n"
                             f"{diagnostics}"
                         )
@@ -382,17 +405,17 @@ class ToolBaseE2E:
                                     except json.JSONDecodeError:
                                         raise AssertionError(
                                             f"Could not parse tool result for "
-                                            f"{expected_tool_name}: "
+                                            f"{canonical}: "
                                             f"{response.tool_results[actual_idx]}"
                                         )
                         assert _check_dict_has_keys(expected_result, actual_result), (
-                            f"Should have called {expected_tool_name} tool with the correct "
+                            f"Should have called {canonical} tool with the correct "
                             f"result structure, but got: {response.tool_results[actual_idx]}\n"
                             f"{diagnostics}"
                         )
                 else:
                     assert len(response.tool_results[actual_idx]) > 0, (
-                        f"Should have called {expected_tool_name} tool with non-empty result, but "
+                        f"Should have called {canonical} tool with non-empty result, but "
                         f"got: {response.tool_results[actual_idx]}\n"
                         f"{diagnostics}"
                     )

--- a/src/datarobot_genai/drtools/predictive/predict.py
+++ b/src/datarobot_genai/drtools/predictive/predict.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import io
 import logging
-import time
 from typing import Annotated
 from typing import Any
 
-import datarobot as dr
 from datarobot.errors import ClientError
 
 from datarobot_genai.drtools.core import tool_metadata
@@ -31,11 +28,6 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 
 logger = logging.getLogger(__name__)
-
-# After completion, links.download can lag (busy queues). SDK download() waits up to 120s for the
-# URL; we only poll status until the link appears—~30s balances real deployments vs giving up.
-_DOWNLOAD_LINK_MAX_ATTEMPTS = 60
-_DOWNLOAD_LINK_POLL_SEC = 0.5
 
 _TERMINAL_FAILURE_STATUSES = frozenset({"ERROR", "FAILED", "ABORTED"})
 
@@ -54,42 +46,24 @@ def _tool_error_with_batch_url(message: str, url: str | None) -> ToolError:
     return ToolError(message, kind=ToolErrorKind.UPSTREAM)
 
 
-def _handle_prediction_resource(job: Any, deployment_id: str, input_desc: str) -> dict[str, Any]:
-    """Return batch job metadata and an authenticated download URL for scored CSV."""
-    download_url: str | None = None
-    last_status: dict[str, Any] | None = None
-    for attempt in range(_DOWNLOAD_LINK_MAX_ATTEMPTS):
-        status = job.get_status()
-        last_status = status
-        st = status.get("status")
-        if st in _TERMINAL_FAILURE_STATUSES:
-            details = status.get("status_details", "")
-            logger.error("Batch job %s terminal status=%s details=%s", job.id, st, details)
-            raise ToolError(
-                f"Batch prediction job failed: status={st!r} details={details!r}",
-                kind=ToolErrorKind.UPSTREAM,
-            )
-        download_url = status.get("links", {}).get("download")
-        if download_url:
-            break
-        output_settings = (status.get("job_spec") or {}).get("output_settings") or {}
-        out_type = output_settings.get("type")
-        if out_type and out_type != "localFile":
-            raise ToolError(
-                "Batch job output is not local file streaming; there is no download URL for this "
-                f"output type ({out_type!r}). Use the configured sink (e.g. JDBC/S3) instead.",
-                kind=ToolErrorKind.UPSTREAM,
-            )
-        if attempt < _DOWNLOAD_LINK_MAX_ATTEMPTS - 1:
-            time.sleep(_DOWNLOAD_LINK_POLL_SEC)
-    if not download_url:
-        st = (last_status or {}).get("status")
-        details = (last_status or {}).get("status_details", "")
+def _batch_job_submitted_payload(job: Any, deployment_id: str, input_desc: str) -> dict[str, Any]:
+    """Return right after score(): job id, current status, download URL if already present."""
+    status = job.get_status()
+    st = status.get("status")
+    if st in _TERMINAL_FAILURE_STATUSES:
+        details = status.get("status_details", "")
+        logger.error("Batch job %s terminal status=%s details=%s", job.id, st, details)
         raise ToolError(
-            "Batch prediction finished but no download URL appeared after polling. "
-            f"Last status={st!r} details={details!r}. "
-            "Confirm the job used local file (streaming) output, or retry later with the same "
-            "job_id.",
+            f"Batch prediction job failed: status={st!r} details={details!r}",
+            kind=ToolErrorKind.UPSTREAM,
+        )
+    download_url = status.get("links", {}).get("download")
+    output_settings = (status.get("job_spec") or {}).get("output_settings") or {}
+    out_type = output_settings.get("type")
+    if out_type and out_type != "localFile":
+        raise ToolError(
+            "Batch job output is not local file streaming; there is no download URL for this "
+            f"output type ({out_type!r}). Use the configured sink (e.g. JDBC/S3) instead.",
             kind=ToolErrorKind.UPSTREAM,
         )
     return {
@@ -97,48 +71,35 @@ def _handle_prediction_resource(job: Any, deployment_id: str, input_desc: str) -
         "deployment_id": deployment_id,
         "input_desc": input_desc,
         "url": download_url,
+        "batch_job_status": st,
         "name": f"Predictions for {deployment_id}",
         "mime_type": "text/csv",
+        "note": (
+            "This tool only submits the batch job. You MUST poll get_batch_prediction_job_status "
+            "with job_id until batch_job_status is COMPLETED and url is present (retry every few "
+            "seconds while RUNNING or INITIALIZING). Then call get_batch_prediction_results for "
+            "inline CSV if small enough, or fetch url with DataRobot API authentication."
+        ),
     }
-
-
-def wait_for_preds_and_cache_results(
-    job: Any, deployment_id: str, input_desc: str, timeout: int
-) -> dict[str, Any]:
-    job.wait_for_completion(timeout)
-    if job.status in _TERMINAL_FAILURE_STATUSES:
-        logger.error("Job failed with status %s", job.status)
-        raise ToolError(f"Job failed with status {job.status}", kind=ToolErrorKind.UPSTREAM)
-    return _handle_prediction_resource(job, deployment_id, input_desc)
-
-
-async def _wait_for_preds_and_cache_results_async(
-    job: Any, deployment_id: str, input_desc: str, timeout: int
-) -> dict[str, Any]:
-    """Run blocking SDK wait in a thread pool so the MCP/async event loop is not stalled."""
-    return await asyncio.to_thread(
-        wait_for_preds_and_cache_results, job, deployment_id, input_desc, timeout
-    )
 
 
 @tool_metadata(
     tags={"predictive", "prediction", "read", "scoring", "batch"},
     description=(
-        "[Predict—deployment + catalog dataset] Use when the user wants batch scoring of one AI "
-        "Catalog tabular dataset through an MLOps deployment (deployment_id + dataset_id). Waits "
-        "until the job finishes. Returns job_id and an authenticated download URL for scored CSV. "
-        "Not the same as scoring with a leaderboard model inside a project "
-        "(score_dataset_with_model), not scoring project holdout/validation partitions "
-        "(predict_from_project_data), and not inline pasted rows (predict_realtime). Use "
-        "get_batch_prediction_results for CSV text when small enough; for synchronous rows from "
-        "catalog data, consider predict_by_ai_catalog_rt."
+        "[Predict—deployment + catalog dataset] Submits batch scoring of one AI Catalog tabular "
+        "dataset through an MLOps deployment (deployment_id + dataset_id). Returns immediately "
+        "with job_id and initial batch_job_status; does NOT wait for completion. Required "
+        "follow-up: poll get_batch_prediction_job_status until COMPLETED and url is set, then "
+        "get_batch_prediction_results or authenticated download of url. Not leaderboard scoring "
+        "(score_dataset_with_model), not project splits (predict_from_project_data), not inline "
+        "rows (predict_realtime). For synchronous small catalog scoring use "
+        "predict_by_ai_catalog_rt."
     ),
 )
 async def predict_by_ai_catalog(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     dataset_id: Annotated[str, "AI Catalog dataset id to score."],
-    timeout: Annotated[int, "Max seconds to wait for batch job completion."] | None = 600,
 ) -> dict[str, Any]:
     if not deployment_id or not deployment_id.strip():
         raise ToolError(
@@ -155,7 +116,7 @@ async def predict_by_ai_catalog(
     client = DataRobotClient(token).get_client()
     try:
         dataset = client.Dataset.get(dataset_id)
-        job = dr.BatchPredictionJob.score(
+        job = client.BatchPredictionJob.score(
             deployment=deployment_id,
             intake_settings={  # type: ignore[arg-type]
                 "type": "dataset",
@@ -165,22 +126,18 @@ async def predict_by_ai_catalog(
         )
     except ClientError as e:
         raise_tool_error_for_client_error(e)
-    return await _wait_for_preds_and_cache_results_async(
-        job, deployment_id, f"Scoring dataset {dataset_id}.", timeout or 600
-    )
+    return _batch_job_submitted_payload(job, deployment_id, f"Scoring dataset {dataset_id}.")
 
 
 @tool_metadata(
     tags={"predictive", "prediction", "read", "scoring", "batch"},
     description=(
-        "[Predict—deployment + project splits] Use when the user asks for batch predictions from a "
-        "deployment using data that already lives in the modeling project: training, holdout, "
-        "validation, or allBacktest partitions (pass partition, e.g. holdout). Optional catalog "
-        "dataset_id if they linked another dataset to the project. This is the right tool for "
-        "phrases like 'batch score the holdout' or 'predict on the training partition', not for "
-        "only a catalog dataset_id without project context, and not for inline CSV/JSON in the "
-        "message. Returns job_id and scored CSV download URL like predict_by_ai_catalog, not "
-        "inline rows."
+        "[Predict—deployment + project splits] Submits batch predictions from a deployment using "
+        "project data: training, holdout, validation, or allBacktest (partition), optional "
+        "catalog dataset_id. Returns immediately with job_id like predict_by_ai_catalog; does NOT "
+        "wait. Required follow-up: poll get_batch_prediction_job_status until COMPLETED and url, "
+        "then get_batch_prediction_results or download url. Not catalog-only scoring without "
+        "project context, not inline CSV in chat."
     ),
 )
 async def predict_from_project_data(
@@ -197,7 +154,6 @@ async def predict_from_project_data(
         "Project data split: holdout, validation, or allBacktest.",
     ]
     | None = None,
-    timeout: Annotated[int, "Max seconds to wait for batch job completion."] | None = 600,
 ) -> dict[str, Any]:
     if not deployment_id or not deployment_id.strip():
         raise ToolError(
@@ -220,7 +176,7 @@ async def predict_from_project_data(
         )
 
     token = await get_datarobot_access_token()
-    DataRobotClient(token).get_client()
+    client = DataRobotClient(token).get_client()
     intake_settings: dict[str, Any] = {
         "type": "dss",
         "project_id": project_id,
@@ -230,33 +186,86 @@ async def predict_from_project_data(
     if dataset_id:
         intake_settings["dataset_id"] = dataset_id
     try:
-        job = dr.BatchPredictionJob.score(
+        job = client.BatchPredictionJob.score(
             deployment=deployment_id,
             intake_settings=intake_settings,  # type: ignore[arg-type]
             output_settings=None,
         )
     except ClientError as e:
         raise_tool_error_for_client_error(e)
-    return await _wait_for_preds_and_cache_results_async(
-        job, deployment_id, f"Scoring project {project_id}.", timeout or 600
-    )
+    return _batch_job_submitted_payload(job, deployment_id, f"Scoring project {project_id}.")
 
 
 @tool_metadata(
     tags={"predictive", "prediction", "read", "scoring", "batch"},
     description=(
-        "[Predict—fetch batch CSV] Use after a batch job completed: returns scored CSV text "
-        "inline given job_id from predict_by_ai_catalog or predict_from_project_data. Only when "
-        "the file is under the inline size cap; otherwise use the job download URL from the "
-        "batch tool with authenticated fetch. Does not start scoring and does not apply to "
-        "score_dataset_with_model jobs (different API surface)."
+        "[Predict—batch job status] REQUIRED polling step after predict_by_ai_catalog or "
+        "predict_from_project_data. Pass job_id from the submit response. Returns "
+        "batch_job_status, optional url when the scored file is ready, and progress fields. "
+        "Poll every few seconds until batch_job_status is COMPLETED and url is non-null, then "
+        "get_batch_prediction_results or download url. Lightweight (no CSV body). Raises on "
+        "terminal failure. Not for score_dataset_with_model jobs."
+    ),
+)
+async def get_batch_prediction_job_status(
+    *,
+    job_id: Annotated[
+        str,
+        "Batch prediction job id from predict_by_ai_catalog or predict_from_project_data.",
+    ],
+) -> dict[str, Any]:
+    if not job_id or not job_id.strip():
+        raise ToolError(
+            "Argument validation error: 'job_id' cannot be empty.", kind=ToolErrorKind.VALIDATION
+        )
+
+    token = await get_datarobot_access_token()
+    client = DataRobotClient(token).get_client()
+    try:
+        job = client.BatchPredictionJob.get(job_id.strip())
+    except ClientError as e:
+        raise_tool_error_for_client_error(e)
+    status = job.get_status()
+    st = status.get("status")
+    if st in _TERMINAL_FAILURE_STATUSES:
+        details = status.get("status_details", "")
+        raise ToolError(
+            f"Batch prediction job failed: status={st!r} details={details!r}",
+            kind=ToolErrorKind.UPSTREAM,
+        )
+    download_url = status.get("links", {}).get("download")
+    output_settings = (status.get("job_spec") or {}).get("output_settings") or {}
+    out_type = output_settings.get("type")
+    if out_type and out_type != "localFile":
+        raise ToolError(
+            "Batch job output is not local file streaming; there is no download URL for this "
+            f"output type ({out_type!r}). Use the configured sink (e.g. JDBC/S3) instead.",
+            kind=ToolErrorKind.UPSTREAM,
+        )
+    return {
+        "job_id": job.id,
+        "batch_job_status": st,
+        "url": download_url,
+        "percentage_completed": status.get("percentage_completed"),
+        "elapsed_time_sec": status.get("elapsed_time_sec"),
+        "status_details": status.get("status_details"),
+    }
+
+
+@tool_metadata(
+    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    description=(
+        "[Predict—fetch batch CSV] After get_batch_prediction_job_status shows COMPLETED and "
+        "url, returns scored CSV text inline for job_id when under the inline size cap. If too "
+        "large, the error includes the download url—fetch with API authentication. Does not start "
+        "scoring; not for score_dataset_with_model jobs."
     ),
 )
 async def get_batch_prediction_results(
     *,
     job_id: Annotated[
         str,
-        "job_id returned by predict_by_ai_catalog or predict_from_project_data.",
+        "job_id from predict_by_ai_catalog or predict_from_project_data (same as status polling).",
     ],
     download_timeout: Annotated[int, "Seconds to wait for the download to become ready."] = 120,
     download_read_timeout: Annotated[int, "Seconds allowed for streaming the CSV body."] = 660,
@@ -267,9 +276,9 @@ async def get_batch_prediction_results(
         )
 
     token = await get_datarobot_access_token()
-    DataRobotClient(token).get_client()
+    client = DataRobotClient(token).get_client()
     try:
-        job = dr.BatchPredictionJob.get(job_id.strip())
+        job = client.BatchPredictionJob.get(job_id.strip())
     except ClientError as e:
         raise_tool_error_for_client_error(e)
     download_url = _batch_job_download_url(job)

--- a/src/datarobot_genai/drtools/predictive/predict_realtime.py
+++ b/src/datarobot_genai/drtools/predictive/predict_realtime.py
@@ -50,8 +50,8 @@ def _parse_datetime(value: str) -> datetime:
         "[Predict—deployment + catalog, synchronous rows] Use when the user already has an AI "
         "Catalog dataset_id and wants realtime-style scoring through a deployment with rows "
         "returned in one response (moderate size). Not for pasted inline CSV/JSON "
-        "(predict_realtime), not for async batch CSV download (predict_by_ai_catalog), not "
-        "project-partition batch (predict_from_project_data)."
+        "(predict_realtime), not for async batch CSV submit-and-poll (predict_by_ai_catalog plus "
+        "get_batch_prediction_job_status), not project-partition batch (predict_from_project_data)."
     ),
 )
 async def predict_by_ai_catalog_rt(

--- a/src/datarobot_genai/drtools/predictive/training.py
+++ b/src/datarobot_genai/drtools/predictive/training.py
@@ -59,6 +59,43 @@ class DatasetInsight:
     missing_data_summary: dict[str, float]
 
 
+def _serialize_catalog_dataset_feature(feature: Any) -> dict[str, Any]:
+    """Map a SDK DatasetFeature to a JSON-friendly dict (DataRobot catalog / allFeaturesDetails)."""
+    out: dict[str, Any] = {}
+    for key in (
+        "name",
+        "feature_type",
+        "unique_count",
+        "na_count",
+        "date_format",
+        "min",
+        "max",
+        "mean",
+        "median",
+        "std_dev",
+        "low_information",
+        "time_series_eligible",
+        "time_series_eligibility_reason",
+        "time_step",
+        "time_unit",
+        "target_leakage",
+        "target_leakage_reason",
+    ):
+        if hasattr(feature, key):
+            val = getattr(feature, key)
+            if val is not None:
+                out[key] = val
+    return out
+
+
+def _find_catalog_dataset_feature_by_name(dataset: Any, feature_name: str) -> Any | None:
+    """Resolve a column to the SDK DatasetFeature from datasets/.../allFeaturesDetails/."""
+    for feat in dataset.iterate_all_features():
+        if feat.name == feature_name:
+            return feat
+    return None
+
+
 def _get_dataset_or_raise(client: Any, dataset_id: str) -> tuple[Any, pd.DataFrame]:
     """Fetch dataset and return it with its dataframe, with proper error handling.
 
@@ -192,8 +229,11 @@ async def suggest_use_cases(
     description=(
         "[Catalog—deep EDA] Use when the user wants richer exploratory stats on one catalog "
         "dataset: memory, per-column missingness, type groupings, optional target distribution "
-        "and numeric correlations. Read-only; does not train or upload data. Heavier than "
-        "analyze_dataset; not time-series eligibility (is_eligible_for_timeseries_training)."
+        "and numeric correlations. For averages/min/max/median/std on a specific column, set "
+        "feature_col to use DataRobot catalog feature metadata (allFeaturesDetails; EDA sample "
+        "per platform), optionally with include_feature_histogram. Read-only; does not train or "
+        "upload data. Heavier than analyze_dataset; not time-series eligibility "
+        "(is_eligible_for_timeseries_training)."
     ),
 )
 async def get_exploratory_insights(
@@ -203,13 +243,24 @@ async def get_exploratory_insights(
         str, "If set, add target-centric stats (must be an existing column name)."
     ]
     | None = None,
+    feature_col: Annotated[
+        str,
+        "If set, include DataRobot API-backed profile for this column (mean/median/min/max/std, "
+        "etc. from catalog EDA). Must match a dataset column name.",
+    ]
+    | None = None,
+    include_feature_histogram: Annotated[
+        bool,
+        "If true and feature_col is set, attach histogram bins from DataRobot "
+        "(datasets/.../featureHistograms).",
+    ] = False,
 ) -> dict[str, Any]:
     if not dataset_id:
         raise ToolError("Dataset ID must be provided", kind=ToolErrorKind.VALIDATION)
 
     token = await get_datarobot_access_token()
     client = DataRobotClient(token).get_client()
-    _, df = _get_dataset_or_raise(client, dataset_id)
+    dataset, df = _get_dataset_or_raise(client, dataset_id)
 
     # Get dataset insights first
     insights_result = await analyze_dataset(dataset_id=dataset_id)
@@ -231,6 +282,37 @@ async def get_exploratory_insights(
             "text": insights["text_columns"],
         },
     }
+
+    if feature_col:
+        if feature_col not in df.columns:
+            raise ToolError(
+                f"feature_col {feature_col!r} is not a column of this dataset.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+        try:
+            details = dataset.get_details()
+        except ClientError as e:
+            raise_tool_error_for_client_error(e)
+        api_feature = _find_catalog_dataset_feature_by_name(dataset, feature_col)
+        if api_feature is None:
+            raise ToolError(
+                f"No catalog feature metadata found for {feature_col!r}. "
+                "The column may not appear in DataRobot allFeaturesDetails yet.",
+                kind=ToolErrorKind.NOT_FOUND,
+            )
+        profile: dict[str, Any] = {
+            "source": "datarobot_catalog_all_features_details",
+            "statistics_basis": "eda_sample_as_computed_by_datarobot",
+            "data_persisted": getattr(details, "data_persisted", None),
+            "feature": _serialize_catalog_dataset_feature(api_feature),
+        }
+        if include_feature_histogram:
+            try:
+                histogram = api_feature.get_histogram()
+                profile["histogram"] = {"plot": histogram.plot}
+            except ClientError as e:
+                profile["histogram_error"] = str(e)
+        eda_insights["catalog_feature_profile"] = profile
 
     # Target-specific analysis
     if target_col and target_col in df.columns:

--- a/src/datarobot_genai/drtools/predictive/training.py
+++ b/src/datarobot_genai/drtools/predictive/training.py
@@ -22,6 +22,9 @@ from typing import Any
 
 import pandas as pd
 from datarobot.errors import ClientError
+from datarobot.utils import from_api
+from datarobot.utils import is_convertable_to_api
+from datarobot.utils import to_api
 
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot import DataRobotClient
@@ -59,33 +62,56 @@ class DatasetInsight:
     missing_data_summary: dict[str, float]
 
 
-def _serialize_catalog_dataset_feature(feature: Any) -> dict[str, Any]:
-    """Map a SDK DatasetFeature to a JSON-friendly dict (DataRobot catalog / allFeaturesDetails)."""
+# Public catalog-feature attributes for plain-object fallbacks (stubs / MagicMock in tests).
+_CATALOG_DATASET_FEATURE_JSON_KEYS: tuple[str, ...] = (
+    "name",
+    "feature_type",
+    "unique_count",
+    "na_count",
+    "date_format",
+    "min",
+    "max",
+    "mean",
+    "median",
+    "std_dev",
+    "low_information",
+    "time_series_eligible",
+    "time_series_eligibility_reason",
+    "time_step",
+    "time_unit",
+    "target_leakage",
+    "target_leakage_reason",
+)
+
+
+def _serialize_catalog_dataset_feature_plain(feature: Any) -> dict[str, Any]:
+    """Serialize a feature-like object that is not an SDK ``APIObject`` (e.g. test doubles)."""
     out: dict[str, Any] = {}
-    for key in (
-        "name",
-        "feature_type",
-        "unique_count",
-        "na_count",
-        "date_format",
-        "min",
-        "max",
-        "mean",
-        "median",
-        "std_dev",
-        "low_information",
-        "time_series_eligible",
-        "time_series_eligibility_reason",
-        "time_step",
-        "time_unit",
-        "target_leakage",
-        "target_leakage_reason",
-    ):
+    for key in _CATALOG_DATASET_FEATURE_JSON_KEYS:
         if hasattr(feature, key):
             val = getattr(feature, key)
             if val is not None:
                 out[key] = val
     return out
+
+
+def _serialize_catalog_dataset_feature(feature: Any) -> dict[str, Any]:
+    """Map a catalog ``DatasetFeature`` (SDK) to a JSON-friendly dict (snake_case).
+
+    Real ``DatasetFeature`` extends ``APIObject``; use ``to_api`` / ``from_api`` so serialization
+    stays aligned with the client library instead of hand-maintaining field lists. Non-APIObject
+    stand-ins (stubs, ``MagicMock``) use a fixed attribute allowlist.
+    """
+    if is_convertable_to_api(feature):
+        payload = to_api(feature)
+        if not isinstance(payload, dict):
+            raise TypeError(f"to_api(feature) must return dict, got {type(payload).__name__}")
+        normalized = from_api(payload, do_recursive=True)
+        if not isinstance(normalized, dict):
+            got = type(normalized).__name__
+            raise TypeError(f"from_api(to_api(feature)) must return dict, got {got}")
+        return normalized
+    return _serialize_catalog_dataset_feature_plain(feature)
 
 
 def _find_catalog_dataset_feature_by_name(dataset: Any, feature_name: str) -> Any | None:

--- a/tests/drmcp/acceptance/test_predict.py
+++ b/tests/drmcp/acceptance/test_predict.py
@@ -40,6 +40,16 @@ def expectations_for_predict_by_ai_catalog_success(
                 },
                 result=SHOULD_NOT_BE_EMPTY,
             ),
+            ToolCallTestExpectations(
+                name="get_batch_prediction_job_status",
+                parameters={"job_id": ANY_NONEMPTY_STRING},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+            ToolCallTestExpectations(
+                name="get_batch_prediction_results",
+                parameters={"job_id": ANY_NONEMPTY_STRING},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
         ],
         llm_response_content_contains_expectations=[
             "prediction",
@@ -62,6 +72,16 @@ def expectations_for_predict_from_project_data_success(
                 },
                 result=SHOULD_NOT_BE_EMPTY,
             ),
+            ToolCallTestExpectations(
+                name="get_batch_prediction_job_status",
+                parameters={"job_id": ANY_NONEMPTY_STRING},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+            ToolCallTestExpectations(
+                name="get_batch_prediction_results",
+                parameters={"job_id": ANY_NONEMPTY_STRING},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
         ],
         llm_response_content_contains_expectations=[
             "prediction",
@@ -82,6 +102,11 @@ def expectations_for_batch_predict_then_get_batch_results_success(
                     "deployment_id": deployment_id,
                     "dataset_id": classification_predict_dataset["dataset_id"],
                 },
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+            ToolCallTestExpectations(
+                name="get_batch_prediction_job_status",
+                parameters={"job_id": ANY_NONEMPTY_STRING},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
             ToolCallTestExpectations(
@@ -130,7 +155,11 @@ class TestPredictE2E(ToolBaseE2E):
         [
             """
         I have a DataRobot deployment with ID '{deployment_id}'.
-        Please run batch predictions using the AI Catalog dataset with ID '{dataset_id}'.
+        Run batch predictions using the AI Catalog dataset with ID '{dataset_id}'.
+        The batch submit tool returns immediately with a job_id: you must call
+        get_batch_prediction_job_status with that job_id until the job is COMPLETED and a
+        download url exists, then call get_batch_prediction_results with the same job_id to
+        retrieve the scored CSV. Summarize the prediction outcome.
         """
         ],
     )
@@ -167,6 +196,8 @@ class TestPredictE2E(ToolBaseE2E):
         The MCP server has no access to my laptop files. Deployment ID is '{deployment_id}'.
         Run batch scoring using only the AI Catalog dataset id '{dataset_id}' as the input source.
         Do not use local file paths or upload from this machine.
+        After submit, poll get_batch_prediction_job_status until COMPLETED with a url, then
+        get_batch_prediction_results for the CSV and describe the predictions.
         """
         ],
     )
@@ -204,7 +235,9 @@ class TestPredictE2E(ToolBaseE2E):
         [
             """
         I have a DataRobot deployment with ID '{deployment_id}' and project ID '{project_id}'.
-        Please run batch predictions using the training data holdout partition.
+        Run batch predictions on the holdout partition. After submit returns job_id, poll
+        get_batch_prediction_job_status until COMPLETED with url, then get_batch_prediction_results
+        and summarize predictions.
         """
         ],
     )
@@ -235,10 +268,9 @@ class TestPredictE2E(ToolBaseE2E):
         "prompt_template",
         [
             """
-        First, run batch scoring on DataRobot deployment '{deployment_id}' using AI Catalog
-        dataset '{dataset_id}'. When the first response includes a batch job identifier, use that
-        identifier in a follow-up step to fetch the scored CSV content (still within this
-        conversation). Summarize what you got back from the second step.
+        Run batch scoring on deployment '{deployment_id}' using AI Catalog dataset '{dataset_id}'.
+        Use the job_id from submit: call get_batch_prediction_job_status until COMPLETED and url
+        is set, then get_batch_prediction_results for the CSV. Summarize the prediction results.
         """
         ],
     )

--- a/tests/drmcp/acceptance/test_predict_realtime.py
+++ b/tests/drmcp/acceptance/test_predict_realtime.py
@@ -85,6 +85,7 @@ def expectations_for_get_deployment_info_success(deployment_id: str) -> ETETestE
         tool_calls_expected=[
             ToolCallTestExpectations(
                 name="get_deployment_info",
+                acceptable_tool_names=["get_deployment_features"],
                 parameters={"deployment_id": deployment_id},
                 result=SHOULD_NOT_BE_EMPTY,
             ),

--- a/tests/drmcp/integration/test_batch_predict.py
+++ b/tests/drmcp/integration/test_batch_predict.py
@@ -1,0 +1,134 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for batch catalog / project prediction tools (stub DataRobot client)."""
+
+import json
+from io import StringIO
+from typing import Any
+
+import pandas as pd
+import pytest
+from mcp.types import TextContent
+
+from datarobot_genai.drmcp.test_utils.mcp_utils_integration import integration_test_mcp_session
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import STUB_BATCH_PREDICTION_JOB_ID
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import STUB_PREDICT_CATALOG_DATASET_ID
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import STUB_PROJECT_ID
+
+
+@pytest.mark.asyncio
+class TestBatchPredictToolsIntegration:
+    """MCP integration tests for predict_by_ai_catalog, status, and results (stdio stub server)."""
+
+    async def test_batch_predict_tools_registered(self) -> None:
+        """Batch prediction tools are registered with predictive tools enabled."""
+        async with integration_test_mcp_session() as session:
+            listed = await session.list_tools()
+            tool_names = [t.name for t in listed.tools]
+            assert "predict_by_ai_catalog" in tool_names
+            assert "predict_from_project_data" in tool_names
+            assert "get_batch_prediction_job_status" in tool_names
+            assert "get_batch_prediction_results" in tool_names
+
+    async def test_predict_by_ai_catalog_submit_status_and_results(
+        self, classification_project: dict[str, Any]
+    ) -> None:
+        """Submit batch scoring from catalog, poll status, and read inline CSV (stub job)."""
+        deployment_id = classification_project["deployment_id"]
+        async with integration_test_mcp_session() as session:
+            submit = await session.call_tool(
+                "predict_by_ai_catalog",
+                {
+                    "deployment_id": deployment_id,
+                    "dataset_id": STUB_PREDICT_CATALOG_DATASET_ID,
+                },
+            )
+            assert not submit.isError
+            assert isinstance(submit.content[0], TextContent)
+            payload = json.loads(submit.content[0].text)
+            assert payload["job_id"] == STUB_BATCH_PREDICTION_JOB_ID
+            assert payload["deployment_id"] == deployment_id
+            assert payload["batch_job_status"] == "COMPLETED"
+            assert payload.get("url")
+            assert "get_batch_prediction_job_status" in payload["note"]
+
+            status = await session.call_tool(
+                "get_batch_prediction_job_status",
+                {"job_id": STUB_BATCH_PREDICTION_JOB_ID},
+            )
+            assert not status.isError
+            st = json.loads(status.content[0].text)
+            assert st["job_id"] == STUB_BATCH_PREDICTION_JOB_ID
+            assert st["batch_job_status"] == "COMPLETED"
+            assert st.get("url")
+
+            results = await session.call_tool(
+                "get_batch_prediction_results",
+                {"job_id": STUB_BATCH_PREDICTION_JOB_ID},
+            )
+            assert not results.isError
+            body = json.loads(results.content[0].text)
+            assert body["job_id"] == STUB_BATCH_PREDICTION_JOB_ID
+            assert body["mime_type"] == "text/csv"
+            assert body["size_bytes"] > 0
+            assert "sentiment_PREDICTION" in body["data"]
+            df = pd.read_csv(StringIO(body["data"]))
+            assert len(df) >= 1
+
+    async def test_predict_from_project_data_submit_status_and_results(
+        self, classification_project: dict[str, Any]
+    ) -> None:
+        """Submit batch scoring from project holdout, poll, and download stub CSV."""
+        deployment_id = classification_project["deployment_id"]
+        async with integration_test_mcp_session() as session:
+            submit = await session.call_tool(
+                "predict_from_project_data",
+                {
+                    "deployment_id": deployment_id,
+                    "project_id": STUB_PROJECT_ID,
+                    "partition": "holdout",
+                },
+            )
+            assert not submit.isError
+            payload = json.loads(submit.content[0].text)
+            assert payload["job_id"] == STUB_BATCH_PREDICTION_JOB_ID
+
+            status = await session.call_tool(
+                "get_batch_prediction_job_status",
+                {"job_id": payload["job_id"]},
+            )
+            assert not status.isError
+
+            results = await session.call_tool(
+                "get_batch_prediction_results",
+                {"job_id": payload["job_id"]},
+            )
+            assert not results.isError
+            body = json.loads(results.content[0].text)
+            assert "data" in body
+
+    async def test_predict_by_ai_catalog_empty_deployment_id_validation(self) -> None:
+        """Empty deployment_id returns a tool validation error."""
+        async with integration_test_mcp_session() as session:
+            result = await session.call_tool(
+                "predict_by_ai_catalog",
+                {
+                    "deployment_id": "   ",
+                    "dataset_id": STUB_PREDICT_CATALOG_DATASET_ID,
+                },
+            )
+            assert result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "deployment_id" in text

--- a/tests/drmcp/integration/test_training_eda.py
+++ b/tests/drmcp/integration/test_training_eda.py
@@ -1,0 +1,77 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for catalog EDA tools (stub DataRobot client via MCP stdio server)."""
+
+import json
+
+import pytest
+from mcp.types import TextContent
+
+from datarobot_genai.drmcp.test_utils.mcp_utils_integration import integration_test_mcp_session
+from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import STUB_DATASET_ID
+
+
+@pytest.mark.asyncio
+class TestGetExploratoryInsightsIntegration:
+    """MCP integration tests for ``get_exploratory_insights`` including catalog API profile."""
+
+    async def test_get_exploratory_insights_registered(self) -> None:
+        """``get_exploratory_insights`` is registered when predictive tools load."""
+        async with integration_test_mcp_session() as session:
+            listed = await session.list_tools()
+            tool_names = [t.name for t in listed.tools]
+            assert "get_exploratory_insights" in tool_names
+
+    async def test_get_exploratory_insights_with_catalog_feature_profile(self) -> None:
+        """``feature_col`` returns DataRobot catalog-style stats and optional histogram."""
+        async with integration_test_mcp_session() as session:
+            result = await session.call_tool(
+                "get_exploratory_insights",
+                {
+                    "dataset_id": STUB_DATASET_ID,
+                    "feature_col": "sales",
+                    "include_feature_histogram": True,
+                },
+            )
+
+            assert not result.isError
+            assert isinstance(result.content[0], TextContent)
+            data = json.loads(result.content[0].text)
+
+            assert "dataset_summary" in data
+            profile = data["catalog_feature_profile"]
+            assert profile["source"] == "datarobot_catalog_all_features_details"
+            assert profile["statistics_basis"] == "eda_sample_as_computed_by_datarobot"
+            assert profile["data_persisted"] is True
+            feat = profile["feature"]
+            assert feat["name"] == "sales"
+            assert feat["mean"] == 550.0
+            assert "histogram" in profile
+            assert profile["histogram"]["plot"][0]["label"] == "stub-bin"
+
+    async def test_get_exploratory_insights_invalid_feature_col(self) -> None:
+        """Unknown ``feature_col`` yields a tool error."""
+        async with integration_test_mcp_session() as session:
+            result = await session.call_tool(
+                "get_exploratory_insights",
+                {
+                    "dataset_id": STUB_DATASET_ID,
+                    "feature_col": "not_a_column",
+                },
+            )
+
+            assert result.isError
+            text = result.content[0].text  # type: ignore[union-attr]
+            assert "feature_col" in text or "not_a_column" in text

--- a/tests/drmcp/unit/predictive_tools/test_predict.py
+++ b/tests/drmcp/unit/predictive_tools/test_predict.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-import datarobot as dr
 import pytest
 
 from datarobot_genai.drtools.core.constants import MAX_INLINE_SIZE
@@ -28,26 +26,24 @@ from datarobot_genai.drtools.predictive import predict
 DOWNLOAD_URL = "https://app.example/api/v2/batchPredictions/jobid/download/"
 
 
-def _completed_job() -> MagicMock:
+def _running_job() -> MagicMock:
     mock_job = MagicMock()
     mock_job.id = "jobid"
-    mock_job.status = "COMPLETED"
-    mock_job.get_status.return_value = {"links": {"download": DOWNLOAD_URL}}
+    mock_job.get_status.return_value = {
+        "status": "RUNNING",
+        "links": {},
+        "job_spec": {"output_settings": {"type": "localFile"}},
+    }
     return mock_job
 
 
 @pytest.fixture()
-def patch_predict_dependencies() -> Generator[dict[str, Any], None, None]:
-    with patch(
-        "datarobot_genai.drtools.predictive.predict.dr.BatchPredictionJob"
-    ) as mock_batch_job:
-        yield {"mock_batch_job": mock_batch_job}
+def mock_batch_prediction_job() -> MagicMock:
+    return MagicMock()
 
 
 @pytest.mark.asyncio
-async def test_predict_by_ai_catalog(
-    patch_predict_dependencies: dict[str, Any],
-) -> None:
+async def test_predict_by_ai_catalog(mock_batch_prediction_job: MagicMock) -> None:
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -56,16 +52,15 @@ async def test_predict_by_ai_catalog(
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
     ):
-        mock_job = _completed_job()
-        patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
+        mock_job = _running_job()
+        mock_batch_prediction_job.score.return_value = mock_job
         mock_dataset = MagicMock()
         mock_client = MagicMock()
         mock_client.Dataset.get.return_value = mock_dataset
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
         mock_drc.return_value.get_client.return_value = mock_client
-        result = await predict.predict_by_ai_catalog(
-            deployment_id="dep", dataset_id="dsid", timeout=5
-        )
-        patch_predict_dependencies["mock_batch_job"].score.assert_called_once_with(
+        result = await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+        mock_batch_prediction_job.score.assert_called_once_with(
             deployment="dep",
             intake_settings={"type": "dataset", "dataset": mock_dataset},
             output_settings=None,
@@ -74,13 +69,23 @@ async def test_predict_by_ai_catalog(
         assert result["job_id"] == "jobid"
         assert result["deployment_id"] == "dep"
         assert "Scoring dataset dsid" in result["input_desc"]
-        assert result["url"] == DOWNLOAD_URL
+        assert result["batch_job_status"] == "RUNNING"
+        assert result["url"] is None
+        assert "get_batch_prediction_job_status" in result["note"]
+        mock_job.wait_for_completion.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_predict_from_project_data(
-    patch_predict_dependencies: dict[str, Any],
+async def test_predict_by_ai_catalog_submit_returns_url_when_ready(
+    mock_batch_prediction_job: MagicMock,
 ) -> None:
+    mock_job = MagicMock()
+    mock_job.id = "jobid"
+    mock_job.get_status.return_value = {
+        "status": "COMPLETED",
+        "links": {"download": DOWNLOAD_URL},
+        "job_spec": {"output_settings": {"type": "localFile"}},
+    }
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -89,17 +94,97 @@ async def test_predict_from_project_data(
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
     ):
-        mock_drc.return_value.get_client.return_value = MagicMock()
-        mock_job = _completed_job()
-        patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
+        mock_dataset = MagicMock()
+        mock_client = MagicMock()
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
+        mock_batch_prediction_job.score.return_value = mock_job
+        mock_drc.return_value.get_client.return_value = mock_client
+        result = await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+    assert result["url"] == DOWNLOAD_URL
+    assert result["batch_job_status"] == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_predict_by_ai_catalog_immediate_failure(
+    mock_batch_prediction_job: MagicMock,
+) -> None:
+    mock_job = MagicMock()
+    mock_job.id = "jobid"
+    mock_job.get_status.return_value = {
+        "status": "FAILED",
+        "status_details": "bad",
+        "links": {},
+    }
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
+    ):
+        mock_dataset = MagicMock()
+        mock_client = MagicMock()
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
+        mock_batch_prediction_job.score.return_value = mock_job
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError, match="FAILED"):
+            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+
+
+@pytest.mark.asyncio
+async def test_predict_by_ai_catalog_non_local_file_output_raises(
+    mock_batch_prediction_job: MagicMock,
+) -> None:
+    mock_job = MagicMock()
+    mock_job.id = "jobid"
+    mock_job.get_status.return_value = {
+        "status": "RUNNING",
+        "links": {},
+        "job_spec": {"output_settings": {"type": "jdbc"}},
+    }
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
+    ):
+        mock_dataset = MagicMock()
+        mock_client = MagicMock()
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
+        mock_batch_prediction_job.score.return_value = mock_job
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError, match="not local file streaming"):
+            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+
+
+@pytest.mark.asyncio
+async def test_predict_from_project_data(mock_batch_prediction_job: MagicMock) -> None:
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
+    ):
+        mock_client = MagicMock()
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
+        mock_drc.return_value.get_client.return_value = mock_client
+        mock_job = _running_job()
+        mock_batch_prediction_job.score.return_value = mock_job
         result = await predict.predict_from_project_data(
             deployment_id="dep",
             project_id="pid",
             dataset_id="dsid",
             partition="holdout",
-            timeout=5,
         )
-        patch_predict_dependencies["mock_batch_job"].score.assert_called_once_with(
+        mock_batch_prediction_job.score.assert_called_once_with(
             deployment="dep",
             intake_settings={
                 "type": "dss",
@@ -113,19 +198,22 @@ async def test_predict_from_project_data(
         assert result["job_id"] == "jobid"
         assert result["deployment_id"] == "dep"
         assert "Scoring project pid" in result["input_desc"]
-        assert result["url"] == DOWNLOAD_URL
+        mock_job.wait_for_completion.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_predict_by_ai_catalog_timeout(
-    patch_predict_dependencies: dict[str, Any],
-) -> None:
+async def test_get_batch_prediction_job_status(mock_batch_prediction_job: MagicMock) -> None:
     mock_job = MagicMock()
-    mock_job.id = "jobid"
-    mock_job.status = "IN_PROGRESS"
-    mock_job.wait_for_completion.side_effect = dr.errors.AsyncTimeoutError(
-        "Job did not complete within the timeout period."
-    )
+    mock_job.id = "jid"
+    mock_job.get_status.return_value = {
+        "status": "COMPLETED",
+        "links": {"download": "https://example.com/dl"},
+        "percentage_completed": 100.0,
+        "elapsed_time_sec": 12,
+        "status_details": "",
+        "job_spec": {"output_settings": {"type": "localFile"}},
+    }
+    mock_batch_prediction_job.get.return_value = mock_job
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -134,26 +222,28 @@ async def test_predict_by_ai_catalog_timeout(
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
     ):
-        mock_dataset = MagicMock()
         mock_client = MagicMock()
-        mock_client.Dataset.get.return_value = mock_dataset
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
         mock_drc.return_value.get_client.return_value = mock_client
-        patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
-        with pytest.raises(dr.errors.AsyncTimeoutError) as exc_info:
-            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=1)
-    assert "Job did not complete within the timeout period." == str(exc_info.value)
+        result = await predict.get_batch_prediction_job_status(job_id="jid")
+    assert result["job_id"] == "jid"
+    assert result["batch_job_status"] == "COMPLETED"
+    assert result["url"] == "https://example.com/dl"
+    assert result["percentage_completed"] == 100.0
 
 
 @pytest.mark.asyncio
-async def test_predict_by_ai_catalog_failure_error(
-    patch_predict_dependencies: dict[str, Any],
+async def test_get_batch_prediction_job_status_non_local_file_raises(
+    mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
-    mock_job.id = "jobid"
-    mock_job.status = "FAILED"
-    mock_job.wait_for_completion.side_effect = dr.errors.AsyncFailureError(
-        "Job failed for some reason."
-    )
+    mock_job.id = "jid"
+    mock_job.get_status.return_value = {
+        "status": "RUNNING",
+        "links": {},
+        "job_spec": {"output_settings": {"type": "s3"}},
+    }
+    mock_batch_prediction_job.get.return_value = mock_job
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -162,26 +252,25 @@ async def test_predict_by_ai_catalog_failure_error(
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
     ):
-        mock_dataset = MagicMock()
         mock_client = MagicMock()
-        mock_client.Dataset.get.return_value = mock_dataset
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
         mock_drc.return_value.get_client.return_value = mock_client
-        patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
-        with pytest.raises(dr.errors.AsyncFailureError) as exc_info:
-            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=1)
-    assert "Job failed for some reason." == str(exc_info.value)
+        with pytest.raises(ToolError, match="not local file streaming"):
+            await predict.get_batch_prediction_job_status(job_id="jid")
 
 
 @pytest.mark.asyncio
-async def test_predict_by_ai_catalog_unsuccessful_error(
-    patch_predict_dependencies: dict[str, Any],
+async def test_get_batch_prediction_job_status_terminal(
+    mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
-    mock_job.id = "jobid"
-    mock_job.status = "FAILED"
-    mock_job.wait_for_completion.side_effect = dr.errors.AsyncProcessUnsuccessfulError(
-        "Job was unsuccessful."
-    )
+    mock_job.id = "jid"
+    mock_job.get_status.return_value = {
+        "status": "FAILED",
+        "status_details": "boom",
+        "links": {},
+    }
+    mock_batch_prediction_job.get.return_value = mock_job
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -190,44 +279,21 @@ async def test_predict_by_ai_catalog_unsuccessful_error(
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
     ):
-        mock_dataset = MagicMock()
         mock_client = MagicMock()
-        mock_client.Dataset.get.return_value = mock_dataset
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
         mock_drc.return_value.get_client.return_value = mock_client
-        patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
-        with pytest.raises(dr.errors.AsyncProcessUnsuccessfulError) as exc_info:
-            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=1)
-    assert "Job was unsuccessful." == str(exc_info.value)
+        with pytest.raises(ToolError, match="FAILED"):
+            await predict.get_batch_prediction_job_status(job_id="jid")
 
 
 @pytest.mark.asyncio
-async def test_predict_by_ai_catalog_missing_download_url(
-    patch_predict_dependencies: dict[str, Any],
-) -> None:
-    mock_job = MagicMock()
-    mock_job.id = "jobid"
-    mock_job.status = "COMPLETED"
-    mock_job.get_status.return_value = {"links": {}}
-    with (
-        patch(
-            "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
-            new_callable=AsyncMock,
-            return_value="token",
-        ),
-        patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
-        patch("datarobot_genai.drtools.predictive.predict.time.sleep"),
-    ):
-        mock_dataset = MagicMock()
-        mock_client = MagicMock()
-        mock_client.Dataset.get.return_value = mock_dataset
-        mock_drc.return_value.get_client.return_value = mock_client
-        patch_predict_dependencies["mock_batch_job"].score.return_value = mock_job
-        with pytest.raises(ToolError, match="no download URL"):
-            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid", timeout=600)
+async def test_get_batch_prediction_job_status_empty_job_id() -> None:
+    with pytest.raises(ToolError, match="job_id"):
+        await predict.get_batch_prediction_job_status(job_id="  ")
 
 
 @pytest.mark.asyncio
-async def test_get_batch_prediction_results_success() -> None:
+async def test_get_batch_prediction_results_success(mock_batch_prediction_job: MagicMock) -> None:
     mock_job = MagicMock()
     mock_job.id = "abc123"
 
@@ -235,6 +301,7 @@ async def test_get_batch_prediction_results_success() -> None:
         buf.write(b"x,y\n1,2\n")
 
     mock_job.download.side_effect = _download
+    mock_batch_prediction_job.get.return_value = mock_job
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -242,12 +309,10 @@ async def test_get_batch_prediction_results_success() -> None:
             return_value="token",
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
-        patch(
-            "datarobot_genai.drtools.predictive.predict.dr.BatchPredictionJob.get",
-            return_value=mock_job,
-        ),
     ):
-        mock_drc.return_value.get_client.return_value = MagicMock()
+        mock_client = MagicMock()
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
+        mock_drc.return_value.get_client.return_value = mock_client
         result = await predict.get_batch_prediction_results(job_id="abc123")
     assert result["job_id"] == "abc123"
     assert result["mime_type"] == "text/csv"
@@ -263,7 +328,7 @@ async def test_get_batch_prediction_results_empty_job_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_batch_prediction_results_too_large() -> None:
+async def test_get_batch_prediction_results_too_large(mock_batch_prediction_job: MagicMock) -> None:
     mock_job = MagicMock()
     mock_job.id = "jid"
     mock_job.get_status.return_value = {"links": {"download": "https://example.com/batch/dl"}}
@@ -272,6 +337,7 @@ async def test_get_batch_prediction_results_too_large() -> None:
         buf.write(b"a" * (MAX_INLINE_SIZE + 1))
 
     mock_job.download.side_effect = _download
+    mock_batch_prediction_job.get.return_value = mock_job
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -279,23 +345,24 @@ async def test_get_batch_prediction_results_too_large() -> None:
             return_value="token",
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
-        patch(
-            "datarobot_genai.drtools.predictive.predict.dr.BatchPredictionJob.get",
-            return_value=mock_job,
-        ),
     ):
-        mock_drc.return_value.get_client.return_value = MagicMock()
+        mock_client = MagicMock()
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
+        mock_drc.return_value.get_client.return_value = mock_client
         with pytest.raises(ToolError, match="exceeding the inline limit") as exc:
             await predict.get_batch_prediction_results(job_id="jid")
         assert "https://example.com/batch/dl" in str(exc.value)
 
 
 @pytest.mark.asyncio
-async def test_get_batch_prediction_results_download_runtime_error() -> None:
+async def test_get_batch_prediction_results_download_runtime_error(
+    mock_batch_prediction_job: MagicMock,
+) -> None:
     mock_job = MagicMock()
     mock_job.id = "jid"
     mock_job.get_status.return_value = {"links": {"download": "https://example.com/batch/dl2"}}
     mock_job.download.side_effect = RuntimeError("queue full")
+    mock_batch_prediction_job.get.return_value = mock_job
     with (
         patch(
             "datarobot_genai.drtools.predictive.predict.get_datarobot_access_token",
@@ -303,12 +370,10 @@ async def test_get_batch_prediction_results_download_runtime_error() -> None:
             return_value="token",
         ),
         patch("datarobot_genai.drtools.predictive.predict.DataRobotClient") as mock_drc,
-        patch(
-            "datarobot_genai.drtools.predictive.predict.dr.BatchPredictionJob.get",
-            return_value=mock_job,
-        ),
     ):
-        mock_drc.return_value.get_client.return_value = MagicMock()
+        mock_client = MagicMock()
+        mock_client.BatchPredictionJob = mock_batch_prediction_job
+        mock_drc.return_value.get_client.return_value = mock_client
         with pytest.raises(ToolError, match="queue full") as exc:
             await predict.get_batch_prediction_results(job_id="jid")
         assert "https://example.com/batch/dl2" in str(exc.value)

--- a/tests/drmcp/unit/predictive_tools/test_training.py
+++ b/tests/drmcp/unit/predictive_tools/test_training.py
@@ -158,6 +158,113 @@ async def test_get_exploratory_insights() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_exploratory_insights_catalog_feature_profile() -> None:
+    mock_dataset = MagicMock()
+    mock_df = pd.DataFrame({"features": [1, 2, 3], "target": [0, 1, 0]})
+    mock_dataset.get_as_dataframe.return_value = mock_df
+
+    mock_details = MagicMock()
+    mock_details.data_persisted = True
+    mock_dataset.get_details.return_value = mock_details
+
+    mock_api_feat = MagicMock()
+    mock_api_feat.name = "features"
+    mock_api_feat.feature_type = "Float"
+    mock_api_feat.unique_count = 3
+    mock_api_feat.na_count = 0
+    mock_api_feat.min = 1.0
+    mock_api_feat.max = 3.0
+    mock_api_feat.mean = 2.0
+    mock_api_feat.median = 2.0
+    mock_api_feat.std_dev = 1.0
+    mock_hist = MagicMock()
+    mock_hist.plot = [{"label": "1", "count": 1, "target": None}]
+    mock_api_feat.get_histogram.return_value = mock_hist
+    mock_dataset.iterate_all_features.return_value = iter([mock_api_feat, MagicMock(name="other")])
+
+    mock_insights = {
+        "total_columns": 2,
+        "total_rows": 3,
+        "numerical_columns": ["features", "target"],
+        "categorical_columns": [],
+        "datetime_columns": [],
+        "text_columns": [],
+        "potential_targets": ["target"],
+        "missing_data_summary": {},
+    }
+
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.training.DataRobotClient") as mock_drc,
+        patch(
+            "datarobot_genai.drtools.predictive.training.analyze_dataset",
+            new_callable=AsyncMock,
+            return_value=mock_insights,
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_drc.return_value.get_client.return_value = mock_client
+        result = await training.get_exploratory_insights(
+            dataset_id="test_dataset_id",
+            feature_col="features",
+            include_feature_histogram=True,
+        )
+
+    profile = result["catalog_feature_profile"]
+    assert profile["source"] == "datarobot_catalog_all_features_details"
+    assert profile["data_persisted"] is True
+    assert profile["feature"]["name"] == "features"
+    assert profile["feature"]["mean"] == 2.0
+    assert profile["histogram"]["plot"][0]["label"] == "1"
+    mock_api_feat.get_histogram.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_exploratory_insights_feature_col_unknown_column() -> None:
+    mock_dataset = MagicMock()
+    mock_df = pd.DataFrame({"a": [1]})
+    mock_dataset.get_as_dataframe.return_value = mock_df
+
+    mock_insights = {
+        "total_columns": 1,
+        "total_rows": 1,
+        "numerical_columns": ["a"],
+        "categorical_columns": [],
+        "datetime_columns": [],
+        "text_columns": [],
+        "potential_targets": [],
+        "missing_data_summary": {},
+    }
+
+    with (
+        patch(
+            "datarobot_genai.drtools.predictive.training.get_datarobot_access_token",
+            new_callable=AsyncMock,
+            return_value="token",
+        ),
+        patch("datarobot_genai.drtools.predictive.training.DataRobotClient") as mock_drc,
+        patch(
+            "datarobot_genai.drtools.predictive.training.analyze_dataset",
+            new_callable=AsyncMock,
+            return_value=mock_insights,
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_client.Dataset.get.return_value = mock_dataset
+        mock_drc.return_value.get_client.return_value = mock_client
+        with pytest.raises(ToolError, match="feature_col"):
+            await training.get_exploratory_insights(
+                dataset_id="test_dataset_id",
+                feature_col="missing",
+            )
+
+
+@pytest.mark.asyncio
 async def test_start_autopilot_new_project() -> None:
     mock_dataset = MagicMock()
     mock_dataset.id = "test_dataset_id"

--- a/tests/drmcp/unit/test_tool_base_ete.py
+++ b/tests/drmcp/unit/test_tool_base_ete.py
@@ -18,6 +18,7 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import ANY_NONEMPTY_STRING
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ETETestExpectations
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolBaseE2E
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectations
+from datarobot_genai.drmcp.test_utils.tool_base_ete import _canonical_tool_name_for_expectation
 from datarobot_genai.drmcp.test_utils.tool_base_ete import _check_dict_has_keys
 from datarobot_genai.drmcp.test_utils.tool_base_ete import _check_dict_params_match
 
@@ -32,8 +33,18 @@ class TestToolCallTestExpectations:
         )
 
         assert expectations.name == "test_tool"
+        assert expectations.acceptable_tool_names == []
         assert expectations.parameters == {"param": "value"}
         assert expectations.result == "result"
+
+    def test_tool_call_test_expectations_allowed_tool_names(self) -> None:
+        expectations = ToolCallTestExpectations(
+            name="a",
+            acceptable_tool_names=["b", "c"],
+            parameters={},
+            result="x",
+        )
+        assert expectations.allowed_tool_names() == {"a", "b", "c"}
 
     def test_tool_call_test_expectations_with_dict_result(self) -> None:
         """Test ToolCallTestExpectations with dict result."""
@@ -43,6 +54,31 @@ class TestToolCallTestExpectations:
 
         assert isinstance(expectations.result, dict)
         assert expectations.result["status"] == "success"
+
+
+class TestCanonicalToolNameForExpectation:
+    def test_matches_primary_name(self) -> None:
+        call = ToolCallTestExpectations(name="get_deployment_info", parameters={}, result="")
+        assert (
+            _canonical_tool_name_for_expectation("get_deployment_info", call)
+            == "get_deployment_info"
+        )
+
+    def test_matches_acceptable_alternative(self) -> None:
+        call = ToolCallTestExpectations(
+            name="get_deployment_info",
+            acceptable_tool_names=["get_deployment_features"],
+            parameters={},
+            result="",
+        )
+        assert (
+            _canonical_tool_name_for_expectation("get_deployment_features", call)
+            == "get_deployment_features"
+        )
+
+    def test_no_match(self) -> None:
+        call = ToolCallTestExpectations(name="get_deployment_info", parameters={}, result="")
+        assert _canonical_tool_name_for_expectation("other_tool", call) is None
 
 
 class TestETETestExpectations:

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.43"
+version = "0.15.44"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Predictive tools core change: batch deployment scoring is submit-and-poll, not “wait inside the tool until the job finishes.

- predict_by_ai_catalog / predict_from_project_data — Submit the batch job and return right away with job_id, batch_job_status, optional early url, and a note that tells the agent to poll. The old timeout and blocking wait_for_completion / download-link polling in those tools are gone.
- New tool: get_batch_prediction_job_status — Lightweight status-only step (batch_job_status, url, progress, status_details) so the agent can poll until COMPLETED and a url exist.
- get_batch_prediction_results — Still fetches CSV inline when small; flow and docs assume poll status first; download uses explicit download_timeout / download_read_timeout.
- Implementation detail: BatchPredictionJob is invoked on the same configured SDK client as Dataset.get (not a separate global dr handle), with the same localFile / terminal-failure checks and clearer errors (including batch URL when useful).

Training tool core change: get_exploratory_insights can optionally attach DataRobot catalog–backed stats for one column.

- New args feature_col and include_feature_histogram — When set, the response gains a catalog_feature_profile built from catalog allFeaturesDetails (and optional histogram), instead of only the existing in-memory EDA summary.

prediction: <img width="1053" height="1192" alt="image" src="https://github.com/user-attachments/assets/9ae7d435-f6a9-4489-984a-1fcedc99789b" />

training: <img width="1010" height="1242" alt="image" src="https://github.com/user-attachments/assets/bd38e2af-dec7-4e9a-896c-19ee89e3e340" />

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the contract/behavior of core predictive tools (removing synchronous waits/timeouts) and introduces new polling flow that downstream agents/tests must follow.
> 
> **Overview**
> **Batch deployment scoring is now non-blocking.** `predict_by_ai_catalog` and `predict_from_project_data` no longer wait for completion or poll for a download link; they return immediately with `job_id`, `batch_job_status`, optional early `url`, and guidance to poll.
> 
> Adds `get_batch_prediction_job_status` for lightweight polling (status/progress + download `url`) and updates `get_batch_prediction_results` docs/behavior to assume status polling first while passing explicit download timeouts; batch job calls now use the configured SDK client instance.
> 
> **EDA enhancement:** `get_exploratory_insights` gains optional `feature_col`/`include_feature_histogram` to attach DataRobot catalog `allFeaturesDetails` stats (and histogram) for a specific column, with new stubs and integration/unit/acceptance test updates to cover the new flows and tool-name equivalence handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 689faa44d7649d90b5730d5637e4f1fe6d289abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->