### PR TITLE
Fix crewai agent failure to read MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.46
+- `crewai/mcp.py`: Fixed `BadRequestError` from Azure OpenAI when an MCP tool has no input schema. `MCPServerAdapter` would leave `args_schema = None` on such tools; litellm then serialized `"parameters": null`, which Azure rejects. Tools with a `None` args schema now fall back to an empty-object schema (`_EmptyArgsSchema`) so the function-calling payload is always valid.
+
 ## 0.15.45
 - `drtools/predictive/predict.py`: **Submit-and-poll batch workflow** — `predict_by_ai_catalog` and `predict_from_project_data` return immediately after submit (removed `timeout` and server-side `wait_for_completion` plus download-link polling); responses include `job_id`, `batch_job_status`, optional early `url`, and a `note` for follow-up instead of only completed-job metadata. **New tool `get_batch_prediction_job_status`** (`job_id`) returns status, optional download `url`, and progress fields without fetching CSV. **`get_batch_prediction_results`** is documented and used after polling for completion; passes `download_timeout` / `download_read_timeout` through to the SDK download. **`BatchPredictionJob.score` / `get`** use the same configured SDK client as `Dataset.get`.
 - `drtools/predictive/training.py` (`get_exploratory_insights`): optional `feature_col` plus `include_feature_histogram` add a DataRobot catalog API-backed column profile (allFeaturesDetails statistics and optional feature histogram) alongside existing EDA output; helpers resolve catalog `DatasetFeature` rows by name and serialize them for the tool response.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.45"
+version = "0.15.46"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.46"
+version = "0.15.47"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -24,10 +24,24 @@ from contextlib import asynccontextmanager
 
 from crewai.tools import BaseTool
 from crewai_tools import MCPServerAdapter
+from pydantic import BaseModel
 
 from datarobot_genai.core.mcp import MCPConfig
 
 logger = logging.getLogger(__name__)
+
+
+class _EmptyArgsSchema(BaseModel):
+    """Fallback schema for MCP tools that declare no input parameters."""
+
+
+def _sanitize_tool_schemas(tools: list[BaseTool]) -> list[BaseTool]:
+    # Azure OpenAI rejects tools whose parameters field is None; replace with
+    # an empty-object schema for any MCP tool that has no input schema.
+    for tool in tools:
+        if tool.args_schema is None:
+            tool.args_schema = _EmptyArgsSchema
+    return tools
 
 
 # here it is async to conform with other MCP adapters
@@ -45,7 +59,7 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
 
     try:
         adapter = MCPServerAdapter(mcp_config.server_config)
-        tools = adapter.__enter__()
+        tools = _sanitize_tool_schemas(adapter.__enter__())
     except Exception as exc:
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -165,7 +165,8 @@ class TestMCPToolsContext:
                 raise RuntimeError("Connection failed")
 
     async def test_mcp_tools_context_sanitizes_none_args_schema(self, mock_adapter):
-        """Tools with None args_schema get a valid empty schema so Azure OpenAI doesn't reject them."""
+        """Tools with None args_schema get a valid empty schema so 
+        Azure OpenAI doesn't reject them."""
         null_schema_tool = MagicMock()
         null_schema_tool.args_schema = None
         with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -165,8 +165,9 @@ class TestMCPToolsContext:
                 raise RuntimeError("Connection failed")
 
     async def test_mcp_tools_context_sanitizes_none_args_schema(self, mock_adapter):
-        """Tools with None args_schema get a valid empty schema so 
-        Azure OpenAI doesn't reject them."""
+        """Tools with None args_schema get a valid empty schema so
+        Azure OpenAI doesn't reject them.
+        """
         null_schema_tool = MagicMock()
         null_schema_tool.args_schema = None
         with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -17,8 +17,11 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
 from datarobot_genai.core.mcp import MCPConfig
+from datarobot_genai.crewai.mcp import _EmptyArgsSchema
+from datarobot_genai.crewai.mcp import _sanitize_tool_schemas
 from datarobot_genai.crewai.mcp import mcp_tools_context
 
 
@@ -42,6 +45,41 @@ def mock_adapter(mock_tools):
 def clear_environment_variables():
     with patch.dict(os.environ, {}, clear=True):
         yield
