### PR TITLE
Pin for MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.76
+- Pin `starlette>=1.0.1` on the `drmcp` extra and use `request.scope["path"]` in MCP middleware to harden against CVE-2026-48710 (BadHost)
+
 ## 0.15.75
 - Upgrade to `nvidia-nat` 1.7.0, and pin `starlette>=1.0.1` to mitigate CVE-2026-48710
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.76
-- Pin `starlette>=1.0.1` on the `drmcp` extra and use `request.scope["path"]` in MCP middleware to harden against CVE-2026-48710 (BadHost)
+- Pinned `starlette>=1.0.1` on the `drmcp` extra and switched MCP middleware to `request.scope["path"]` to harden against CVE-2026-48710 (BadHost)
 
 ## 0.15.75
 - Upgrade to `nvidia-nat` 1.7.0, and pin `starlette>=1.0.1` to mitigate CVE-2026-48710

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.75"
+version = "0.15.76"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1261,6 +1261,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'nat'", specifier = ">=2.32.4,<3.0.0" },
     { name = "rich", marker = "extra == 'drmcp'", specifier = ">=13.0.0,<16.0.0" },
     { name = "starlette", marker = "extra == 'dragent'", specifier = ">=1.0.1" },
+    { name = "starlette", marker = "extra == 'drmcp'", specifier = ">=1.0.1" },
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.75"
+version = "0.15.76"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ nat = core + [
 dragent = nat + [
     # 'FastAPI' object has no attribute 'add_event_handler'
     # in fastapi_front_end_plugin_worker.py", line 328, in configure
-    "starlette>=1.0.1",  # CVE-2026-48710 fixed in 1.0.1
+    "starlette>=1.0.1",
 ]
 
 # Eventually NAT will be merged into dragent

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ nat = core + [
 dragent = nat + [
     # 'FastAPI' object has no attribute 'add_event_handler'
     # in fastapi_front_end_plugin_worker.py", line 328, in configure
-    "starlette>=1.0.1",
+    "starlette>=1.0.1",  # CVE-2026-48710 fixed in 1.0.1
 ]
 
 # Eventually NAT will be merged into dragent
@@ -127,6 +127,7 @@ drtools = auth + [
 
 # drmcp is standalone set of dependencies for MCP Server only (no core), only depends on drtools.
 drmcp = drtools + [
+    "starlette>=1.0.1",  # CVE-2026-48710 fixed in 1.0.1
     "fastmcp>=3.2.0,<4.0.0",
     "requests>=2.32.4,<3.0.0",
     "openai>=2.0.0,<3.0.0",

--- a/src/datarobot_genai/drmcp/core/clients.py
+++ b/src/datarobot_genai/drmcp/core/clients.py
@@ -43,8 +43,7 @@ class RequestHeadersMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         mcp_path = prefix_mount_path(MCP_PATH_ENDPOINT).rstrip("/") or "/"
-        # Use the ASGI request line and are not affected by Host-header poisoning attacks
-        path = request.scope["path"]
+        path = request.url.path
         if path == mcp_path or path.startswith(mcp_path + "/"):
             return await call_next(request)
         headers = {k.lower(): v for k, v in request.headers.items()}

--- a/src/datarobot_genai/drmcp/core/clients.py
+++ b/src/datarobot_genai/drmcp/core/clients.py
@@ -43,7 +43,7 @@ class RequestHeadersMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         mcp_path = prefix_mount_path(MCP_PATH_ENDPOINT).rstrip("/") or "/"
-        # path checks use the ASGI request line and are not affected by Host-header poisoning attacks
+        # Use the ASGI request line and are not affected by Host-header poisoning attacks
         path = request.scope["path"]
         if path == mcp_path or path.startswith(mcp_path + "/"):
             return await call_next(request)

--- a/src/datarobot_genai/drmcp/core/clients.py
+++ b/src/datarobot_genai/drmcp/core/clients.py
@@ -43,7 +43,8 @@ class RequestHeadersMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         mcp_path = prefix_mount_path(MCP_PATH_ENDPOINT).rstrip("/") or "/"
-        path = request.url.path
+        # path checks use the ASGI request line and are not affected by Host-header poisoning attacks
+        path = request.scope["path"]
         if path == mcp_path or path.startswith(mcp_path + "/"):
             return await call_next(request)
         headers = {k.lower(): v for k, v in request.headers.items()}

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.75"
+version = "0.15.76"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1187,6 +1187,7 @@ drmcp = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "rich" },
+    { name = "starlette" },
     { name = "tavily-python" },
 ]
 drtools = [
@@ -1491,6 +1492,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'nat'", specifier = ">=2.32.4,<3.0.0" },
     { name = "rich", marker = "extra == 'drmcp'", specifier = ">=13.0.0,<16.0.0" },
     { name = "starlette", marker = "extra == 'dragent'", specifier = ">=1.0.1" },
+    { name = "starlette", marker = "extra == 'drmcp'", specifier = ">=1.0.1" },
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- Pin `starlette>=1.0.1` on the `drmcp` extra and use `request.scope["path"]` in MCP middleware to harden against CVE-2026-48710 (BadHost)


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-focused HTTP middleware and dependency changes for the MCP server; limited scope but touches request routing and auth header context selection.
> 
> **Overview**
> Release **0.15.76** hardens the MCP stack against **CVE-2026-48710 (BadHost)**.
> 
> The **`drmcp`** install extra now requires **`starlette>=1.0.1`** (matching the existing **`dragent`** pin from 0.15.75). **`RequestHeadersMiddleware`** in `drmcp` no longer uses **`request.url.path`** for MCP vs custom-route branching; it uses **`request.scope["path"]`** so path decisions follow the ASGI request line and are not influenced by a poisoned **Host** header on affected Starlette versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 402d149ac1bba73f0331cc1bc95cb4ba641bcb4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->