### PR TITLE
Handle agent card registry resolution errors gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.15.75
+## 0.15.76
 - A non-existent `deployment_id` or `external_id` in the agent card registry now returns an actionable error message instead of a generic JSON-RPC `-32603 Internal error`.
 
 ## 0.15.74

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-<<<<<<< mdambski/fix-resolution
+
 ## 0.15.76
 - A non-existent `deployment_id` or `external_id` in the agent card registry now returns an actionable error message instead of a generic JSON-RPC `-32603 Internal error`.
-=======
+
 ## 0.15.75
 - Upgrade to `nvidia-nat` 1.7.0, and pin `starlette>=1.0.1` to mitigate CVE-2026-48710
->>>>>>> main
 
 ## 0.15.74
 - Fixed `datarobot_api_key` auth provider not forwarding `Authorization: Bearer` header on A2A RPC calls when the agent card has no `security_schemes`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.75
+- A non-existent `deployment_id` or `external_id` in the agent card registry now returns an actionable error message instead of a generic JSON-RPC `-32603 Internal error`.
+
 ## 0.15.74
 - Fixed `datarobot_api_key` auth provider not forwarding `Authorization: Bearer` header on A2A RPC calls when the agent card has no `security_schemes`.
 - Fixed `asyncio.isasyncgenfunction` error on Python 3.12+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
-## 0.15.76
+## 0.15.77
 - A non-existent `deployment_id` or `external_id` in the agent card registry now returns an actionable error message instead of a generic JSON-RPC `-32603 Internal error`.
 
 ## 0.15.75

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.75"
+version = "0.15.76"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-<<<<<<< mdambski/fix-resolution
 version = "0.15.76"
-=======
-version = "0.15.75"
->>>>>>> main
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.74"
+version = "0.15.75"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.76"
+version = "0.15.77"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -27,6 +27,7 @@ from a2a.client import A2ACardResolver
 from a2a.client import AuthInterceptor
 from a2a.client import ClientConfig
 from a2a.client import ClientFactory
+from a2a.types import AgentCapabilities
 from a2a.types import AgentCard
 from nat.authentication.interfaces import AuthProviderBase
 from nat.builder.builder import Builder
@@ -42,6 +43,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
 
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
 from datarobot_genai.dragent.agent_card_registry import get_default_registry_sync
 
@@ -327,6 +329,11 @@ def _sanitize_a2a_error(exc: Exception) -> str:
     if isinstance(exc, (httpx.ConnectError, httpx.NetworkError, ConnectionError, OSError)):
         return "network error communicating with remote agent"
 
+    # Safe to surface verbatim — crafted by this codebase, never contains secrets.
+    # Checked before RuntimeError (its superclass).
+    if isinstance(exc, AgentCardRegistryError):
+        return f"agent card registry error: {exc}"
+
     if isinstance(exc, (RuntimeError, ValueError)):
         return f"{type(exc).__name__}: authentication or protocol error"
 
@@ -379,6 +386,61 @@ def _wrap_a2a_function(fn: Any) -> Any:
     return fn
 
 
