### PR TITLE
Add TTL option to mem0 endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.86
+- `nat/datarobot_mem0_memory`: added `default_ttl_seconds` to `dr_mem0_memory` config (defaults from the `AGENT_MEMORY_TTL_SECONDS` env var / DataRobot runtime parameter via `DataRobotAppFrameworkBaseSettings`). When set to a positive value, `DRMem0Editor.add_items` sends `expiration_date = today + ttl` (UTC, `YYYY-MM-DD`) to Mem0's `add` API so memories auto-expire on the platform's expiration sweep. A per-call `expiration_date` in `add_params` overrides the default; `None` / `0` leaves the field unset (no expiration), matching prior behavior.
+
 ## 0.15.85
 - Expanded the `e2e-dragent-llmgw` job in `.github/workflows/e2e.yml` to cover multiple model providers. Matrix is now loaded from a new `e2e-tests/llmgw_matrix.yaml` file (5 agents × 4 models). The `default` model (bedrock) runs the full `dragent_tests` suite; other models (gpt, sonnet, gemini) run `test_streaming.py` only as a fast cross-model smoke check. This pre-empts model-specific framework bugs (like the LlamaIndex `tool_choice` issue below) before they reach downstream consumers.
 - Tightened the planner/writer system prompts in `e2e-tests/dragent/{langgraph,crewai,llamaindex,nat}/` to reduce input tokens, output verbosity, and TTFT during e2e runs. Dropped the `make_system_prompt` boilerplate wrapper from test agents and shortened outputs to "1 bullet" + "1 short sentence". Test contracts (tool calls, HITL interrupt, multi-agent handoff) are preserved.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.82"
+version = "0.15.84"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.85"
+version = "0.15.86"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -36,9 +36,13 @@ import asyncio
 import logging
 import os
 from collections.abc import AsyncGenerator
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
 from typing import Any
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from datarobot.core.config import getenv
 from nat.builder.builder import Builder
 from nat.builder.context import Context
 from nat.cli.register_workflow import register_memory
@@ -64,6 +68,43 @@ class Config(DataRobotAppFrameworkBaseSettings):
 
 def _get_default_mem0_api_key() -> str | None:
     return Config().mem0_api_key
+
+
+def _get_default_ttl_seconds() -> int | None:
+    """Read ``AGENT_MEMORY_TTL_SECONDS`` from env or DR runtime parameters.
+
+    Uses ``datarobot.core.config.getenv`` (not ``os.getenv``) so the
+    DataRobot ``MLOPS_RUNTIME_PARAM_AGENT_MEMORY_TTL_SECONDS`` runtime
+    parameter set by ``infra/agent.py`` is honored when the agent runs
+    inside DRUM. The env-var name is fixed at ``AGENT_MEMORY_TTL_SECONDS``
+    to match the runtime parameter key — going through a
+    ``DataRobotAppFrameworkBaseSettings`` field would require the env-var
+    name to match the field name (uppercased), which doesn't fit the
+    "default" qualifier the recipe applies on its side.
+    """
+    raw = getenv("AGENT_MEMORY_TTL_SECONDS")
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "AGENT_MEMORY_TTL_SECONDS=%r is not an integer; treating as unset.",
+            raw,
+        )
+        return None
+
+
+def _ttl_to_expiration_date(ttl_seconds: int) -> str:
+    """Translate a TTL in seconds into Mem0's ``expiration_date`` format.
+
+    Mem0's REST ``add`` endpoint expects ``expiration_date`` as a
+    ``YYYY-MM-DD`` calendar date (not a timestamp); the platform's
+    expiration sweep deletes memories on or after that date. Sub-day TTLs
+    are rounded up to "today" by the calendar floor — callers needing
+    finer granularity should pass ``expiration_date`` explicitly.
+    """
+    return (datetime.now(UTC) + timedelta(seconds=ttl_seconds)).strftime("%Y-%m-%d")
 
 
 class _UserManagerShim:
@@ -142,14 +183,29 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
             "Defaults to the ``DATAROBOT_API_TOKEN`` env var."
         ),
     )
