### PR TITLE
[BUZZOK-30289] Use new async and streaming interface for DataRobotModerationMiddleware

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   TASK_VERSION: 3.48.0
-  TARGET_NAME: response
 
 jobs:
   detect-changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.67
+- The `core` extra declares `datarobot-moderations[all]>=11.2.30,<12.0.0` (bumped from 11.2.29). Stack extras built on core install the same constraint.
+
 ## 0.15.66
 - Added `datarobot_genai.dragent.execute_dragent_inline` (plus an async variant) — an in-process runner so `datarobot-user-models`'s `run_agent.py` can route between DRUM and dragent with a single env-var-gated branch. Workflow YAML is taken from the `config_file` argument when supplied, otherwise from `<custom_model_dir>/workflow.yaml`. Always returns a single aggregated OpenAI `ChatCompletion`; the `stream` flag on the request is ignored because the agentic playground only renders the final assistant message.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.67
-- The `core` extra declares `datarobot-moderations[all]>=11.2.30,<12.0.0` (bumped from 11.2.29). Stack extras built on core install the same constraint.
+- Bump `datarobot-moderations` to 11.2.30 to use the async interface with `DataRobotModerationMiddleware`
 
 ## 0.15.66
 - Added `datarobot_genai.dragent.execute_dragent_inline` (plus an async variant) — an in-process runner so `datarobot-user-models`'s `run_agent.py` can route between DRUM and dragent with a single env-var-gated branch. Workflow YAML is taken from the `config_file` argument when supplied, otherwise from `<custom_model_dir>/workflow.yaml`. Always returns a single aggregated OpenAI `ChatCompletion`; the `stream` flag on the request is ignored because the agentic playground only renders the final assistant message.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.66"
