### PR TITLE
[BUZZOK-30926] Bugfix: Handle gracefully A2A remote call failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.73
+- Unhandled exceptions in A2A remote calls (auth failures, network errors, timeouts) no longer crash the agent. Errors are caught and sanitised.
+- Fixed agent card registry returning at most 25 cards by adding pagination support. 
+
 ## 0.15.72
 - `dragent/plugins/streaming_memory_agent`: new `streaming_memory_agent` function (registered on the `nat.plugins` entry point) that wraps an inner agent with NAT's mem0 capture/retrieve semantics while preserving its `ChatResponseChunk` stream. The wrapper `astream`s the inner agent and pipes chunks through `convert_chunks_to_agui_events` so token deltas and tool-call deltas surface as AG-UI `TextMessage*` / `ToolCall*` events (NAT's upstream `auto_memory_agent` collapses the stream to a single `DEFAULT_NAT_RESPONSE`). `StreamingMemoryAgentConfig` inherits from upstream `AutoMemoryAgentConfig`, so the configuration surface (`memory_name`, `inner_agent_name`, `save_user_messages_to_memory`, `retrieve_memory_for_every_response`, `save_ai_messages_to_memory`, `search_params`, `add_params`) is identical to `auto_memory_agent`; switching wrappers is a `_type` rename in `workflow.yaml`. mem0 errors are logged and swallowed so partial output still reaches the client. Includes unit-test coverage for config registration/inheritance/defaults, the helper functions, all-flags-off streaming, user-message capture and AI-response persistence, memory retrieval and system-message injection, param forwarding, and the swallow-and-log error semantics.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.72"
+version = "0.15.73"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -57,6 +57,12 @@ _DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
 # Default HTTP timeout for registry requests (in seconds).
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 
+# Maximum page size accepted by the registry API.
+_MAX_PAGE_SIZE = 100
+
+# Safety limit to prevent infinite pagination loops.
+_MAX_PAGES = 100
+
 # Allowed strategies for duplicate external IDs.
 DuplicateStrategy = Literal["first", "last", "error"]
 
@@ -284,10 +290,17 @@ class AgentCardRegistry:
     # ------------------------------------------------------------------
 
     async def _fetch(self, params: dict[str, str]) -> dict[str, AgentCard]:
-        """Execute a single registry HTTP GET and return parsed cards."""
+        """Execute registry HTTP GET(s) with pagination and return all parsed cards.
+
+        Requests the maximum page size (100) to minimise round-trips, then
+        follows ``next`` links until all pages are consumed.  All entries are
+        accumulated and parsed together so that the ``on_duplicate`` strategy
+        is applied consistently across the full result set.
+        """
         token, endpoint = _resolve_settings(self._api_token, self._endpoint)
         registry_url = build_agent_cards_registry_url(endpoint)
         headers = {"Authorization": f"Bearer {token}"}
+        params_with_limit = {"limit": str(_MAX_PAGE_SIZE), **params}
 
         logger.info(
             "Fetching agent cards from registry: %s (params=%s)",
@@ -295,10 +308,35 @@ class AgentCardRegistry:
             params,
         )
 
+        all_entries: list[dict[str, Any]] = []
+
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(self._timeout)) as client:
-                response = await client.get(registry_url, params=params, headers=headers)
+                response = await client.get(
+                    registry_url, params=params_with_limit, headers=headers
+                )
                 response.raise_for_status()
+                body = response.json()
+                all_entries.extend(body.get("data", []))
+
+                next_url = body.get("next")
+                pages_fetched = 1
+                while next_url:
+                    if pages_fetched >= _MAX_PAGES:
+                        logger.warning(
+                            "Pagination safety limit reached (%d pages). "
+                            "Some agent cards may not have been fetched.",
+                            _MAX_PAGES,
+                        )
+                        break
+                    logger.debug("Following pagination link (page %d).", pages_fetched + 1)
+                    response = await client.get(next_url, headers=headers)
+                    response.raise_for_status()
+                    body = response.json()
+                    all_entries.extend(body.get("data", []))
+                    next_url = body.get("next")
+                    pages_fetched += 1
+
         except httpx.HTTPStatusError as exc:
             raise AgentCardRegistryError(
                 f"Agent card registry request failed with HTTP "
@@ -308,8 +346,10 @@ class AgentCardRegistry:
         except httpx.HTTPError as exc:
             raise AgentCardRegistryError(f"Agent card registry request failed: {exc}") from exc
 
-        cards = _parse_registry_response(response.json(), on_duplicate=self._on_duplicate)
-        logger.info("Fetched %d agent card(s) from registry.", len(cards))
+        cards = _parse_registry_response(
+            {"data": all_entries}, on_duplicate=self._on_duplicate
+        )
+        logger.info("Fetched %d agent card(s) from registry (%d pages).", len(cards), pages_fetched)
         return cards
 
     def _is_cached(self, key: str) -> bool:

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -312,9 +312,7 @@ class AgentCardRegistry:
 
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(self._timeout)) as client:
-                response = await client.get(
-                    registry_url, params=params_with_limit, headers=headers
-                )
+                response = await client.get(registry_url, params=params_with_limit, headers=headers)
                 response.raise_for_status()
                 body = response.json()
                 all_entries.extend(body.get("data", []))