+    default_ttl_seconds: int | None = Field(
+        default_factory=_get_default_ttl_seconds,
+        ge=0,
+        description=(
+            "Default TTL in seconds for stored memories. When set to a "
+            "positive value, the editor passes "
+            "``expiration_date = today + default_ttl_seconds`` (UTC, "
+            "``YYYY-MM-DD``) through to Mem0's ``add`` API so memories "
+            "auto-expire. Callers may override per-call by passing "
+            "``expiration_date`` in ``add_params``. ``None`` or ``0`` "
+            "leaves the field unset (no expiration). Defaults from the "
+            "``AGENT_MEMORY_TTL_SECONDS`` env var."
+        ),
+    )
 
 
 class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
     """Adapt ``Mem0Client`` to NAT's ``MemoryEditor`` interface."""
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, default_ttl_seconds: int | None = None) -> None:
         self._client = client
         self._mem0 = client._memory
+        self._default_ttl_seconds = default_ttl_seconds
 
     async def add_items(self, items: list[MemoryItem], **kwargs: Any) -> None:
         add_kwargs = dict(kwargs)
@@ -158,6 +214,13 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         configured_tags = add_kwargs.pop("tags", None)
         configured_metadata = dict(add_kwargs.pop("metadata", None) or {})
         configured_user_id = add_kwargs.pop("user_id", None)
+
+        # Inject the configured TTL as Mem0's ``expiration_date`` only when
+        # the caller hasn't supplied one. Per-call overrides (e.g. via
+        # ``add_params: {expiration_date: ...}`` in workflow.yaml) win so
+        # special-case memories can opt out of or extend the default.
+        if "expiration_date" not in add_kwargs and self._default_ttl_seconds:
+            add_kwargs["expiration_date"] = _ttl_to_expiration_date(self._default_ttl_seconds)
 
         coroutines = []
         for item in items:
@@ -294,7 +357,10 @@ async def dr_mem0_memory_client(
             "or set memory_space_id to target the DataRobot mem0 endpoint."
         )
 
