### PR TITLE
Use Datarobot memory space when memory space id is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.63
+- `nat/datarobot_mem0_memory`: the `dr_mem0_memory` provider now routes on config. When `memory_space_id` is set, requests go to the DataRobot Memory Service's mem0-compatible endpoint at `{datarobot_endpoint}/memory/{memory_space_id}` (authenticated with `datarobot_api_token` / `DATAROBOT_API_TOKEN`); otherwise `api_key` / `MEM0_API_KEY` is used against Mem0 SaaS. Both routes share the same `DRMem0Editor` because the DR endpoint is API-compatible with mem0 (PBMP-7431). New config fields: `memory_space_id`, `datarobot_endpoint`, `datarobot_api_token`.
+- `nat/datarobot_mem0_memory`: providing both `memory_space_id` and `api_key` now raises `RuntimeError("...mutually exclusive...")` at factory time. The fields target different services with different tokens, so silently picking one would mask misconfiguration (e.g. a stray `MEM0_API_KEY` in env hydrating `api_key` via its default factory). The error message documents the `api_key=None` escape hatch for the env-contamination case.
+
 ## 0.15.61
 - Added central agent card registry support to `authenticated_a2a_client`. Set `registry.deployment_id` or `registry.external_id` instead of `url` to resolve agent cards from the tenant-wide DataRobot registry.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.60"
+version = "0.15.63"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.61"
+version = "0.15.63"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -15,14 +15,26 @@
 """NAT memory provider backed by DataRobot's Mem0 client.
 
 This provider wires ``datarobot-genai[memory]`` into NAT's ``MemoryEditor``
-interface so ``auto_memory_agent`` can store and retrieve long-term memory
-without relying on the upstream ``nvidia-nat-mem0ai`` plugin.
+interface so ``auto_memory_agent`` can store and retrieve long-term memory.
+
+Backend selection is driven by config:
+
+* ``memory_space_id`` → the DataRobot Memory Service's mem0-compatible API,
+  reached at ``{DATAROBOT_ENDPOINT}/memory/{memory_space_id}/`` and
+  authenticated with the DataRobot API token. See PBMP-7431 ("Agentic Memory
+  Service"), section "Connect to DataRobot memory" / "API Layout".
+* ``api_key`` (or ``MEM0_API_KEY``) → Mem0's hosted SaaS at
+  ``https://api.mem0.ai``. Used when no ``memory_space_id`` is configured.
+
+Both routes share the same ``MemoryEditor`` adapter because the DR endpoint
+is API-compatible with mem0 — only the host and auth token differ.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -115,15 +127,53 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
     RetryMixin,  # type: ignore[misc]
     name="dr_mem0_memory",
 ):
-    """A NAT memory backend backed by ``datarobot-genai``'s Mem0 client."""
+    """A NAT memory backend backed by ``datarobot-genai``'s Mem0 client.
+
+    Backend selection:
+
+    * If ``memory_space_id`` is set, requests go to the DataRobot Memory
+      Service's mem0-compatible endpoint at
+      ``{datarobot_endpoint}/memory/{memory_space_id}/`` authenticated with
+      ``datarobot_api_token`` (or ``DATAROBOT_API_TOKEN``).
+    * Otherwise, ``api_key`` (or ``MEM0_API_KEY``) is used against Mem0's
+      hosted SaaS (``host`` defaults to ``https://api.mem0.ai``).
+    """
 
     api_key: str | None = Field(
         default_factory=_get_default_mem0_api_key,
-        description="Mem0 API key used by the memory backend.",
+        description="Mem0 API key used when targeting Mem0's hosted SaaS.",
     )
-    host: str | None = None
+    host: str | None = Field(
+        default=None,
+        description=(
+            "Mem0 base URL for the SaaS backend. Ignored when ``memory_space_id`` is set."
+        ),
+    )
     org_id: str | None = None
     project_id: str | None = None
+    memory_space_id: str | None = Field(
+        default=None,
+        description=(
+            "DataRobot MemorySpace ID. When set, the editor uses the DataRobot "
+            "Memory Service's mem0-compatible endpoint instead of Mem0 SaaS. "
+            "The endpoint is built as ``{datarobot_endpoint}/memory/{id}/``."
+        ),
+    )
+    datarobot_endpoint: str | None = Field(
+        default=None,
+        description=(
+            "DataRobot API base URL used to build the mem0 endpoint when "
+            "``memory_space_id`` is set (e.g. ``https://app.datarobot.com/api/v2``). "
+            "Defaults to the ``DATAROBOT_ENDPOINT`` env var."
+        ),
+    )
+    datarobot_api_token: str | None = Field(
+        default=None,
+        description=(
+            "DataRobot API token used when ``memory_space_id`` is set. "
+            "Defaults to the ``DATAROBOT_API_TOKEN`` env var."
+        ),
+    )
 
 
 class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
