### PR TITLE
instrument tracing dragent genai package attempt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,9 @@ dragent = nat + [
     # in fastapi_front_end_plugin_worker.py", line 328, in configure
     "fastapi<0.133.0",
     "starlette<1.0.0",
+    # Required to instrument the FastAPI app for OpenTelemetry tracing on the
+    # DRAgent execution path.
+    "opentelemetry-instrumentation-fastapi>=0.60b1,<1.0.0",
 ]
 
 # Eventually NAT will be merged into dragent

--- a/src/datarobot_genai/core/telemetry_bootstrap.py
+++ b/src/datarobot_genai/core/telemetry_bootstrap.py
@@ -1,0 +1,161 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared TracerProvider + OTLP exporter bootstrap for DataRobot agent runtimes.
+
+DRUM bootstraps the global ``TracerProvider`` outside this repo, so generated
+``custom.py`` only needs to call :func:`instrument` from :mod:`telemetry_agent`.
+The DRAgent execution path has no equivalent bootstrap; without one, every
+span emitted by an instrumented library lands in the no-op default provider
+and is dropped. This module fills that gap.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
+
+from pydantic_core import PydanticUseDefault
+
+from datarobot_genai.drtools.core.config_utils import extract_datarobot_runtime_param_payload
+from datarobot_genai.drtools.core.constants import DEFAULT_DATAROBOT_ENDPOINT
+from datarobot_genai.drtools.core.constants import RUNTIME_PARAM_ENV_VAR_NAME_PREFIX
+
+logger = logging.getLogger(__name__)
+
+# Idempotency guard so that multiple call sites (FastAPI build_app, inline
+# entry) cooperate safely. Wrapped in a single-key dict to mutate without a
+# ``global`` statement (matches the pattern in :mod:`telemetry_agent`).
+_BOOTSTRAP_STATE: dict[str, bool] = {"installed": False}
+
+
+def _read_runtime_param(name: str, default: str = "") -> str:
+    """Return the value of a DataRobot runtime param env var, unwrapped.
+
+    DataRobot deployments expose runtime parameters as
+    ``MLOPS_RUNTIME_PARAM_<NAME>`` env vars whose value is a JSON envelope
+    like ``{"type":"string","payload":"value"}``. Outside deployments the
+    plain ``<NAME>`` env var is honoured. The payload is unwrapped via the
+    same helper Pydantic validators use elsewhere so a deployed agent and a
+    local dev shell see the same values.
+    """
+    raw = os.environ.get(RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + name) or os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        unwrapped = extract_datarobot_runtime_param_payload(raw)
+    except PydanticUseDefault:
+        return default
+    if unwrapped is None:
+        return default
+    return str(unwrapped)
+
+
+def _default_otlp_endpoint() -> str:
+    """Derive ``{DR_ENDPOINT_HOST}/otel`` from ``DATAROBOT_ENDPOINT``."""
+    parsed = urlparse(_read_runtime_param("DATAROBOT_ENDPOINT", DEFAULT_DATAROBOT_ENDPOINT))
+    return urlunparse((parsed.scheme, parsed.netloc, "otel", "", "", ""))
+
+
+def _otel_enabled() -> bool:
+    raw = _read_runtime_param("OTEL_ENABLED", "true").strip().lower()
+    return raw not in {"false", "0", "no", "off"}
+
+
+def _setup_otel_env_variables() -> bool:
+    """Populate ``OTEL_EXPORTER_OTLP_ENDPOINT`` / ``OTEL_EXPORTER_OTLP_HEADERS``.
+
+    Returns True when an exporter destination is known (either pre-set in env
+    or derived from a DataRobot entity id), False when there is nowhere to
+    send spans (in which case the caller should skip provider setup).
+    """
+    if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or os.environ.get(
+        "OTEL_EXPORTER_OTLP_HEADERS"
+    ):
+        logger.debug(
+            "OTEL_EXPORTER_OTLP_ENDPOINT or OTEL_EXPORTER_OTLP_HEADERS already set, skipping"
+        )
+        return True
+
+    entity_id = _read_runtime_param("OTEL_ENTITY_ID")
+    if not entity_id:
+        logger.info("OTEL_ENTITY_ID is not set; skipping DataRobot OTLP exporter configuration")
+        return False
+
+    api_token = _read_runtime_param("DATAROBOT_API_TOKEN")
+    endpoint = _read_runtime_param("OTEL_COLLECTOR_BASE_URL", _default_otlp_endpoint())
+
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+    os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = (
+        f"X-DataRobot-Api-Key={api_token},X-DataRobot-Entity-Id={entity_id}"
+    )
+    logger.info("Configured OTLP exporter: endpoint=%s, entity_id=%s", endpoint, entity_id)
+    return True
+
+
+def initialize_tracer_provider(*, service_name: str) -> bool:
+    """Set the global ``TracerProvider`` with an OTLP exporter, once per process.
+
+    Idempotent: subsequent calls are no-ops once a provider has been installed.
+    Returns True when a provider was installed (now or earlier in the process),
+    False when telemetry is disabled or no exporter destination is configured.
+    """
+    if _BOOTSTRAP_STATE["installed"]:
+        return True
+
+    if not _otel_enabled():
+        logger.info("OpenTelemetry is disabled via OTEL_ENABLED")
+        return False
+
+    if not _setup_otel_env_variables():
+        return False
+
+    # Local imports defer the heavyweight SDK/exporter imports until we have
+    # decided to actually wire up tracing.
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    provider = TracerProvider(resource=Resource.create({"datarobot.service.name": service_name}))
+    provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    _BOOTSTRAP_STATE["installed"] = True
+    logger.info("Installed global TracerProvider for service %s", service_name)
+    return True
+
+
+def setup_dragent_tracing(*, service_name: str) -> None:
+    """Bootstrap the tracer provider and attach NAT instrumentors.
+
+    Single entry point used by both the DRAgent FastAPI worker and the inline
+    execution path. Swallows and logs any failure so a broken telemetry stack
+    cannot prevent agent execution.
+    """
+    try:
+        from datarobot_genai.core.telemetry_agent import instrument
+
+        initialize_tracer_provider(service_name=service_name)
+        instrument(framework="nat")
+    except Exception:
+        logger.exception("Failed to initialize OpenTelemetry tracing for dragent")
+
+
+def _reset_for_tests() -> None:
+    """Test-only hook to clear the idempotency guard."""
+    _BOOTSTRAP_STATE["installed"] = False

