### PR TITLE
[BUZZOK-30720] fix OKTA token name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.47
+- Fixed default `okta_token_header` value in `OAuth2CrossApplicationAccessAuthProviderConfig`: renamed `x-datarobot-okta-access-token` → `x-datarobot-external-access-token` to match the actual header name used by the DataRobot API gateway when forwarding Okta access tokens.
+
 ## 0.15.46
 - Fixed CrewAI tool calling by enforcing client-side stop-word truncation when upstream APIs ignore the `stop` parameter
 - 

--- a/docs/nat/a2a-auth.md
+++ b/docs/nat/a2a-auth.md
@@ -233,7 +233,7 @@ remote XAA-protected agent.
 
 | Field | Default | Purpose |
 |-------|---------|---------|
-| `okta_token_header` | `x-datarobot-okta-access-token` | Incoming request header carrying the caller's Okta access token. |
+| `okta_token_header` | `x-datarobot-external-access-token` | Incoming request header carrying the caller's Okta access token. |
 | `principal_id` | `PRINCIPAL_ID` env var | Okta AI agent principal ID. |
 | `private_jwk` | `PRIVATE_JWK` env var | Base64-encoded or raw-JSON private JWK. |
 | `id_jag_scopes` | `["read_data"]` | Scopes for the Step 1 ID-JAG request. |
@@ -269,7 +269,7 @@ in `securitySchemes`, while flow-specific parameters go in
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `RuntimeError: Header 'x-datarobot-okta-access-token' not found` | The incoming request doesn't carry the Okta token. | Ensure the upstream caller forwards the Okta access token in the expected header. |
+| `RuntimeError: Header 'x-datarobot-external-access-token' not found` | The incoming request doesn't carry the Okta token. | Ensure the upstream caller forwards the Okta access token in the expected header. |
 | `ValueError: principal_id is required` | `PRINCIPAL_ID` env var not set. | Set `PRINCIPAL_ID` in your environment or Runtime Parameters. |
 | `ValueError: Could not parse private_jwk` | `PRIVATE_JWK` is neither valid base64-encoded JSON nor raw JSON. | Verify your JWK — try `echo $PRIVATE_JWK | base64 -d | python -m json.tool`. |
 | `ValueError: Agent card ... missing required fields` | Remote agent card doesn't have the XAA extension. | Verify the remote agent has `cross_application_access` configured. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.46"
+version = "0.15.47"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -82,7 +82,7 @@ class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
 
         # Forward incoming A2A HTTP headers so DRAgentAGUISessionManager.session()
         # can inject them into NAT context metadata.  Auth providers pick the specific
-        # headers they need (e.g. x-datarobot-okta-access-token, Authorization).
+        # headers they need (e.g. x-datarobot-external-access-token, Authorization).
         token_headers = None
         if context.call_context and isinstance(context.call_context.state, dict):
             raw_headers = context.call_context.state.get("headers")

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -16,7 +16,7 @@
 
 Registered as ``_type: okta_cross_app_access`` in workflow YAML.
 
-Discovery phase: forwards the incoming ``x-datarobot-okta-access-token`` header
+Discovery phase: forwards the incoming ``x-datarobot-external-access-token`` header
 directly to the agent card endpoint as a Bearer token.
 
 Call phase: executes a two-step Okta Cross App Access (XAA) token exchange:
@@ -183,7 +183,7 @@ class OAuth2CrossApplicationAccessAuthProviderConfig(
     """
 
     okta_token_header: str = Field(
-        default="x-datarobot-okta-access-token",
+        default="x-datarobot-external-access-token",
         description=(
             "Incoming header carrying the caller's Okta access token. "
             "Forwarded as Bearer for discovery; used as subject token in Step 1. "
@@ -195,7 +195,7 @@ class OAuth2CrossApplicationAccessAuthProviderConfig(
         description=(
             "Fallback headers to try (in order) when ``okta_token_header`` is absent. "
             "Useful for local development without an API gateway that remaps "
-            "``Authorization`` → ``x-datarobot-okta-access-token``. "
+            "``Authorization`` → ``x-datarobot-external-access-token``. "
             "If the value starts with 'Bearer ', the prefix is stripped automatically."
         ),
     )
@@ -331,7 +331,7 @@ class OAuth2CrossApplicationAccessOAuth2AuthProvider(
         Tries ``okta_token_header`` first, then each entry in
         ``fallback_token_headers`` (stripping ``Bearer `` prefix if present).
         This supports local development where no API gateway remaps
-        ``Authorization`` into the canonical ``x-datarobot-okta-access-token``.
+        ``Authorization`` into the canonical ``x-datarobot-external-access-token``.
         """
         context_headers: dict[str, str] = Context.get().metadata.headers or {}
 

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -133,7 +133,7 @@ class TestOAuth2CrossApplicationAccessAuthProviderDiscovery:
         """authenticate_for_discovery() returns the Okta token as Authorization: Bearer."""
         with patch(f"{_MODULE}.Context") as mock_ctx:
             mock_ctx.get.return_value.metadata.headers = {
-                "x-datarobot-okta-access-token": "my-okta-token"
+                "x-datarobot-external-access-token": "my-okta-token"
             }
             headers = await provider.authenticate_for_discovery()
 
@@ -143,7 +143,7 @@ class TestOAuth2CrossApplicationAccessAuthProviderDiscovery:
         """authenticate_for_discovery() raises RuntimeError when header is absent."""
         with patch(f"{_MODULE}.Context") as mock_ctx:
             mock_ctx.get.return_value.metadata.headers = {}
-            with pytest.raises(RuntimeError, match="x-datarobot-okta-access-token"):
+            with pytest.raises(RuntimeError, match="x-datarobot-external-access-token"):
                 await provider.authenticate_for_discovery()
 
 
@@ -175,7 +175,7 @@ class TestOAuth2CrossApplicationAccessAuthProviderFallbackHeaders:
         """Primary header wins even if fallback is also present."""
         with patch(f"{_MODULE}.Context") as mock_ctx:
             mock_ctx.get.return_value.metadata.headers = {
-                "x-datarobot-okta-access-token": "primary-token",
+                "x-datarobot-external-access-token": "primary-token",
                 "authorization": "Bearer fallback-token",
             }
             headers = await provider.authenticate_for_discovery()
@@ -197,7 +197,7 @@ class TestOAuth2CrossApplicationAccessAuthProviderFallbackHeaders:
         )
         with patch(f"{_MODULE}.Context") as mock_ctx:
             mock_ctx.get.return_value.metadata.headers = {"authorization": "Bearer token"}
-            with pytest.raises(RuntimeError, match="x-datarobot-okta-access-token"):
+            with pytest.raises(RuntimeError, match="x-datarobot-external-access-token"):
                 await provider.authenticate_for_discovery()
 
 
@@ -272,7 +272,7 @@ class TestOAuth2CrossApplicationAccessAuthProviderAuthenticate:
             patch.object(provider_with_card, "_build_cross_app_flow", return_value=mock_flow),
         ):
             mock_ctx.get.return_value.metadata.headers = {
-                "x-datarobot-okta-access-token": "incoming-okta-token"
+                "x-datarobot-external-access-token": "incoming-okta-token"
             }
             result = await provider_with_card.authenticate(user_id="test-user")
 
@@ -298,7 +298,7 @@ class TestOAuth2CrossApplicationAccessAuthProviderAuthenticate:
             patch.object(provider_with_card, "_build_cross_app_flow", return_value=mock_flow),
         ):
             mock_ctx.get.return_value.metadata.headers = {
-                "x-datarobot-okta-access-token": "bad-token"
+                "x-datarobot-external-access-token": "bad-token"
             }
             with pytest.raises(RuntimeError, match="token exchange failed"):
                 await provider_with_card.authenticate()
@@ -310,7 +310,9 @@ class TestOAuth2CrossApplicationAccessAuthProviderAuthenticate:
         )
 
         with patch(f"{_MODULE}.Context") as mock_ctx:
-            mock_ctx.get.return_value.metadata.headers = {"x-datarobot-okta-access-token": "token"}
+            mock_ctx.get.return_value.metadata.headers = {
+                "x-datarobot-external-access-token": "token"
+            }
             with pytest.raises(RuntimeError, match="set_agent_card"):
                 await provider.authenticate()
 
@@ -385,7 +387,7 @@ class TestCrossAppAccessEndToEnd:
     def mock_context(self, incoming_token):
         with patch(f"{_MODULE}.Context") as ctx:
             ctx.get.return_value.metadata.headers = {
-                "x-datarobot-okta-access-token": incoming_token,
+                "x-datarobot-external-access-token": incoming_token,
             }
             yield ctx
 


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This change aligns the token naming to the api-gateway [default](https://github.com/datarobot/DataRobot/blob/f807c2501b41ed2e614177d6dda111e41252dbb6/predictions_gateway/ai-context/specs/request-forwarding.md?plain=1#L111)
 
## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are a string-default rename for the Okta token header plus corresponding docs/tests/version bumps; behavioral impact is limited to which incoming header is read by default for XAA auth.
> 
> **Overview**
> Bumps the package to `0.15.47` and updates the default Okta XAA incoming token header from `x-datarobot-okta-access-token` to `x-datarobot-external-access-token` across the `okta_cross_app_access` auth provider, FastAPI A2A header-forwarding comments, and troubleshooting/docs.
> 
> Updates unit tests and the changelog to match the new canonical header name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3554e0a0bcd449630cb1a6cb6e4512221a757db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->