### PR TITLE
A2A AgentCard - handle snake_case/camelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.64
+- `dragent`: agent card XAA extension params now use camelCase (`tokenExchange`, `tokenRequest`, `tokenEndpointAuthMethod`, etc.) for consistency with the rest of the agentCard API response. The parser accepts both camelCase and snake_case for backward compatibility with previously generated cards.
+
 ## 0.15.63
 - `nat/datarobot_mem0_memory`: the `dr_mem0_memory` provider now routes on config. When `memory_space_id` is set, requests go to the DataRobot Memory Service's mem0-compatible endpoint at `{datarobot_endpoint}/memory/{memory_space_id}` (authenticated with `datarobot_api_token` / `DATAROBOT_API_TOKEN`); otherwise `api_key` / `MEM0_API_KEY` is used against Mem0 SaaS. Both routes share the same `DRMem0Editor` because the DR endpoint is API-compatible with mem0 (PBMP-7431). New config fields: `memory_space_id`, `datarobot_endpoint`, `datarobot_api_token`.
 - `nat/datarobot_mem0_memory`: providing both `memory_space_id` and `api_key` now raises `RuntimeError("...mutually exclusive...")` at factory time. The fields target different services with different tokens, so silently picking one would mask misconfiguration (e.g. a stray `MEM0_API_KEY` in env hydrating `api_key` via its default factory). The error message documents the `api_key=None` escape hatch for the env-contamination case.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.63"
+version = "0.15.64"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -181,14 +181,15 @@ def build_cross_app_capability_extension(
             "scheme": CROSS_APP_SECURITY_SCHEME_REF,
             "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
         },
