### PR TITLE
[APP-6074] PulumiConfigSettingsSource and standard OTel fields to MCPServerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.68
+- `drmcp`: `MCPServerConfig` now reads `pulumi_config.json` via `PulumiConfigSettingsSource` (lowest priority) and accepts standard `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` fields. Telemetry setup bridges these to `os.environ` so local OTel tracing works without manual env var configuration.
+
 ## 0.15.67
 - Bump `datarobot-moderations` to 11.2.30 to use the async interface with `DataRobotModerationMiddleware`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.80"
+version = "0.15.81"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.79"
+version = "0.15.80"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.67"
+version = "0.15.68"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -24,6 +24,9 @@ from pydantic import Field
 from pydantic import field_validator
 from pydantic_settings import BaseSettings
 from pydantic_settings import SettingsConfigDict
+from pydantic_settings.sources import PydanticBaseSettingsSource
+
+from datarobot.core.config import PulumiConfigSettingsSource
 
 from datarobot_genai.drtools.core.config_utils import extract_datarobot_dict_runtime_param_payload
 from datarobot_genai.drtools.core.config_utils import extract_datarobot_runtime_param_payload
@@ -315,6 +318,22 @@ class MCPServerConfig(BaseSettings):
         ),
         description="Enable/disable HTTP instrumentors",
     )
