### PR TITLE
[BUZZOK-30616] Harden the mcp tools to be more resilient to raising the correct errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.54
+- `langgraph/mcp.py`: Fixed `RuntimeError: generator didn't stop after athrow()` in `mcp_tools_context` when a connection-type exception (`ConnectionError`, `OSError`, `TimeoutError`, `ExceptionGroup`) is raised by the consumer inside the `async with` block. A `connected` flag now distinguishes setup-phase failures (graceful fallback to empty tools) from consumer exceptions (re-raised so the caller sees them). Without this guard the except clause would execute a second `yield []`, violating the `@asynccontextmanager` single-yield contract.
+
 ## 0.15.53
 - LangGraph `LangGraphAgent`: DR FS checkpointing is opt-in via `use_datarobot_fs_checkpointer=True` when `checkpointer` is omitted (no longer automatic). Optional `langgraph_checkpoint_base` sets the `dr://` prefix for the default saver (typically from application settings); when omitted, the default root is `dr://`. Process exit cleanup removes only `<prefix>/checkpoints`, not the entire prefix (so other DR FS objects under the same root are preserved).
 - `DataRobotFileSystemSaver` (`dr_fs_checkpointer`): checkpoint files use length-prefixed binary (`struct`, `.bin` suffix) without pickle or per-file magic headers; layout is implied by directory (`blobs/`, `cpts/`, `writes/`).

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.53"
+version = "0.15.54"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.53"
+version = "0.15.54"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/langgraph/mcp.py
+++ b/src/datarobot_genai/langgraph/mcp.py
@@ -123,15 +123,24 @@ async def mcp_tools_context(
         raise RuntimeError("Unsupported MCP transport specified.")
 
     # Graceful fallback: if we can't connect to the MCP server, yield empty tools
-    # instead of crashing. The try/except wraps only the connect+load phase (before
-    # yield) to avoid double-yielding -- an asynccontextmanager must yield exactly once.
+    # instead of crashing.
+    #
+    # The `connected` flag distinguishes two cases for the except clause:
+    #   - Exception raised during setup (before yield): log a warning and yield [].
+    #   - Exception thrown back in from the consumer (after yield, via athrow()): re-raise.
+    # Without this guard, a consumer exception of a caught type would hit `yield []` as a
+    # second yield, causing `RuntimeError: generator didn't stop after athrow()`.
+    connected = False
     try:
         async with create_session(connection=connection) as session:
             raw_tools = await load_mcp_tools(session=session)
             tools = [_wrap_mcp_tool_for_langgraph(t) for t in raw_tools]
             logger.info("Successfully loaded %d MCP tools", len(tools))
+            connected = True
             yield tools
     except (ConnectionError, OSError, TimeoutError, ExceptionGroup) as exc:
+        if connected:
+            raise
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",
             url,

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -289,7 +289,8 @@ class TestMCPToolsContext:
     async def test_mcp_tools_context_consumer_connection_error_propagates(self):
         """A connection-type exception raised by the consumer must propagate, not trigger
         the setup-phase fallback.  Before the `connected` guard this would hit `yield []`
-        as a second yield and raise RuntimeError: generator didn't stop after athrow()."""
+        as a second yield and raise RuntimeError: generator didn't stop after athrow().
+        """
         external_url = "https://mcp-server.example.com/mcp"
         mcp_config = MCPConfig(external_mcp_url=external_url, external_mcp_transport="sse")
 

--- a/tests/langgraph/test_mcp.py
+++ b/tests/langgraph/test_mcp.py
@@ -284,3 +284,15 @@ class TestMCPToolsContext:
         ):
             async with mcp_tools_context(mcp_config) as tools:
                 assert tools == []
+
+    @pytest.mark.usefixtures("setup_session_and_tools")
+    async def test_mcp_tools_context_consumer_connection_error_propagates(self):
+        """A connection-type exception raised by the consumer must propagate, not trigger
+        the setup-phase fallback.  Before the `connected` guard this would hit `yield []`
+        as a second yield and raise RuntimeError: generator didn't stop after athrow()."""
+        external_url = "https://mcp-server.example.com/mcp"
+        mcp_config = MCPConfig(external_mcp_url=external_url, external_mcp_transport="sse")
+
+        with pytest.raises(ConnectionError, match="downstream failure"):
+            async with mcp_tools_context(mcp_config):
+                raise ConnectionError("downstream failure")

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.53"
+version = "0.15.54"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Fixed `RuntimeError: generator didn't stop after athrow()` in `mcp_tools_context` when a connection-type exception (`ConnectionError`, `OSError`, `TimeoutError`, `ExceptionGroup`) is raised by the consumer inside the `async with` block. A `connected` flag now distinguishes setup-phase failures (graceful fallback to empty tools) from consumer exceptions (re-raised so the caller sees them). Without this guard the except clause would execute a second `yield []`, violating the `@asynccontextmanager` single-yield contract.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Small tweak to detect when connected and properly raise an exception instead of falling back into a generator failure
- Added associated test

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts async context manager exception handling for MCP tool loading; incorrect classification of exceptions could change whether errors propagate or tools silently fall back to empty.
> 
> **Overview**
> Fixes `mcp_tools_context` in `langgraph/mcp.py` to avoid `@asynccontextmanager` double-yield when a connection-type exception is raised *inside* the consumer `async with` block. A new `connected` flag ensures only setup-time connection failures fall back to `yield []`, while post-yield consumer exceptions are re-raised.
> 
> Adds a regression test asserting that a consumer-raised `ConnectionError` propagates, alongside the existing test that setup-time connection failures yield an empty tool list. Updates the changelog for version `0.15.53` to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f91d8cbf4cc69b35945b87034f437313cf3648. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->