### PR TITLE
[BUZZOK-30864] Fix extra_body additional kwargs for workflow.yaml NAT dragent server run frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.65
+- Fix `extra_body` passthrough for `workflow.yaml` LLM configs (e.g. `mock_response`). PR #274 switched from `ChatOpenAI` to `ChatLiteLLM`/`LiteLLM` which silently drop unknown kwargs; `extra_body` is now routed through `model_kwargs` (langgraph) and `additional_kwargs` (llamaindex) so it reaches the underlying DataRobot LLM gateway API call.
+
 ## 0.15.64
 - `dragent`: agent card XAA extension params now use camelCase (`tokenExchange`, `tokenRequest`, `tokenEndpointAuthMethod`, etc.) for consistency with the rest of the agentCard API response. The parser accepts both camelCase and snake_case for backward compatibility with previously generated cards.
 

--- a/docs/nat/llm.md
+++ b/docs/nat/llm.md
@@ -40,6 +40,18 @@ llms:
 
 The exact fields inside each block mirror what you would set in env for routing (model name, gateway on/off, deployment ids). Prefer the **same env vars as the e2e tests** unless you need to pin something in YAML for a deployment.
 
+## Passing extra kwargs with `extra_body`
+
+Add **`extra_body`** to any LLM block to forward arbitrary key-value pairs in the request body. Works with every `_type`.
+
+```yaml
+llms:
+  datarobot_llm:
+    _type: datarobot-llm-component
+    extra_body:
+      mock_response: "this is a mock response"
+```
+
 ## Linking workflows to an LLM
 
 Any **`workflow`** or **`functions.*`** entry that needs a model sets **`llm_name:`** to the key under **`llms:`** (e.g. `llm_name: datarobot_llm`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.64"
+version = "0.15.65"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -36,6 +36,12 @@ def _create_datarobot_chat_litellm(config: dict[str, Any]) -> Any:
     else:
         config.pop("stream_options", None)
 
+    extra_body = config.pop("extra_body", None)
+    if extra_body is not None:
+        model_kwargs = config.get("model_kwargs") or {}
+        model_kwargs["extra_body"] = extra_body
+        config["model_kwargs"] = model_kwargs
+
     return ChatLiteLLM(**config)
 
 

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -53,6 +53,12 @@ def _create_datarobot_litellm(config: dict[str, Any]) -> Any:
                 model_name=self.model,
             )
 
+    extra_body = config.pop("extra_body", None)
+    if extra_body is not None:
+        additional_kwargs = dict(config.get("additional_kwargs") or {})
+        additional_kwargs["extra_body"] = extra_body
+        config["additional_kwargs"] = additional_kwargs
+
     return DataRobotLiteLLM(**config)
 
 

--- a/tests/langgraph/test_llm.py
+++ b/tests/langgraph/test_llm.py
@@ -210,6 +210,39 @@ def test_get_llm_forwards_model_name_and_parameters() -> None:
     assert llm.temperature == 0.5
 
 
+def test_gateway_llm_forwards_extra_body_via_model_kwargs() -> None:
+    llm = langgraph_llm.get_datarobot_gateway_llm(
+        parameters={"extra_body": {"mock_response": "hello"}}
+    )
+    assert llm.model_kwargs.get("extra_body") == {"mock_response": "hello"}
+
+
+def test_deployment_llm_forwards_extra_body_via_model_kwargs() -> None:
+    llm = langgraph_llm.get_datarobot_deployment_llm(
+        "dep-1", parameters={"extra_body": {"mock_response": "hello"}}
+    )
+    assert llm.model_kwargs.get("extra_body") == {"mock_response": "hello"}
+
+
+def test_external_llm_forwards_extra_body_via_model_kwargs() -> None:
+    llm = langgraph_llm.get_external_llm(
+        parameters={"extra_body": {"mock_response": "hello"}}
+    )
+    assert llm.model_kwargs.get("extra_body") == {"mock_response": "hello"}
+
+
+def test_factory_preserves_existing_model_kwargs_when_adding_extra_body() -> None:
+    llm = langgraph_llm.get_datarobot_gateway_llm(
+        parameters={"extra_body": {"mock_response": "hello"}, "model_kwargs": {"top_k": 5}}
+    )
+    assert llm.model_kwargs == {"top_k": 5, "extra_body": {"mock_response": "hello"}}
+
+
+def test_factory_omits_model_kwargs_when_no_extra_body() -> None:
+    llm = langgraph_llm.get_datarobot_gateway_llm()
+    assert llm.model_kwargs == {}
+
+
 def test_get_llm_forwards_streaming_flag() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY

--- a/tests/langgraph/test_llm.py
+++ b/tests/langgraph/test_llm.py
@@ -225,9 +225,7 @@ def test_deployment_llm_forwards_extra_body_via_model_kwargs() -> None:
 
 
 def test_external_llm_forwards_extra_body_via_model_kwargs() -> None:
-    llm = langgraph_llm.get_external_llm(
-        parameters={"extra_body": {"mock_response": "hello"}}
-    )
+    llm = langgraph_llm.get_external_llm(parameters={"extra_body": {"mock_response": "hello"}})
     assert llm.model_kwargs.get("extra_body") == {"mock_response": "hello"}
 
 

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -155,6 +155,43 @@ def test_get_external_llm_merges_parameters() -> None:
     assert llm.temperature == 0.7
 
 
+def test_gateway_llm_forwards_extra_body_via_additional_kwargs() -> None:
+    llm = llama_index_llm.get_datarobot_gateway_llm(
+        parameters={"extra_body": {"mock_response": "hello"}}
+    )
+    assert llm.additional_kwargs.get("extra_body") == {"mock_response": "hello"}
+
+
+def test_deployment_llm_forwards_extra_body_via_additional_kwargs() -> None:
+    llm = llama_index_llm.get_datarobot_deployment_llm(
+        "dep-1", parameters={"extra_body": {"mock_response": "hello"}}
+    )
+    assert llm.additional_kwargs.get("extra_body") == {"mock_response": "hello"}
+
+
+def test_external_llm_forwards_extra_body_via_additional_kwargs() -> None:
+    llm = llama_index_llm.get_external_llm(
+        parameters={"extra_body": {"mock_response": "hello"}}
+    )
+    assert llm.additional_kwargs.get("extra_body") == {"mock_response": "hello"}
+
+
+def test_factory_preserves_existing_additional_kwargs_when_adding_extra_body() -> None:
+    llm = llama_index_llm.get_datarobot_gateway_llm(
+        parameters={
+            "extra_body": {"mock_response": "hello"},
+            "additional_kwargs": {"extra_headers": {"X-Custom": "val"}},
+        }
+    )
+    assert llm.additional_kwargs.get("extra_body") == {"mock_response": "hello"}
+    assert llm.additional_kwargs.get("extra_headers") == {"X-Custom": "val"}
+
+
+def test_factory_does_not_add_extra_body_when_absent() -> None:
+    llm = llama_index_llm.get_datarobot_gateway_llm()
+    assert "extra_body" not in (llm.additional_kwargs or {})
+
+
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -170,9 +170,7 @@ def test_deployment_llm_forwards_extra_body_via_additional_kwargs() -> None:
 
 
 def test_external_llm_forwards_extra_body_via_additional_kwargs() -> None:
-    llm = llama_index_llm.get_external_llm(
-        parameters={"extra_body": {"mock_response": "hello"}}
-    )
+    llm = llama_index_llm.get_external_llm(parameters={"extra_body": {"mock_response": "hello"}})
     assert llm.additional_kwargs.get("extra_body") == {"mock_response": "hello"}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.64"
+version = "0.15.65"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->
Fixing ignored `extra_body` kwargs field for `workflow.yaml` NAT dragent server ran agent frameworks. This is useful for specifying `mock_response` payload parameter for load testing purposes.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies how request payload overrides are passed into LangGraph and LlamaIndex LiteLLM wrappers; could subtly change outbound LLM request bodies if callers already relied on the old parameter placement.
> 
> **Overview**
> **Adds support for `extra_body` passthrough in LLM factory functions.** The LangGraph `ChatLiteLLM` factory now moves a top-level `extra_body` parameter into `model_kwargs["extra_body"]`, and the LlamaIndex `LiteLLM` factory moves it into `additional_kwargs["extra_body"]`, preserving any existing kwargs.
> 
> **Expands test coverage** to verify `extra_body` forwarding for gateway/deployment/external LLMs and to ensure existing `model_kwargs`/`additional_kwargs` are not overwritten (and are omitted when `extra_body` is absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d3ba62c233f0cd4e4eddec47b67bc2c8b842ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->