### PR TITLE
use user id from context provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.69
+- `nat/datarobot_mem0_memory`: `_UserManagerShim.get_id()` now reads `Context.user_id` instead of re-decoding the `X-DataRobot-Authorization-Context` header. Identity resolution already happens upstream in `DRAgentAGUISessionManager` (via `DRAgentUserManager`, added in 0.15.60) and is stored on `ContextState.user_id`, so the shim just forwards it. Removed `_memory_user_uuid()` and the `AuthContextHeaderHandler` / `UserInfo` imports from the module. Per-user-workflow `default-user` fallback now flows through to the editor when no identity is present (previously the shim returned `None` and the editor fell back to the api-key owner).
+
 ## 0.15.68
 - `nat/datarobot_moderation_middleware`: refactored DRAgent and NAT chat moderation to use OpenAI `ChatCompletionChunk` at the dome streaming boundary only. Shared AG-UI delta extraction and NAT↔OpenAI chunk converters live in `dragent/frontends/converters.py` (`convert_dragent_event_response_to_openai_chat_completion_chunk`, `convert_nat_chat_response_chunk_to_openai_chat_completion_chunk`).
 - Prescore prompt extraction now delegates to `get_chat_prompt` from `datarobot_moderation_interface` (via `workflow_input_to_completion_dict`), matching DRUM integration behavior for multimodal content and tool context.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.68"
+version = "0.15.69"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.68"
+version = "0.15.69"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -44,44 +44,12 @@ from nat.builder.context import Context
 from nat.cli.register_workflow import register_memory
 from nat.data_models.memory import MemoryBaseConfig
 from nat.data_models.retry_mixin import RetryMixin
-from nat.data_models.user_info import UserInfo
 from nat.memory.interfaces import MemoryEditor
 from nat.memory.models import MemoryItem
 from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 from pydantic import Field
 
-from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
-
 logger = logging.getLogger(__name__)
-
-
-def _memory_user_uuid() -> str | None:
-    """Derive NAT's canonical UUIDv5 from the current request's DR auth header.
-
-    Reads ``X-DataRobot-Authorization-Context`` from the active NAT
-    ``Context``, decodes it with :class:`AuthContextHeaderHandler`, and hashes
-    ``auth_ctx.user.id`` through :meth:`UserInfo._from_session_cookie` so the
-    raw DataRobot identity never leaves the process. Returns ``None`` when
-    the header is missing or undecodable (e.g. ``SESSION_SECRET_KEY`` is
-    unset in local dev) so the caller can fall back to the api-key owner.
-    """
-    metadata = Context.get().metadata
-    headers = getattr(metadata, "headers", None) if metadata else None
-    if headers is None:
-        return None
-    try:
-        header_dict = dict(headers)
-    except Exception:
-        logger.debug("Failed to normalize request headers", exc_info=True)
-        return None
-    try:
-        auth_ctx = AuthContextHeaderHandler().get_context(header_dict)
-    except Exception:
-        logger.debug("Failed to decode DR auth context", exc_info=True)
-        return None
-    if auth_ctx is None or auth_ctx.user is None or not auth_ctx.user.id:
-        return None
-    return UserInfo._from_session_cookie(auth_ctx.user.id).get_user_id()
 
 
 class Config(DataRobotAppFrameworkBaseSettings):
@@ -99,23 +67,23 @@ def _get_default_mem0_api_key() -> str | None:
 
 
 class _UserManagerShim:
-    """Bridge ``Context.user_manager`` to the DR-user UUIDv5 on NAT 1.6.
+    """Bridge ``Context.user_manager.get_id()`` to ``Context.user_id`` on NAT 1.6.
 
