### PR TITLE
[BUZZOK-30696][BUZZOK-30697] A2A: Support Agent Card lookup via central registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.58
+- Added central agent card registry support to `authenticated_a2a_client`. Set `registry.deployment_id` or `registry.external_id` instead of `url` to resolve agent cards from the tenant-wide DataRobot registry.
+
 ## 0.15.57
 - Registered DataRobot moderation middleware on the `nat.plugins` entry point `datarobot_moderation_middleware` so `_type: datarobot_moderation` is available when NAT loads plugins.
 - NAT / dragent moderation: `DataRobotModerationConfig` no longer uses `model_dir` to locate guard YAML. Configure guards with the optional `moderation` field (`ModerationConfig` from `datarobot_dome`). In `workflow.yaml`, nest guard definitions under `middleware.datarobot_guardrails.moderation` instead of setting `model_dir` to a directory that contained `moderation_config.yaml`.

--- a/docs/nat/README.md
+++ b/docs/nat/README.md
@@ -17,6 +17,9 @@ pip install "datarobot-genai[dragent]"
 | [agent.md](agent.md) | Top-level **`workflow.yaml`**: `functions`, `workflow`, `llms`, how they connect |
 | [llm.md](llm.md) | The **`llms:`** block and `_type` values (e.g. `datarobot-llm-component`) |
 | [mcp.md](mcp.md) | **`function_groups`**, **`authentication`**, MCP tools in **`tool_names`** |
+| [a2a-client.md](a2a-client.md) | A2A client: calling remote agents, agent card resolution (`url` / `registry`) |
+| [a2a-auth.md](a2a-auth.md) | A2A authentication: DataRobot API key and Okta XAA |
+| [memory.md](memory.md) | Optional long-term memory with Mem0 |
 | [caveats.md](caveats.md) | Interface caveats |
 
 Shared env vars: [LLM configuration (shared)](../llm.md). Streaming behavior (NAT ≥ 1.6): [NAT 1.6 streaming in DRAgent](../design/nat-1.6-streaming.md).

--- a/docs/nat/README.md
+++ b/docs/nat/README.md
@@ -19,7 +19,6 @@ pip install "datarobot-genai[dragent]"
 | [mcp.md](mcp.md) | **`function_groups`**, **`authentication`**, MCP tools in **`tool_names`** |
 | [a2a-client.md](a2a-client.md) | A2A client: calling remote agents, agent card resolution (`url` / `registry`) |
 | [a2a-auth.md](a2a-auth.md) | A2A authentication: DataRobot API key and Okta XAA |
-| [memory.md](memory.md) | Optional long-term memory with Mem0 |
 | [caveats.md](caveats.md) | Interface caveats |
 
 Shared env vars: [LLM configuration (shared)](../llm.md). Streaming behavior (NAT ≥ 1.6): [NAT 1.6 streaming in DRAgent](../design/nat-1.6-streaming.md).

--- a/docs/nat/a2a-client.md
+++ b/docs/nat/a2a-client.md
@@ -52,6 +52,9 @@ mutually exclusive ways to obtain it.
 
 ### Direct fetch (`url`)
 
+This is the simplest setup — use it when the card endpoint is directly reachable with the same
+credentials used for RPC calls.
+
 In a direct fetch, the client fetches the card from `{url}/.well-known/agent-card.json`. The `auth_provider` is used
 for both the card fetch and subsequent RPC calls.
 
@@ -63,12 +66,10 @@ function_groups:
     auth_provider: datarobot_auth
 ```
 
-This is the simplest setup — use it when the card endpoint is directly reachable with the same
-credentials used for RPC calls.
 
 ### Central registry (`registry`)
 
-In DataRobot deployments, the agent card endpoint is protected by per-agent AuthN/Auth. However, the
+In DataRobot deployments, the agent card endpoint is protected by per-agent AuthN/AuthZ. However, the
 card itself describes *how* to authenticate, creating a chicken-and-egg problem. The **central
 agent card registry** solves this by exposing all agent cards in the tenant at a single endpoint
 that requires only a standard `DATAROBOT_API_TOKEN`.
@@ -112,8 +113,8 @@ reused until the TTL expires.
 | `AGENT_CARD_REGISTRY_CACHE_TTL` | No | Cache TTL in seconds. Default `86400` (24 h). Set to `0` to disable caching. |
 | `AGENT_CARD_REGISTRY_TIMEOUT` | No | HTTP timeout in seconds for registry requests. Default `30`. |
 
-Variables are loaded via env vars, `.env` files, file secrets, Runtime Parameters, and Pulumi
-config.
+Variables are loaded via `DataRobotAppFrameworkBaseSettings`, which supports env vars, `.env`
+files, file secrets, Runtime Parameters, and Pulumi config.
 
 ## Configuration reference
 

--- a/docs/nat/a2a-client.md
+++ b/docs/nat/a2a-client.md
@@ -112,6 +112,7 @@ reused until the TTL expires.
 | `DATAROBOT_ENDPOINT` | Yes | DataRobot API base URL, e.g. `https://app.datarobot.com/api/v2`. |
 | `AGENT_CARD_REGISTRY_CACHE_TTL` | No | Cache TTL in seconds. Default `86400` (24 h). Set to `0` to disable caching. |
 | `AGENT_CARD_REGISTRY_TIMEOUT` | No | HTTP timeout in seconds for registry requests. Default `30`. |
+| `AGENT_CARD_REGISTRY_ON_DUPLICATE` | No | Strategy when multiple cards share the same external ID: `first` keeps the earliest registered card, `last` keeps the most recently registered card, `error` raises an exception. Default: `first`. |
 
 Variables are loaded via `DataRobotAppFrameworkBaseSettings`, which supports env vars, `.env`
 files, file secrets, Runtime Parameters, and Pulumi config.