--- a/src/datarobot_genai/core/telemetry_bootstrap.py
+++ b/src/datarobot_genai/core/telemetry_bootstrap.py
@@ -23,8 +23,10 @@ and is dropped. This module fills that gap.
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
+from urllib.parse import quote
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
@@ -100,7 +102,8 @@ def _setup_otel_env_variables() -> bool:
 
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
     os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = (
-        f"X-DataRobot-Api-Key={api_token},X-DataRobot-Entity-Id={entity_id}"
+        f"X-DataRobot-Api-Key={quote(api_token, safe='')}"
+        f",X-DataRobot-Entity-Id={quote(entity_id, safe='')}"
     )
     logger.info("Configured OTLP exporter: endpoint=%s, entity_id=%s", endpoint, entity_id)
     return True
@@ -129,11 +132,12 @@ def initialize_tracer_provider(*, service_name: str) -> bool:
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
     provider = TracerProvider(resource=Resource.create({"datarobot.service.name": service_name}))
-    provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     trace.set_tracer_provider(provider)
+    atexit.register(provider.shutdown)
 
     _BOOTSTRAP_STATE["installed"] = True
     logger.info("Installed global TracerProvider for service %s", service_name)
@@ -150,7 +154,8 @@ def setup_dragent_tracing(*, service_name: str) -> None:
     try:
         from datarobot_genai.core.telemetry_agent import instrument
 
-        initialize_tracer_provider(service_name=service_name)
+        if not initialize_tracer_provider(service_name=service_name):
+            return
         instrument(framework="nat")
     except Exception:
         logger.exception("Failed to initialize OpenTelemetry tracing for dragent")

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -170,7 +170,12 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
     def build_app(self) -> FastAPI:
         """Build the FastAPI app, wrapping the parent lifespan to clean up the A2A worker."""
+        # Bootstrap tracing before constructing the app so NAT's own workflow
+        # build/run spans flow through the exporter.
+        self._init_tracing()
+
         app = super().build_app()