+
+
+class TestSanitizeToolSchemas:
+    def test_none_args_schema_replaced_with_empty_schema(self):
+        tool = MagicMock()
+        tool.args_schema = None
+        result = _sanitize_tool_schemas([tool])
+        assert result[0].args_schema is _EmptyArgsSchema
+
+    def test_existing_args_schema_untouched(self):
+        class MySchema(BaseModel):
+            value: int
+
+        tool = MagicMock()
+        tool.args_schema = MySchema
+        result = _sanitize_tool_schemas([tool])
+        assert result[0].args_schema is MySchema
+
+    def test_mixed_tools_sanitized_correctly(self):
+        class MySchema(BaseModel):
+            value: int
+
+        tool_with_schema = MagicMock()
+        tool_with_schema.args_schema = MySchema
+        tool_without_schema = MagicMock()
+        tool_without_schema.args_schema = None
+        result = _sanitize_tool_schemas([tool_with_schema, tool_without_schema])
+        assert result[0].args_schema is MySchema
+        assert result[1].args_schema is _EmptyArgsSchema
+
+    def test_empty_args_schema_produces_valid_openai_parameters(self):
+        # Azure OpenAI requires parameters to be type "object"; verify the
+        # fallback schema serializes correctly.
+        schema = _EmptyArgsSchema.model_json_schema()
+        assert schema.get("type") == "object"
 
 
 class TestMCPToolsContext:
@@ -125,6 +163,39 @@ class TestMCPToolsContext:
         with pytest.raises(RuntimeError):
             async with mcp_tools_context(mcp_config):
                 raise RuntimeError("Connection failed")
+
+    async def test_mcp_tools_context_sanitizes_none_args_schema(self, mock_adapter):
+        """Tools with None args_schema get a valid empty schema so Azure OpenAI doesn't reject them."""
+        null_schema_tool = MagicMock()
+        null_schema_tool.args_schema = None
+        with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:
+            instance = MagicMock()
+            instance.__enter__.return_value = [null_schema_tool]
+            instance.__exit__.return_value = None
+            mock.return_value = instance
+            test_url = "https://mcp-server.example.com/mcp"
+            mcp_config = MCPConfig(external_mcp_url=test_url)
+            async with mcp_tools_context(mcp_config) as tools:
+                assert len(tools) == 1
+                assert tools[0].args_schema is _EmptyArgsSchema
+
+    async def test_mcp_tools_context_preserves_existing_args_schema(self, mock_adapter):
+        """Tools that already have a valid args_schema are left untouched."""
+
+        class MySchema(BaseModel):
+            query: str
+
+        tool_with_schema = MagicMock()
+        tool_with_schema.args_schema = MySchema
+        with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:
+            instance = MagicMock()
+            instance.__enter__.return_value = [tool_with_schema]
+            instance.__exit__.return_value = None
+            mock.return_value = instance
+            test_url = "https://mcp-server.example.com/mcp"
+            mcp_config = MCPConfig(external_mcp_url=test_url)
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools[0].args_schema is MySchema
 
     async def test_mcp_tools_context_connection_error_yields_empty(self):
         """Test graceful fallback when MCP server connection fails."""

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.45"
+version = "0.15.46"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.46"
+version = "0.15.47"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

Fixed `BadRequestError` from Azure OpenAI when an MCP tool has no input schema. `MCPServerAdapter` would leave `args_schema = None` on such tools; litellm then serialized `"parameters": null`, which Azure rejects. Tools with a `None` args schema now fall back to an empty-object schema (`_EmptyArgsSchema`) so the function-calling payload is always valid.

## CHANGES

Add small fix for handling this in MCP before the error occurs.

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to CrewAI MCP tool loading that only fills missing `args_schema` with an empty Pydantic model; behavior is covered by new unit tests and mainly affects Azure OpenAI function-calling serialization.
> 
> **Overview**
> Prevents Azure OpenAI `BadRequestError` when CrewAI loads MCP tools that declare no input schema by replacing `args_schema=None` with an empty-object Pydantic schema (`_EmptyArgsSchema`) before tool registration.
> 
> Adds focused unit tests for schema sanitization and verifies `mcp_tools_context` preserves existing schemas while ensuring tools without schemas serialize valid OpenAI `parameters`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3f71b90cbe9ebba9fdc89e2a621672ac06bc51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->