@@ -206,6 +256,26 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
             await self._mem0.delete_all(user_id=user_id)
 
 
+def _dr_mem0_endpoint(config: DRMem0MemoryClientConfig) -> str:
+    """Build the DataRobot Memory Service mem0 endpoint for a memory space.
+
+    Per PBMP-7431 ("API Layout"), the DR memory service exposes a
+    mem0-compatible API at ``{DATAROBOT_ENDPOINT}/memory/{memory_space_id}``.
+
+    No trailing slash: mem0's ``AsyncMemoryClient._validate_api_key`` builds
+    its ping URL as ``f"{host}/v1/ping/"`` via raw string concat (it does not
+    use httpx's base-url joining for that call). A trailing slash on the
+    host would produce a double slash there.
+    """
+    base = config.datarobot_endpoint or os.getenv("DATAROBOT_ENDPOINT")
+    if not base:
+        raise RuntimeError(
+            "DataRobot endpoint is not set. Configure memory.datarobot_endpoint "
+            "or DATAROBOT_ENDPOINT when using memory_space_id."
+        )
+    return f"{base.rstrip('/')}/memory/{config.memory_space_id}"
+
+
 def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:
     try:
         from datarobot_genai.core.memory.mem0client import Mem0Client
@@ -215,9 +285,10 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -
             'Install it with `pip install "datarobot-genai[nat,memory]"`.'
         ) from exc
 
+    host = _dr_mem0_endpoint(config) if config.memory_space_id else config.host
     return Mem0Client(
         api_key=api_key,
-        host=config.host,
+        host=host,
         org_id=config.org_id,
         project_id=config.project_id,
     )
@@ -227,12 +298,22 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -
 async def dr_mem0_memory_client(
     config: DRMem0MemoryClientConfig, builder: Builder
 ) -> AsyncGenerator[MemoryEditor]:
-    if not config.api_key:
+    if config.memory_space_id:
+        api_key = config.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
+        if not api_key:
+            raise RuntimeError(
+                "DataRobot API token is not set. Configure memory.datarobot_api_token "
+                "or DATAROBOT_API_TOKEN when using memory_space_id."
+            )
+    elif config.api_key:
+        api_key = config.api_key
+    else:
         raise RuntimeError(
-            "Mem0 API key is not set. Please configure memory.api_key or MEM0_API_KEY."
+            "Mem0 API key is not set. Please configure memory.api_key or MEM0_API_KEY, "
+            "or set memory_space_id to target the DataRobot mem0 endpoint."
         )
 