+        self._instrument_fastapi_app(app)
 
         # Register DataRobot health routes (/, /ping, /ping/, /health, /health/).
         # NAT 1.6 no longer calls self.add_health_route() so we register here.
@@ -193,6 +198,31 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         setup_logging()
         return app
+
+    def _init_tracing(self) -> None:
+        """Install a TracerProvider + OTLP exporter and attach instrumentors."""
+        from datarobot_genai.core.telemetry_bootstrap import setup_dragent_tracing
+
+        workflow = getattr(self._config, "workflow", None)
+        workflow_type = getattr(workflow, "type", None) if workflow is not None else None
+        setup_dragent_tracing(service_name=workflow_type or "dragent")
+
+    @staticmethod
+    def _instrument_fastapi_app(app: FastAPI) -> None:
+        """Attach OpenTelemetry FastAPI middleware to a specific app instance.
+
+        Per-app instrumentation is more reliable than the global
+        ``FastAPIInstrumentor().instrument()`` hook, which depends on import
+        order relative to ``FastAPI()`` construction. ``opentelemetry-
+        instrumentation-fastapi`` ships only with the ``dragent`` extra, so
+        the import is deferred to keep module loading dep-free in dev.
+        """
+        try:
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+            FastAPIInstrumentor.instrument_app(app)
+        except Exception:
+            logger.exception("Failed to instrument FastAPI app for OpenTelemetry")
 
     def _register_health_routes(self, app: FastAPI) -> None:
         """Register DataRobot health check endpoints."""