-        "token_endpoint_auth_method": config.token_endpoint_auth_method,
-        "token_exchange": {
-            "grant_type": TOKEN_EXCHANGE_GRANT_TYPE_URI,
-            "requested_token_type": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
-            **config.token_exchange.model_dump(),
+        "tokenEndpointAuthMethod": config.token_endpoint_auth_method,
+        "tokenExchange": {
+            "grantType": TOKEN_EXCHANGE_GRANT_TYPE_URI,
+            "requestedTokenType": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
+            "trustedIssuer": config.token_exchange.trusted_issuer,
+            "audience": config.token_exchange.audience,
         },
-        "token_request": {
-            "grant_type": JWT_BEARER_GRANT_TYPE_URI,
+        "tokenRequest": {
+            "grantType": JWT_BEARER_GRANT_TYPE_URI,
             "audience": config.token_request.audience,
         },
     }

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -731,9 +731,7 @@ class _TokenExchangeParams(BaseModel):
     requested_token_type: str | None = Field(
         default=None, validation_alias=AliasChoices("requestedTokenType", "requested_token_type")
     )
-    trusted_issuer: str = Field(
-        validation_alias=AliasChoices("trustedIssuer", "trusted_issuer")
-    )
+    trusted_issuer: str = Field(validation_alias=AliasChoices("trustedIssuer", "trusted_issuer"))
     audience: str
 
 

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -106,6 +106,8 @@ from nat.data_models.authentication import AuthResult
 from nat.data_models.authentication import BearerTokenCred
 from nat.data_models.common import OptionalSecretStr
 from pydantic import AliasChoices
+from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import SecretStr
 
@@ -687,9 +689,9 @@ def _parse_cross_app_params(card: AgentCard) -> _CrossAppFlowParams:
 
     return _CrossAppFlowParams(
         token_url=token_url,
-        trusted_issuer=ext.trusted_issuer,
-        exchange_audience=ext.exchange_audience,
-        target_audience=ext.target_audience,
+        trusted_issuer=ext.token_exchange.trusted_issuer,
+        exchange_audience=ext.token_exchange.audience,
+        target_audience=ext.token_request.audience,
         token_endpoint_auth_method=ext.token_endpoint_auth_method,
         id_jag_scopes=scopes,
     )
@@ -718,21 +720,58 @@ def _parse_security_schemes(card: AgentCard) -> tuple[str, list[str]]:
     return token_url, scopes
 
 
-@dataclass
-class _CrossAppExtensionFields:
-    """Raw fields extracted from the JWT Bearer capability extension."""
+class _TokenExchangeParams(BaseModel):
+    """Nested ``tokenExchange`` / ``token_exchange`` block inside the extension."""
 
-    trusted_issuer: str
-    exchange_audience: str
-    target_audience: str
-    token_endpoint_auth_method: str
+    model_config = ConfigDict(populate_by_name=True)
+
+    grant_type: str | None = Field(
+        default=None, validation_alias=AliasChoices("grantType", "grant_type")
+    )
+    requested_token_type: str | None = Field(
+        default=None, validation_alias=AliasChoices("requestedTokenType", "requested_token_type")
+    )
+    trusted_issuer: str = Field(
+        validation_alias=AliasChoices("trustedIssuer", "trusted_issuer")
+    )
+    audience: str
+
+
+class _TokenRequestParams(BaseModel):
+    """Nested ``tokenRequest`` / ``token_request`` block inside the extension."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    grant_type: str = Field(validation_alias=AliasChoices("grantType", "grant_type"))
+    audience: str
+
+
+class _CrossAppExtensionFields(BaseModel):
+    """Fields extracted from the JWT Bearer capability extension.
+
+    Accepts both camelCase (as returned by the agent card registry API) and
+    snake_case keys via ``AliasChoices``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    token_endpoint_auth_method: str = Field(
+        validation_alias=AliasChoices("tokenEndpointAuthMethod", "token_endpoint_auth_method")
+    )
+    token_exchange: _TokenExchangeParams = Field(
+        validation_alias=AliasChoices("tokenExchange", "token_exchange")
+    )
+    token_request: _TokenRequestParams = Field(
+        validation_alias=AliasChoices("tokenRequest", "token_request")
+    )
 
 
 def _parse_cross_app_extension(card: AgentCard) -> _CrossAppExtensionFields:
     """Extract Cross-Application Access fields from the JWT Bearer capability extension.
 
     Finds the extension with ``uri == _JWT_BEARER_GRANT_TYPE_URI`` and validates
-    required fields.  ``token_request.grant_type`` is validated but not returned.
+    required fields using pydantic.  Both camelCase and snake_case keys are
+    accepted via ``AliasChoices``.
 
     Raises ``ValueError`` if the extension is missing or any required field is absent.
     """
@@ -742,38 +781,13 @@ def _parse_cross_app_extension(card: AgentCard) -> _CrossAppExtensionFields:
     for ext in extensions:
         if ext.uri == _JWT_BEARER_GRANT_TYPE_URI:
             params = ext.params or {}
-            token_exchange = params.get("token_exchange") or {}
-            token_request = params.get("token_request") or {}
-
-            token_endpoint_auth_method = params.get("token_endpoint_auth_method")
-            trusted_issuer = token_exchange.get("trusted_issuer")
-            exchange_audience = token_exchange.get("audience")
-            grant_type = token_request.get("grant_type")
-            target_audience = token_request.get("audience")
-
-            missing = [
-                name
-                for name, val in [
-                    ("token_endpoint_auth_method", token_endpoint_auth_method),
-                    ("token_exchange.trusted_issuer", trusted_issuer),
-                    ("token_exchange.audience", exchange_audience),
-                    ("token_request.grant_type", grant_type),
-                    ("token_request.audience", target_audience),
-                ]
-                if not val
-            ]
-            if missing:
+            try:
+                return _CrossAppExtensionFields.model_validate(params)
+            except Exception as exc:
                 raise ValueError(
-                    f"Agent card Cross-Application Access extension is missing required "
-                    f"fields: {missing}"
-                )
-
-            return _CrossAppExtensionFields(
-                trusted_issuer=trusted_issuer,  # type: ignore[arg-type]
-                exchange_audience=exchange_audience,  # type: ignore[arg-type]
-                target_audience=target_audience,  # type: ignore[arg-type]
-                token_endpoint_auth_method=token_endpoint_auth_method,  # type: ignore[arg-type]
-            )
+                    f"Agent card Cross-Application Access extension has invalid or missing "
+                    f"fields: {exc}"
+                ) from exc
 
     raise ValueError(
         f"Agent card capabilities.extensions has no entry with uri='{_JWT_BEARER_GRANT_TYPE_URI}'. "

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -413,15 +413,15 @@ class TestCreateAgentCard:
                 "scheme": CROSS_APP_SECURITY_SCHEME_REF,
                 "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
             },