+version = "0.15.67"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1135,12 +1135,12 @@ requires-dist = [
     { name = "datarobot-early-access", marker = "extra == 'langgraph'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'llamaindex'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'nat'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.29,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.30,<12.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1373,7 +1373,7 @@ example-quickstart = [{ name = "datarobot-genai", extras = ["langgraph"], editab
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.29"
+version = "11.2.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1390,7 +1390,7 @@ dependencies = [
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/2d/892f2be271027dba8ec550e8d2db78bc43b7fe5c531c8851d0e5fe72990e/datarobot_moderations-11.2.29-py3-none-any.whl", hash = "sha256:f49dd5651b73684d80809916ee7f0eafe5d342ccb5494f3c59f0129adbf225d6", size = 113903, upload-time = "2026-05-11T13:05:11.248Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ba/d594bdcb2a21817ca854f593302b31c7dd7c064db76873de73c686e5768b/datarobot_moderations-11.2.30-py3-none-any.whl", hash = "sha256:a31d5d80a946d664d6d267898d41b9041134a0eef4a02037bc31adfe01ed6f28", size = 123894, upload-time = "2026-05-19T16:20:45.444Z" },
 ]
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.66"
+version = "0.15.67"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ core = [
     "opentelemetry-instrumentation-httpx>=0.43b0,<1.0.0",
     "opentelemetry-instrumentation-openai>=0.40.5,<1.0.0",
     "opentelemetry-instrumentation-threading>=0.43b0,<1.0.0",
-    "datarobot-moderations[all]>=11.2.29,<12.0.0",
+    "datarobot-moderations[all]>=11.2.30,<12.0.0",
     # Keep this version in sync with all consumers of agent messages e.g. the fastapi_server of the
     # agent application template
     "ag-ui-protocol==0.1.15",

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1263,16 +1263,42 @@ def _defer_until_after_moderated_chunk(event: Event) -> bool:
     )
 
 
-def _pending_deferred_in_emit_order(
-    pending: list[DRAgentEventResponse],
+def _pending_after_moderated_chunk(
+    pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
 ) -> list[DRAgentEventResponse]:
-    """TEXT_MESSAGE_END before other deferred items so END always precedes a following START."""
-    ends_first = [
+    """Order buffered events after a moderated text chunk.
+
+    Deferred ``TEXT_MESSAGE_END`` closes the prior segment first. Pass-through events (for example
+    ``STEP_FINISHED`` / ``STEP_STARTED``) keep upstream order. Deferred ``TEXT_MESSAGE_START`` for
+    the next segment follows so step boundaries stay valid for AG-UI verification.
+    """
+    deferred_ends = [
         item
-        for item in pending
+        for item in pending_deferred
         if item.events and item.events[0].type == EventType.TEXT_MESSAGE_END
     ]
-    return ends_first + [item for item in pending if item not in ends_first]
+    deferred_starts = [
+        item
+        for item in pending_deferred
+        if item.events and item.events[0].type == EventType.TEXT_MESSAGE_START
+    ]
+    deferred_other = [
+        item
+        for item in pending_deferred
+        if item not in deferred_ends and item not in deferred_starts
+    ]
+    return deferred_ends + list(pending_pass_through) + deferred_starts + deferred_other
+
+
+def _drain_pending_after_moderated_chunk(
+    pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
+) -> list[DRAgentEventResponse]:
+    ordered = _pending_after_moderated_chunk(pending_deferred, pending_pass_through)
+    pending_deferred.clear()
+    pending_pass_through.clear()
+    return ordered
 
 
 def _buffer_dragent_passthrough(
@@ -1677,14 +1703,20 @@ class DataRobotModerationMiddleware(
                     stream_tool_index_map=stream_tool_index_map,
                 )
                 yield ctx.output
-                for item in _pending_deferred_in_emit_order(pending_deferred_pass_through):
-                    yield item
-                pending_deferred_pass_through.clear()
-                for item in pending_pass_through:
+                for item in _drain_pending_after_moderated_chunk(
+                    pending_deferred_pass_through,
+                    pending_pass_through,
+                ):
                     yield item
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
                     return
+
+            for item in _drain_pending_after_moderated_chunk(
+                pending_deferred_pass_through,
+                pending_pass_through,
+            ):
+                yield item
         finally:
             _clear_moderation_invoke_state_if_set()
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -19,17 +19,12 @@ loads ``@register_middleware`` without a custom recipe mapping (``_type: datarob
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import contextvars
 import logging
 import math
 import os
-import queue
-import threading
 import uuid
 from collections.abc import AsyncIterator
-from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
@@ -65,8 +60,6 @@ from datarobot_dome.constants import MODERATION_MODEL_NAME
 from datarobot_dome.constants import GuardStage
 from datarobot_dome.runtime import get_runtime_parameter_value_bool
 from datarobot_dome.schema.moderation_config import ModerationConfig
-from datarobot_dome.streaming import ModerationIterator
-from datarobot_dome.streaming import StreamingContextBuilder
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_middleware
 from nat.data_models.api_server import ChatRequest
@@ -1293,39 +1286,11 @@ def _pending_deferred_in_emit_order(
     return ends_first + [item for item in pending if item not in ends_first]
 
 
-_STREAM_INPUT_END = object()
-_WORKER_QUEUE_END = object()
-
-
-@contextlib.contextmanager
-def _agentic_pipeline_interactions_column_for_postscore(input_df: pd.DataFrame) -> Iterator[None]:
-    """Provide ``pipeline_interactions`` for postscore only, matching ``evaluate_response``.
-
-    ``ModerationPipeline.evaluate_response`` adds ``AGENTIC_PIPELINE_INTERACTIONS_ATTR`` to the
-    dataframe passed to the postscore executor. ``ModerationIterator`` copies ``input_df`` for
-    postscore but omits that column, so OOTB guards that require it (for example task adherence)
-    do not populate metrics. The iterator also merges prescore and postscore on
-    ``list(input_df.columns)``, so the column must not remain on ``input_df`` after postscore.
-    """
+def _ensure_agentic_pipeline_interactions_on_input_df(input_df: pd.DataFrame) -> None:
+    """Ensure streaming postscore sees ``pipeline_interactions`` (see ``evaluate_response_async``)."""
     col = AGENTIC_PIPELINE_INTERACTIONS_ATTR
-    if col in input_df.columns:
-        yield
-        return
-    input_df[col] = [None]
-    try:
-        yield
-    finally:
-        input_df.drop(columns=[col], inplace=True)
-
-
-class _ModerationIteratorWithPostscorePipelineInteractions(ModerationIterator):
-    def _run_postscore_guards_on_chunk(self, return_chunk: Any) -> Any:
-        with _agentic_pipeline_interactions_column_for_postscore(self.input_df):
-            return super()._run_postscore_guards_on_chunk(return_chunk)
-
-    def _run_postscore_guards_on_assembled_response(self, citations: Any) -> Any:
-        with _agentic_pipeline_interactions_column_for_postscore(self.input_df):
-            return super()._run_postscore_guards_on_assembled_response(citations)
+    if col not in input_df.columns:
+        input_df[col] = [None]
 
 
 @dataclass
@@ -1432,33 +1397,14 @@ class DataRobotModerationMiddleware(
 
         pipeline = self._moderation._pipeline
 
-        # the chat request is not a dataframe, but we'll build a DF internally for moderation.
         prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
         prompt = moderation_prompt_from_workflow_input(workflow_input)
 
+        # Step 1: Prescore via ``ModerationPipeline.evaluate_prompt_async`` (non-blocking).
+        prompt_eval, prescore_latency, prescore_df = await self._moderation.evaluate_prompt_async(
+            prompt
+        )
         data = pd.DataFrame({prompt_column_name: [prompt]})
-
-        # ==================================================================
-        # Step 1: Prescore guards (single run, same path as
-        # ``ModerationPipeline.evaluate_prompt`` / ``_run_stage``)
-        #
-        # We need the full prescore DataFrame for postscore, ``format_result_df``, and
-        # streaming; we derive ``EvaluationResult`` with the same ``_from_dataframe`` helper
-        # used by the public API (avoids ``run_prescore_guards`` + ``evaluate_prompt``,
-        # which would execute prescore twice).
-        guards = pipeline.get_prescore_guards()
-        if not guards:
-            prescore_df = data.copy(deep=True)
-            prescore_df[f"blocked_{prompt_column_name}"] = False
-            prescore_df[f"replaced_{prompt_column_name}"] = False
-            prescore_latency = 0.0
-        else:
-            prescore_df, prescore_latency = self._moderation._executor.run_guards(
-                data.copy(deep=True),
-                guards,
-                GuardStage.PROMPT,
-            )
-        prompt_eval = _from_dataframe(prescore_df, prompt_column_name)
 
         if prompt_eval.blocked:
             # If all prompts in the input are blocked, means history as well as the prompt
@@ -1538,7 +1484,7 @@ class DataRobotModerationMiddleware(
         prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
         prompt_for_eval = state.input_df.loc[0, prompt_column_name]
 
-        response_eval, _ = self._moderation.evaluate_response(
+        response_eval, _, _postscore_df = await self._moderation.evaluate_response_async(
             _text_for_moderation_eval(response_text),
             prompt=_optional_prompt_for_moderation_eval(prompt_for_eval),
         )
@@ -1650,52 +1596,14 @@ class DataRobotModerationMiddleware(
             assert moderation is not None
 
             stream_tool_index_map: dict[int, str] = {}
+            _ensure_agentic_pipeline_interactions_on_input_df(stream_state.input_df)
 
-            streaming_context = (
-                StreamingContextBuilder()
-                .set_pipeline(moderation._pipeline)
-                .set_prescore_df(stream_state.prescore_df)
-                .set_prescore_latency(stream_state.latency_so_far)
-                .set_input_df(stream_state.input_df)
-                .build()
+            prompt_column_name = moderation._pipeline.get_input_column(GuardStage.PROMPT)
+            prompt_for_stream = _text_for_moderation_eval(
+                stream_state.input_df.loc[0, prompt_column_name]
             )
 
-            in_q: queue.Queue[Any] = queue.Queue()
-            out_q: queue.Queue[Any] = queue.Queue()
-            mod_errors: list[BaseException] = []
-            worker: threading.Thread | None = None
-
-            def input_chunk_iter() -> Iterator[Any]:
-                while True:
-                    item = in_q.get()
-                    if item is _STREAM_INPUT_END:
-                        break
-                    yield item
-
-            def moderation_worker() -> None:
-                try:
-                    mit = _ModerationIteratorWithPostscorePipelineInteractions(
-                        streaming_context, input_chunk_iter()
-                    )
-                    for moderated_chunk in mit:
-                        out_q.put(moderated_chunk)
-                except BaseException as exc:
-                    mod_errors.append(exc)
-                finally:
-                    out_q.put(_WORKER_QUEUE_END)
-
-            def start_moderation_worker() -> threading.Thread:
-                t = threading.Thread(
-                    target=moderation_worker,
-                    name="datarobot-moderation-stream",
-                    daemon=True,
-                )
-                t.start()
-                return t
-
             upstream = call_next(*ctx.modified_args, **ctx.modified_kwargs).__aiter__()
-            loop = asyncio.get_running_loop()
-            worker_sentinel_received = False
 
             async def read_upstream() -> DRAgentEventResponse | None:
                 try:
@@ -1703,42 +1611,31 @@ class DataRobotModerationMiddleware(
                 except StopAsyncIteration:
                     return None
 
-            try:
-                # Leading pass-through (non–text-message) events
-                while True:
-                    response = await read_upstream()
-                    if response is None:
-                        return
-                    if not response.events or skip_event_type(response.events[0]):
-                        yield response
-                        continue
-                    break
+            # Leading pass-through (non–text-message) events
+            while True:
+                response = await read_upstream()
+                if response is None:
+                    return
+                if not response.events or skip_event_type(response.events[0]):
+                    yield response
+                    continue
+                break
 
-                # ``ModerationIterator`` peeks one chunk ahead: each ``__next__`` pulls the next
-                # item from the iterable before returning the moderated current chunk. Feed that
-                # peek *before* awaiting each moderated output or the worker deadlocks.
-                worker = start_moderation_worker()
-                current_response = response
-                in_q.put(
-                    cast(
-                        ChatCompletionChunk,
-                        dragent_event_response_to_chat_completion(
-                            current_response, as_streaming_chunk=True
-                        ),
-                    )
+            current_response = response
+            pending_deferred_pass_through: list[DRAgentEventResponse] = []
+            pending_pass_through: list[DRAgentEventResponse] = []
+
+            async def upstream_completion_chunks() -> AsyncIterator[ChatCompletionChunk]:
+                """Feed ``stream_response_async``; collect pass-through while peeking ahead."""
+                nonlocal current_response
+                yield cast(
+                    ChatCompletionChunk,
+                    dragent_event_response_to_chat_completion(
+                        current_response, as_streaming_chunk=True
+                    ),
                 )
-
-                # Defer TEXT_MESSAGE_START/END until after the moderated chunk for this step.
-                # (See _defer_until_after_moderated_chunk.) Other pass-through events keep
-                # upstream order relative to non-text events.
-                pending_deferred_pass_through: list[DRAgentEventResponse] = []
-
                 while True:
-                    # Pass-through events read while advancing to the next moderation input chunk
-                    # must follow the moderated output for ``current_response`` (ModerationIterator
-                    # peeks one chunk ahead). Yielding them early breaks ordering (e.g. RUN_FINISHED
-                    # before TEXT_MESSAGE_CONTENT / TEXT_MESSAGE_END).
-                    pending_pass_through: list[DRAgentEventResponse] = []
+                    pending_pass_through.clear()
                     peek = await read_upstream()
                     while peek is not None and (not peek.events or skip_event_type(peek.events[0])):
                         if peek.events and _defer_until_after_moderated_chunk(peek.events[0]):
@@ -1746,63 +1643,34 @@ class DataRobotModerationMiddleware(
                         else:
                             pending_pass_through.append(peek)
                         peek = await read_upstream()
-
                     if peek is None:
-                        in_q.put(_STREAM_INPUT_END)
-                    else:
-                        in_q.put(
-                            cast(
-                                ChatCompletionChunk,
-                                dragent_event_response_to_chat_completion(
-                                    peek, as_streaming_chunk=True
-                                ),
-                            )
-                        )
-
-                    moderated = await loop.run_in_executor(None, out_q.get)
-                    if moderated is _WORKER_QUEUE_END:
-                        for item in _pending_deferred_in_emit_order(pending_deferred_pass_through):
-                            yield item
-                        pending_deferred_pass_through.clear()
-                        for item in pending_pass_through:
-                            yield item
-                        worker_sentinel_received = True
-                        if mod_errors:
-                            raise mod_errors[0]
-                        break
-
-                    ctx.output = chat_completion_to_dragent_event_response(
-                        moderated,
-                        source_ag_ui_events=current_response.events,
-                        stream_tool_index_map=stream_tool_index_map,
-                    )
-                    yield ctx.output
-                    for item in _pending_deferred_in_emit_order(pending_deferred_pass_through):
-                        yield item
-                    pending_deferred_pass_through.clear()
-                    for item in pending_pass_through:
-                        yield item
-                    finish = moderated.choices[0].finish_reason if moderated.choices else None
-                    if finish == "content_filter":
-                        break
-
-                    if peek is None:
-                        break
-
+                        return
                     current_response = peek
-            finally:
-                if worker is not None:
-                    in_q.put(_STREAM_INPUT_END)
-                    if not worker_sentinel_received:
-                        # Short-circuit paths (e.g. ``content_filter``) can exit before draining
-                        # ``out_q``. The iterator may have already queued another moderated chunk
-                        # before ``_WORKER_QUEUE_END``; drain until the sentinel instead of treating
-                        # the first leftover item as an anomaly.
-                        while True:
-                            item = await loop.run_in_executor(None, out_q.get)
-                            if item is _WORKER_QUEUE_END:
-                                break
-                    worker.join(timeout=120.0)
+                    yield cast(
+                        ChatCompletionChunk,
+                        dragent_event_response_to_chat_completion(peek, as_streaming_chunk=True),
+                    )
+
+            async for moderated in moderation.stream_response_async(
+                upstream_completion_chunks(),
+                prompt=prompt_for_stream,
+                prescore_df=stream_state.prescore_df,
+                prescore_latency=stream_state.latency_so_far,
+            ):
+                ctx.output = chat_completion_to_dragent_event_response(
+                    moderated,
+                    source_ag_ui_events=current_response.events,
+                    stream_tool_index_map=stream_tool_index_map,
+                )
+                yield ctx.output
+                for item in _pending_deferred_in_emit_order(pending_deferred_pass_through):
+                    yield item
+                pending_deferred_pass_through.clear()
+                for item in pending_pass_through:
+                    yield item
+                finish = moderated.choices[0].finish_reason if moderated.choices else None
+                if finish == "content_filter":
+                    return
         finally:
             _clear_moderation_invoke_state_if_set()
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1275,6 +1275,61 @@ def _pending_deferred_in_emit_order(
     return ends_first + [item for item in pending if item not in ends_first]
 
 
+def _buffer_dragent_passthrough(
+    response: DRAgentEventResponse,
+    *,
+    pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
+) -> None:
+    if response.events and _defer_until_after_moderated_chunk(response.events[0]):
+        pending_deferred.append(response)
+    else:
+        pending_pass_through.append(response)
+
+
+async def _next_text_dragent_response(
+    upstream: AsyncIterator[DRAgentEventResponse],
+    *,
+    pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
+) -> DRAgentEventResponse | None:
+    """Advance upstream, buffering pass-through until the next text chunk or exhaustion."""
+    async for response in upstream:
+        if not response.events or skip_event_type(response.events[0]):
+            _buffer_dragent_passthrough(
+                response,
+                pending_deferred=pending_deferred,
+                pending_pass_through=pending_pass_through,
+            )
+            continue
+        return response
+    return None
+
+
+async def _completion_chunks_from_dragent_upstream(
+    upstream: AsyncIterator[DRAgentEventResponse],
+    first_text: DRAgentEventResponse,
+    *,
+    moderation_source_responses: list[DRAgentEventResponse],
+    pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
+) -> AsyncIterator[ChatCompletionChunk]:
+    """Feed ``stream_response_async``; align sources with peek-ahead inside the pipeline."""
+    current: DRAgentEventResponse | None = first_text
+    while current is not None:
+        pending_pass_through.clear()
+        moderation_source_responses.append(current)
+        yield cast(
+            ChatCompletionChunk,
+            dragent_event_response_to_chat_completion(current, as_streaming_chunk=True),
+        )
+        current = await _next_text_dragent_response(
+            upstream,
+            pending_deferred=pending_deferred,
+            pending_pass_through=pending_pass_through,
+        )
+
+
 @dataclass
 class _ModerationInvokeState:
     """Per-async-task prescore payload for post_invoke / streaming (middleware may be shared)."""
@@ -1584,60 +1639,33 @@ class DataRobotModerationMiddleware(
                 stream_state.input_df.loc[0, prompt_column_name]
             )
 
-            upstream = call_next(*ctx.modified_args, **ctx.modified_kwargs).__aiter__()
+            upstream = cast(
+                AsyncIterator[DRAgentEventResponse],
+                call_next(*ctx.modified_args, **ctx.modified_kwargs),
+            )
 
-            async def read_upstream() -> DRAgentEventResponse | None:
-                try:
-                    return cast(DRAgentEventResponse, await upstream.__anext__())
-                except StopAsyncIteration:
-                    return None
+            # Leading pass-through (non–text-message) events before the first moderated chunk.
+            first_text: DRAgentEventResponse | None = None
+            async for response in upstream:
+                if response.events and not skip_event_type(response.events[0]):
+                    first_text = response
+                    break
+                yield response
+            if first_text is None:
+                return
 
-            # Leading pass-through (non–text-message) events
-            while True:
-                response = await read_upstream()
-                if response is None:
-                    return
-                if not response.events or skip_event_type(response.events[0]):
-                    yield response
-                    continue
-                break
-
-            current_response = response
             pending_deferred_pass_through: list[DRAgentEventResponse] = []
             pending_pass_through: list[DRAgentEventResponse] = []
-            # ``stream_response_async`` peeks one chunk ahead on the completion iterator.
-            # Queue each upstream response when its chunk is yielded so the outer loop can
-            # pop the matching source after moderation (not the peeked-next response).
             moderation_source_responses: list[DRAgentEventResponse] = []
 
-            async def upstream_completion_chunks() -> AsyncIterator[ChatCompletionChunk]:
-                """Feed ``stream_response_async``; collect pass-through while peeking ahead."""
-                moderation_source_responses.append(current_response)
-                yield cast(
-                    ChatCompletionChunk,
-                    dragent_event_response_to_chat_completion(
-                        current_response, as_streaming_chunk=True
-                    ),
-                )
-                while True:
-                    pending_pass_through.clear()
-                    peek = await read_upstream()
-                    while peek is not None and (not peek.events or skip_event_type(peek.events[0])):
-                        if peek.events and _defer_until_after_moderated_chunk(peek.events[0]):
-                            pending_deferred_pass_through.append(peek)
-                        else:
-                            pending_pass_through.append(peek)
-                        peek = await read_upstream()
-                    if peek is None:
-                        return
-                    moderation_source_responses.append(peek)
-                    yield cast(
-                        ChatCompletionChunk,
-                        dragent_event_response_to_chat_completion(peek, as_streaming_chunk=True),
-                    )
-
             async for moderated in moderation.stream_response_async(
-                upstream_completion_chunks(),
+                _completion_chunks_from_dragent_upstream(
+                    upstream,
+                    first_text,
+                    moderation_source_responses=moderation_source_responses,
+                    pending_deferred=pending_deferred_pass_through,
+                    pending_pass_through=pending_pass_through,
+                ),
                 prompt=prompt_for_stream,
                 prescore_df=stream_state.prescore_df,
                 prescore_latency=stream_state.latency_so_far,

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -123,19 +123,12 @@ def load_llm_moderation_pipeline(config: DataRobotModerationConfig) -> Moderatio
         _logger.warning("Moderation is disabled via runtime parameter on the model")
         return None
 
-    os.environ["RAGAS_DO_NOT_TRACK"] = "true"
-    os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "YES"
-
     if config.moderation is None:
         _logger.warning("Middleware has no ``moderation`` block; moderations will not be enforced")
         return None
 
     model_dir = os.path.abspath(os.getcwd())
-    pipeline = ModerationPipeline.from_config(config.moderation, model_dir=model_dir)
-
-    os.environ["PROMPT_COLUMN_NAME"] = pipeline._pipeline.get_input_column(GuardStage.PROMPT)
-    os.environ["RESPONSE_COLUMN_NAME"] = pipeline._pipeline.get_input_column(GuardStage.RESPONSE)
-    return pipeline
+    return ModerationPipeline.from_config(config.moderation, model_dir=model_dir)
 
 
 def _text_for_moderation_eval(value: Any) -> str:

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1624,10 +1624,14 @@ class DataRobotModerationMiddleware(
             current_response = response
             pending_deferred_pass_through: list[DRAgentEventResponse] = []
             pending_pass_through: list[DRAgentEventResponse] = []
+            # ``stream_response_async`` peeks one chunk ahead on the completion iterator.
+            # Queue each upstream response when its chunk is yielded so the outer loop can
+            # pop the matching source after moderation (not the peeked-next response).
+            moderation_source_responses: list[DRAgentEventResponse] = []
 
             async def upstream_completion_chunks() -> AsyncIterator[ChatCompletionChunk]:
                 """Feed ``stream_response_async``; collect pass-through while peeking ahead."""
-                nonlocal current_response
+                moderation_source_responses.append(current_response)
                 yield cast(
                     ChatCompletionChunk,
                     dragent_event_response_to_chat_completion(
@@ -1645,7 +1649,7 @@ class DataRobotModerationMiddleware(
                         peek = await read_upstream()
                     if peek is None:
                         return
-                    current_response = peek
+                    moderation_source_responses.append(peek)
                     yield cast(
                         ChatCompletionChunk,
                         dragent_event_response_to_chat_completion(peek, as_streaming_chunk=True),
@@ -1657,9 +1661,10 @@ class DataRobotModerationMiddleware(
                 prescore_df=stream_state.prescore_df,
                 prescore_latency=stream_state.latency_so_far,
             ):
+                source_response = moderation_source_responses.pop(0)
                 ctx.output = chat_completion_to_dragent_event_response(
                     moderated,
-                    source_ag_ui_events=current_response.events,
+                    source_ag_ui_events=source_response.events,
                     stream_tool_index_map=stream_tool_index_map,
                 )
                 yield ctx.output

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1301,58 +1301,82 @@ def _drain_pending_after_moderated_chunk(
     return ordered
 
 
-def _buffer_dragent_passthrough(
-    response: DRAgentEventResponse,
-    *,
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
-) -> None:
-    if response.events and _defer_until_after_moderated_chunk(response.events[0]):
-        pending_deferred.append(response)
-    else:
-        pending_pass_through.append(response)
-
-
-async def _next_text_dragent_response(
+async def _moderated_dragent_stream(
     upstream: AsyncIterator[DRAgentEventResponse],
     *,
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
-) -> DRAgentEventResponse | None:
-    """Advance upstream, buffering pass-through until the next text chunk or exhaustion."""
-    async for response in upstream:
-        if not response.events or skip_event_type(response.events[0]):
-            _buffer_dragent_passthrough(
-                response,
-                pending_deferred=pending_deferred,
-                pending_pass_through=pending_pass_through,
+    moderation: ModerationPipeline,
+    prompt_for_stream: str,
+    stream_state: _ModerationInvokeState,
+    stream_tool_index_map: dict[int, str],
+) -> AsyncIterator[tuple[bool, DRAgentEventResponse]]:
+    """Yield ``(is_moderated_text, response)`` with AG-UI-safe ordering around moderated deltas.
+
+    Non-text upstream events pass through immediately until the first text delta. Text deltas are
+    moderated via ``stream_response_async``; ``TEXT_MESSAGE_START`` / ``END`` and other events read
+    during peek-ahead are buffered and emitted after each moderated chunk.
+    """
+    pending_deferred: list[DRAgentEventResponse] = []
+    pending_pass_through: list[DRAgentEventResponse] = []
+    moderation_source_responses: list[DRAgentEventResponse] = []
+
+    def buffer_passthrough(response: DRAgentEventResponse) -> None:
+        if response.events and _defer_until_after_moderated_chunk(response.events[0]):
+            pending_deferred.append(response)
+        else:
+            pending_pass_through.append(response)
+
+    async def next_text_response() -> DRAgentEventResponse | None:
+        async for response in upstream:
+            if not response.events or skip_event_type(response.events[0]):
+                buffer_passthrough(response)
+                continue
+            return response
+        return None
+
+    async def completion_chunks(
+        first_text: DRAgentEventResponse,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        current: DRAgentEventResponse | None = first_text
+        while current is not None:
+            moderation_source_responses.append(current)
+            yield cast(
+                ChatCompletionChunk,
+                dragent_event_response_to_chat_completion(current, as_streaming_chunk=True),
             )
-            continue
-        return response
-    return None
+            current = await next_text_response()
 
+    first_text: DRAgentEventResponse | None = None
+    async for response in upstream:
+        if response.events and not skip_event_type(response.events[0]):
+            first_text = response
+            break
+        yield False, response
+    if first_text is None:
+        return
 
-async def _completion_chunks_from_dragent_upstream(
-    upstream: AsyncIterator[DRAgentEventResponse],
-    first_text: DRAgentEventResponse,
-    *,
-    moderation_source_responses: list[DRAgentEventResponse],
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
-) -> AsyncIterator[ChatCompletionChunk]:
-    """Feed ``stream_response_async``; align sources with peek-ahead inside the pipeline."""
-    current: DRAgentEventResponse | None = first_text
-    while current is not None:
-        moderation_source_responses.append(current)
-        yield cast(
-            ChatCompletionChunk,
-            dragent_event_response_to_chat_completion(current, as_streaming_chunk=True),
+    async for moderated in moderation.stream_response_async(
+        completion_chunks(first_text),
+        prompt=prompt_for_stream,
+        prescore_df=stream_state.prescore_df,
+        prescore_latency=stream_state.latency_so_far,
+    ):
+        source_response = moderation_source_responses.pop(0)
+        yield (
+            True,
+            chat_completion_to_dragent_event_response(
+                moderated,
+                source_ag_ui_events=source_response.events,
+                stream_tool_index_map=stream_tool_index_map,
+            ),
         )
-        current = await _next_text_dragent_response(
-            upstream,
-            pending_deferred=pending_deferred,
-            pending_pass_through=pending_pass_through,
-        )
+        for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
+            yield False, item
+        finish = moderated.choices[0].finish_reason if moderated.choices else None
+        if finish == "content_filter":
+            return
+
+    for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
+        yield False, item
 
 
 @dataclass
@@ -1657,65 +1681,26 @@ class DataRobotModerationMiddleware(
             moderation = self._moderation
             assert moderation is not None
 
-            stream_tool_index_map: dict[int, str] = {}
-
             prompt_column_name = moderation._pipeline.get_input_column(GuardStage.PROMPT)
             prompt_for_stream = _text_for_moderation_eval(
                 stream_state.input_df.loc[0, prompt_column_name]
             )
-
             upstream = cast(
                 AsyncIterator[DRAgentEventResponse],
                 call_next(*ctx.modified_args, **ctx.modified_kwargs),
             )
+            stream_tool_index_map: dict[int, str] = {}
 
-            # Leading pass-through (non–text-message) events before the first moderated chunk.
-            first_text: DRAgentEventResponse | None = None
-            async for response in upstream:
-                if response.events and not skip_event_type(response.events[0]):
-                    first_text = response
-                    break
+            async for is_moderated, response in _moderated_dragent_stream(
+                upstream,
+                moderation=moderation,
+                prompt_for_stream=prompt_for_stream,
+                stream_state=stream_state,
+                stream_tool_index_map=stream_tool_index_map,
+            ):
+                if is_moderated:
+                    ctx.output = response
                 yield response
-            if first_text is None:
-                return
-
-            pending_deferred_pass_through: list[DRAgentEventResponse] = []
-            pending_pass_through: list[DRAgentEventResponse] = []
-            moderation_source_responses: list[DRAgentEventResponse] = []
-
-            async for moderated in moderation.stream_response_async(
-                _completion_chunks_from_dragent_upstream(
-                    upstream,
-                    first_text,
-                    moderation_source_responses=moderation_source_responses,
-                    pending_deferred=pending_deferred_pass_through,
-                    pending_pass_through=pending_pass_through,
-                ),
-                prompt=prompt_for_stream,
-                prescore_df=stream_state.prescore_df,
-                prescore_latency=stream_state.latency_so_far,
-            ):
-                source_response = moderation_source_responses.pop(0)
-                ctx.output = chat_completion_to_dragent_event_response(
-                    moderated,
-                    source_ag_ui_events=source_response.events,
-                    stream_tool_index_map=stream_tool_index_map,
-                )
-                yield ctx.output
-                for item in _drain_pending_after_moderated_chunk(
-                    pending_deferred_pass_through,
-                    pending_pass_through,
-                ):
-                    yield item
-                finish = moderated.choices[0].finish_reason if moderated.choices else None
-                if finish == "content_filter":
-                    return
-
-            for item in _drain_pending_after_moderated_chunk(
-                pending_deferred_pass_through,
-                pending_pass_through,
-            ):
-                yield item
         finally:
             _clear_moderation_invoke_state_if_set()
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1343,7 +1343,6 @@ async def _completion_chunks_from_dragent_upstream(
     """Feed ``stream_response_async``; align sources with peek-ahead inside the pipeline."""
     current: DRAgentEventResponse | None = first_text
     while current is not None:
-        pending_pass_through.clear()
         moderation_source_responses.append(current)
         yield cast(
             ChatCompletionChunk,

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -52,7 +52,6 @@ from ag_ui.core import UserMessage
 from datarobot_dome.api import EvaluationResult
 from datarobot_dome.api import ModerationPipeline
 from datarobot_dome.api import _from_dataframe
-from datarobot_dome.constants import AGENTIC_PIPELINE_INTERACTIONS_ATTR
 from datarobot_dome.constants import CHAT_COMPLETION_OBJECT
 from datarobot_dome.constants import DATAROBOT_MODERATIONS_ATTR
 from datarobot_dome.constants import DISABLE_MODERATION_RUNTIME_PARAM_NAME
@@ -1276,13 +1275,6 @@ def _pending_deferred_in_emit_order(
     return ends_first + [item for item in pending if item not in ends_first]
 
 
-def _ensure_agentic_pipeline_interactions_on_input_df(input_df: pd.DataFrame) -> None:
-    """Ensure streaming postscore sees ``pipeline_interactions`` (see ``evaluate_response_async``)."""
-    col = AGENTIC_PIPELINE_INTERACTIONS_ATTR
-    if col not in input_df.columns:
-        input_df[col] = [None]
-
-
 @dataclass
 class _ModerationInvokeState:
     """Per-async-task prescore payload for post_invoke / streaming (middleware may be shared)."""
@@ -1586,7 +1578,6 @@ class DataRobotModerationMiddleware(
             assert moderation is not None
 
             stream_tool_index_map: dict[int, str] = {}
-            _ensure_agentic_pipeline_interactions_on_input_df(stream_state.input_df)
 
             prompt_column_name = moderation._pipeline.get_input_column(GuardStage.PROMPT)
             prompt_for_stream = _text_for_moderation_eval(

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -133,9 +133,6 @@ def load_llm_moderation_pipeline(config: DataRobotModerationConfig) -> Moderatio
     model_dir = os.path.abspath(os.getcwd())
     pipeline = ModerationPipeline.from_config(config.moderation, model_dir=model_dir)
 
-    # LLMPipeline.get_input_column(GuardStage.RESPONSE) falls back to TARGET_NAME when the YAML
-    # does not set a response column. DRUM sets TARGET_NAME; local NAT often does not (see e2e CI env).
-    os.environ.setdefault("TARGET_NAME", "response")
     os.environ["PROMPT_COLUMN_NAME"] = pipeline._pipeline.get_input_column(GuardStage.PROMPT)
     os.environ["RESPONSE_COLUMN_NAME"] = pipeline._pipeline.get_input_column(GuardStage.RESPONSE)
     return pipeline

--- a/tests/nat/integration/test_datarobot_moderation_middleware_real_credentials.py
+++ b/tests/nat/integration/test_datarobot_moderation_middleware_real_credentials.py
@@ -88,7 +88,6 @@ def _build_moderation_middleware_for_model_dir(
     builder_mock: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> DataRobotModerationMiddleware:
-    monkeypatch.setenv("TARGET_NAME", '"response"')
     try:
         mw = DataRobotModerationMiddleware(
             DataRobotModerationConfig(moderation=_moderation_config_from_fixture_dir(model_dir)),

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -1744,6 +1744,55 @@ async def test_function_middleware_stream_passthrough_when_no_run_agent_input(
     assert chunks[0].events == _text_response("passthrough").events
 
 
+async def test_function_middleware_stream_preserves_message_id_per_text_chunk(
+    builder_mock: MagicMock,
+) -> None:
+    """Each moderated chunk must use the source response for that chunk, not the peeked next one."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hi")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    mid_a = "msg-chunk-a"
+    mid_b = "msg-chunk-b"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_a, delta="a")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_b, delta="b")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    content_events = [
+        ev for resp in chunks for ev in resp.events if isinstance(ev, TextMessageContentEvent)
+    ]
+    assert len(content_events) == 2
+    assert content_events[0].message_id == mid_a
+    assert content_events[0].delta == "a"
+    assert content_events[1].message_id == mid_b
+    assert content_events[1].delta == "b"
+
+
 async def test_function_middleware_stream_defers_text_message_end_before_run_finished(
     builder_mock: MagicMock,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -35,6 +35,8 @@ pytest.importorskip("datarobot_dome")
 from ag_ui.core import EventType
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
+from ag_ui.core import StepFinishedEvent
+from ag_ui.core import StepStartedEvent
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
@@ -1838,6 +1840,104 @@ async def test_function_middleware_stream_defers_text_message_end_before_run_fin
     end_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TEXT_MESSAGE_END)
     finished_idx = next(i for i, e in enumerate(flat) if e.type == EventType.RUN_FINISHED)
     assert end_idx < finished_idx
+
+
+async def test_function_middleware_stream_preserves_step_order_at_agent_transition(
+    builder_mock: MagicMock,
+) -> None:
+    """CrewAI emits END, STEP_FINISHED, STEP_STARTED, START between agent text segments."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("topic")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    planner_mid = "msg-planner"
+    writer_mid = "msg-writer"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepStartedEvent(step_name="Content Planner")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                TextMessageStartEvent(message_id=planner_mid, role="assistant"),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=planner_mid, delta="plan")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=planner_mid)],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepFinishedEvent(step_name="Content Planner")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepStartedEvent(step_name="Content Writer")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                TextMessageStartEvent(message_id=writer_mid, role="assistant"),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=writer_mid, delta="write")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=writer_mid)],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepFinishedEvent(step_name="Content Writer")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("topic"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    writer_start_idx = next(
+        i
+        for i, e in enumerate(flat)
+        if e.type == EventType.STEP_STARTED and e.step_name == "Content Writer"
+    )
+    writer_finish_idx = next(
+        i
+        for i, e in enumerate(flat)
+        if e.type == EventType.STEP_FINISHED and e.step_name == "Content Writer"
+    )
+    assert writer_start_idx < writer_finish_idx
 
 
 def test_chat_completion_to_dragent_event_response_keeps_tool_calls_with_text() -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -43,6 +43,7 @@ from ag_ui.core import ToolCallArgsEvent
 from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import UserMessage
 from datarobot_dome.api import EvaluationResult
+from datarobot_dome.api import _from_dataframe
 from datarobot_dome.async_http_client import AsyncHTTPClient
 from datarobot_dome.constants import DATAROBOT_MODERATIONS_ATTR
 from datarobot_dome.constants import MODERATION_MODEL_NAME
@@ -241,7 +242,40 @@ def _moderation_mock(pipeline: MagicMock) -> MagicMock:
     mod = MagicMock()
     mod._pipeline = pipeline
     mod._executor = MagicMock()
+    mod.evaluate_prompt_async = AsyncMock()
+    mod.evaluate_response_async = AsyncMock()
+    mod.stream_response_async = _passthrough_stream_response_async
     return mod
+
+
+def _set_evaluate_prompt_async_return(
+    moderation: MagicMock,
+    prescore_df: pd.DataFrame,
+    *,
+    latency: float = 0.0,
+) -> None:
+    prompt_eval = _from_dataframe(prescore_df, PROMPT_COL)
+    moderation.evaluate_prompt_async.return_value = (prompt_eval, latency, prescore_df)
+
+
+async def _passthrough_stream_response_async(
+    completion: Any,
+    **kwargs: Any,
+) -> Any:
+    """Mirror ``ModerationPipeline.stream_response_async`` peek-ahead chunk ordering."""
+    aiter = completion.__aiter__()
+    try:
+        current = await aiter.__anext__()
+    except StopAsyncIteration:
+        return
+    while True:
+        try:
+            peek = await aiter.__anext__()
+        except StopAsyncIteration:
+            yield current
+            return
+        yield current
+        current = peek
 
 
 def _prescore_df_blocked(prompt: str, blocked_message: str) -> pd.DataFrame:
@@ -346,12 +380,18 @@ def test_enabled_false_when_pipeline_not_loaded(builder_mock: MagicMock) -> None
 async def test_pre_invoke_no_prescore_guards_prescore_df_has_blocked_and_replaced_columns(
     builder_mock: MagicMock,
 ) -> None:
-    # GIVEN the pipeline has no prescore guards (``run_guards`` is not used for prompt stage)
+    # GIVEN the pipeline has no prescore guards
     # WHEN pre_invoke runs
-    # THEN prescore_df matches the executor shape so downstream streaming/metadata sees both flags
+    # THEN prescore state is stored for downstream streaming/postscore
     pipeline = _pipeline_mock()
     pipeline.get_prescore_guards.return_value = []
     moderation = _moderation_mock(pipeline)
+    prescore_df = pd.DataFrame({PROMPT_COL: ["hello"]})
+    moderation.evaluate_prompt_async.return_value = (
+        EvaluationResult(blocked=False),
+        0.0,
+        prescore_df,
+    )
 
     run_input = _make_run_input("hello")
     ctx = _invocation(run_input)
@@ -367,26 +407,22 @@ async def test_pre_invoke_no_prescore_guards_prescore_df_has_blocked_and_replace
             await mw.pre_invoke(ctx)
             st = _moderation_invoke_state_ctx.get()
             assert st is not None
-            df = st.prescore_df
-            assert f"blocked_{PROMPT_COL}" in df.columns
-            assert bool(df.loc[0, f"blocked_{PROMPT_COL}"]) is False
-            assert f"replaced_{PROMPT_COL}" in df.columns
-            assert bool(df.loc[0, f"replaced_{PROMPT_COL}"]) is False
+            assert st.prescore_df.equals(prescore_df)
         finally:
             _clear_moderation_invoke_state_if_set()
 
-    moderation._executor.run_guards.assert_not_called()
+    moderation.evaluate_prompt_async.assert_awaited_once_with("hello")
 
 
 async def test_pre_invoke_blocks_and_sets_output(builder_mock: MagicMock) -> None:
-    # GIVEN prescore ``run_guards`` marks the prompt blocked (single execution path)
+    # GIVEN prescore marks the prompt blocked
     # WHEN pre_invoke runs
     # THEN context.output is set to a DRAgentEventResponse and call_next must not run
     pipeline = _pipeline_mock()
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_blocked("bad", "blocked-by-test")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
 
     run_input = _make_run_input("bad")
     ctx = _invocation(run_input)
@@ -422,7 +458,7 @@ async def test_pre_invoke_blocked_includes_datarobot_moderations_from_prescore_m
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_blocked("bad", "blocked-by-test")
     prescore_df["token_count_prompt"] = [42]
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
 
     run_input = _make_run_input("bad")
     ctx = _invocation(run_input)
@@ -444,14 +480,14 @@ async def test_pre_invoke_blocked_includes_datarobot_moderations_from_prescore_m
 
 
 async def test_pre_invoke_replaces_last_user_message(builder_mock: MagicMock) -> None:
-    # GIVEN prescore ``run_guards`` requests a replacement string
+    # GIVEN prescore requests a replacement string
     # WHEN pre_invoke runs
     # THEN the last UserMessage content is updated and context.output stays unset
     pipeline = _pipeline_mock()
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_replaced("secret", "[redacted]")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
 
     run_input = _make_run_input("secret")
     ctx = _invocation(run_input)
@@ -486,7 +522,7 @@ async def test_pre_invoke_replaces_chat_request_or_message_input_message(
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_replaced("secret", "[redacted]")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
 
     crm = ChatRequestOrMessage(input_message="secret")
     ctx = InvocationContext(
@@ -529,7 +565,7 @@ async def test_pre_invoke_replacement_apply_failure_clears_prescore_replaced_fla
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_replaced("secret", "[redacted]")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
 
     run_input = _make_run_input("secret")
     ctx = _invocation(run_input)
@@ -650,7 +686,7 @@ async def test_post_invoke_skips_dr_agent_when_joined_text_blank(
 
     assert out is None
     assert ctx.output is response
-    moderation.evaluate_response.assert_not_called()
+    moderation.evaluate_response_async.assert_not_awaited()
 
 
 async def test_post_invoke_preserves_aggregate_ag_ui_when_response_text_unchanged(
@@ -660,9 +696,10 @@ async def test_post_invoke_preserves_aggregate_ag_ui_when_response_text_unchange
     pipeline = _pipeline_mock()
     pipeline.get_postscore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
-    moderation.evaluate_response.return_value = (
+    moderation.evaluate_response_async.return_value = (
         EvaluationResult(blocked=False, metrics={"token_count": 2}),
         0.0,
+        pd.DataFrame(),
     )
 
     mid = "msg-1"
@@ -716,9 +753,10 @@ async def test_post_invoke_rewrites_completion_when_postscore_succeeds(
     pipeline = _pipeline_mock()
     pipeline.get_postscore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
-    moderation.evaluate_response.return_value = (
+    moderation.evaluate_response_async.return_value = (
         EvaluationResult(blocked=False, replaced=True, replacement="final-out"),
         0.0,
+        pd.DataFrame(),
     )
 
     run_input = _make_run_input()
@@ -755,9 +793,10 @@ async def test_post_invoke_rewrites_nat_chat_response_when_postscore_succeeds(
     pipeline = _pipeline_mock()
     pipeline.get_postscore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
-    moderation.evaluate_response.return_value = (
+    moderation.evaluate_response_async.return_value = (
         EvaluationResult(blocked=False, replaced=True, replacement="final-out"),
         0.0,
+        pd.DataFrame(),
     )
 
     nat_out = _nat_chat_response_assistant_text("model-out")
@@ -790,9 +829,10 @@ async def test_post_invoke_rewrites_plain_str_when_postscore_succeeds(
     pipeline = _pipeline_mock()
     pipeline.get_postscore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
-    moderation.evaluate_response.return_value = (
+    moderation.evaluate_response_async.return_value = (
         EvaluationResult(blocked=False, replaced=True, replacement="final-out"),
         0.0,
+        pd.DataFrame(),
     )
 
     ctx = _invocation(_make_run_input(), output="model-out")
@@ -825,9 +865,10 @@ async def test_post_invoke_blocked_empty_postscore_coerces_none_blocked_message_
     # THEN assistant content is "" (not None) and finish_reason is content_filter
     pipeline = _pipeline_mock()
     moderation = _moderation_mock(pipeline)
-    moderation.evaluate_response.return_value = (
+    moderation.evaluate_response_async.return_value = (
         EvaluationResult(blocked=True, blocked_message=None),
         0.0,
+        pd.DataFrame(),
     )
 
     ctx = _invocation(_make_run_input(), output=_text_response("ignored"))
@@ -864,7 +905,7 @@ async def test_function_middleware_invoke_blocked_short_circuits(builder_mock: M
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_blocked("x", "stop")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
 
     call_next = AsyncMock()
 
@@ -890,32 +931,28 @@ async def test_function_middleware_invoke_preserves_prescore_data_across_concurr
 ) -> None:
     """Each asyncio task must keep its own prescore frame across ``await call_next``.
 
-    Postscore reads task-local state via ``moderation.evaluate_response`` (same hook as
-    ``ModerationPipeline.evaluate_response`` on the loaded pipeline); the prompt passed there
+    Postscore reads task-local state via ``evaluate_response_async``; the prompt passed there
     must match the prescore row for that task, not a sibling task.
     """
     pipeline = _pipeline_mock()
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
-
-    def run_guards_side_effect(
-        data: pd.DataFrame, guards: Any, stage: Any
-    ) -> tuple[pd.DataFrame, float]:
-        prompt = str(data.loc[0, PROMPT_COL])
-        return _prescore_df_ok(prompt), 0.0
-
-    moderation._executor.run_guards.side_effect = run_guards_side_effect
     seen_in_evaluate_response: dict[asyncio.Task[Any], str] = {}
 
-    def evaluate_response_side_effect(
+    async def evaluate_prompt_async_side_effect(prompt: str) -> tuple[Any, float, pd.DataFrame]:
+        prescore_df = _prescore_df_ok(prompt)
+        return _from_dataframe(prescore_df, PROMPT_COL), 0.0, prescore_df
+
+    async def evaluate_response_async_side_effect(
         _response_text: str, *, prompt: str | None = None, **_: Any
-    ) -> tuple[EvaluationResult, float]:
+    ) -> tuple[EvaluationResult, float, pd.DataFrame]:
         task = asyncio.current_task()
         assert task is not None
         seen_in_evaluate_response[task] = prompt or ""
-        return (EvaluationResult(blocked=False), 0.0)
+        return EvaluationResult(blocked=False), 0.0, pd.DataFrame()
 
-    moderation.evaluate_response.side_effect = evaluate_response_side_effect
+    moderation.evaluate_prompt_async.side_effect = evaluate_prompt_async_side_effect
+    moderation.evaluate_response_async.side_effect = evaluate_response_async_side_effect
 
     async def slow_call_next(*_a: Any, **_k: Any) -> DRAgentEventResponse:
         await asyncio.sleep(0.05)
@@ -1612,7 +1649,7 @@ async def test_function_middleware_stream_yields_blocked_pre_invoke(
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_blocked("x", "no-stream")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
     stream_next = MagicMock()
 
     with (
@@ -1637,14 +1674,14 @@ async def test_function_middleware_stream_yields_blocked_pre_invoke(
 
 
 async def test_function_middleware_stream_echoes_single_text_chunk(builder_mock: MagicMock) -> None:
-    # GIVEN one streamed text chunk from upstream and ModerationIterator echoes chunks
+    # GIVEN one streamed text chunk from upstream and stream_response_async echoes chunks
     # WHEN function_middleware_stream runs
     # THEN one moderated DRAgentEventResponse is yielded
     pipeline = _pipeline_mock()
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_ok("hi")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
 
     async def upstream():
         yield _text_response("delta-one")
@@ -1655,10 +1692,6 @@ async def test_function_middleware_stream_echoes_single_text_chunk(builder_mock:
         patch(
             "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
             return_value=moderation,
-        ),
-        patch(
-            "datarobot_genai.nat.datarobot_moderation_middleware.ModerationIterator",
-            side_effect=lambda _sc, src: src,
         ),
     ):
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
@@ -1682,7 +1715,7 @@ async def test_function_middleware_stream_passthrough_when_no_run_agent_input(
 ) -> None:
     # GIVEN pre_invoke returns before prescore (no first positional arg / no run input)
     # WHEN function_middleware_stream runs
-    # THEN upstream chunks are yielded and ModerationIterator is never used
+    # THEN upstream chunks are yielded and stream_response_async is never used
     pipeline = _pipeline_mock()
     moderation = _moderation_mock(pipeline)
 
@@ -1695,10 +1728,6 @@ async def test_function_middleware_stream_passthrough_when_no_run_agent_input(
         patch(
             "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
             return_value=moderation,
-        ),
-        patch(
-            "datarobot_genai.nat.datarobot_moderation_middleware.ModerationIterator",
-            side_effect=AssertionError("ModerationIterator should not run without prescore"),
         ),
     ):
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
@@ -1723,7 +1752,7 @@ async def test_function_middleware_stream_defers_text_message_end_before_run_fin
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
     prescore_df = _prescore_df_ok("hi")
-    moderation._executor.run_guards.return_value = (prescore_df, 0.0)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
     mid = "msg-1"
     zero = default_usage_metrics()
 
@@ -1755,10 +1784,6 @@ async def test_function_middleware_stream_defers_text_message_end_before_run_fin
         patch(
             "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
             return_value=moderation,
-        ),
-        patch(
-            "datarobot_genai.nat.datarobot_moderation_middleware.ModerationIterator",
-            side_effect=lambda _sc, src: src,
         ),
     ):
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -46,6 +46,7 @@ from datarobot_dome.api import EvaluationResult
 from datarobot_dome.api import _from_dataframe
 from datarobot_dome.async_http_client import AsyncHTTPClient
 from datarobot_dome.constants import DATAROBOT_MODERATIONS_ATTR
+from datarobot_dome.constants import DEFAULT_RESPONSE_COLUMN_NAME
 from datarobot_dome.constants import MODERATION_MODEL_NAME
 from datarobot_dome.constants import GuardStage
 from datarobot_dome.schema.moderation_config import ModerationConfig
@@ -352,7 +353,6 @@ def test_load_llm_moderation_pipeline_from_config_moderation_field() -> None:
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         pipeline = load_llm_moderation_pipeline(cfg)
@@ -992,7 +992,6 @@ async def test_function_middleware_invoke_integration_executes_real_moderations(
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1040,7 +1039,6 @@ async def test_function_middleware_invoke_integration_nat_chat_input_chat_respon
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1086,7 +1084,6 @@ async def test_function_middleware_stream_integration_executes_real_moderations(
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1129,7 +1126,6 @@ async def test_function_middleware_invoke_prompt_token_limit_blocks(
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1170,7 +1166,6 @@ async def test_function_middleware_invoke_nat_chat_input_chat_response_prompt_to
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1209,7 +1204,6 @@ async def test_function_middleware_stream_prompt_token_limit_blocks(
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1249,7 +1243,6 @@ async def test_function_middleware_invoke_response_token_limit_blocks(
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1272,8 +1265,9 @@ async def test_function_middleware_invoke_response_token_limit_blocks(
     assert result.datarobot_moderations is not None
     mods = result.datarobot_moderations
     assert mods["Responses_token_count"] == 80
-    assert any(k.endswith("_blocked_response") and mods[k] is True for k in mods), (
-        f"expected a blocked_response flag in {mods!r}"
+    blocked_suffix = f"_blocked_{DEFAULT_RESPONSE_COLUMN_NAME}"
+    assert any(k.endswith(blocked_suffix) and mods[k] is True for k in mods), (
+        f"expected a {blocked_suffix!r} flag in {mods!r}"
     )
 
 
@@ -1294,7 +1288,6 @@ async def test_function_middleware_invoke_nat_chat_input_chat_response_response_
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1316,8 +1309,9 @@ async def test_function_middleware_invoke_nat_chat_input_chat_response_response_
     assert result.datarobot_moderations is not None
     mods = result.datarobot_moderations
     assert mods["Responses_token_count"] == 80
-    assert any(k.endswith("_blocked_response") and mods[k] is True for k in mods), (
-        f"expected a blocked_response flag in {mods!r}"
+    blocked_suffix = f"_blocked_{DEFAULT_RESPONSE_COLUMN_NAME}"
+    assert any(k.endswith(blocked_suffix) and mods[k] is True for k in mods), (
+        f"expected a {blocked_suffix!r} flag in {mods!r}"
     )
 
 
@@ -1335,7 +1329,6 @@ async def test_function_middleware_stream_response_token_limit_blocks(
         {
             "DATAROBOT_API_TOKEN": "test-token",
             "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-            "TARGET_NAME": '"response"',
         },
     ):
         mw = DataRobotModerationMiddleware(
@@ -1360,8 +1353,9 @@ async def test_function_middleware_stream_response_token_limit_blocks(
     assert chunk.datarobot_moderations is not None
     mods = chunk.datarobot_moderations
     assert mods["Responses_token_count"] == 80
-    assert any(k.endswith("_blocked_response") and mods[k] is True for k in mods), (
-        f"expected a blocked_response flag in {mods!r}"
+    blocked_suffix = f"_blocked_{DEFAULT_RESPONSE_COLUMN_NAME}"
+    assert any(k.endswith(blocked_suffix) and mods[k] is True for k in mods), (
+        f"expected a {blocked_suffix!r} flag in {mods!r}"
     )
 
 
@@ -1384,7 +1378,6 @@ async def test_function_middleware_invoke_prompt_replace(
             {
                 "DATAROBOT_API_TOKEN": "test-token",
                 "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-                "TARGET_NAME": '"response"',
             },
         ),
         patch("datarobot.Deployment.get", return_value=_model_guard_deployment_stub()),
@@ -1429,7 +1422,6 @@ async def test_function_middleware_invoke_nat_chat_input_chat_response_prompt_re
             {
                 "DATAROBOT_API_TOKEN": "test-token",
                 "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-                "TARGET_NAME": '"response"',
             },
         ),
         patch("datarobot.Deployment.get", return_value=_model_guard_deployment_stub()),
@@ -1476,7 +1468,6 @@ async def test_function_middleware_stream_prompt_replace(
             {
                 "DATAROBOT_API_TOKEN": "test-token",
                 "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-                "TARGET_NAME": '"response"',
             },
         ),
         patch("datarobot.Deployment.get", return_value=_model_guard_deployment_stub()),
@@ -1521,7 +1512,6 @@ async def test_function_middleware_invoke_response_replace(
             {
                 "DATAROBOT_API_TOKEN": "test-token",
                 "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-                "TARGET_NAME": '"response"',
             },
         ),
         patch("datarobot.Deployment.get", return_value=_model_guard_deployment_stub()),
@@ -1566,7 +1556,6 @@ async def test_function_middleware_invoke_nat_chat_input_chat_response_response_
             {
                 "DATAROBOT_API_TOKEN": "test-token",
                 "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-                "TARGET_NAME": '"response"',
             },
         ),
         patch("datarobot.Deployment.get", return_value=_model_guard_deployment_stub()),
@@ -1613,7 +1602,6 @@ async def test_function_middleware_stream_response_replace(
             {
                 "DATAROBOT_API_TOKEN": "test-token",
                 "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
-                "TARGET_NAME": '"response"',
             },
         ),
         patch("datarobot.Deployment.get", return_value=_model_guard_deployment_stub()),

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.66"
+version = "0.15.67"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1365,12 +1365,12 @@ requires-dist = [
     { name = "datarobot-early-access", marker = "extra == 'langgraph'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'llamaindex'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'nat'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.29,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.29,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.30,<12.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1532,7 +1532,7 @@ dev = [
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.29"
+version = "11.2.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1550,7 +1550,7 @@ dependencies = [
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/2d/892f2be271027dba8ec550e8d2db78bc43b7fe5c531c8851d0e5fe72990e/datarobot_moderations-11.2.29-py3-none-any.whl", hash = "sha256:f49dd5651b73684d80809916ee7f0eafe5d342ccb5494f3c59f0129adbf225d6", size = 113903, upload-time = "2026-05-11T13:05:11.248Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ba/d594bdcb2a21817ca854f593302b31c7dd7c064db76873de73c686e5768b/datarobot_moderations-11.2.30-py3-none-any.whl", hash = "sha256:a31d5d80a946d664d6d267898d41b9041134a0eef4a02037bc31adfe01ed6f28", size = 123894, upload-time = "2026-05-19T16:20:45.444Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
`datarobot-moderations` was recently updated with a new async and streaming interface for `ModerationPipeline`. This allows us to simplify the implementation of `DataRobotModerationMiddleware`.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Bump `datarobot-moderations`. Use the new async and streaming interface in `DataRobotModerationMiddleware`.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderation behavior for both non-streaming and streaming paths is refactored to use new async/streaming interfaces, which can affect guard evaluation ordering and event sequencing. Dependency bumps to `datarobot-moderations` may also subtly change moderation results or metadata shape.
> 
> **Overview**
> Updates `DataRobotModerationMiddleware` to use the new `datarobot-moderations` async APIs: prescore now calls `evaluate_prompt_async`, postscore uses `evaluate_response_async`, and streaming moderation is reworked to drive `stream_response_async` instead of the custom `ModerationIterator` worker thread/queue approach.
> 
> Bumps package version to `0.15.65` and raises the `core` (and derived extras) constraint for `datarobot-moderations[all]` to `>=11.2.30,<12.0.0`, updating lockfiles accordingly, and adjusts/extends unit tests to mock the new async/streaming methods and preserve expected AG-UI event ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4fef8423e8309392d8e85952193916ce639012. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->