--- a/src/datarobot_genai/dragent/inline.py
+++ b/src/datarobot_genai/dragent/inline.py
@@ -103,8 +103,14 @@ async def execute_dragent_inline_async(
     from datarobot_genai.core.chat.completions import (
         convert_chat_completion_params_to_run_agent_input,
     )
+    from datarobot_genai.core.telemetry_bootstrap import setup_dragent_tracing
     from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
     from datarobot_genai.nat.helpers import load_workflow
+
+    # Wire tracing before NAT loads the workflow so spans from workflow build
+    # and execution reach the OTLP exporter. Idempotent and safely shares
+    # state with the FastAPI server path.
+    setup_dragent_tracing(service_name="dragent-inline")
 
     workflow_path = _resolve_config_path(Path(custom_model_dir), config_file)
     logger.info("Running dragent workflow from %s", workflow_path)

--- a/tests/core/test_telemetry_bootstrap.py
+++ b/tests/core/test_telemetry_bootstrap.py
@@ -1,0 +1,164 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from datarobot_genai.core import telemetry_bootstrap
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    telemetry_bootstrap._reset_for_tests()
+    yield
+    telemetry_bootstrap._reset_for_tests()
+
+
+def test_disabled_via_otel_enabled_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "false")
+
+    assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is False
+
+
+def test_no_entity_id_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("OTEL_ENTITY_ID", raising=False)
+    monkeypatch.delenv("MLOPS_RUNTIME_PARAM_OTEL_ENTITY_ID", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+
+    assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is False
+
+
+def test_installs_provider_when_entity_id_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv("OTEL_ENTITY_ID", "test-entity")
+    monkeypatch.setenv("OTEL_COLLECTOR_BASE_URL", "http://collector.test/otel")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+
+    # Avoid hitting the real OTLP exporter constructor in CI: the exporter is
+    # only built lazily inside initialize_tracer_provider, but constructing it
+    # parses env URLs and is otherwise fine in-process. We still patch it to
+    # keep the test isolated from network/registry imports.
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"
+    ) as exporter_cls:
+        assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is True
+
+    exporter_cls.assert_called_once()
+    provider = trace.get_tracer_provider()
+    assert isinstance(provider, TracerProvider)
+
+
+def test_idempotent_second_call_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv("OTEL_ENTITY_ID", "test-entity")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"
+    ) as exporter_cls:
+        assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is True
+        # Second call must be a no-op (no new exporter constructed).
+        assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is True
+
+    assert exporter_cls.call_count == 1
+
+
+def test_respects_preset_otlp_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://preset.test/otel")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("OTEL_ENTITY_ID", raising=False)
+    monkeypatch.delenv("MLOPS_RUNTIME_PARAM_OTEL_ENTITY_ID", raising=False)
+
+    with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"):
+        # When OTEL_EXPORTER_OTLP_ENDPOINT is already set externally, the
+        # bootstrap should proceed even without an entity id and not overwrite
+        # the preset value.
+        assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is True
+
+    import os
+
+    assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://preset.test/otel"
+
+
+def test_mlops_runtime_param_prefix_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_OTEL_ENTITY_ID", "runtime-entity")
+    monkeypatch.setenv("OTEL_ENTITY_ID", "plain-entity")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+
+    with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"):
+        assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is True
+
+    import os
+
+    headers = os.environ["OTEL_EXPORTER_OTLP_HEADERS"]
+    assert "X-DataRobot-Entity-Id=runtime-entity" in headers
+
+
+def test_unwraps_datarobot_runtime_param_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deployed agents see runtime params as JSON envelopes; the bootstrap must unwrap."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "MLOPS_RUNTIME_PARAM_OTEL_ENTITY_ID",
+        '{"type":"string","payload":"deployed-entity"}',
+    )
+    monkeypatch.setenv(
+        "MLOPS_RUNTIME_PARAM_DATAROBOT_API_TOKEN",
+        '{"type":"string","payload":"deployed-token"}',
+    )
+
+    with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"):
+        assert telemetry_bootstrap.initialize_tracer_provider(service_name="svc") is True
+
+    import os
+
+    headers = os.environ["OTEL_EXPORTER_OTLP_HEADERS"]
+    assert "X-DataRobot-Entity-Id=deployed-entity" in headers
+    assert "X-DataRobot-Api-Key=deployed-token" in headers
+
+
+def test_setup_dragent_tracing_calls_instrument(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTEL_ENABLED", "false")  # short-circuit provider install
+
+    with patch("datarobot_genai.core.telemetry_agent.instrument") as instrument_call:
+        telemetry_bootstrap.setup_dragent_tracing(service_name="svc")
+
+    instrument_call.assert_called_once_with(framework="nat")
+
+
+def test_setup_dragent_tracing_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTEL_ENABLED", "false")
+
+    with patch(
+        "datarobot_genai.core.telemetry_bootstrap.initialize_tracer_provider",
+        side_effect=RuntimeError("boom"),
+    ):
+        # Must not raise — agent execution should never be blocked by tracing.
+        telemetry_bootstrap.setup_dragent_tracing(service_name="svc")

--- a/tests/core/test_telemetry_bootstrap.py
+++ b/tests/core/test_telemetry_bootstrap.py
@@ -145,12 +145,30 @@ def test_unwraps_datarobot_runtime_param_payload(monkeypatch: pytest.MonkeyPatch
 
 
 def test_setup_dragent_tracing_calls_instrument(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OTEL_ENABLED", "false")  # short-circuit provider install
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv("OTEL_ENTITY_ID", "test-entity")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+
+    with (
+        patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"),
+        patch("datarobot_genai.core.telemetry_agent.instrument") as instrument_call,
+    ):
+        telemetry_bootstrap.setup_dragent_tracing(service_name="svc")
+
+    instrument_call.assert_called_once_with(framework="nat")
+
+
+def test_setup_dragent_tracing_skips_instrument_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OTEL_ENABLED", "false")
 
     with patch("datarobot_genai.core.telemetry_agent.instrument") as instrument_call:
         telemetry_bootstrap.setup_dragent_tracing(service_name="svc")
 
-    instrument_call.assert_called_once_with(framework="nat")
+    instrument_call.assert_not_called()
 
 
 def test_setup_dragent_tracing_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -162,3 +180,38 @@ def test_setup_dragent_tracing_swallows_errors(monkeypatch: pytest.MonkeyPatch) 
     ):
         # Must not raise — agent execution should never be blocked by tracing.
         telemetry_bootstrap.setup_dragent_tracing(service_name="svc")
+
+
+def test_default_otlp_endpoint_strips_api_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
+    monkeypatch.delenv("MLOPS_RUNTIME_PARAM_DATAROBOT_ENDPOINT", raising=False)
+
+    endpoint = telemetry_bootstrap._default_otlp_endpoint()
+    assert endpoint == "https://app.datarobot.com/otel"
+
+
+def test_default_otlp_endpoint_respects_custom_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://custom.dr.io/api/v2")
+    monkeypatch.delenv("MLOPS_RUNTIME_PARAM_DATAROBOT_ENDPOINT", raising=False)
+
+    endpoint = telemetry_bootstrap._default_otlp_endpoint()
+    assert endpoint == "https://custom.dr.io/otel"
+
+
+def test_headers_url_encode_special_chars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+    monkeypatch.setenv("OTEL_ENTITY_ID", "id=with,special")
+    monkeypatch.setenv("OTEL_COLLECTOR_BASE_URL", "http://collector.test/otel")
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "tok=en,val")
+
+    with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"):
+        telemetry_bootstrap.initialize_tracer_provider(service_name="svc")
+
+    import os
+
+    headers = os.environ["OTEL_EXPORTER_OTLP_HEADERS"]
+    assert "tok%3Den%2Cval" in headers
+    assert "id%3Dwith%2Cspecial" in headers
+    assert headers.count(",") == 1

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -140,6 +140,16 @@ def patch_super_add_routes():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _reset_telemetry_bootstrap_state():
+    """Keep the global bootstrap idempotency flag from leaking between tests."""
+    from datarobot_genai.core import telemetry_bootstrap
+
+    telemetry_bootstrap._reset_for_tests()
+    yield
+    telemetry_bootstrap._reset_for_tests()
+
+
 class TestDRAgentFastApiFrontEndPluginWorker:
     @pytest.mark.parametrize("path", DATAROBOT_EXPECTED_HEALTH_ROUTES)
     def test_health_routes_return_healthy_status(self, app_with_health, path):
@@ -147,6 +157,32 @@ class TestDRAgentFastApiFrontEndPluginWorker:
             response = client.get(path)
             assert response.status_code == 200, f"Expected 200 at {path}"
             assert response.json() == {"status": "healthy"}, f"Unexpected response at {path}"
+
+    def test_build_app_invokes_tracer_bootstrap_and_instruments_app(self, worker):
+        @asynccontextmanager
+        async def mock_from_config(_config):
+            yield MagicMock()
+
+        instrument_mock = MagicMock()
+        fake_module = MagicMock()
+        fake_module.FastAPIInstrumentor = instrument_mock
+
+        with (
+            patch.object(worker, "configure", new_callable=AsyncMock),
+            patch.object(WorkflowBuilder, "from_config", side_effect=mock_from_config),
+            patch(
+                "datarobot_genai.core.telemetry_bootstrap.setup_dragent_tracing"
+            ) as setup_tracing,
+            patch.dict(
+                "sys.modules",
+                {"opentelemetry.instrumentation.fastapi": fake_module},
+            ),
+        ):
+            app = worker.build_app()
+
+        setup_tracing.assert_called_once()
+        assert "service_name" in setup_tracing.call_args.kwargs
+        instrument_mock.instrument_app.assert_called_once_with(app)
 
     def test_step_adaptor(self, worker):
         assert isinstance(worker.get_step_adaptor(), DRAgentNestedReasoningStepAdaptor)


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->
WIP

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new OpenTelemetry bootstrap logic that sets global tracer provider/exporter configuration and adds FastAPI middleware, which can impact runtime behavior/performance if misconfigured. Changes are guarded/idempotent and error-swallowing, but affect core request/agent execution paths.
> 
> **Overview**
> Adds a DRAgent-specific OpenTelemetry bootstrap (`core/telemetry_bootstrap.py`) that initializes a global `TracerProvider` with an OTLP HTTP exporter, deriving exporter env vars from DataRobot runtime params (including JSON-envelope unwrapping) and supporting opt-out via `OTEL_ENABLED`.
> 
> Wires this bootstrap into both DRAgent execution paths: the FastAPI worker now initializes tracing before app construction and instruments the app via `FastAPIInstrumentor.instrument_app`, and the inline runner initializes tracing before loading/executing NAT workflows.
> 
> Updates packaging/tests: the `dragent` extra now includes `opentelemetry-instrumentation-fastapi`, and new/updated tests cover bootstrap behavior (idempotency, env handling, URL-encoded headers) and verify FastAPI build triggers tracing + instrumentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00bef51ce4f1ac221d2315a870d588d4f960d860. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->