### PR TITLE
[BUZZOK-30827] Support X-DataRobot-User-Id header for direct deployment calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.15.58
-- `dragent`: replace the `UserManager` monkey-patch with a `DRAgentUserManager` subclass that resolves `user_id` from the signed `X-DataRobot-Authorization-Context` header, falls back to NAT's standard extractors (Bearer/JWT/cookie/API-key), and finally a constant `default-user` so per-user workflows do not fail for callers without an identity (e.g. direct API-token calls to a deployed agent). The subclass is wired in by rebinding `nat.runtime.session.UserManager`.
+## 0.15.59
+- `dragent`: replace the `UserManager` monkey-patch with a `DRAgentUserManager` subclass that resolves `user_id` from the signed `X-DataRobot-Authorization-Context` header (then NAT's standard extractors). `DRAgentAGUISessionManager.session()` invokes it explicitly and, for per-user workflows only, falls back to a constant `default-user` key when no identity is present so the workflow does not crash (e.g. direct API-token calls to a deployed agent). The identity resolver and the per-user workflow fallback are kept separate so callers that need real identity are not silently handed a default.
 
 ## 0.15.57
 - Registered DataRobot moderation middleware on the `nat.plugins` entry point `datarobot_moderation_middleware` so `_type: datarobot_moderation` is available when NAT loads plugins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.15.59
+## 0.15.60
 - `dragent`: replace the `UserManager` monkey-patch with a `DRAgentUserManager` subclass that resolves `user_id` from the signed `X-DataRobot-Authorization-Context` header (then NAT's standard extractors). `DRAgentAGUISessionManager.session()` invokes it explicitly and, for per-user workflows only, falls back to a constant `default-user` key when no identity is present so the workflow does not crash (e.g. direct API-token calls to a deployed agent). The identity resolver and the per-user workflow fallback are kept separate so callers that need real identity are not silently handed a default.
 
 ## 0.15.58

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.58
+- `dragent`: resolve `user_id` from `X-DataRobot-User-Id` (set by predictions-gateway for any authenticated deployment request) in addition to `X-DataRobot-Authorization-Context`. Replaces the `UserManager` monkey-patch with an explicit override in `DRAgentAGUISessionManager.session()`.
+
 ## 0.15.57
 - Registered DataRobot moderation middleware on the `nat.plugins` entry point `datarobot_moderation_middleware` so `_type: datarobot_moderation` is available when NAT loads plugins.
 - NAT / dragent moderation: `DataRobotModerationConfig` no longer uses `model_dir` to locate guard YAML. Configure guards with the optional `moderation` field (`ModerationConfig` from `datarobot_dome`). In `workflow.yaml`, nest guard definitions under `middleware.datarobot_guardrails.moderation` instead of setting `model_dir` to a directory that contained `moderation_config.yaml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.58
-- `dragent`: resolve `user_id` from `X-DataRobot-User-Id` (set by predictions-gateway for any authenticated deployment request) in addition to `X-DataRobot-Authorization-Context`. Replaces the `UserManager` monkey-patch with an explicit override in `DRAgentAGUISessionManager.session()`.
+- `dragent`: replace the `UserManager` monkey-patch with a `DRAgentUserManager` subclass that resolves `user_id` from the signed `X-DataRobot-Authorization-Context` header, falls back to NAT's standard extractors (Bearer/JWT/cookie/API-key), and finally a constant `default-user` so per-user workflows do not fail for callers without an identity (e.g. direct API-token calls to a deployed agent). The subclass is wired in by rebinding `nat.runtime.session.UserManager`.
 
 ## 0.15.57
 - Registered DataRobot moderation middleware on the `nat.plugins` entry point `datarobot_moderation_middleware` so `_type: datarobot_moderation` is available when NAT loads plugins.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.59"
+version = "0.15.60"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.58"
+version = "0.15.59"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.57"
+version = "0.15.58"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1861,6 +1861,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.58"
+version = "0.15.59"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.57"
+version = "0.15.58"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.59"
+version = "0.15.60"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -46,15 +46,22 @@ logger = logging.getLogger(__name__)
 
 _auth_handler = AuthContextHeaderHandler()
 
-# Constant key used by DRAgentAGUISessionManager.session() to satisfy NAT's
-# per-user workflow requirement when no caller identity is present. Purely a
+# Constant key used by DRAgentUserManager when no caller identity resolves but
+# the surrounding workflow needs *some* user_id (per-user workflows). Purely a
 # workflow-keying fallback — not an identity claim. Must not be used by any
 # code that depends on the result being a real user.
 DEFAULT_DR_AGENT_USER_ID = "default-user"
 
+# Set by DRAgentAGUISessionManager.session() before delegating to NAT, so
+# DRAgentUserManager.extract_user_from_connection (called inside NAT's session()
+# via the module rebind) knows whether to fall back to default-user. Keeps
+# workflow-keying concerns out of the public extract signature while letting
+# the rebound class still satisfy NAT's per-user requirement.
+_per_user_workflow: ContextVar[bool] = ContextVar("_per_user_workflow", default=False)
+
 
 class DRAgentUserManager(UserManager):
-    """Add DataRobot signed auth-context resolution to NAT's standard identity extractors."""
+    """DataRobot signed auth-context → NAT extractors → (per-user only) default-user."""
 
     @classmethod
     def extract_user_from_connection(cls, connection: Request | WebSocket) -> UserInfo | None:
@@ -65,7 +72,18 @@ class DRAgentUserManager(UserManager):
                     "Resolved user_id from X-DataRobot-Authorization-Context: %s", auth_ctx.user.id
                 )
                 return UserInfo._from_session_cookie(auth_ctx.user.id)
-        return super().extract_user_from_connection(connection)
+
+        resolved = super().extract_user_from_connection(connection)
+        if resolved is not None:
+            return resolved
+
+        if _per_user_workflow.get():
+            logger.debug(
+                "No identity resolved for per-user workflow — using %s as key",
+                DEFAULT_DR_AGENT_USER_ID,
+            )
+            return UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
+        return None
 
 
 # NAT 1.6 calls ``UserManager.extract_user_from_connection(...)`` directly on the
@@ -106,23 +124,11 @@ class DRAgentAGUISessionManager(SessionManager):
         ]
         | None = None,
     ) -> AsyncIterator[Session]:
-        """Resolve user_id (A2A preset, DR headers, per-user default) and inject A2A headers."""
+        """Forward A2A preset, signal per-user workflow context, inject A2A headers."""
         if user_id is None:
             preset = self._context_state.user_id.get()
             if preset:
                 user_id = preset
-
-        # Per-user workflows need *a* key in the per-user-builder dict.
-        # Fall back to a constant so they do not crash when no identity is
-        # available (e.g. locust against a deployed agent). This is a
-        # workflow-keying concern, not an identity claim — all such requests
-        # share one builder/state.
-        if user_id is None and self.is_workflow_per_user:
-            logger.debug(
-                "No identity resolved for per-user workflow — using %s as key",
-                DEFAULT_DR_AGENT_USER_ID,
-            )
-            user_id = DEFAULT_DR_AGENT_USER_ID
 
         # Inject A2A request headers BEFORE super().session() so they are
         # available during per-user builder creation (agent card discovery
@@ -135,8 +141,14 @@ class DRAgentAGUISessionManager(SessionManager):
             attrs = _build_metadata_from_headers(preset_headers)
             token_metadata = self._context_state._metadata.set(attrs)
 
-        # Wrap the entire super().session() in try/finally so _metadata is
-        # always reset — even if super().session().__aenter__() raises
+        # Signal per-user-workflow context to DRAgentUserManager (called inside
+        # NAT's session() via the rebind). Lets the resolver fall back to
+        # default-user when no identity is present, without coupling workflow
+        # state to the extract signature.
+        token_per_user = _per_user_workflow.set(self.is_workflow_per_user)
+
+        # Wrap the entire super().session() in try/finally so the ContextVars
+        # are always reset — even if super().session().__aenter__() raises
         # (e.g. per-user builder creation failure).
         try:
             async with super().session(
@@ -149,6 +161,7 @@ class DRAgentAGUISessionManager(SessionManager):
             ) as sess:
                 yield sess
         finally:
+            _per_user_workflow.reset(token_per_user)
             if token_metadata is not None:
                 self._context_state._metadata.reset(token_metadata)
 

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -46,35 +46,33 @@ logger = logging.getLogger(__name__)
 
 _auth_handler = AuthContextHeaderHandler()
 
-
-def _resolve_dr_user_id(headers: dict[str, str]) -> str | None:
-    """Try signed X-DataRobot-Authorization-Context, then unsigned X-DataRobot-User-Id."""
-    auth_ctx = _auth_handler.get_context(headers)
-    if auth_ctx is not None:
-        logger.debug(
-            "Resolved user_id from X-DataRobot-Authorization-Context: %s", auth_ctx.user.id
-        )
-        return auth_ctx.user.id
-
-    user_id = headers.get("x-datarobot-user-id") or headers.get("X-DataRobot-User-Id")
-    if user_id:
-        # Unsigned — trusted because predictions-gateway rebuilds it from the authenticated user.
-        logger.debug("Resolved user_id from X-DataRobot-User-Id header: %s", user_id)
-        return user_id
-
-    return None
+# Used when neither a signed DataRobot auth-context nor NAT's standard extractors
+# can resolve an identity. Keeps per-user workflows from crashing for callers
+# that lack proper auth context (e.g. locust against a deployed agent); all such
+# requests share the same per-user builder/state, so do not rely on this for
+# any kind of authorization decision.
+DEFAULT_DR_AGENT_USER_ID = "default-user"
 
 
 class DRAgentUserManager(UserManager):
-    """UserManager that adds DataRobot header resolution before falling back to standard auth."""
+    """Resolve DataRobot signed auth-context, then NAT's extractors, then fall back to a default."""
 
     @classmethod
     def extract_user_from_connection(cls, connection: Request | WebSocket) -> UserInfo | None:
         if isinstance(connection, Request):
-            user_id = _resolve_dr_user_id(dict(connection.headers))
-            if user_id is not None:
-                return UserInfo._from_session_cookie(user_id)
-        return super().extract_user_from_connection(connection)
+            auth_ctx = _auth_handler.get_context(dict(connection.headers))
+            if auth_ctx is not None:
+                logger.debug(
+                    "Resolved user_id from X-DataRobot-Authorization-Context: %s", auth_ctx.user.id
+                )
+                return UserInfo._from_session_cookie(auth_ctx.user.id)
+
+        resolved = super().extract_user_from_connection(connection)
+        if resolved is not None:
+            return resolved
+
+        logger.debug("No identity resolved — falling back to %s", DEFAULT_DR_AGENT_USER_ID)
+        return UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
 
 
 # NAT 1.6 calls ``UserManager.extract_user_from_connection(...)`` directly on the

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -46,22 +46,15 @@ logger = logging.getLogger(__name__)
 
 _auth_handler = AuthContextHeaderHandler()
 
-# Constant key used by DRAgentUserManager when no caller identity resolves but
-# the surrounding workflow needs *some* user_id (per-user workflows). Purely a
+# Constant key used by DRAgentAGUISessionManager.session() to satisfy NAT's
+# per-user workflow requirement when no caller identity is present. Purely a
 # workflow-keying fallback — not an identity claim. Must not be used by any
 # code that depends on the result being a real user.
 DEFAULT_DR_AGENT_USER_ID = "default-user"
 
-# Set by DRAgentAGUISessionManager.session() before delegating to NAT, so
-# DRAgentUserManager.extract_user_from_connection (called inside NAT's session()
-# via the module rebind) knows whether to fall back to default-user. Keeps
-# workflow-keying concerns out of the public extract signature while letting
-# the rebound class still satisfy NAT's per-user requirement.
-_per_user_workflow: ContextVar[bool] = ContextVar("_per_user_workflow", default=False)
-
 
 class DRAgentUserManager(UserManager):
-    """DataRobot signed auth-context → NAT extractors → (per-user only) default-user."""
+    """Add DataRobot signed auth-context resolution to NAT's standard identity extractors."""
 
     @classmethod
     def extract_user_from_connection(cls, connection: Request | WebSocket) -> UserInfo | None:
@@ -72,18 +65,7 @@ class DRAgentUserManager(UserManager):
                     "Resolved user_id from X-DataRobot-Authorization-Context: %s", auth_ctx.user.id
                 )
                 return UserInfo._from_session_cookie(auth_ctx.user.id)
-
-        resolved = super().extract_user_from_connection(connection)
-        if resolved is not None:
-            return resolved
-
-        if _per_user_workflow.get():
-            logger.debug(
-                "No identity resolved for per-user workflow — using %s as key",
-                DEFAULT_DR_AGENT_USER_ID,
-            )
-            return UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
-        return None
+        return super().extract_user_from_connection(connection)
 
 
 # NAT 1.6 calls ``UserManager.extract_user_from_connection(...)`` directly on the
@@ -124,11 +106,23 @@ class DRAgentAGUISessionManager(SessionManager):
         ]
         | None = None,
     ) -> AsyncIterator[Session]:
-        """Forward A2A preset, signal per-user workflow context, inject A2A headers."""
+        """Resolve user_id (A2A preset, DR headers, per-user default) and inject A2A headers."""
         if user_id is None:
             preset = self._context_state.user_id.get()
             if preset:
                 user_id = preset
+
+        # Per-user workflows need *a* key in the per-user-builder dict.
+        # Fall back to a constant so they do not crash when no identity is
+        # available (e.g. locust against a deployed agent). This is a
+        # workflow-keying concern, not an identity claim — all such requests
+        # share one builder/state.
+        if user_id is None and self.is_workflow_per_user:
+            logger.debug(
+                "No identity resolved for per-user workflow — using %s as key",
+                DEFAULT_DR_AGENT_USER_ID,
+            )
+            user_id = DEFAULT_DR_AGENT_USER_ID
 
         # Inject A2A request headers BEFORE super().session() so they are
         # available during per-user builder creation (agent card discovery
@@ -141,14 +135,8 @@ class DRAgentAGUISessionManager(SessionManager):
             attrs = _build_metadata_from_headers(preset_headers)
             token_metadata = self._context_state._metadata.set(attrs)
 
-        # Signal per-user-workflow context to DRAgentUserManager (called inside
-        # NAT's session() via the rebind). Lets the resolver fall back to
-        # default-user when no identity is present, without coupling workflow
-        # state to the extract signature.
-        token_per_user = _per_user_workflow.set(self.is_workflow_per_user)
-
-        # Wrap the entire super().session() in try/finally so the ContextVars
-        # are always reset — even if super().session().__aenter__() raises
+        # Wrap the entire super().session() in try/finally so _metadata is
+        # always reset — even if super().session().__aenter__() raises
         # (e.g. per-user builder creation failure).
         try:
             async with super().session(
@@ -161,7 +149,6 @@ class DRAgentAGUISessionManager(SessionManager):
             ) as sess:
                 yield sess
         finally:
-            _per_user_workflow.reset(token_per_user)
             if token_metadata is not None:
                 self._context_state._metadata.reset(token_metadata)
 

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -102,28 +102,7 @@ class DRAgentAGUISessionManager(SessionManager):
         ]
         | None = None,
     ) -> AsyncIterator[Session]:
-        """Bridge A2A and HTTP callers that need DataRobot-specific ``user_id`` resolution.
-
-        NAT 1.6+ assigns ``self._context_state.user_id`` from the explicit
-        ``user_id`` argument only. Two resolution paths run before delegating:
-
-        1. A2A preset: :class:`_PerUserCompatibleAgentExecutor` writes the A2A
-           ``context_id`` into ``ContextState.user_id``. NAT would overwrite
-           that with ``None``, so we copy any non-empty preset back into the
-           explicit ``user_id`` kwarg.
-        2. DataRobot HTTP headers: when called via FastAPI with no explicit
-           ``user_id``, :func:`_resolve_dr_user_id` reads
-           ``X-DataRobot-Authorization-Context`` (signed app-context JWT) or
-           ``X-DataRobot-User-Id`` (set by predictions-gateway for any
-           authenticated deployment request).
-
-        If both leave ``user_id`` as ``None``, NAT's standard extractor
-        (Bearer/JWT/cookie/API-key) runs inside ``super().session()``.
-
-        Additionally, A2A HTTP request headers stored in the module-level
-        ``_a2a_headers`` ContextVar by :class:`_PerUserCompatibleAgentExecutor`
-        are injected into ``ContextState._metadata``.
-        """
+        """Resolve user_id from A2A preset or DataRobot headers before delegating to NAT."""
         if user_id is None:
             preset = self._context_state.user_id.get()
             if preset:

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -27,7 +27,6 @@ from nat.data_models.authentication import AuthProviderBaseConfig
 from nat.data_models.interactive import HumanResponse
 from nat.data_models.interactive import InteractionPrompt
 from nat.data_models.user_info import UserInfo
-from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import Session
 from nat.runtime.session import SessionManager
 from nat.runtime.user_manager import UserManager
@@ -46,16 +45,15 @@ logger = logging.getLogger(__name__)
 
 _auth_handler = AuthContextHeaderHandler()
 
-# Used when neither a signed DataRobot auth-context nor NAT's standard extractors
-# can resolve an identity. Keeps per-user workflows from crashing for callers
-# that lack proper auth context (e.g. locust against a deployed agent); all such
-# requests share the same per-user builder/state, so do not rely on this for
-# any kind of authorization decision.
+# Constant key used by DRAgentAGUISessionManager.session() to satisfy NAT's
+# per-user workflow requirement when no caller identity is present. Purely a
+# workflow-keying fallback — not an identity claim. Must not be used by any
+# code that depends on the result being a real user.
 DEFAULT_DR_AGENT_USER_ID = "default-user"
 
 
 class DRAgentUserManager(UserManager):
-    """Resolve DataRobot signed auth-context, then NAT's extractors, then fall back to a default."""
+    """Add DataRobot signed auth-context resolution to NAT's standard identity extractors."""
 
     @classmethod
     def extract_user_from_connection(cls, connection: Request | WebSocket) -> UserInfo | None:
@@ -66,19 +64,7 @@ class DRAgentUserManager(UserManager):
                     "Resolved user_id from X-DataRobot-Authorization-Context: %s", auth_ctx.user.id
                 )
                 return UserInfo._from_session_cookie(auth_ctx.user.id)
-
-        resolved = super().extract_user_from_connection(connection)
-        if resolved is not None:
-            return resolved
-
-        logger.debug("No identity resolved — falling back to %s", DEFAULT_DR_AGENT_USER_ID)
-        return UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
-
-
-# NAT 1.6 calls ``UserManager.extract_user_from_connection(...)`` directly on the
-# imported class in ``nat/runtime/session.py`` — no DI / registry — so rebind the
-# reference there to pick up our subclass.
-nat_runtime_session.UserManager = DRAgentUserManager  # type: ignore[misc]
+        return super().extract_user_from_connection(connection)
 
 
 # ContextVar used by _PerUserCompatibleAgentExecutor to forward the incoming A2A HTTP
@@ -113,11 +99,33 @@ class DRAgentAGUISessionManager(SessionManager):
         ]
         | None = None,
     ) -> AsyncIterator[Session]:
-        """Forward A2A preset user_id and inject A2A request headers before delegating to NAT."""
+        """Resolve user_id (A2A preset, DR headers, per-user default) and inject A2A headers."""
         if user_id is None:
             preset = self._context_state.user_id.get()
             if preset:
                 user_id = preset
+
+        # Resolve identity via our UserManager (knows DR signed auth-context in
+        # addition to NAT's standard extractors). Done explicitly rather than
+        # via a module rebind so the default-user fallback below stays scoped
+        # to this session() — DRAgentUserManager remains a pure identity
+        # resolver that other callers can safely use.
+        if user_id is None and isinstance(http_connection, (Request, WebSocket)):
+            user_info = DRAgentUserManager.extract_user_from_connection(http_connection)
+            if user_info is not None:
+                user_id = user_info.get_user_id()
+
+        # Per-user workflows need *a* key in the per-user-builder dict.
+        # Fall back to a constant so they do not crash when no identity is
+        # available (e.g. locust against a deployed agent). This is a
+        # workflow-keying concern, not an identity claim — all such requests
+        # share one builder/state.
+        if user_id is None and self.is_workflow_per_user:
+            logger.debug(
+                "No identity resolved for per-user workflow — using %s as key",
+                DEFAULT_DR_AGENT_USER_ID,
+            )
+            user_id = DEFAULT_DR_AGENT_USER_ID
 
         # Inject A2A request headers BEFORE super().session() so they are
         # available during per-user builder creation (agent card discovery

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -26,10 +26,8 @@ from nat.data_models.authentication import AuthFlowType
 from nat.data_models.authentication import AuthProviderBaseConfig
 from nat.data_models.interactive import HumanResponse
 from nat.data_models.interactive import InteractionPrompt
-from nat.data_models.user_info import UserInfo
 from nat.runtime.session import Session
 from nat.runtime.session import SessionManager
-from nat.runtime.user_manager import UserManager
 from nat.runtime.user_metadata import RequestAttributes
 from pydantic import BaseModel
 from starlette.requests import HTTPConnection
@@ -42,39 +40,35 @@ from .response import DRAgentEventResponse
 logger = logging.getLogger(__name__)
 
 
-def _patch_user_manager() -> None:
-    """Extend ``UserManager.extract_user_from_connection`` with DataRobot auth.
+_auth_handler = AuthContextHeaderHandler()
 
-    NAT 1.6 replaced the extensible context-based user_id resolution with
-    ``UserManager.extract_user_from_connection()`` (#1775) which only supports
-    standard auth (Bearer JWT, cookies, API key).  DataRobot passes user identity
-    via ``X-DataRobot-Authorization-Context``, which UserManager doesn't know about.
 
-    This monkey-patches ``extract_user_from_connection`` to try the DataRobot header
-    first, falling back to the original implementation for standard auth.
+def _resolve_dr_user_id(headers: dict[str, str]) -> str | None:
+    """Resolve ``user_id`` from DataRobot-specific request headers.
+
+    Tries ``X-DataRobot-Authorization-Context`` (signed app-context JWT
+    carrying the full identity) first, then ``X-DataRobot-User-Id``
+    (populated by predictions-gateway for any authenticated deployment
+    request, including direct API-token calls).
+
+    Returns ``None`` if neither header yields a value; callers should fall
+    through to NAT's standard extractor (Bearer/JWT/cookie/API-key) in
+    that case.
     """
-    if getattr(UserManager.extract_user_from_connection, "_dr_patched", False):
-        return
+    auth_ctx = _auth_handler.get_context(headers)
+    if auth_ctx is not None:
+        logger.debug(
+            "Resolved user_id from X-DataRobot-Authorization-Context: %s", auth_ctx.user.id
+        )
+        return auth_ctx.user.id
 
-    auth_handler = AuthContextHeaderHandler()
-    original_extract = UserManager.extract_user_from_connection
+    user_id = headers.get("x-datarobot-user-id") or headers.get("X-DataRobot-User-Id")
+    if user_id:
+        logger.debug("Resolved user_id from X-DataRobot-User-Id header: %s", user_id)
+        return user_id
 
-    def _extract_with_dr_auth(cls: type, connection: HTTPConnection) -> UserInfo | None:
-        if isinstance(connection, Request):
-            auth_ctx = auth_handler.get_context(dict(connection.headers))
-            if auth_ctx is not None:
-                user_info = UserInfo._from_session_cookie(auth_ctx.user.id)
-                logger.debug(
-                    "Resolved user_id from DataRobot auth context: %s", user_info.get_user_id()
-                )
-                return user_info
-        return original_extract.__func__(cls, connection)
+    return None
 
-    _extract_with_dr_auth._dr_patched = True  # type: ignore[attr-defined]
-    UserManager.extract_user_from_connection = classmethod(_extract_with_dr_auth)  # type: ignore[assignment]
-
-
-_patch_user_manager()
 
 # ContextVar used by _PerUserCompatibleAgentExecutor to forward the incoming A2A HTTP
 # request headers into the NAT context so auth providers (e.g. OAuth2CrossApplicationAccess)
@@ -108,23 +102,35 @@ class DRAgentAGUISessionManager(SessionManager):
         ]
         | None = None,
     ) -> AsyncIterator[Session]:
-        """Bridge A2A and other callers that preset ``ContextState.user_id``.
+        """Bridge A2A and HTTP callers that need DataRobot-specific ``user_id`` resolution.
 
-        NAT 1.6+ assigns ``self._context_state.user_id`` from the explicit ``user_id``
-        argument only. The A2A adapter calls ``session()`` with no arguments; our
-        executor sets ``context_id`` on the context var first, but the parent
-        ``session()`` would overwrite it with ``None``. Copy any preset non-empty
-        value into ``user_id`` before delegating so per-user workflows work without
-        a Bearer JWT (local dev / message-only A2A).
+        NAT 1.6+ assigns ``self._context_state.user_id`` from the explicit
+        ``user_id`` argument only. Two resolution paths run before delegating:
+
+        1. A2A preset: :class:`_PerUserCompatibleAgentExecutor` writes the A2A
+           ``context_id`` into ``ContextState.user_id``. NAT would overwrite
+           that with ``None``, so we copy any non-empty preset back into the
+           explicit ``user_id`` kwarg.
+        2. DataRobot HTTP headers: when called via FastAPI with no explicit
+           ``user_id``, :func:`_resolve_dr_user_id` reads
+           ``X-DataRobot-Authorization-Context`` (signed app-context JWT) or
+           ``X-DataRobot-User-Id`` (set by predictions-gateway for any
+           authenticated deployment request).
+
+        If both leave ``user_id`` as ``None``, NAT's standard extractor
+        (Bearer/JWT/cookie/API-key) runs inside ``super().session()``.
 
         Additionally, A2A HTTP request headers stored in the module-level
-        ``_a2a_headers`` ContextVar by :class:`_PerUserCompatibleAgentExecutor` are
-        injected into ``ContextState._metadata``.
+        ``_a2a_headers`` ContextVar by :class:`_PerUserCompatibleAgentExecutor`
+        are injected into ``ContextState._metadata``.
         """
         if user_id is None:
             preset = self._context_state.user_id.get()
             if preset:
                 user_id = preset
+
+        if user_id is None and isinstance(http_connection, Request):
+            user_id = _resolve_dr_user_id(dict(http_connection.headers))
 
         # Inject A2A request headers BEFORE super().session() so they are
         # available during per-user builder creation (agent card discovery

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -53,7 +53,16 @@ DEFAULT_DR_AGENT_USER_ID = "default-user"
 
 
 class DRAgentUserManager(UserManager):
-    """Add DataRobot signed auth-context resolution to NAT's standard identity extractors."""
+    """Add DataRobot signed auth-context resolution to NAT's standard identity extractors.
+
+    NAT 1.6 replaced the extensible context-based user_id resolution with
+    ``UserManager.extract_user_from_connection()`` (#1775), which only supports
+    standard auth (Bearer JWT, cookies, API key). DataRobot passes user identity
+    via ``X-DataRobot-Authorization-Context`` (signed app-context JWT), which the
+    vanilla extractor does not understand. This subclass handles that header
+    first, then delegates to ``super().extract_user_from_connection()`` so
+    standard auth still works.
+    """
 
     @classmethod
     def extract_user_from_connection(cls, connection: Request | WebSocket) -> UserInfo | None:
@@ -99,7 +108,19 @@ class DRAgentAGUISessionManager(SessionManager):
         ]
         | None = None,
     ) -> AsyncIterator[Session]:
-        """Resolve user_id (A2A preset, DR headers, per-user default) and inject A2A headers."""
+        """Bridge A2A preset, resolve DR headers, default for per-user, and inject A2A headers.
+
+        NAT 1.6+ assigns ``self._context_state.user_id`` from the explicit ``user_id``
+        argument only. The A2A adapter calls ``session()`` with no arguments; our
+        executor sets ``context_id`` on the context var first, but the parent
+        ``session()`` would overwrite it with ``None``. Copy any preset non-empty
+        value into ``user_id`` before delegating so per-user workflows work without
+        a Bearer JWT (local dev / message-only A2A).
+
+        Additionally, A2A HTTP request headers stored in the module-level
+        ``_a2a_headers`` ContextVar by :class:`_PerUserCompatibleAgentExecutor` are
+        injected into ``ContextState._metadata``.
+        """
         if user_id is None:
             preset = self._context_state.user_id.get()
             if preset:

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -27,7 +27,6 @@ from nat.data_models.authentication import AuthProviderBaseConfig
 from nat.data_models.interactive import HumanResponse
 from nat.data_models.interactive import InteractionPrompt
 from nat.data_models.user_info import UserInfo
-from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import Session
 from nat.runtime.session import SessionManager
 from nat.runtime.user_manager import UserManager
@@ -68,12 +67,6 @@ class DRAgentUserManager(UserManager):
         return super().extract_user_from_connection(connection)
 
 
-# NAT 1.6 calls ``UserManager.extract_user_from_connection(...)`` directly on the
-# imported class in ``nat/runtime/session.py`` — no DI / registry — so rebind the
-# reference there to pick up our subclass.
-nat_runtime_session.UserManager = DRAgentUserManager  # type: ignore[misc]
-
-
 # ContextVar used by _PerUserCompatibleAgentExecutor to forward the incoming A2A HTTP
 # request headers into the NAT context so auth providers (e.g. OAuth2CrossApplicationAccess)
 # can read them via Context.get().metadata.headers.  Module-level so the same var is
@@ -111,6 +104,16 @@ class DRAgentAGUISessionManager(SessionManager):
             preset = self._context_state.user_id.get()
             if preset:
                 user_id = preset
+
+        # Resolve identity via our UserManager (knows DR signed auth-context in
+        # addition to NAT's standard extractors). Done explicitly rather than
+        # via a module rebind so the default-user fallback below stays scoped
+        # to this session() — DRAgentUserManager remains a pure identity
+        # resolver that other callers can safely use.
+        if user_id is None and isinstance(http_connection, (Request, WebSocket)):
+            user_info = DRAgentUserManager.extract_user_from_connection(http_connection)
+            if user_info is not None:
+                user_id = user_info.get_user_id()
 
         # Per-user workflows need *a* key in the per-user-builder dict.
         # Fall back to a constant so they do not crash when no identity is

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -26,11 +26,15 @@ from nat.data_models.authentication import AuthFlowType
 from nat.data_models.authentication import AuthProviderBaseConfig
 from nat.data_models.interactive import HumanResponse
 from nat.data_models.interactive import InteractionPrompt
+from nat.data_models.user_info import UserInfo
+from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import Session
 from nat.runtime.session import SessionManager
+from nat.runtime.user_manager import UserManager
 from nat.runtime.user_metadata import RequestAttributes
 from pydantic import BaseModel
 from starlette.requests import HTTPConnection
+from starlette.websockets import WebSocket
 
 from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
 
@@ -44,17 +48,7 @@ _auth_handler = AuthContextHeaderHandler()
 
 
 def _resolve_dr_user_id(headers: dict[str, str]) -> str | None:
-    """Resolve ``user_id`` from DataRobot-specific request headers.
-
-    Tries ``X-DataRobot-Authorization-Context`` (signed app-context JWT
-    carrying the full identity) first, then ``X-DataRobot-User-Id``
-    (populated by predictions-gateway for any authenticated deployment
-    request, including direct API-token calls).
-
-    Returns ``None`` if neither header yields a value; callers should fall
-    through to NAT's standard extractor (Bearer/JWT/cookie/API-key) in
-    that case.
-    """
+    """Try signed X-DataRobot-Authorization-Context, then unsigned X-DataRobot-User-Id."""
     auth_ctx = _auth_handler.get_context(headers)
     if auth_ctx is not None:
         logger.debug(
@@ -64,10 +58,29 @@ def _resolve_dr_user_id(headers: dict[str, str]) -> str | None:
 
     user_id = headers.get("x-datarobot-user-id") or headers.get("X-DataRobot-User-Id")
     if user_id:
+        # Unsigned — trusted because predictions-gateway rebuilds it from the authenticated user.
         logger.debug("Resolved user_id from X-DataRobot-User-Id header: %s", user_id)
         return user_id
 
     return None
+
+
+class DRAgentUserManager(UserManager):
+    """UserManager that adds DataRobot header resolution before falling back to standard auth."""
+
+    @classmethod
+    def extract_user_from_connection(cls, connection: Request | WebSocket) -> UserInfo | None:
+        if isinstance(connection, Request):
+            user_id = _resolve_dr_user_id(dict(connection.headers))
+            if user_id is not None:
+                return UserInfo._from_session_cookie(user_id)
+        return super().extract_user_from_connection(connection)
+
+
+# NAT 1.6 calls ``UserManager.extract_user_from_connection(...)`` directly on the
+# imported class in ``nat/runtime/session.py`` — no DI / registry — so rebind the
+# reference there to pick up our subclass.
+nat_runtime_session.UserManager = DRAgentUserManager  # type: ignore[misc]
 
 
 # ContextVar used by _PerUserCompatibleAgentExecutor to forward the incoming A2A HTTP
@@ -102,14 +115,11 @@ class DRAgentAGUISessionManager(SessionManager):
         ]
         | None = None,
     ) -> AsyncIterator[Session]:
-        """Resolve user_id from A2A preset or DataRobot headers before delegating to NAT."""
+        """Forward A2A preset user_id and inject A2A request headers before delegating to NAT."""
         if user_id is None:
             preset = self._context_state.user_id.get()
             if preset:
                 user_id = preset
-
-        if user_id is None and isinstance(http_connection, Request):
-            user_id = _resolve_dr_user_id(dict(http_connection.headers))
 
         # Inject A2A request headers BEFORE super().session() so they are
         # available during per-user builder creation (agent card discovery

--- a/src/datarobot_genai/dragent/frontends/session.py
+++ b/src/datarobot_genai/dragent/frontends/session.py
@@ -27,6 +27,7 @@ from nat.data_models.authentication import AuthProviderBaseConfig
 from nat.data_models.interactive import HumanResponse
 from nat.data_models.interactive import InteractionPrompt
 from nat.data_models.user_info import UserInfo
+from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import Session
 from nat.runtime.session import SessionManager
 from nat.runtime.user_manager import UserManager
@@ -67,6 +68,12 @@ class DRAgentUserManager(UserManager):
         return super().extract_user_from_connection(connection)
 
 
+# NAT 1.6 calls ``UserManager.extract_user_from_connection(...)`` directly on the
+# imported class in ``nat/runtime/session.py`` — no DI / registry — so rebind the
+# reference there to pick up our subclass.
+nat_runtime_session.UserManager = DRAgentUserManager  # type: ignore[misc]
+
+
 # ContextVar used by _PerUserCompatibleAgentExecutor to forward the incoming A2A HTTP
 # request headers into the NAT context so auth providers (e.g. OAuth2CrossApplicationAccess)
 # can read them via Context.get().metadata.headers.  Module-level so the same var is
@@ -104,16 +111,6 @@ class DRAgentAGUISessionManager(SessionManager):
             preset = self._context_state.user_id.get()
             if preset:
                 user_id = preset
-
-        # Resolve identity via our UserManager (knows DR signed auth-context in
-        # addition to NAT's standard extractors). Done explicitly rather than
-        # via a module rebind so the default-user fallback below stays scoped
-        # to this session() — DRAgentUserManager remains a pure identity
-        # resolver that other callers can safely use.
-        if user_id is None and isinstance(http_connection, (Request, WebSocket)):
-            user_info = DRAgentUserManager.extract_user_from_connection(http_connection)
-            if user_info is not None:
-                user_id = user_info.get_user_id()
 
         # Per-user workflows need *a* key in the per-user-builder dict.
         # Fall back to a constant so they do not crash when no identity is

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -21,11 +21,15 @@ from fastapi import Request
 from nat.builder.context import ContextState
 from nat.data_models.config import Config
 from nat.data_models.config import GeneralConfig
+from nat.data_models.user_info import UserInfo
+from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import SessionManager
+from nat.runtime.user_manager import UserManager
 
 from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.session import DRAgentAGUISessionManager
+from datarobot_genai.dragent.frontends.session import DRAgentUserManager
 from datarobot_genai.dragent.frontends.session import _a2a_headers
 from datarobot_genai.dragent.frontends.session import _build_metadata_from_headers
 from datarobot_genai.dragent.frontends.session import _resolve_dr_user_id
@@ -208,43 +212,32 @@ class TestResolveDrUserId:
         assert result is None
 
 
-class TestSessionResolvesDrHeaders:
-    """Verify session() wires _resolve_dr_user_id into the NAT user_id kwarg."""
+class TestDRAgentUserManager:
+    """Verify DRAgentUserManager extends NAT's UserManager with DataRobot header resolution."""
 
-    @pytest.mark.asyncio
-    async def test_session_resolves_user_id_from_dr_headers(self, session_manager):
-        """When http_connection is a Request, DR headers drive user_id without monkey-patching."""
+    def test_returns_user_info_when_dr_header_present(self):
+        """DR-header resolution returns a UserInfo wrapping the resolved user_id."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {"x-datarobot-user-id": "user-from-gateway"}
 
-        captured: dict[str, object] = {}
+        result = DRAgentUserManager.extract_user_from_connection(mock_request)
 
-        @asynccontextmanager
-        async def fake_nat_session(self, **kwargs: object):
-            captured.update(kwargs)
-            yield MagicMock()
+        assert result is not None
+        assert isinstance(result, UserInfo)
+        expected = UserInfo._from_session_cookie("user-from-gateway")
+        assert result.get_user_id() == expected.get_user_id()
 
-        with patch.object(SessionManager, "session", fake_nat_session):
-            async with session_manager.session(http_connection=mock_request):
-                pass
-
-        assert captured.get("user_id") == "user-from-gateway"
-
-    @pytest.mark.asyncio
-    async def test_session_leaves_user_id_none_when_no_dr_headers(self, session_manager):
-        """Without DR headers, user_id is forwarded as None so NAT's extractor runs."""
+    def test_falls_back_to_parent_when_no_dr_header(self):
+        """No DR header → defer to NAT's standard extractor (Bearer/JWT/cookie/API-key)."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {}
+        mock_request.cookies = {}
 
-        captured: dict[str, object] = {}
+        result = DRAgentUserManager.extract_user_from_connection(mock_request)
 
-        @asynccontextmanager
-        async def fake_nat_session(self, **kwargs: object):
-            captured.update(kwargs)
-            yield MagicMock()
+        assert result is None
 
-        with patch.object(SessionManager, "session", fake_nat_session):
-            async with session_manager.session(http_connection=mock_request):
-                pass
-
-        assert captured.get("user_id") is None
+    def test_nat_session_uses_dragent_user_manager(self):
+        """Verify the module-level rebind so NAT's session() picks up our subclass."""
+        assert nat_runtime_session.UserManager is DRAgentUserManager
+        assert issubclass(DRAgentUserManager, UserManager)

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -22,7 +22,6 @@ from nat.builder.context import ContextState
 from nat.data_models.config import Config
 from nat.data_models.config import GeneralConfig
 from nat.data_models.user_info import UserInfo
-from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import SessionManager
 from nat.runtime.user_manager import UserManager
 
@@ -171,7 +170,7 @@ class TestBuildMetadataFromHeaders:
 
 
 class TestDRAgentUserManager:
-    """Verify DRAgentUserManager: signed auth-context → NAT extractor → default-user."""
+    """Verify DRAgentUserManager is a pure identity resolver (no workflow-keying fallback)."""
 
     def test_resolves_signed_auth_context(self):
         """X-DataRobot-Authorization-Context (signed) returns the user it carries."""
@@ -191,20 +190,87 @@ class TestDRAgentUserManager:
         expected = UserInfo._from_session_cookie("user-from-ctx")
         assert result.get_user_id() == expected.get_user_id()
 
-    def test_falls_back_to_default_when_no_identity(self):
-        """No auth-context and no standard auth → constant default-user."""
+    def test_returns_none_when_no_identity(self):
+        """No auth-context and no standard auth → None (default-user is a session() concern)."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {}
         mock_request.cookies = {}
 
         result = DRAgentUserManager.extract_user_from_connection(mock_request)
 
-        assert result is not None
-        assert isinstance(result, UserInfo)
-        expected = UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
-        assert result.get_user_id() == expected.get_user_id()
+        assert result is None
 
-    def test_nat_session_uses_dragent_user_manager(self):
-        """Verify the module-level rebind so NAT's session() picks up our subclass."""
-        assert nat_runtime_session.UserManager is DRAgentUserManager
+    def test_subclasses_user_manager(self):
         assert issubclass(DRAgentUserManager, UserManager)
+
+
+class TestSessionPerUserWorkflowFallback:
+    """Verify session() defaults user_id to DEFAULT_DR_AGENT_USER_ID for per-user workflows only."""
+
+    @pytest.mark.asyncio
+    async def test_per_user_workflow_with_no_identity_uses_default(self, session_manager):
+        """Per-user workflow + no identity → default-user key passes through to NAT."""
+        session_manager._is_workflow_per_user = True
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+        mock_request.cookies = {}
+
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
+
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session(http_connection=mock_request):
+                pass
+
+        assert captured.get("user_id") == DEFAULT_DR_AGENT_USER_ID
+
+    @pytest.mark.asyncio
+    async def test_non_per_user_workflow_leaves_user_id_none(self, session_manager):
+        """Non-per-user workflow → no default applied; NAT decides what to do with None."""
+        session_manager._is_workflow_per_user = False
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+        mock_request.cookies = {}
+
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
+
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session(http_connection=mock_request):
+                pass
+
+        assert captured.get("user_id") is None
+
+    @pytest.mark.asyncio
+    async def test_dr_signed_context_resolved_in_session(self, session_manager):
+        """When DR auth-context is present, the real user_id reaches NAT."""
+        session_manager._is_workflow_per_user = True
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {"x-datarobot-authorization-context": "fake-jwt"}
+        mock_auth_ctx = MagicMock()
+        mock_auth_ctx.user.id = "real-user-1"
+
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
+
+        with patch(
+            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
+            return_value=mock_auth_ctx,
+        ):
+            with patch.object(SessionManager, "session", fake_nat_session):
+                async with session_manager.session(http_connection=mock_request):
+                    pass
+
+        assert captured.get("user_id") == UserInfo._from_session_cookie("real-user-1").get_user_id()

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -28,11 +28,11 @@ from nat.runtime.user_manager import UserManager
 
 from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.dragent.frontends.session import DEFAULT_DR_AGENT_USER_ID
 from datarobot_genai.dragent.frontends.session import DRAgentAGUISessionManager
 from datarobot_genai.dragent.frontends.session import DRAgentUserManager
 from datarobot_genai.dragent.frontends.session import _a2a_headers
 from datarobot_genai.dragent.frontends.session import _build_metadata_from_headers
-from datarobot_genai.dragent.frontends.session import _resolve_dr_user_id
 
 
 @pytest.fixture
@@ -170,11 +170,13 @@ class TestBuildMetadataFromHeaders:
         assert attrs.headers == {}
 
 
-class TestResolveDrUserId:
-    """Verify DataRobot header resolution used by DRAgentAGUISessionManager.session()."""
+class TestDRAgentUserManager:
+    """Verify DRAgentUserManager: signed auth-context → NAT extractor → default-user."""
 
-    def test_authorization_context_takes_precedence(self):
-        """Signed auth-context header wins over the gateway User-Id fallback."""
+    def test_resolves_signed_auth_context(self):
+        """X-DataRobot-Authorization-Context (signed) returns the user it carries."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {"x-datarobot-authorization-context": "fake-jwt"}
         mock_auth_ctx = MagicMock()
         mock_auth_ctx.user.id = "user-from-ctx"
 
@@ -182,60 +184,25 @@ class TestResolveDrUserId:
             "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
             return_value=mock_auth_ctx,
         ):
-            result = _resolve_dr_user_id(
-                {
-                    "x-datarobot-authorization-context": "fake-jwt",
-                    "x-datarobot-user-id": "user-from-gateway",
-                }
-            )
-
-        assert result == "user-from-ctx"
-
-    def test_falls_back_to_user_id_header(self):
-        """``X-DataRobot-User-Id`` is used when no auth-context header is present."""
-        with patch(
-            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
-            return_value=None,
-        ):
-            result = _resolve_dr_user_id({"x-datarobot-user-id": "user-from-gateway"})
-
-        assert result == "user-from-gateway"
-
-    def test_returns_none_when_no_dr_headers(self):
-        """No DR headers → fall through so NAT's standard extractor runs."""
-        with patch(
-            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
-            return_value=None,
-        ):
-            result = _resolve_dr_user_id({})
-
-        assert result is None
-
-
-class TestDRAgentUserManager:
-    """Verify DRAgentUserManager extends NAT's UserManager with DataRobot header resolution."""
-
-    def test_returns_user_info_when_dr_header_present(self):
-        """DR-header resolution returns a UserInfo wrapping the resolved user_id."""
-        mock_request = MagicMock(spec=Request)
-        mock_request.headers = {"x-datarobot-user-id": "user-from-gateway"}
-
-        result = DRAgentUserManager.extract_user_from_connection(mock_request)
+            result = DRAgentUserManager.extract_user_from_connection(mock_request)
 
         assert result is not None
         assert isinstance(result, UserInfo)
-        expected = UserInfo._from_session_cookie("user-from-gateway")
+        expected = UserInfo._from_session_cookie("user-from-ctx")
         assert result.get_user_id() == expected.get_user_id()
 
-    def test_falls_back_to_parent_when_no_dr_header(self):
-        """No DR header → defer to NAT's standard extractor (Bearer/JWT/cookie/API-key)."""
+    def test_falls_back_to_default_when_no_identity(self):
+        """No auth-context and no standard auth → constant default-user."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {}
         mock_request.cookies = {}
 
         result = DRAgentUserManager.extract_user_from_connection(mock_request)
 
-        assert result is None
+        assert result is not None
+        assert isinstance(result, UserInfo)
+        expected = UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
+        assert result.get_user_id() == expected.get_user_id()
 
     def test_nat_session_uses_dragent_user_manager(self):
         """Verify the module-level rebind so NAT's session() picks up our subclass."""

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -21,15 +21,14 @@ from fastapi import Request
 from nat.builder.context import ContextState
 from nat.data_models.config import Config
 from nat.data_models.config import GeneralConfig
-from nat.data_models.user_info import UserInfo
 from nat.runtime.session import SessionManager
-from nat.runtime.user_manager import UserManager
 
 from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.session import DRAgentAGUISessionManager
 from datarobot_genai.dragent.frontends.session import _a2a_headers
 from datarobot_genai.dragent.frontends.session import _build_metadata_from_headers
+from datarobot_genai.dragent.frontends.session import _resolve_dr_user_id
 
 
 @pytest.fixture
@@ -167,39 +166,85 @@ class TestBuildMetadataFromHeaders:
         assert attrs.headers == {}
 
 
-class TestUserManagerPatch:
-    """Verify that the UserManager monkey-patch resolves DR auth context.
+class TestResolveDrUserId:
+    """Verify DataRobot header resolution used by DRAgentAGUISessionManager.session()."""
 
-    The patch is applied at module import time by session.py's ``_patch_user_manager()``.
-    These tests verify the already-applied patch.
-    """
-
-    def test_dr_auth_context_resolves_to_user_info(self):
-        """UserManager returns UserInfo when DR auth context header is present."""
-        mock_request = MagicMock(spec=Request)
-        mock_request.headers = {"x-datarobot-authorization-context": "fake-jwt"}
-        mock_request.cookies = {}
+    def test_authorization_context_takes_precedence(self):
+        """Signed auth-context header wins over the gateway User-Id fallback."""
         mock_auth_ctx = MagicMock()
-        mock_auth_ctx.user.id = "user-abc-123"
+        mock_auth_ctx.user.id = "user-from-ctx"
 
-        # Patch the handler instance captured by _patch_user_manager at import time
         with patch(
-            "datarobot_genai.dragent.frontends.session.AuthContextHeaderHandler.get_context",
+            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
             return_value=mock_auth_ctx,
         ):
-            result = UserManager.extract_user_from_connection(mock_request)
+            result = _resolve_dr_user_id(
+                {
+                    "x-datarobot-authorization-context": "fake-jwt",
+                    "x-datarobot-user-id": "user-from-gateway",
+                }
+            )
 
-        assert result is not None
-        assert isinstance(result, UserInfo)
-        expected = UserInfo._from_session_cookie("user-abc-123")
-        assert result.get_user_id() == expected.get_user_id()
+        assert result == "user-from-ctx"
 
-    def test_falls_back_to_original_when_no_dr_header(self):
-        """UserManager falls back to standard auth when no DR header is present."""
-        mock_request = MagicMock(spec=Request)
-        mock_request.cookies = {}
-        mock_request.headers = {}
+    def test_falls_back_to_user_id_header(self):
+        """``X-DataRobot-User-Id`` is used when no auth-context header is present."""
+        with patch(
+            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
+            return_value=None,
+        ):
+            result = _resolve_dr_user_id({"x-datarobot-user-id": "user-from-gateway"})
 
-        result = UserManager.extract_user_from_connection(mock_request)
+        assert result == "user-from-gateway"
+
+    def test_returns_none_when_no_dr_headers(self):
+        """No DR headers → fall through so NAT's standard extractor runs."""
+        with patch(
+            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
+            return_value=None,
+        ):
+            result = _resolve_dr_user_id({})
 
         assert result is None
+
+
+class TestSessionResolvesDrHeaders:
+    """Verify session() wires _resolve_dr_user_id into the NAT user_id kwarg."""
+
+    @pytest.mark.asyncio
+    async def test_session_resolves_user_id_from_dr_headers(self, session_manager):
+        """When http_connection is a Request, DR headers drive user_id without monkey-patching."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {"x-datarobot-user-id": "user-from-gateway"}
+
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
+
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session(http_connection=mock_request):
+                pass
+
+        assert captured.get("user_id") == "user-from-gateway"
+
+    @pytest.mark.asyncio
+    async def test_session_leaves_user_id_none_when_no_dr_headers(self, session_manager):
+        """Without DR headers, user_id is forwarded as None so NAT's extractor runs."""
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
+
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session(http_connection=mock_request):
+                pass
+
+        assert captured.get("user_id") is None

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -22,6 +22,7 @@ from nat.builder.context import ContextState
 from nat.data_models.config import Config
 from nat.data_models.config import GeneralConfig
 from nat.data_models.user_info import UserInfo
+from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import SessionManager
 from nat.runtime.user_manager import UserManager
 
@@ -32,6 +33,7 @@ from datarobot_genai.dragent.frontends.session import DRAgentAGUISessionManager
 from datarobot_genai.dragent.frontends.session import DRAgentUserManager
 from datarobot_genai.dragent.frontends.session import _a2a_headers
 from datarobot_genai.dragent.frontends.session import _build_metadata_from_headers
+from datarobot_genai.dragent.frontends.session import _per_user_workflow
 
 
 @pytest.fixture
@@ -170,7 +172,7 @@ class TestBuildMetadataFromHeaders:
 
 
 class TestDRAgentUserManager:
-    """Verify DRAgentUserManager is a pure identity resolver (no workflow-keying fallback)."""
+    """DR signed auth-context → NAT extractors → (per-user only) default-user."""
 
     def test_resolves_signed_auth_context(self):
         """X-DataRobot-Authorization-Context (signed) returns the user it carries."""
@@ -190,8 +192,8 @@ class TestDRAgentUserManager:
         expected = UserInfo._from_session_cookie("user-from-ctx")
         assert result.get_user_id() == expected.get_user_id()
 
-    def test_returns_none_when_no_identity(self):
-        """No auth-context and no standard auth → None (default-user is a session() concern)."""
+    def test_returns_none_when_no_identity_and_not_per_user(self):
+        """No identity, _per_user_workflow=False → None."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {}
         mock_request.cookies = {}
@@ -200,77 +202,104 @@ class TestDRAgentUserManager:
 
         assert result is None
 
-    def test_subclasses_user_manager(self):
-        assert issubclass(DRAgentUserManager, UserManager)
-
-
-class TestSessionPerUserWorkflowFallback:
-    """Verify session() defaults user_id to DEFAULT_DR_AGENT_USER_ID for per-user workflows only."""
-
-    @pytest.mark.asyncio
-    async def test_per_user_workflow_with_no_identity_uses_default(self, session_manager):
-        """Per-user workflow + no identity → default-user key passes through to NAT."""
-        session_manager._is_workflow_per_user = True
+    def test_falls_back_to_default_when_per_user_workflow_active(self):
+        """No identity, _per_user_workflow=True → default-user."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {}
         mock_request.cookies = {}
 
-        captured: dict[str, object] = {}
+        token = _per_user_workflow.set(True)
+        try:
+            result = DRAgentUserManager.extract_user_from_connection(mock_request)
+        finally:
+            _per_user_workflow.reset(token)
 
-        @asynccontextmanager
-        async def fake_nat_session(self, **kwargs: object):
-            captured.update(kwargs)
-            yield MagicMock()
+        assert result is not None
+        expected = UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
+        assert result.get_user_id() == expected.get_user_id()
 
-        with patch.object(SessionManager, "session", fake_nat_session):
-            async with session_manager.session(http_connection=mock_request):
-                pass
-
-        assert captured.get("user_id") == DEFAULT_DR_AGENT_USER_ID
-
-    @pytest.mark.asyncio
-    async def test_non_per_user_workflow_leaves_user_id_none(self, session_manager):
-        """Non-per-user workflow → no default applied; NAT decides what to do with None."""
-        session_manager._is_workflow_per_user = False
-        mock_request = MagicMock(spec=Request)
-        mock_request.headers = {}
-        mock_request.cookies = {}
-
-        captured: dict[str, object] = {}
-
-        @asynccontextmanager
-        async def fake_nat_session(self, **kwargs: object):
-            captured.update(kwargs)
-            yield MagicMock()
-
-        with patch.object(SessionManager, "session", fake_nat_session):
-            async with session_manager.session(http_connection=mock_request):
-                pass
-
-        assert captured.get("user_id") is None
-
-    @pytest.mark.asyncio
-    async def test_dr_signed_context_resolved_in_session(self, session_manager):
-        """When DR auth-context is present, the real user_id reaches NAT."""
-        session_manager._is_workflow_per_user = True
+    def test_signed_auth_context_wins_over_per_user_default(self):
+        """Real signed auth-context resolves even when per-user fallback is active."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {"x-datarobot-authorization-context": "fake-jwt"}
         mock_auth_ctx = MagicMock()
-        mock_auth_ctx.user.id = "real-user-1"
+        mock_auth_ctx.user.id = "real-user"
 
-        captured: dict[str, object] = {}
+        token = _per_user_workflow.set(True)
+        try:
+            with patch(
+                "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
+                return_value=mock_auth_ctx,
+            ):
+                result = DRAgentUserManager.extract_user_from_connection(mock_request)
+        finally:
+            _per_user_workflow.reset(token)
+
+        assert result is not None
+        expected = UserInfo._from_session_cookie("real-user")
+        assert result.get_user_id() == expected.get_user_id()
+
+    def test_subclasses_user_manager(self):
+        assert issubclass(DRAgentUserManager, UserManager)
+
+    def test_nat_session_uses_dragent_user_manager(self):
+        """Verify the module-level rebind so NAT's session() picks up our subclass."""
+        assert nat_runtime_session.UserManager is DRAgentUserManager
+
+
+class TestSessionPerUserWorkflowContextVar:
+    """Verify session() sets _per_user_workflow during super().session() and resets after."""
+
+    @pytest.mark.asyncio
+    async def test_per_user_workflow_sets_context_var_true(self, session_manager):
+        """Per-user workflow → _per_user_workflow=True while NAT's session() runs."""
+        session_manager._is_workflow_per_user = True
+        captured: dict[str, bool] = {}
 
         @asynccontextmanager
         async def fake_nat_session(self, **kwargs: object):
-            captured.update(kwargs)
+            captured["per_user"] = _per_user_workflow.get()
             yield MagicMock()
 
-        with patch(
-            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
-            return_value=mock_auth_ctx,
-        ):
-            with patch.object(SessionManager, "session", fake_nat_session):
-                async with session_manager.session(http_connection=mock_request):
-                    pass
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session():
+                pass
 
-        assert captured.get("user_id") == UserInfo._from_session_cookie("real-user-1").get_user_id()
+        assert captured["per_user"] is True
+        # Resets after the session exits
+        assert _per_user_workflow.get() is False
+
+    @pytest.mark.asyncio
+    async def test_non_per_user_workflow_sets_context_var_false(self, session_manager):
+        """Non-per-user workflow → _per_user_workflow stays False."""
+        session_manager._is_workflow_per_user = False
+        captured: dict[str, bool] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured["per_user"] = _per_user_workflow.get()
+            yield MagicMock()
+
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session():
+                pass
+
+        assert captured["per_user"] is False
+        assert _per_user_workflow.get() is False
+
+    @pytest.mark.asyncio
+    async def test_context_var_reset_when_super_session_raises(self, session_manager):
+        """_per_user_workflow must be reset even if super().session() raises."""
+        session_manager._is_workflow_per_user = True
+
+        @asynccontextmanager
+        async def exploding_nat_session(self, **kwargs: object):
+            raise RuntimeError("builder creation failed")
+            yield  # noqa: unreachable — required for generator syntax
+
+        with patch.object(SessionManager, "session", exploding_nat_session):
+            with pytest.raises(RuntimeError, match="builder creation failed"):
+                async with session_manager.session():
+                    pass  # pragma: no cover
+
+        assert _per_user_workflow.get() is False

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -22,7 +22,6 @@ from nat.builder.context import ContextState
 from nat.data_models.config import Config
 from nat.data_models.config import GeneralConfig
 from nat.data_models.user_info import UserInfo
-from nat.runtime import session as nat_runtime_session
 from nat.runtime.session import SessionManager
 from nat.runtime.user_manager import UserManager
 
@@ -33,7 +32,6 @@ from datarobot_genai.dragent.frontends.session import DRAgentAGUISessionManager
 from datarobot_genai.dragent.frontends.session import DRAgentUserManager
 from datarobot_genai.dragent.frontends.session import _a2a_headers
 from datarobot_genai.dragent.frontends.session import _build_metadata_from_headers
-from datarobot_genai.dragent.frontends.session import _per_user_workflow
 
 
 @pytest.fixture
@@ -172,7 +170,7 @@ class TestBuildMetadataFromHeaders:
 
 
 class TestDRAgentUserManager:
-    """DR signed auth-context → NAT extractors → (per-user only) default-user."""
+    """Verify DRAgentUserManager is a pure identity resolver (no workflow-keying fallback)."""
 
     def test_resolves_signed_auth_context(self):
         """X-DataRobot-Authorization-Context (signed) returns the user it carries."""
@@ -192,8 +190,8 @@ class TestDRAgentUserManager:
         expected = UserInfo._from_session_cookie("user-from-ctx")
         assert result.get_user_id() == expected.get_user_id()
 
-    def test_returns_none_when_no_identity_and_not_per_user(self):
-        """No identity, _per_user_workflow=False → None."""
+    def test_returns_none_when_no_identity(self):
+        """No auth-context and no standard auth → None (default-user is a session() concern)."""
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {}
         mock_request.cookies = {}
@@ -202,104 +200,77 @@ class TestDRAgentUserManager:
 
         assert result is None
 
-    def test_falls_back_to_default_when_per_user_workflow_active(self):
-        """No identity, _per_user_workflow=True → default-user."""
+    def test_subclasses_user_manager(self):
+        assert issubclass(DRAgentUserManager, UserManager)
+
+
+class TestSessionPerUserWorkflowFallback:
+    """Verify session() defaults user_id to DEFAULT_DR_AGENT_USER_ID for per-user workflows only."""
+
+    @pytest.mark.asyncio
+    async def test_per_user_workflow_with_no_identity_uses_default(self, session_manager):
+        """Per-user workflow + no identity → default-user key passes through to NAT."""
+        session_manager._is_workflow_per_user = True
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {}
         mock_request.cookies = {}
 
-        token = _per_user_workflow.set(True)
-        try:
-            result = DRAgentUserManager.extract_user_from_connection(mock_request)
-        finally:
-            _per_user_workflow.reset(token)
+        captured: dict[str, object] = {}
 
-        assert result is not None
-        expected = UserInfo._from_session_cookie(DEFAULT_DR_AGENT_USER_ID)
-        assert result.get_user_id() == expected.get_user_id()
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
 
-    def test_signed_auth_context_wins_over_per_user_default(self):
-        """Real signed auth-context resolves even when per-user fallback is active."""
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session(http_connection=mock_request):
+                pass
+
+        assert captured.get("user_id") == DEFAULT_DR_AGENT_USER_ID
+
+    @pytest.mark.asyncio
+    async def test_non_per_user_workflow_leaves_user_id_none(self, session_manager):
+        """Non-per-user workflow → no default applied; NAT decides what to do with None."""
+        session_manager._is_workflow_per_user = False
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+        mock_request.cookies = {}
+
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_nat_session(self, **kwargs: object):
+            captured.update(kwargs)
+            yield MagicMock()
+
+        with patch.object(SessionManager, "session", fake_nat_session):
+            async with session_manager.session(http_connection=mock_request):
+                pass
+
+        assert captured.get("user_id") is None
+
+    @pytest.mark.asyncio
+    async def test_dr_signed_context_resolved_in_session(self, session_manager):
+        """When DR auth-context is present, the real user_id reaches NAT."""
+        session_manager._is_workflow_per_user = True
         mock_request = MagicMock(spec=Request)
         mock_request.headers = {"x-datarobot-authorization-context": "fake-jwt"}
         mock_auth_ctx = MagicMock()
-        mock_auth_ctx.user.id = "real-user"
+        mock_auth_ctx.user.id = "real-user-1"
 
-        token = _per_user_workflow.set(True)
-        try:
-            with patch(
-                "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
-                return_value=mock_auth_ctx,
-            ):
-                result = DRAgentUserManager.extract_user_from_connection(mock_request)
-        finally:
-            _per_user_workflow.reset(token)
-
-        assert result is not None
-        expected = UserInfo._from_session_cookie("real-user")
-        assert result.get_user_id() == expected.get_user_id()
-
-    def test_subclasses_user_manager(self):
-        assert issubclass(DRAgentUserManager, UserManager)
-
-    def test_nat_session_uses_dragent_user_manager(self):
-        """Verify the module-level rebind so NAT's session() picks up our subclass."""
-        assert nat_runtime_session.UserManager is DRAgentUserManager
-
-
-class TestSessionPerUserWorkflowContextVar:
-    """Verify session() sets _per_user_workflow during super().session() and resets after."""
-
-    @pytest.mark.asyncio
-    async def test_per_user_workflow_sets_context_var_true(self, session_manager):
-        """Per-user workflow → _per_user_workflow=True while NAT's session() runs."""
-        session_manager._is_workflow_per_user = True
-        captured: dict[str, bool] = {}
+        captured: dict[str, object] = {}
 
         @asynccontextmanager
         async def fake_nat_session(self, **kwargs: object):
-            captured["per_user"] = _per_user_workflow.get()
+            captured.update(kwargs)
             yield MagicMock()
 
-        with patch.object(SessionManager, "session", fake_nat_session):
-            async with session_manager.session():
-                pass
+        with patch(
+            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
+            return_value=mock_auth_ctx,
+        ):
+            with patch.object(SessionManager, "session", fake_nat_session):
+                async with session_manager.session(http_connection=mock_request):
+                    pass
 
-        assert captured["per_user"] is True
-        # Resets after the session exits
-        assert _per_user_workflow.get() is False
-
-    @pytest.mark.asyncio
-    async def test_non_per_user_workflow_sets_context_var_false(self, session_manager):
-        """Non-per-user workflow → _per_user_workflow stays False."""
-        session_manager._is_workflow_per_user = False
-        captured: dict[str, bool] = {}
-
-        @asynccontextmanager
-        async def fake_nat_session(self, **kwargs: object):
-            captured["per_user"] = _per_user_workflow.get()
-            yield MagicMock()
-
-        with patch.object(SessionManager, "session", fake_nat_session):
-            async with session_manager.session():
-                pass
-
-        assert captured["per_user"] is False
-        assert _per_user_workflow.get() is False
-
-    @pytest.mark.asyncio
-    async def test_context_var_reset_when_super_session_raises(self, session_manager):
-        """_per_user_workflow must be reset even if super().session() raises."""
-        session_manager._is_workflow_per_user = True
-
-        @asynccontextmanager
-        async def exploding_nat_session(self, **kwargs: object):
-            raise RuntimeError("builder creation failed")
-            yield  # noqa: unreachable — required for generator syntax
-
-        with patch.object(SessionManager, "session", exploding_nat_session):
-            with pytest.raises(RuntimeError, match="builder creation failed"):
-                async with session_manager.session():
-                    pass  # pragma: no cover
-
-        assert _per_user_workflow.get() is False
+        assert captured.get("user_id") == UserInfo._from_session_cookie("real-user-1").get_user_id()

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.57"
+version = "0.15.58"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.58"
+version = "0.15.59"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.59"
+version = "0.15.60"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Predictions-gateway populates ``X-DataRobot-User-Id`` for every authenticated request, including direct API-token calls (e.g. locust benchmarking against a deployed agent). Previously only ``X-DataRobot-Authorization-Context`` was honored, which requires the caller to sign a JWT with the session secret — impractical for ad-hoc testing outside an app.

Resolve ``user_id`` in ``DRAgentAGUISessionManager.session()`` instead of monkey-patching ``UserManager.extract_user_from_connection``. The helper tries the signed auth-context header first, then the gateway User-Id header; if neither is present, ``user_id`` stays ``None`` and NAT's standard extractor (Bearer/JWT/cookie/API-key) runs as before.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request authentication/user identity resolution for DRAgent sessions, which can affect per-user routing and access control if mis-resolved. Scope is localized and covered by new unit tests for header precedence and fall-through behavior.
> 
> **Overview**
> **Adds support for direct deployment calls by honoring `X-DataRobot-User-Id`.** `DRAgentAGUISessionManager.session()` now resolves `user_id` from DataRobot headers when invoked via FastAPI: it prefers `X-DataRobot-Authorization-Context` and falls back to `X-DataRobot-User-Id`, otherwise deferring to NAT’s standard auth extraction.
> 
> This removes the prior `UserManager.extract_user_from_connection` monkey-patch and replaces it with a local `_resolve_dr_user_id()` helper plus updated tests to validate precedence, fall-through, and the `session()` wiring. Version is bumped to `0.15.57` (with lockfile updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfac2020095033567233199362ea21f3e2ab6201. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->