@@ -346,9 +344,7 @@ class AgentCardRegistry:
         except httpx.HTTPError as exc:
             raise AgentCardRegistryError(f"Agent card registry request failed: {exc}") from exc
 
-        cards = _parse_registry_response(
-            {"data": all_entries}, on_duplicate=self._on_duplicate
-        )
+        cards = _parse_registry_response({"data": all_entries}, on_duplicate=self._on_duplicate)
         logger.info("Fetched %d agent card(s) from registry (%d pages).", len(cards), pages_fetched)
         return cards
 

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import abc
+import asyncio
+import functools
 import logging
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -287,8 +289,46 @@ class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_clie
         return self
 
 
+def _wrap_a2a_function(fn: Any) -> Any:
+    """Wrap an A2A function so that exceptions are returned as error strings
+    instead of propagating and crashing the agent.
+
+    Works for both regular async functions and async generators.
+    """
+    if asyncio.iscoroutinefunction(fn):
+
+        @functools.wraps(fn)
+        async def _safe(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as exc:
+                logger.error("A2A remote call failed: %s", exc, exc_info=True)
+                return f"Error: failed to communicate with the remote agent: {exc}"
+
+        return _safe
+
+    if asyncio.isasyncgenfunction(fn):
+
+        @functools.wraps(fn)
+        async def _safe_gen(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:
+            try:
+                async for event in fn(*args, **kwargs):
+                    yield event
+            except Exception as exc:
+                logger.error("A2A remote call failed: %s", exc, exc_info=True)
+                yield f"Error: failed to communicate with the remote agent: {exc}"
+
+        return _safe_gen
+
+    return fn
+
+
 class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
     """Uses :class:`_AuthenticatedA2ABaseClient` so both A2A phases are authenticated."""
+
+    def add_function(self, name: str, fn: Any, **kwargs: Any) -> None:  # type: ignore[override]
+        """Intercept function registration to wrap *fn* with error handling."""
+        super().add_function(name, _wrap_a2a_function(fn), **kwargs)
 
     async def __aenter__(self) -> "AuthenticatedA2AClientFunctionGroup":
         config: AuthenticatedA2AClientConfig = self._config  # type: ignore[assignment]

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -136,7 +136,7 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
                 self._agent_card = await resolver.get_agent_card()
                 logger.info("Successfully fetched agent card")
         except Exception as e:
-            logger.error("Failed to fetch agent card: %s", e, exc_info=True)
+            logger.error("Failed to fetch agent card from %s: %s", self._base_url, e)
             raise RuntimeError(f"Failed to fetch agent card from {self._base_url}") from e
 
     async def __aenter__(self) -> "_AuthenticatedA2ABaseClient":
@@ -289,11 +289,43 @@ class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_clie
         return self
 
 
+def _sanitize_a2a_error(exc: Exception) -> str:
+    """Return a safe, single-line error description without sensitive material.
+
+    Strips raw HTTP bodies, traceback detail, and anything that could echo
+    back tokens or assertions.  Only the exception *type* and a curated
+    category survive — the raw ``str(exc)`` is never surfaced.
+    """
+    # httpx status errors — include status + URL but NOT the response body
+    # (which could echo submitted parameters like tokens or assertions).
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"HTTP {exc.response.status_code} from {exc.request.url.host}{exc.request.url.path}"
+
+    # Categorise by type so the LLM gets actionable context without
+    # exposing the raw message which may contain sensitive material.
+    if isinstance(exc, httpx.TimeoutException):
+        return "request to remote agent timed out"
+
+    if isinstance(exc, (httpx.ConnectError, httpx.NetworkError, ConnectionError, OSError)):
+        return "network error communicating with remote agent"
+
+    if isinstance(exc, (RuntimeError, ValueError)):
+        return f"{type(exc).__name__}: authentication or protocol error"
+
+    return f"{type(exc).__name__}: request to remote agent failed"
+
+
 def _wrap_a2a_function(fn: Any) -> Any:
     """Wrap an A2A function so that exceptions are returned as error strings
     instead of propagating and crashing the agent.
 
     Works for both regular async functions and async generators.
+
+    Sensitive material (tokens, assertions, HTTP bodies) is stripped from
+    both the returned error string and the log line — only a sanitized
+    summary is emitted.  The full traceback is deliberately **not** logged
+    (``exc_info=False``) to prevent token values captured in frame locals
+    from reaching log sinks.
     """
     if asyncio.iscoroutinefunction(fn):
 
@@ -302,8 +334,10 @@ def _wrap_a2a_function(fn: Any) -> Any:
             try:
                 return await fn(*args, **kwargs)
             except Exception as exc:
-                logger.error("A2A remote call failed: %s", exc, exc_info=True)
-                return f"Error: failed to communicate with the remote agent: {exc}"
+                safe_msg = _sanitize_a2a_error(exc)
+                logger.error("A2A remote call failed: %s", safe_msg)
+                logger.debug("A2A remote call exception detail: %s: %s", type(exc).__name__, exc)
+                return f"Error: failed to communicate with the remote agent: {safe_msg}"
 
         return _safe
 
@@ -315,8 +349,10 @@ def _wrap_a2a_function(fn: Any) -> Any:
                 async for event in fn(*args, **kwargs):
                     yield event
             except Exception as exc:
-                logger.error("A2A remote call failed: %s", exc, exc_info=True)
-                yield f"Error: failed to communicate with the remote agent: {exc}"
+                safe_msg = _sanitize_a2a_error(exc)
+                logger.error("A2A remote call failed: %s", safe_msg)
+                logger.debug("A2A remote call exception detail: %s: %s", type(exc).__name__, exc)
+                yield f"Error: failed to communicate with the remote agent: {safe_msg}"
 
         return _safe_gen
 

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -30,6 +30,7 @@ from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClie
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientFunctionGroup
 from datarobot_genai.dragent.plugins.auth_a2a_client import _AuthenticatedA2ABaseClient
 from datarobot_genai.dragent.plugins.auth_a2a_client import _extract_auth_headers
+from datarobot_genai.dragent.plugins.auth_a2a_client import _sanitize_a2a_error
 from datarobot_genai.dragent.plugins.auth_a2a_client import _wrap_a2a_function
 
 _AGENT_URL = "http://agent.example.com"
@@ -352,6 +353,62 @@ class TestAuthenticatedA2AClientFunctionGroup:
 
 
 # ---------------------------------------------------------------------------
+# Tests: _sanitize_a2a_error — sensitive data stripping
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeA2AError:
+    """Verify that _sanitize_a2a_error never leaks tokens or response bodies."""
+
+    def test_runtime_error_does_not_expose_message(self):
+        """RuntimeError messages could originate from third-party SDKs — never trusted."""
+        exc = RuntimeError("token=eyJhbGciOi... failed at https://as.example.com")
+        result = _sanitize_a2a_error(exc)
+        assert "eyJhbGciOi" not in result
+        assert "RuntimeError" in result
+
+    def test_generic_exception_hides_message(self):
+        """Unknown exception types could carry token material — only class name survives."""
+        exc = ValueError("subject_token=eyJhbGciOi...")
+        result = _sanitize_a2a_error(exc)
+        assert "eyJhbGciOi" not in result
+        assert "ValueError" in result
+
+    def test_httpx_status_error_strips_body(self):
+        """Httpx errors could echo submitted form params — only status + host survive."""
+        import httpx
+
+        request = httpx.Request("POST", "https://as.example.com/oauth2/v1/token")
+        response = httpx.Response(
+            401,
+            request=request,
+            content=b'{"error":"invalid_client","assertion":"eyJ..."}',
+        )
+        exc = httpx.HTTPStatusError("401", request=request, response=response)
+        result = _sanitize_a2a_error(exc)
+        assert "401" in result
+        assert "as.example.com" in result
+        assert "eyJ" not in result
+        assert "invalid_client" not in result
+
+    def test_timeout_gives_actionable_message(self):
+        import httpx
+
+        exc = httpx.ReadTimeout("timed out")
+        result = _sanitize_a2a_error(exc)
+        assert "timed out" in result
+        assert "ReadTimeout" not in result  # generic, not class name
+
+    def test_network_error_gives_actionable_message(self):
+        import httpx
+
+        exc = httpx.ConnectError("Connection refused to host with token=secret")
+        result = _sanitize_a2a_error(exc)
+        assert "network error" in result
+        assert "secret" not in result
+
+
+# ---------------------------------------------------------------------------
 # Tests: _wrap_a2a_function — error handling wrapper
 # ---------------------------------------------------------------------------
 
@@ -377,7 +434,20 @@ class TestWrapA2AFunction:
 
         assert isinstance(result, str)
         assert "Error" in result
-        assert "connection refused" in result
+        # RuntimeError message is sanitised — not passed through verbatim
+        assert "connection refused" not in result
+
+    async def test_async_fn_does_not_leak_token_material(self):
+        """Exception messages containing tokens must be sanitised."""
+
+        async def leak(x: str) -> str:
+            raise ValueError("subject_token=eyJhbGciOiJSUzI1NiJ9.secret")
+
+        wrapped = _wrap_a2a_function(leak)
+        result = await wrapped("hello")
+
+        assert "eyJhbGciOi" not in result
+        assert "Error" in result
 
     async def test_async_gen_success_passes_through(self):
         async def gen(x: str):
@@ -398,7 +468,8 @@ class TestWrapA2AFunction:
 
         assert events[0] == "a"
         assert "Error" in events[-1]
-        assert "stream broken" in events[-1]
+        # RuntimeError message is sanitised — not passed through verbatim
+        assert "stream broken" not in events[-1]
 
     def test_sync_fn_returned_unchanged(self):
         def plain(x: str) -> str:
@@ -430,7 +501,8 @@ class TestAuthenticatedA2AClientFunctionGroupAddFunction:
 
         assert isinstance(result, str)
         assert "Error" in result
-        assert "auth failed" in result
+        # RuntimeError message is sanitised — not passed through verbatim
+        assert "auth failed" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -30,6 +30,7 @@ from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClie
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientFunctionGroup
 from datarobot_genai.dragent.plugins.auth_a2a_client import _AuthenticatedA2ABaseClient
 from datarobot_genai.dragent.plugins.auth_a2a_client import _extract_auth_headers
+from datarobot_genai.dragent.plugins.auth_a2a_client import _wrap_a2a_function
 
 _AGENT_URL = "http://agent.example.com"
 
@@ -348,6 +349,88 @@ class TestAuthenticatedA2AClientFunctionGroup:
             fg = AuthenticatedA2AClientFunctionGroup(config=a2a_config, builder=mock_builder)
             with pytest.raises(RuntimeError, match="User ID not found in context"):
                 await fg.__aenter__()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _wrap_a2a_function — error handling wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestWrapA2AFunction:
+    """Verify that _wrap_a2a_function catches errors and returns them as values,
+    not raising exceptions that would crash the agent.
+    """
+
+    async def test_async_fn_success_passes_through(self):
+        async def ok(x: str) -> str:
+            return f"ok:{x}"
+
+        wrapped = _wrap_a2a_function(ok)
+        assert await wrapped("hello") == "ok:hello"
+
+    async def test_async_fn_error_returns_error_string(self):
+        async def boom(x: str) -> str:
+            raise RuntimeError("connection refused")
+
+        wrapped = _wrap_a2a_function(boom)
+        result = await wrapped("hello")
+
+        assert isinstance(result, str)
+        assert "Error" in result
+        assert "connection refused" in result
+
+    async def test_async_gen_success_passes_through(self):
+        async def gen(x: str):
+            yield "a"
+            yield "b"
+
+        wrapped = _wrap_a2a_function(gen)
+        events = [e async for e in wrapped("hello")]
+        assert events == ["a", "b"]
+
+    async def test_async_gen_error_yields_error_string(self):
+        async def gen(x: str):
+            yield "a"
+            raise RuntimeError("stream broken")
+
+        wrapped = _wrap_a2a_function(gen)
+        events = [e async for e in wrapped("hello")]
+
+        assert events[0] == "a"
+        assert "Error" in events[-1]
+        assert "stream broken" in events[-1]
+
+    def test_sync_fn_returned_unchanged(self):
+        def plain(x: str) -> str:
+            return x
+
+        assert _wrap_a2a_function(plain) is plain
+
+
+# ---------------------------------------------------------------------------
+# Tests: AuthenticatedA2AClientFunctionGroup.add_function wraps with error handling
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticatedA2AClientFunctionGroupAddFunction:
+    """Verify that add_function applies _wrap_a2a_function transparently."""
+
+    async def test_registered_fn_catches_error(self, a2a_config, mock_builder):
+        """A function added via add_function should return error strings on failure."""
+        fg = AuthenticatedA2AClientFunctionGroup(config=a2a_config, builder=mock_builder)
+
+        async def exploding(query: str) -> str:
+            raise RuntimeError("auth failed")
+
+        fg.add_function(name="test_fn", fn=exploding, description="test")
+
+        # The function was wrapped — invoke the underlying callable
+        fn_obj = fg._functions["test_fn"]
+        result = await fn_obj.ainvoke("hello")
+
+        assert isinstance(result, str)
+        assert "Error" in result
+        assert "auth failed" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -19,12 +19,12 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from datarobot_genai.dragent.agent_card_registry import _MAX_PAGES
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import DataRobotRegistrySettings
 from datarobot_genai.dragent.agent_card_registry import _CacheEntry
-from datarobot_genai.dragent.agent_card_registry import _MAX_PAGES
 from datarobot_genai.dragent.agent_card_registry import _parse_registry_response
 from datarobot_genai.dragent.agent_card_registry import _resolve_settings
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
@@ -536,9 +536,7 @@ class TestAgentCardRegistryFetch:
         page3_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
-        mock_client.get = AsyncMock(
-            side_effect=[page1_response, page2_response, page3_response]
-        )
+        mock_client.get = AsyncMock(side_effect=[page1_response, page2_response, page3_response])
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
@@ -571,9 +569,7 @@ class TestAgentCardRegistryFetch:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            registry = AgentCardRegistry(
-                api_token="tok", endpoint="https://ep", cache_ttl=3600
-            )
+            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
             cards = await registry._fetch({"deploymentIds": "dep-1"})
 
         assert "dep-1" in cards

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -24,6 +24,7 @@ from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import DataRobotRegistrySettings
 from datarobot_genai.dragent.agent_card_registry import _CacheEntry
+from datarobot_genai.dragent.agent_card_registry import _MAX_PAGES
 from datarobot_genai.dragent.agent_card_registry import _parse_registry_response
 from datarobot_genai.dragent.agent_card_registry import _resolve_settings
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
@@ -478,7 +479,8 @@ class TestAgentCardRegistryFetch:
         assert "dep-1" in cards
         assert "dep-2" in cards
         call_kwargs = mock_httpx_client.get.call_args.kwargs
-        assert call_kwargs["params"] == {"deploymentIds": "dep-1,dep-2"}
+        assert call_kwargs["params"]["deploymentIds"] == "dep-1,dep-2"
+        assert call_kwargs["params"]["limit"] == "100"
         assert call_kwargs["headers"]["Authorization"] == "Bearer my-tok"
 
     async def test_fetch_http_error(self):
@@ -497,6 +499,144 @@ class TestAgentCardRegistryFetch:
             registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
             with pytest.raises(AgentCardRegistryError, match="HTTP 403"):
                 await registry._fetch({"deploymentIds": "dep-1"})
+
+    async def test_fetch_paginates_through_all_pages(self):
+        """_fetch follows the 'next' link until all pages are consumed."""
+        page1_response = MagicMock(spec=httpx.Response)
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "data": [_entry(dep_id="dep-1")],
+            "count": 1,
+            "totalCount": 3,
+            "next": "https://app.dr.com/api/v2/agentCards/?offset=1&limit=1",
+            "previous": None,
+        }
+        page1_response.raise_for_status = MagicMock()
+
+        page2_response = MagicMock(spec=httpx.Response)
+        page2_response.status_code = 200
+        page2_response.json.return_value = {
+            "data": [_entry(dep_id="dep-2", card=_SAMPLE_AGENT_CARD_2)],
+            "count": 1,
+            "totalCount": 3,
+            "next": "https://app.dr.com/api/v2/agentCards/?offset=2&limit=1",
+            "previous": "https://app.dr.com/api/v2/agentCards/?offset=0&limit=1",
+        }
+        page2_response.raise_for_status = MagicMock()
+
+        page3_response = MagicMock(spec=httpx.Response)
+        page3_response.status_code = 200
+        page3_response.json.return_value = {
+            "data": [_entry(dep_id="dep-3", card=_SAMPLE_AGENT_CARD_3)],
+            "count": 1,
+            "totalCount": 3,
+            "next": None,
+            "previous": "https://app.dr.com/api/v2/agentCards/?offset=1&limit=1",
+        }
+        page3_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=[page1_response, page2_response, page3_response]
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            registry = AgentCardRegistry(
+                api_token="my-tok", endpoint="https://app.dr.com/api/v2", cache_ttl=3600
+            )
+            cards = await registry._fetch({"deploymentIds": "dep-1,dep-2,dep-3"})
+
+        assert "dep-1" in cards
+        assert "dep-2" in cards
+        assert "dep-3" in cards
+        assert len(cards) == 3
+        assert mock_client.get.await_count == 3
+
+    async def test_fetch_no_pagination_when_next_absent(self):
+        """When 'next' is absent or null, only one request is made."""
+        single_response = MagicMock(spec=httpx.Response)
+        single_response.status_code = 200
+        single_response.json.return_value = {
+            "data": [_entry(dep_id="dep-1")],
+            "count": 1,
+            "totalCount": 1,
+        }
+        single_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=single_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            registry = AgentCardRegistry(
+                api_token="tok", endpoint="https://ep", cache_ttl=3600
+            )
+            cards = await registry._fetch({"deploymentIds": "dep-1"})
+
+        assert "dep-1" in cards
+        assert mock_client.get.await_count == 1
+
+    async def test_fetch_pagination_error_on_second_page_raises(self):
+        """HTTP error on a pagination request propagates correctly."""
+        page1_response = MagicMock(spec=httpx.Response)
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "data": [_entry(dep_id="dep-1")],
+            "count": 1,
+            "totalCount": 2,
+            "next": "https://app.dr.com/api/v2/agentCards/?offset=1&limit=1",
+        }
+        page1_response.raise_for_status = MagicMock()
+
+        page2_response = MagicMock(spec=httpx.Response)
+        page2_response.status_code = 500
+        page2_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=page2_response
+        )
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[page1_response, page2_response])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            with pytest.raises(AgentCardRegistryError, match="HTTP 500"):
+                await registry._fetch({"deploymentIds": "dep-1,dep-2"})
+
+    async def test_fetch_stops_at_safety_limit(self):
+        """Pagination stops after _MAX_PAGES to prevent infinite loops."""
+
+        def _make_page(page_num: int, has_next: bool):
+            resp = MagicMock(spec=httpx.Response)
+            resp.status_code = 200
+            resp.json.return_value = {
+                "data": [_entry(dep_id=f"dep-{page_num}")],
+                "count": 1,
+                "totalCount": 9999,
+                "next": f"https://ep/agentCards/?offset={page_num}&limit=100" if has_next else None,
+            }
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        # All pages claim there's a next page (simulating a buggy API / infinite loop)
+        pages = [_make_page(i, has_next=True) for i in range(_MAX_PAGES + 5)]
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=pages)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
+            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            cards = await registry._fetch({"deploymentIds": "dep-0"})
+
+        # Should have fetched exactly _MAX_PAGES (stopped at the safety limit)
+        assert mock_client.get.await_count == _MAX_PAGES
+        assert len(cards) == _MAX_PAGES
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.72"
+version = "0.15.73"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes A2A error propagation and logging (security-sensitive) and registry fetch behavior for large result sets; well covered by new unit tests.
> 
> **Overview**
> Remote A2A tool calls no longer take down the host agent when a peer fails: registered async functions and streaming generators are wrapped so failures become **sanitized error strings** returned to the model, with logs that avoid tracebacks and raw exception text that might contain tokens or HTTP bodies.
> 
> **Agent card registry** `_fetch` now requests `limit=100`, follows API `next` links until done, merges all pages before duplicate handling, and stops after **100 pages** with a warning if the API never clears `next`.
> 
> Agent card discovery logging drops `exc_info` on fetch failure in favor of a shorter error line with base URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00288873730bff6d151a8d5e43baa14936f6030. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->