-    editor: MemoryEditor = DRMem0Editor(_create_mem0_client(config, config.api_key))
+    editor: MemoryEditor = DRMem0Editor(_create_mem0_client(config, api_key))
     if isinstance(config, RetryMixin):
         editor = patch_with_retry(
             editor,

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -298,6 +298,19 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -
 async def dr_mem0_memory_client(
     config: DRMem0MemoryClientConfig, builder: Builder
 ) -> AsyncGenerator[MemoryEditor]:
+    if config.memory_space_id and config.api_key:
+        # These point at different services with different tokens. Silently
+        # picking one masks misconfiguration — e.g. a config copied from a
+        # Mem0-SaaS deployment that left ``api_key`` populated, or a stray
+        # ``MEM0_API_KEY`` in env hydrating ``api_key`` via its default
+        # factory. Force the caller to disambiguate.
+        raise RuntimeError(
+            "memory_space_id and api_key are mutually exclusive: they target "
+            "different services (DataRobot Memory Service vs. Mem0 SaaS) with "
+            "different auth tokens. Set exactly one. If MEM0_API_KEY is in env, "
+            "either unset it or pass api_key=None explicitly when using memory_space_id."
+        )
+
     if config.memory_space_id:
         api_key = config.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
         if not api_key:

--- a/tests/nat/integration/test_dr_mem0_integration.py
+++ b/tests/nat/integration/test_dr_mem0_integration.py
@@ -1,0 +1,333 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live integration tests for the unified DR/Mem0 memory provider.
+
+Two backends are exercised against their real services:
+
+* **DataRobot Memory Service** — a real ``MemorySpace`` is created via the
+  DataRobot SDK (``datarobot.models.memory.MemorySpace``, see
+  ``public_api_client``'s ``datarobot/models/memory.py``), the provider is
+  built with ``memory_space_id=<that id>``, and add/search/remove round-trip
+  through the path-prefixed mem0-compatible endpoint at
+  ``{DATAROBOT_ENDPOINT}/memory/{memory_space_id}/``. The space is deleted in
+  a finalizer so we never leak resources across runs.
+* **Mem0 SaaS** — same provider, no ``memory_space_id``, just a ``MEM0_API_KEY``.
+  Confirms the existing SaaS path still works after the routing changes.
+
+All tests skip when the required credentials aren't in the environment so
+this module is safe to run in CI without secrets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from nat.memory.models import MemoryItem
+
+from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
+from datarobot_genai.nat.datarobot_mem0_memory import DRMem0MemoryClientConfig
+from datarobot_genai.nat.datarobot_mem0_memory import dr_mem0_memory_client
+
+
+# --------------------------------------------------------------------------- #
+# Skip conditions                                                             #
+# --------------------------------------------------------------------------- #
+def _dr_memory_sdk_available() -> bool:
+    try:
+        importlib.import_module("datarobot.models.memory")
+    except ImportError:
+        return False
+    return True
+
+
+_HAS_DR_CREDS = bool(os.getenv("DATAROBOT_ENDPOINT") and os.getenv("DATAROBOT_API_TOKEN"))
+_HAS_DR_SDK = _dr_memory_sdk_available()
+_HAS_MEM0_KEY = bool(os.getenv("MEM0_API_KEY"))
+
+skip_unless_dr = pytest.mark.skipif(
+    not (_HAS_DR_CREDS and _HAS_DR_SDK),
+    reason=(
+        "DR live tests require DATAROBOT_ENDPOINT + DATAROBOT_API_TOKEN and a "
+        "DataRobot SDK that ships datarobot.models.memory (v3.15+)."
+    ),
+)
+skip_unless_mem0 = pytest.mark.skipif(
+    not _HAS_MEM0_KEY, reason="Mem0 live tests require MEM0_API_KEY."
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+def _unique_user_id() -> str:
+    """Return a 24-hex-char ObjectId-shaped string.
+
+    The DR memory service rejects ``participants`` and ``emitter.id`` values
+    that aren't valid MongoDB ObjectIds with HTTP 422. For mem0 SaaS this is
+    just an arbitrary user identifier.
+    """
+    return uuid.uuid4().hex[:24]
+
+
+async def _build_editor(
+    config: DRMem0MemoryClientConfig,
+) -> AsyncGenerator[DRMem0Editor]:
+    """Yield a real editor from the registered NAT factory.
+
+    We use the registered factory (not just ``DRMem0Editor(...)`` directly)
+    so the routing logic in :func:`dr_mem0_memory_client` is on the hot
+    path — that's the integration we want to validate.
+    """
+    async with dr_mem0_memory_client(config, object()) as editor:
+        assert isinstance(editor, DRMem0Editor)
+        yield editor
+
+
+async def _search_until_visible(
+    editor: DRMem0Editor,
+    *,
+    query: str,
+    user_id: str,
+    needle: str,
+    timeout_s: float = 30.0,
+    interval_s: float = 1.5,
+) -> list[Any]:
+    """Poll ``editor.search`` until ``needle`` appears or the deadline passes.
+
+    Mem0 SaaS defaults to ``async_mode=True`` so ``add`` returns before the
+    fact-extraction worker has ingested the memory. The DR endpoint behaves
+    similarly. A short poll absorbs that ingest lag without making the test
+    rely on fixed sleeps that flake under load.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    last: list[Any] = []
+    while asyncio.get_event_loop().time() < deadline:
+        last = await editor.search(query, top_k=10, user_id=user_id)
+        if any(needle in (m.memory or "") for m in last):
+            return last
+        await asyncio.sleep(interval_s)
+    return last
+
+
+# --------------------------------------------------------------------------- #
+# DataRobot Memory Service (live)                                             #
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def _dr_client() -> Any:
+    """Configure the process-global DR SDK client against the test endpoint."""
+    import datarobot as dr  # type: ignore[import-not-found]
+
+    dr.Client(
+        endpoint=os.environ["DATAROBOT_ENDPOINT"],
+        token=os.environ["DATAROBOT_API_TOKEN"],
+    )
+    return dr
+
+
+@pytest.fixture
+def dr_memory_space(_dr_client: Any) -> Any:
+    """Create and tear down a real DataRobot MemorySpace.
+
+    The space is named per-test (uuid suffix) so concurrent runs don't
+    collide, and is deleted in the finalizer even when the test fails.
+    """
+    from datarobot.models.memory import MemorySpace  # type: ignore[import-not-found]
+
+    test_id = uuid.uuid4().hex
+    space = MemorySpace.create(description=f"NAT dr-mem0 integration test {test_id}")
+    try:
+        yield space
+    finally:
+        space.delete()
+
+
+@skip_unless_dr
+async def test_dr_mem0_endpoint_add_search_round_trip(
+    dr_memory_space: Any,
+) -> None:
+    # GIVEN a real DR memory space and the unified provider configured to
+    # route through the path-prefixed DR mem0 endpoint (memory_space_id set,
+    # DR token used as the auth credential).
+    config = DRMem0MemoryClientConfig(
+        api_key=None,
+        memory_space_id=dr_memory_space.id,
+        datarobot_endpoint=os.environ["DATAROBOT_ENDPOINT"],
+        datarobot_api_token=os.environ["DATAROBOT_API_TOKEN"],
+    )
+    user_id = _unique_user_id()
+    secret = f"DR-MEM0-INT-{uuid.uuid4().hex[:12]}"
+
+    # WHEN we add a memory item, then search for it.
+    async for editor in _build_editor(config):
+        await editor.add_items(
+            [
+                MemoryItem(
+                    conversation=[
+                        {"role": "user", "content": f"Please remember my code: {secret}."},
+                        {"role": "assistant", "content": "Got it."},
+                    ],
+                    user_id=user_id,
+                    tags=["preference"],
+                    metadata={"thread_id": "t-1"},
+                )
+            ]
+        )
+
+        # THEN the stored secret is recoverable through the DR endpoint —
+        # proves the editor → Mem0Client → DR mem0 endpoint → MemorySpace
+        # pipeline is wired correctly end to end. Poll because mem0 ingests
+        # facts asynchronously by default.
+        memories = await _search_until_visible(
+            editor, query="my code", user_id=user_id, needle=secret
+        )
+        joined = " ".join(m.memory or "" for m in memories)
+        assert secret in joined, (
+            f"Expected secret {secret!r} in DR-memory search results within timeout, got: "
+            f"{[m.memory for m in memories]!r}"
+        )
+
+        # AND deleting by user_id wipes only this user's memories.
+        await editor.remove_items(user_id=user_id)
+        post_delete = await editor.search("my code", top_k=5, user_id=user_id)
+        assert all(secret not in (m.memory or "") for m in post_delete), (
+            f"After remove_items(user_id=...), expected no traces of {secret!r}; "
+            f"got: {[m.memory for m in post_delete]!r}"
+        )
+
+
+@skip_unless_dr
+async def test_dr_mem0_endpoint_isolates_memories_per_user(
+    dr_memory_space: Any,
+) -> None:
+    # GIVEN the provider pointed at the same DR memory space, and two
+    # distinct users.
+    config = DRMem0MemoryClientConfig(
+        api_key=None,
+        memory_space_id=dr_memory_space.id,
+        datarobot_endpoint=os.environ["DATAROBOT_ENDPOINT"],
+        datarobot_api_token=os.environ["DATAROBOT_API_TOKEN"],
+    )
+    user_a, user_b = _unique_user_id(), _unique_user_id()
+    secret_a = f"A-{uuid.uuid4().hex[:10]}"
+    secret_b = f"B-{uuid.uuid4().hex[:10]}"
+
+    async for editor in _build_editor(config):
+        await editor.add_items(
+            [
+                MemoryItem(
+                    conversation=[{"role": "user", "content": f"My code is {secret_a}."}],
+                    user_id=user_a,
+                ),
+                MemoryItem(
+                    conversation=[{"role": "user", "content": f"My code is {secret_b}."}],
+                    user_id=user_b,
+                ),
+            ]
+        )
+
+        # WHEN each user searches their own scope (after async ingest lands).
+        results_a = await _search_until_visible(
+            editor, query="code", user_id=user_a, needle=secret_a
+        )
+        results_b = await _search_until_visible(
+            editor, query="code", user_id=user_b, needle=secret_b
+        )
+
+        # THEN each user only sees their own memory — the mem0 v2 filters
+        # ({"AND": [{"user_id": ...}]}) are correctly forwarded through the
+        # DR endpoint, not collapsed into a global scope.
+        text_a = " ".join(m.memory or "" for m in results_a)
+        text_b = " ".join(m.memory or "" for m in results_b)
+        assert secret_a in text_a and secret_b not in text_a, (
+            f"user_a results bled across users: {text_a!r}"
+        )
+        assert secret_b in text_b and secret_a not in text_b, (
+            f"user_b results bled across users: {text_b!r}"
+        )
+
+        await editor.remove_items(user_id=user_a)
+        await editor.remove_items(user_id=user_b)
+
+
+# --------------------------------------------------------------------------- #
+# Mem0 SaaS (live) — regression after routing changes                         #
+# --------------------------------------------------------------------------- #
+@skip_unless_mem0
+async def test_mem0_saas_add_search_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    # GIVEN the unified provider configured *without* memory_space_id — it
+    # must fall through to the Mem0 SaaS endpoint and use MEM0_API_KEY.
+    # We also ensure no stale DR creds steer the router elsewhere.
+    monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
+    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+
+    config = DRMem0MemoryClientConfig(
+        api_key=os.environ["MEM0_API_KEY"],
+        memory_space_id=None,
+    )
+    user_id = f"nat-int-{uuid.uuid4().hex[:12]}"
+    secret = f"MEM0-SAAS-INT-{uuid.uuid4().hex[:12]}"
+
+    async for editor in _build_editor(config):
+        await editor.add_items(
+            [
+                MemoryItem(
+                    conversation=[
+                        {"role": "user", "content": f"Remember: my code is {secret}."},
+                        {"role": "assistant", "content": "Acknowledged."},
+                    ],
+                    user_id=user_id,
+                    tags=["integration"],
+                )
+            ]
+        )
+
+        try:
+            # THEN Mem0 SaaS returns the stored fact — proves the routing
+            # changes didn't regress the original SaaS path. Poll because
+            # mem0 ingests facts asynchronously by default.
+            memories = await _search_until_visible(
+                editor, query="code", user_id=user_id, needle=secret
+            )
+            joined = " ".join(m.memory or "" for m in memories)
+            assert secret in joined, (
+                f"Expected secret {secret!r} in Mem0 SaaS search results within timeout, got: "
+                f"{[m.memory for m in memories]!r}"
+            )
+        finally:
+            await editor.remove_items(user_id=user_id)
+
+
+@skip_unless_mem0
+async def test_mem0_saas_validates_credentials_on_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # GIVEN a deliberately invalid Mem0 API key.
+    monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
+    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+    config = DRMem0MemoryClientConfig(api_key="m0-this-key-does-not-exist", memory_space_id=None)
+
+    # WHEN we try to build the client, THEN Mem0's _validate_api_key surfaces
+    # the auth failure as ValueError (it wraps the HTTPError). This proves
+    # the SaaS path is actually contacting Mem0, not silently returning a
+    # broken client.
+    with pytest.raises((ValueError, RuntimeError)):
+        async for _editor in _build_editor(config):
+            pass

--- a/tests/nat/integration/test_dr_mem0_integration.py
+++ b/tests/nat/integration/test_dr_mem0_integration.py
@@ -107,7 +107,7 @@ async def _search_until_visible(
     query: str,
     user_id: str,
     needle: str,
-    timeout_s: float = 30.0,
+    timeout_s: float = 60.0,
     interval_s: float = 1.5,
 ) -> list[Any]:
     """Poll ``editor.search`` until ``needle`` appears or the deadline passes.

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -490,7 +490,14 @@ def test_dr_mem0_endpoint_requires_a_base_url(monkeypatch: Any) -> None:
 def test_create_mem0_client_routes_to_dr_endpoint_when_memory_space_id_set(
     monkeypatch: Any,
 ) -> None:
-    # GIVEN a memory_space_id and a DR endpoint.
+    # GIVEN a memory_space_id and a DR endpoint. This test exercises the real
+    # ``_create_mem0_client`` body (host computation), which transitively
+    # imports ``mem0``. Skip on minimal installs (the ``nat`` test module in
+    # CI doesn't include the ``[memory]`` extra) — the factory-level tests
+    # below already cover the routing decision by monkey-patching
+    # ``_create_mem0_client`` directly.
+    pytest.importorskip("mem0")
+
     captured: dict[str, Any] = {}
 
     class FakeMem0Client:
@@ -505,7 +512,6 @@ def test_create_mem0_client_routes_to_dr_endpoint_when_memory_space_id_set(
                 {"api_key": api_key, "host": host, "org_id": org_id, "project_id": project_id}
             )
 
-    # Stub the import inside the function so we don't need the [memory] extra installed.
     import datarobot_genai.core.memory.mem0client as mem0client_module
 
     monkeypatch.setattr(mem0client_module, "Mem0Client", FakeMem0Client)
@@ -534,6 +540,10 @@ def test_create_mem0_client_uses_config_host_when_no_memory_space_id(
     monkeypatch: Any,
 ) -> None:
     # GIVEN no memory_space_id (Mem0 SaaS path) and an explicit host override.
+    # Same skip rationale as ``..._routes_to_dr_endpoint...``: this hits the
+    # real ``_create_mem0_client`` body which imports ``mem0``.
+    pytest.importorskip("mem0")
+
     captured: dict[str, Any] = {}
 
     class FakeMem0Client:
@@ -593,7 +603,11 @@ async def test_registered_memory_client_prefers_explicit_dr_token_over_env(
     monkeypatch: Any,
 ) -> None:
     # GIVEN an explicit datarobot_api_token on the config and a different env var.
+    # Clear MEM0_API_KEY so the api_key default_factory doesn't hydrate from
+    # env and trip the mutually-exclusive guardrail (this is a DR-routing test,
+    # we don't want the Mem0 SaaS field populated).
     monkeypatch.setenv("DATAROBOT_API_TOKEN", "env-token")
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
     created: list[dict[str, Any]] = []
 
     def fake_create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:
@@ -622,6 +636,7 @@ async def test_registered_memory_client_requires_dr_token_when_memory_space_id_s
 ) -> None:
     # GIVEN a memory_space_id but neither datarobot_api_token nor DATAROBOT_API_TOKEN.
     monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
 
     # WHEN NAT builds the memory client, THEN it raises a DR-specific error so
     # users know to set the DR token, not the Mem0 api_key.
@@ -634,3 +649,73 @@ async def test_registered_memory_client_requires_dr_token_when_memory_space_id_s
             object(),
         ):
             pass
+
+
+async def test_registered_memory_client_rejects_memory_space_id_and_api_key_together(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN both memory_space_id and api_key set (e.g. a config copied from a
+    # Mem0-SaaS deployment that forgot to clear api_key after switching to DR,
+    # or a stray MEM0_API_KEY in env hydrating api_key via its default factory).
+    # The two fields point at different services with different auth tokens,
+    # so silently picking one risks routing traffic to the wrong scope.
+
+    # WHEN NAT builds the memory client, THEN it refuses to guess which one
+    # the caller meant and raises a clear error that names both fields.
+    with pytest.raises(RuntimeError, match="mutually exclusive"):
+        async with datarobot_mem0_memory.dr_mem0_memory_client(
+            DRMem0MemoryClientConfig(
+                api_key="mem0-saas-key",
+                memory_space_id="space-42",
+                datarobot_endpoint="https://app.datarobot.com/api/v2",
+                datarobot_api_token="dr-token",
+            ),
+            object(),
+        ):
+            pass
+
+
+async def test_registered_memory_client_rejects_memory_space_id_with_env_mem0_key(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN MEM0_API_KEY contamination in env (e.g. another tool set it) and
+    # an explicit memory_space_id config. The default_factory will pick up
+    # MEM0_API_KEY and populate api_key, creating an ambiguous config.
+    monkeypatch.setenv("MEM0_API_KEY", "stray-env-key")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "dr-token")
+
+    config = DRMem0MemoryClientConfig(memory_space_id="space-42")
+    # Confirm the env did hydrate api_key — this is the exact ambiguity the
+    # guardrail exists to catch.
+    assert config.api_key == "stray-env-key"
+
+    # WHEN NAT builds the client, THEN the guardrail fires regardless of how
+    # api_key got populated; the error message tells the user how to fix it
+    # (pass api_key=None explicitly or unset MEM0_API_KEY).
+    with pytest.raises(RuntimeError, match="api_key=None"):
+        async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()):
+            pass
+
+
+async def test_registered_memory_client_allows_memory_space_id_with_explicit_null_api_key(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN MEM0_API_KEY in env but the caller explicitly passes api_key=None
+    # to disambiguate — the documented escape hatch from the previous test.
+    monkeypatch.setenv("MEM0_API_KEY", "stray-env-key")
+    monkeypatch.setattr(
+        datarobot_mem0_memory, "_create_mem0_client", lambda *_a, **_k: FakeMem0Client()
+    )
+    monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
+
+    config = DRMem0MemoryClientConfig(
+        api_key=None,  # explicit override beats the env default_factory
+        memory_space_id="space-42",
+        datarobot_endpoint="https://app.datarobot.com/api/v2",
+        datarobot_api_token="dr-token",
+    )
+
+    # WHEN NAT builds the client, THEN it routes to DR without complaint —
+    # the explicit None signals the caller knows what they want.
+    async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
+        assert isinstance(editor, DRMem0Editor)

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -445,3 +445,192 @@ async def test_registered_memory_client_requires_api_key(monkeypatch: Any) -> No
             DRMem0MemoryClientConfig(api_key=None), object()
         ):
             pass
+
+
+def test_dr_mem0_endpoint_builds_path_prefixed_url(monkeypatch: Any) -> None:
+    # GIVEN a memory_space_id and an explicit datarobot_endpoint.
+    # WHEN the endpoint URL is built.
+    # THEN it follows PBMP-7431's "API Layout": {endpoint}/memory/{id}, with no
+    # trailing slash (mem0's _validate_api_key uses raw f"{host}/v1/ping/"
+    # concat, so a trailing slash would produce a double slash). Any
+    # caller-supplied trailing slash on the base is collapsed.
+    config = DRMem0MemoryClientConfig(
+        memory_space_id="space-123",
+        datarobot_endpoint="https://app.datarobot.com/api/v2/",
+    )
+    assert (
+        datarobot_mem0_memory._dr_mem0_endpoint(config)
+        == "https://app.datarobot.com/api/v2/memory/space-123"
+    )
+
+
+def test_dr_mem0_endpoint_falls_back_to_datarobot_endpoint_env(monkeypatch: Any) -> None:
+    # GIVEN no explicit datarobot_endpoint on the config but DATAROBOT_ENDPOINT in env.
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://staging.datarobot.com/api/v2")
+    config = DRMem0MemoryClientConfig(memory_space_id="space-xyz")
+
+    # THEN the env var is used as the base.
+    assert (
+        datarobot_mem0_memory._dr_mem0_endpoint(config)
+        == "https://staging.datarobot.com/api/v2/memory/space-xyz"
+    )
+
+
+def test_dr_mem0_endpoint_requires_a_base_url(monkeypatch: Any) -> None:
+    # GIVEN no datarobot_endpoint configured and no env var.
+    monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
+    config = DRMem0MemoryClientConfig(memory_space_id="space-xyz")
+
+    # THEN the builder refuses to fabricate a URL — better to fail loud than to
+    # point at a wrong host.
+    with pytest.raises(RuntimeError, match="DATAROBOT_ENDPOINT"):
+        datarobot_mem0_memory._dr_mem0_endpoint(config)
+
+
+def test_create_mem0_client_routes_to_dr_endpoint_when_memory_space_id_set(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN a memory_space_id and a DR endpoint.
+    captured: dict[str, Any] = {}
+
+    class FakeMem0Client:
+        def __init__(
+            self,
+            api_key: str | None = None,
+            host: str | None = None,
+            org_id: str | None = None,
+            project_id: str | None = None,
+        ) -> None:
+            captured.update(
+                {"api_key": api_key, "host": host, "org_id": org_id, "project_id": project_id}
+            )
+
+    # Stub the import inside the function so we don't need the [memory] extra installed.
+    import datarobot_genai.core.memory.mem0client as mem0client_module
+
+    monkeypatch.setattr(mem0client_module, "Mem0Client", FakeMem0Client)
+
+    config = DRMem0MemoryClientConfig(
+        memory_space_id="space-42",
+        datarobot_endpoint="https://app.datarobot.com/api/v2",
+        org_id="org-1",
+        project_id="proj-1",
+    )
+
+    # WHEN the Mem0Client is constructed.
+    datarobot_mem0_memory._create_mem0_client(config, "dr-token")
+
+    # THEN it points at the path-prefixed DR memory endpoint with the DR token
+    # (not Mem0 SaaS), and forwards org/project as-is.
+    assert captured == {
+        "api_key": "dr-token",
+        "host": "https://app.datarobot.com/api/v2/memory/space-42",
+        "org_id": "org-1",
+        "project_id": "proj-1",
+    }
+
+
+def test_create_mem0_client_uses_config_host_when_no_memory_space_id(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN no memory_space_id (Mem0 SaaS path) and an explicit host override.
+    captured: dict[str, Any] = {}
+
+    class FakeMem0Client:
+        def __init__(
+            self,
+            api_key: str | None = None,
+            host: str | None = None,
+            org_id: str | None = None,
+            project_id: str | None = None,
+        ) -> None:
+            captured.update({"api_key": api_key, "host": host})
+
+    import datarobot_genai.core.memory.mem0client as mem0client_module
+
+    monkeypatch.setattr(mem0client_module, "Mem0Client", FakeMem0Client)
+    config = DRMem0MemoryClientConfig(api_key="mem0-key", host="https://mem0.example.com")
+
+    # WHEN the Mem0Client is constructed.
+    datarobot_mem0_memory._create_mem0_client(config, "mem0-key")
+
+    # THEN the SaaS host wins (no DR prefix injection).
+    assert captured == {"api_key": "mem0-key", "host": "https://mem0.example.com"}
+
+
+async def test_registered_memory_client_uses_dr_token_when_memory_space_id_set(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN a memory_space_id config and a DATAROBOT_API_TOKEN in env.
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "dr-secret-token")
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+
+    created: list[dict[str, Any]] = []
+
+    def fake_create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:
+        created.append({"config": config, "api_key": api_key})
+        return FakeMem0Client()
+
+    monkeypatch.setattr(datarobot_mem0_memory, "_create_mem0_client", fake_create_mem0_client)
+    monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
+
+    config = DRMem0MemoryClientConfig(
+        api_key=None,
+        memory_space_id="space-42",
+        datarobot_endpoint="https://app.datarobot.com/api/v2",
+    )
+
+    # WHEN NAT builds the memory client.
+    async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
+        assert isinstance(editor, DRMem0Editor)
+
+    # THEN the DR token (not the mem0 api_key) is used as the auth credential
+    # against the DR mem0 endpoint.
+    assert created == [{"config": config, "api_key": "dr-secret-token"}]
+
+
+async def test_registered_memory_client_prefers_explicit_dr_token_over_env(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN an explicit datarobot_api_token on the config and a different env var.
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "env-token")
+    created: list[dict[str, Any]] = []
+
+    def fake_create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:
+        created.append({"api_key": api_key})
+        return FakeMem0Client()
+
+    monkeypatch.setattr(datarobot_mem0_memory, "_create_mem0_client", fake_create_mem0_client)
+    monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
+
+    config = DRMem0MemoryClientConfig(
+        memory_space_id="space-42",
+        datarobot_endpoint="https://app.datarobot.com/api/v2",
+        datarobot_api_token="explicit-token",
+    )
+
+    # WHEN NAT builds the memory client.
+    async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()):
+        pass
+
+    # THEN the config field wins (env is only the fallback).
+    assert created == [{"api_key": "explicit-token"}]
+
+
+async def test_registered_memory_client_requires_dr_token_when_memory_space_id_set(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN a memory_space_id but neither datarobot_api_token nor DATAROBOT_API_TOKEN.
+    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+
+    # WHEN NAT builds the memory client, THEN it raises a DR-specific error so
+    # users know to set the DR token, not the Mem0 api_key.
+    with pytest.raises(RuntimeError, match="DATAROBOT_API_TOKEN"):
+        async with datarobot_mem0_memory.dr_mem0_memory_client(
+            DRMem0MemoryClientConfig(
+                memory_space_id="space-42",
+                datarobot_endpoint="https://app.datarobot.com/api/v2",
+            ),
+            object(),
+        ):
+            pass

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.61"
+version = "0.15.63"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
When `memory_space_id` is set, requests go to the DataRobot Memory Service's mem0-compatible endpoint at `{datarobot_endpoint}/memory/{memory_space_id}` (authenticated with `datarobot_api_token` / `DATAROBOT_API_TOKEN`)

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