-    ``nvidia-nat-langchain`` 1.6.0's ``auto_memory_wrapper`` accesses
-    ``Context.user_manager.get_id()`` to resolve the user_id it passes to the
-    memory editor, but ``Context.user_manager`` only exists on newer NAT
-    versions. Return :func:`_memory_user_uuid`, NAT's canonical UUIDv5
-    derived from the request's ``X-DataRobot-Authorization-Context`` header,
-    so the wrapper feeds the editor a stable per-user identity (the raw id
-    never leaves the process). When the header is absent or undecodable,
-    return ``None`` and let the editor fall back to its api-key owner.
+    ``nvidia-nat-langchain`` 1.6.0's ``auto_memory_wrapper`` reads
+    ``Context.user_manager.get_id()``, but NAT 1.6 doesn't expose
+    ``user_manager`` on ``Context``. Identity resolution itself already happens
+    upstream in :class:`DRAgentAGUISessionManager` (decodes
+    ``X-DataRobot-Authorization-Context`` via ``DRAgentUserManager`` and stores
+    the resolved id on ``ContextState.user_id``), so this shim just forwards
+    that value. Falls through to the per-user-workflow ``default-user``
+    constant when no identity is available.
     """
 
     def __init__(self, context: Context) -> None:
         self._context = context
 
     def get_id(self) -> str | None:
-        return _memory_user_uuid()
+        return self._context.user_id
 
 
 if not hasattr(Context, "user_manager"):

--- a/tests/dragent/frontends/test_session.py
+++ b/tests/dragent/frontends/test_session.py
@@ -180,7 +180,7 @@ class TestDRAgentUserManager:
         mock_auth_ctx.user.id = "user-from-ctx"
 
         with patch(
-            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
+            "datarobot_genai.dragent.frontends.session.AuthContextHeaderHandler.get_context",
             return_value=mock_auth_ctx,
         ):
             result = DRAgentUserManager.extract_user_from_connection(mock_request)
@@ -266,7 +266,7 @@ class TestSessionPerUserWorkflowFallback:
             yield MagicMock()
 
         with patch(
-            "datarobot_genai.dragent.frontends.session._auth_handler.get_context",
+            "datarobot_genai.dragent.frontends.session.AuthContextHeaderHandler.get_context",
             return_value=mock_auth_ctx,
         ):
             with patch.object(SessionManager, "session", fake_nat_session):
@@ -274,3 +274,65 @@ class TestSessionPerUserWorkflowFallback:
                     pass
 
         assert captured.get("user_id") == UserInfo._from_session_cookie("real-user-1").get_user_id()
+
+    @pytest.mark.asyncio
+    async def test_dr_header_reaches_user_manager_shim_through_real_nat_session(
+        self, session_manager
+    ):
+        """End-to-end: DR header → DRAgentAGUISessionManager → real NAT session() → shim.
+
+        ``test_dr_signed_context_resolved_in_session`` stubs ``SessionManager.session``
+        and only checks the ``user_id`` kwarg, so it can't catch a regression where
+        NAT's base ``session()`` fails to write that kwarg into
+        ``ContextState.user_id`` (which is what the shim — and therefore
+        ``auto_memory_wrapper`` — actually reads). This test runs the real
+        ``super().session()`` and asserts the value that ends up on
+        ``Context.get().user_manager.get_id()`` inside the session block.
+        """
+        # Importing installs the property(_UserManagerShim) on Context.
+        from starlette.requests import Request as StarletteRequest
+
+        from datarobot_genai.nat import datarobot_mem0_memory  # noqa: F401
+
+        session_manager._is_workflow_per_user = False
+        session_manager._shared_workflow = MagicMock()
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/agent/run",
+            "raw_path": b"/agent/run",
+            "query_string": b"",
+            "path_params": {},
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "headers": [(b"x-datarobot-authorization-context", b"fake-jwt")],
+        }
+
+        async def _empty_receive() -> dict[str, object]:
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        request = StarletteRequest(scope, receive=_empty_receive)
+
+        mock_auth_ctx = MagicMock()
+        mock_auth_ctx.user.id = "real-dr-user"
+        expected = UserInfo._from_session_cookie("real-dr-user").get_user_id()
+
+        captured: dict[str, object] = {}
+
+        with patch(
+            "datarobot_genai.dragent.frontends.session.AuthContextHeaderHandler.get_context",
+            return_value=mock_auth_ctx,
+        ):
+            async with session_manager.session(http_connection=request):
+                # The shim is what auto_memory_wrapper actually calls. Reading it
+                # inside the session block reproduces the call site exactly.
+                ctx = ContextState.get()
+                captured["context_state_user_id"] = ctx.user_id.get()
+                from nat.builder.context import Context as NATContext
+
+                captured["shim_get_id"] = NATContext.get().user_manager.get_id()
+
+        assert captured["context_state_user_id"] == expected
+        assert captured["shim_get_id"] == expected

--- a/tests/nat/integration/test_auto_memory.py
+++ b/tests/nat/integration/test_auto_memory.py
@@ -84,13 +84,18 @@ async def test_auto_memory_agent_wrapper_round_trips_with_real_mem0(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # GIVEN a workflow.yaml with a real Mem0-backed NAT memory provider and
-    # auto-memory wrapper. The provider's ``_UserManagerShim`` resolves the
-    # per-user id via ``_memory_user_uuid``, which in production reads the DR
-    # auth header. Stub it to a stable per-test UUID so the round-trip proves
-    # memories are scoped per user rather than globally per api key.
+    # auto-memory wrapper. The provider's ``_UserManagerShim`` reads
+    # ``Context.user_id``, which in production is populated by
+    # ``DRAgentAGUISessionManager`` from the DR signed auth header. Stub the
+    # shim to a stable per-test UUID so the round-trip proves memories are
+    # scoped per user rather than globally per api key.
     test_id = uuid.uuid4().hex
     dr_memory_user_uuid = f"nat-auto-memory-{test_id}"
-    monkeypatch.setattr(datarobot_mem0_memory, "_memory_user_uuid", lambda: dr_memory_user_uuid)
+    monkeypatch.setattr(
+        datarobot_mem0_memory._UserManagerShim,
+        "get_id",
+        lambda self: dr_memory_user_uuid,
+    )
 
     secret_code = f"DRMEM-{test_id}"
     first_message = f"My NAT auto-memory integration secret code is {secret_code}."

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -234,26 +234,27 @@ async def test_search_honors_explicit_filters() -> None:
     assert mem0.search_calls[0]["kwargs"]["filters"] == filters
 
 
-def test_user_manager_shim_get_id_returns_dr_memory_user_uuid(monkeypatch: Any) -> None:
-    # GIVEN the shim installed by ``datarobot_mem0_memory`` for NAT 1.6 and a
-    # request whose DR auth header decodes to a known UUIDv5.
-    monkeypatch.setattr(datarobot_mem0_memory, "_memory_user_uuid", lambda: "uuid-from-dr-auth")
-    shim = datarobot_mem0_memory._UserManagerShim(object())  # type: ignore[arg-type]
+def test_user_manager_shim_get_id_forwards_context_user_id() -> None:
+    # GIVEN a Context whose ``user_id`` was set by ``DRAgentAGUISessionManager``
+    # (which resolves the DR signed auth header via ``DRAgentUserManager``).
+    class FakeContext:
+        user_id = "uuid-from-dragent-session"
 
-    # THEN ``get_id`` returns the canonical DR-user UUID so ``auto_memory_wrapper``
-    # passes a stable per-user identity to the editor.
-    assert shim.get_id() == "uuid-from-dr-auth"
+    shim = datarobot_mem0_memory._UserManagerShim(FakeContext())  # type: ignore[arg-type]
+
+    # THEN ``get_id`` returns whatever the session manager wrote, so
+    # ``auto_memory_wrapper`` keys memory on the resolved per-user identity.
+    assert shim.get_id() == "uuid-from-dragent-session"
 
 
-def test_user_manager_shim_get_id_returns_none_when_dr_auth_header_missing(
-    monkeypatch: Any,
-) -> None:
-    # GIVEN no DR auth header on the current request (e.g. local dev).
-    monkeypatch.setattr(datarobot_mem0_memory, "_memory_user_uuid", lambda: None)
-    shim = datarobot_mem0_memory._UserManagerShim(object())  # type: ignore[arg-type]
+def test_user_manager_shim_get_id_returns_none_when_context_user_id_unset() -> None:
+    # GIVEN a Context with no resolved user_id (e.g. ran outside a session).
+    class FakeContext:
+        user_id = None
 
-    # THEN ``get_id`` returns None so the wrapper falls through to its default
-    # and the editor falls back to the api-key owner.
+    shim = datarobot_mem0_memory._UserManagerShim(FakeContext())  # type: ignore[arg-type]
+
+    # THEN ``get_id`` returns None so the wrapper falls through to its default.
     assert shim.get_id() is None
 
 
@@ -261,95 +262,6 @@ def test_context_user_manager_property_is_patched() -> None:
     # GIVEN ``datarobot_mem0_memory`` is imported (this test module imports it).
     # THEN every ``Context`` exposes a ``user_manager`` attribute that is a shim.
     assert isinstance(Context.get().user_manager, datarobot_mem0_memory._UserManagerShim)
-
-
-def test_memory_user_uuid_returns_uuid_for_decodable_dr_auth_header(
-    monkeypatch: Any,
-) -> None:
-    # GIVEN a request whose headers carry a decodable DR auth context.
-    class FakeUser:
-        id = "datarobot-user-abc"
-
-    class FakeAuthCtx:
-        user = FakeUser()
-
-    class FakeHandler:
-        def get_context(self, headers: dict[str, str]) -> Any:
-            assert headers == {"x-datarobot-authorization-context": "encoded-token"}
-            return FakeAuthCtx()
-
-    class FakeMetadata:
-        headers = {"x-datarobot-authorization-context": "encoded-token"}
-
-    class FakeContextInstance:
-        metadata = FakeMetadata()
-
-    monkeypatch.setattr(datarobot_mem0_memory, "AuthContextHeaderHandler", FakeHandler)
-    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
-
-    # WHEN we resolve the memory user id.
-    user_id = datarobot_mem0_memory._memory_user_uuid()
-
-    # THEN it matches what NAT's ``UserInfo._from_session_cookie`` derives — a
-    # UUIDv5 over the raw DR user id (the raw id never leaves the process).
-    from nat.data_models.user_info import UserInfo
-
-    assert user_id == UserInfo._from_session_cookie("datarobot-user-abc").get_user_id()
-
-
-def test_memory_user_uuid_returns_none_when_no_metadata(monkeypatch: Any) -> None:
-    # GIVEN a Context with no metadata at all.
-    class FakeContextInstance:
-        metadata = None
-
-    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
-
-    # WHEN we resolve the memory user id.
-    # THEN it returns None — caller will fall back to the api-key owner.
-    assert datarobot_mem0_memory._memory_user_uuid() is None
-
-
-def test_memory_user_uuid_returns_none_when_handler_returns_none(
-    monkeypatch: Any,
-) -> None:
-    # GIVEN a request whose DR auth header is missing/undecodable (handler returns None).
-    class FakeHandler:
-        def get_context(self, headers: dict[str, str]) -> Any:
-            return None
-
-    class FakeMetadata:
-        headers = {"other-header": "value"}
-
-    class FakeContextInstance:
-        metadata = FakeMetadata()
-
-    monkeypatch.setattr(datarobot_mem0_memory, "AuthContextHeaderHandler", FakeHandler)
-    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
-
-    # WHEN we resolve the memory user id.
-    # THEN it returns None — caller will fall back to the api-key owner.
-    assert datarobot_mem0_memory._memory_user_uuid() is None
-
-
-def test_memory_user_uuid_returns_none_when_handler_raises(monkeypatch: Any) -> None:
-    # GIVEN a handler that crashes (e.g. SESSION_SECRET_KEY unset in local dev).
-    class FakeHandler:
-        def get_context(self, headers: dict[str, str]) -> Any:
-            raise RuntimeError("SESSION_SECRET_KEY not set")
-
-    class FakeMetadata:
-        headers = {"x-datarobot-authorization-context": "token"}
-
-    class FakeContextInstance:
-        metadata = FakeMetadata()
-
-    monkeypatch.setattr(datarobot_mem0_memory, "AuthContextHeaderHandler", FakeHandler)
-    monkeypatch.setattr(datarobot_mem0_memory.Context, "get", staticmethod(FakeContextInstance))
-
-    # WHEN we resolve the memory user id.
-    # THEN it swallows the error and returns None so memory writes don't crash
-    # the request — caller falls back to the api-key owner.
-    assert datarobot_mem0_memory._memory_user_uuid() is None
 
 
 async def test_remove_items_deletes_by_memory_id_or_session_user_id() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.68"
+version = "0.15.69"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Use the new set context user id for user id in dragent workflows
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
