### PR TITLE
Update user context of memory memory client to be constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.58
+- Update User ID for mem0 client to be per user
+
 ## 0.15.57
 - Registered DataRobot moderation middleware on the `nat.plugins` entry point `datarobot_moderation_middleware` so `_type: datarobot_moderation` is available when NAT loads plugins.
 - NAT / dragent moderation: `DataRobotModerationConfig` no longer uses `model_dir` to locate guard YAML. Configure guards with the optional `moderation` field (`ModerationConfig` from `datarobot_dome`). In `workflow.yaml`, nest guard definitions under `middleware.datarobot_guardrails.moderation` instead of setting `model_dir` to a directory that contained `moderation_config.yaml`.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.57"
+version = "0.15.58"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.57"
+version = "0.15.58"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -220,24 +220,6 @@ class NatAgent(BaseAgent[None]):
         text_started = False
 
         async with load_workflow(self.workflow_path, headers=self.forwarded_headers) as workflow:
-            # Bridge ``self.forwarded_headers`` (the DataRobot-namespaced headers
-            # extracted by ``custom.py``) into ``ContextState._metadata`` so
-            # downstream consumers (e.g. the auto-memory wrapper resolving a
-            # per-user identity from ``X-DataRobot-Authorization-Context``) can
-            # read them via ``Context.get().metadata.headers``. Mirrors the A2A
-            # side-channel: ``_PerUserCompatibleAgentExecutor.execute`` sets
-            # ``_a2a_headers`` → ``DRAgentAGUISessionManager.session`` injects it
-            # into ``_metadata``. We're outside that flow (DRUM ``/chat/completions``)
-            # so we wire it directly here. ContextVars are task-scoped, so the
-            # value set on this task does not leak to subsequent requests.
-            if self.forwarded_headers:
-                from nat.data_models.api_server import Request as NATRequest
-                from nat.runtime.user_metadata import RequestAttributes
-
-                attrs = RequestAttributes()
-                attrs._request = NATRequest(headers=dict(self.forwarded_headers))
-                workflow._context_state._metadata.set(attrs)
-
             async with workflow.session(user_id=thread_id) as session:
                 async with session.run(chat_request) as runner:
                     intermediate_future = pull_intermediate_structured()

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -220,6 +220,24 @@ class NatAgent(BaseAgent[None]):
         text_started = False
 
         async with load_workflow(self.workflow_path, headers=self.forwarded_headers) as workflow:
+            # Bridge ``self.forwarded_headers`` (the DataRobot-namespaced headers
+            # extracted by ``custom.py``) into ``ContextState._metadata`` so
+            # downstream consumers (e.g. the auto-memory wrapper resolving a
+            # per-user identity from ``X-DataRobot-Authorization-Context``) can
+            # read them via ``Context.get().metadata.headers``. Mirrors the A2A
+            # side-channel: ``_PerUserCompatibleAgentExecutor.execute`` sets
+            # ``_a2a_headers`` → ``DRAgentAGUISessionManager.session`` injects it
+            # into ``_metadata``. We're outside that flow (DRUM ``/chat/completions``)
+            # so we wire it directly here. ContextVars are task-scoped, so the
+            # value set on this task does not leak to subsequent requests.
+            if self.forwarded_headers:
+                from nat.data_models.api_server import Request as NATRequest
+                from nat.runtime.user_metadata import RequestAttributes
+
+                attrs = RequestAttributes()
+                attrs._request = NATRequest(headers=dict(self.forwarded_headers))
+                workflow._context_state._metadata.set(attrs)
+
             async with workflow.session(user_id=thread_id) as session:
                 async with session.run(chat_request) as runner:
                     intermediate_future = pull_intermediate_structured()

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -22,6 +22,7 @@ without relying on the upstream ``nvidia-nat-mem0ai`` plugin.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -31,10 +32,44 @@ from nat.builder.context import Context
 from nat.cli.register_workflow import register_memory
 from nat.data_models.memory import MemoryBaseConfig
 from nat.data_models.retry_mixin import RetryMixin
+from nat.data_models.user_info import UserInfo
 from nat.memory.interfaces import MemoryEditor
 from nat.memory.models import MemoryItem
 from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 from pydantic import Field
+
+from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
+
+logger = logging.getLogger(__name__)
+
+
+def _memory_user_uuid() -> str | None:
+    """Derive NAT's canonical UUIDv5 from the current request's DR auth header.
+
+    Reads ``X-DataRobot-Authorization-Context`` from the active NAT
+    ``Context``, decodes it with :class:`AuthContextHeaderHandler`, and hashes
+    ``auth_ctx.user.id`` through :meth:`UserInfo._from_session_cookie` so the
+    raw DataRobot identity never leaves the process. Returns ``None`` when
+    the header is missing or undecodable (e.g. ``SESSION_SECRET_KEY`` is
+    unset in local dev) so the caller can fall back to the api-key owner.
+    """
+    metadata = Context.get().metadata
+    headers = getattr(metadata, "headers", None) if metadata else None
+    if headers is None:
+        return None
+    try:
+        header_dict = dict(headers)
+    except Exception:
+        logger.debug("Failed to normalize request headers", exc_info=True)
+        return None
+    try:
+        auth_ctx = AuthContextHeaderHandler().get_context(header_dict)
+    except Exception:
+        logger.debug("Failed to decode DR auth context", exc_info=True)
+        return None
+    if auth_ctx is None or auth_ctx.user is None or not auth_ctx.user.id:
+        return None
+    return UserInfo._from_session_cookie(auth_ctx.user.id).get_user_id()
 
 
 class Config(DataRobotAppFrameworkBaseSettings):
@@ -52,25 +87,27 @@ def _get_default_mem0_api_key() -> str | None:
 
 
 class _UserManagerShim:
-    """Stub that prevents ``AttributeError`` on NAT 1.6.
+    """Bridge ``Context.user_manager`` to the DR-user UUIDv5 on NAT 1.6.
 
     ``nvidia-nat-langchain`` 1.6.0's ``auto_memory_wrapper`` accesses
-    ``Context.user_manager.get_id()`` to resolve a user_id, but
-    ``Context.user_manager`` only exists on newer NAT versions.
-    Returning ``None`` lets the wrapper's fallback chain run without
-    raising; the value it eventually picks is overridden by
-    :class:`DRMem0Editor`, which pins every add and search to
-    ``DataRobotMemoryClient.user_id`` (= ``sha256(MEM0_API_KEY)``).
+    ``Context.user_manager.get_id()`` to resolve the user_id it passes to the
+    memory editor, but ``Context.user_manager`` only exists on newer NAT
+    versions. Return :func:`_memory_user_uuid`, NAT's canonical UUIDv5
+    derived from the request's ``X-DataRobot-Authorization-Context`` header,
+    so the wrapper feeds the editor a stable per-user identity (the raw id
+    never leaves the process). When the header is absent or undecodable,
+    return ``None`` and let the editor fall back to its api-key owner.
     """
 
+    def __init__(self, context: Context) -> None:
+        self._context = context
+
     def get_id(self) -> str | None:
-        return None
+        return _memory_user_uuid()
 
 
 if not hasattr(Context, "user_manager"):
-    Context.user_manager = property(  # type: ignore[attr-defined]
-        lambda self: _UserManagerShim()
-    )
+    Context.user_manager = property(_UserManagerShim)  # type: ignore[attr-defined]
 
 
 class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
@@ -102,16 +139,13 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         configured_run_id = add_kwargs.pop("run_id", None)
         configured_tags = add_kwargs.pop("tags", None)
         configured_metadata = dict(add_kwargs.pop("metadata", None) or {})
-        add_kwargs.pop("user_id", None)
-
-        # Pin every write to the API-key owner so add and search share scope.
-        # See ``DataRobotMemoryClient.user_id`` (= ``sha256(api_key)``).
-        user_id = self._mem0.user_id
+        configured_user_id = add_kwargs.pop("user_id", None)
 
         coroutines = []
         for item in items:
             metadata = configured_metadata | dict(item.metadata or {})
             run_id = metadata.pop("run_id", configured_run_id)
+            user_id = item.user_id or configured_user_id or self._mem0.user_id
             item_kwargs = add_kwargs | {
                 "user_id": user_id,
                 "tags": item.tags or configured_tags or [],
@@ -126,10 +160,7 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
             await asyncio.gather(*coroutines)
 
     async def search(self, query: str, top_k: int = 5, **kwargs: Any) -> list[MemoryItem]:
-        # Mem0's v2 search endpoint expects filters instead of top-level user/run/app ids.
-        # Pin to the API-key owner; see ``add_items`` for rationale.
-        kwargs.pop("user_id", None)
-        user_id = self._mem0.user_id
+        user_id = kwargs.pop("user_id", None) or self._mem0.user_id
         conditions: list[dict[str, Any]] = [{"user_id": user_id}]
         for key in ("run_id", "agent_id", "app_id"):
             value = kwargs.pop(key, None)
@@ -169,9 +200,10 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
     async def remove_items(self, **kwargs: Any) -> None:
         if "memory_id" in kwargs:
             await self._mem0.delete(kwargs.pop("memory_id"))
-        elif "user_id" in kwargs:
-            kwargs.pop("user_id")
-            await self._mem0.delete_all(user_id=self._mem0.user_id)
+            return
+        user_id = kwargs.pop("user_id", None)
+        if user_id:
+            await self._mem0.delete_all(user_id=user_id)
 
 
 def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -170,7 +170,8 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         if "memory_id" in kwargs:
             await self._mem0.delete(kwargs.pop("memory_id"))
         elif "user_id" in kwargs:
-            await self._mem0.delete_all(user_id=kwargs.pop("user_id"))
+            kwargs.pop("user_id")
+            await self._mem0.delete_all(user_id=self._mem0.user_id)
 
 
 def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from nat.builder.builder import Builder
+from nat.builder.context import Context
 from nat.cli.register_workflow import register_memory
 from nat.data_models.memory import MemoryBaseConfig
 from nat.data_models.retry_mixin import RetryMixin
@@ -48,6 +49,28 @@ class Config(DataRobotAppFrameworkBaseSettings):
 
 def _get_default_mem0_api_key() -> str | None:
     return Config().mem0_api_key
+
+
+class _UserManagerShim:
+    """Stub that prevents ``AttributeError`` on NAT 1.6.
+
+    ``nvidia-nat-langchain`` 1.6.0's ``auto_memory_wrapper`` accesses
+    ``Context.user_manager.get_id()`` to resolve a user_id, but
+    ``Context.user_manager`` only exists on newer NAT versions.
+    Returning ``None`` lets the wrapper's fallback chain run without
+    raising; the value it eventually picks is overridden by
+    :class:`DRMem0Editor`, which pins every add and search to
+    ``DataRobotMemoryClient.user_id`` (= ``sha256(MEM0_API_KEY)``).
+    """
+
+    def get_id(self) -> str | None:
+        return None
+
+
+if not hasattr(Context, "user_manager"):
+    Context.user_manager = property(  # type: ignore[attr-defined]
+        lambda self: _UserManagerShim()
+    )
 
 
 class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
@@ -81,12 +104,16 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         configured_metadata = dict(add_kwargs.pop("metadata", None) or {})
         add_kwargs.pop("user_id", None)
 
+        # Pin every write to the API-key owner so add and search share scope.
+        # See ``DataRobotMemoryClient.user_id`` (= ``sha256(api_key)``).
+        user_id = self._mem0.user_id
+
         coroutines = []
         for item in items:
             metadata = configured_metadata | dict(item.metadata or {})
             run_id = metadata.pop("run_id", configured_run_id)
             item_kwargs = add_kwargs | {
-                "user_id": item.user_id,
+                "user_id": user_id,
                 "tags": item.tags or configured_tags or [],
                 "metadata": metadata,
                 "output_format": output_format,
@@ -100,7 +127,9 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
 
     async def search(self, query: str, top_k: int = 5, **kwargs: Any) -> list[MemoryItem]:
         # Mem0's v2 search endpoint expects filters instead of top-level user/run/app ids.
-        user_id = kwargs.pop("user_id")
+        # Pin to the API-key owner; see ``add_items`` for rationale.
+        kwargs.pop("user_id", None)
+        user_id = self._mem0.user_id
         conditions: list[dict[str, Any]] = [{"user_id": user_id}]
         for key in ("run_id", "agent_id", "app_id"):
             value = kwargs.pop(key, None)

--- a/tests/nat/integration/test_auto_memory.py
+++ b/tests/nat/integration/test_auto_memory.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 import pytest
 from nat.builder.builder import Builder
-from nat.builder.context import Context
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
@@ -29,22 +28,11 @@ from nat.runtime.session import SessionManager
 
 import datarobot_genai.nat.datarobot_mem0_memory  # noqa: F401
 from datarobot_genai.core.memory.mem0client import Mem0Client
+from datarobot_genai.nat import datarobot_mem0_memory
 from datarobot_genai.nat.datarobot_mem0_memory import Config as Mem0Settings
 from datarobot_genai.nat.helpers import load_workflow
 
 WORKFLOW_WITH_MEMORY_PATH = Path(__file__).parent / "workflow_with_memory.yaml"
-
-
-class ContextUserManager:
-    def __init__(self, context: Context) -> None:
-        self._context = context
-
-    def get_id(self) -> str | None:
-        return self._context.user_id
-
-
-def get_context_user_manager(context: Context) -> ContextUserManager:
-    return ContextUserManager(context)
 
 
 class AutoMemoryProbeAgentConfig(  # type: ignore[call-arg]
@@ -84,16 +72,6 @@ def mem0_api_key() -> str:
     return api_key
 
 
-@pytest.fixture(autouse=True)
-def context_user_manager(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        Context,
-        "user_manager",
-        property(get_context_user_manager),
-        raising=False,
-    )
-
-
 @pytest.fixture
 async def workflow_with_memory(mem0_api_key: str) -> AsyncGenerator[SessionManager, None]:
     async with load_workflow(WORKFLOW_WITH_MEMORY_PATH) as workflow:
@@ -103,83 +81,62 @@ async def workflow_with_memory(mem0_api_key: str) -> AsyncGenerator[SessionManag
 async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
     workflow_with_memory: SessionManager,
     mem0_api_key: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # GIVEN a workflow.yaml with a real Mem0-backed NAT memory provider and auto-memory wrapper.
+    # GIVEN a workflow.yaml with a real Mem0-backed NAT memory provider and
+    # auto-memory wrapper. The provider's ``_UserManagerShim`` resolves the
+    # per-user id via ``_memory_user_uuid``, which in production reads the DR
+    # auth header. Stub it to a stable per-test UUID so the round-trip proves
+    # memories are scoped per user rather than globally per api key.
     test_id = uuid.uuid4().hex
-    session_user_id = f"nat-auto-memory-{test_id}"
+    dr_memory_user_uuid = f"nat-auto-memory-{test_id}"
+    monkeypatch.setattr(datarobot_mem0_memory, "_memory_user_uuid", lambda: dr_memory_user_uuid)
+
     secret_code = f"DRMEM-{test_id}"
     first_message = f"My NAT auto-memory integration secret code is {secret_code}."
     recall_message = "What is my NAT auto-memory integration secret code?"
 
     async def run_memory_workflow(message: str) -> str:
-        async with workflow_with_memory.session(user_id=session_user_id) as session:
+        async with workflow_with_memory.session() as session:
             async with session.run(message) as runner:
                 return await runner.result(to_type=str)
 
-    # The editor pins every add/search to ``DataRobotMemoryClient.user_id``
-    # (= sha256(api_key)), ignoring the session user_id supplied by NAT's
-    # auto-memory wrapper. Cleanup must target that pinned scope, not the
-    # session user_id — and must be narrowed to this test's memories so we
-    # don't wipe other tests sharing the same api key.
     mem0 = Mem0Client(api_key=mem0_api_key)._memory
-    pinned_user_id = mem0.user_id
-    assert pinned_user_id != session_user_id
+    api_key_user_id = mem0.user_id
+    assert api_key_user_id != dr_memory_user_uuid
 
     try:
         # WHEN the wrapped workflow sees one message to store.
         await run_memory_workflow(first_message)
 
-        # THEN the memory is stored under sha256(api_key), NOT the session user_id.
-        pinned_memory_found = False
-        for _ in range(10):
-            pinned_hits = await mem0.search(
-                query=secret_code,
-                filters={"AND": [{"user_id": pinned_user_id}]},
-            )
-            if any(
-                secret_code in (item.get("memory") or "")
-                for item in pinned_hits.get("results", []) or []
-            ):
-                pinned_memory_found = True
-                break
-            await asyncio.sleep(2)
-        assert pinned_memory_found, (
-            f"Editor did not pin memory to sha256(api_key)={pinned_user_id!r}; "
-            f"secret_code {secret_code!r} not found under the api-key scope."
-        )
-
-        session_hits = await mem0.search(
-            query=secret_code,
-            filters={"AND": [{"user_id": session_user_id}]},
-        )
-        assert not [
-            item
-            for item in session_hits.get("results", []) or []
-            if secret_code in (item.get("memory") or "")
-        ], (
-            f"Memory leaked to session user_id={session_user_id!r}; "
-            f"expected the editor to pin every write to {pinned_user_id!r}."
-        )
-
-        # AND a later turn retrieves the real Mem0 memory and injects it as context.
+        # THEN a later turn retrieves the real Mem0 memory and injects it as context.
+        # New per-user user_ids need a few seconds for Mem0 to index the first
+        # write, so the budget is generous.
         last_response = ""
-        for _ in range(10):
+        for _ in range(20):
             last_response = await run_memory_workflow(recall_message)
             if secret_code in last_response:
                 break
-            await asyncio.sleep(2)
+            await asyncio.sleep(3)
         else:
             pytest.fail(
                 f"Mem0 did not return expected memory text. Last response: {last_response!r}"
             )
-    finally:
-        # Narrow cleanup to this test's memories: search the pinned scope for
-        # the unique secret_code and delete each matching memory by id.
-        cleanup_hits = await mem0.search(
-            query=secret_code,
-            filters={"AND": [{"user_id": pinned_user_id}]},
+
+        # AND the memory is scoped to the DR-user UUID, NOT the api-key-derived
+        # fallback. Recall succeeded, so indexing is done — this lookup is immediate.
+        user_hits = await mem0.get_all(
+            filters={"AND": [{"user_id": dr_memory_user_uuid}]},
+            page=1,
+            page_size=50,
         )
-        for item in cleanup_hits.get("results", []) or []:
-            memory_id = item.get("id")
-            if memory_id and secret_code in (item.get("memory") or ""):
-                await mem0.delete(memory_id)
+        assert any(
+            secret_code in (item.get("memory") or "") for item in user_hits.get("results", []) or []
+        ), (
+            f"Memory not found under user_id={dr_memory_user_uuid!r}; the shim "
+            f"should have propagated the stubbed user uuid through the wrapper."
+        )
+    finally:
+        # Scope is per-user, so delete_all by the stubbed uuid is safe — it
+        # only wipes this test's memories.
+        await mem0.delete_all(user_id=dr_memory_user_uuid)

--- a/tests/nat/integration/test_auto_memory.py
+++ b/tests/nat/integration/test_auto_memory.py
@@ -106,21 +106,62 @@ async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
 ) -> None:
     # GIVEN a workflow.yaml with a real Mem0-backed NAT memory provider and auto-memory wrapper.
     test_id = uuid.uuid4().hex
-    user_id = f"nat-auto-memory-{test_id}"
+    session_user_id = f"nat-auto-memory-{test_id}"
     secret_code = f"DRMEM-{test_id}"
     first_message = f"My NAT auto-memory integration secret code is {secret_code}."
     recall_message = "What is my NAT auto-memory integration secret code?"
 
     async def run_memory_workflow(message: str) -> str:
-        async with workflow_with_memory.session(user_id=user_id) as session:
+        async with workflow_with_memory.session(user_id=session_user_id) as session:
             async with session.run(message) as runner:
                 return await runner.result(to_type=str)
+
+    # The editor pins every add/search to ``DataRobotMemoryClient.user_id``
+    # (= sha256(api_key)), ignoring the session user_id supplied by NAT's
+    # auto-memory wrapper. Cleanup must target that pinned scope, not the
+    # session user_id — and must be narrowed to this test's memories so we
+    # don't wipe other tests sharing the same api key.
+    mem0 = Mem0Client(api_key=mem0_api_key)._memory
+    pinned_user_id = mem0.user_id
+    assert pinned_user_id != session_user_id
 
     try:
         # WHEN the wrapped workflow sees one message to store.
         await run_memory_workflow(first_message)
 
-        # THEN a later turn retrieves the real Mem0 memory and injects it as context.
+        # THEN the memory is stored under sha256(api_key), NOT the session user_id.
+        pinned_memory_found = False
+        for _ in range(10):
+            pinned_hits = await mem0.search(
+                query=secret_code,
+                filters={"AND": [{"user_id": pinned_user_id}]},
+            )
+            if any(
+                secret_code in (item.get("memory") or "")
+                for item in pinned_hits.get("results", []) or []
+            ):
+                pinned_memory_found = True
+                break
+            await asyncio.sleep(2)
+        assert pinned_memory_found, (
+            f"Editor did not pin memory to sha256(api_key)={pinned_user_id!r}; "
+            f"secret_code {secret_code!r} not found under the api-key scope."
+        )
+
+        session_hits = await mem0.search(
+            query=secret_code,
+            filters={"AND": [{"user_id": session_user_id}]},
+        )
+        assert not [
+            item
+            for item in session_hits.get("results", []) or []
+            if secret_code in (item.get("memory") or "")
+        ], (
+            f"Memory leaked to session user_id={session_user_id!r}; "
+            f"expected the editor to pin every write to {pinned_user_id!r}."
+        )
+
+        # AND a later turn retrieves the real Mem0 memory and injects it as context.
         last_response = ""
         for _ in range(10):
             last_response = await run_memory_workflow(recall_message)
@@ -132,4 +173,13 @@ async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
                 f"Mem0 did not return expected memory text. Last response: {last_response!r}"
             )
     finally:
-        await Mem0Client(api_key=mem0_api_key)._memory.delete_all(user_id=user_id)
+        # Narrow cleanup to this test's memories: search the pinned scope for
+        # the unique secret_code and delete each matching memory by id.
+        cleanup_hits = await mem0.search(
+            query=secret_code,
+            filters={"AND": [{"user_id": pinned_user_id}]},
+        )
+        for item in cleanup_hits.get("results", []) or []:
+            memory_id = item.get("id")
+            if memory_id and secret_code in (item.get("memory") or ""):
+                await mem0.delete(memory_id)

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -216,18 +216,34 @@ def test_context_user_manager_property_is_patched() -> None:
     assert isinstance(Context.get().user_manager, datarobot_mem0_memory._UserManagerShim)
 
 
-async def test_remove_items_deletes_by_memory_id_or_user_id() -> None:
+async def test_remove_items_deletes_by_memory_id_or_pins_user_id() -> None:
     # GIVEN a Mem0-backed editor.
     mem0 = FakeMem0Api()
     editor = DRMem0Editor(FakeMem0Client(mem0))
 
-    # WHEN deleting a single memory and then all memories for a user.
+    # WHEN deleting a single memory and then "all memories for a user".
     await editor.remove_items(memory_id="memory-123")
     await editor.remove_items(user_id="user-123")
 
-    # THEN the corresponding Mem0 delete APIs are used.
+    # THEN delete-by-id is unchanged, but delete_all targets the editor's
+    # pinned user_id (api-key owner) instead of the caller-supplied one — so
+    # remove_items shares scope with add_items/search.
     assert mem0.delete_calls == ["memory-123"]
-    assert mem0.delete_all_calls == [{"user_id": "user-123"}]
+    assert mem0.delete_all_calls == [{"user_id": FAKE_API_KEY_USER_ID}]
+
+
+async def test_remove_items_without_memory_id_or_user_id_is_a_noop() -> None:
+    # GIVEN a Mem0-backed editor.
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+
+    # WHEN remove_items is called with no targeting args.
+    await editor.remove_items()
+
+    # THEN no Mem0 delete API is invoked — the pinned scope is api-key-wide and
+    # shared across all NAT sessions, so we never wipe it implicitly.
+    assert mem0.delete_calls == []
+    assert mem0.delete_all_calls == []
 
 
 async def test_registered_memory_client_uses_config_api_key_and_retry(monkeypatch: Any) -> None:

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from nat.builder.context import Context
 from nat.memory.models import MemoryItem
 
 from datarobot_genai.nat import datarobot_mem0_memory
@@ -24,9 +25,14 @@ from datarobot_genai.nat.datarobot_mem0_memory import Config
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0MemoryClientConfig
 
+# Matches ``DataRobotMemoryClient.user_id`` (= ``sha256(api_key)``); the editor
+# pins every add/search to this so add and search share scope.
+FAKE_API_KEY_USER_ID = "fake-api-key-sha256"
+
 
 class FakeMem0Api:
-    def __init__(self) -> None:
+    def __init__(self, user_id: str = FAKE_API_KEY_USER_ID) -> None:
+        self.user_id = user_id
         self.add_calls: list[dict[str, Any]] = []
         self.search_calls: list[dict[str, Any]] = []
         self.delete_calls: list[str] = []
@@ -52,8 +58,8 @@ class FakeMem0Client:
         self._memory = mem0 or FakeMem0Api()
 
 
-async def test_add_items_forwards_nat_memory_items_to_mem0() -> None:
-    # GIVEN a NAT MemoryItem with runtime user id and metadata.
+async def test_add_items_pins_user_id_to_mem0_client() -> None:
+    # GIVEN a NAT MemoryItem whose user_id differs from the Mem0 client's.
     mem0 = FakeMem0Api()
     editor = DRMem0Editor(FakeMem0Client(mem0))
     item = MemoryItem(
@@ -66,12 +72,14 @@ async def test_add_items_forwards_nat_memory_items_to_mem0() -> None:
     # WHEN the editor stores it.
     await editor.add_items([item], agent_id="agent-abc")
 
-    # THEN the underlying Mem0 client receives NAT's user id and v1.1 payload shape.
+    # THEN the Mem0 call uses ``DataRobotMemoryClient.user_id`` (api-key owner),
+    # ignoring the wrapper-supplied ``MemoryItem.user_id``, while still forwarding
+    # tags, metadata, and v1.1 payload shape.
     assert mem0.add_calls == [
         {
             "conversation": [{"role": "user", "content": "remember Python"}],
             "kwargs": {
-                "user_id": "user-123",
+                "user_id": FAKE_API_KEY_USER_ID,
                 "run_id": "run-456",
                 "tags": ["preference"],
                 "metadata": {"thread_id": "thread-789"},
@@ -82,8 +90,8 @@ async def test_add_items_forwards_nat_memory_items_to_mem0() -> None:
     ]
 
 
-async def test_add_items_resolves_conflicting_add_params() -> None:
-    # GIVEN add_params that overlap with NAT MemoryItem fields.
+async def test_add_items_pins_user_id_even_with_conflicting_add_params() -> None:
+    # GIVEN add_params and a MemoryItem that both set user_id.
     mem0 = FakeMem0Api()
     editor = DRMem0Editor(FakeMem0Client(mem0))
     item = MemoryItem(
@@ -104,12 +112,13 @@ async def test_add_items_resolves_conflicting_add_params() -> None:
         async_mode=False,
     )
 
-    # THEN the Mem0 call has no duplicate kwargs and preserves NAT item identity.
+    # THEN the editor's pinned user_id wins over BOTH the kwarg and the item,
+    # other NAT item fields still take precedence over configured add_params.
     assert mem0.add_calls == [
         {
             "conversation": [{"role": "user", "content": "remember TypeScript"}],
             "kwargs": {
-                "user_id": "item-user",
+                "user_id": FAKE_API_KEY_USER_ID,
                 "run_id": "item-run",
                 "tags": ["item-tag"],
                 "metadata": {"thread_id": "item-thread", "source": "workflow"},
@@ -120,7 +129,7 @@ async def test_add_items_resolves_conflicting_add_params() -> None:
     ]
 
 
-async def test_search_builds_mem0_v2_filters_from_nat_kwargs() -> None:
+async def test_search_builds_mem0_v2_filters_pinned_to_client_user_id() -> None:
     # GIVEN a Mem0 search result and NAT auto-memory user/run/app parameters.
     mem0 = FakeMem0Api()
     mem0.search_result = {
@@ -147,14 +156,16 @@ async def test_search_builds_mem0_v2_filters_from_nat_kwargs() -> None:
         threshold=0.75,
     )
 
-    # THEN the search uses Mem0 v2 filters and returns NAT MemoryItems.
+    # THEN the search filters the v2 endpoint by the editor's pinned user_id
+    # (api-key owner), ignoring the wrapper-supplied ``user_id`` kwarg, and the
+    # returned NAT MemoryItem inherits that same pinned user_id.
     assert mem0.search_calls == [
         {
             "query": "language",
             "kwargs": {
                 "filters": {
                     "AND": [
-                        {"user_id": "user-123"},
+                        {"user_id": FAKE_API_KEY_USER_ID},
                         {"run_id": "run-456"},
                         {"app_id": "app-abc"},
                         {"metadata": {"thread_id": "thread-789"}},
@@ -169,7 +180,7 @@ async def test_search_builds_mem0_v2_filters_from_nat_kwargs() -> None:
     assert memories == [
         MemoryItem(
             conversation=[{"role": "user", "content": "I prefer Python"}],
-            user_id="user-123",
+            user_id=FAKE_API_KEY_USER_ID,
             memory="User prefers Python.",
             tags=["preference"],
             metadata={"thread_id": "thread-789"},
@@ -188,6 +199,21 @@ async def test_search_honors_explicit_filters() -> None:
 
     # THEN those filters are forwarded without rebuilding them.
     assert mem0.search_calls[0]["kwargs"]["filters"] == filters
+
+
+def test_user_manager_shim_get_id_returns_none() -> None:
+    # GIVEN the shim installed by ``datarobot_mem0_memory`` for NAT 1.6.
+    shim = datarobot_mem0_memory._UserManagerShim()
+
+    # THEN ``get_id`` returns None — the editor pins the real user_id, the shim
+    # only exists to keep ``auto_memory_wrapper`` from raising AttributeError.
+    assert shim.get_id() is None
+
+
+def test_context_user_manager_property_is_patched() -> None:
+    # GIVEN ``datarobot_mem0_memory`` is imported (this test module imports it).
+    # THEN every ``Context`` exposes a ``user_manager`` attribute that is a shim.
+    assert isinstance(Context.get().user_manager, datarobot_mem0_memory._UserManagerShim)
 
 
 async def test_remove_items_deletes_by_memory_id_or_user_id() -> None:

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -25,8 +25,9 @@ from datarobot_genai.nat.datarobot_mem0_memory import Config
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0MemoryClientConfig
 
-# Matches ``DataRobotMemoryClient.user_id`` (= ``sha256(api_key)``); the editor
-# pins every add/search to this so add and search share scope.
+# Matches ``DataRobotMemoryClient.user_id`` (= ``sha256(api_key)``). The editor
+# falls back to this when no per-session user_id is supplied (e.g. direct calls
+# outside the auto-memory wrapper).
 FAKE_API_KEY_USER_ID = "fake-api-key-sha256"
 
 
@@ -58,13 +59,14 @@ class FakeMem0Client:
         self._memory = mem0 or FakeMem0Api()
 
 
-async def test_add_items_pins_user_id_to_mem0_client() -> None:
-    # GIVEN a NAT MemoryItem whose user_id differs from the Mem0 client's.
+async def test_add_items_forwards_per_session_user_id_from_memory_item() -> None:
+    # GIVEN a NAT MemoryItem whose user_id was set by ``auto_memory_wrapper``
+    # from ``Context.user_id`` (= the per-session user id).
     mem0 = FakeMem0Api()
     editor = DRMem0Editor(FakeMem0Client(mem0))
     item = MemoryItem(
         conversation=[{"role": "user", "content": "remember Python"}],
-        user_id="user-123",
+        user_id="session-user-123",
         tags=["preference"],
         metadata={"run_id": "run-456", "thread_id": "thread-789"},
     )
@@ -72,14 +74,13 @@ async def test_add_items_pins_user_id_to_mem0_client() -> None:
     # WHEN the editor stores it.
     await editor.add_items([item], agent_id="agent-abc")
 
-    # THEN the Mem0 call uses ``DataRobotMemoryClient.user_id`` (api-key owner),
-    # ignoring the wrapper-supplied ``MemoryItem.user_id``, while still forwarding
-    # tags, metadata, and v1.1 payload shape.
+    # THEN the Mem0 call uses the MemoryItem's user_id so memories are scoped
+    # per session, not globally per api key.
     assert mem0.add_calls == [
         {
             "conversation": [{"role": "user", "content": "remember Python"}],
             "kwargs": {
-                "user_id": FAKE_API_KEY_USER_ID,
+                "user_id": "session-user-123",
                 "run_id": "run-456",
                 "tags": ["preference"],
                 "metadata": {"thread_id": "thread-789"},
@@ -90,7 +91,26 @@ async def test_add_items_pins_user_id_to_mem0_client() -> None:
     ]
 
 
-async def test_add_items_pins_user_id_even_with_conflicting_add_params() -> None:
+async def test_add_items_falls_back_to_mem0_user_id_when_no_session_user_id() -> None:
+    # GIVEN a MemoryItem with an empty user_id and no configured user_id kwarg
+    # (direct call outside the wrapper, no session context).
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember TypeScript"}],
+        user_id="",
+        tags=["preference"],
+    )
+
+    # WHEN the editor stores it.
+    await editor.add_items([item])
+
+    # THEN the api-key owner is used as a last-resort fallback so the call
+    # still succeeds (Mem0 requires a user_id).
+    assert mem0.add_calls[0]["kwargs"]["user_id"] == FAKE_API_KEY_USER_ID
+
+
+async def test_add_items_item_user_id_beats_configured_user_id() -> None:
     # GIVEN add_params and a MemoryItem that both set user_id.
     mem0 = FakeMem0Api()
     editor = DRMem0Editor(FakeMem0Client(mem0))
@@ -112,13 +132,14 @@ async def test_add_items_pins_user_id_even_with_conflicting_add_params() -> None
         async_mode=False,
     )
 
-    # THEN the editor's pinned user_id wins over BOTH the kwarg and the item,
-    # other NAT item fields still take precedence over configured add_params.
+    # THEN the MemoryItem's per-session user_id wins over the configured kwarg
+    # (the wrapper's identity is authoritative); other NAT item fields still
+    # take precedence over configured add_params.
     assert mem0.add_calls == [
         {
             "conversation": [{"role": "user", "content": "remember TypeScript"}],
             "kwargs": {
-                "user_id": FAKE_API_KEY_USER_ID,
+                "user_id": "item-user",
                 "run_id": "item-run",
                 "tags": ["item-tag"],
                 "metadata": {"thread_id": "item-thread", "source": "workflow"},
@@ -129,7 +150,7 @@ async def test_add_items_pins_user_id_even_with_conflicting_add_params() -> None
     ]
 
 
-async def test_search_builds_mem0_v2_filters_pinned_to_client_user_id() -> None:
+async def test_search_builds_mem0_v2_filters_with_session_user_id() -> None:
     # GIVEN a Mem0 search result and NAT auto-memory user/run/app parameters.
     mem0 = FakeMem0Api()
     mem0.search_result = {
@@ -144,11 +165,11 @@ async def test_search_builds_mem0_v2_filters_pinned_to_client_user_id() -> None:
     }
     editor = DRMem0Editor(FakeMem0Client(mem0))
 
-    # WHEN the editor searches memory.
+    # WHEN the editor searches memory using the per-session user_id.
     memories = await editor.search(
         "language",
         top_k=2,
-        user_id="user-123",
+        user_id="session-user-123",
         run_id="run-456",
         app_id="app-abc",
         metadata={"thread_id": "thread-789"},
@@ -156,16 +177,15 @@ async def test_search_builds_mem0_v2_filters_pinned_to_client_user_id() -> None:
         threshold=0.75,
     )
 
-    # THEN the search filters the v2 endpoint by the editor's pinned user_id
-    # (api-key owner), ignoring the wrapper-supplied ``user_id`` kwarg, and the
-    # returned NAT MemoryItem inherits that same pinned user_id.
+    # THEN the v2 endpoint filters by the per-session user_id, and the returned
+    # NAT MemoryItem carries that same user_id so add and search share scope.
     assert mem0.search_calls == [
         {
             "query": "language",
             "kwargs": {
                 "filters": {
                     "AND": [
-                        {"user_id": FAKE_API_KEY_USER_ID},
+                        {"user_id": "session-user-123"},
                         {"run_id": "run-456"},
                         {"app_id": "app-abc"},
                         {"metadata": {"thread_id": "thread-789"}},
@@ -180,12 +200,25 @@ async def test_search_builds_mem0_v2_filters_pinned_to_client_user_id() -> None:
     assert memories == [
         MemoryItem(
             conversation=[{"role": "user", "content": "I prefer Python"}],
-            user_id=FAKE_API_KEY_USER_ID,
+            user_id="session-user-123",
             memory="User prefers Python.",
             tags=["preference"],
             metadata={"thread_id": "thread-789"},
         )
     ]
+
+
+async def test_search_falls_back_to_mem0_user_id_when_no_session_user_id() -> None:
+    # GIVEN a search with no user_id (direct call outside the wrapper).
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+
+    # WHEN the editor searches.
+    await editor.search("language", top_k=2)
+
+    # THEN the api-key owner is used as a last-resort fallback so the call
+    # still succeeds (Mem0 v2 filters require user_id).
+    assert mem0.search_calls[0]["kwargs"]["filters"] == {"AND": [{"user_id": FAKE_API_KEY_USER_ID}]}
 
 
 async def test_search_honors_explicit_filters() -> None:
@@ -201,12 +234,26 @@ async def test_search_honors_explicit_filters() -> None:
     assert mem0.search_calls[0]["kwargs"]["filters"] == filters
 
 
-def test_user_manager_shim_get_id_returns_none() -> None:
-    # GIVEN the shim installed by ``datarobot_mem0_memory`` for NAT 1.6.
-    shim = datarobot_mem0_memory._UserManagerShim()
+def test_user_manager_shim_get_id_returns_dr_memory_user_uuid(monkeypatch: Any) -> None:
+    # GIVEN the shim installed by ``datarobot_mem0_memory`` for NAT 1.6 and a
+    # request whose DR auth header decodes to a known UUIDv5.
+    monkeypatch.setattr(datarobot_mem0_memory, "_memory_user_uuid", lambda: "uuid-from-dr-auth")
+    shim = datarobot_mem0_memory._UserManagerShim(object())  # type: ignore[arg-type]
 
-    # THEN ``get_id`` returns None — the editor pins the real user_id, the shim
-    # only exists to keep ``auto_memory_wrapper`` from raising AttributeError.
+    # THEN ``get_id`` returns the canonical DR-user UUID so ``auto_memory_wrapper``
+    # passes a stable per-user identity to the editor.
+    assert shim.get_id() == "uuid-from-dr-auth"
+
+
+def test_user_manager_shim_get_id_returns_none_when_dr_auth_header_missing(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN no DR auth header on the current request (e.g. local dev).
+    monkeypatch.setattr(datarobot_mem0_memory, "_memory_user_uuid", lambda: None)
+    shim = datarobot_mem0_memory._UserManagerShim(object())  # type: ignore[arg-type]
+
+    # THEN ``get_id`` returns None so the wrapper falls through to its default
+    # and the editor falls back to the api-key owner.
     assert shim.get_id() is None
 
 
@@ -216,20 +263,108 @@ def test_context_user_manager_property_is_patched() -> None:
     assert isinstance(Context.get().user_manager, datarobot_mem0_memory._UserManagerShim)
 
 
-async def test_remove_items_deletes_by_memory_id_or_pins_user_id() -> None:
+def test_memory_user_uuid_returns_uuid_for_decodable_dr_auth_header(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN a request whose headers carry a decodable DR auth context.
+    class FakeUser:
+        id = "datarobot-user-abc"
+
+    class FakeAuthCtx:
+        user = FakeUser()
+
+    class FakeHandler:
+        def get_context(self, headers: dict[str, str]) -> Any:
+            assert headers == {"x-datarobot-authorization-context": "encoded-token"}
+            return FakeAuthCtx()
+
+    class FakeMetadata:
+        headers = {"x-datarobot-authorization-context": "encoded-token"}
+
+    class FakeContextInstance:
+        metadata = FakeMetadata()
+
+    monkeypatch.setattr(datarobot_mem0_memory, "AuthContextHeaderHandler", FakeHandler)
+    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
+
+    # WHEN we resolve the memory user id.
+    user_id = datarobot_mem0_memory._memory_user_uuid()
+
+    # THEN it matches what NAT's ``UserInfo._from_session_cookie`` derives — a
+    # UUIDv5 over the raw DR user id (the raw id never leaves the process).
+    from nat.data_models.user_info import UserInfo
+
+    assert user_id == UserInfo._from_session_cookie("datarobot-user-abc").get_user_id()
+
+
+def test_memory_user_uuid_returns_none_when_no_metadata(monkeypatch: Any) -> None:
+    # GIVEN a Context with no metadata at all.
+    class FakeContextInstance:
+        metadata = None
+
+    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
+
+    # WHEN we resolve the memory user id.
+    # THEN it returns None — caller will fall back to the api-key owner.
+    assert datarobot_mem0_memory._memory_user_uuid() is None
+
+
+def test_memory_user_uuid_returns_none_when_handler_returns_none(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN a request whose DR auth header is missing/undecodable (handler returns None).
+    class FakeHandler:
+        def get_context(self, headers: dict[str, str]) -> Any:
+            return None
+
+    class FakeMetadata:
+        headers = {"other-header": "value"}
+
+    class FakeContextInstance:
+        metadata = FakeMetadata()
+
+    monkeypatch.setattr(datarobot_mem0_memory, "AuthContextHeaderHandler", FakeHandler)
+    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
+
+    # WHEN we resolve the memory user id.
+    # THEN it returns None — caller will fall back to the api-key owner.
+    assert datarobot_mem0_memory._memory_user_uuid() is None
+
+
+def test_memory_user_uuid_returns_none_when_handler_raises(monkeypatch: Any) -> None:
+    # GIVEN a handler that crashes (e.g. SESSION_SECRET_KEY unset in local dev).
+    class FakeHandler:
+        def get_context(self, headers: dict[str, str]) -> Any:
+            raise RuntimeError("SESSION_SECRET_KEY not set")
+
+    class FakeMetadata:
+        headers = {"x-datarobot-authorization-context": "token"}
+
+    class FakeContextInstance:
+        metadata = FakeMetadata()
+
+    monkeypatch.setattr(datarobot_mem0_memory, "AuthContextHeaderHandler", FakeHandler)
+    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
+
+    # WHEN we resolve the memory user id.
+    # THEN it swallows the error and returns None so memory writes don't crash
+    # the request — caller falls back to the api-key owner.
+    assert datarobot_mem0_memory._memory_user_uuid() is None
+
+
+async def test_remove_items_deletes_by_memory_id_or_session_user_id() -> None:
     # GIVEN a Mem0-backed editor.
     mem0 = FakeMem0Api()
     editor = DRMem0Editor(FakeMem0Client(mem0))
 
-    # WHEN deleting a single memory and then "all memories for a user".
+    # WHEN deleting a single memory and then all memories for a session user.
     await editor.remove_items(memory_id="memory-123")
-    await editor.remove_items(user_id="user-123")
+    await editor.remove_items(user_id="session-user-123")
 
-    # THEN delete-by-id is unchanged, but delete_all targets the editor's
-    # pinned user_id (api-key owner) instead of the caller-supplied one — so
-    # remove_items shares scope with add_items/search.
+    # THEN delete-by-id and delete_all both target the caller-supplied scope,
+    # so a delete targeting a session user_id matches what add/search wrote.
     assert mem0.delete_calls == ["memory-123"]
-    assert mem0.delete_all_calls == [{"user_id": FAKE_API_KEY_USER_ID}]
+    assert mem0.delete_all_calls == [{"user_id": "session-user-123"}]
 
 
 async def test_remove_items_without_memory_id_or_user_id_is_a_noop() -> None:
@@ -240,8 +375,7 @@ async def test_remove_items_without_memory_id_or_user_id_is_a_noop() -> None:
     # WHEN remove_items is called with no targeting args.
     await editor.remove_items()
 
-    # THEN no Mem0 delete API is invoked — the pinned scope is api-key-wide and
-    # shared across all NAT sessions, so we never wipe it implicitly.
+    # THEN no Mem0 delete API is invoked — we never wipe a scope implicitly.
     assert mem0.delete_calls == []
     assert mem0.delete_all_calls == []
 

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.57"
+version = "0.15.58"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Mem0 memories are scoped by forcing all add/search operations to use the API-key-derived `user_id`, which can alter multi-user behavior and cleanup expectations. Also monkey-patches `nat.builder.context.Context` to add a missing `user_manager` property for NAT 1.6 compatibility.
> 
> **Overview**
> Ensures NAT’s Mem0-backed memory provider uses a **constant, API-key-derived user scope** by pinning `DRMem0Editor.add_items` and `DRMem0Editor.search` to `DataRobotMemoryClient.user_id` (sha256 of `MEM0_API_KEY`) and ignoring wrapper/session-provided `user_id` values.
> 
> Adds a small NAT 1.6 compatibility shim by patching `Context.user_manager` when absent to avoid `auto_memory_wrapper` `AttributeError`, and updates unit/integration tests to assert pinned scoping and to perform **targeted cleanup** (delete-by-id) under the pinned user scope. Bumps package version to `0.15.54` (locks updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e948baf40a70a34ffbf3c8baf8f4aeadb004f41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->