+class _FailedRegistryClient:
+    """Stand-in for :class:`A2ABaseClient` when registry lookup fails.
+
+    Provides ``agent_card`` so NAT's ``_register_functions()`` succeeds at
+    registration time.  All other attribute accesses return async-generator
+    factories that raise the original error at invocation time, where
+    ``_wrap_a2a_function`` catches it and surfaces an actionable message.
+
+    Decoupled from NAT's function set — no hardcoded method names.
+    """
+
+    def __init__(self, agent_card: AgentCard, error: AgentCardRegistryError) -> None:
+        self._agent_card = agent_card
+        self._error = error
+
+    @property
+    def agent_card(self) -> AgentCard:
+        return self._agent_card
+
+    def __getattr__(self, name: str) -> Any:
+        """Return an async-generator factory that raises the stored error.
+
+        Satisfies both ``await`` and ``async for`` patterns used by NAT.
+        """
+        error = self._error
+
+        def _make_gen(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:
+            async def _gen() -> AsyncGenerator[Any, None]:
+                raise error
+                yield  # noqa: RET503 — unreachable, makes this an async generator
+
+            return _gen()
+
+        return _make_gen
+
+    async def __aexit__(self, *args: Any) -> None:
+        """No-op cleanup — nothing to close."""
+
+
+def _make_placeholder_agent_card(error_msg: str) -> AgentCard:
+    """Build a minimal :class:`AgentCard` so ``_register_functions()`` can read
+    agent metadata without crashing. The description carries the original error.
+    """
+    return AgentCard(
+        name="unavailable",
+        description=f"Agent card could not be resolved: {error_msg}",
+        url="https://unavailable/",
+        version="0.0.0",
+        skills=[],
+        capabilities=AgentCapabilities(streaming=False),
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+    )
+
+
 class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
     """Uses :class:`_AuthenticatedA2ABaseClient` so both A2A phases are authenticated."""
 
@@ -415,12 +477,27 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
         pre_resolved_card: AgentCard | None = None
 
         if config.registry:
-            # Fetch the card from the central DataRobot agent card registry
-            registry = await get_default_registry()
-            pre_resolved_card = await registry.get(
-                deployment_id=config.registry.deployment_id,
-                external_id=config.registry.external_id,
-            )
+            # Catch AgentCardRegistryError so the function group initialises
+            # in a degraded state instead of crashing (generic JSON-RPC -32603).
+            try:
+                registry = await get_default_registry()
+                pre_resolved_card = await registry.get(
+                    deployment_id=config.registry.deployment_id,
+                    external_id=config.registry.external_id,
+                )
+            except AgentCardRegistryError as exc:
+                error_msg = str(exc)
+                logger.error(
+                    "Agent card registry lookup failed: %s",
+                    error_msg,
+                )
+                # Install a placeholder client: registration succeeds, but
+                # every RPC call raises the error → caught by _wrap_a2a_function.
+                placeholder_card = _make_placeholder_agent_card(error_msg)
+                self._client = _FailedRegistryClient(placeholder_card, exc)  # type: ignore[assignment]
+                self._register_functions()
+                return self
+
             base_url = str(pre_resolved_card.url)
             logger.info(
                 "Agent card resolved via central registry (deployment_id=%s, external_id=%s), "

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -387,47 +387,31 @@ def _wrap_a2a_function(fn: Any) -> Any:
 
 
 class _FailedRegistryClient:
-    """Stand-in for :class:`A2ABaseClient` when registry lookup fails.
+    """Minimal stand-in providing ``agent_card`` for ``_register_functions()``.
 
-    Provides ``agent_card`` so NAT's ``_register_functions()`` succeeds at
-    registration time.  All other attribute accesses return async-generator
-    factories that raise the original error at invocation time, where
-    ``_wrap_a2a_function`` catches it and surfaces an actionable message.
-
-    Decoupled from NAT's function set — no hardcoded method names.
+    Used when registry lookup fails.  Only ``agent_card`` and ``__aexit__``
+    are needed — the actual RPC methods are never called because
+    ``add_function`` replaces every registered function before it can
+    reference the client.
     """
 
-    def __init__(self, agent_card: AgentCard, error: AgentCardRegistryError) -> None:
+    __slots__ = ("_agent_card",)
+
+    def __init__(self, agent_card: AgentCard) -> None:
         self._agent_card = agent_card
-        self._error = error
 
     @property
     def agent_card(self) -> AgentCard:
         return self._agent_card
 
-    def __getattr__(self, name: str) -> Any:
-        """Return an async-generator factory that raises the stored error.
-
-        Satisfies both ``await`` and ``async for`` patterns used by NAT.
-        """
-        error = self._error
-
-        def _make_gen(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:
-            async def _gen() -> AsyncGenerator[Any, None]:
-                raise error
-                yield  # noqa: RET503 — unreachable, makes this an async generator
-
-            return _gen()
-
-        return _make_gen
-
     async def __aexit__(self, *args: Any) -> None:
-        """No-op cleanup — nothing to close."""
+        """No-op — nothing to close."""
 
 
 def _make_placeholder_agent_card(error_msg: str) -> AgentCard:
-    """Build a minimal :class:`AgentCard` so ``_register_functions()`` can read
-    agent metadata without crashing. The description carries the original error.
+    """Build a minimal ``AgentCard`` for ``_register_functions()`` to read.
+
+    The description embeds the original error for observability in logs.
     """
     return AgentCard(
         name="unavailable",
@@ -445,7 +429,22 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
     """Uses :class:`_AuthenticatedA2ABaseClient` so both A2A phases are authenticated."""
 
     def add_function(self, name: str, fn: Any, **kwargs: Any) -> None:  # type: ignore[override]
-        """Intercept function registration to wrap *fn* with error handling."""
+        """Intercept function registration to wrap *fn* with error handling.
+
+        In degraded mode (registry lookup failed), replaces *fn* entirely
+        with one that raises the stored error — so ``_wrap_a2a_function``
+        catches it and returns an actionable message to the LLM.
+        This avoids coupling to NAT's client method signatures or protocols.
+        """
+        registry_error = getattr(self, "_registry_error", None)
+        if registry_error is not None:
+            err = registry_error
+
+            @functools.wraps(fn)
+            async def _raise_registry_error(*args: Any, **kwargs: Any) -> Any:
+                raise err
+
+            fn = _raise_registry_error
         super().add_function(name, _wrap_a2a_function(fn), **kwargs)
 
     async def __aenter__(self) -> "AuthenticatedA2AClientFunctionGroup":
@@ -491,10 +490,11 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
                     "Agent card registry lookup failed: %s",
                     error_msg,
                 )
-                # Install a placeholder client: registration succeeds, but
-                # every RPC call raises the error → caught by _wrap_a2a_function.
+                # Store the error so add_function replaces every registered
+                # function with one that raises it (caught by _wrap_a2a_function).
+                self._registry_error = exc
                 placeholder_card = _make_placeholder_agent_card(error_msg)
-                self._client = _FailedRegistryClient(placeholder_card, exc)  # type: ignore[assignment]
+                self._client = _FailedRegistryClient(placeholder_card)  # type: ignore[assignment]
                 self._register_functions()
                 return self
 

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -739,27 +739,54 @@ class TestAuthenticatedA2AClientFunctionGroupRegistryError:
 
     The group should complete __aenter__, register functions via NAT, and
     return actionable error messages when those functions are invoked.
+    Covered for both deployment_id and external_id lookup keys.
     """
 
-    _REGISTRY_ERROR_MSG = (
-        "No agent card found in the central registry for "
-        "deployment_id='000000000000000000000000'. "
-        "Verify that the deployment exists and is registered in your organisation."
+    @pytest.fixture(
+        params=[
+            pytest.param(
+                {
+                    "key": "deployment_id",
+                    "value": "000000000000000000000000",
+                    "error_msg": (
+                        "No agent card found in the central registry for "
+                        "deployment_id='000000000000000000000000'. "
+                        "Verify that the deployment exists and is registered "
+                        "in your organisation."
+                    ),
+                },
+                id="deployment_id",
+            ),
+            pytest.param(
+                {
+                    "key": "external_id",
+                    "value": "my-external-agent",
+                    "error_msg": (
+                        "No agent card found in the central registry for "
+                        "external_id='my-external-agent'. "
+                        "Verify that the deployment exists and is registered "
+                        "in your organisation."
+                    ),
+                },
+                id="external_id",
+            ),
+        ]
     )
+    def registry_scenario(self, request):
+        return request.param
 
     @pytest.fixture
-    def registry_config(self):
+    def registry_config(self, registry_scenario):
+        lookup_kwargs = {registry_scenario["key"]: registry_scenario["value"]}
         return AuthenticatedA2AClientConfig(
-            registry=AgentCardRegistryLookup(deployment_id="000000000000000000000000"),
+            registry=AgentCardRegistryLookup(**lookup_kwargs),
         )
 
     @pytest.fixture
-    def failing_registry(self):
+    def failing_registry(self, registry_scenario):
         mock_registry = AsyncMock()
         mock_registry.get = AsyncMock(
-            side_effect=AgentCardRegistryError(
-                TestAuthenticatedA2AClientFunctionGroupRegistryError._REGISTRY_ERROR_MSG
-            )
+            side_effect=AgentCardRegistryError(registry_scenario["error_msg"])
         )
         return mock_registry
 
@@ -798,11 +825,10 @@ class TestAuthenticatedA2AClientFunctionGroupRegistryError:
 
             # Don't assert exact names — stay resilient to NAT upgrades.
             assert len(fg._functions) > 0
-            # At minimum, the "call" function should always exist.
             assert "call" in fg._functions
 
     async def test_call_stub_returns_error_with_original_message(
-        self, registry_config, mock_builder, failing_registry
+        self, registry_config, registry_scenario, mock_builder, failing_registry
     ):
         """Invoking 'call' returns an error string with the original registry error message."""
         with (
@@ -822,7 +848,7 @@ class TestAuthenticatedA2AClientFunctionGroupRegistryError:
 
             assert isinstance(result, str)
             assert "Error" in result
-            assert "000000000000000000000000" in result
+            assert registry_scenario["value"] in result
             assert "Verify that the deployment exists" in result
 
     async def test_client_is_failed_registry_client(

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -671,7 +671,7 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
 
 
 class TestFailedRegistryClient:
-    """Verify _FailedRegistryClient exposes agent_card and raises on RPC calls."""
+    """Verify _FailedRegistryClient provides agent_card for registration."""
 
     def test_agent_card_property_returns_card(self):
         card = AgentCard(
@@ -684,35 +684,10 @@ class TestFailedRegistryClient:
             default_input_modes=["text"],
             default_output_modes=["text"],
         )
-        error = AgentCardRegistryError("not found")
-        client = _FailedRegistryClient(card, error)
+        client = _FailedRegistryClient(card)
         assert client.agent_card is card
 
-    async def test_any_method_raises_stored_error(self):
-
-        card = AgentCard(
-            name="test",
-            description="test",
-            url="https://test/",
-            version="1.0.0",
-            skills=[],
-            capabilities=AgentCapabilities(streaming=False),
-            default_input_modes=["text"],
-            default_output_modes=["text"],
-        )
-        error = AgentCardRegistryError("deployment not found")
-        client = _FailedRegistryClient(card, error)
-
-        with pytest.raises(AgentCardRegistryError, match="deployment not found"):
-            async for _ in client.send_message("hello"):
-                pass  # pragma: no cover
-
-        with pytest.raises(AgentCardRegistryError, match="deployment not found"):
-            async for _ in client.cancel_task("task-1"):
-                pass  # pragma: no cover
-
     async def test_aexit_is_noop(self):
-
         card = AgentCard(
             name="test",
             description="test",
@@ -723,8 +698,7 @@ class TestFailedRegistryClient:
             default_input_modes=["text"],
             default_output_modes=["text"],
         )
-        error = AgentCardRegistryError("not found")
-        client = _FailedRegistryClient(card, error)
+        client = _FailedRegistryClient(card)
         # Should not raise
         await client.__aexit__(None, None, None)
 

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -19,11 +19,14 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from a2a.types import AgentCapabilities
+from a2a.types import AgentCard
 from nat.data_models.authentication import AuthResult
 from nat.data_models.authentication import BearerTokenCred
 from nat.data_models.authentication import HeaderCred
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import reset_default_registry
 from datarobot_genai.dragent.plugins.auth_a2a_client import A2ADiscoveryAuthMixin
 from datarobot_genai.dragent.plugins.auth_a2a_client import AgentCardRegistryLookup
@@ -31,6 +34,7 @@ from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClie
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientFunctionGroup
 from datarobot_genai.dragent.plugins.auth_a2a_client import _AuthenticatedA2ABaseClient
 from datarobot_genai.dragent.plugins.auth_a2a_client import _extract_auth_headers
+from datarobot_genai.dragent.plugins.auth_a2a_client import _FailedRegistryClient
 from datarobot_genai.dragent.plugins.auth_a2a_client import _sanitize_a2a_error
 from datarobot_genai.dragent.plugins.auth_a2a_client import _wrap_a2a_function
 
@@ -440,6 +444,26 @@ class TestSanitizeA2AError:
         assert "network error" in result
         assert "secret" not in result
 
+    def test_agent_card_registry_error_surfaces_message(self):
+        """AgentCardRegistryError messages are safe — they contain only IDs and guidance."""
+        exc = AgentCardRegistryError(
+            "No agent card found in the central registry for "
+            "deployment_id='000000000000000000000000'. "
+            "Verify that the deployment exists and is registered in your organisation."
+        )
+        result = _sanitize_a2a_error(exc)
+        assert "000000000000000000000000" in result
+        assert "agent card registry error" in result
+        assert "Verify that the deployment exists" in result
+
+    def test_agent_card_registry_error_not_treated_as_generic_runtime_error(self):
+        """AgentCardRegistryError should NOT fall through to the generic RuntimeError branch."""
+        exc = AgentCardRegistryError("deployment not found")
+        result = _sanitize_a2a_error(exc)
+        # Must not hit the generic "authentication or protocol error" branch
+        assert "authentication or protocol error" not in result
+        assert "deployment not found" in result
+
 
 # ---------------------------------------------------------------------------
 # Tests: _wrap_a2a_function — error handling wrapper
@@ -639,3 +663,182 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
 
             # The client should have the pre-resolved card, not call _resolve_agent_card
             assert fg._client._agent_card is mock_card
+
+
+# ---------------------------------------------------------------------------
+# Tests: _FailedRegistryClient — placeholder client for failed registry lookups
+# ---------------------------------------------------------------------------
+
+
+class TestFailedRegistryClient:
+    """Verify _FailedRegistryClient exposes agent_card and raises on RPC calls."""
+
+    def test_agent_card_property_returns_card(self):
+        card = AgentCard(
+            name="test",
+            description="test",
+            url="https://test/",
+            version="1.0.0",
+            skills=[],
+            capabilities=AgentCapabilities(streaming=False),
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+        )
+        error = AgentCardRegistryError("not found")
+        client = _FailedRegistryClient(card, error)
+        assert client.agent_card is card
+
+    async def test_any_method_raises_stored_error(self):
+
+        card = AgentCard(
+            name="test",
+            description="test",
+            url="https://test/",
+            version="1.0.0",
+            skills=[],
+            capabilities=AgentCapabilities(streaming=False),
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+        )
+        error = AgentCardRegistryError("deployment not found")
+        client = _FailedRegistryClient(card, error)
+
+        with pytest.raises(AgentCardRegistryError, match="deployment not found"):
+            async for _ in client.send_message("hello"):
+                pass  # pragma: no cover
+
+        with pytest.raises(AgentCardRegistryError, match="deployment not found"):
+            async for _ in client.cancel_task("task-1"):
+                pass  # pragma: no cover
+
+    async def test_aexit_is_noop(self):
+
+        card = AgentCard(
+            name="test",
+            description="test",
+            url="https://test/",
+            version="1.0.0",
+            skills=[],
+            capabilities=AgentCapabilities(streaming=False),
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+        )
+        error = AgentCardRegistryError("not found")
+        client = _FailedRegistryClient(card, error)
+        # Should not raise
+        await client.__aexit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: AuthenticatedA2AClientFunctionGroup — registry error (graceful degradation)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticatedA2AClientFunctionGroupRegistryError:
+    """Verify that a failed registry lookup produces a degraded function group.
+
+    The group should complete __aenter__, register functions via NAT, and
+    return actionable error messages when those functions are invoked.
+    """
+
+    _REGISTRY_ERROR_MSG = (
+        "No agent card found in the central registry for "
+        "deployment_id='000000000000000000000000'. "
+        "Verify that the deployment exists and is registered in your organisation."
+    )
+
+    @pytest.fixture
+    def registry_config(self):
+        return AuthenticatedA2AClientConfig(
+            registry=AgentCardRegistryLookup(deployment_id="000000000000000000000000"),
+        )
+
+    @pytest.fixture
+    def failing_registry(self):
+        mock_registry = AsyncMock()
+        mock_registry.get = AsyncMock(
+            side_effect=AgentCardRegistryError(
+                TestAuthenticatedA2AClientFunctionGroupRegistryError._REGISTRY_ERROR_MSG
+            )
+        )
+        return mock_registry
+
+    async def test_aenter_succeeds_on_registry_error(
+        self, registry_config, mock_builder, failing_registry
+    ):
+        """__aenter__ must return self, not raise."""
+        with (
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch(
+                f"{_MODULE}.get_default_registry",
+                new_callable=AsyncMock,
+                return_value=failing_registry,
+            ),
+        ):
+            mock_ctx.get.return_value.user_id = "test-user"
+            fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
+            result = await fg.__aenter__()
+            assert result is fg
+
+    async def test_functions_are_registered_via_nat(
+        self, registry_config, mock_builder, failing_registry
+    ):
+        """NAT's _register_functions populates functions against the placeholder client."""
+        with (
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch(
+                f"{_MODULE}.get_default_registry",
+                new_callable=AsyncMock,
+                return_value=failing_registry,
+            ),
+        ):
+            mock_ctx.get.return_value.user_id = "test-user"
+            fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
+            await fg.__aenter__()
+
+            # Don't assert exact names — stay resilient to NAT upgrades.
+            assert len(fg._functions) > 0
+            # At minimum, the "call" function should always exist.
+            assert "call" in fg._functions
+
+    async def test_call_stub_returns_error_with_original_message(
+        self, registry_config, mock_builder, failing_registry
+    ):
+        """Invoking 'call' returns an error string with the original registry error message."""
+        with (
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch(
+                f"{_MODULE}.get_default_registry",
+                new_callable=AsyncMock,
+                return_value=failing_registry,
+            ),
+        ):
+            mock_ctx.get.return_value.user_id = "test-user"
+            fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
+            await fg.__aenter__()
+
+            fn_obj = fg._functions["call"]
+            result = await fn_obj.ainvoke({"query": "say hi"})
+
+            assert isinstance(result, str)
+            assert "Error" in result
+            assert "000000000000000000000000" in result
+            assert "Verify that the deployment exists" in result
+
+    async def test_client_is_failed_registry_client(
+        self, registry_config, mock_builder, failing_registry
+    ):
+        """self._client should be a _FailedRegistryClient, not a real A2A client."""
+        with (
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch(
+                f"{_MODULE}.get_default_registry",
+                new_callable=AsyncMock,
+                return_value=failing_registry,
+            ),
+        ):
+            mock_ctx.get.return_value.user_id = "test-user"
+            fg = AuthenticatedA2AClientFunctionGroup(config=registry_config, builder=mock_builder)
+            await fg.__aenter__()
+
+            assert isinstance(fg._client, _FailedRegistryClient)

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.74"
+version = "0.15.75"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1074,11 +1074,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-<<<<<<< mdambski/fix-resolution
 version = "0.15.76"
-=======
-version = "0.15.75"
->>>>>>> main
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.75"
+version = "0.15.76"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Failure-mode handling for registry lookups and error sanitization only; no changes to auth, RPC, or successful registry paths.
> 
> **Overview**
> When **central agent card registry** lookup fails, the authenticated A2A client no longer aborts function-group startup. **`AuthenticatedA2AClientFunctionGroup`** catches **`AgentCardRegistryError`**, installs a **`_FailedRegistryClient`** with a minimal placeholder **`AgentCard`**, still runs NAT **`_register_functions()`**, and defers failure to invocation time so **`_wrap_a2a_function`** can return a safe error string instead of a generic JSON-RPC crash.
> 
> **`_sanitize_a2a_error`** now passes through registry error text (IDs and guidance only), ahead of the generic **`RuntimeError`** sanitization path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22580cb8745e796ba839bbe19dccde2d7a8bedd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->