+    otel_exporter_otlp_endpoint: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+        ),
+        description="Standard OTel OTLP endpoint. Takes priority over otel_collector_base_url.",
+    )
+    otel_exporter_otlp_headers: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "OTEL_EXPORTER_OTLP_HEADERS",
+            "OTEL_EXPORTER_OTLP_HEADERS",
+        ),
+        description="Standard OTel OTLP headers. Takes priority over entity_id construction.",
+    )
     mcp_server_register_dynamic_tools_on_startup: bool = Field(
         default=False,
         validation_alias=AliasChoices(
@@ -412,6 +431,8 @@ class MCPServerConfig(BaseSettings):
         "otel_entity_id",
         "otel_enabled",
         "otel_enabled_http_instrumentors",
+        "otel_exporter_otlp_endpoint",
+        "otel_exporter_otlp_headers",
         "enable_memory_management",
         "mcp_cli_configs",
         "tool_registration_allow_empty_schema",
@@ -424,6 +445,23 @@ class MCPServerConfig(BaseSettings):
     def validate_runtime_params(cls, v: Any) -> Any:
         """Validate runtime parameters."""
         return extract_datarobot_runtime_param_payload(v)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            file_secret_settings,
+            PulumiConfigSettingsSource(settings_cls),
+        )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -18,6 +18,7 @@ from typing import Literal
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
+from datarobot.core.config import PulumiConfigSettingsSource
 from fastmcp.settings import DuplicateBehavior
 from pydantic import AliasChoices
 from pydantic import Field
@@ -25,8 +26,6 @@ from pydantic import field_validator
 from pydantic_settings import BaseSettings
 from pydantic_settings import SettingsConfigDict
 from pydantic_settings.sources import PydanticBaseSettingsSource
-
-from datarobot.core.config import PulumiConfigSettingsSource
 
 from datarobot_genai.drtools.core.config_utils import extract_datarobot_dict_runtime_param_payload
 from datarobot_genai.drtools.core.config_utils import extract_datarobot_runtime_param_payload

--- a/src/datarobot_genai/drmcp/core/telemetry.py
+++ b/src/datarobot_genai/drmcp/core/telemetry.py
@@ -152,6 +152,13 @@ class OtelASGIMiddleware(BaseHTTPMiddleware):
 
 def _setup_otel_env_variables() -> None:
     """Set up OpenTelemetry environment variables for DataRobot integration."""
+    config = get_config()
+
+    if config.otel_exporter_otlp_endpoint:
+        os.environ.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", config.otel_exporter_otlp_endpoint)
+    if config.otel_exporter_otlp_headers:
+        os.environ.setdefault("OTEL_EXPORTER_OTLP_HEADERS", config.otel_exporter_otlp_headers)
+
     # do not override if already set
     if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or os.environ.get(
         "OTEL_EXPORTER_OTLP_HEADERS"
@@ -163,7 +170,6 @@ def _setup_otel_env_variables() -> None:
 
     credentials = get_credentials()
 
-    config = get_config()
     otlp_endpoint = config.otel_collector_base_url
     entity_id = config.otel_entity_id
 
@@ -275,7 +281,11 @@ def initialize_telemetry(mcp: FastMCP) -> None:
         return None
 
     # If OTEL_ENTITY_ID is not set, skip telemetry
-    if not config.otel_entity_id and not os.environ.get("OTEL_EXPORTER_OTLP_HEADERS"):
+    if (
+        not config.otel_entity_id
+        and not config.otel_exporter_otlp_headers
+        and not os.environ.get("OTEL_EXPORTER_OTLP_HEADERS")
+    ):
         root_logger.info(
             "Neither OTEL_ENTITY_ID nor OTEL_EXPORTER_OTLP_HEADERS is set, skipping telemetry"
         )

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import os
+from pathlib import Path
 from typing import Any
 from typing import get_args
 from unittest.mock import patch
@@ -534,3 +536,94 @@ class TestMCPCLIConfigs:
             assert config.tool_config.enable_perplexity_tools is False
             assert config.tool_config.enable_tavily_tools is False
             self._reset_config()
+
+
+class TestOtelStandardFields:
+    """Test standard OTel env var fields on MCPServerConfig."""
+
+    def test_otel_exporter_fields_default_empty(self) -> None:
+        """Standard OTel fields default to empty string."""
+        with patch.dict(os.environ, clear=True):
+            config_module._config = None
+            config = MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
+            assert config.otel_exporter_otlp_endpoint == ""
+            assert config.otel_exporter_otlp_headers == ""
+            config_module._config = None
+
+    def test_otel_exporter_fields_from_env(self) -> None:
+        """Standard OTel fields can be set via env vars."""
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "https://collector.example.com/otel",
+                "OTEL_EXPORTER_OTLP_HEADERS": "x-api-key=test123",
+            },
+            clear=False,
+        ):
+            config = MCPServerConfig()
+            assert config.otel_exporter_otlp_endpoint == "https://collector.example.com/otel"
+            assert config.otel_exporter_otlp_headers == "x-api-key=test123"
+
+    def test_otel_exporter_fields_from_runtime_params(self) -> None:
+        """Standard OTel fields accept MLOPS_RUNTIME_PARAM_ prefix."""
+        with patch.dict(
+            os.environ,
+            {
+                "MLOPS_RUNTIME_PARAM_OTEL_EXPORTER_OTLP_ENDPOINT": '{"type":"string","payload":"https://rt.example.com/otel"}',
+                "MLOPS_RUNTIME_PARAM_OTEL_EXPORTER_OTLP_HEADERS": '{"type":"string","payload":"x-key=rt123"}',
+            },
+            clear=False,
+        ):
+            config = MCPServerConfig()
+            assert config.otel_exporter_otlp_endpoint == "https://rt.example.com/otel"
+            assert config.otel_exporter_otlp_headers == "x-key=rt123"
+
+
+class TestPulumiConfigSource:
+    """Test that MCPServerConfig reads from pulumi_config.json."""
+
+    def test_reads_otel_from_pulumi_config_json(self, tmp_path: Path) -> None:
+        """Config reads OTel vars from pulumi_config.json when env vars are absent."""
+        pulumi_config = {
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "https://pulumi.example.com/otel",
+            "OTEL_EXPORTER_OTLP_HEADERS": "x-key=pulumi123",
+        }
+        config_file = tmp_path / "pulumi_config.json"
+        config_file.write_text(json.dumps(pulumi_config))
+
+        with patch.dict(os.environ, {}, clear=True):
+            config_module._config = None
+            original_cwd = os.getcwd()
+            os.chdir(tmp_path)
+            try:
+                config = MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
+                assert config.otel_exporter_otlp_endpoint == "https://pulumi.example.com/otel"
+                assert config.otel_exporter_otlp_headers == "x-key=pulumi123"
+            finally:
+                os.chdir(original_cwd)
+                config_module._config = None
+
+    def test_env_var_takes_priority_over_pulumi_config(self, tmp_path: Path) -> None:
+        """Env vars override pulumi_config.json values."""
+        pulumi_config = {
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "https://pulumi.example.com/otel",
+        }
+        config_file = tmp_path / "pulumi_config.json"
+        config_file.write_text(json.dumps(pulumi_config))
+
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "https://env.example.com/otel",
+            },
+            clear=True,
+        ):
+            config_module._config = None
+            original_cwd = os.getcwd()
+            os.chdir(tmp_path)
+            try:
+                config = MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
+                assert config.otel_exporter_otlp_endpoint == "https://env.example.com/otel"
+            finally:
+                os.chdir(original_cwd)
+                config_module._config = None

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -569,8 +569,12 @@ class TestOtelStandardFields:
         with patch.dict(
             os.environ,
             {
-                "MLOPS_RUNTIME_PARAM_OTEL_EXPORTER_OTLP_ENDPOINT": '{"type":"string","payload":"https://rt.example.com/otel"}',
-                "MLOPS_RUNTIME_PARAM_OTEL_EXPORTER_OTLP_HEADERS": '{"type":"string","payload":"x-key=rt123"}',
+                "MLOPS_RUNTIME_PARAM_OTEL_EXPORTER_OTLP_ENDPOINT": (
+                    '{"type":"string","payload":"https://rt.example.com/otel"}'
+                ),
+                "MLOPS_RUNTIME_PARAM_OTEL_EXPORTER_OTLP_HEADERS": (
+                    '{"type":"string","payload":"x-key=rt123"}'
+                ),
             },
             clear=False,
         ):

