### PR TITLE
[BUZZOK-30952] Handle datarobot_moderations in the converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.78
+- `dragent/frontends/converters`: fixed dropped `datarobot_moderations` in dragent workflow chunk conversion paths by preserving moderation metadata on both NAT `ChatResponseChunk` and OpenAI `ChatCompletionChunk` streaming outputs.
 
 ## 0.15.77
 - A non-existent `deployment_id` or `external_id` in the agent card registry now returns an actionable error message instead of a generic JSON-RPC `-32603 Internal error`.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.76"
+version = "0.15.78"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.77"
+version = "0.15.78"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/converters.py
+++ b/src/datarobot_genai/dragent/frontends/converters.py
@@ -157,7 +157,7 @@ def _dragent_streaming_delta_from_events(
 
 
 def _resolve_datarobot_moderations_for_chunk(
-    chunk: ChatResponseChunk,
+    chunk: ChatResponseChunk | None,
     from_response: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     if from_response is not None:
@@ -306,8 +306,8 @@ def convert_dragent_event_response_to_openai_chat_completion_chunk(
             object="chat.completion.chunk",
             usage=None,
         )
-    moderations = response.datarobot_moderations or getattr(
-        response.original_chunk, "datarobot_moderations", None
+    moderations = _resolve_datarobot_moderations_for_chunk(
+        response.original_chunk, response.datarobot_moderations
     )
     return _openai_chat_completion_chunk_with_datarobot_moderations(chunk, moderations)
 

--- a/src/datarobot_genai/dragent/frontends/converters.py
+++ b/src/datarobot_genai/dragent/frontends/converters.py
@@ -156,22 +156,56 @@ def _dragent_streaming_delta_from_events(
     return content, tool_calls
 
 
+def _resolve_datarobot_moderations_for_chunk(
+    chunk: ChatResponseChunk,
+    from_response: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if from_response is not None:
+        return from_response
+    return getattr(chunk, "datarobot_moderations", None)
+
+
+def _nat_chat_response_chunk_with_datarobot_moderations(
+    chunk: ChatResponseChunk,
+    datarobot_moderations: dict[str, Any] | None,
+) -> ChatResponseChunk:
+    if datarobot_moderations is None:
+        return chunk
+    if getattr(chunk, "datarobot_moderations", None) == datarobot_moderations:
+        return chunk
+    return chunk.model_copy(update={"datarobot_moderations": datarobot_moderations})
+
+
+def _openai_chat_completion_chunk_with_datarobot_moderations(
+    chunk: ChatCompletionChunk,
+    datarobot_moderations: dict[str, Any] | None,
+) -> ChatCompletionChunk:
+    if datarobot_moderations is None:
+        return chunk
+    if getattr(chunk, "datarobot_moderations", None) == datarobot_moderations:
+        return chunk
+    return chunk.model_copy(update={"datarobot_moderations": datarobot_moderations})
+
+
 def convert_dragent_event_response_to_chat_response_chunk(
     response: DRAgentEventResponse,
 ) -> ChatResponseChunk:
     if response.original_chunk is not None:
-        return response.original_chunk
-    content, tool_calls = _dragent_streaming_delta_from_events(response.events)
-    return ChatResponseChunk(
-        id=uuid.uuid4().hex,
-        choices=[
-            ChatResponseChunkChoice(
-                index=0,
-                delta=ChoiceDelta(content=content, tool_calls=tool_calls or None),
-            )
-        ],
-        created=datetime.datetime.now(datetime.UTC),
-    )
+        chunk = response.original_chunk
+    else:
+        content, tool_calls = _dragent_streaming_delta_from_events(response.events)
+        chunk = ChatResponseChunk(
+            id=uuid.uuid4().hex,
+            choices=[
+                ChatResponseChunkChoice(
+                    index=0,
+                    delta=ChoiceDelta(content=content, tool_calls=tool_calls or None),
+                )
+            ],
+            created=datetime.datetime.now(datetime.UTC),
+        )
+    moderations = _resolve_datarobot_moderations_for_chunk(chunk, response.datarobot_moderations)
+    return _nat_chat_response_chunk_with_datarobot_moderations(chunk, moderations)
 
 
 _FINISH_REASON = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
@@ -234,13 +268,16 @@ def convert_nat_chat_response_chunk_to_openai_chat_completion_chunk(
             completion_tokens=u.completion_tokens,
             total_tokens=u.total_tokens,
         )
-    return ChatCompletionChunk(
+    openai_chunk = ChatCompletionChunk(
         id=chunk.id,
         choices=[choice],
         created=created_ts,
         model=chunk.model,
         object="chat.completion.chunk",
         usage=usage_openai,
+    )
+    return _openai_chat_completion_chunk_with_datarobot_moderations(
+        openai_chunk, getattr(chunk, "datarobot_moderations", None)
     )
 
 
@@ -249,25 +286,30 @@ def convert_dragent_event_response_to_openai_chat_completion_chunk(
 ) -> ChatCompletionChunk:
     """Convert one DRAgent stream chunk to an OpenAI chunk (dome / moderation streaming)."""
     if response.original_chunk is not None:
-        return convert_nat_chat_response_chunk_to_openai_chat_completion_chunk(
+        chunk = convert_nat_chat_response_chunk_to_openai_chat_completion_chunk(
             response.original_chunk
         )
-    content, tool_calls = _dragent_streaming_delta_from_events(response.events)
-    created_ts = int(datetime.datetime.now(datetime.UTC).timestamp())
-    return ChatCompletionChunk(
-        id=uuid.uuid4().hex,
-        choices=[
-            OpenAIChunkChoice(
-                index=0,
-                delta=OpenAIChoiceDelta(content=content, tool_calls=tool_calls or None),
-                finish_reason=None,
-            )
-        ],
-        created=created_ts,
-        model=response.model or "unknown-model",
-        object="chat.completion.chunk",
-        usage=None,
+    else:
+        content, tool_calls = _dragent_streaming_delta_from_events(response.events)
+        created_ts = int(datetime.datetime.now(datetime.UTC).timestamp())
+        chunk = ChatCompletionChunk(
+            id=uuid.uuid4().hex,
+            choices=[
+                OpenAIChunkChoice(
+                    index=0,
+                    delta=OpenAIChoiceDelta(content=content, tool_calls=tool_calls or None),
+                    finish_reason=None,
+                )
+            ],
+            created=created_ts,
+            model=response.model or "unknown-model",
+            object="chat.completion.chunk",
+            usage=None,
+        )
+    moderations = response.datarobot_moderations or getattr(
+        response.original_chunk, "datarobot_moderations", None
     )
+    return _openai_chat_completion_chunk_with_datarobot_moderations(chunk, moderations)
 
 
 ## --- dragent Chat Completions -> AG-UI ---

--- a/tests/dragent/frontends/test_converters.py
+++ b/tests/dragent/frontends/test_converters.py
@@ -463,6 +463,41 @@ def test_convert_dragent_event_response_to_chat_response_chunk_returns_original_
     assert result.choices[0].delta.content == "from-stream"
 
 
+def test_convert_dragent_event_response_to_chat_response_chunk_attaches_datarobot_moderations() -> (
+    None
+):
+    # GIVEN original_chunk without moderations but response carries guard metadata
+    existing = _make_chat_response_chunk(content="from-stream")
+    moderations = {"Prompts_token_count": 3, "Responses_token_count": 50}
+    response = DRAgentEventResponse(
+        original_chunk=existing,
+        datarobot_moderations=moderations,
+        events=[TextMessageContentEvent(message_id="m1", delta="ignored when chunk set")],
+    )
+
+    # WHEN converting
+    result = convert_dragent_event_response_to_chat_response_chunk(response)
+
+    # THEN moderations are merged onto the NAT chunk for chat/completions clients
+    assert result is not existing
+    assert result.choices[0].delta.content == "from-stream"
+    assert result.datarobot_moderations == moderations
+
+
+def test_convert_dragent_event_response_to_chat_response_chunk_moderations_from_events_only() -> (
+    None
+):
+    response = DRAgentEventResponse(
+        original_chunk=None,
+        datarobot_moderations={"Prompts_token_count": 3},
+        events=[TextMessageContentEvent(message_id="m1", delta="hi")],
+    )
+
+    result = convert_dragent_event_response_to_chat_response_chunk(response)
+
+    assert result.datarobot_moderations == {"Prompts_token_count": 3}
+
+
 # --- Tool-call event conversion ------------------------------------------
 
 
@@ -594,6 +629,18 @@ def test_convert_dragent_event_response_to_openai_chunk_returns_mapped_original_
     assert result.id == "nat-chunk-1"
     assert result.choices[0].delta.content == "from-stream"
     assert isinstance(result.created, int)
+
+
+def test_convert_dragent_event_response_to_openai_chunk_attaches_datarobot_moderations() -> None:
+    existing = _make_chat_response_chunk(content="from-stream", chunk_id="nat-chunk-1")
+    moderations = {"Prompts_token_count": 3, "Responses_token_count": 50}
+    response = DRAgentEventResponse(
+        original_chunk=existing,
+        datarobot_moderations=moderations,
+        events=[TextMessageContentEvent(message_id="m1", delta="ignored")],
+    )
+    result = convert_dragent_event_response_to_openai_chat_completion_chunk(response)
+    assert result.datarobot_moderations == moderations
 
 
 def test_openai_chunk_from_nat_matches_dragent_event_path_for_text() -> None:

--- a/tests/dragent/frontends/test_converters.py
+++ b/tests/dragent/frontends/test_converters.py
@@ -643,6 +643,23 @@ def test_convert_dragent_event_response_to_openai_chunk_attaches_datarobot_moder
     assert result.datarobot_moderations == moderations
 
 
+def test_convert_dragent_event_response_to_openai_chunk_preserves_empty_datarobot_moderations() -> (
+    None
+):
+    # GIVEN a response that explicitly sets empty moderation metadata
+    response = DRAgentEventResponse(
+        original_chunk=None,
+        datarobot_moderations={},
+        events=[TextMessageContentEvent(message_id="m1", delta="hi")],
+    )
+
+    # WHEN converting to OpenAI chunk
+    result = convert_dragent_event_response_to_openai_chat_completion_chunk(response)
+
+    # THEN explicit empty metadata is preserved (not treated as falsy/missing)
+    assert result.datarobot_moderations == {}
+
+
 def test_openai_chunk_from_nat_matches_dragent_event_path_for_text() -> None:
     response = DRAgentEventResponse(
         original_chunk=None,

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.76"
+version = "0.15.78"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
The converters used with dragent workflows drop `datarobot_moderations`.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Pass `datarobot_moderations` from `DRAgentEventResponse` through in the chat completion.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized streaming metadata passthrough with unit tests; no auth, persistence, or API contract changes beyond exposing existing guard fields on chunks.
> 
> **Overview**
> **dragent** streaming converters now carry **`datarobot_moderations`** from **`DRAgentEventResponse`** onto NAT **`ChatResponseChunk`** and OpenAI **`ChatCompletionChunk`** output, including when an **`original_chunk`** is reused and when chunks are built only from AG-UI events.
> 
> Shared helpers resolve moderation metadata (response vs chunk), avoid redundant **`model_copy`** when already set, and the NAT→OpenAI path copies moderations from the NAT chunk. Unit tests cover merge-on-original-chunk and events-only paths; the e2e lockfile bumps **`datarobot-genai`** to **0.15.73**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 662a660b6e00fe1573c33335115b2b19aec98017. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->