-    editor: MemoryEditor = DRMem0Editor(_create_mem0_client(config, api_key))
+    editor: MemoryEditor = DRMem0Editor(
+        _create_mem0_client(config, api_key),
+        default_ttl_seconds=config.default_ttl_seconds,
+    )
     if isinstance(config, RetryMixin):
         editor = patch_with_retry(
             editor,

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -42,7 +42,6 @@ from datetime import timedelta
 from typing import Any
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
-from datarobot.core.config import getenv
 from nat.builder.builder import Builder
 from nat.builder.context import Context
 from nat.cli.register_workflow import register_memory
@@ -64,6 +63,7 @@ class Config(DataRobotAppFrameworkBaseSettings):
     """
 
     mem0_api_key: str | None = None
+    agent_memory_ttl_seconds: int | None = None
 
 
 def _get_default_mem0_api_key() -> str | None:
@@ -71,28 +71,7 @@ def _get_default_mem0_api_key() -> str | None:
 
 
 def _get_default_ttl_seconds() -> int | None:
-    """Read ``AGENT_MEMORY_TTL_SECONDS`` from env or DR runtime parameters.
-
-    Uses ``datarobot.core.config.getenv`` (not ``os.getenv``) so the
-    DataRobot ``MLOPS_RUNTIME_PARAM_AGENT_MEMORY_TTL_SECONDS`` runtime
-    parameter set by ``infra/agent.py`` is honored when the agent runs
-    inside DRUM. The env-var name is fixed at ``AGENT_MEMORY_TTL_SECONDS``
-    to match the runtime parameter key — going through a
-    ``DataRobotAppFrameworkBaseSettings`` field would require the env-var
-    name to match the field name (uppercased), which doesn't fit the
-    "default" qualifier the recipe applies on its side.
-    """
-    raw = getenv("AGENT_MEMORY_TTL_SECONDS")
-    if not raw:
-        return None
-    try:
-        return int(raw)
-    except ValueError:
-        logger.warning(
-            "AGENT_MEMORY_TTL_SECONDS=%r is not an integer; treating as unset.",
-            raw,
-        )
-        return None
+    return Config().agent_memory_ttl_seconds
 
 
 def _ttl_to_expiration_date(ttl_seconds: int) -> str:
@@ -202,10 +181,10 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
 class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
     """Adapt ``Mem0Client`` to NAT's ``MemoryEditor`` interface."""
 
-    def __init__(self, client: Any, default_ttl_seconds: int | None = None) -> None:
+    def __init__(self, client: Any, ttl_seconds: int | None = None) -> None:
         self._client = client
         self._mem0 = client._memory
-        self._default_ttl_seconds = default_ttl_seconds
+        self._ttl_seconds = ttl_seconds
 
     async def add_items(self, items: list[MemoryItem], **kwargs: Any) -> None:
         add_kwargs = dict(kwargs)
@@ -219,8 +198,8 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         # the caller hasn't supplied one. Per-call overrides (e.g. via
         # ``add_params: {expiration_date: ...}`` in workflow.yaml) win so
         # special-case memories can opt out of or extend the default.
-        if "expiration_date" not in add_kwargs and self._default_ttl_seconds:
-            add_kwargs["expiration_date"] = _ttl_to_expiration_date(self._default_ttl_seconds)
+        if "expiration_date" not in add_kwargs and self._ttl_seconds:
+            add_kwargs["expiration_date"] = _ttl_to_expiration_date(self._ttl_seconds)
 
         coroutines = []
         for item in items:
@@ -359,7 +338,7 @@ async def dr_mem0_memory_client(
 
     editor: MemoryEditor = DRMem0Editor(
         _create_mem0_client(config, api_key),
-        default_ttl_seconds=config.default_ttl_seconds,
+        ttl_seconds=config.default_ttl_seconds,
     )
     if isinstance(config, RetryMixin):
         editor = patch_with_retry(

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC
 from typing import Any
 
 import pytest
@@ -148,6 +149,103 @@ async def test_add_items_item_user_id_beats_configured_user_id() -> None:
             },
         }
     ]
+
+
+async def test_add_items_injects_expiration_date_from_default_ttl() -> None:
+    # GIVEN an editor configured with a positive TTL (e.g. AGENT_MEMORY_TTL_SECONDS = 1 day).
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0), default_ttl_seconds=86_400)
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember Python"}],
+        user_id="session-user-123",
+    )
+
+    # WHEN the editor stores a memory.
+    from datetime import datetime
+    from datetime import timedelta
+
+    before = datetime.now(UTC)
+    await editor.add_items([item])
+    after = datetime.now(UTC)
+
+    # THEN the Mem0 call carries ``expiration_date = today + ttl`` as YYYY-MM-DD,
+    # so the platform's expiration sweep will delete the memory after that date.
+    valid_dates = {
+        (before + timedelta(seconds=86_400)).strftime("%Y-%m-%d"),
+        (after + timedelta(seconds=86_400)).strftime("%Y-%m-%d"),
+    }
+    assert mem0.add_calls[0]["kwargs"]["expiration_date"] in valid_dates
+
+
+async def test_add_items_omits_expiration_date_when_no_default_ttl() -> None:
+    # GIVEN an editor with no TTL configured (the default, backward-compatible path).
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember Python"}],
+        user_id="session-user-123",
+    )
+
+    # WHEN the editor stores a memory.
+    await editor.add_items([item])
+
+    # THEN no expiration_date is set — memories live forever, matching prior behavior.
+    assert "expiration_date" not in mem0.add_calls[0]["kwargs"]
+
+
+async def test_add_items_treats_ttl_zero_as_no_expiration() -> None:
+    # GIVEN an editor explicitly configured with ttl=0 (the "no expiration" opt-out).
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0), default_ttl_seconds=0)
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember Python"}],
+        user_id="session-user-123",
+    )
+
+    # WHEN the editor stores a memory.
+    await editor.add_items([item])
+
+    # THEN ``expiration_date`` is unset — 0 means "no TTL", not "expire immediately".
+    assert "expiration_date" not in mem0.add_calls[0]["kwargs"]
+
+
+async def test_add_items_caller_supplied_expiration_date_beats_default_ttl() -> None:
+    # GIVEN an editor with a configured TTL and a per-call expiration_date override.
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0), default_ttl_seconds=86_400)
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember Python"}],
+        user_id="session-user-123",
+    )
+
+    # WHEN the caller passes ``expiration_date`` explicitly (e.g. via
+    # ``add_params`` in workflow.yaml) for a memory that needs a longer life.
+    await editor.add_items([item], expiration_date="2099-12-31")
+
+    # THEN the explicit override wins so callers can keep special memories
+    # past the configured TTL.
+    assert mem0.add_calls[0]["kwargs"]["expiration_date"] == "2099-12-31"
+
+
+def test_ttl_to_expiration_date_returns_calendar_date() -> None:
+    # GIVEN a TTL in seconds.
+    # WHEN converted to mem0's expiration_date format.
+    from datetime import datetime
+    from datetime import timedelta
+
+    from datarobot_genai.nat.datarobot_mem0_memory import _ttl_to_expiration_date
+
+    before = datetime.now(UTC)
+    result = _ttl_to_expiration_date(7 * 86_400)
+    after = datetime.now(UTC)
+
+    # THEN the result is a YYYY-MM-DD string within +7 days of "now".
+    # Accept either bound to avoid flakiness when the test straddles UTC midnight.
+    valid_dates = {
+        (before + timedelta(days=7)).strftime("%Y-%m-%d"),
+        (after + timedelta(days=7)).strftime("%Y-%m-%d"),
+    }
+    assert result in valid_dates
 
 
 async def test_search_builds_mem0_v2_filters_with_session_user_id() -> None:
@@ -292,6 +390,26 @@ async def test_remove_items_without_memory_id_or_user_id_is_a_noop() -> None:
     assert mem0.delete_all_calls == []
 
 
+async def test_registered_memory_client_forwards_default_ttl_to_editor(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN a config with a configured default_ttl_seconds and a stubbed mem0
+    # client (the real one needs network access to validate the API key).
+    monkeypatch.setattr(
+        datarobot_mem0_memory, "_create_mem0_client", lambda *_a, **_k: FakeMem0Client()
+    )
+    monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
+
+    config = DRMem0MemoryClientConfig(api_key="secret-key", default_ttl_seconds=12_345)
+
+    # WHEN NAT builds the memory client.
+    async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
+        # THEN the editor stores the TTL so subsequent add_items calls inject
+        # expiration_date — without this hop the config value would be inert.
+        assert isinstance(editor, DRMem0Editor)
+        assert editor._default_ttl_seconds == 12_345
+
+
 async def test_registered_memory_client_uses_config_api_key_and_retry(monkeypatch: Any) -> None:
     # GIVEN a configured NAT memory provider with an explicit Mem0 API key.
     created_clients: list[dict[str, Any]] = []
@@ -345,6 +463,46 @@ def test_memory_client_config_uses_settings_mem0_api_key(monkeypatch: Any) -> No
     # THEN the api_key defaults from the settings config.
     assert Config().mem0_api_key == "settings-key"
     assert config.api_key == "settings-key"
+
+
+def test_memory_client_config_uses_settings_default_ttl(monkeypatch: Any) -> None:
+    # GIVEN AGENT_MEMORY_TTL_SECONDS is set in the env (e.g. by infra/agent.py's
+    # runtime parameter), exposing the recipe's configured retention to the
+    # NAT memory editor.
+    monkeypatch.setenv("AGENT_MEMORY_TTL_SECONDS", "604800")
+
+    # WHEN the NAT memory config is created without an explicit default_ttl_seconds.
+    config = DRMem0MemoryClientConfig(api_key="any")
+
+    # THEN the field defaults from the AGENT_MEMORY_TTL_SECONDS env var, so the
+    # recipe's runtime parameter automatically reaches mem0 via expiration_date.
+    assert config.default_ttl_seconds == 604800
+
+
+def test_memory_client_config_explicit_default_ttl_beats_env(monkeypatch: Any) -> None:
+    # GIVEN AGENT_MEMORY_TTL_SECONDS set in env but the workflow passing an
+    # explicit override (e.g. a per-deployment retention different from the
+    # global default).
+    monkeypatch.setenv("AGENT_MEMORY_TTL_SECONDS", "100")
+
+    # WHEN the config is constructed with an explicit value.
+    config = DRMem0MemoryClientConfig(api_key="any", default_ttl_seconds=42)
+
+    # THEN the explicit value wins (env is only the default).
+    assert config.default_ttl_seconds == 42
+
+
+def test_memory_client_config_default_ttl_is_none_without_env(monkeypatch: Any) -> None:
+    # GIVEN no AGENT_MEMORY_TTL_SECONDS env var (e.g. a deployment that
+    # opted out of TTL or never set the recipe's runtime parameter).
+    monkeypatch.delenv("AGENT_MEMORY_TTL_SECONDS", raising=False)
+
+    # WHEN the config is constructed without an explicit override.
+    config = DRMem0MemoryClientConfig(api_key="any")
+
+    # THEN default_ttl_seconds is None — memories never expire, matching the
+    # pre-TTL behavior so existing deployments don't silently change semantics.
+    assert config.default_ttl_seconds is None
 
 
 async def test_registered_memory_client_requires_api_key(monkeypatch: Any) -> None:

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -154,7 +154,7 @@ async def test_add_items_item_user_id_beats_configured_user_id() -> None:
 async def test_add_items_injects_expiration_date_from_default_ttl() -> None:
     # GIVEN an editor configured with a positive TTL (e.g. AGENT_MEMORY_TTL_SECONDS = 1 day).
     mem0 = FakeMem0Api()
-    editor = DRMem0Editor(FakeMem0Client(mem0), default_ttl_seconds=86_400)
+    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_seconds=86_400)
     item = MemoryItem(
         conversation=[{"role": "user", "content": "remember Python"}],
         user_id="session-user-123",
@@ -196,7 +196,7 @@ async def test_add_items_omits_expiration_date_when_no_default_ttl() -> None:
 async def test_add_items_treats_ttl_zero_as_no_expiration() -> None:
     # GIVEN an editor explicitly configured with ttl=0 (the "no expiration" opt-out).
     mem0 = FakeMem0Api()
-    editor = DRMem0Editor(FakeMem0Client(mem0), default_ttl_seconds=0)
+    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_seconds=0)
     item = MemoryItem(
         conversation=[{"role": "user", "content": "remember Python"}],
         user_id="session-user-123",
@@ -212,7 +212,7 @@ async def test_add_items_treats_ttl_zero_as_no_expiration() -> None:
 async def test_add_items_caller_supplied_expiration_date_beats_default_ttl() -> None:
     # GIVEN an editor with a configured TTL and a per-call expiration_date override.
     mem0 = FakeMem0Api()
-    editor = DRMem0Editor(FakeMem0Client(mem0), default_ttl_seconds=86_400)
+    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_seconds=86_400)
     item = MemoryItem(
         conversation=[{"role": "user", "content": "remember Python"}],
         user_id="session-user-123",
@@ -407,7 +407,7 @@ async def test_registered_memory_client_forwards_default_ttl_to_editor(
         # THEN the editor stores the TTL so subsequent add_items calls inject
         # expiration_date — without this hop the config value would be inert.
         assert isinstance(editor, DRMem0Editor)
-        assert editor._default_ttl_seconds == 12_345
+        assert editor._ttl_seconds == 12_345
 
 
 async def test_registered_memory_client_uses_config_api_key_and_retry(monkeypatch: Any) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.85"
+version = "0.15.86"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Update mem0 to delete a specific memory during request for a specific date.

usage in workflow:

`memory:`
`  _type: dr_mem0_memory`
 `  default_ttl_seconds: 86400`

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