--- a/tests/drmcp/unit/test_telemetry.py
+++ b/tests/drmcp/unit/test_telemetry.py
@@ -24,6 +24,7 @@ from opentelemetry.trace import SpanContext
 
 from datarobot_genai.drmcp.core import telemetry
 from datarobot_genai.drmcp.core.telemetry import OpenTelemetryMiddleware
+from datarobot_genai.drmcp.core.telemetry import initialize_telemetry as _real_initialize_telemetry
 from datarobot_genai.drmcp.core.telemetry import with_otel_context
 
 
@@ -40,6 +41,8 @@ def test_setup_otel_env_variables() -> None:
     mock_config = MagicMock()
     mock_config.otel_collector_base_url = "http://test-collector:4318"
     mock_config.otel_entity_id = "test-entity"
+    mock_config.otel_exporter_otlp_endpoint = ""
+    mock_config.otel_exporter_otlp_headers = ""
 
     mock_credentials = MagicMock()
     mock_credentials.datarobot.application_api_token = "test-app-token"
@@ -60,6 +63,73 @@ def test_setup_otel_env_variables() -> None:
             os.environ["OTEL_EXPORTER_OTLP_HEADERS"]
             == "X-DataRobot-Api-Key=test-app-token,X-DataRobot-Entity-Id=test-entity"
         )
