### PR TITLE
[BUZZOK-30992] DataRobotModerationMiddleware is a no-op if no moderations configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.80
+- `nat/datarobot_moderation_middleware`: `DataRobotModerationMiddleware` is now a no-op when the `moderation` block is omitted or has no guards configured, so it can be listed unconditionally in `workflow.yaml` without requiring DataRobot credentials or emitting a warning. `load_llm_moderation_pipeline` returns `None` in those cases and skips `ModerationPipeline.from_config`.
+
 ## 0.15.79
 - Added `drmcpbase` subpackage and standalone extra `datarobot-genai[drmcpbase]` (`fastmcp` only, no core). The `drmcp` extra now composes `drmcpbase` + `drtools` + template-server dependencies. Documented both extras in `README.md`.
 - Import lint (`scripts/check_imports.py`): scans `drmcpbase`; `drmcp` may import `drtools`, `drmcp`, and `drmcpbase`; `drmcpbase` may only import `drmcpbase` (must not import `drtools`, `drmcp`, or `core`); `drtools` forbids `drmcpbase`.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.79"
+version = "0.15.80"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.79"
+version = "0.15.80"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -136,14 +136,27 @@ class DataRobotModerationConfig(
     )
 
 
+def moderation_config_has_guards(moderation: ModerationConfig) -> bool:
+    """Return whether ``moderation`` defines at least one guard across all targets."""
+    return any(target.guards for target in moderation.targets)
+
+
 def load_llm_moderation_pipeline(config: DataRobotModerationConfig) -> ModerationPipeline | None:
-    """Build an LLM moderation pipeline via ``ModerationPipeline.from_config``."""
+    """Build an LLM moderation pipeline via ``ModerationPipeline.from_config``.
+
+    Returns ``None`` when moderation is disabled, omitted, or has no guards configured so the
+    middleware is a no-op and can be listed unconditionally in ``workflow.yaml``.
+    """
     if get_runtime_parameter_value_bool(DISABLE_MODERATION_RUNTIME_PARAM_NAME, default_value=False):
         _logger.warning("Moderation is disabled via runtime parameter on the model")
         return None
 
     if config.moderation is None:
-        _logger.warning("Middleware has no ``moderation`` block; moderations will not be enforced")
+        _logger.debug("No ``moderation`` block configured; moderation middleware is a no-op")
+        return None
+
+    if not moderation_config_has_guards(config.moderation):
+        _logger.debug("Moderation config has no guards; moderation middleware is a no-op")
         return None
 
     model_dir = os.path.abspath(os.getcwd())

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -83,6 +83,7 @@ from datarobot_genai.nat.datarobot_moderation_middleware import _set_moderation_
 from datarobot_genai.nat.datarobot_moderation_middleware import _workflow_input_from_args
 from datarobot_genai.nat.datarobot_moderation_middleware import dome_chunk_to_dragent_event_response
 from datarobot_genai.nat.datarobot_moderation_middleware import load_llm_moderation_pipeline
+from datarobot_genai.nat.datarobot_moderation_middleware import moderation_config_has_guards
 from datarobot_genai.nat.datarobot_moderation_middleware import (
     moderation_prompt_from_workflow_input,
 )
@@ -363,6 +364,46 @@ async def test_pre_invoke_unrecognized_workflow_input_raises(builder_mock: Magic
         mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
         with pytest.raises(TypeError, match="Unsupported workflow input type for moderation"):
             await mw.pre_invoke(ctx)
+
+
+def test_moderation_config_has_guards() -> None:
+    assert moderation_config_has_guards(
+        ModerationConfig.model_validate(
+            {
+                "guards": [
+                    {
+                        "name": "Prompt Tokens",
+                        "description": "x",
+                        "ootb_type": "token_count",
+                        "stage": "prompt",
+                        "type": "ootb",
+                    }
+                ],
+            }
+        )
+    )
+    assert not moderation_config_has_guards(ModerationConfig.model_validate({"guards": []}))
+    assert not moderation_config_has_guards(ModerationConfig.model_validate({}))
+
+
+def test_load_llm_moderation_pipeline_no_guards_is_noop_without_credentials() -> None:
+    cfg = DataRobotModerationConfig(moderation=ModerationConfig.model_validate({"guards": []}))
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch(
+            "datarobot_genai.nat.datarobot_moderation_middleware.ModerationPipeline.from_config",
+        ) as from_config,
+    ):
+        assert load_llm_moderation_pipeline(cfg) is None
+    from_config.assert_not_called()
+
+
+def test_load_llm_moderation_pipeline_missing_moderation_block_is_noop() -> None:
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.ModerationPipeline.from_config",
+    ) as from_config:
+        assert load_llm_moderation_pipeline(DataRobotModerationConfig()) is None
+    from_config.assert_not_called()
 
 
 def test_load_llm_moderation_pipeline_from_config_moderation_field() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.79"
+version = "0.15.80"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Make moderations a no-op if there are no moderations configured so we can include it unconditionally in the `workflow.yaml` in the recipe when using dragent.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change only short-circuits pipeline creation when guards are absent; active moderation paths are unchanged.
> 
> **Overview**
> **DataRobot moderation middleware** now treats missing or empty guard configuration as a **no-op**: `load_llm_moderation_pipeline` returns `None` when there is no `moderation` block or when `moderation_config_has_guards` finds no guards on any target, so **`ModerationPipeline.from_config` is not invoked** (avoiding DataRobot credential requirements when nothing would run).
> 
> Logging for those cases moves from a warning to **debug**, and docs clarify the middleware can stay listed unconditionally in **`workflow.yaml`** in dragent recipes. Package version bumps to **0.15.79** with unit tests for the guard-detection helper and no-op load paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ced2f502dea599613ec85bf8e0d48cc98bb7903. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->