### PR TITLE
[BUZZOK-30809] [BUZZOK-30616] Fix the invalid message event crashes for NIM deployment models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.52
+- `langgraph/agent.py`: Fixed `ValueError: Invalid message event` crash in `_stream_generator` when an intermediate LangGraph node (e.g. a planner-to-writer relay) emits a `HumanMessage` as a state update. `HumanMessage` events from relay nodes are now silently skipped rather than raising, which also prevents the cascading `RuntimeError: generator didn't stop after athrow()` from the MCP tools context manager failing to clean up.
+
 ## 0.15.51
 - Bump ragas to "ragas>=0.4.3,<0.5.0" to align with execution environments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.51"
+version = "0.15.52"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -38,6 +38,7 @@ from ag_ui.core import ToolCallStartEvent
 from langchain.chat_models import BaseChatModel
 from langchain.tools import BaseTool
 from langchain_core.messages import AIMessageChunk
+from langchain_core.messages import HumanMessage
 from langchain_core.messages import ToolMessage
 from langchain_core.prompts import ChatPromptTemplate
 from langgraph.graph import START
@@ -450,6 +451,10 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
                             None,
                             usage_metrics,
                         )
+                elif isinstance(message, HumanMessage):
+                    # Intermediate relay nodes (e.g. planner-to-writer handoffs) may emit
+                    # HumanMessages as state updates. These are not streamed to the caller.
+                    pass
                 else:
                     raise ValueError(f"Invalid message event: {message_event}")
             elif mode == "updates":

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -488,6 +488,95 @@ async def test_convert_input_message_zero_history_disables_history() -> None:
     assert isinstance(all_messages[1], HumanMessage)
 
 
+class RelayLangGraphAgent(LangGraphAgent):
+    """Agent whose graph includes a planner-to-writer relay node that emits a HumanMessage."""
+
+    @cached_property
+    def workflow(self) -> StateGraph[MessagesState]:
+        async def mock_stream_generator():
+            # planner node produces an AI response
+            yield (
+                "planner_node",
+                "messages",
+                (AIMessageChunk(content="Here is the plan.", id="plan-1"), {}),
+            )
+            # relay node converts the plan to a HumanMessage for the writer
+            yield (
+                "planner_to_writer_relay",
+                "messages",
+                (HumanMessage(content="Here is the plan.", id="relay-1"), {}),
+            )
+            # writer node produces the final response
+            yield (
+                "writer_node",
+                "messages",
+                (AIMessageChunk(content="Here is the article.", id="write-1"), {}),
+            )
+            yield (
+                "writer_node",
+                "updates",
+                {
+                    "writer_node": {
+                        "usage": {
+                            "total_tokens": 50,
+                            "prompt_tokens": 25,
+                            "completion_tokens": 25,
+                        },
+                        "messages": [
+                            HumanMessage(content="Here is the plan."),
+                            AIMessage(content="Here is the article.", id="write-1"),
+                        ],
+                    }
+                },
+            )
+
+        mock_graph_stream = Mock(astream=Mock(return_value=mock_stream_generator()))
+        return Mock(compile=Mock(return_value=mock_graph_stream))
+
+    @property
+    def prompt_template(self) -> ChatPromptTemplate:
+        return ChatPromptTemplate.from_messages(
+            [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant. Tell user about {topic}.",
+                },
+                {"role": "user", "content": "Hi, tell me about {topic}."},
+            ]
+        )
+
+    @property
+    def langgraph_config(self) -> dict[str, Any]:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_relay_human_message_is_skipped(run_agent_input):
+    # GIVEN an agent whose graph contains a planner-to-writer relay node that emits a HumanMessage
+    agent = RelayLangGraphAgent()
+
+    # WHEN invoking the agent
+    events = []
+    async for response_event, _, _ in agent.invoke(run_agent_input):
+        if isinstance(response_event, BaseEvent):
+            events.append(response_event)
+
+    # THEN the HumanMessage from the relay node is silently skipped — no ValueError raised —
+    # and only the planner and writer AI text events appear in the output
+    event_types = [e.type for e in events]
+    assert EventType.RUN_STARTED in event_types
+    assert EventType.RUN_FINISHED in event_types
+
+    text_content_events = [e for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT]
+    assert len(text_content_events) == 2
+    assert text_content_events[0].delta == "Here is the plan."
+    assert text_content_events[1].delta == "Here is the article."
+
+    # No HumanMessage content should appear as a text event
+    all_deltas = {e.delta for e in text_content_events}
+    assert not any("relay" in d.lower() for d in all_deltas)
+
+
 async def test_langgraph_non_streaming(run_agent_input):
     # GIVEN a simple langgraph agent implementation
     agent = SimpleLangGraphAgent()

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.51"
+version = "0.15.52"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Fixed `ValueError: Invalid message event` crash in `_stream_generator` when an intermediate LangGraph node (e.g. a planner-to-writer relay) emits a `HumanMessage` as a state update. `HumanMessage` events from relay nodes are now silently skipped rather than raising, which also prevents the cascading `RuntimeError: generator didn't stop after athrow()` from the MCP tools context manager failing to clean up.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Added a pass condition to the stream handler
- Added a test

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly scoped change to event handling that only alters behavior for previously-unhandled `HumanMessage` stream events.
> 
> **Overview**
> Prevents `_stream_generator` in `langgraph/agent.py` from raising `ValueError: Invalid message event` when intermediate LangGraph relay nodes emit `HumanMessage` state updates, by explicitly ignoring those events.
> 
> Adds a `0.15.52` changelog entry documenting the crash fix and the related downstream `generator didn't stop after athrow()` cleanup failure it avoids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d70134af0c8e448d24405699d9e5742b46e056. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->