+
+
+def test_setup_otel_env_variables_bridges_config_fields() -> None:
+    """When Config has standard OTel fields (e.g. from pulumi_config.json),
+    they are bridged to os.environ via setdefault."""
+    mock_config = MagicMock()
+    mock_config.otel_exporter_otlp_endpoint = "https://config.example.com/otel"
+    mock_config.otel_exporter_otlp_headers = "x-key=config123"
+    mock_config.otel_collector_base_url = "http://fallback:4318"
+    mock_config.otel_entity_id = "fallback-entity"
+
+    with (
+        patch("datarobot_genai.drmcp.core.telemetry.get_config", return_value=mock_config),
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        telemetry._setup_otel_env_variables()
+
+        assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "https://config.example.com/otel"
+        assert os.environ["OTEL_EXPORTER_OTLP_HEADERS"] == "x-key=config123"
+
+
+def test_setup_otel_env_variables_setdefault_no_override() -> None:
+    """Explicit env vars are NOT overridden by Config values (setdefault semantics)."""
+    mock_config = MagicMock()
+    mock_config.otel_exporter_otlp_endpoint = "https://config.example.com/otel"
+    mock_config.otel_exporter_otlp_headers = "x-key=config123"
+
+    with (
+        patch("datarobot_genai.drmcp.core.telemetry.get_config", return_value=mock_config),
+        patch.dict(
+            "os.environ",
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "https://explicit.example.com/otel",
+                "OTEL_EXPORTER_OTLP_HEADERS": "x-key=explicit",
+            },
+            clear=True,
+        ),
+    ):
+        telemetry._setup_otel_env_variables()
+
+        assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "https://explicit.example.com/otel"
+        assert os.environ["OTEL_EXPORTER_OTLP_HEADERS"] == "x-key=explicit"
+
+
+def test_initialize_telemetry_proceeds_with_config_headers() -> None:
+    """initialize_telemetry should NOT skip when otel_exporter_otlp_headers is set
+    in Config, even if otel_entity_id is empty."""
+    mcp_mock = MagicMock()
+    mock_config = MagicMock()
+    mock_config.otel_enabled = True
+    mock_config.otel_entity_id = ""
+    mock_config.otel_exporter_otlp_headers = "x-key=from-config"
+    mock_config.otel_exporter_otlp_endpoint = "https://config.example.com/otel"
+    mock_config.mcp_server_name = "test-mcp"
+    mock_config.otel_attributes = {}
+    mock_config.otel_enabled_http_instrumentors = False
+
+    with (
+        patch("datarobot_genai.drmcp.core.telemetry.get_config", return_value=mock_config),
+        patch("datarobot_genai.drmcp.core.telemetry._setup_otel_env_variables"),
+        patch("datarobot_genai.drmcp.core.telemetry._setup_otel_exporter"),
+        patch("datarobot_genai.drmcp.core.telemetry._setup_otel_logging"),
+        patch("datarobot_genai.drmcp.core.telemetry.trace") as mock_trace,
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        _real_initialize_telemetry(mcp_mock)
+        mock_trace.set_tracer_provider.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/test_telemetry.py
+++ b/tests/drmcp/unit/test_telemetry.py
@@ -67,7 +67,8 @@ def test_setup_otel_env_variables() -> None:
 
 def test_setup_otel_env_variables_bridges_config_fields() -> None:
     """When Config has standard OTel fields (e.g. from pulumi_config.json),
-    they are bridged to os.environ via setdefault."""
+    they are bridged to os.environ via setdefault.
+    """
     mock_config = MagicMock()
     mock_config.otel_exporter_otlp_endpoint = "https://config.example.com/otel"
     mock_config.otel_exporter_otlp_headers = "x-key=config123"
@@ -109,7 +110,8 @@ def test_setup_otel_env_variables_setdefault_no_override() -> None:
 
 def test_initialize_telemetry_proceeds_with_config_headers() -> None:
     """initialize_telemetry should NOT skip when otel_exporter_otlp_headers is set
-    in Config, even if otel_entity_id is empty."""
+    in Config, even if otel_entity_id is empty.
+    """
     mcp_mock = MagicMock()
     mock_config = MagicMock()
     mock_config.otel_enabled = True


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `MCPServerConfig` settings source precedence and alters telemetry initialization/env-var bridging logic, which could affect tracing behavior in deployed MCP servers.
> 
> **Overview**
> **Adds new configuration inputs for MCP telemetry and Pulumi-based local config.** `MCPServerConfig` now reads `pulumi_config.json` via `PulumiConfigSettingsSource` (lowest priority) and adds first-class support for standard `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` fields (including `MLOPS_RUNTIME_PARAM_` aliases).
> 
> **Updates telemetry initialization to honor these standard fields.** `_setup_otel_env_variables()` now bridges config-provided exporter endpoint/headers into `os.environ` using `setdefault`, and `initialize_telemetry()` no longer skips setup when headers are provided via config rather than `otel_entity_id`.
> 
> Version bumped to `0.15.68` and unit tests expanded to cover Pulumi config loading, env precedence, and the new OTel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d367fb6612775591388398f3e3998744b44cec2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->