### PR TITLE
[BUZZOK-30894] Fix crewai streaming when chunk is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.71
-- Fix issue with empty `chunk.content` value for CrewAI
+- Fixed issue with empty `chunk.content` value for CrewAI.
 
 ## 0.15.70
-- Added `prompt.py` for prompt templates integration
+- Added `prompt.py` for prompt templates integration in `langgraph` and `llamaindex`.
 
 ## 0.15.69
 - `nat/datarobot_mem0_memory`: `_UserManagerShim.get_id()` now reads `Context.user_id` instead of re-decoding the `X-DataRobot-Authorization-Context` header. Identity resolution already happens upstream in `DRAgentAGUISessionManager` (via `DRAgentUserManager`, added in 0.15.60) and is stored on `ContextState.user_id`, so the shim just forwards it. Removed `_memory_user_uuid()` and the `AuthContextHeaderHandler` / `UserInfo` imports from the module. Per-user-workflow `default-user` fallback now flows through to the editor when no identity is present (previously the shim returned `None` and the editor fell back to the api-key owner).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.71
+- Fix issue with empty `chunk.content` value for CrewAI
+
 ## 0.15.70
 - Added `prompt.py` for prompt templates integration
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -980,7 +980,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.69"
+version = "0.15.71"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.70"
+version = "0.15.71"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -537,7 +537,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                         reasoning_started = False
 
                     # Display text chunks
-                    if chunk.chunk_type == StreamChunkType.TEXT:
+                    if chunk.chunk_type == StreamChunkType.TEXT and chunk.content:
                         if streaming_event_listener.reasoning_event:
                             yield (
                                 ReasoningMessageContentEvent(

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -831,6 +831,35 @@ async def test_invoke_streaming_emits_separate_messages_per_agent_role(
     assert planner_end_idx < planner_step_finish_idx < writer_step_start_idx
 
 
+async def test_invoke_streaming_skips_empty_text_chunks(
+    mock_ragas_event_listener, run_agent_input
+) -> None:
+    # GIVEN a streaming crew that emits empty TEXT chunks alongside real content
+    chunks = [
+        _text_chunk("", "Solo"),
+        _text_chunk("hello", "Solo"),
+        _text_chunk("", "Solo"),
+        _text_chunk(" world", "Solo"),
+    ]
+    result = CrewOutput(raw="ignored")
+    streaming = _FakeStreamingOutput(chunks, result)
+    agent = AgentForTest(api_base="https://x/", api_key="k", verbose=False)
+    agent._crew_for_test = CrewForTest(streaming)
+
+    # WHEN we collect the AG-UI event stream
+    events = [e async for (e, _, _) in agent.invoke(run_agent_input)]
+
+    # THEN the sequence is valid and empty chunks do not open a text message
+    validate_sequence(events)
+    starts = [e for e in events if isinstance(e, TextMessageStartEvent)]
+    ends = [e for e in events if isinstance(e, TextMessageEndEvent)]
+    contents = [e for e in events if isinstance(e, TextMessageContentEvent)]
+    assert len(starts) == 1
+    assert len(ends) == 1
+    assert [c.delta for c in contents] == ["hello", " world"]
+    assert all(c.delta for c in contents)
+
+
 async def test_invoke_streaming_single_agent_role_uses_single_message(
     mock_ragas_event_listener, run_agent_input
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.70"
+version = "0.15.71"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

[Test](https://app.harness.io/ng/account/oP3BKzKwSDe_4hCFYw_UWA/all/orgs/buzok/projects/recipedatarobotagentapplication/pipelines/E2E_tests_af_component_agent/deployments/qaBkUBQHRT-Ar2aTX5-1_A/pipeline?connectorRef=account.svc_harness_git1&repoName=recipe-datarobot-agent-application&branch=anatolii%2FBUZZOK-30290&storeType=REMOTE&stage=DaxiSb0TQZW5UnHp8Q2_Zg) 🟢 

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow streaming guard with unit test coverage; no auth, data, or API contract changes beyond version bump.
> 
> **Overview**
> **Release 0.15.71** documents and ships a fix for CrewAI streaming when upstream emits **TEXT** chunks with an empty `chunk.content`.
> 
> The CrewAI AG-UI adapter now treats only non-empty TEXT chunks as displayable deltas (`chunk.chunk_type == StreamChunkType.TEXT and chunk.content`), so empty chunks no longer start a text message or emit zero-length content events. A new streaming test asserts a single text message lifecycle and deltas `["hello", " world"]` when empty chunks are interleaved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d186cab6e2bc893fa004de3dc8ba521b41bd5254. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->