--- a/docs/nat/a2a-client.md
+++ b/docs/nat/a2a-client.md
@@ -18,7 +18,7 @@
 
 A NAT workflow can call other agents over the [A2A protocol](https://google.github.io/A2A/) by
 adding an `authenticated_a2a_client` entry under **`function_groups`**. The remote agent appears as
-a tool the orchestrator can invoke — just like MCP tools or local functions.
+a tool the orchestrator can invoke, just like MCP tools or local functions.
 
 ```yaml
 function_groups:
@@ -39,20 +39,20 @@ authentication:
 ```
 
 The function group handles agent card discovery, authentication for both the discovery and RPC
-phases, and SSE streaming — all driven by `workflow.yaml`.
+phases, and SSE streaming, all driven by `workflow.yaml`.
 
-For details on **which auth providers are available** and how to configure them (DataRobot API key,
+For details on which auth providers are available and how to configure them (DataRobot API key,
 Okta XAA), see [a2a-auth.md](a2a-auth.md).
 
 ## Agent card resolution
 
 Before the first RPC call, the client must obtain the remote agent's **agent card** — a JSON
 document describing the agent's capabilities and authentication requirements. There are two
-mutually exclusive ways to resolve it.
+mutually exclusive ways to obtain it.
 
 ### Direct fetch (`url`)
 
-The client fetches the card from `{url}/.well-known/agent-card.json`. The `auth_provider` is used
+In a direct fetch, the client fetches the card from `{url}/.well-known/agent-card.json`. The `auth_provider` is used
 for both the card fetch and subsequent RPC calls.
 
 ```yaml
@@ -68,7 +68,7 @@ credentials used for RPC calls.
 
 ### Central registry (`registry`)
 
-In DataRobot deployments the agent card endpoint is protected by per-agent AuthN/AuthZ — but the
+In DataRobot deployments, the agent card endpoint is protected by per-agent AuthN/Auth. However, the
 card itself describes *how* to authenticate, creating a chicken-and-egg problem. The **central
 agent card registry** solves this by exposing all agent cards in the tenant at a single endpoint
 that requires only a standard `DATAROBOT_API_TOKEN`.
@@ -95,13 +95,12 @@ function_groups:
     auth_provider: okta_auth
 ```
 
-When using the registry the RPC base URL is derived from the card's advertised `url` — you do not
-need to specify it.
+> [!NOTE]
+> When using the registry the RPC base URL is derived from the card's advertised `url` — you do not need to specify it.
 
 #### Batch fetching
 
-When a workflow has many registry-backed function groups, all cards are resolved in **at most
-2 HTTP calls** (one for deployment IDs, one for external IDs). Results are cached in-memory and
+When a workflow has many registry-backed function groups, all cards are resolved in a maximum of two HTTP calls: one for deployment IDs, one for external IDs. Results are cached in-memory and
 reused until the TTL expires.
 
 #### Registry environment variables

--- a/docs/nat/a2a-client.md
+++ b/docs/nat/a2a-client.md
@@ -1,0 +1,149 @@
+<!--
+  ~ Copyright 2026 DataRobot, Inc. and its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+# A2A client (calling remote agents)
+
+A NAT workflow can call other agents over the [A2A protocol](https://google.github.io/A2A/) by
+adding an `authenticated_a2a_client` entry under **`function_groups`**. The remote agent appears as
+a tool the orchestrator can invoke — just like MCP tools or local functions.
+
+```yaml
+function_groups:
+  remote_agent:
+    _type: authenticated_a2a_client
+    url: "https://app.datarobot.com/api/v2/deployments/<deployment-id>/directAccess/a2a/"
+    auth_provider: datarobot_auth
+
+workflow:
+  _type: langgraph_agent
+  llm_name: datarobot_llm
+  tool_names:
+    - remote_agent          # ← the orchestrator can now call this agent
+
+authentication:
+  datarobot_auth:
+    _type: datarobot_api_key
+```
+
+The function group handles agent card discovery, authentication for both the discovery and RPC
+phases, and SSE streaming — all driven by `workflow.yaml`.
+
+For details on **which auth providers are available** and how to configure them (DataRobot API key,
+Okta XAA), see [a2a-auth.md](a2a-auth.md).
+
+## Agent card resolution
+
+Before the first RPC call, the client must obtain the remote agent's **agent card** — a JSON
+document describing the agent's capabilities and authentication requirements. There are two
+mutually exclusive ways to resolve it.
+
+### Direct fetch (`url`)
+
+The client fetches the card from `{url}/.well-known/agent-card.json`. The `auth_provider` is used
+for both the card fetch and subsequent RPC calls.
+
+```yaml
+function_groups:
+  remote_agent:
+    _type: authenticated_a2a_client
+    url: "https://app.datarobot.com/api/v2/deployments/<deployment-id>/directAccess/a2a/"
+    auth_provider: datarobot_auth
+```
+
+This is the simplest setup — use it when the card endpoint is directly reachable with the same
+credentials used for RPC calls.
+
+### Central registry (`registry`)
+
+In DataRobot deployments the agent card endpoint is protected by per-agent AuthN/AuthZ — but the
+card itself describes *how* to authenticate, creating a chicken-and-egg problem. The **central
+agent card registry** solves this by exposing all agent cards in the tenant at a single endpoint
+that requires only a standard `DATAROBOT_API_TOKEN`.
+
+**Lookup by deployment ID:**
+
+```yaml
+function_groups:
+  remote_agent:
+    _type: authenticated_a2a_client
+    registry:
+      deployment_id: "64a1b2c3d4e5f6a7b8c9d0e1"
+    auth_provider: okta_auth
+```
+
+**Lookup by external ID** (when the remote agent sets `general.front_end.a2a.external.id`):
+
+```yaml
+function_groups:
+  remote_agent:
+    _type: authenticated_a2a_client
+    registry:
+      external_id: "my-remote-agent"
+    auth_provider: okta_auth
+```
+
+When using the registry the RPC base URL is derived from the card's advertised `url` — you do not
+need to specify it.
+
+#### Batch fetching
+
+When a workflow has many registry-backed function groups, all cards are resolved in **at most
+2 HTTP calls** (one for deployment IDs, one for external IDs). Results are cached in-memory and
+reused until the TTL expires.
+
+#### Registry environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATAROBOT_API_TOKEN` | Yes | DataRobot API token for registry authentication. |
+| `DATAROBOT_ENDPOINT` | Yes | DataRobot API base URL, e.g. `https://app.datarobot.com/api/v2`. |
+| `AGENT_CARD_REGISTRY_CACHE_TTL` | No | Cache TTL in seconds. Default `86400` (24 h). Set to `0` to disable caching. |
+| `AGENT_CARD_REGISTRY_TIMEOUT` | No | HTTP timeout in seconds for registry requests. Default `30`. |
+
+Variables are loaded via env vars, `.env` files, file secrets, Runtime Parameters, and Pulumi
+config.
+
+## Configuration reference
+
+### `authenticated_a2a_client` function group
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `url` | — | Base URL for direct card fetch. Mutually exclusive with `registry`. |
+| `registry` | — | Registry lookup block. Mutually exclusive with `url`. |
+| `auth_provider` | `None` | Name of an `authentication` entry for A2A RPC calls. |
+| `agent_card_path` | `/.well-known/agent-card.json` | Card path for direct fetch — ignored when using `registry`. |
+
+### `registry` block
+
+Exactly one field must be set.
+
+| Field | Description |
+|-------|-------------|
+| `deployment_id` | DataRobot deployment ID. |
+| `external_id` | External agent catalogue identifier. |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `RuntimeError: Failed to fetch agent card from …` | Direct-fetch URL unreachable or auth failed. | Verify `url` and `auth_provider` configuration. |
+| `AgentCardRegistryError: DataRobot API token is required` | `DATAROBOT_API_TOKEN` not set. | Export the variable or add it to `.env`. |
+| `AgentCardRegistryError: DataRobot API endpoint is required` | `DATAROBOT_ENDPOINT` not set. | Export the variable or add it to `.env`. |
+| `AgentCardRegistryError: … HTTP 401` | Token invalid or expired. | Regenerate your API token in the DataRobot console. |
+| `AgentCardRegistryError: No agent card found …` | Deployment not in the registry. | Confirm the deployment has an A2A agent card published. |
+| `ValueError: … 'url' … or 'registry' …, not both` | Both fields set. | Remove one — they are mutually exclusive. |
+| Stale card after redeployment | Cache TTL has not expired. | Set `AGENT_CARD_REGISTRY_CACHE_TTL=0` or wait for TTL to elapse. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.57"
+version = "0.15.58"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -23,26 +23,38 @@ The :class:`AgentCardRegistry` supports **batch fetching** so that many
 function groups sharing the same workflow can resolve all their cards in a
 minimum number of HTTP round-trips instead of N+1 individual requests.
 
+Lookups can be **registered** before the first fetch so that ``get()``
+automatically triggers a single batch prefetch for all pending IDs on its
+first invocation — no explicit ``prefetch()`` call required.
+
 .. note::
     The registry API uses AND semantics when both ``deploymentIds`` and
     ``externalIds`` parameters are provided in a single request, which would
-    return empty results.  Therefore :meth:`AgentCardRegistry.prefetch` issues
-    **separate** HTTP calls for deployment IDs and external IDs.
+    return empty results.  Therefore the registry issues **separate** HTTP
+    calls for deployment IDs and external IDs.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any
 
 import httpx
 from a2a.types import AgentCard
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from pydantic import Field
 
 from datarobot_genai.dragent.deployment_urls import build_agent_cards_registry_url
 
 logger = logging.getLogger(__name__)
+
+# Default cache TTL: 24 hours (in seconds).
+_DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
+
+# Default HTTP timeout for registry requests (in seconds).
+_DEFAULT_TIMEOUT_SECONDS = 30.0
 
 
 class DataRobotRegistrySettings(DataRobotAppFrameworkBaseSettings):
@@ -56,6 +68,33 @@ class DataRobotRegistrySettings(DataRobotAppFrameworkBaseSettings):
 
     datarobot_api_token: str | None = None
     datarobot_endpoint: str | None = None
+
+
+class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
+    """Configuration for the agent card registry cache.
+
+    Controllable via environment variables (prefix-free, following the
+    standard :class:`DataRobotAppFrameworkBaseSettings` resolution chain).
+
+    Set ``AGENT_CARD_REGISTRY_CACHE_TTL=0`` to disable caching entirely
+    (every ``get()`` triggers a fresh HTTP fetch).
+    """
+
+    agent_card_registry_cache_ttl: int = Field(
+        default=_DEFAULT_CACHE_TTL_SECONDS,
+        ge=0,
+        description=(
+            "Time-to-live for cached agent cards in seconds. "
+            "Set to 0 to disable caching (every get() triggers a fresh fetch). "
+            "Default: 86400 (24 hours)."
+        ),
+    )
+
+    agent_card_registry_timeout: float = Field(
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        gt=0,
+        description=("HTTP timeout in seconds for registry API requests. Default: 30."),
+    )
 
 
 class AgentCardRegistryError(RuntimeError):
@@ -115,47 +154,85 @@ def _parse_registry_response(body: dict[str, Any]) -> dict[str, AgentCard]:
     return cards
 
 
+class _CacheEntry:
+    """A cached agent card with its fetch timestamp."""
+
+    __slots__ = ("card", "fetched_at")
+
+    def __init__(self, card: AgentCard) -> None:
+        self.card = card
+        self.fetched_at = time.monotonic()
+
+    def is_expired(self, ttl: int) -> bool:
+        """Return *True* if this entry is older than *ttl* seconds.
+
+        A TTL of 0 means "always expired" (no caching).
+        """
+        if ttl == 0:
+            return True
+        return (time.monotonic() - self.fetched_at) >= ttl
+
+
 class AgentCardRegistry:
-    """Async-safe, batch-capable cache for agent cards from the central registry.
+    """Batch-capable, TTL-cached client for the central agent card registry.
 
-    Designed to solve the **N+1 problem**: when a workflow defines many
-    function groups that all need registry lookup, callers can
-    :meth:`prefetch` all IDs in a minimum number of HTTP calls, then
-    :meth:`get` each card from the local cache.
-
-    .. important::
-        The registry API uses AND semantics when both ``deploymentIds`` and
-        ``externalIds`` are sent in a single request.  This class always
-        issues **separate** requests for each ID type.
-
-    Usage::
-
-        registry = AgentCardRegistry()
-
-        # Batch-prefetch — issues at most 2 HTTP calls (one per ID type)
-        await registry.prefetch(
-            deployment_ids=["dep-1", "dep-2"],
-            external_ids=["ext-3"],
-        )
-
-        # Individual lookups hit the local cache (no HTTP)
-        card = await registry.get(deployment_id="dep-1")
-
-    The :meth:`get` method also works standalone — if the card is not cached
-    it fetches it individually.
+    IDs are ``register()``-ed synchronously at config-parse time (no I/O).
+    The first ``get()`` flushes all pending IDs in ≤2 HTTP calls
+    (one per ID type — API uses AND when both are mixed).
+    Subsequent ``get()`` calls hit the in-memory cache until TTL expires.
+    Cache TTL is controlled via ``AGENT_CARD_REGISTRY_CACHE_TTL`` env var
+    (default 86400s / 24h, set to 0 to disable caching).
     """
 
     def __init__(
         self,
         api_token: str | None = None,
         endpoint: str | None = None,
-        timeout: float = 30.0,
+        timeout: float | None = None,
+        cache_ttl: int | None = None,
     ) -> None:
         self._api_token = api_token
         self._endpoint = endpoint
-        self._timeout = timeout
-        self._cache: dict[str, AgentCard] = {}
+        self._cache: dict[str, _CacheEntry] = {}
         self._lock = asyncio.Lock()
+
+        # Pending registrations (filled synchronously, flushed on first get)
+        self._pending_deployment_ids: set[str] = set()
+        self._pending_external_ids: set[str] = set()
+
+        config = AgentCardRegistryConfig()
+        self._timeout = timeout if timeout is not None else config.agent_card_registry_timeout
+        self._cache_ttl = (
+            cache_ttl if cache_ttl is not None else config.agent_card_registry_cache_ttl
+        )
+
+        logger.debug("AgentCardRegistry created (cache_ttl=%ds)", self._cache_ttl)
+
+    # ------------------------------------------------------------------
+    # Registration (synchronous — called at config-parse time)
+    # ------------------------------------------------------------------
+
+    def register(
+        self,
+        *,
+        deployment_id: str | None = None,
+        external_id: str | None = None,
+    ) -> None:
+        """Declare intent to look up an agent card.
+
+        Call this at config-parse/validation time so that the first
+        :meth:`get` can batch all pending IDs into a single prefetch.
+
+        Exactly one of ``deployment_id`` or ``external_id`` must be given.
+        """
+        if deployment_id:
+            self._pending_deployment_ids.add(deployment_id)
+        elif external_id:
+            self._pending_external_ids.add(external_id)
+
+    # ------------------------------------------------------------------
+    # Internal HTTP
+    # ------------------------------------------------------------------
 
     async def _fetch(self, params: dict[str, str]) -> dict[str, AgentCard]:
         """Execute a single registry HTTP GET and return parsed cards."""
@@ -164,7 +241,9 @@ class AgentCardRegistry:
         headers = {"Authorization": f"Bearer {token}"}
 
         logger.info(
-            "Fetching agent cards from registry: %s (params=%s)", registry_url, params,
+            "Fetching agent cards from registry: %s (params=%s)",
+            registry_url,
+            params,
         )
 
         try:
@@ -178,13 +257,42 @@ class AgentCardRegistry:
                 f"the agents are registered."
             ) from exc
         except httpx.HTTPError as exc:
-            raise AgentCardRegistryError(
-                f"Agent card registry request failed: {exc}"
-            ) from exc
+            raise AgentCardRegistryError(f"Agent card registry request failed: {exc}") from exc
 
         cards = _parse_registry_response(response.json())
         logger.info("Fetched %d agent card(s) from registry.", len(cards))
         return cards
+
+    def _is_cached(self, key: str) -> bool:
+        """Return True if *key* is cached and not expired."""
+        entry = self._cache.get(key)
+        return entry is not None and not entry.is_expired(self._cache_ttl)
+
+    async def _flush_pending(self) -> None:
+        """Batch-fetch all registered-but-uncached IDs.  Must be called under ``_lock``."""
+        missing_dep = [d for d in self._pending_deployment_ids if not self._is_cached(d)]
+        missing_ext = [e for e in self._pending_external_ids if not self._is_cached(e)]
+
+        # Clear pending sets regardless — they've been processed
+        self._pending_deployment_ids.clear()
+        self._pending_external_ids.clear()
+
+        if not missing_dep and not missing_ext:
+            return
+
+        if missing_dep:
+            cards = await self._fetch({"deploymentIds": ",".join(missing_dep)})
+            for k, card in cards.items():
+                self._cache[k] = _CacheEntry(card)
+
+        if missing_ext:
+            cards = await self._fetch({"externalIds": ",".join(missing_ext)})
+            for k, card in cards.items():
+                self._cache[k] = _CacheEntry(card)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     async def prefetch(
         self,
@@ -198,7 +306,7 @@ class AgentCardRegistry:
         ``external_ids`` because the API uses AND semantics when both
         parameters are present in a single request.
 
-        Already-cached IDs are skipped.  This method is concurrency-safe.
+        Already-cached (non-expired) IDs are skipped.
 
         Parameters
         ----------
@@ -208,8 +316,8 @@ class AgentCardRegistry:
             External IDs to prefetch.
         """
         async with self._lock:
-            missing_dep = [d for d in (deployment_ids or []) if d not in self._cache]
-            missing_ext = [e for e in (external_ids or []) if e not in self._cache]
+            missing_dep = [d for d in (deployment_ids or []) if not self._is_cached(d)]
+            missing_ext = [e for e in (external_ids or []) if not self._is_cached(e)]
 
             if not missing_dep and not missing_ext:
                 logger.debug("All requested agent cards already cached — skipping prefetch.")
@@ -217,11 +325,13 @@ class AgentCardRegistry:
 
             if missing_dep:
                 cards = await self._fetch({"deploymentIds": ",".join(missing_dep)})
-                self._cache.update(cards)
+                for k, card in cards.items():
+                    self._cache[k] = _CacheEntry(card)
 
             if missing_ext:
                 cards = await self._fetch({"externalIds": ",".join(missing_ext)})
-                self._cache.update(cards)
+                for k, card in cards.items():
+                    self._cache[k] = _CacheEntry(card)
 
     async def get(
         self,
@@ -231,6 +341,10 @@ class AgentCardRegistry:
     ) -> AgentCard:
         """Return a single agent card, using the cache or fetching on demand.
 
+        On the first call, all IDs previously passed to :meth:`register`
+        are batch-fetched in a single prefetch (at most 2 HTTP calls).
+        Subsequent calls for already-cached, non-expired cards are instant.
+
         Exactly one of ``deployment_id`` or ``external_id`` must be provided.
 
         Raises
@@ -239,49 +353,56 @@ class AgentCardRegistry:
             If the card cannot be found or the request fails.
         """
         if bool(deployment_id) == bool(external_id):
-            raise AgentCardRegistryError(
-                "Specify exactly one of 'deployment_id' or 'external_id'."
-            )
+            raise AgentCardRegistryError("Specify exactly one of 'deployment_id' or 'external_id'.")
 
         lookup_key: str = deployment_id or external_id  # type: ignore[assignment]
 
-        # Fast path — already cached
-        if lookup_key in self._cache:
-            return self._cache[lookup_key]
+        # Fast path — cached and not expired
+        if self._is_cached(lookup_key):
+            return self._cache[lookup_key].card
 
-        # Slow path — fetch individually (double-check under lock)
         async with self._lock:
-            if lookup_key in self._cache:
-                return self._cache[lookup_key]
+            # Double-check after acquiring lock
+            if self._is_cached(lookup_key):
+                return self._cache[lookup_key].card
 
+            # Flush all pending registrations in a batch
+            if self._pending_deployment_ids or self._pending_external_ids:
+                await self._flush_pending()
+                if self._is_cached(lookup_key):
+                    return self._cache[lookup_key].card
+
+            # Still not found — fetch individually
             params: dict[str, str] = (
-                {"deploymentIds": deployment_id}
-                if deployment_id
-                else {"externalIds": external_id}  # type: ignore[dict-item]
+                {"deploymentIds": deployment_id} if deployment_id else {"externalIds": external_id}  # type: ignore[dict-item]
             )
             cards = await self._fetch(params)
-            self._cache.update(cards)
+            for k, card in cards.items():
+                self._cache[k] = _CacheEntry(card)
 
-        if lookup_key not in self._cache:
-            id_label = (
-                f"deployment_id='{deployment_id}'"
-                if deployment_id
-                else f"external_id='{external_id}'"
-            )
-            raise AgentCardRegistryError(
-                f"No agent card found in the central registry for {id_label}. "
-                "Verify that the deployment exists and is registered in your organisation."
-            )
+            if lookup_key in self._cache:
+                return self._cache[lookup_key].card
 
-        return self._cache[lookup_key]
+        # If we got here, the key was not found despite fetching
+        id_label = (
+            f"deployment_id='{deployment_id}'" if deployment_id else f"external_id='{external_id}'"
+        )
+        raise AgentCardRegistryError(
+            f"No agent card found in the central registry for {id_label}. "
+            "Verify that the deployment exists and is registered in your organisation."
+        )
 
 
 # ---------------------------------------------------------------------------
 # Module-level singleton
 # ---------------------------------------------------------------------------
 
-_default_registry: AgentCardRegistry | None = None
-_registry_lock = asyncio.Lock()
+
+class _RegistryHolder:
+    """Mutable container for the singleton."""
+
+    instance: AgentCardRegistry | None = None
+    lock = asyncio.Lock()
 
 
 async def get_default_registry() -> AgentCardRegistry:
@@ -290,15 +411,25 @@ async def get_default_registry() -> AgentCardRegistry:
     Created lazily on first access.  Credentials are resolved from
     :class:`DataRobotRegistrySettings` at instantiation time.
     """
-    global _default_registry
-    if _default_registry is None:
-        async with _registry_lock:
-            if _default_registry is None:
-                _default_registry = AgentCardRegistry()
-    return _default_registry
+    if _RegistryHolder.instance is None:
+        async with _RegistryHolder.lock:
+            if _RegistryHolder.instance is None:
+                _RegistryHolder.instance = AgentCardRegistry()
+    return _RegistryHolder.instance
+
+
+def get_default_registry_sync() -> AgentCardRegistry:
+    """Return the singleton, creating it if needed (synchronous).
+
+    Safe to call from pydantic validators and other sync contexts
+    (e.g. config-parse time) because :class:`AgentCardRegistry.__init__`
+    does no I/O.
+    """
+    if _RegistryHolder.instance is None:
+        _RegistryHolder.instance = AgentCardRegistry()
+    return _RegistryHolder.instance
 
 
 def reset_default_registry() -> None:
     """Reset the module-level singleton (for testing)."""
-    global _default_registry
-    _default_registry = None
+    _RegistryHolder.instance = None

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -18,8 +18,21 @@ The central registry provides a tenant-scoped list of agent cards that requires
 only standard DataRobot API-token authentication (``DATAROBOT_API_TOKEN``).
 This avoids the chicken-and-egg problem where an individual agent's card
 endpoint is behind per-agent AuthN/AuthZ.
+
+The :class:`AgentCardRegistry` supports **batch fetching** so that many
+function groups sharing the same workflow can resolve all their cards in a
+minimum number of HTTP round-trips instead of N+1 individual requests.
+
+.. note::
+    The registry API uses AND semantics when both ``deploymentIds`` and
+    ``externalIds`` parameters are provided in a single request, which would
+    return empty results.  Therefore :meth:`AgentCardRegistry.prefetch` issues
+    **separate** HTTP calls for deployment IDs and external IDs.
 """
 
+from __future__ import annotations
+
+import asyncio
 import logging
 from typing import Any
 
@@ -49,54 +62,11 @@ class AgentCardRegistryError(RuntimeError):
     """Raised when the central agent card registry lookup fails."""
 
 
-async def fetch_agent_card_from_registry(
-    *,
-    deployment_id: str | None = None,
-    external_id: str | None = None,
+def _resolve_settings(
     api_token: str | None = None,
     endpoint: str | None = None,
-    timeout: float = 30.0,
-) -> AgentCard:
-    """Fetch an :class:`~a2a.types.AgentCard` from the central DataRobot registry.
-
-    Exactly one of ``deployment_id`` or ``external_id`` must be provided.
-
-    Parameters
-    ----------
-    deployment_id:
-        The DataRobot deployment ID to look up.
-    external_id:
-        The external agent identifier to look up.
-    api_token:
-        DataRobot API token.  Falls back to ``DATAROBOT_API_TOKEN`` resolved
-        via :class:`DataRobotRegistrySettings` when *None*.
-    endpoint:
-        DataRobot API endpoint.  Falls back to ``DATAROBOT_ENDPOINT`` resolved
-        via :class:`DataRobotRegistrySettings` when *None*.
-    timeout:
-        HTTP request timeout in seconds.
-
-    Returns
-    -------
-    AgentCard
-        The deserialized agent card from the registry.
-
-    Raises
-    ------
-    AgentCardRegistryError
-        If the lookup fails (missing credentials, HTTP error, or no matching
-        card in the registry).
-    """
-    if not deployment_id and not external_id:
-        raise AgentCardRegistryError(
-            "Either 'deployment_id' or 'external_id' must be provided for registry lookup."
-        )
-    if deployment_id and external_id:
-        raise AgentCardRegistryError(
-            "Specify exactly one of 'deployment_id' or 'external_id', not both."
-        )
-
-    # Resolve credentials via DataRobotAppFrameworkBaseSettings
+) -> tuple[str, str]:
+    """Return validated ``(api_token, endpoint)`` from explicit values or settings."""
     settings = DataRobotRegistrySettings()
     resolved_token = api_token or settings.datarobot_api_token
     if not resolved_token:
@@ -104,72 +74,231 @@ async def fetch_agent_card_from_registry(
             "DataRobot API token is required for agent card registry lookup. "
             "Set the DATAROBOT_API_TOKEN environment variable or provide it explicitly."
         )
-
     resolved_endpoint = endpoint or settings.datarobot_endpoint
     if not resolved_endpoint:
         raise AgentCardRegistryError(
             "DataRobot API endpoint is required for agent card registry lookup. "
             "Set the DATAROBOT_ENDPOINT environment variable or provide it explicitly."
         )
+    return resolved_token, resolved_endpoint
 
-    registry_url = build_agent_cards_registry_url(resolved_endpoint)
 
-    # Build query parameters
-    params: dict[str, str] = {}
-    if deployment_id:
-        params["deploymentIds"] = deployment_id
-    else:
-        params["externalIds"] = external_id  # type: ignore[assignment]
+def _parse_registry_response(body: dict[str, Any]) -> dict[str, AgentCard]:
+    """Parse a paginated registry response into ``{id: AgentCard}``.
 
-    headers = {"Authorization": f"Bearer {resolved_token}"}
+    Each record is indexed by *both* ``deploymentId`` and ``externalId``
+    (when present) so callers can look up by either key type.
+    """
+    cards: dict[str, AgentCard] = {}
+    for entry in body.get("data", []):
+        raw_card = entry.get("agentCard")
+        if not raw_card:
+            logger.warning(
+                "Registry entry %s has no 'agentCard' payload — skipping.",
+                entry.get("id", "?"),
+            )
+            continue
+        try:
+            card = AgentCard.model_validate(raw_card)
+        except Exception:
+            logger.warning(
+                "Failed to parse agent card for registry entry %s — skipping.",
+                entry.get("id", "?"),
+                exc_info=True,
+            )
+            continue
 
-    lookup_key = f"deployment_id={deployment_id}" if deployment_id else f"external_id={external_id}"
-    logger.info("Fetching agent card from central registry (%s): %s", lookup_key, registry_url)
+        if dep_id := entry.get("deploymentId"):
+            cards[dep_id] = card
+        if ext_id := entry.get("externalId"):
+            cards[ext_id] = card
+    return cards
 
-    try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as client:
-            response = await client.get(registry_url, params=params, headers=headers)
-            response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        raise AgentCardRegistryError(
-            f"Agent card registry request failed with HTTP {exc.response.status_code} "
-            f"for {lookup_key}. Verify your API token and that the agent is registered."
-        ) from exc
-    except httpx.HTTPError as exc:
-        raise AgentCardRegistryError(
-            f"Agent card registry request failed for {lookup_key}: {exc}"
-        ) from exc
 
-    body: dict[str, Any] = response.json()
-    data: list[dict[str, Any]] = body.get("data", [])
+class AgentCardRegistry:
+    """Async-safe, batch-capable cache for agent cards from the central registry.
 
-    if not data:
-        raise AgentCardRegistryError(
-            f"No agent card found in the central registry for {lookup_key}. "
-            "Verify that the deployment exists and is registered in your organisation."
+    Designed to solve the **N+1 problem**: when a workflow defines many
+    function groups that all need registry lookup, callers can
+    :meth:`prefetch` all IDs in a minimum number of HTTP calls, then
+    :meth:`get` each card from the local cache.
+
+    .. important::
+        The registry API uses AND semantics when both ``deploymentIds`` and
+        ``externalIds`` are sent in a single request.  This class always
+        issues **separate** requests for each ID type.
+
+    Usage::
+
+        registry = AgentCardRegistry()
+
+        # Batch-prefetch — issues at most 2 HTTP calls (one per ID type)
+        await registry.prefetch(
+            deployment_ids=["dep-1", "dep-2"],
+            external_ids=["ext-3"],
         )
 
-    agent_card_json = data[0].get("agentCard")
-    if not agent_card_json:
-        raise AgentCardRegistryError(
-            f"Registry entry for {lookup_key} exists but contains no 'agentCard' payload."
+        # Individual lookups hit the local cache (no HTTP)
+        card = await registry.get(deployment_id="dep-1")
+
+    The :meth:`get` method also works standalone — if the card is not cached
+    it fetches it individually.
+    """
+
+    def __init__(
+        self,
+        api_token: str | None = None,
+        endpoint: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self._api_token = api_token
+        self._endpoint = endpoint
+        self._timeout = timeout
+        self._cache: dict[str, AgentCard] = {}
+        self._lock = asyncio.Lock()
+
+    async def _fetch(self, params: dict[str, str]) -> dict[str, AgentCard]:
+        """Execute a single registry HTTP GET and return parsed cards."""
+        token, endpoint = _resolve_settings(self._api_token, self._endpoint)
+        registry_url = build_agent_cards_registry_url(endpoint)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        logger.info(
+            "Fetching agent cards from registry: %s (params=%s)", registry_url, params,
         )
 
-    try:
-        card = AgentCard.model_validate(agent_card_json)
-    except Exception as exc:
-        raise AgentCardRegistryError(
-            f"Failed to parse agent card from registry for {lookup_key}: {exc}"
-        ) from exc
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(self._timeout)) as client:
+                response = await client.get(registry_url, params=params, headers=headers)
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise AgentCardRegistryError(
+                f"Agent card registry request failed with HTTP "
+                f"{exc.response.status_code}. Verify your API token and that "
+                f"the agents are registered."
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise AgentCardRegistryError(
+                f"Agent card registry request failed: {exc}"
+            ) from exc
 
-    logger.info(
-        "Successfully fetched agent card from registry (%s): name=%s, url=%s",
-        lookup_key,
-        card.name,
-        card.url,
-    )
-    return card
+        cards = _parse_registry_response(response.json())
+        logger.info("Fetched %d agent card(s) from registry.", len(cards))
+        return cards
+
+    async def prefetch(
+        self,
+        *,
+        deployment_ids: list[str] | None = None,
+        external_ids: list[str] | None = None,
+    ) -> None:
+        """Batch-fetch and cache agent cards in a minimum number of HTTP calls.
+
+        Issues **separate** requests for ``deployment_ids`` and
+        ``external_ids`` because the API uses AND semantics when both
+        parameters are present in a single request.
+
+        Already-cached IDs are skipped.  This method is concurrency-safe.
+
+        Parameters
+        ----------
+        deployment_ids:
+            Deployment IDs to prefetch.
+        external_ids:
+            External IDs to prefetch.
+        """
+        async with self._lock:
+            missing_dep = [d for d in (deployment_ids or []) if d not in self._cache]
+            missing_ext = [e for e in (external_ids or []) if e not in self._cache]
+
+            if not missing_dep and not missing_ext:
+                logger.debug("All requested agent cards already cached — skipping prefetch.")
+                return
+
+            if missing_dep:
+                cards = await self._fetch({"deploymentIds": ",".join(missing_dep)})
+                self._cache.update(cards)
+
+            if missing_ext:
+                cards = await self._fetch({"externalIds": ",".join(missing_ext)})
+                self._cache.update(cards)
+
+    async def get(
+        self,
+        *,
+        deployment_id: str | None = None,
+        external_id: str | None = None,
+    ) -> AgentCard:
+        """Return a single agent card, using the cache or fetching on demand.
+
+        Exactly one of ``deployment_id`` or ``external_id`` must be provided.
+
+        Raises
+        ------
+        AgentCardRegistryError
+            If the card cannot be found or the request fails.
+        """
+        if bool(deployment_id) == bool(external_id):
+            raise AgentCardRegistryError(
+                "Specify exactly one of 'deployment_id' or 'external_id'."
+            )
+
+        lookup_key: str = deployment_id or external_id  # type: ignore[assignment]
+
+        # Fast path — already cached
+        if lookup_key in self._cache:
+            return self._cache[lookup_key]
+
+        # Slow path — fetch individually (double-check under lock)
+        async with self._lock:
+            if lookup_key in self._cache:
+                return self._cache[lookup_key]
+
+            params: dict[str, str] = (
+                {"deploymentIds": deployment_id}
+                if deployment_id
+                else {"externalIds": external_id}  # type: ignore[dict-item]
+            )
+            cards = await self._fetch(params)
+            self._cache.update(cards)
+
+        if lookup_key not in self._cache:
+            id_label = (
+                f"deployment_id='{deployment_id}'"
+                if deployment_id
+                else f"external_id='{external_id}'"
+            )
+            raise AgentCardRegistryError(
+                f"No agent card found in the central registry for {id_label}. "
+                "Verify that the deployment exists and is registered in your organisation."
+            )
+
+        return self._cache[lookup_key]
 
 
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_default_registry: AgentCardRegistry | None = None
+_registry_lock = asyncio.Lock()
 
 
+async def get_default_registry() -> AgentCardRegistry:
+    """Return the module-level :class:`AgentCardRegistry` singleton.
+
+    Created lazily on first access.  Credentials are resolved from
+    :class:`DataRobotRegistrySettings` at instantiation time.
+    """
+    global _default_registry
+    if _default_registry is None:
+        async with _registry_lock:
+            if _default_registry is None:
+                _default_registry = AgentCardRegistry()
+    return _default_registry
+
+
+def reset_default_registry() -> None:
+    """Reset the module-level singleton (for testing)."""
+    global _default_registry
+    _default_registry = None

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -1,0 +1,175 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client for the central DataRobot agent card registry.
+
+The central registry provides a tenant-scoped list of agent cards that requires
+only standard DataRobot API-token authentication (``DATAROBOT_API_TOKEN``).
+This avoids the chicken-and-egg problem where an individual agent's card
+endpoint is behind per-agent AuthN/AuthZ.
+"""
+
+import logging
+from typing import Any
+
+import httpx
+from a2a.types import AgentCard
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+
+from datarobot_genai.dragent.deployment_urls import build_agent_cards_registry_url
+
+logger = logging.getLogger(__name__)
+
+
+class DataRobotRegistrySettings(DataRobotAppFrameworkBaseSettings):
+    """DataRobot connection settings for the central agent card registry.
+
+    Loads ``DATAROBOT_API_TOKEN`` and ``DATAROBOT_ENDPOINT`` from env vars
+    (including Runtime Parameters), ``.env``, file secrets, or Pulumi config
+    using the standard :class:`DataRobotAppFrameworkBaseSettings` priority
+    chain.
+    """
+
+    datarobot_api_token: str | None = None
+    datarobot_endpoint: str | None = None
+
+
+class AgentCardRegistryError(RuntimeError):
+    """Raised when the central agent card registry lookup fails."""
+
+
+async def fetch_agent_card_from_registry(
+    *,
+    deployment_id: str | None = None,
+    external_id: str | None = None,
+    api_token: str | None = None,
+    endpoint: str | None = None,
+    timeout: float = 30.0,
+) -> AgentCard:
+    """Fetch an :class:`~a2a.types.AgentCard` from the central DataRobot registry.
+
+    Exactly one of ``deployment_id`` or ``external_id`` must be provided.
+
+    Parameters
+    ----------
+    deployment_id:
+        The DataRobot deployment ID to look up.
+    external_id:
+        The external agent identifier to look up.
+    api_token:
+        DataRobot API token.  Falls back to ``DATAROBOT_API_TOKEN`` resolved
+        via :class:`DataRobotRegistrySettings` when *None*.
+    endpoint:
+        DataRobot API endpoint.  Falls back to ``DATAROBOT_ENDPOINT`` resolved
+        via :class:`DataRobotRegistrySettings` when *None*.
+    timeout:
+        HTTP request timeout in seconds.
+
+    Returns
+    -------
+    AgentCard
+        The deserialized agent card from the registry.
+
+    Raises
+    ------
+    AgentCardRegistryError
+        If the lookup fails (missing credentials, HTTP error, or no matching
+        card in the registry).
+    """
+    if not deployment_id and not external_id:
+        raise AgentCardRegistryError(
+            "Either 'deployment_id' or 'external_id' must be provided for registry lookup."
+        )
+    if deployment_id and external_id:
+        raise AgentCardRegistryError(
+            "Specify exactly one of 'deployment_id' or 'external_id', not both."
+        )
+
+    # Resolve credentials via DataRobotAppFrameworkBaseSettings
+    settings = DataRobotRegistrySettings()
+    resolved_token = api_token or settings.datarobot_api_token
+    if not resolved_token:
+        raise AgentCardRegistryError(
+            "DataRobot API token is required for agent card registry lookup. "
+            "Set the DATAROBOT_API_TOKEN environment variable or provide it explicitly."
+        )
+
+    resolved_endpoint = endpoint or settings.datarobot_endpoint
+    if not resolved_endpoint:
+        raise AgentCardRegistryError(
+            "DataRobot API endpoint is required for agent card registry lookup. "
+            "Set the DATAROBOT_ENDPOINT environment variable or provide it explicitly."
+        )
+
+    registry_url = build_agent_cards_registry_url(resolved_endpoint)
+
+    # Build query parameters
+    params: dict[str, str] = {}
+    if deployment_id:
+        params["deploymentIds"] = deployment_id
+    else:
+        params["externalIds"] = external_id  # type: ignore[assignment]
+
+    headers = {"Authorization": f"Bearer {resolved_token}"}
+
+    lookup_key = f"deployment_id={deployment_id}" if deployment_id else f"external_id={external_id}"
+    logger.info("Fetching agent card from central registry (%s): %s", lookup_key, registry_url)
+
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as client:
+            response = await client.get(registry_url, params=params, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise AgentCardRegistryError(
+            f"Agent card registry request failed with HTTP {exc.response.status_code} "
+            f"for {lookup_key}. Verify your API token and that the agent is registered."
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise AgentCardRegistryError(
+            f"Agent card registry request failed for {lookup_key}: {exc}"
+        ) from exc
+
+    body: dict[str, Any] = response.json()
+    data: list[dict[str, Any]] = body.get("data", [])
+
+    if not data:
+        raise AgentCardRegistryError(
+            f"No agent card found in the central registry for {lookup_key}. "
+            "Verify that the deployment exists and is registered in your organisation."
+        )
+
+    agent_card_json = data[0].get("agentCard")
+    if not agent_card_json:
+        raise AgentCardRegistryError(
+            f"Registry entry for {lookup_key} exists but contains no 'agentCard' payload."
+        )
+
+    try:
+        card = AgentCard.model_validate(agent_card_json)
+    except Exception as exc:
+        raise AgentCardRegistryError(
+            f"Failed to parse agent card from registry for {lookup_key}: {exc}"
+        ) from exc
+
+    logger.info(
+        "Successfully fetched agent card from registry (%s): name=%s, url=%s",
+        lookup_key,
+        card.name,
+        card.url,
+    )
+    return card
+
+
+
+

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -40,6 +40,7 @@ import asyncio
 import logging
 import time
 from typing import Any
+from typing import Literal
 
 import httpx
 from a2a.types import AgentCard
@@ -55,6 +56,9 @@ _DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
 
 # Default HTTP timeout for registry requests (in seconds).
 _DEFAULT_TIMEOUT_SECONDS = 30.0
+
+# Allowed strategies for duplicate external IDs.
+DuplicateStrategy = Literal["first", "last", "error"]
 
 
 class DataRobotRegistrySettings(DataRobotAppFrameworkBaseSettings):
@@ -93,7 +97,18 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
     agent_card_registry_timeout: float = Field(
         default=_DEFAULT_TIMEOUT_SECONDS,
         gt=0,
-        description=("HTTP timeout in seconds for registry API requests. Default: 30."),
+        description="HTTP timeout in seconds for registry API requests. Default: 30.",
+    )
+
+    agent_card_registry_on_duplicate: DuplicateStrategy = Field(
+        default="first",
+        description=(
+            "Strategy when the registry returns multiple agent cards for the "
+            "same external ID.  The registry API returns cards sorted by "
+            "creation time (ascending), so 'first' keeps the earliest "
+            "registered card, 'last' keeps the most recently registered card, "
+            "and 'error' raises AgentCardRegistryError.  Default: 'first'."
+        ),
     )
 
 
@@ -122,11 +137,22 @@ def _resolve_settings(
     return resolved_token, resolved_endpoint
 
 
-def _parse_registry_response(body: dict[str, Any]) -> dict[str, AgentCard]:
+def _parse_registry_response(
+    body: dict[str, Any],
+    on_duplicate: DuplicateStrategy = "first",
+) -> dict[str, AgentCard]:
     """Parse a paginated registry response into ``{id: AgentCard}``.
 
-    Each record is indexed by *both* ``deploymentId`` and ``externalId``
-    (when present) so callers can look up by either key type.
+    Each record is indexed by ``deploymentId`` (always unique) and
+    ``externalId`` (may have duplicates).  The ``on_duplicate`` strategy
+    controls what happens when multiple entries share the same external ID.
+
+    The registry API returns entries sorted by ``_id`` ascending (creation
+    time), so the iteration order matches chronological registration order:
+
+    * ``"first"`` — keep the earliest registered card, log a warning.
+    * ``"last"`` — keep the most recently registered card, log a warning.
+    * ``"error"`` — raise :class:`AgentCardRegistryError`.
     """
     cards: dict[str, AgentCard] = {}
     for entry in body.get("data", []):
@@ -147,10 +173,29 @@ def _parse_registry_response(body: dict[str, Any]) -> dict[str, AgentCard]:
             )
             continue
 
+        # Deployment IDs are unique by platform design — always overwrite.
         if dep_id := entry.get("deploymentId"):
             cards[dep_id] = card
+
+        # External IDs may have duplicates — apply the configured strategy.
         if ext_id := entry.get("externalId"):
-            cards[ext_id] = card
+            if ext_id not in cards:
+                cards[ext_id] = card
+            else:
+                logger.warning(
+                    "Duplicate external ID '%s' in registry response (on_duplicate=%s).",
+                    ext_id,
+                    on_duplicate,
+                )
+                if on_duplicate == "error":
+                    raise AgentCardRegistryError(
+                        f"Multiple agent cards found for external_id='{ext_id}'. "
+                        "Set AGENT_CARD_REGISTRY_ON_DUPLICATE='first' or 'last' "
+                        "to pick one, or fix the duplicate registrations."
+                    )
+                if on_duplicate == "last":
+                    cards[ext_id] = card
+                # "first" — keep existing entry (no-op)
     return cards
 
 
@@ -190,6 +235,7 @@ class AgentCardRegistry:
         endpoint: str | None = None,
         timeout: float | None = None,
         cache_ttl: int | None = None,
+        on_duplicate: DuplicateStrategy | None = None,
     ) -> None:
         self._api_token = api_token
         self._endpoint = endpoint
@@ -204,6 +250,9 @@ class AgentCardRegistry:
         self._timeout = timeout if timeout is not None else config.agent_card_registry_timeout
         self._cache_ttl = (
             cache_ttl if cache_ttl is not None else config.agent_card_registry_cache_ttl
+        )
+        self._on_duplicate: DuplicateStrategy = (
+            on_duplicate if on_duplicate is not None else config.agent_card_registry_on_duplicate
         )
 
         logger.debug("AgentCardRegistry created (cache_ttl=%ds)", self._cache_ttl)
@@ -259,7 +308,7 @@ class AgentCardRegistry:
         except httpx.HTTPError as exc:
             raise AgentCardRegistryError(f"Agent card registry request failed: {exc}") from exc
 
-        cards = _parse_registry_response(response.json())
+        cards = _parse_registry_response(response.json(), on_duplicate=self._on_duplicate)
         logger.info("Fetched %d agent card(s) from registry.", len(cards))
         return cards
 

--- a/src/datarobot_genai/dragent/deployment_urls.py
+++ b/src/datarobot_genai/dragent/deployment_urls.py
@@ -106,3 +106,26 @@ def build_deployment_agent_card_url(endpoint: str, deployment_id: str) -> str:
     """
     base = endpoint.rstrip("/")
     return f"{base}/deployments/{deployment_id}/agentCard/"
+
+
+def build_agent_cards_registry_url(endpoint: str) -> str:
+    """Construct the URL for the central agent card registry.
+
+    The central registry lists all agent cards within the user's organisation
+    (tenant context) and requires only API-token authentication, not the
+    per-agent AuthZ that the agent's own card endpoint demands.
+
+    Parameters
+    ----------
+    endpoint:
+        DataRobot API endpoint base URL, e.g. ``https://app.datarobot.com/api/v2``.
+        A trailing slash is stripped before composing the URL.
+
+    Returns
+    -------
+    str
+        A URL of the form ``{endpoint}/agentCards/``.
+    """
+    base = endpoint.rstrip("/")
+    return f"{base}/agentCards/"
+

--- a/src/datarobot_genai/dragent/deployment_urls.py
+++ b/src/datarobot_genai/dragent/deployment_urls.py
@@ -128,4 +128,3 @@ def build_agent_cards_registry_url(endpoint: str) -> str:
     """
     base = endpoint.rstrip("/")
     return f"{base}/agentCards/"
-

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -39,7 +39,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
 
-from datarobot_genai.dragent.agent_card_registry import fetch_agent_card_from_registry
+from datarobot_genai.dragent.agent_card_registry import get_default_registry
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +309,8 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
 
         if config.registry:
             # Fetch the card from the central DataRobot agent card registry
-            pre_resolved_card = await fetch_agent_card_from_registry(
+            registry = await get_default_registry()
+            pre_resolved_card = await registry.get(
                 deployment_id=config.registry.deployment_id,
                 external_id=config.registry.external_id,
             )

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -40,6 +40,7 @@ from pydantic import Field
 from pydantic import model_validator
 
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
+from datarobot_genai.dragent.agent_card_registry import get_default_registry_sync
 
 logger = logging.getLogger(__name__)
 
@@ -252,8 +253,7 @@ class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_clie
 
     registry: AgentCardRegistryLookup | None = Field(
         default=None,
-        description="Central DataRobot agent card registry lookup. "
-        "Mutually exclusive with 'url'.",
+        description="Central DataRobot agent card registry lookup. Mutually exclusive with 'url'.",
     )
 
     @model_validator(mode="after")
@@ -272,6 +272,17 @@ class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_clie
                 "Either 'url' or 'registry' must be provided. "
                 "Use 'url' to fetch the agent card directly from the agent, "
                 "or 'registry' to look it up in the central DataRobot agent card registry."
+            )
+        # Eager registration for batch prefetch (N+1 optimisation).
+        # register() here is sync, no I/O — just queues the ID.
+        # First async get() in __aenter__ flushes all pending IDs
+        # in ≤2 HTTP calls; subsequent gets hit the warm cache.
+        # See AgentCardRegistry docstring for full details.
+        if has_registry:
+            registry = get_default_registry_sync()
+            registry.register(
+                deployment_id=self.registry.deployment_id,  # type: ignore[union-attr]
+                external_id=self.registry.external_id,  # type: ignore[union-attr]
             )
         return self
 

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -35,6 +35,11 @@ from nat.plugins.a2a.auth.credential_service import A2ACredentialService
 from nat.plugins.a2a.client.client_base import A2ABaseClient
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 from nat.plugins.a2a.client.client_impl import A2AClientFunctionGroup
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import model_validator
+
+from datarobot_genai.dragent.agent_card_registry import fetch_agent_card_from_registry
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +144,10 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
             timeout=httpx.Timeout(self._task_timeout.total_seconds()),
         )
 
-        await self._resolve_agent_card()
+        if not self._agent_card:
+            await self._resolve_agent_card()
+        else:
+            logger.info("Using pre-resolved agent card (registry lookup).")
         if not self._agent_card:
             raise RuntimeError("Agent card not resolved")
 
@@ -169,12 +177,103 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
         return self
 
 
+class AgentCardRegistryLookup(BaseModel):
+    """Identifies an agent card in the central DataRobot agent card registry.
+
+    Exactly one of ``deployment_id`` or ``external_id`` must be specified.
+    The registry is queried using standard DataRobot API-token authentication
+    (``DATAROBOT_API_TOKEN``), which avoids the chicken-and-egg problem where the
+    agent's own card endpoint requires per-agent AuthN/AuthZ.
+
+    Example YAML::
+
+        registry:
+          deployment_id: "64a1b2c3d4e5f6a7b8c9d0e1"
+    """
+
+    deployment_id: str | None = Field(
+        default=None,
+        description="DataRobot deployment ID to look up in the central agent card registry.",
+    )
+    external_id: str | None = Field(
+        default=None,
+        description="External agent identifier to look up in the central agent card registry.",
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one_identifier(self) -> "AgentCardRegistryLookup":
+        if self.deployment_id and self.external_id:
+            raise ValueError(
+                "Specify exactly one of 'deployment_id' or 'external_id' inside 'registry', "
+                "not both. Each identifies the agent card differently in the central registry."
+            )
+        if not self.deployment_id and not self.external_id:
+            raise ValueError(
+                "The 'registry' block requires exactly one of 'deployment_id' or 'external_id' "
+                "to identify the agent card in the central registry."
+            )
+        return self
+
+
 class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_client"):  # type: ignore[call-arg]
     """A2A client config with separate discovery and call-phase auth.
 
-    If ``auth_provider`` implements :class:`A2ADiscoveryAuthMixin`, it supplies
-    different credentials for discovery vs RPC calls.
+    Supports two modes for agent card resolution:
+
+    **Direct fetch** (existing behaviour) — set ``url`` to the agent's base URL
+    and the card is fetched from ``{url}/.well-known/agent-card.json``::
+
+        function_groups:
+          my_agent:
+            _type: authenticated_a2a_client
+            url: "http://agent.example.com:8080"
+            auth_provider: my_auth
+
+    **Central registry lookup** — set ``registry`` with either ``deployment_id``
+    or ``external_id``.  The card is fetched from the DataRobot central agent card
+    registry using ``DATAROBOT_API_TOKEN``, and the agent's RPC URL is derived
+    from the card's advertised ``url``::
+
+        function_groups:
+          my_agent:
+            _type: authenticated_a2a_client
+            registry:
+              deployment_id: "64a1b2c3d4e5f6a7b8c9d0e1"
+            auth_provider: okta_auth
+
+    The two modes are mutually exclusive.
     """
+
+    url: Any = Field(  # type: ignore[assignment]
+        default=None,
+        description="Base URL of the A2A agent for direct agent card fetch. "
+        "Mutually exclusive with 'registry'.",
+    )
+
+    registry: AgentCardRegistryLookup | None = Field(
+        default=None,
+        description="Central DataRobot agent card registry lookup. "
+        "Mutually exclusive with 'url'.",
+    )
+
+    @model_validator(mode="after")
+    def _url_xor_registry(self) -> "AuthenticatedA2AClientConfig":
+        has_url = self.url is not None
+        has_registry = self.registry is not None
+        if has_url and has_registry:
+            raise ValueError(
+                "Provide either 'url' for direct agent card fetch or 'registry' for "
+                "central registry lookup, not both. "
+                "When 'registry' is set, the agent's RPC URL is derived from the "
+                "agent card's advertised URL."
+            )
+        if not has_url and not has_registry:
+            raise ValueError(
+                "Either 'url' or 'registry' must be provided. "
+                "Use 'url' to fetch the agent card directly from the agent, "
+                "or 'registry' to look it up in the central DataRobot agent card registry."
+            )
+        return self
 
 
 class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
@@ -203,7 +302,28 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
                 )
                 raise RuntimeError(f"Failed to resolve auth provider: {e}") from e
 
-        base_url = str(config.url)
+        # -------------------------------------------------------------------
+        # Resolve agent card: registry lookup vs. direct fetch
+        # -------------------------------------------------------------------
+        pre_resolved_card: AgentCard | None = None
+
+        if config.registry:
+            # Fetch the card from the central DataRobot agent card registry
+            pre_resolved_card = await fetch_agent_card_from_registry(
+                deployment_id=config.registry.deployment_id,
+                external_id=config.registry.external_id,
+            )
+            base_url = str(pre_resolved_card.url)
+            logger.info(
+                "Agent card resolved via central registry (deployment_id=%s, external_id=%s), "
+                "RPC base URL derived from card: %s",
+                config.registry.deployment_id,
+                config.registry.external_id,
+                base_url,
+            )
+        else:
+            base_url = str(config.url)
+
         self._client = _AuthenticatedA2ABaseClient(
             base_url=base_url,
             agent_card_path=config.agent_card_path,
@@ -211,13 +331,19 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
             streaming=config.streaming,
             auth_provider=auth_provider,
         )
+
+        # Inject pre-resolved card so _AuthenticatedA2ABaseClient skips discovery
+        if pre_resolved_card:
+            self._client._agent_card = pre_resolved_card
+
         await self._client.__aenter__()
 
         logger.info(
-            "Connected to A2A agent at %s (auth_provider: %s, user_id: %s)",
+            "Connected to A2A agent at %s (auth_provider: %s, user_id: %s, registry: %s)",
             base_url,
             config.auth_provider or "none",
             user_id,
+            bool(config.registry),
         )
 
         self._register_functions()

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -371,12 +371,14 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
         mock_card = MagicMock()
         mock_card.url = "https://agent.example.com/a2a/"
 
-        with patch(f"{_MODULE}.fetch_agent_card_from_registry", new_callable=AsyncMock) as mock_fetch:
-            mock_fetch.return_value = mock_card
+        mock_registry = AsyncMock()
+        mock_registry.get = AsyncMock(return_value=mock_card)
+
+        with patch(f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry):
             fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
             await fg.__aenter__()
 
-            mock_fetch.assert_awaited_once_with(
+            mock_registry.get.assert_awaited_once_with(
                 deployment_id="dep-001",
                 external_id=None,
             )
@@ -389,14 +391,16 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
         mock_card = MagicMock()
         mock_card.url = "https://agent.example.com/a2a/"
 
-        with patch(f"{_MODULE}.fetch_agent_card_from_registry", new_callable=AsyncMock) as mock_fetch:
-            mock_fetch.return_value = mock_card
+        mock_registry = AsyncMock()
+        mock_registry.get = AsyncMock(return_value=mock_card)
+
+        with patch(f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry):
             fg = AuthenticatedA2AClientFunctionGroup(
                 config=registry_config_external, builder=mock_builder
             )
             await fg.__aenter__()
 
-            mock_fetch.assert_awaited_once_with(
+            mock_registry.get.assert_awaited_once_with(
                 deployment_id=None,
                 external_id="ext-001",
             )
@@ -412,14 +416,16 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
         mock_card.url = "https://agent.example.com/a2a/"
         mock_card.security_schemes = None
 
+        mock_registry = AsyncMock()
+        mock_registry.get = AsyncMock(return_value=mock_card)
+
         with (
-            patch(f"{_MODULE}.fetch_agent_card_from_registry", new_callable=AsyncMock) as mock_fetch,
+            patch(f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry),
             patch(f"{_MODULE}.Context") as mock_ctx,
             patch(f"{_MODULE}.httpx") as mock_httpx,
             patch(f"{_MODULE}.ClientFactory") as mock_factory,
             patch.object(AuthenticatedA2AClientFunctionGroup, "_register_functions"),
         ):
-            mock_fetch.return_value = mock_card
             mock_ctx.get.return_value.user_id = "test-user"
             mock_httpx.AsyncClient.return_value = MagicMock(aclose=AsyncMock())
             mock_httpx.Timeout = MagicMock()

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -24,6 +24,7 @@ from nat.data_models.authentication import HeaderCred
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 
 from datarobot_genai.dragent.plugins.auth_a2a_client import A2ADiscoveryAuthMixin
+from datarobot_genai.dragent.plugins.auth_a2a_client import AgentCardRegistryLookup
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientConfig
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientFunctionGroup
 from datarobot_genai.dragent.plugins.auth_a2a_client import _AuthenticatedA2ABaseClient
@@ -156,6 +157,26 @@ class TestA2ADiscoveryAuthMixin:
 # ---------------------------------------------------------------------------
 
 
+class TestAgentCardRegistryLookup:
+    def test_deployment_id_only(self):
+        lookup = AgentCardRegistryLookup(deployment_id="dep-123")
+        assert lookup.deployment_id == "dep-123"
+        assert lookup.external_id is None
+
+    def test_external_id_only(self):
+        lookup = AgentCardRegistryLookup(external_id="ext-456")
+        assert lookup.external_id == "ext-456"
+        assert lookup.deployment_id is None
+
+    def test_both_ids_raises(self):
+        with pytest.raises(ValueError, match="not both"):
+            AgentCardRegistryLookup(deployment_id="dep-1", external_id="ext-1")
+
+    def test_neither_id_raises(self):
+        with pytest.raises(ValueError, match="requires exactly one"):
+            AgentCardRegistryLookup()
+
+
 class TestAuthenticatedA2AClientConfig:
     def test_is_a2a_client_config(self, a2a_config):
         assert isinstance(a2a_config, A2AClientConfig)
@@ -163,6 +184,32 @@ class TestAuthenticatedA2AClientConfig:
     def test_url_only_is_valid(self):
         cfg = AuthenticatedA2AClientConfig(url=_AGENT_URL)
         assert str(cfg.url).rstrip("/") == _AGENT_URL
+
+    def test_registry_only_is_valid(self):
+        cfg = AuthenticatedA2AClientConfig(
+            registry=AgentCardRegistryLookup(deployment_id="dep-123")
+        )
+        assert cfg.registry is not None
+        assert cfg.registry.deployment_id == "dep-123"
+        assert cfg.url is None
+
+    def test_registry_with_external_id(self):
+        cfg = AuthenticatedA2AClientConfig(
+            registry=AgentCardRegistryLookup(external_id="ext-456")
+        )
+        assert cfg.registry is not None
+        assert cfg.registry.external_id == "ext-456"
+
+    def test_url_and_registry_raises(self):
+        with pytest.raises(ValueError, match="not both"):
+            AuthenticatedA2AClientConfig(
+                url=_AGENT_URL,
+                registry=AgentCardRegistryLookup(deployment_id="dep-1"),
+            )
+
+    def test_neither_url_nor_registry_raises(self):
+        with pytest.raises(ValueError, match="Either 'url' or 'registry'"):
+            AuthenticatedA2AClientConfig()
 
 
 # ---------------------------------------------------------------------------
@@ -294,3 +341,93 @@ class TestAuthenticatedA2AClientFunctionGroup:
             fg = AuthenticatedA2AClientFunctionGroup(config=a2a_config, builder=mock_builder)
             with pytest.raises(RuntimeError, match="User ID not found in context"):
                 await fg.__aenter__()
+
+
+# ---------------------------------------------------------------------------
+# Tests: AuthenticatedA2AClientFunctionGroup — registry path
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticatedA2AClientFunctionGroupRegistry:
+    @pytest.fixture
+    def registry_config(self):
+        return AuthenticatedA2AClientConfig(
+            registry=AgentCardRegistryLookup(deployment_id="dep-001"),
+            auth_provider="my_auth",
+        )
+
+    @pytest.fixture
+    def registry_config_external(self):
+        return AuthenticatedA2AClientConfig(
+            registry=AgentCardRegistryLookup(external_id="ext-001"),
+        )
+
+    async def test_registry_fetches_card_and_derives_base_url(
+        self, registry_config, mock_builder, patched_fg_env
+    ):
+        mock_auth_provider = MagicMock()
+        mock_builder.get_auth_provider.return_value = mock_auth_provider
+
+        mock_card = MagicMock()
+        mock_card.url = "https://agent.example.com/a2a/"
+
+        with patch(f"{_MODULE}.fetch_agent_card_from_registry", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_card
+            fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
+            await fg.__aenter__()
+
+            mock_fetch.assert_awaited_once_with(
+                deployment_id="dep-001",
+                external_id=None,
+            )
+            # Verify base_url derived from card.url
+            assert patched_fg_env.call_args.kwargs["base_url"] == "https://agent.example.com/a2a/"
+
+    async def test_registry_external_id_path(
+        self, registry_config_external, mock_builder, patched_fg_env
+    ):
+        mock_card = MagicMock()
+        mock_card.url = "https://agent.example.com/a2a/"
+
+        with patch(f"{_MODULE}.fetch_agent_card_from_registry", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_card
+            fg = AuthenticatedA2AClientFunctionGroup(
+                config=registry_config_external, builder=mock_builder
+            )
+            await fg.__aenter__()
+
+            mock_fetch.assert_awaited_once_with(
+                deployment_id=None,
+                external_id="ext-001",
+            )
+
+    async def test_registry_pre_resolved_card_skips_discovery(
+        self, registry_config, mock_builder
+    ):
+        """When registry provides a card, _AuthenticatedA2ABaseClient skips _resolve_agent_card."""
+        mock_auth_provider = MagicMock()
+        mock_builder.get_auth_provider.return_value = mock_auth_provider
+
+        mock_card = MagicMock()
+        mock_card.url = "https://agent.example.com/a2a/"
+        mock_card.security_schemes = None
+
+        with (
+            patch(f"{_MODULE}.fetch_agent_card_from_registry", new_callable=AsyncMock) as mock_fetch,
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch(f"{_MODULE}.httpx") as mock_httpx,
+            patch(f"{_MODULE}.ClientFactory") as mock_factory,
+            patch.object(AuthenticatedA2AClientFunctionGroup, "_register_functions"),
+        ):
+            mock_fetch.return_value = mock_card
+            mock_ctx.get.return_value.user_id = "test-user"
+            mock_httpx.AsyncClient.return_value = MagicMock(aclose=AsyncMock())
+            mock_httpx.Timeout = MagicMock()
+            mock_factory.return_value.create.return_value = MagicMock(aclose=AsyncMock())
+
+            fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
+            await fg.__aenter__()
+
+            # The client should have the pre-resolved card, not call _resolve_agent_card
+            assert fg._client._agent_card is mock_card
+

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -23,6 +23,7 @@ from nat.data_models.authentication import BearerTokenCred
 from nat.data_models.authentication import HeaderCred
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 
+from datarobot_genai.dragent.agent_card_registry import reset_default_registry
 from datarobot_genai.dragent.plugins.auth_a2a_client import A2ADiscoveryAuthMixin
 from datarobot_genai.dragent.plugins.auth_a2a_client import AgentCardRegistryLookup
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientConfig
@@ -119,6 +120,14 @@ def patched_fg_env():
         yield mock_cls
 
 
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Reset the agent card registry singleton between tests."""
+    reset_default_registry()
+    yield
+    reset_default_registry()
+
+
 # ---------------------------------------------------------------------------
 # Tests: _extract_auth_headers
 # ---------------------------------------------------------------------------
@@ -194,9 +203,7 @@ class TestAuthenticatedA2AClientConfig:
         assert cfg.url is None
 
     def test_registry_with_external_id(self):
-        cfg = AuthenticatedA2AClientConfig(
-            registry=AgentCardRegistryLookup(external_id="ext-456")
-        )
+        cfg = AuthenticatedA2AClientConfig(registry=AgentCardRegistryLookup(external_id="ext-456"))
         assert cfg.registry is not None
         assert cfg.registry.external_id == "ext-456"
 
@@ -374,7 +381,9 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
         mock_registry = AsyncMock()
         mock_registry.get = AsyncMock(return_value=mock_card)
 
-        with patch(f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry):
+        with patch(
+            f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry
+        ):
             fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
             await fg.__aenter__()
 
@@ -394,7 +403,9 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
         mock_registry = AsyncMock()
         mock_registry.get = AsyncMock(return_value=mock_card)
 
-        with patch(f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry):
+        with patch(
+            f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry
+        ):
             fg = AuthenticatedA2AClientFunctionGroup(
                 config=registry_config_external, builder=mock_builder
             )
@@ -405,9 +416,7 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
                 external_id="ext-001",
             )
 
-    async def test_registry_pre_resolved_card_skips_discovery(
-        self, registry_config, mock_builder
-    ):
+    async def test_registry_pre_resolved_card_skips_discovery(self, registry_config, mock_builder):
         """When registry provides a card, _AuthenticatedA2ABaseClient skips _resolve_agent_card."""
         mock_auth_provider = MagicMock()
         mock_builder.get_auth_provider.return_value = mock_auth_provider
@@ -420,7 +429,11 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
         mock_registry.get = AsyncMock(return_value=mock_card)
 
         with (
-            patch(f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry),
+            patch(
+                f"{_MODULE}.get_default_registry",
+                new_callable=AsyncMock,
+                return_value=mock_registry,
+            ),
             patch(f"{_MODULE}.Context") as mock_ctx,
             patch(f"{_MODULE}.httpx") as mock_httpx,
             patch(f"{_MODULE}.ClientFactory") as mock_factory,
@@ -436,4 +449,3 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
 
             # The client should have the pre-resolved card, not call _resolve_agent_card
             assert fg._client._agent_card is mock_card
-

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -20,11 +20,14 @@ import httpx
 import pytest
 
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import DataRobotRegistrySettings
+from datarobot_genai.dragent.agent_card_registry import _CacheEntry
 from datarobot_genai.dragent.agent_card_registry import _parse_registry_response
 from datarobot_genai.dragent.agent_card_registry import _resolve_settings
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
+from datarobot_genai.dragent.agent_card_registry import get_default_registry_sync
 from datarobot_genai.dragent.agent_card_registry import reset_default_registry
 
 _MODULE = "datarobot_genai.dragent.agent_card_registry"
@@ -64,6 +67,46 @@ def _entry(dep_id=None, ext_id=None, card=_SAMPLE_AGENT_CARD):
         "externalId": ext_id,
         "agentCard": card,
     }
+
+
+# ---------------------------------------------------------------------------
+# Tests: AgentCardRegistryConfig
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRegistryConfig:
+    def test_default_ttl(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_cache_ttl == 24 * 3600
+
+    def test_ttl_zero_allowed(self):
+        config = AgentCardRegistryConfig(agent_card_registry_cache_ttl=0)
+        assert config.agent_card_registry_cache_ttl == 0
+
+    def test_ttl_from_env(self):
+        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_CACHE_TTL": "120"}):
+            config = AgentCardRegistryConfig()
+            assert config.agent_card_registry_cache_ttl == 120
+
+
+# ---------------------------------------------------------------------------
+# Tests: _CacheEntry
+# ---------------------------------------------------------------------------
+
+
+class TestCacheEntry:
+    def test_not_expired_within_ttl(self):
+        entry = _CacheEntry(MagicMock())
+        assert not entry.is_expired(3600)
+
+    def test_expired_with_zero_ttl(self):
+        entry = _CacheEntry(MagicMock())
+        assert entry.is_expired(0)
+
+    def test_expired_after_ttl(self):
+        entry = _CacheEntry(MagicMock())
+        entry.fetched_at -= 100  # Simulate 100s ago
+        assert entry.is_expired(50)
 
 
 # ---------------------------------------------------------------------------
@@ -113,13 +156,12 @@ class TestParseRegistryResponse:
 
     def test_skips_entries_with_invalid_card(self):
         body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": {"bad": True}})
-        # Should not raise; just skips
         cards = _parse_registry_response(body)
         assert cards == {}
 
 
 # ---------------------------------------------------------------------------
-# Tests: AgentCardRegistry
+# Tests: AgentCardRegistry — core get/cache
 # ---------------------------------------------------------------------------
 
 
@@ -132,74 +174,157 @@ class TestAgentCardRegistry:
 
     async def test_get_single_deployment_id(self, mock_fetch):
         mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         card = await registry.get(deployment_id="dep-1")
         assert card is mock_fetch.return_value["dep-1"]
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1"})
 
     async def test_get_single_external_id(self, mock_fetch):
         mock_fetch.return_value = {"ext-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         card = await registry.get(external_id="ext-1")
         assert card is mock_fetch.return_value["ext-1"]
         mock_fetch.assert_awaited_once_with({"externalIds": "ext-1"})
 
     async def test_get_raises_when_both_ids(self):
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         with pytest.raises(AgentCardRegistryError, match="exactly one"):
             await registry.get(deployment_id="d", external_id="e")
 
     async def test_get_raises_when_neither_id(self):
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         with pytest.raises(AgentCardRegistryError, match="exactly one"):
             await registry.get()
 
     async def test_get_raises_when_not_found(self, mock_fetch):
-        mock_fetch.return_value = {}  # Empty result
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        mock_fetch.return_value = {}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         with pytest.raises(AgentCardRegistryError, match="No agent card found"):
             await registry.get(deployment_id="missing")
 
     async def test_get_uses_cache(self, mock_fetch):
         mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
 
         card1 = await registry.get(deployment_id="dep-1")
         card2 = await registry.get(deployment_id="dep-1")
 
         assert card1 is card2
-        # Only one HTTP call — second get() used cache
         mock_fetch.assert_awaited_once()
+
+    async def test_cache_ttl_zero_always_refetches(self, mock_fetch):
+        """cache_ttl=0 means every get() triggers a fresh fetch."""
+        card_mock = MagicMock(name="card1")
+        mock_fetch.return_value = {"dep-1": card_mock}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=0)
+
+        await registry.get(deployment_id="dep-1")
+        await registry.get(deployment_id="dep-1")
+
+        assert mock_fetch.await_count == 2
+
+    async def test_expired_cache_triggers_refetch(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
+
+        await registry.get(deployment_id="dep-1")
+        # Simulate expiry
+        registry._cache["dep-1"].fetched_at -= 120
+
+        mock_fetch.return_value = {"dep-1": MagicMock(name="card1-refreshed")}
+        await registry.get(deployment_id="dep-1")
+        assert mock_fetch.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: AgentCardRegistry — register + batch flush
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRegistryRegisterFlush:
+    @pytest.fixture
+    def mock_fetch(self):
+        with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
+            yield m
+
+    async def test_register_then_get_flushes_batch(self, mock_fetch):
+        """Registered IDs are batch-fetched on first get()."""
+        mock_fetch.side_effect = [
+            {"dep-1": MagicMock(name="c1"), "dep-2": MagicMock(name="c2")},
+            {"ext-1": MagicMock(name="c3")},
+        ]
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry.register(deployment_id="dep-1")
+        registry.register(deployment_id="dep-2")
+        registry.register(external_id="ext-1")
+
+        # First get triggers batch flush
+        await registry.get(deployment_id="dep-1")
+
+        assert mock_fetch.await_count == 2
+        calls = mock_fetch.call_args_list
+        assert calls[0].args[0] == {"deploymentIds": "dep-1,dep-2"} or calls[0].args[0] == {
+            "deploymentIds": "dep-2,dep-1"
+        }
+        assert calls[1].args[0] == {"externalIds": "ext-1"}
+
+        # Subsequent gets are cache hits
+        mock_fetch.reset_mock()
+        await registry.get(deployment_id="dep-2")
+        await registry.get(external_id="ext-1")
+        mock_fetch.assert_not_awaited()
+
+    async def test_register_deduplicates(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="c1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry.register(deployment_id="dep-1")
+        registry.register(deployment_id="dep-1")
+        registry.register(deployment_id="dep-1")
+
+        await registry.get(deployment_id="dep-1")
+        mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1"})
+
+    async def test_pending_cleared_after_flush(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="c1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry.register(deployment_id="dep-1")
+
+        await registry.get(deployment_id="dep-1")
+        assert len(registry._pending_deployment_ids) == 0
+        assert len(registry._pending_external_ids) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: AgentCardRegistry — prefetch
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRegistryPrefetch:
+    @pytest.fixture
+    def mock_fetch(self):
+        with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
+            yield m
 
     async def test_prefetch_deployment_ids(self, mock_fetch):
         mock_fetch.return_value = {
             "dep-1": MagicMock(name="card1"),
             "dep-2": MagicMock(name="card2"),
         }
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         await registry.prefetch(deployment_ids=["dep-1", "dep-2"])
 
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1,dep-2"})
-        # Subsequent gets should not trigger fetch
         mock_fetch.reset_mock()
         await registry.get(deployment_id="dep-1")
         await registry.get(deployment_id="dep-2")
         mock_fetch.assert_not_awaited()
 
-    async def test_prefetch_external_ids(self, mock_fetch):
-        mock_fetch.return_value = {"ext-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
-        await registry.prefetch(external_ids=["ext-1"])
-
-        mock_fetch.assert_awaited_once_with({"externalIds": "ext-1"})
-
     async def test_prefetch_mixed_issues_separate_calls(self, mock_fetch):
-        """deployment_ids and external_ids must be separate HTTP calls."""
         mock_fetch.side_effect = [
             {"dep-1": MagicMock(name="card1")},
             {"ext-1": MagicMock(name="card2")},
         ]
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         await registry.prefetch(deployment_ids=["dep-1"], external_ids=["ext-1"])
 
         assert mock_fetch.await_count == 2
@@ -209,12 +334,11 @@ class TestAgentCardRegistry:
 
     async def test_prefetch_skips_already_cached(self, mock_fetch):
         mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
 
         await registry.prefetch(deployment_ids=["dep-1"])
         mock_fetch.reset_mock()
 
-        # dep-1 already cached, only dep-2 should be fetched
         mock_fetch.return_value = {"dep-2": MagicMock(name="card2")}
         await registry.prefetch(deployment_ids=["dep-1", "dep-2"])
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-2"})
@@ -231,7 +355,8 @@ class TestAgentCardRegistryFetch:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = _registry_response(
-            _entry(dep_id="dep-1"), _entry(dep_id="dep-2", card=_SAMPLE_AGENT_CARD_2),
+            _entry(dep_id="dep-1"),
+            _entry(dep_id="dep-2", card=_SAMPLE_AGENT_CARD_2),
         )
         mock_response.raise_for_status = MagicMock()
 
@@ -243,7 +368,9 @@ class TestAgentCardRegistryFetch:
 
     async def test_fetch_passes_params_and_auth(self, mock_httpx_client):
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client):
-            registry = AgentCardRegistry(api_token="my-tok", endpoint="https://app.dr.com/api/v2")
+            registry = AgentCardRegistry(
+                api_token="my-tok", endpoint="https://app.dr.com/api/v2", cache_ttl=3600
+            )
             cards = await registry._fetch({"deploymentIds": "dep-1,dep-2"})
 
         assert "dep-1" in cards
@@ -265,13 +392,13 @@ class TestAgentCardRegistryFetch:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
             with pytest.raises(AgentCardRegistryError, match="HTTP 403"):
                 await registry._fetch({"deploymentIds": "dep-1"})
 
 
 # ---------------------------------------------------------------------------
-# Tests: get_default_registry singleton
+# Tests: get_default_registry / get_default_registry_sync singleton
 # ---------------------------------------------------------------------------
 
 
@@ -292,3 +419,13 @@ class TestGetDefaultRegistry:
         reset_default_registry()
         r2 = await get_default_registry()
         assert r1 is not r2
+
+    def test_sync_returns_singleton(self):
+        r1 = get_default_registry_sync()
+        r2 = get_default_registry_sync()
+        assert r1 is r2
+
+    async def test_sync_and_async_share_singleton(self):
+        r1 = get_default_registry_sync()
+        r2 = await get_default_registry()
+        assert r1 is r2

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -20,9 +19,13 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import DataRobotRegistrySettings
-from datarobot_genai.dragent.agent_card_registry import fetch_agent_card_from_registry
+from datarobot_genai.dragent.agent_card_registry import _parse_registry_response
+from datarobot_genai.dragent.agent_card_registry import _resolve_settings
+from datarobot_genai.dragent.agent_card_registry import get_default_registry
+from datarobot_genai.dragent.agent_card_registry import reset_default_registry
 
 _MODULE = "datarobot_genai.dragent.agent_card_registry"
 
@@ -37,146 +40,219 @@ _SAMPLE_AGENT_CARD = {
     "capabilities": {"streaming": False},
 }
 
-_REGISTRY_RESPONSE = {
-    "data": [
-        {
-            "id": "abc123",
-            "deploymentId": "dep-001",
-            "externalId": "ext-001",
-            "createdAt": "2026-01-01T00:00:00Z",
-            "updatedAt": "2026-01-01T00:00:00Z",
-            "agentCard": _SAMPLE_AGENT_CARD,
-        }
-    ],
-    "count": 1,
-    "totalCount": 1,
-    "next": None,
-    "previous": None,
+_SAMPLE_AGENT_CARD_2 = {
+    "name": "Second Agent",
+    "description": "Another agent",
+    "url": "https://agent2.example.com/a2a/",
+    "version": "2.0.0",
+    "skills": [],
+    "defaultInputModes": ["text"],
+    "defaultOutputModes": ["text"],
+    "capabilities": {"streaming": True},
 }
 
 
+def _registry_response(*entries):
+    """Build a registry response envelope from entry dicts."""
+    return {"data": list(entries), "count": len(entries), "totalCount": len(entries)}
+
+
+def _entry(dep_id=None, ext_id=None, card=_SAMPLE_AGENT_CARD):
+    return {
+        "id": f"doc-{dep_id or ext_id}",
+        "deploymentId": dep_id,
+        "externalId": ext_id,
+        "agentCard": card,
+    }
+
+
 # ---------------------------------------------------------------------------
-# Parameter validation
+# Tests: _resolve_settings
 # ---------------------------------------------------------------------------
 
 
-class TestFetchAgentCardValidation:
-    async def test_raises_when_neither_id_provided(self):
-        with pytest.raises(AgentCardRegistryError, match="Either 'deployment_id' or 'external_id'"):
-            await fetch_agent_card_from_registry()
+class TestResolveSettings:
+    def test_explicit_values_used(self):
+        token, endpoint = _resolve_settings(api_token="tok", endpoint="https://ep")
+        assert token == "tok"
+        assert endpoint == "https://ep"
 
-    async def test_raises_when_both_ids_provided(self):
-        with pytest.raises(AgentCardRegistryError, match="not both"):
-            await fetch_agent_card_from_registry(
-                deployment_id="dep-1", external_id="ext-1"
-            )
-
-    async def test_raises_when_no_api_token(self):
+    def test_raises_when_no_token(self):
         mock_settings = MagicMock(spec=DataRobotRegistrySettings)
         mock_settings.datarobot_api_token = None
         mock_settings.datarobot_endpoint = None
         with patch(f"{_MODULE}.DataRobotRegistrySettings", return_value=mock_settings):
             with pytest.raises(AgentCardRegistryError, match="API token is required"):
-                await fetch_agent_card_from_registry(deployment_id="dep-1")
+                _resolve_settings()
 
-    async def test_raises_when_no_endpoint(self):
+    def test_raises_when_no_endpoint(self):
         mock_settings = MagicMock(spec=DataRobotRegistrySettings)
-        mock_settings.datarobot_api_token = "some-token"
+        mock_settings.datarobot_api_token = "tok"
         mock_settings.datarobot_endpoint = None
         with patch(f"{_MODULE}.DataRobotRegistrySettings", return_value=mock_settings):
             with pytest.raises(AgentCardRegistryError, match="API endpoint is required"):
-                await fetch_agent_card_from_registry(deployment_id="dep-1")
+                _resolve_settings()
 
 
 # ---------------------------------------------------------------------------
-# Successful lookups
+# Tests: _parse_registry_response
 # ---------------------------------------------------------------------------
 
 
-class TestFetchAgentCardSuccess:
+class TestParseRegistryResponse:
+    def test_indexes_by_both_ids(self):
+        body = _registry_response(_entry(dep_id="dep-1", ext_id="ext-1"))
+        cards = _parse_registry_response(body)
+        assert "dep-1" in cards
+        assert "ext-1" in cards
+        assert cards["dep-1"] is cards["ext-1"]
+
+    def test_skips_entries_without_agent_card(self):
+        body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": None})
+        assert _parse_registry_response(body) == {}
+
+    def test_skips_entries_with_invalid_card(self):
+        body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": {"bad": True}})
+        # Should not raise; just skips
+        cards = _parse_registry_response(body)
+        assert cards == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: AgentCardRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRegistry:
+    @pytest.fixture
+    def mock_fetch(self):
+        """Patch _fetch to avoid HTTP calls."""
+        with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
+            yield m
+
+    async def test_get_single_deployment_id(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        card = await registry.get(deployment_id="dep-1")
+        assert card is mock_fetch.return_value["dep-1"]
+        mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1"})
+
+    async def test_get_single_external_id(self, mock_fetch):
+        mock_fetch.return_value = {"ext-1": MagicMock(name="card1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        card = await registry.get(external_id="ext-1")
+        assert card is mock_fetch.return_value["ext-1"]
+        mock_fetch.assert_awaited_once_with({"externalIds": "ext-1"})
+
+    async def test_get_raises_when_both_ids(self):
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        with pytest.raises(AgentCardRegistryError, match="exactly one"):
+            await registry.get(deployment_id="d", external_id="e")
+
+    async def test_get_raises_when_neither_id(self):
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        with pytest.raises(AgentCardRegistryError, match="exactly one"):
+            await registry.get()
+
+    async def test_get_raises_when_not_found(self, mock_fetch):
+        mock_fetch.return_value = {}  # Empty result
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        with pytest.raises(AgentCardRegistryError, match="No agent card found"):
+            await registry.get(deployment_id="missing")
+
+    async def test_get_uses_cache(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+
+        card1 = await registry.get(deployment_id="dep-1")
+        card2 = await registry.get(deployment_id="dep-1")
+
+        assert card1 is card2
+        # Only one HTTP call — second get() used cache
+        mock_fetch.assert_awaited_once()
+
+    async def test_prefetch_deployment_ids(self, mock_fetch):
+        mock_fetch.return_value = {
+            "dep-1": MagicMock(name="card1"),
+            "dep-2": MagicMock(name="card2"),
+        }
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        await registry.prefetch(deployment_ids=["dep-1", "dep-2"])
+
+        mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1,dep-2"})
+        # Subsequent gets should not trigger fetch
+        mock_fetch.reset_mock()
+        await registry.get(deployment_id="dep-1")
+        await registry.get(deployment_id="dep-2")
+        mock_fetch.assert_not_awaited()
+
+    async def test_prefetch_external_ids(self, mock_fetch):
+        mock_fetch.return_value = {"ext-1": MagicMock(name="card1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        await registry.prefetch(external_ids=["ext-1"])
+
+        mock_fetch.assert_awaited_once_with({"externalIds": "ext-1"})
+
+    async def test_prefetch_mixed_issues_separate_calls(self, mock_fetch):
+        """deployment_ids and external_ids must be separate HTTP calls."""
+        mock_fetch.side_effect = [
+            {"dep-1": MagicMock(name="card1")},
+            {"ext-1": MagicMock(name="card2")},
+        ]
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+        await registry.prefetch(deployment_ids=["dep-1"], external_ids=["ext-1"])
+
+        assert mock_fetch.await_count == 2
+        calls = mock_fetch.call_args_list
+        assert calls[0].args[0] == {"deploymentIds": "dep-1"}
+        assert calls[1].args[0] == {"externalIds": "ext-1"}
+
+    async def test_prefetch_skips_already_cached(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
+
+        await registry.prefetch(deployment_ids=["dep-1"])
+        mock_fetch.reset_mock()
+
+        # dep-1 already cached, only dep-2 should be fetched
+        mock_fetch.return_value = {"dep-2": MagicMock(name="card2")}
+        await registry.prefetch(deployment_ids=["dep-1", "dep-2"])
+        mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-2"})
+
+
+# ---------------------------------------------------------------------------
+# Tests: AgentCardRegistry._fetch (HTTP integration)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRegistryFetch:
     @pytest.fixture
     def mock_httpx_client(self):
-        """Provide a mock httpx.AsyncClient that returns a valid registry response."""
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.json.return_value = _REGISTRY_RESPONSE
+        mock_response.json.return_value = _registry_response(
+            _entry(dep_id="dep-1"), _entry(dep_id="dep-2", card=_SAMPLE_AGENT_CARD_2),
+        )
         mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=mock_response)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
-
         return mock_client
 
-    async def test_lookup_by_deployment_id(self, mock_httpx_client):
+    async def test_fetch_passes_params_and_auth(self, mock_httpx_client):
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client):
-            card = await fetch_agent_card_from_registry(
-                deployment_id="dep-001",
-                api_token="test-token",
-                endpoint="https://app.datarobot.com/api/v2",
-            )
+            registry = AgentCardRegistry(api_token="my-tok", endpoint="https://app.dr.com/api/v2")
+            cards = await registry._fetch({"deploymentIds": "dep-1,dep-2"})
 
-        assert card.name == "Test Agent"
-        assert str(card.url) == "https://agent.example.com/a2a/"
+        assert "dep-1" in cards
+        assert "dep-2" in cards
+        call_kwargs = mock_httpx_client.get.call_args.kwargs
+        assert call_kwargs["params"] == {"deploymentIds": "dep-1,dep-2"}
+        assert call_kwargs["headers"]["Authorization"] == "Bearer my-tok"
 
-        call_kwargs = mock_httpx_client.get.call_args
-        assert call_kwargs.kwargs["params"]["deploymentIds"] == "dep-001"
-        assert "Bearer test-token" in call_kwargs.kwargs["headers"]["Authorization"]
-
-    async def test_lookup_by_external_id(self, mock_httpx_client):
-        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client):
-            card = await fetch_agent_card_from_registry(
-                external_id="ext-001",
-                api_token="test-token",
-                endpoint="https://app.datarobot.com/api/v2",
-            )
-
-        assert card.name == "Test Agent"
-        call_kwargs = mock_httpx_client.get.call_args
-        assert call_kwargs.kwargs["params"]["externalIds"] == "ext-001"
-
-    async def test_uses_settings_when_not_explicit(self, mock_httpx_client):
-        mock_settings = MagicMock(spec=DataRobotRegistrySettings)
-        mock_settings.datarobot_api_token = "settings-token"
-        mock_settings.datarobot_endpoint = "https://settings.datarobot.com/api/v2"
-        with (
-            patch(f"{_MODULE}.DataRobotRegistrySettings", return_value=mock_settings),
-            patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client),
-        ):
-            card = await fetch_agent_card_from_registry(deployment_id="dep-001")
-
-        assert card.name == "Test Agent"
-        call_kwargs = mock_httpx_client.get.call_args
-        assert "Bearer settings-token" in call_kwargs.kwargs["headers"]["Authorization"]
-
-
-# ---------------------------------------------------------------------------
-# Error cases
-# ---------------------------------------------------------------------------
-
-
-class TestFetchAgentCardErrors:
-    async def test_empty_data_raises(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"data": [], "count": 0, "totalCount": 0}
-        mock_response.raise_for_status = MagicMock()
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            with pytest.raises(AgentCardRegistryError, match="No agent card found"):
-                await fetch_agent_card_from_registry(
-                    deployment_id="missing",
-                    api_token="tok",
-                    endpoint="https://app.datarobot.com/api/v2",
-                )
-
-    async def test_http_error_raises(self):
+    async def test_fetch_http_error(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 403
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
@@ -189,43 +265,30 @@ class TestFetchAgentCardErrors:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep")
             with pytest.raises(AgentCardRegistryError, match="HTTP 403"):
-                await fetch_agent_card_from_registry(
-                    deployment_id="dep-001",
-                    api_token="tok",
-                    endpoint="https://app.datarobot.com/api/v2",
-                )
-
-    async def test_missing_agent_card_payload_raises(self):
-        response_data = {
-            "data": [
-                {
-                    "id": "abc123",
-                    "deploymentId": "dep-001",
-                    "agentCard": None,
-                }
-            ],
-            "count": 1,
-        }
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.json.return_value = response_data
-        mock_response.raise_for_status = MagicMock()
-
-        mock_client = AsyncMock()
-        mock_client.get = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            with pytest.raises(AgentCardRegistryError, match="contains no 'agentCard' payload"):
-                await fetch_agent_card_from_registry(
-                    deployment_id="dep-001",
-                    api_token="tok",
-                    endpoint="https://app.datarobot.com/api/v2",
-                )
+                await registry._fetch({"deploymentIds": "dep-1"})
 
 
+# ---------------------------------------------------------------------------
+# Tests: get_default_registry singleton
+# ---------------------------------------------------------------------------
 
 
+class TestGetDefaultRegistry:
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        reset_default_registry()
+        yield
+        reset_default_registry()
 
+    async def test_returns_singleton(self):
+        r1 = await get_default_registry()
+        r2 = await get_default_registry()
+        assert r1 is r2
+
+    async def test_reset_clears_singleton(self):
+        r1 = await get_default_registry()
+        reset_default_registry()
+        r2 = await get_default_registry()
+        assert r1 is not r2

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -1,0 +1,231 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
+from datarobot_genai.dragent.agent_card_registry import DataRobotRegistrySettings
+from datarobot_genai.dragent.agent_card_registry import fetch_agent_card_from_registry
+
+_MODULE = "datarobot_genai.dragent.agent_card_registry"
+
+_SAMPLE_AGENT_CARD = {
+    "name": "Test Agent",
+    "description": "A test agent",
+    "url": "https://agent.example.com/a2a/",
+    "version": "1.0.0",
+    "skills": [],
+    "defaultInputModes": ["text"],
+    "defaultOutputModes": ["text"],
+    "capabilities": {"streaming": False},
+}
+
+_REGISTRY_RESPONSE = {
+    "data": [
+        {
+            "id": "abc123",
+            "deploymentId": "dep-001",
+            "externalId": "ext-001",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "agentCard": _SAMPLE_AGENT_CARD,
+        }
+    ],
+    "count": 1,
+    "totalCount": 1,
+    "next": None,
+    "previous": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAgentCardValidation:
+    async def test_raises_when_neither_id_provided(self):
+        with pytest.raises(AgentCardRegistryError, match="Either 'deployment_id' or 'external_id'"):
+            await fetch_agent_card_from_registry()
+
+    async def test_raises_when_both_ids_provided(self):
+        with pytest.raises(AgentCardRegistryError, match="not both"):
+            await fetch_agent_card_from_registry(
+                deployment_id="dep-1", external_id="ext-1"
+            )
+
+    async def test_raises_when_no_api_token(self):
+        mock_settings = MagicMock(spec=DataRobotRegistrySettings)
+        mock_settings.datarobot_api_token = None
+        mock_settings.datarobot_endpoint = None
+        with patch(f"{_MODULE}.DataRobotRegistrySettings", return_value=mock_settings):
+            with pytest.raises(AgentCardRegistryError, match="API token is required"):
+                await fetch_agent_card_from_registry(deployment_id="dep-1")
+
+    async def test_raises_when_no_endpoint(self):
+        mock_settings = MagicMock(spec=DataRobotRegistrySettings)
+        mock_settings.datarobot_api_token = "some-token"
+        mock_settings.datarobot_endpoint = None
+        with patch(f"{_MODULE}.DataRobotRegistrySettings", return_value=mock_settings):
+            with pytest.raises(AgentCardRegistryError, match="API endpoint is required"):
+                await fetch_agent_card_from_registry(deployment_id="dep-1")
+
+
+# ---------------------------------------------------------------------------
+# Successful lookups
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAgentCardSuccess:
+    @pytest.fixture
+    def mock_httpx_client(self):
+        """Provide a mock httpx.AsyncClient that returns a valid registry response."""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = _REGISTRY_RESPONSE
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        return mock_client
+
+    async def test_lookup_by_deployment_id(self, mock_httpx_client):
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client):
+            card = await fetch_agent_card_from_registry(
+                deployment_id="dep-001",
+                api_token="test-token",
+                endpoint="https://app.datarobot.com/api/v2",
+            )
+
+        assert card.name == "Test Agent"
+        assert str(card.url) == "https://agent.example.com/a2a/"
+
+        call_kwargs = mock_httpx_client.get.call_args
+        assert call_kwargs.kwargs["params"]["deploymentIds"] == "dep-001"
+        assert "Bearer test-token" in call_kwargs.kwargs["headers"]["Authorization"]
+
+    async def test_lookup_by_external_id(self, mock_httpx_client):
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client):
+            card = await fetch_agent_card_from_registry(
+                external_id="ext-001",
+                api_token="test-token",
+                endpoint="https://app.datarobot.com/api/v2",
+            )
+
+        assert card.name == "Test Agent"
+        call_kwargs = mock_httpx_client.get.call_args
+        assert call_kwargs.kwargs["params"]["externalIds"] == "ext-001"
+
+    async def test_uses_settings_when_not_explicit(self, mock_httpx_client):
+        mock_settings = MagicMock(spec=DataRobotRegistrySettings)
+        mock_settings.datarobot_api_token = "settings-token"
+        mock_settings.datarobot_endpoint = "https://settings.datarobot.com/api/v2"
+        with (
+            patch(f"{_MODULE}.DataRobotRegistrySettings", return_value=mock_settings),
+            patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client),
+        ):
+            card = await fetch_agent_card_from_registry(deployment_id="dep-001")
+
+        assert card.name == "Test Agent"
+        call_kwargs = mock_httpx_client.get.call_args
+        assert "Bearer settings-token" in call_kwargs.kwargs["headers"]["Authorization"]
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAgentCardErrors:
+    async def test_empty_data_raises(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": [], "count": 0, "totalCount": 0}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(AgentCardRegistryError, match="No agent card found"):
+                await fetch_agent_card_from_registry(
+                    deployment_id="missing",
+                    api_token="tok",
+                    endpoint="https://app.datarobot.com/api/v2",
+                )
+
+    async def test_http_error_raises(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 403
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Forbidden", request=MagicMock(), response=mock_response
+        )
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(AgentCardRegistryError, match="HTTP 403"):
+                await fetch_agent_card_from_registry(
+                    deployment_id="dep-001",
+                    api_token="tok",
+                    endpoint="https://app.datarobot.com/api/v2",
+                )
+
+    async def test_missing_agent_card_payload_raises(self):
+        response_data = {
+            "data": [
+                {
+                    "id": "abc123",
+                    "deploymentId": "dep-001",
+                    "agentCard": None,
+                }
+            ],
+            "count": 1,
+        }
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = response_data
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(AgentCardRegistryError, match="contains no 'agentCard' payload"):
+                await fetch_agent_card_from_registry(
+                    deployment_id="dep-001",
+                    api_token="tok",
+                    endpoint="https://app.datarobot.com/api/v2",
+                )
+
+
+
+
+

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -88,6 +88,19 @@ class TestAgentCardRegistryConfig:
             config = AgentCardRegistryConfig()
             assert config.agent_card_registry_cache_ttl == 120
 
+    def test_default_on_duplicate(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_on_duplicate == "first"
+
+    def test_on_duplicate_from_env(self):
+        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_ON_DUPLICATE": "error"}):
+            config = AgentCardRegistryConfig()
+            assert config.agent_card_registry_on_duplicate == "error"
+
+    def test_on_duplicate_last(self):
+        config = AgentCardRegistryConfig(agent_card_registry_on_duplicate="last")
+        assert config.agent_card_registry_on_duplicate == "last"
+
 
 # ---------------------------------------------------------------------------
 # Tests: _CacheEntry
@@ -158,6 +171,95 @@ class TestParseRegistryResponse:
         body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": {"bad": True}})
         cards = _parse_registry_response(body)
         assert cards == {}
+
+
+class TestParseRegistryResponseDuplicates:
+    """Tests for the on_duplicate strategy with duplicate external IDs."""
+
+    def _body_with_duplicate_ext(self):
+        return _registry_response(
+            _entry(dep_id="dep-1", ext_id="shared-ext", card=_SAMPLE_AGENT_CARD),
+            _entry(dep_id="dep-2", ext_id="shared-ext", card=_SAMPLE_AGENT_CARD_2),
+        )
+
+    def test_first_keeps_first_card(self):
+        cards = _parse_registry_response(self._body_with_duplicate_ext(), on_duplicate="first")
+        assert cards["shared-ext"].name == "Test Agent"
+        # Both deployment IDs are still indexed independently
+        assert "dep-1" in cards
+        assert "dep-2" in cards
+
+    def test_last_keeps_last_card(self):
+        cards = _parse_registry_response(self._body_with_duplicate_ext(), on_duplicate="last")
+        assert cards["shared-ext"].name == "Second Agent"
+
+    def test_error_raises_on_duplicate(self):
+        with pytest.raises(AgentCardRegistryError, match="Multiple agent cards found"):
+            _parse_registry_response(self._body_with_duplicate_ext(), on_duplicate="error")
+
+    def test_no_duplicate_no_error(self):
+        """When external IDs are unique, 'error' strategy passes."""
+        body = _registry_response(
+            _entry(dep_id="dep-1", ext_id="ext-1"),
+            _entry(dep_id="dep-2", ext_id="ext-2"),
+        )
+        cards = _parse_registry_response(body, on_duplicate="error")
+        assert "ext-1" in cards
+        assert "ext-2" in cards
+
+    def test_default_strategy_is_first(self):
+        cards = _parse_registry_response(self._body_with_duplicate_ext())
+        assert cards["shared-ext"].name == "Test Agent"
+
+
+_SAMPLE_AGENT_CARD_3 = {
+    "name": "Third Agent",
+    "description": "Third agent",
+    "url": "https://agent3.example.com/a2a/",
+    "version": "3.0.0",
+    "skills": [],
+    "defaultInputModes": ["text"],
+    "defaultOutputModes": ["text"],
+    "capabilities": {"streaming": False},
+}
+
+
+class TestParseRegistryResponseMultiIdBatch:
+    """Simulate a batch query for externalIds=A,B where A has 3 cards and B has 1.
+
+    The API returns 4 rows total.  The on_duplicate strategy must apply
+    per-external-ID, and IDs without duplicates must be unaffected.
+    """
+
+    def _batch_response(self):
+        """Three entries for ext_id 'agent-A', one for ext_id 'agent-B'."""
+        return _registry_response(
+            _entry(dep_id="dep-a1", ext_id="agent-A", card=_SAMPLE_AGENT_CARD),
+            _entry(dep_id="dep-a2", ext_id="agent-A", card=_SAMPLE_AGENT_CARD_2),
+            _entry(dep_id="dep-a3", ext_id="agent-A", card=_SAMPLE_AGENT_CARD_3),
+            _entry(dep_id="dep-b1", ext_id="agent-B", card=_SAMPLE_AGENT_CARD_2),
+        )
+
+    def test_first_picks_first_of_three(self):
+        cards = _parse_registry_response(self._batch_response(), on_duplicate="first")
+        # agent-A → first card (Test Agent)
+        assert cards["agent-A"].name == "Test Agent"
+        # agent-B has no duplicates → stored as-is
+        assert cards["agent-B"].name == "Second Agent"
+        # All deployment IDs are independently indexed
+        assert len({cards[k].name for k in ["dep-a1", "dep-a2", "dep-a3", "dep-b1"]}) == 3
+
+    def test_last_picks_last_of_three(self):
+        cards = _parse_registry_response(self._batch_response(), on_duplicate="last")
+        # agent-A → last card (Third Agent)
+        assert cards["agent-A"].name == "Third Agent"
+        # agent-B unaffected
+        assert cards["agent-B"].name == "Second Agent"
+
+    def test_error_raises_for_duplicate_id_only(self):
+        """Error is raised for agent-A (3 cards) — agent-B (1 card) never reached."""
+        with pytest.raises(AgentCardRegistryError, match="agent-A"):
+            _parse_registry_response(self._batch_response(), on_duplicate="error")
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.60"
+version = "0.15.61"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new network-dependent registry lookup path (with caching and new env-config) that changes how A2A clients derive their base URL and resolve agent cards; failures/misconfigurations could break remote-agent calls.
> 
> **Overview**
> Adds support for resolving A2A agent cards via a **central DataRobot registry** instead of always fetching from `{url}/.well-known/agent-card.json`. `authenticated_a2a_client` now accepts a mutually-exclusive `registry` block (`deployment_id` or `external_id`), derives the RPC `base_url` from the returned card, and skips direct discovery when a card is pre-resolved.
> 
> Implements a new `AgentCardRegistry` client with **batch fetching**, **TTL caching**, and env-driven configuration (`DATAROBOT_API_TOKEN`, `DATAROBOT_ENDPOINT`, cache TTL/timeout), plus a new `build_agent_cards_registry_url()` helper. Updates NAT docs to describe the new `registry` mode and adds unit tests covering config validation, registry caching/batching behavior, and the new function-group flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8628caca33d69fd2d822466484ff919dcdb296. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->