### PR TITLE
[BUZZOK-30289] Specialize types and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.68
+- `nat/datarobot_moderation_middleware`: refactored DRAgent and NAT chat moderation to use OpenAI `ChatCompletionChunk` at the dome streaming boundary only. Shared AG-UI delta extraction and NAT↔OpenAI chunk converters live in `dragent/frontends/converters.py` (`convert_dragent_event_response_to_openai_chat_completion_chunk`, `convert_nat_chat_response_chunk_to_openai_chat_completion_chunk`).
+- Prescore prompt extraction now delegates to `get_chat_prompt` from `datarobot_moderation_interface` (via `workflow_input_to_completion_dict`), matching DRUM integration behavior for multimodal content and tool context.
+- Per-invoke moderation state stores the moderated prompt string instead of a prescore `DataFrame`; postscore reads `state.prompt`. Invoke context is not set when prescore blocks the prompt (post_invoke and streaming are skipped).
+- `pre_invoke` fails closed with `TypeError` when the workflow argument is not `RunAgentInput`, `ChatRequest`, or `ChatRequestOrMessage`.
+
 ## 0.15.67
 - Bump `datarobot-moderations` to 11.2.30 to use the async interface with `DataRobotModerationMiddleware`
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.67"
+version = "0.15.68"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1306,7 +1306,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
-    { name = "ipdb" },
     { name = "nbmake" },
     { name = "openai" },
     { name = "pytest" },
@@ -1314,7 +1313,6 @@ dependencies = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "python-dotenv" },
-    { name = "rpdb" },
 ]
 
 [package.dev-dependencies]