-            "token_endpoint_auth_method": "private_key_jwt",
-            "token_exchange": {
-                "grant_type": TOKEN_EXCHANGE_GRANT_TYPE_URI,
-                "requested_token_type": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
-                "trusted_issuer": "https://your-org.oktapreview.com",
+            "tokenEndpointAuthMethod": "private_key_jwt",
+            "tokenExchange": {
+                "grantType": TOKEN_EXCHANGE_GRANT_TYPE_URI,
+                "requestedTokenType": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
+                "trustedIssuer": "https://your-org.oktapreview.com",
                 "audience": "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             },
-            "token_request": {
-                "grant_type": JWT_BEARER_GRANT_TYPE_URI,
+            "tokenRequest": {
+                "grantType": JWT_BEARER_GRANT_TYPE_URI,
                 "audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             },
         }
@@ -508,15 +508,15 @@ class TestCreateAgentCard:
                 "scheme": CROSS_APP_SECURITY_SCHEME_REF,
                 "flow": CROSS_APP_SECURITY_SCHEME_FLOW_REF,
             },
-            "token_endpoint_auth_method": "private_key_jwt",
-            "token_exchange": {
-                "grant_type": TOKEN_EXCHANGE_GRANT_TYPE_URI,
-                "requested_token_type": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
-                "trusted_issuer": "https://your-org.oktapreview.com",
+            "tokenEndpointAuthMethod": "private_key_jwt",
+            "tokenExchange": {
+                "grantType": TOKEN_EXCHANGE_GRANT_TYPE_URI,
+                "requestedTokenType": TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE,
+                "trustedIssuer": "https://your-org.oktapreview.com",
                 "audience": "https://your-org.okta.com/oauth2/aussu3akcsQeofA0C1d7",
             },
-            "token_request": {
-                "grant_type": JWT_BEARER_GRANT_TYPE_URI,
+            "tokenRequest": {
+                "grantType": JWT_BEARER_GRANT_TYPE_URI,
                 "audience": "https://app.datarobot.com/dr_org_id/my_agent_id",
             },
         }

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -95,15 +95,15 @@ def _make_agent_card() -> AgentCard:
         ),
         params={
             "ref": {"scheme": "oauth2", "flow": "clientCredentials"},
-            "token_endpoint_auth_method": _AUTH_METHOD,
-            "token_exchange": {
-                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-                "requested_token_type": "urn:ietf:params:oauth:token-type:id-jag",
-                "trusted_issuer": _TRUSTED_ISSUER,
+            "tokenEndpointAuthMethod": _AUTH_METHOD,
+            "tokenExchange": {
+                "grantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+                "requestedTokenType": "urn:ietf:params:oauth:token-type:id-jag",
+                "trustedIssuer": _TRUSTED_ISSUER,
                 "audience": _EXCHANGE_AUDIENCE,
             },
-            "token_request": {
-                "grant_type": _GRANT_TYPE,
+            "tokenRequest": {
+                "grantType": _GRANT_TYPE,
                 "audience": _TARGET_AUDIENCE,
             },
         },
@@ -217,7 +217,8 @@ class TestSetAgentCard:
 
 
 class TestParseCrossAppParams:
-    def test_happy_path(self):
+    def test_camel_case_params(self):
+        """Extension params in camelCase (canonical — matches agent card generation)."""
         params = _parse_cross_app_params(_make_agent_card())
 
         assert params.token_url == _AGENT_TOKEN_URL
@@ -226,6 +227,51 @@ class TestParseCrossAppParams:
         assert params.target_audience == _TARGET_AUDIENCE
         assert params.token_endpoint_auth_method == _AUTH_METHOD
         assert params.id_jag_scopes == ["read_data"]
+
+    def test_snake_case_params(self):
+        """Extension params in snake_case (backward compatibility)."""
+        cc_flow = ClientCredentialsOAuthFlow(
+            token_url=_AGENT_TOKEN_URL,
+            scopes={"read_data": "Read access"},
+        )
+        security_scheme = SecurityScheme(
+            root=OAuth2SecurityScheme(type="oauth2", flows=OAuthFlows(client_credentials=cc_flow))
+        )
+        extension = AgentExtension(
+            uri="urn:ietf:params:oauth:grant-type:jwt-bearer",
+            description="",
+            params={
+                "token_endpoint_auth_method": _AUTH_METHOD,
+                "token_exchange": {
+                    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                    "requested_token_type": "urn:ietf:params:oauth:token-type:id-jag",
+                    "trusted_issuer": _TRUSTED_ISSUER,
+                    "audience": _EXCHANGE_AUDIENCE,
+                },
+                "token_request": {
+                    "grant_type": _GRANT_TYPE,
+                    "audience": _TARGET_AUDIENCE,
+                },
+            },
+        )
+        card = AgentCard(
+            name="Test Agent",
+            description="Test",
+            url="https://agent.example.com/",
+            version="1.0.0",
+            skills=[],
+            capabilities=AgentCapabilities(streaming=False, extensions=[extension]),
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+            security_schemes={"oauth2": security_scheme},
+            security=[{"oauth2": ["read_data"]}],
+        )
+        params = _parse_cross_app_params(card)
+        assert params.token_url == _AGENT_TOKEN_URL
+        assert params.trusted_issuer == _TRUSTED_ISSUER
+        assert params.exchange_audience == _EXCHANGE_AUDIENCE
+        assert params.target_audience == _TARGET_AUDIENCE
+        assert params.token_endpoint_auth_method == _AUTH_METHOD
 
     def test_scopes_come_from_card(self):
         cc_flow = ClientCredentialsOAuthFlow(
@@ -266,6 +312,52 @@ class TestParseCrossAppParams:
         )
         params = _parse_cross_app_params(card)
         assert set(params.id_jag_scopes) == {"dr.impersonation", "openid"}
+
+    def test_camel_case_params(self):
+        """Extension params in camelCase (as returned by the agent card registry API)."""
+        cc_flow = ClientCredentialsOAuthFlow(
+            token_url=_AGENT_TOKEN_URL,
+            scopes={"dr.impersonation": "Impersonation scope"},
+        )
+        security_scheme = SecurityScheme(
+            root=OAuth2SecurityScheme(type="oauth2", flows=OAuthFlows(client_credentials=cc_flow))
+        )
+        extension = AgentExtension(
+            uri="urn:ietf:params:oauth:grant-type:jwt-bearer",
+            description="",
+            params={
+                "ref": {"scheme": "oauth2", "flow": "clientCredentials"},
+                "tokenEndpointAuthMethod": _AUTH_METHOD,
+                "tokenExchange": {
+                    "grantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+                    "requestedTokenType": "urn:ietf:params:oauth:token-type:id-jag",
+                    "trustedIssuer": _TRUSTED_ISSUER,
+                    "audience": _EXCHANGE_AUDIENCE,
+                },
+                "tokenRequest": {
+                    "grantType": _GRANT_TYPE,
+                    "audience": _TARGET_AUDIENCE,
+                },
+            },
+        )
+        card = AgentCard(
+            name="Test Agent",
+            description="Test",
+            url="https://agent.example.com/",
+            version="1.0.0",
+            skills=[],
+            capabilities=AgentCapabilities(streaming=False, extensions=[extension]),
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+            security_schemes={"oauth2": security_scheme},
+            security=[{"oauth2": ["dr.impersonation"]}],
+        )
+        params = _parse_cross_app_params(card)
+        assert params.token_url == _AGENT_TOKEN_URL
+        assert params.trusted_issuer == _TRUSTED_ISSUER
+        assert params.exchange_audience == _EXCHANGE_AUDIENCE
+        assert params.target_audience == _TARGET_AUDIENCE
+        assert params.token_endpoint_auth_method == _AUTH_METHOD
 
 
 class TestConfigSerialization:

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -313,52 +313,6 @@ class TestParseCrossAppParams:
         params = _parse_cross_app_params(card)
         assert set(params.id_jag_scopes) == {"dr.impersonation", "openid"}
 
-    def test_camel_case_params(self):
-        """Extension params in camelCase (as returned by the agent card registry API)."""
-        cc_flow = ClientCredentialsOAuthFlow(
-            token_url=_AGENT_TOKEN_URL,
-            scopes={"dr.impersonation": "Impersonation scope"},
-        )
-        security_scheme = SecurityScheme(
-            root=OAuth2SecurityScheme(type="oauth2", flows=OAuthFlows(client_credentials=cc_flow))
-        )
-        extension = AgentExtension(
-            uri="urn:ietf:params:oauth:grant-type:jwt-bearer",
-            description="",
-            params={
-                "ref": {"scheme": "oauth2", "flow": "clientCredentials"},
-                "tokenEndpointAuthMethod": _AUTH_METHOD,
-                "tokenExchange": {
-                    "grantType": "urn:ietf:params:oauth:grant-type:token-exchange",
-                    "requestedTokenType": "urn:ietf:params:oauth:token-type:id-jag",
-                    "trustedIssuer": _TRUSTED_ISSUER,
-                    "audience": _EXCHANGE_AUDIENCE,
-                },
-                "tokenRequest": {
-                    "grantType": _GRANT_TYPE,
-                    "audience": _TARGET_AUDIENCE,
-                },
-            },
-        )
-        card = AgentCard(
-            name="Test Agent",
-            description="Test",
-            url="https://agent.example.com/",
-            version="1.0.0",
-            skills=[],
-            capabilities=AgentCapabilities(streaming=False, extensions=[extension]),
-            default_input_modes=["text"],
-            default_output_modes=["text"],
-            security_schemes={"oauth2": security_scheme},
-            security=[{"oauth2": ["dr.impersonation"]}],
-        )
-        params = _parse_cross_app_params(card)
-        assert params.token_url == _AGENT_TOKEN_URL
-        assert params.trusted_issuer == _TRUSTED_ISSUER
-        assert params.exchange_audience == _EXCHANGE_AUDIENCE
-        assert params.target_audience == _TARGET_AUDIENCE
-        assert params.token_endpoint_auth_method == _AUTH_METHOD
-
 
 class TestConfigSerialization:
     def test_private_jwk_survives_json_roundtrip(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.63"
+version = "0.15.64"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches A2A Okta Cross-Application Access parameter parsing used to drive token exchange, so malformed parsing could break authentication at runtime. Risk is mitigated by new unit coverage for both camelCase and legacy snake_case payloads.
> 
> **Overview**
> Updates Okta A2A Cross-Application Access AgentCard parsing to **accept both camelCase (registry/canonical) and legacy snake_case** keys in the JWT-bearer capability extension.
> 
> Replaces the manual dict extraction/required-field checks with pydantic `BaseModel` validation (`AliasChoices`) for `tokenExchange`/`tokenRequest`, and adjusts `_parse_cross_app_params` to read the new nested model fields. Tests are updated to emit camelCase by default and add explicit coverage for snake_case backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a25ff49d53c22eac961b03ecf9dfd22358e9476. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->