@@ -1322,6 +1320,7 @@ dev = [
     { name = "ipdb" },
     { name = "jupyter" },
     { name = "mypy" },
+    { name = "rpdb" },
     { name = "ruff" },
 ]
 dragent-base = [
@@ -1346,7 +1345,6 @@ example-quickstart = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
-    { name = "ipdb", specifier = ">=0.13.13" },
     { name = "nbmake", specifier = ">=1.5.5" },
     { name = "openai", specifier = ">=2.0.0,<3.0.0" },
     { name = "pytest" },
@@ -1354,7 +1352,6 @@ requires-dist = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-dotenv" },
-    { name = "rpdb", specifier = ">=0.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1362,6 +1359,7 @@ dev = [
     { name = "ipdb", specifier = ">=0.13.13" },
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "rpdb", specifier = ">=0.2.0" },
     { name = "ruff", specifier = ">=0.15.2" },
 ]
 dragent-base = [{ name = "datarobot-genai", extras = ["dragent"], editable = "../" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.67"
+version = "0.15.68"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/converters.py
+++ b/src/datarobot_genai/dragent/frontends/converters.py
@@ -16,6 +16,8 @@ import datetime
 import logging
 import uuid
 from typing import Any
+from typing import Literal
+from typing import cast
 
 from ag_ui.core import CustomEvent
 from ag_ui.core import RunAgentInput
@@ -33,6 +35,14 @@ from nat.data_models.api_server import ChoiceDelta
 from nat.data_models.api_server import ChoiceDeltaToolCall
 from nat.data_models.api_server import ChoiceDeltaToolCallFunction
 from nat.data_models.api_server import Message
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import Choice as OpenAIChunkChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta as OpenAIChoiceDelta
+from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall as OpenAIChoiceDeltaToolCall
+from openai.types.chat.chat_completion_chunk import (
+    ChoiceDeltaToolCallFunction as OpenAIChoiceDeltaToolCallFunction,
+)
+from openai.types.completion_usage import CompletionUsage
 
 from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.core.chat.completions import convert_chat_completion_params_to_run_agent_input
@@ -85,20 +95,16 @@ def convert_dragent_run_agent_input_to_chat_request_or_message(
     return ChatRequestOrMessage.model_validate(chat_request.model_dump())
 
 
-def convert_dragent_event_response_to_chat_response_chunk(
-    response: DRAgentEventResponse,
-) -> ChatResponseChunk:
-    if response.original_chunk is not None:
-        return response.original_chunk
-
+def _dragent_streaming_delta_from_events(
+    events: list[Any],
+) -> tuple[str | None, list[ChoiceDeltaToolCall]]:
+    """Extract streaming delta fields from AG-UI events (shared NAT / OpenAI chunk builders)."""
     content_parts: list[str] = []
     tool_calls: list[ChoiceDeltaToolCall] = []
-
-    for event in response.events:
+    for event in events:
         if isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
             content_parts.append(event.delta)
             continue
-
         # AG-UI tool-call events -> OpenAI streaming tool_calls deltas.
         # OpenAI's streaming format expects the *first* chunk of a tool call
         # to carry ``id``, ``type`` and ``function.name``; subsequent
@@ -141,17 +147,21 @@ def convert_dragent_event_response_to_chat_response_chunk(
         # tool-call completion is signalled by ``finish_reason`` at the
         # outer choice level, and tool results are sent as separate
         # ``role="tool"`` messages rather than streaming deltas.
-
-    # Preserve the existing empty-string semantics for the "no events"
-    # case while matching OpenAI's streaming convention of ``null`` content
-    # whenever a chunk carries only tool_calls.
     if content_parts:
         content: str | None = "".join(content_parts)
     elif tool_calls:
         content = None
     else:
         content = ""
+    return content, tool_calls
 
+
+def convert_dragent_event_response_to_chat_response_chunk(
+    response: DRAgentEventResponse,
+) -> ChatResponseChunk:
+    if response.original_chunk is not None:
+        return response.original_chunk
+    content, tool_calls = _dragent_streaming_delta_from_events(response.events)
     return ChatResponseChunk(
         id=uuid.uuid4().hex,
         choices=[
@@ -161,6 +171,102 @@ def convert_dragent_event_response_to_chat_response_chunk(
             )
         ],
         created=datetime.datetime.now(datetime.UTC),
+    )
+
+
+_FINISH_REASON = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
+
+
+def _nat_choice_delta_tool_calls_to_openai(
+    nat_tool_calls: list[ChoiceDeltaToolCall] | None,
+) -> list[OpenAIChoiceDeltaToolCall] | None:
+    if not nat_tool_calls:
+        return None
+    out: list[OpenAIChoiceDeltaToolCall] = []
+    for tc in nat_tool_calls:
+        fn = tc.function
+        out.append(
+            OpenAIChoiceDeltaToolCall(
+                index=tc.index,
+                id=tc.id,
+                type=tc.type or "function",
+                function=(
+                    OpenAIChoiceDeltaToolCallFunction(
+                        name=(fn.name if fn else None) or "",
+                        arguments=(fn.arguments if fn else None) or "",
+                    )
+                    if fn is not None
+                    else None
+                ),
+            )
+        )
+    return out or None
+
+
+def convert_nat_chat_response_chunk_to_openai_chat_completion_chunk(
+    chunk: ChatResponseChunk,
+) -> ChatCompletionChunk:
+    """Map NAT streaming chunk to OpenAI ``chat.completion.chunk``."""
+    if not chunk.choices:
+        raise ValueError("ChatResponseChunk has no choices")
+    c0 = chunk.choices[0]
+    delta = c0.delta
+    openai_delta = OpenAIChoiceDelta(
+        content=delta.content,
+        role=delta.role.value if delta.role is not None else None,
+        tool_calls=_nat_choice_delta_tool_calls_to_openai(delta.tool_calls),
+    )
+    finish = cast(_FINISH_REASON | None, c0.finish_reason)
+    choice = OpenAIChunkChoice(
+        index=0,
+        delta=openai_delta,
+        finish_reason=finish,
+    )
+    created = chunk.created
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=datetime.UTC)
+    created_ts = int(created.timestamp())
+    usage_openai: CompletionUsage | None = None
+    if chunk.usage is not None:
+        u = chunk.usage
+        usage_openai = CompletionUsage(
+            prompt_tokens=u.prompt_tokens,
+            completion_tokens=u.completion_tokens,
+            total_tokens=u.total_tokens,
+        )
+    return ChatCompletionChunk(
+        id=chunk.id,
+        choices=[choice],
+        created=created_ts,
+        model=chunk.model,
+        object="chat.completion.chunk",
+        usage=usage_openai,
+    )
+
+
+def convert_dragent_event_response_to_openai_chat_completion_chunk(
+    response: DRAgentEventResponse,
+) -> ChatCompletionChunk:
+    """Convert one DRAgent stream chunk to an OpenAI chunk (dome / moderation streaming)."""
+    if response.original_chunk is not None:
+        return convert_nat_chat_response_chunk_to_openai_chat_completion_chunk(
+            response.original_chunk
+        )
+    content, tool_calls = _dragent_streaming_delta_from_events(response.events)
+    created_ts = int(datetime.datetime.now(datetime.UTC).timestamp())
+    return ChatCompletionChunk(
+        id=uuid.uuid4().hex,
+        choices=[
+            OpenAIChunkChoice(
+                index=0,
+                delta=OpenAIChoiceDelta(content=content, tool_calls=tool_calls or None),
+                finish_reason=None,
+            )
+        ],
+        created=created_ts,
+        model=response.model or "unknown-model",
+        object="chat.completion.chunk",
+        usage=None,
     )
 
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1194,12 +1194,7 @@ class DataRobotModerationMiddleware(
 
         if prompt_eval.blocked:
             # If all prompts in the input are blocked, means history as well as the prompt
-            # are not worthy to be sent to LLM
-            _set_moderation_invoke_state(
-                input_df=data,
-                prescore_df=prescore_df,
-                latency_so_far=prescore_latency,
-            )
+            # are not worthy to be sent to LLM. No invoke state: post_invoke / streaming never run.
             context.output = _dragent_event_response_from_blocked_prompt_eval(prompt_eval)
             return context
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -71,6 +71,7 @@ from datarobot_dome.constants import MODERATION_MODEL_NAME
 from datarobot_dome.constants import GuardStage
 from datarobot_dome.runtime import get_runtime_parameter_value_bool
 from datarobot_dome.schema.moderation_config import ModerationConfig
+from datarobot_moderation_interface.drum_integration import get_chat_prompt
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_middleware
 from nat.data_models.api_server import ChatRequest
@@ -761,143 +762,19 @@ def _user_content_to_openai(content: object) -> object:
     return str(content)
 
 
-def _moderation_prompt_from_openai_style_content(prompt_content: Any) -> str:
-    """Stringify user message content like ``get_chat_prompt`` (multimodal OpenAI-style parts)."""
-    if isinstance(prompt_content, str):
-        return prompt_content
-    if isinstance(prompt_content, list):
-        concatenated_prompt: list[str] = []
-        for content in prompt_content:
-            if not isinstance(content, dict):
-                continue
-            ctype = content.get("type")
-            if ctype == "text":
-                concatenated_prompt.append(content["text"])
-            elif ctype == "image_url":
-                concatenated_prompt.append(f"Image URL: {content['image_url']['url']}")
-            elif ctype == "input_audio":
-                concatenated_prompt.append(
-                    f"Audio Input, Format: {content['input_audio']['format']}"
-                )
-            else:
-                concatenated_prompt.append(f"Unhandled content type: {ctype}")
-        return "\n".join(concatenated_prompt)
-    raise ValueError(f"Unhandled prompt type: {type(prompt_content)}")
-
-
-def _ag_ui_user_content_to_prompt_string(content: object) -> str:
-    """Stringify AG-UI user ``content`` (same result as the last user message in a CCP dict)."""
-    return _moderation_prompt_from_openai_style_content(_user_content_to_openai(content))
-
-
-def _nat_message_content_to_prompt_string(content: str | list[Any]) -> str:
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[dict[str, Any]] = []
-        for part in content:
-            if isinstance(part, dict):
-                parts.append(part)
-            elif hasattr(part, "model_dump"):
-                parts.append(part.model_dump(mode="json"))
-        return _moderation_prompt_from_openai_style_content(parts)
-    raise ValueError(f"Unhandled prompt type: {type(content)}")
-
-
-def _format_moderation_prompt(
-    chat_prompt: str,
-    *,
-    tool_call_lines: list[str] | None = None,
-    tool_names: list[str] | None = None,
-) -> str:
-    if tool_call_lines:
-        return "\n".join([chat_prompt, "Tool Calls:", "\n".join(tool_call_lines)])
-    if tool_names:
-        return "\n".join([chat_prompt, "Tool Names:", "\n".join(tool_names)])
-    return chat_prompt
-
-
-def _validate_messages_nonempty_for_moderation(
-    messages: list[Any],
-    workflow_input: WorkflowInput,
-) -> None:
-    if not messages:
-        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
-    last = messages[-1]
-    if not hasattr(last, "content"):
-        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
-    if getattr(last, "content", None) is None:
-        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
-
-
-def _moderation_prompt_from_run_agent_input(run_input: RunAgentInput) -> str:
-    msgs = run_input.messages
-    _validate_messages_nonempty_for_moderation(msgs, run_input)
-    last_user: UserMessage | None = None
-    tool_lines: list[str] = []
-    for msg in msgs:
-        if isinstance(msg, UserMessage):
-            last_user = msg
-        elif isinstance(msg, ToolMessage):
-            # Matches OpenAI-style tool dicts from ``_ag_ui_message_to_openai`` (no ``name`` field).
-            tool_lines.append(f"_{msg.content}")
-    if last_user is None:
-        raise ValueError("No message with 'user' role found in input")
-    chat_prompt = _ag_ui_user_content_to_prompt_string(last_user.content)
-    tool_names = [t.name for t in (run_input.tools or [])]
-    return _format_moderation_prompt(chat_prompt, tool_call_lines=tool_lines, tool_names=tool_names)
-
-
-def _moderation_prompt_from_nat_chat(
-    workflow_input: ChatRequest | ChatRequestOrMessage,
-) -> str:
-    messages = workflow_input.messages
-    if messages is None:
-        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
-    _validate_messages_nonempty_for_moderation(messages, workflow_input)
-    last_user_msg = None
-    for msg in messages:
-        if msg.role == UserMessageContentRoleType.USER:
-            last_user_msg = msg
-    if last_user_msg is None:
-        raise ValueError("No message with 'user' role found in input")
-    chat_prompt = _nat_message_content_to_prompt_string(last_user_msg.content)
-    tool_names = _tool_names_from_nat_tools(getattr(workflow_input, "tools", None))
-    return _format_moderation_prompt(chat_prompt, tool_names=tool_names)
-
-
-def _tool_names_from_nat_tools(tools: list[dict[str, Any]] | None) -> list[str]:
-    names: list[str] = []
-    for tool in tools or []:
-        fn = tool.get("function") if isinstance(tool, dict) else None
-        if isinstance(fn, dict):
-            name = fn.get("name")
-            if name:
-                names.append(name)
-    return names
-
-
 def moderation_prompt_from_workflow_input(workflow_input: WorkflowInput) -> str:
     """Extract the prescore prompt string from AG-UI or NAT chat input.
 
-    Matches ``get_chat_prompt(workflow_input_to_completion_dict(...))`` without building a full
-    completion-params dict or converting every message to OpenAI-style dicts.
+    Delegates to ``get_chat_prompt`` on completion-params built from ``workflow_input``.
+    ``ChatRequestOrMessage`` with only ``input_message`` (no ``messages``) is handled directly
+    because ``get_chat_prompt`` requires a non-empty ``messages`` list.
     """
-    if isinstance(workflow_input, RunAgentInput):
-        return _moderation_prompt_from_run_agent_input(workflow_input)
-
     if (
         isinstance(workflow_input, ChatRequestOrMessage)
         and workflow_input.input_message is not None
     ):
         return workflow_input.input_message
-
-    if isinstance(workflow_input, (ChatRequest, ChatRequestOrMessage)):
-        return _moderation_prompt_from_nat_chat(workflow_input)
-
-    raise TypeError(
-        f"Unsupported workflow input type for moderation: {type(workflow_input).__name__}"
-    )
+    return get_chat_prompt(workflow_input_to_completion_dict(workflow_input))
 
 
 def run_agent_input_to_completion_dict(rai: RunAgentInput) -> dict[str, Any]:

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -898,7 +898,7 @@ def _clear_prompt_replacement_flags_in_prescore_df(df: pd.DataFrame, prompt_colu
     """Clear replacement columns when moderated text could not be written to the workflow object.
 
     Keeps ``state.prescore_df`` / streaming ``ModerationIterator`` metadata aligned with the
-    prompt text actually sent to the LLM (original row in ``input_df``).
+    prompt text actually sent to the LLM (``state.prompt``).
     """
     replaced_col = f"replaced_{prompt_column}"
     if replaced_col in df.columns:
@@ -1076,7 +1076,7 @@ async def _moderated_dragent_stream(
 class _ModerationInvokeState:
     """Per-async-task prescore payload for post_invoke / streaming (middleware may be shared)."""
 
-    input_df: pd.DataFrame
+    prompt: str
     prescore_df: pd.DataFrame
     latency_so_far: float
     ctx_token: contextvars.Token[_ModerationInvokeState | None] | None = None
@@ -1089,12 +1089,12 @@ _moderation_invoke_state_ctx: contextvars.ContextVar[_ModerationInvokeState | No
 
 def _set_moderation_invoke_state(
     *,
-    input_df: pd.DataFrame,
+    prompt: str,
     prescore_df: pd.DataFrame,
     latency_so_far: float,
 ) -> None:
     state = _ModerationInvokeState(
-        input_df=input_df,
+        prompt=prompt,
         prescore_df=prescore_df,
         latency_so_far=latency_so_far,
     )
@@ -1190,7 +1190,7 @@ class DataRobotModerationMiddleware(
         prompt_eval, prescore_latency, prescore_df = await self._moderation.evaluate_prompt_async(
             prompt
         )
-        data = pd.DataFrame({prompt_column_name: [prompt]})
+        prompt_sent = prompt
 
         if prompt_eval.blocked:
             # If all prompts in the input are blocked, means history as well as the prompt
@@ -1202,19 +1202,19 @@ class DataRobotModerationMiddleware(
         applied_replacement = False
         if replacement_requested:
             # PII-style guards may redact the prompt; apply the replacement on the workflow
-            # object so ``call_next`` (LLM) receives moderated text; align postscore ``data``.
+            # object so ``call_next`` (LLM) receives moderated text; track the string sent.
             moderated_prompt = prompt_eval.replacement
             assert moderated_prompt is not None
             applied_replacement = _apply_moderated_prompt_text_to_workflow_input(
                 workflow_input, moderated_prompt
             )
             if applied_replacement:
-                data.at[0, prompt_column_name] = moderated_prompt
+                prompt_sent = moderated_prompt
             else:
                 _clear_prompt_replacement_flags_in_prescore_df(prescore_df, prompt_column_name)
 
         _set_moderation_invoke_state(
-            input_df=data,
+            prompt=prompt_sent,
             prescore_df=prescore_df,
             latency_so_far=prescore_latency,
         )
@@ -1263,7 +1263,7 @@ class DataRobotModerationMiddleware(
         # Step 3: Postscore via ``ModerationPipeline.evaluate_response`` (same path as
         # ``_run_stage`` in dome) when response text is present.
         prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
-        prompt_for_eval = state.input_df.loc[0, prompt_column_name]
+        prompt_for_eval = state.prompt
 
         response_eval, _, _postscore_df = await self._moderation.evaluate_response_async(
             _text_for_moderation_eval(response_text),
@@ -1376,10 +1376,7 @@ class DataRobotModerationMiddleware(
             moderation = self._moderation
             assert moderation is not None
 
-            prompt_column_name = moderation._pipeline.get_input_column(GuardStage.PROMPT)
-            prompt_for_stream = _text_for_moderation_eval(
-                stream_state.input_df.loc[0, prompt_column_name]
-            )
+            prompt_for_stream = _text_for_moderation_eval(stream_state.prompt)
             upstream = call_next(*ctx.modified_args, **ctx.modified_kwargs)
             stream_tool_index_map: dict[int, str] = {}
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -908,6 +908,24 @@ def _clear_prompt_replacement_flags_in_prescore_df(df: pd.DataFrame, prompt_colu
         df.loc[df.index[0], replaced_msg_col] = np.nan
 
 
+def _prompt_sent_after_prescore_replacement(
+    workflow_input: WorkflowInput,
+    *,
+    original_prompt: str,
+    prompt_eval: EvaluationResult,
+    prescore_df: pd.DataFrame,
+    prompt_column: str,
+) -> tuple[str, bool]:
+    """Apply prescore replacement to workflow input; return prompt for postscore and whether it applied."""
+    replacement = prompt_eval.replacement
+    if not (prompt_eval.replaced and replacement is not None):
+        return original_prompt, False
+    if _apply_moderated_prompt_text_to_workflow_input(workflow_input, replacement):
+        return replacement, True
+    _clear_prompt_replacement_flags_in_prescore_df(prescore_df, prompt_column)
+    return original_prompt, False
+
+
 def skip_event_type(event: Event) -> bool:
     return event.type not in {
         EventType.TEXT_MESSAGE_CONTENT,
@@ -1190,7 +1208,6 @@ class DataRobotModerationMiddleware(
         prompt_eval, prescore_latency, prescore_df = await self._moderation.evaluate_prompt_async(
             prompt
         )
-        prompt_sent = prompt
 
         if prompt_eval.blocked:
             # If all prompts in the input are blocked, means history as well as the prompt
@@ -1198,32 +1215,20 @@ class DataRobotModerationMiddleware(
             context.output = _dragent_event_response_from_blocked_prompt_eval(prompt_eval)
             return context
 
-        replacement_requested = bool(prompt_eval.replaced and prompt_eval.replacement is not None)
-        applied_replacement = False
-        if replacement_requested:
-            # PII-style guards may redact the prompt; apply the replacement on the workflow
-            # object so ``call_next`` (LLM) receives moderated text; track the string sent.
-            moderated_prompt = prompt_eval.replacement
-            assert moderated_prompt is not None
-            applied_replacement = _apply_moderated_prompt_text_to_workflow_input(
-                workflow_input, moderated_prompt
-            )
-            if applied_replacement:
-                prompt_sent = moderated_prompt
-            else:
-                _clear_prompt_replacement_flags_in_prescore_df(prescore_df, prompt_column_name)
-
+        prompt_sent, workflow_rewritten = _prompt_sent_after_prescore_replacement(
+            workflow_input,
+            original_prompt=prompt,
+            prompt_eval=prompt_eval,
+            prescore_df=prescore_df,
+            prompt_column=prompt_column_name,
+        )
         _set_moderation_invoke_state(
             prompt=prompt_sent,
             prescore_df=prescore_df,
             latency_so_far=prescore_latency,
         )
-
-        if replacement_requested:
-            # Return context only when this middleware actually rewrote the workflow input;
-            # otherwise behave like a no-op for ``InvocationContext`` (same as no replacement).
-            return context if applied_replacement else None
-        return None
+        # Return context only when workflow input was rewritten (signals modified_args to NAT).
+        return context if workflow_rewritten else None
 
     async def post_invoke(self, context: InvocationContext) -> InvocationContext | None:
         """Post-invocation hook called after the function returns.

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -797,10 +797,6 @@ def dome_chunk_to_dragent_event_response(
     )
 
 
-# Backward-compatible alias for tests and external imports.
-chat_completion_to_dragent_event_response = dome_chunk_to_dragent_event_response
-
-
 def _ag_ui_message_to_openai(msg: object) -> dict[str, Any]:
     if isinstance(msg, UserMessage):
         return {"role": "user", "content": _user_content_to_openai(msg.content)}

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -24,8 +24,8 @@ Expected workflow contracts:
   non-streaming output ``ChatResponse``.
 
 ``ModerationPipeline.stream_response_async`` only accepts OpenAI ``ChatCompletionChunk``; DRAgent
-streaming converts ``DRAgentEventResponse`` → NAT ``ChatResponseChunk`` → dome chunk at that
-boundary, then reverses on the way out.
+streaming uses ``convert_dragent_event_response_to_openai_chat_completion_chunk`` at that
+boundary, then reverses to AG-UI on the way out.
 """
 
 from __future__ import annotations
@@ -93,19 +93,17 @@ from nat.middleware.middleware import FunctionMiddlewareContext
 from nat.middleware.middleware import InvocationContext
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.chat.chat_completion_chunk import Choice as OpenAIChunkChoice
-from openai.types.chat.chat_completion_chunk import ChoiceDelta as OpenAIChoiceDelta
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall as OpenAIChoiceDeltaToolCall
 from openai.types.chat.chat_completion_chunk import (
     ChoiceDeltaToolCallFunction as OpenAIChoiceDeltaToolCallFunction,
 )
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion_message_tool_call import Function as OpenAIToolFunction
-from openai.types.completion_usage import CompletionUsage
 from pydantic import Field
 
 from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.dragent.frontends.converters import (
-    convert_dragent_event_response_to_chat_response_chunk,
+    convert_dragent_event_response_to_openai_chat_completion_chunk,
 )
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
@@ -173,9 +171,6 @@ def _optional_prompt_for_moderation_eval(value: Any) -> str | None:
     return s or None
 
 
-_FINISH_REASON = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
-
-
 def _tool_calls_from_ag_ui_events(
     events: list[Any],
 ) -> list[ChatCompletionMessageToolCall] | None:
@@ -208,73 +203,6 @@ def _tool_calls_from_ag_ui_events(
             )
         )
     return calls or None
-
-
-def _nat_choice_delta_tool_calls_to_openai(
-    nat_tool_calls: list[ChoiceDeltaToolCall] | None,
-) -> list[OpenAIChoiceDeltaToolCall] | None:
-    if not nat_tool_calls:
-        return None
-    out: list[OpenAIChoiceDeltaToolCall] = []
-    for tc in nat_tool_calls:
-        fn = tc.function
-        out.append(
-            OpenAIChoiceDeltaToolCall(
-                index=tc.index,
-                id=tc.id,
-                type=tc.type or "function",
-                function=(
-                    OpenAIChoiceDeltaToolCallFunction(
-                        name=(fn.name if fn else None) or "",
-                        arguments=(fn.arguments if fn else None) or "",
-                    )
-                    if fn is not None
-                    else None
-                ),
-            )
-        )
-    return out or None
-
-
-def _nat_chat_response_chunk_to_openai_chat_completion_chunk(
-    chunk: ChatResponseChunk,
-) -> ChatCompletionChunk:
-    """Map NAT streaming chunk to OpenAI ``chat.completion.chunk`` (delta, not aggregated message)."""
-    if not chunk.choices:
-        raise ValueError("ChatResponseChunk has no choices")
-    c0 = chunk.choices[0]
-    delta = c0.delta
-    openai_delta = OpenAIChoiceDelta(
-        content=delta.content,
-        role=delta.role.value if delta.role is not None else None,
-        tool_calls=_nat_choice_delta_tool_calls_to_openai(delta.tool_calls),
-    )
-    finish = cast(_FINISH_REASON | None, c0.finish_reason)
-    choice = OpenAIChunkChoice(
-        index=0,
-        delta=openai_delta,
-        finish_reason=finish,
-    )
-    created = chunk.created
-    if created.tzinfo is None:
-        created = created.replace(tzinfo=UTC)
-    created_ts = int(created.timestamp())
-    usage_openai: CompletionUsage | None = None
-    if chunk.usage is not None:
-        u = chunk.usage
-        usage_openai = CompletionUsage(
-            prompt_tokens=u.prompt_tokens,
-            completion_tokens=u.completion_tokens,
-            total_tokens=u.total_tokens,
-        )
-    return ChatCompletionChunk(
-        id=chunk.id,
-        choices=[choice],
-        created=created_ts,
-        model=chunk.model,
-        object="chat.completion.chunk",
-        usage=usage_openai,
-    )
 
 
 def _message_tool_calls_to_openai_delta_tool_calls(
@@ -404,9 +332,8 @@ def dragent_event_response_to_dome_chunk(
     response: DRAgentEventResponse,
 ) -> ChatCompletionChunk:
     """Convert one DRAgent stream chunk to an OpenAI chunk for ``ModerationPipeline`` streaming."""
-    nat_chunk = convert_dragent_event_response_to_chat_response_chunk(response)
+    completion_chunk = convert_dragent_event_response_to_openai_chat_completion_chunk(response)
     event_tool_calls = _tool_calls_from_ag_ui_events(response.events)
-    completion_chunk = _nat_chat_response_chunk_to_openai_chat_completion_chunk(nat_chunk)
     if not event_tool_calls:
         return completion_chunk
     stream_choice = completion_chunk.choices[0]

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -997,8 +997,8 @@ async def _moderated_dragent_stream(
     *,
     moderation: ModerationPipeline,
     stream_state: _ModerationInvokeState,
-) -> AsyncIterator[tuple[bool, DRAgentEventResponse]]:
-    """Yield ``(is_moderated_text, response)`` with AG-UI-safe ordering around moderated deltas.
+) -> AsyncIterator[DRAgentEventResponse]:
+    """Yield DRAgent stream chunks with AG-UI-safe ordering around moderated text deltas.
 
     Non-text upstream events pass through immediately until the first text delta. Text deltas are
     moderated via ``stream_response_async``; ``TEXT_MESSAGE_START`` / ``END`` and other events read
@@ -1037,7 +1037,7 @@ async def _moderated_dragent_stream(
         if response.events and not skip_event_type(response.events[0]):
             first_text = response
             break
-        yield False, response
+        yield response
     if first_text is None:
         return
 
@@ -1048,22 +1048,19 @@ async def _moderated_dragent_stream(
         prescore_latency=stream_state.latency_so_far,
     ):
         source_response = moderation_source_responses.pop(0)
-        yield (
-            True,
-            dome_chunk_to_dragent_event_response(
-                moderated,
-                source_ag_ui_events=source_response.events,
-                stream_tool_index_map=stream_tool_index_map,
-            ),
+        yield dome_chunk_to_dragent_event_response(
+            moderated,
+            source_ag_ui_events=source_response.events,
+            stream_tool_index_map=stream_tool_index_map,
         )
         for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
-            yield False, item
+            yield item
         finish = moderated.choices[0].finish_reason if moderated.choices else None
         if finish == "content_filter":
             return
 
     for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
-        yield False, item
+        yield item
 
 
 @dataclass
@@ -1317,7 +1314,7 @@ class DataRobotModerationMiddleware(
             kwargs: Keyword arguments for the function.
 
         Yields:
-            Stream chunks (potentially transformed by post_invoke).
+            Stream chunks with per-delta postscore via ``ModerationPipeline.stream_response_async``.
 
         When prescore blocks the prompt, ``pre_invoke`` sets ``ctx.output``; we yield that
         response once and return without calling ``call_next``, so the LLM stream is never
@@ -1352,13 +1349,11 @@ class DataRobotModerationMiddleware(
             moderation = self._moderation
             assert moderation is not None
 
-            async for is_moderated, response in _moderated_dragent_stream(
+            async for response in _moderated_dragent_stream(
                 call_next(*ctx.modified_args, **ctx.modified_kwargs),
                 moderation=moderation,
                 stream_state=stream_state,
             ):
-                if is_moderated:
-                    ctx.output = response
                 yield response
         finally:
             _clear_moderation_invoke_state_if_set()

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -120,7 +120,7 @@ def _workflow_input_from_args(args: tuple[Any, ...]) -> WorkflowInput | None:
     candidate = args[0]
     if isinstance(candidate, (RunAgentInput, ChatRequest, ChatRequestOrMessage)):
         return candidate
-    return None
+    raise TypeError(f"Unsupported workflow input type for moderation: {type(candidate).__name__}")
 
 
 class DataRobotModerationConfig(

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -15,6 +15,17 @@
 
 Registered under the ``nat.plugins`` distribution entry ``datarobot_moderation_middleware`` so NAT
 loads ``@register_middleware`` without a custom recipe mapping (``_type: datarobot_moderation``).
+
+Expected workflow contracts:
+
+* **DRAgent** (``dragent_fastapi`` + LangGraph / LlamaIndex / CrewAI per-user functions): input
+  ``RunAgentInput`` (or ``DRAgentRunAgentInput``), streaming output ``DRAgentEventResponse``.
+* **Native NAT chat** (LLM Gateway agents): input ``ChatRequest`` / ``ChatRequestOrMessage``,
+  non-streaming output ``ChatResponse``.
+
+``ModerationPipeline.stream_response_async`` only accepts OpenAI ``ChatCompletionChunk``; DRAgent
+streaming converts ``DRAgentEventResponse`` → NAT ``ChatResponseChunk`` → dome chunk at that
+boundary, then reverses on the way out.
 """
 
 from __future__ import annotations
@@ -30,6 +41,7 @@ from datetime import UTC
 from datetime import datetime
 from typing import Any
 from typing import Literal
+from typing import TypeAlias
 from typing import cast
 
 import numpy as np
@@ -79,8 +91,6 @@ from nat.middleware.middleware import CallNext
 from nat.middleware.middleware import CallNextStream
 from nat.middleware.middleware import FunctionMiddlewareContext
 from nat.middleware.middleware import InvocationContext
-from openai.types.chat.chat_completion import ChatCompletion
-from openai.types.chat.chat_completion import Choice as OpenAIChoice
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.chat.chat_completion_chunk import Choice as OpenAIChunkChoice
 from openai.types.chat.chat_completion_chunk import ChoiceDelta as OpenAIChoiceDelta
@@ -88,7 +98,6 @@ from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall as OpenA
 from openai.types.chat.chat_completion_chunk import (
     ChoiceDeltaToolCallFunction as OpenAIChoiceDeltaToolCallFunction,
 )
-from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion_message_tool_call import Function as OpenAIToolFunction
 from openai.types.completion_usage import CompletionUsage
@@ -102,6 +111,18 @@ from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
 
 _logger = logging.getLogger(__name__)
+
+WorkflowInput: TypeAlias = RunAgentInput | ChatRequest | ChatRequestOrMessage
+WorkflowOutput: TypeAlias = DRAgentEventResponse | ChatResponse | str
+
+
+def _workflow_input_from_args(args: tuple[Any, ...]) -> WorkflowInput | None:
+    if not args:
+        return None
+    candidate = args[0]
+    if isinstance(candidate, (RunAgentInput, ChatRequest, ChatRequestOrMessage)):
+        return candidate
+    return None
 
 
 class DataRobotModerationConfig(
@@ -154,54 +175,6 @@ def _optional_prompt_for_moderation_eval(value: Any) -> str | None:
 
 
 _FINISH_REASON = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
-
-
-def _nat_chat_response_chunk_to_openai_chat_completion(
-    chunk: ChatResponseChunk,
-) -> ChatCompletion:
-    if not chunk.choices:
-        raise ValueError("ChatResponseChunk has no choices")
-    c0 = chunk.choices[0]
-    delta = c0.delta
-    openai_tool_calls: list[ChatCompletionMessageToolCall] | None = None
-    if delta.tool_calls:
-        openai_tool_calls = []
-        for tc in delta.tool_calls:
-            fn = tc.function
-            openai_tool_calls.append(
-                ChatCompletionMessageToolCall(
-                    id=tc.id or str(uuid.uuid4()),
-                    type="function",
-                    function=OpenAIToolFunction(
-                        name=(fn.name if fn else None) or "",
-                        arguments=(fn.arguments if fn else None) or "",
-                    ),
-                )
-            )
-    finish: _FINISH_REASON
-    if c0.finish_reason is not None:
-        finish = cast(_FINISH_REASON, c0.finish_reason)
-    elif openai_tool_calls:
-        finish = "tool_calls"
-    else:
-        finish = "stop"
-    msg = ChatCompletionMessage(
-        role="assistant",
-        content=delta.content,
-        tool_calls=openai_tool_calls,
-    )
-    created = chunk.created
-    if created.tzinfo is None:
-        created = created.replace(tzinfo=UTC)
-    created_ts = int(created.timestamp())
-    return ChatCompletion(
-        id=chunk.id,
-        choices=[OpenAIChoice(finish_reason=finish, index=0, message=msg)],
-        created=created_ts,
-        model=chunk.model,
-        object=CHAT_COMPLETION_OBJECT,
-        usage=None,
-    )
 
 
 def _tool_calls_from_ag_ui_events(
@@ -428,65 +401,32 @@ def _streaming_text_events_from_openai_chunk(
     return [TextMessageChunkEvent(message_id=mid, role="assistant", delta="")]
 
 
-def dragent_event_response_to_chat_completion(
+def dragent_event_response_to_dome_chunk(
     response: DRAgentEventResponse,
-    *,
-    as_streaming_chunk: bool = False,
-) -> ChatCompletion | ChatCompletionChunk:
-    """Convert a DRAgent response to OpenAI format for moderation.
-
-    Non-streaming callers use the default aggregated ``ChatCompletion`` (``message``).
-    Streaming callers should pass ``as_streaming_chunk=True`` to preserve
-    ``chat.completion.chunk`` shape with incremental ``delta`` content.
-    """
-    chunk = convert_dragent_event_response_to_chat_response_chunk(response)
+) -> ChatCompletionChunk:
+    """Convert one DRAgent stream chunk to an OpenAI chunk for ``ModerationPipeline`` streaming."""
+    nat_chunk = convert_dragent_event_response_to_chat_response_chunk(response)
     event_tool_calls = _tool_calls_from_ag_ui_events(response.events)
-
-    if as_streaming_chunk:
-        completion_chunk = _nat_chat_response_chunk_to_openai_chat_completion_chunk(chunk)
-        if not event_tool_calls:
-            return completion_chunk
-        stream_choice = completion_chunk.choices[0]
-        new_delta = stream_choice.delta.model_copy(
-            update={"tool_calls": _message_tool_calls_to_openai_delta_tool_calls(event_tool_calls)}
-        )
-        return ChatCompletionChunk(
-            id=completion_chunk.id,
-            choices=[
-                OpenAIChunkChoice(
-                    index=0,
-                    delta=new_delta,
-                    finish_reason="tool_calls",
-                )
-            ],
-            created=completion_chunk.created,
-            model=completion_chunk.model,
-            object="chat.completion.chunk",
-            usage=completion_chunk.usage,
-        )
-
-    non_stream = _nat_chat_response_chunk_to_openai_chat_completion(chunk)
+    completion_chunk = _nat_chat_response_chunk_to_openai_chat_completion_chunk(nat_chunk)
     if not event_tool_calls:
-        return non_stream
-    ns_choice = non_stream.choices[0]
-    msg = ns_choice.message
-    return ChatCompletion(
-        id=non_stream.id,
+        return completion_chunk
+    stream_choice = completion_chunk.choices[0]
+    new_delta = stream_choice.delta.model_copy(
+        update={"tool_calls": _message_tool_calls_to_openai_delta_tool_calls(event_tool_calls)}
+    )
+    return ChatCompletionChunk(
+        id=completion_chunk.id,
         choices=[
-            OpenAIChoice(
-                finish_reason="tool_calls",
+            OpenAIChunkChoice(
                 index=0,
-                message=ChatCompletionMessage(
-                    role="assistant",
-                    content=msg.content,
-                    tool_calls=event_tool_calls,
-                ),
+                delta=new_delta,
+                finish_reason="tool_calls",
             )
         ],
-        created=non_stream.created,
-        model=non_stream.model,
-        object=non_stream.object,
-        usage=non_stream.usage,
+        created=completion_chunk.created,
+        model=completion_chunk.model,
+        object="chat.completion.chunk",
+        usage=completion_chunk.usage,
     )
 
 
@@ -503,61 +443,6 @@ def _openai_usage_to_usage_metrics(usage: Any) -> dict[str, int] | None:
         "completion_tokens": int(ct or 0),
         "total_tokens": int(tt or 0),
     }
-
-
-def _openai_chat_completion_to_nat_chat_response_chunk(
-    completion: ChatCompletion,
-) -> ChatResponseChunk:
-    if not completion.choices:
-        raise ValueError("ChatCompletion has no choices")
-    c0 = completion.choices[0]
-    msg = c0.message
-    delta_tool_calls: list[ChoiceDeltaToolCall] | None = None
-    if msg.tool_calls:
-        built: list[ChoiceDeltaToolCall] = []
-        idx = 0
-        for tc in msg.tool_calls:
-            if tc.type != "function":
-                continue
-            built.append(
-                ChoiceDeltaToolCall(
-                    index=idx,
-                    id=tc.id,
-                    type=tc.type,
-                    function=ChoiceDeltaToolCallFunction(
-                        name=tc.function.name,
-                        arguments=tc.function.arguments,
-                    ),
-                )
-            )
-            idx += 1
-        if built:
-            delta_tool_calls = built
-    finish = c0.finish_reason
-    delta = ChoiceDelta(
-        content=msg.content,
-        role=UserMessageContentRoleType.ASSISTANT,
-        tool_calls=delta_tool_calls,
-    )
-    nat_usage: NATUsage | None = None
-    if completion.usage is not None:
-        u = completion.usage
-        nat_usage = NATUsage(
-            prompt_tokens=u.prompt_tokens,
-            completion_tokens=u.completion_tokens,
-            total_tokens=u.total_tokens,
-        )
-    created_dt = datetime.fromtimestamp(int(completion.created), tz=UTC)
-    return ChatResponseChunk(
-        id=completion.id,
-        choices=[
-            ChatResponseChunkChoice(index=0, delta=delta, finish_reason=finish),
-        ],
-        created=created_dt,
-        model=completion.model,
-        object="chat.completion.chunk",
-        usage=nat_usage,
-    )
 
 
 def _json_safe_moderation_metadata(obj: Any) -> Any:  # noqa: PLR0911
@@ -613,7 +498,7 @@ def _assistant_text_events_from_message(content: str | None) -> list[Any]:
 
 
 def _datarobot_moderations_from_completion(
-    completion: ChatCompletion | ChatCompletionChunk,
+    completion: ChatCompletionChunk,
 ) -> dict[str, Any] | None:
     raw = getattr(completion, DATAROBOT_MODERATIONS_ATTR, None)
     if not isinstance(raw, dict):
@@ -765,8 +650,7 @@ def _dragent_event_response_from_postscore_assistant_text(
 ) -> DRAgentEventResponse:
     """Build AG-UI output after postscore from message, finish reason, and eval (no ChatCompletion).
 
-    Matches ``chat_completion_to_dragent_event_response`` for a text-only non-streaming completion
-    built via ``build_non_streaming_chat_completion``, without constructing that intermediate object.
+    Matches ``dome_chunk_to_dragent_event_response`` for a text-only chunk without going through dome.
     """
     use_moderation_model = _should_use_moderation_model_name(response_eval, prompt_eval=prompt_eval)
     chunk_model = (
@@ -856,54 +740,49 @@ def _nat_chat_response_from_postscore_assistant_text(
     )
 
 
-def chat_completion_to_dragent_event_response(
-    completion: ChatCompletion | ChatCompletionChunk,
+def dome_chunk_to_dragent_event_response(
+    completion: ChatCompletionChunk,
     *,
     response_eval: EvaluationResult | None = None,
     source_ag_ui_events: list[Any] | None = None,
     stream_tool_index_map: dict[int, str] | None = None,
 ) -> DRAgentEventResponse:
-    """Convert OpenAI completion or streaming chunk back to DRAgentEventResponse.
+    """Convert a moderated OpenAI streaming chunk back to ``DRAgentEventResponse``.
 
     When ``response_eval`` is set (non-streaming postscore path), ``datarobot_moderations`` is
     taken from ``response_eval.metrics``; otherwise it is read from the completion's moderation
     sidecar attribute (streaming chunks from ``ModerationIterator``).
     """
-    if isinstance(completion, ChatCompletionChunk):
-        chunk = _openai_chat_completion_chunk_to_nat_chat_response_chunk(completion)
-        d = completion.choices[0].delta
-        idx_map = stream_tool_index_map if stream_tool_index_map is not None else {}
-        events: list[Any] = []
-        if d.content:
-            idx_map.clear()
-            events.extend(
-                _streaming_text_events_from_openai_chunk(
-                    completion, source_ag_ui_events=source_ag_ui_events
-                )
+    chunk = _openai_chat_completion_chunk_to_nat_chat_response_chunk(completion)
+    d = completion.choices[0].delta
+    idx_map = stream_tool_index_map if stream_tool_index_map is not None else {}
+    events: list[Any] = []
+    if d.content:
+        idx_map.clear()
+        events.extend(
+            _streaming_text_events_from_openai_chunk(
+                completion, source_ag_ui_events=source_ag_ui_events
             )
-        elif not d.tool_calls:
-            events.extend(
-                _streaming_text_events_from_openai_chunk(
-                    completion, source_ag_ui_events=source_ag_ui_events
-                )
+        )
+    elif not d.tool_calls:
+        events.extend(
+            _streaming_text_events_from_openai_chunk(
+                completion, source_ag_ui_events=source_ag_ui_events
             )
-        if d.tool_calls:
-            if d.content and events:
-                last = events[-1]
-                if isinstance(last, (TextMessageContentEvent, TextMessageChunkEvent)):
-                    events.append(TextMessageEndEvent(message_id=last.message_id))
-            parent_id = _infer_parent_message_id_for_tool_calls(source_ag_ui_events, events)
-            events.extend(
-                _agui_tool_events_from_openai_delta_tool_calls(
-                    d.tool_calls,
-                    parent_message_id=parent_id,
-                    tool_index_map=idx_map,
-                )
+        )
+    if d.tool_calls:
+        if d.content and events:
+            last = events[-1]
+            if isinstance(last, (TextMessageContentEvent, TextMessageChunkEvent)):
+                events.append(TextMessageEndEvent(message_id=last.message_id))
+        parent_id = _infer_parent_message_id_for_tool_calls(source_ag_ui_events, events)
+        events.extend(
+            _agui_tool_events_from_openai_delta_tool_calls(
+                d.tool_calls,
+                parent_message_id=parent_id,
+                tool_index_map=idx_map,
             )
-    else:
-        chunk = _openai_chat_completion_to_nat_chat_response_chunk(completion)
-        msg = completion.choices[0].message
-        events = _assistant_text_events_from_message(msg.content)
+        )
     usage_metrics = _openai_usage_to_usage_metrics(completion.usage) or default_usage_metrics()
     datarobot_moderations = (
         _datarobot_moderations_from_evaluation_result(response_eval)
@@ -917,6 +796,10 @@ def chat_completion_to_dragent_event_response(
         model=completion.model,
         datarobot_moderations=datarobot_moderations,
     )
+
+
+# Backward-compatible alias for tests and external imports.
+chat_completion_to_dragent_event_response = dome_chunk_to_dragent_event_response
 
 
 def _ag_ui_message_to_openai(msg: object) -> dict[str, Any]:
@@ -1008,9 +891,7 @@ def _tool_call_lines_from_openai_style_messages(messages: list[dict[str, Any]]) 
     return lines
 
 
-def moderation_prompt_from_workflow_input(
-    workflow_input: RunAgentInput | ChatRequest | ChatRequestOrMessage,
-) -> str:
+def moderation_prompt_from_workflow_input(workflow_input: WorkflowInput) -> str:
     """Extract the prescore prompt string from AG-UI or NAT chat input.
 
     Matches ``get_chat_prompt(workflow_input_to_completion_dict(...))`` without building a full
@@ -1123,9 +1004,7 @@ def nat_chat_request_like_to_completion_dict(
     return _normalize_nat_chat_request_completion_dict(request.model_dump(mode="json"))
 
 
-def workflow_input_to_completion_dict(
-    workflow_input: RunAgentInput | ChatRequest | ChatRequestOrMessage,
-) -> dict[str, Any]:
+def workflow_input_to_completion_dict(workflow_input: WorkflowInput) -> dict[str, Any]:
     """Build OpenAI-style completion params for prescore from AG-UI or NAT chat inputs."""
     if isinstance(workflow_input, RunAgentInput):
         return run_agent_input_to_completion_dict(workflow_input)
@@ -1176,7 +1055,7 @@ def _apply_moderated_prompt_text_to_nat_chat_messages(
 
 
 def _apply_moderated_prompt_text_to_workflow_input(
-    workflow_input: RunAgentInput | ChatRequest | ChatRequestOrMessage,
+    workflow_input: WorkflowInput,
     moderated_text: str,
 ) -> bool:
     if isinstance(workflow_input, RunAgentInput):
@@ -1339,10 +1218,7 @@ async def _moderated_dragent_stream(
         current: DRAgentEventResponse | None = first_text
         while current is not None:
             moderation_source_responses.append(current)
-            yield cast(
-                ChatCompletionChunk,
-                dragent_event_response_to_chat_completion(current, as_streaming_chunk=True),
-            )
+            yield dragent_event_response_to_dome_chunk(current)
             current = await next_text_response()
 
     first_text: DRAgentEventResponse | None = None
@@ -1363,7 +1239,7 @@ async def _moderated_dragent_stream(
         source_response = moderation_source_responses.pop(0)
         yield (
             True,
-            chat_completion_to_dragent_event_response(
+            dome_chunk_to_dragent_event_response(
                 moderated,
                 source_ag_ui_events=source_response.events,
                 stream_tool_index_map=stream_tool_index_map,
@@ -1419,6 +1295,15 @@ def _clear_moderation_invoke_state_if_set() -> None:
 class DataRobotModerationMiddleware(
     FunctionMiddleware,  # type: ignore[misc]
 ):
+    """Guardrails middleware for DRAgent NAT workflows and native NAT chat agents.
+
+    * **DRAgent** (``RunAgentInput`` in, ``DRAgentEventResponse`` stream out): prescore/postscore
+      on AG-UI text; streaming moderation uses ``dragent_event_response_to_dome_chunk`` at the
+      dome boundary.
+    * **NAT chat** (``ChatRequest`` / ``ChatRequestOrMessage`` in, ``ChatResponse`` out): same
+      guard pipeline with NAT message models instead of AG-UI.
+    """
+
     def __init__(self, config: DataRobotModerationConfig, builder: Builder) -> None:  # noqa: ARG002
         super().__init__()
         self._moderation = load_llm_moderation_pipeline(config)
@@ -1473,9 +1358,7 @@ class DataRobotModerationMiddleware(
             InvocationContext if modified (including when the prompt is blocked and
             ``context.output`` holds the guard message), or None to pass through unchanged.
         """
-        workflow_input: RunAgentInput | ChatRequest | ChatRequestOrMessage | None = (
-            context.original_args[0] if context.original_args else None
-        )
+        workflow_input = _workflow_input_from_args(context.original_args)
         if workflow_input is None:
             return None
         if self._moderation is None:
@@ -1627,8 +1510,8 @@ class DataRobotModerationMiddleware(
         call_next: CallNextStream,
         context: FunctionMiddlewareContext,
         **kwargs: Any,
-    ) -> AsyncIterator[Any]:
-        """Execute middleware hooks around streaming function call.
+    ) -> AsyncIterator[DRAgentEventResponse]:
+        """Execute middleware hooks around DRAgent streaming (``DRAgentEventResponse`` chunks).
 
         Pre-invoke runs once before streaming starts.
         Post-invoke runs per-chunk as they stream through.
@@ -1685,10 +1568,7 @@ class DataRobotModerationMiddleware(
             prompt_for_stream = _text_for_moderation_eval(
                 stream_state.input_df.loc[0, prompt_column_name]
             )
-            upstream = cast(
-                AsyncIterator[DRAgentEventResponse],
-                call_next(*ctx.modified_args, **ctx.modified_kwargs),
-            )
+            upstream = call_next(*ctx.modified_args, **ctx.modified_kwargs)
             stream_tool_index_map: dict[int, str] = {}
 
             async for is_moderated, response in _moderated_dragent_stream(

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -113,7 +113,6 @@ from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_c
 _logger = logging.getLogger(__name__)
 
 WorkflowInput: TypeAlias = RunAgentInput | ChatRequest | ChatRequestOrMessage
-WorkflowOutput: TypeAlias = DRAgentEventResponse | ChatResponse | str
 
 
 def _workflow_input_from_args(args: tuple[Any, ...]) -> WorkflowInput | None:

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -785,13 +785,85 @@ def _moderation_prompt_from_openai_style_content(prompt_content: Any) -> str:
     raise ValueError(f"Unhandled prompt type: {type(prompt_content)}")
 
 
-def _nat_user_message_content_to_prompt_string(content: str | list[Any]) -> str:
+def _ag_ui_user_content_to_prompt_string(content: object) -> str:
+    """Stringify AG-UI user ``content`` (same result as the last user message in a CCP dict)."""
+    return _moderation_prompt_from_openai_style_content(_user_content_to_openai(content))
+
+
+def _nat_message_content_to_prompt_string(content: str | list[Any]) -> str:
     if isinstance(content, str):
         return content
-    dumped = [
-        part.model_dump(mode="json") if hasattr(part, "model_dump") else part for part in content
-    ]
-    return _moderation_prompt_from_openai_style_content(dumped)
+    if isinstance(content, list):
+        parts: list[dict[str, Any]] = []
+        for part in content:
+            if isinstance(part, dict):
+                parts.append(part)
+            elif hasattr(part, "model_dump"):
+                parts.append(part.model_dump(mode="json"))
+        return _moderation_prompt_from_openai_style_content(parts)
+    raise ValueError(f"Unhandled prompt type: {type(content)}")
+
+
+def _format_moderation_prompt(
+    chat_prompt: str,
+    *,
+    tool_call_lines: list[str] | None = None,
+    tool_names: list[str] | None = None,
+) -> str:
+    if tool_call_lines:
+        return "\n".join([chat_prompt, "Tool Calls:", "\n".join(tool_call_lines)])
+    if tool_names:
+        return "\n".join([chat_prompt, "Tool Names:", "\n".join(tool_names)])
+    return chat_prompt
+
+
+def _validate_messages_nonempty_for_moderation(
+    messages: list[Any],
+    workflow_input: WorkflowInput,
+) -> None:
+    if not messages:
+        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
+    last = messages[-1]
+    if not hasattr(last, "content"):
+        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
+    if getattr(last, "content", None) is None:
+        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
+
+
+def _moderation_prompt_from_run_agent_input(run_input: RunAgentInput) -> str:
+    msgs = run_input.messages
+    _validate_messages_nonempty_for_moderation(msgs, run_input)
+    last_user: UserMessage | None = None
+    tool_lines: list[str] = []
+    for msg in msgs:
+        if isinstance(msg, UserMessage):
+            last_user = msg
+        elif isinstance(msg, ToolMessage):
+            # Matches OpenAI-style tool dicts from ``_ag_ui_message_to_openai`` (no ``name`` field).
+            tool_lines.append(f"_{msg.content}")
+    if last_user is None:
+        raise ValueError("No message with 'user' role found in input")
+    chat_prompt = _ag_ui_user_content_to_prompt_string(last_user.content)
+    tool_names = [t.name for t in (run_input.tools or [])]
+    return _format_moderation_prompt(chat_prompt, tool_call_lines=tool_lines, tool_names=tool_names)
+
+
+def _moderation_prompt_from_nat_chat(
+    workflow_input: ChatRequest | ChatRequestOrMessage,
+) -> str:
+    messages = workflow_input.messages
+    if messages is None:
+        raise ValueError(f"Chat input for moderation does not contain a message: {workflow_input}")
+    _validate_messages_nonempty_for_moderation(messages, workflow_input)
+    last_user_msg = None
+    for msg in messages:
+        if msg.role == UserMessageContentRoleType.USER:
+            last_user_msg = msg
+    if last_user_msg is None:
+        raise ValueError("No message with 'user' role found in input")
+    chat_prompt = _nat_message_content_to_prompt_string(last_user_msg.content)
+    tool_names = _tool_names_from_nat_tools(getattr(workflow_input, "tools", None))
+    return _format_moderation_prompt(chat_prompt, tool_names=tool_names)
 
 
 def _tool_names_from_nat_tools(tools: list[dict[str, Any]] | None) -> list[str]:
@@ -805,48 +877,14 @@ def _tool_names_from_nat_tools(tools: list[dict[str, Any]] | None) -> list[str]:
     return names
 
 
-def _tool_call_lines_from_openai_style_messages(messages: list[dict[str, Any]]) -> list[str]:
-    lines: list[str] = []
-    for message in messages:
-        if message.get("role") == "tool":
-            lines.append(f"{message.get('name', '')}_{message['content']}")
-    return lines
-
-
 def moderation_prompt_from_workflow_input(workflow_input: WorkflowInput) -> str:
     """Extract the prescore prompt string from AG-UI or NAT chat input.
 
     Matches ``get_chat_prompt(workflow_input_to_completion_dict(...))`` without building a full
-    completion-params dict.
+    completion-params dict or converting every message to OpenAI-style dicts.
     """
     if isinstance(workflow_input, RunAgentInput):
-        msgs = workflow_input.messages
-        if not msgs:
-            raise ValueError(
-                f"Chat input for moderation does not contain a message: {workflow_input}"
-            )
-        openai_msgs = [_ag_ui_message_to_openai(m) for m in msgs]
-        last = openai_msgs[-1]
-        if not isinstance(last, dict) or "content" not in last or last["content"] is None:
-            raise ValueError(
-                f"Chat input for moderation does not contain a message: {workflow_input}"
-            )
-        last_user_ag: UserMessage | None = None
-        for m in reversed(workflow_input.messages):
-            if isinstance(m, UserMessage):
-                last_user_ag = m
-                break
-        if last_user_ag is None:
-            raise ValueError("No message with 'user' role found in input")
-        inner = _user_content_to_openai(last_user_ag.content)
-        chat_prompt = _moderation_prompt_from_openai_style_content(inner)
-        tool_lines = _tool_call_lines_from_openai_style_messages(openai_msgs)
-        tool_names = [t.name for t in (workflow_input.tools or [])]
-        if tool_lines:
-            return "\n".join([chat_prompt, "Tool Calls:", "\n".join(tool_lines)])
-        if tool_names:
-            return "\n".join([chat_prompt, "Tool Names:", "\n".join(tool_names)])
-        return chat_prompt
+        return _moderation_prompt_from_run_agent_input(workflow_input)
 
     if (
         isinstance(workflow_input, ChatRequestOrMessage)
@@ -855,27 +893,7 @@ def moderation_prompt_from_workflow_input(workflow_input: WorkflowInput) -> str:
         return workflow_input.input_message
 
     if isinstance(workflow_input, (ChatRequest, ChatRequestOrMessage)):
-        messages = workflow_input.messages
-        if messages is None or len(messages) == 0:
-            raise ValueError(
-                f"Chat input for moderation does not contain a message: {workflow_input}"
-            )
-        last_dump = messages[-1].model_dump(mode="json")
-        if not isinstance(last_dump, dict) or "content" not in last_dump:
-            raise ValueError(
-                f"Chat input for moderation does not contain a message: {workflow_input}"
-            )
-        last_user_msg = None
-        for m in messages:
-            if m.role == UserMessageContentRoleType.USER:
-                last_user_msg = m
-        if last_user_msg is None:
-            raise ValueError("No message with 'user' role found in input")
-        chat_prompt = _nat_user_message_content_to_prompt_string(last_user_msg.content)
-        tool_names = _tool_names_from_nat_tools(getattr(workflow_input, "tools", None))
-        if tool_names:
-            return "\n".join([chat_prompt, "Tool Names:", "\n".join(tool_names)])
-        return chat_prompt
+        return _moderation_prompt_from_nat_chat(workflow_input)
 
     raise TypeError(
         f"Unsupported workflow input type for moderation: {type(workflow_input).__name__}"

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -149,29 +149,6 @@ def load_llm_moderation_pipeline(config: DataRobotModerationConfig) -> Moderatio
     return ModerationPipeline.from_config(config.moderation, model_dir=model_dir)
 
 
-def _text_for_moderation_eval(value: Any) -> str:
-    if value is None:
-        return ""
-    try:
-        if pd.isna(value):
-            return ""
-    except TypeError:
-        pass
-    return str(value)
-
-
-def _optional_prompt_for_moderation_eval(value: Any) -> str | None:
-    if value is None:
-        return None
-    try:
-        if pd.isna(value):
-            return None
-    except TypeError:
-        pass
-    s = str(value)
-    return s or None
-
-
 def _tool_calls_from_ag_ui_events(
     events: list[Any],
 ) -> list[ChatCompletionMessageToolCall] | None:
@@ -1019,9 +996,7 @@ async def _moderated_dragent_stream(
     upstream: AsyncIterator[DRAgentEventResponse],
     *,
     moderation: ModerationPipeline,
-    prompt_for_stream: str,
     stream_state: _ModerationInvokeState,
-    stream_tool_index_map: dict[int, str],
 ) -> AsyncIterator[tuple[bool, DRAgentEventResponse]]:
     """Yield ``(is_moderated_text, response)`` with AG-UI-safe ordering around moderated deltas.
 
@@ -1029,6 +1004,7 @@ async def _moderated_dragent_stream(
     moderated via ``stream_response_async``; ``TEXT_MESSAGE_START`` / ``END`` and other events read
     during peek-ahead are buffered and emitted after each moderated chunk.
     """
+    stream_tool_index_map: dict[int, str] = {}
     pending_deferred: list[DRAgentEventResponse] = []
     pending_pass_through: list[DRAgentEventResponse] = []
     moderation_source_responses: list[DRAgentEventResponse] = []
@@ -1067,7 +1043,7 @@ async def _moderated_dragent_stream(
 
     async for moderated in moderation.stream_response_async(
         completion_chunks(first_text),
-        prompt=prompt_for_stream,
+        prompt=stream_state.prompt,
         prescore_df=stream_state.prescore_df,
         prescore_latency=stream_state.latency_so_far,
     ):
@@ -1268,11 +1244,9 @@ class DataRobotModerationMiddleware(
         # Step 3: Postscore via ``ModerationPipeline.evaluate_response`` (same path as
         # ``_run_stage`` in dome) when response text is present.
         prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
-        prompt_for_eval = state.prompt
-
         response_eval, _, _postscore_df = await self._moderation.evaluate_response_async(
-            _text_for_moderation_eval(response_text),
-            prompt=_optional_prompt_for_moderation_eval(prompt_for_eval),
+            response_text,
+            prompt=state.prompt,
         )
 
         prompt_eval = _from_dataframe(state.prescore_df, prompt_column_name)
@@ -1331,10 +1305,7 @@ class DataRobotModerationMiddleware(
         """Execute middleware hooks around DRAgent streaming (``DRAgentEventResponse`` chunks).
 
         Pre-invoke runs once before streaming starts.
-        Post-invoke runs per-chunk as they stream through.
-
-        Override for custom streaming behavior (e.g., buffering,
-        aggregation, chunk filtering).
+        Moderation is applied per-chunk as they stream through.
 
         Note: Framework checks ``enabled`` before calling this method.
         You do NOT need to check ``enabled`` yourself.
@@ -1381,16 +1352,10 @@ class DataRobotModerationMiddleware(
             moderation = self._moderation
             assert moderation is not None
 
-            prompt_for_stream = _text_for_moderation_eval(stream_state.prompt)
-            upstream = call_next(*ctx.modified_args, **ctx.modified_kwargs)
-            stream_tool_index_map: dict[int, str] = {}
-
             async for is_moderated, response in _moderated_dragent_stream(
-                upstream,
+                call_next(*ctx.modified_args, **ctx.modified_kwargs),
                 moderation=moderation,
-                prompt_for_stream=prompt_for_stream,
                 stream_state=stream_state,
-                stream_tool_index_map=stream_tool_index_map,
             ):
                 if is_moderated:
                     ctx.output = response

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -106,6 +106,7 @@ from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.dragent.frontends.converters import (
     convert_dragent_event_response_to_openai_chat_completion_chunk,
 )
+from datarobot_genai.dragent.frontends.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
 
@@ -919,14 +920,6 @@ def _response_has_assistant_text_deltas(response: DRAgentEventResponse) -> bool:
     )
 
 
-def _assistant_text_joined_from_ag_ui(response: DRAgentEventResponse) -> str:
-    return "".join(
-        ev.delta
-        for ev in response.events
-        if isinstance(ev, (TextMessageContentEvent, TextMessageChunkEvent))
-    )
-
-
 def _merge_moderations_into_multi_event_response(
     incoming: DRAgentEventResponse,
     moderated_completion_response: DRAgentEventResponse,
@@ -1219,7 +1212,7 @@ class DataRobotModerationMiddleware(
         if isinstance(original_output, DRAgentEventResponse):
             if not _response_has_assistant_text_deltas(original_output):
                 return None
-            response_text = _assistant_text_joined_from_ag_ui(original_output)
+            response_text = convert_dragent_event_response_to_str(original_output)
         elif isinstance(original_output, ChatResponse):
             if not original_output.choices:
                 return None

--- a/tests/dragent/frontends/test_converters.py
+++ b/tests/dragent/frontends/test_converters.py
@@ -36,12 +36,18 @@ from datarobot_genai.dragent.frontends.converters import convert_chat_request_to
 from datarobot_genai.dragent.frontends.converters import (
     convert_dragent_event_response_to_chat_response_chunk,
 )
+from datarobot_genai.dragent.frontends.converters import (
+    convert_dragent_event_response_to_openai_chat_completion_chunk,
+)
 from datarobot_genai.dragent.frontends.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.frontends.converters import (
     convert_dragent_run_agent_input_to_chat_request,
 )
 from datarobot_genai.dragent.frontends.converters import (
     convert_dragent_run_agent_input_to_chat_request_or_message,
+)
+from datarobot_genai.dragent.frontends.converters import (
+    convert_nat_chat_response_chunk_to_openai_chat_completion_chunk,
 )
 from datarobot_genai.dragent.frontends.converters import convert_str_to_dragent_event_response
 from datarobot_genai.dragent.frontends.converters import convert_tool_message_to_str
@@ -559,3 +565,43 @@ def test_convert_dragent_event_response_to_chat_response_chunk_tool_call_end_is_
     # THEN no tool_calls are emitted and content reverts to the empty default
     assert result.choices[0].delta.tool_calls is None
     assert result.choices[0].delta.content == ""
+
+
+# --- convert_dragent_event_response_to_openai_chat_completion_chunk ---
+
+
+def test_convert_dragent_event_response_to_openai_chunk_from_text_events() -> None:
+    response = DRAgentEventResponse(
+        original_chunk=None,
+        events=[
+            TextMessageContentEvent(message_id="m1", delta="Hello "),
+            TextMessageContentEvent(message_id="m1", delta="world"),
+        ],
+    )
+    result = convert_dragent_event_response_to_openai_chat_completion_chunk(response)
+    assert result.object == "chat.completion.chunk"
+    assert result.choices[0].delta.content == "Hello world"
+    assert isinstance(result.created, int)
+
+
+def test_convert_dragent_event_response_to_openai_chunk_returns_mapped_original_chunk() -> None:
+    existing = _make_chat_response_chunk(content="from-stream", chunk_id="nat-chunk-1")
+    response = DRAgentEventResponse(
+        original_chunk=existing,
+        events=[TextMessageContentEvent(message_id="m1", delta="ignored")],
+    )
+    result = convert_dragent_event_response_to_openai_chat_completion_chunk(response)
+    assert result.id == "nat-chunk-1"
+    assert result.choices[0].delta.content == "from-stream"
+    assert isinstance(result.created, int)
+
+
+def test_openai_chunk_from_nat_matches_dragent_event_path_for_text() -> None:
+    response = DRAgentEventResponse(
+        original_chunk=None,
+        events=[TextMessageContentEvent(message_id="m1", delta="same")],
+    )
+    nat = convert_dragent_event_response_to_chat_response_chunk(response)
+    via_nat = convert_nat_chat_response_chunk_to_openai_chat_completion_chunk(nat)
+    direct = convert_dragent_event_response_to_openai_chat_completion_chunk(response)
+    assert direct.choices[0].delta.content == via_nat.choices[0].delta.content == "same"

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -507,7 +507,7 @@ async def test_pre_invoke_replaces_last_user_message(builder_mock: MagicMock) ->
             out = await mw.pre_invoke(ctx)
             st = _moderation_invoke_state_ctx.get()
             assert st is not None
-            assert st.input_df.loc[0, PROMPT_COL] == "[redacted]"
+            assert st.prompt == "[redacted]"
         finally:
             _clear_moderation_invoke_state_if_set()
 
@@ -549,7 +549,7 @@ async def test_pre_invoke_replaces_chat_request_or_message_input_message(
             out = await mw.pre_invoke(ctx)
             st = _moderation_invoke_state_ctx.get()
             assert st is not None
-            assert st.input_df.loc[0, PROMPT_COL] == "[redacted]"
+            assert st.prompt == "[redacted]"
         finally:
             _clear_moderation_invoke_state_if_set()
 
@@ -589,7 +589,7 @@ async def test_pre_invoke_replacement_apply_failure_clears_prescore_replaced_fla
             out = await mw.pre_invoke(ctx)
             st = _moderation_invoke_state_ctx.get()
             assert st is not None
-            assert st.input_df.loc[0, PROMPT_COL] == "secret"
+            assert st.prompt == "secret"
             assert bool(st.prescore_df.loc[0, f"replaced_{PROMPT_COL}"]) is False
         finally:
             _clear_moderation_invoke_state_if_set()
@@ -679,7 +679,7 @@ async def test_post_invoke_skips_dr_agent_when_joined_text_blank(
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         prescore = pd.DataFrame({PROMPT_COL: ["p"]})
         _set_moderation_invoke_state(
-            input_df=prescore,
+            prompt="p",
             prescore_df=prescore.copy(),
             latency_so_far=0.0,
         )
@@ -733,7 +733,7 @@ async def test_post_invoke_preserves_aggregate_ag_ui_when_response_text_unchange
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         prescore = pd.DataFrame({PROMPT_COL: ["p"]})
         _set_moderation_invoke_state(
-            input_df=prescore,
+            prompt="p",
             prescore_df=prescore.copy(),
             latency_so_far=0.0,
         )
@@ -773,7 +773,7 @@ async def test_post_invoke_rewrites_completion_when_postscore_succeeds(
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         prescore = pd.DataFrame({PROMPT_COL: ["p"]})
         _set_moderation_invoke_state(
-            input_df=prescore,
+            prompt="p",
             prescore_df=prescore.copy(),
             latency_so_far=0.0,
         )
@@ -813,7 +813,7 @@ async def test_post_invoke_rewrites_nat_chat_response_when_postscore_succeeds(
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         prescore = pd.DataFrame({PROMPT_COL: ["p"]})
         _set_moderation_invoke_state(
-            input_df=prescore,
+            prompt="p",
             prescore_df=prescore.copy(),
             latency_so_far=0.0,
         )
@@ -848,7 +848,7 @@ async def test_post_invoke_rewrites_plain_str_when_postscore_succeeds(
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         prescore = pd.DataFrame({PROMPT_COL: ["p"]})
         _set_moderation_invoke_state(
-            input_df=prescore,
+            prompt="p",
             prescore_df=prescore.copy(),
             latency_so_far=0.0,
         )
@@ -884,7 +884,7 @@ async def test_post_invoke_blocked_empty_postscore_coerces_none_blocked_message_
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         prescore = pd.DataFrame({PROMPT_COL: ["p"]})
         _set_moderation_invoke_state(
-            input_df=prescore,
+            prompt="p",
             prescore_df=prescore.copy(),
             latency_so_far=0.0,
         )

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -439,6 +439,7 @@ async def test_pre_invoke_blocks_and_sets_output(builder_mock: MagicMock) -> Non
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         try:
             out = await mw.pre_invoke(ctx)
+            assert _moderation_invoke_state_ctx.get() is None
         finally:
             _clear_moderation_invoke_state_if_set()
 

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -319,14 +319,17 @@ def test_workflow_input_to_completion_dict_chat_request_or_message() -> None:
     params = workflow_input_to_completion_dict(crm)
     assert params["tools"] == []
     assert get_chat_prompt(params) == "hello gateway"
-    assert moderation_prompt_from_workflow_input(crm) == get_chat_prompt(params)
+    assert moderation_prompt_from_workflow_input(crm) == "hello gateway"
 
 
-def test_moderation_prompt_from_workflow_input_parity_with_completion_dict() -> None:
+def test_moderation_prompt_from_workflow_input_run_agent_input() -> None:
     run_input = _make_run_input("plan the thing")
-    direct = moderation_prompt_from_workflow_input(run_input)
-    via_ccp = get_chat_prompt(workflow_input_to_completion_dict(run_input))
-    assert direct == via_ccp
+    assert moderation_prompt_from_workflow_input(run_input) == "plan the thing"
+
+
+def test_moderation_prompt_from_workflow_input_input_message_only() -> None:
+    crm = ChatRequestOrMessage(input_message="gateway string only")
+    assert moderation_prompt_from_workflow_input(crm) == "gateway string only"
 
 
 def test_load_llm_moderation_pipeline_from_config_moderation_field() -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -80,6 +80,7 @@ from datarobot_genai.nat.datarobot_moderation_middleware import (
 )
 from datarobot_genai.nat.datarobot_moderation_middleware import _moderation_invoke_state_ctx
 from datarobot_genai.nat.datarobot_moderation_middleware import _set_moderation_invoke_state
+from datarobot_genai.nat.datarobot_moderation_middleware import _workflow_input_from_args
 from datarobot_genai.nat.datarobot_moderation_middleware import dome_chunk_to_dragent_event_response
 from datarobot_genai.nat.datarobot_moderation_middleware import load_llm_moderation_pipeline
 from datarobot_genai.nat.datarobot_moderation_middleware import (
@@ -330,6 +331,38 @@ def test_moderation_prompt_from_workflow_input_run_agent_input() -> None:
 def test_moderation_prompt_from_workflow_input_input_message_only() -> None:
     crm = ChatRequestOrMessage(input_message="gateway string only")
     assert moderation_prompt_from_workflow_input(crm) == "gateway string only"
+
+
+def test_workflow_input_from_args_empty_returns_none() -> None:
+    assert _workflow_input_from_args(()) is None
+
+
+def test_workflow_input_from_args_unrecognized_type_raises() -> None:
+    with pytest.raises(TypeError, match="Unsupported workflow input type for moderation"):
+        _workflow_input_from_args(("not a workflow input",))
+
+
+@pytest.mark.asyncio
+async def test_pre_invoke_unrecognized_workflow_input_raises(builder_mock: MagicMock) -> None:
+    pipeline = _pipeline_mock()
+    moderation = _moderation_mock(pipeline)
+    ctx = InvocationContext(
+        function_context=_fn_context(),
+        original_args=("unexpected",),
+        original_kwargs={},
+        modified_args=("unexpected",),
+        modified_kwargs={},
+        output=None,
+    )
+    with (
+        patch(
+            "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+            return_value=moderation,
+        ),
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        with pytest.raises(TypeError, match="Unsupported workflow input type for moderation"):
+            await mw.pre_invoke(ctx)
 
 
 def test_load_llm_moderation_pipeline_from_config_moderation_field() -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -80,9 +80,7 @@ from datarobot_genai.nat.datarobot_moderation_middleware import (
 )
 from datarobot_genai.nat.datarobot_moderation_middleware import _moderation_invoke_state_ctx
 from datarobot_genai.nat.datarobot_moderation_middleware import _set_moderation_invoke_state
-from datarobot_genai.nat.datarobot_moderation_middleware import (
-    chat_completion_to_dragent_event_response,
-)
+from datarobot_genai.nat.datarobot_moderation_middleware import dome_chunk_to_dragent_event_response
 from datarobot_genai.nat.datarobot_moderation_middleware import load_llm_moderation_pipeline
 from datarobot_genai.nat.datarobot_moderation_middleware import (
     moderation_prompt_from_workflow_input,
@@ -1940,7 +1938,7 @@ async def test_function_middleware_stream_preserves_step_order_at_agent_transiti
     assert writer_start_idx < writer_finish_idx
 
 
-def test_chat_completion_to_dragent_event_response_keeps_tool_calls_with_text() -> None:
+def test_dome_chunk_to_dragent_event_response_keeps_tool_calls_with_text() -> None:
     """Moderation rehydration must not drop tool AG-UI events bundled with a text delta."""
     mid = "msg-1"
     source = [
@@ -1979,7 +1977,7 @@ def test_chat_completion_to_dragent_event_response_keeps_tool_calls_with_text() 
         model="test-model",
         object="chat.completion.chunk",
     )
-    out = chat_completion_to_dragent_event_response(
+    out = dome_chunk_to_dragent_event_response(
         moderated_chunk,
         source_ag_ui_events=source,
         stream_tool_index_map={},
@@ -1993,7 +1991,7 @@ def test_chat_completion_to_dragent_event_response_keeps_tool_calls_with_text() 
     assert starts[0].tool_call_name == "generate_objectid"
 
 
-def test_chat_completion_to_dragent_event_response_serializes_numpy_moderations() -> None:
+def test_dome_chunk_to_dragent_event_response_serializes_numpy_moderations() -> None:
     """datarobot_dome may attach numpy scalars; SSE must still serialize via model_dump_json."""
     chunk = ChatCompletionChunk(
         id="chunk-1",
@@ -2017,7 +2015,7 @@ def test_chat_completion_to_dragent_event_response_serializes_numpy_moderations(
             "ts": pd.Timestamp("2026-01-01T00:00:00Z"),
         },
     )
-    out = chat_completion_to_dragent_event_response(chunk)
+    out = dome_chunk_to_dragent_event_response(chunk)
     assert out.datarobot_moderations is not None
     assert out.datarobot_moderations["count"] == 42
     assert out.datarobot_moderations["nested"]["x"] == 1.5

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.67"
+version = "0.15.68"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
`DataRobotModerationMiddleware` is used with dragent/NAT flow only so we can specialize the types and simplify a bit.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors moderation streaming to only use `ChatCompletionChunk` at the dome boundary and tightens middleware input/output typing, which could subtly affect tool-call/text event reconstruction and streamed moderation behavior.
> 
> **Overview**
> Bumps `datarobot-genai` to `0.15.68` and updates lockfiles; the e2e test package moves `rpdb` into dev-only deps and drops `ipdb`/`rpdb` from runtime requirements.
> 
> Refactors `DataRobotModerationMiddleware` to specialize workflow types (`WorkflowInput`/`WorkflowOutput`) and simplify the moderation boundary: streaming now converts `DRAgentEventResponse` → NAT chunk → OpenAI `ChatCompletionChunk` via `dragent_event_response_to_dome_chunk`, and converts moderated chunks back via `dome_chunk_to_dragent_event_response` (with a backward-compatible alias). Removed non-streaming `ChatCompletion` conversion paths and tightened streaming return types/casts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87dea221dbb8b8151624f619d482ddf317366d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->