### PR TITLE
[MODEL-23408] Support bearer MCP OAuth context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.89
+- `drtools`: refresh DataRobot OAuth provider tokens with a request-scoped DataRobot PAT/API token when direct MCP clients call OAuth-backed tools, without treating Hydra JWTs as DataRobot API tokens.
+- `drtools`: classify missing OAuth provider authorizations as authentication errors instead of internal errors, while preserving header-token fallback.
+- `core/mcp`: merge `EXTERNAL_MCP_HEADERS` case-insensitively so explicit header overrides replace injected authorization headers.
+
 ## 0.15.87
 - `dragent/plugins/streaming_memory_agent`: registered via `register_per_user_function` (instead of `register_function`) so the wrapper builds lazily inside a `PerUserWorkflowBuilder` and `builder.get_function(inner_agent_name)` resolves per-user inner agents from the per-user cache (shared inner agents still resolve via fall-through). Switched the wrapper's I/O from NAT `ChatRequest` / `ChatResponseChunk` to AG-UI `RunAgentInput` and `DRAgentEventResponse`, so inner agents' native AG-UI events pass straight through without the intermediate `convert_chunks_to_agui_events` step. Added `stream_to_single_fn` so the function is also usable in non-streaming contexts.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.88"
+version = "0.15.89"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.87"
+version = "0.15.88"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/mcp/config.py
+++ b/src/datarobot_genai/core/mcp/config.py
@@ -159,10 +159,10 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
             }
 
         if self.external_mcp_url:
-            # External MCP URL - no authentication needed
-            headers = {}
-
-            # Merge external headers if provided
+            # external_mcp_url does not have a DataRobot gateway wrapper to add auth headers,
+            # so turn datarobot_api_token config into the outbound Authorization header here.
+            # Other external MCP headers remain explicit via EXTERNAL_MCP_HEADERS.
+            headers = self._authorization_bearer_header()
             if self.external_mcp_headers:
                 external_headers = json.loads(self.external_mcp_headers)
                 headers.update(external_headers)

--- a/src/datarobot_genai/core/mcp/config.py
+++ b/src/datarobot_genai/core/mcp/config.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any
 from typing import Literal
 
@@ -24,6 +25,21 @@ from pydantic import field_validator
 from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
 
 logger = logging.getLogger(__name__)
+
+
+def _merge_headers_case_insensitive(
+    headers: dict[str, Any],
+    overrides: Mapping[str, Any],
+) -> dict[str, Any]:
+    merged = dict(headers)
+    for key, value in overrides.items():
+        header = str(key)
+        for existing in list(merged):
+            if existing.lower() == header.lower():
+                del merged[existing]
+        merged[header] = value
+
+    return merged
 
 
 class MCPConfig(DataRobotAppFrameworkBaseSettings):
@@ -165,7 +181,9 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
             headers = self._authorization_bearer_header()
             if self.external_mcp_headers:
                 external_headers = json.loads(self.external_mcp_headers)
-                headers.update(external_headers)
+                # HTTP header names are case-insensitive, so explicit external headers
+                # must replace injected auth even when casing differs.
+                headers = _merge_headers_case_insensitive(headers, external_headers)
 
             logger.info(f"Using external MCP URL: {self.external_mcp_url}")
 

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -34,8 +34,8 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
-# Request-local DataRobot bearer for concurrent FastMCP tool calls. A module global
-# could leak one caller's PAT into another caller's OAuth refresh request; OAuthMiddleWare
+# Request-local DataRobot API bearer for concurrent FastMCP tool calls. A module global
+# could leak one caller's token into another caller's OAuth refresh request; OAuthMiddleWare
 # binds this at tool entry and resets it in finally after the call completes.
 _mcp_datarobot_bearer_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "mcp_datarobot_bearer_token", default=None
@@ -45,12 +45,12 @@ _mcp_datarobot_bearer_token: contextvars.ContextVar[str | None] = contextvars.Co
 def set_current_datarobot_bearer_token(
     token: str | None,
 ) -> contextvars.Token[str | None]:
-    """Bind the inbound PAT used for DataRobot OAuth refresh calls in this task."""
+    """Bind the inbound DataRobot API token used for OAuth refresh calls in this task."""
     return _mcp_datarobot_bearer_token.set(token)
 
 
 def reset_current_datarobot_bearer_token(token: contextvars.Token[str | None]) -> None:
-    """Clear/restore the task-local PAT so concurrent MCP calls do not share it."""
+    """Clear/restore the task-local API token so concurrent MCP calls do not share it."""
     _mcp_datarobot_bearer_token.reset(token)
 
 

--- a/src/datarobot_genai/core/utils/auth.py
+++ b/src/datarobot_genai/core/utils/auth.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextvars
 import logging
 import os
 import warnings
@@ -32,6 +33,30 @@ from datarobot.models.genai.agent.auth import get_authorization_context
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+# Request-local DataRobot bearer for concurrent FastMCP tool calls. A module global
+# could leak one caller's PAT into another caller's OAuth refresh request; OAuthMiddleWare
+# binds this at tool entry and resets it in finally after the call completes.
+_mcp_datarobot_bearer_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_datarobot_bearer_token", default=None
+)
+
+
+def set_current_datarobot_bearer_token(
+    token: str | None,
+) -> contextvars.Token[str | None]:
+    """Bind the inbound PAT used for DataRobot OAuth refresh calls in this task."""
+    return _mcp_datarobot_bearer_token.set(token)
+
+
+def reset_current_datarobot_bearer_token(token: contextvars.Token[str | None]) -> None:
+    """Clear/restore the task-local PAT so concurrent MCP calls do not share it."""
+    _mcp_datarobot_bearer_token.reset(token)
+
+
+def get_current_datarobot_bearer_token() -> str | None:
+    """Return the bound token, if any."""
+    return _mcp_datarobot_bearer_token.get()
 
 
 class AuthContextConfig(DataRobotAppFrameworkBaseSettings):
@@ -218,9 +243,6 @@ class TokenRetriever(Protocol):
 class DatarobotTokenRetriever:
     """Retrieves OAuth tokens using the DataRobot platform."""
 
-    def __init__(self) -> None:
-        self._client = DatarobotOAuthClient()
-
     def filter_identities(self, identities: Sequence[Identity]) -> list[Identity]:
         """Filter oauth2 identities to only those with provider_identity_id.
 
@@ -230,8 +252,21 @@ class DatarobotTokenRetriever:
         return [i for i in identities if i.type == "oauth2" and i.provider_identity_id]
 
     async def refresh_access_token(self, identity: Identity) -> OAuthToken:
-        """Refresh the access token using DataRobot's OAuth client."""
-        return await self._client.refresh_access_token(identity_id=identity.provider_identity_id)
+        """Refresh the access token using DataRobot's OAuth client.
+
+        The request bearer preserves per-user OAuth refresh for MCP calls; the deploy-time
+        ``DATAROBOT_API_TOKEN`` remains the fallback for non-HTTP jobs and local utilities.
+        """
+        # AuthCtx selects the OAuth provider authorization; this bearer authorizes
+        # the DataRobot refresh call for the current request.
+        token = get_current_datarobot_bearer_token() or os.environ.get("DATAROBOT_API_TOKEN")
+        if not token:
+            raise ValueError(
+                "Set DATAROBOT_API_TOKEN or invoke tools with a DataRobot bearer token "
+                "in request headers."
+            )
+        async with DatarobotOAuthClient(datarobot_api_token=token) as client:
+            return await client.refresh_access_token(identity_id=identity.provider_identity_id)
 
 
 class AuthlibTokenRetriever:

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -18,6 +18,8 @@ import logging
 from typing import Any
 
 from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
+from datarobot.auth.exceptions import OAuthProviderNotFound
+from datarobot.auth.exceptions import OAuthValidationErr
 from datarobot.auth.session import AuthCtx
 from datarobot.models.genai.agent.auth import ToolAuth
 
@@ -286,6 +288,14 @@ async def get_oauth_access_token_with_header_fallback(
             e,
             exc_info=True,
         )
+    except (OAuthProviderNotFound, OAuthValidationErr) as e:
+        oauth_exc = e
+        logger.info(
+            "OAuth provider authorization not available for %s (%s); checking header fallback.",
+            pt,
+            e,
+            exc_info=True,
+        )
     except RuntimeError as e:
         oauth_exc = e
         logger.info("No OAuth auth context for %s (%s); checking header fallback.", pt, e)
@@ -302,7 +312,7 @@ async def get_oauth_access_token_with_header_fallback(
         return header_token
 
     header = oauth_access_token_header_name(access_token_header_segment)
-    if isinstance(oauth_exc, OAuthServiceClientErr):
+    if isinstance(oauth_exc, (OAuthServiceClientErr, OAuthProviderNotFound, OAuthValidationErr)):
         logger.error("OAuth client error (no header fallback): %s", oauth_exc, exc_info=True)
         return ToolError(
             f"Could not obtain access token for {display_name}. Complete the OAuth flow or pass "

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -34,8 +34,8 @@ from datarobot_genai.drtools.core.constants import HEADER_TOKEN_CANDIDATE_NAMES
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
-# Try to import get_http_headers from FastMCP if available
-# The deplyment is expected to have the fastmcp dependency installed.
+# Try to import get_http_headers from FastMCP if available.
+# The deployment is expected to have the fastmcp dependency installed.
 # If not, you need to add your own implementation of get_http_headers.
 try:
     from fastmcp.server.dependencies import get_context
@@ -49,6 +49,9 @@ try:
     _get_context = get_context
 except ImportError:
     # FastMCP not available - create a stub that returns empty dict
+    class Middleware:  # type: ignore[no-redef]
+        pass
+
     def _get_http_headers(**kwargs: Any) -> dict[str, str]:
         return {}
 
@@ -114,7 +117,7 @@ class OAuthMiddleWare(Middleware):
         # authorizes the DataRobot refresh call. Bind it only for this tool call and
         # reset in finally so concurrent FastMCP calls cannot share bearer state.
         bearer = resolve_datarobot_api_token_from_headers()
-        bearer_ctx_token = set_current_datarobot_bearer_token(bearer)
+        bearer_ctx_token = set_current_datarobot_bearer_token(bearer) if bearer else None
         try:
             auth_context = self._extract_auth_context()
             if not auth_context:
@@ -126,7 +129,8 @@ class OAuthMiddleWare(Middleware):
 
             return await call_next(context)
         finally:
-            reset_current_datarobot_bearer_token(bearer_ctx_token)
+            if bearer_ctx_token is not None:
+                reset_current_datarobot_bearer_token(bearer_ctx_token)
 
     def _extract_auth_context(self) -> AuthCtx | None:
         """Extract and validate authentication context from request headers.

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -24,6 +24,8 @@ from datarobot.models.genai.agent.auth import ToolAuth
 from datarobot_genai.core.utils.auth import AsyncOAuthTokenProvider
 from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
 from datarobot_genai.core.utils.auth import DRAppCtx
+from datarobot_genai.core.utils.auth import reset_current_datarobot_bearer_token
+from datarobot_genai.core.utils.auth import set_current_datarobot_bearer_token
 from datarobot_genai.drtools.core.constants import AUTH_CTX_KEY
 from datarobot_genai.drtools.core.constants import HEADER_TOKEN_CANDIDATE_NAMES
 from datarobot_genai.drtools.core.exceptions import ToolError
@@ -94,15 +96,23 @@ class OAuthMiddleWare(Middleware):
         ToolResult
             The result from the tool execution.
         """
-        auth_context = self._extract_auth_context()
-        if not auth_context:
-            logger.debug("No valid authorization context extracted from request headers.")
+        # AuthCtx identifies the provider authorization, while this request bearer
+        # authorizes the DataRobot refresh call. Bind it only for this tool call and
+        # reset in finally so concurrent FastMCP calls cannot share bearer state.
+        bearer = resolve_token_from_headers()
+        bearer_ctx_token = set_current_datarobot_bearer_token(bearer)
+        try:
+            auth_context = self._extract_auth_context()
+            if not auth_context:
+                logger.debug("No valid authorization context extracted from request headers.")
 
-        if context.fastmcp_context is not None:
-            await context.fastmcp_context.set_state(AUTH_CTX_KEY, auth_context)
-            logger.debug("Authorization context attached to state.")
+            if context.fastmcp_context is not None:
+                await context.fastmcp_context.set_state(AUTH_CTX_KEY, auth_context)
+                logger.debug("Authorization context attached to state.")
 
-        return await call_next(context)
+            return await call_next(context)
+        finally:
+            reset_current_datarobot_bearer_token(bearer_ctx_token)
 
     def _extract_auth_context(self) -> AuthCtx | None:
         """Extract and validate authentication context from request headers.
@@ -435,10 +445,9 @@ def resolve_token_from_headers() -> str | None:
     """
     Resolve API token from request headers, trying both sources.
 
-    Order: try framework get_http_headers() first (preferred), then context
-    (set by RequestHeadersMiddleware). If both have headers, tries token extraction
-    from the first; if no token found, tries the second so the token is used
-    whichever source it came from.
+    Framework headers are preferred because FastMCP owns the active request context.
+    The RequestHeadersMiddleware context fallback keeps custom routes/tests working when
+    no FastMCP HTTP context is available.
     """
     framework_headers = None
     try:

--- a/src/datarobot_genai/drtools/core/auth.py
+++ b/src/datarobot_genai/drtools/core/auth.py
@@ -29,6 +29,7 @@ from datarobot_genai.core.utils.auth import DRAppCtx
 from datarobot_genai.core.utils.auth import reset_current_datarobot_bearer_token
 from datarobot_genai.core.utils.auth import set_current_datarobot_bearer_token
 from datarobot_genai.drtools.core.constants import AUTH_CTX_KEY
+from datarobot_genai.drtools.core.constants import DATAROBOT_API_TOKEN_HEADER_CANDIDATE_NAMES
 from datarobot_genai.drtools.core.constants import HEADER_TOKEN_CANDIDATE_NAMES
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
@@ -68,6 +69,17 @@ _request_headers_ctx: contextvars.ContextVar[dict[str, str] | None] = contextvar
 )
 
 
+def _resolve_framework_headers() -> dict[str, str] | None:
+    try:
+        return _get_http_headers()
+    except RuntimeError as exc:
+        logger.debug("No FastMCP HTTP context available for header resolution: %s", exc)
+        return None
+    except Exception:
+        logger.exception("Unexpected error resolving FastMCP HTTP headers.")
+        return None
+
+
 class OAuthMiddleWare(Middleware):
     """Middleware that parses `x-datarobot-authorization-context` for tool calls.
 
@@ -101,7 +113,7 @@ class OAuthMiddleWare(Middleware):
         # AuthCtx identifies the provider authorization, while this request bearer
         # authorizes the DataRobot refresh call. Bind it only for this tool call and
         # reset in finally so concurrent FastMCP calls cannot share bearer state.
-        bearer = resolve_token_from_headers()
+        bearer = resolve_datarobot_api_token_from_headers()
         bearer_ctx_token = set_current_datarobot_bearer_token(bearer)
         try:
             auth_context = self._extract_auth_context()
@@ -236,11 +248,7 @@ def resolve_oauth_access_token_from_headers(header_segment: str) -> str | None:
     """
     header_key = oauth_access_token_header_name(header_segment).lower()
 
-    framework_headers: dict[str, str] | None = None
-    try:
-        framework_headers = _get_http_headers()
-    except Exception:
-        pass
+    framework_headers = _resolve_framework_headers()
 
     if framework_headers:
         if token := _extract_oauth_fallback_token_from_headers(framework_headers, header_key):
@@ -360,18 +368,26 @@ def set_request_headers_for_context(headers: dict[str, str]) -> None:
     _request_headers_ctx.set(headers)
 
 
-def _extract_token_from_headers(headers: dict[str, str]) -> str | None:
+def _is_jwt_shaped_token(token: str) -> bool:
+    return token.count(".") == 2
+
+
+def _extract_token_from_candidate_headers(
+    headers: dict[str, str],
+    candidate_names: list[str],
+) -> str | None:
     """
-    Extract a Bearer token from headers by checking multiple header name candidates.
+    Extract a token from headers by checking multiple header name candidates.
 
     Args:
         headers: Dictionary of headers (keys should be lowercase)
+        candidate_names: Header names to check in preference order
 
     Returns
     -------
         The extracted token string, or None if not found
     """
-    for candidate_name in HEADER_TOKEN_CANDIDATE_NAMES:
+    for candidate_name in candidate_names:
         auth_header = headers.get(candidate_name)
         if not auth_header:
             continue
@@ -390,6 +406,38 @@ def _extract_token_from_headers(headers: dict[str, str]) -> str | None:
         if token:
             return token
 
+    return None
+
+
+def _extract_token_from_headers(headers: dict[str, str]) -> str | None:
+    """
+    Extract a Bearer token from headers by checking multiple header name candidates.
+
+    Args:
+        headers: Dictionary of headers (keys should be lowercase)
+
+    Returns
+    -------
+        The extracted token string, or None if not found
+    """
+    return _extract_token_from_candidate_headers(headers, HEADER_TOKEN_CANDIDATE_NAMES)
+
+
+def _extract_datarobot_api_token_from_headers(headers: dict[str, str]) -> str | None:
+    """Extract a DataRobot API token/PAT without treating Hydra JWTs as refresh tokens."""
+    if token := _extract_token_from_candidate_headers(
+        headers,
+        DATAROBOT_API_TOKEN_HEADER_CANDIDATE_NAMES,
+    ):
+        return token
+
+    auth_header = headers.get("authorization")
+    if not isinstance(auth_header, str):
+        return None
+
+    token = _parse_optional_bearer_token(auth_header)
+    if token and not _is_jwt_shaped_token(token):
+        return token
     return None
 
 
@@ -422,8 +470,8 @@ def _extract_token_from_auth_context(headers: dict[str, str]) -> str | None:
 
         return None
 
-    except Exception as e:
-        logger.debug(f"Failed to get token from auth context: {e}")
+    except Exception:
+        logger.warning("Failed to get token from auth context.", exc_info=True)
         return None
 
 
@@ -451,6 +499,19 @@ def _extract_token_from_headers_with_fallback(headers: dict[str, str]) -> str | 
     return None
 
 
+def _extract_datarobot_api_token_from_headers_with_fallback(
+    headers: dict[str, str],
+) -> str | None:
+    """Extract a DataRobot API token/PAT, then fall back to AuthCtx metadata."""
+    if token := _extract_datarobot_api_token_from_headers(headers):
+        return token
+
+    if token := _extract_token_from_auth_context(headers):
+        return token
+
+    return None
+
+
 def resolve_token_from_headers() -> str | None:
     """
     Resolve API token from request headers, trying both sources.
@@ -459,11 +520,7 @@ def resolve_token_from_headers() -> str | None:
     The RequestHeadersMiddleware context fallback keeps custom routes/tests working when
     no FastMCP HTTP context is available.
     """
-    framework_headers = None
-    try:
-        framework_headers = _get_http_headers()
-    except Exception:
-        pass  # No HTTP context (e.g. stdio transport)
+    framework_headers = _resolve_framework_headers()
 
     request_headers_ctx = _request_headers_ctx.get()
 
@@ -472,6 +529,28 @@ def resolve_token_from_headers() -> str | None:
     )
     if not token and request_headers_ctx:
         token = _extract_token_from_headers_with_fallback(request_headers_ctx)
+    return token
+
+
+def resolve_datarobot_api_token_from_headers() -> str | None:
+    """
+    Resolve a DataRobot API token/PAT for SDK calls and OAuth refresh.
+
+    A Hydra JWT in the standard Authorization header authenticates the inbound MCP
+    request but cannot refresh provider OAuth tokens through the DataRobot API. Explicit
+    DataRobot API token headers and AuthCtx metadata remain valid refresh-token sources.
+    """
+    framework_headers = _resolve_framework_headers()
+
+    request_headers_ctx = _request_headers_ctx.get()
+
+    token = (
+        _extract_datarobot_api_token_from_headers_with_fallback(framework_headers)
+        if framework_headers
+        else None
+    )
+    if not token and request_headers_ctx:
+        token = _extract_datarobot_api_token_from_headers_with_fallback(request_headers_ctx)
     return token
 
 

--- a/src/datarobot_genai/drtools/core/constants.py
+++ b/src/datarobot_genai/drtools/core/constants.py
@@ -19,10 +19,15 @@ MAX_INLINE_SIZE = 1024 * 1024  # 1MB
 
 AUTH_CTX_KEY = "authorization_context"
 
-# Header names to check for authorization tokens (in order of preference)
-HEADER_TOKEN_CANDIDATE_NAMES = [
+# Headers that explicitly carry a DataRobot API token/PAT for SDK and OAuth refresh calls.
+DATAROBOT_API_TOKEN_HEADER_CANDIDATE_NAMES = [
     "x-datarobot-authorization",
     "x-datarobot-api-key",
     "x-datarobot-api-token",
+]
+
+# Generic token resolution preserves historical behavior for callers that need any bearer.
+HEADER_TOKEN_CANDIDATE_NAMES = [
+    *DATAROBOT_API_TOKEN_HEADER_CANDIDATE_NAMES,
     "authorization",
 ]

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -60,7 +60,9 @@ class TestMCPConfig:
             assert config.external_mcp_url == test_url
             assert config.server_config is not None
             assert config.server_config["url"] == test_url
-            assert config.server_config["headers"] == {}
+            assert config.server_config["headers"] == {
+                "Authorization": "Bearer dummy-token",
+            }
             assert config.server_config["transport"] == "streamable-http"
 
     def test_mcp_config_with_datarobot_deployment_id(self, agent_auth_context_data):
@@ -237,9 +239,11 @@ class TestMCPConfig:
             config = MCPConfig()
             # Invalid JSON should result in None for external_mcp_headers
             assert config.external_mcp_headers is None
-            # Server config should still work, just without the invalid headers
+            # Server config should still work; Bearer from DATAROBOT_API_TOKEN is sent
             assert config.server_config is not None
-            assert config.server_config["headers"] == {}
+            assert config.server_config["headers"] == {
+                "Authorization": "Bearer dummy-token",
+            }
 
     def test_mcp_config_with_external_transport(self):
         test_url = "https://mcp-server.example.com/mcp"
@@ -339,7 +343,10 @@ class TestMCPConfig:
         ):
             config = MCPConfig()
             assert config.external_mcp_headers == raw.strip()
-            assert config.server_config["headers"] == {"X-Test": "value"}
+            assert config.server_config["headers"] == {
+                "Authorization": "Bearer dummy-token",
+                "X-Test": "value",
+            }
 
     def test_mcp_deployment_id_validation_errors(self):
         """Invalid deployment IDs should return None and log warning, not raise error."""

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -348,6 +348,23 @@ class TestMCPConfig:
                 "X-Test": "value",
             }
 
+    def test_external_mcp_headers_override_authorization_case_insensitively(self):
+        """Lowercase authorization in external headers should replace injected Authorization."""
+        with patch.dict(
+            os.environ,
+            {
+                "EXTERNAL_MCP_URL": "https://mcp-server.example.com/mcp",
+                "EXTERNAL_MCP_HEADERS": json.dumps({"authorization": "Bearer external-token"}),
+                "DATAROBOT_ENDPOINT": "https://app.datarobot.example/api/v2",
+                "DATAROBOT_API_TOKEN": "dummy-token",
+            },
+            clear=True,
+        ):
+            config = MCPConfig()
+            assert config.server_config["headers"] == {
+                "authorization": "Bearer external-token",
+            }
+
     def test_mcp_deployment_id_validation_errors(self):
         """Invalid deployment IDs should return None and log warning, not raise error."""
         # Invalid length / characters

--- a/tests/core/utils/test_auth.py
+++ b/tests/core/utils/test_auth.py
@@ -889,6 +889,28 @@ class TestOAuthMiddlewareBearerContext:
         assert observed["during"] == "pat-token"
         assert get_current_datarobot_bearer_token() is None
 
+    @pytest.mark.asyncio
+    async def test_on_call_tool_does_not_bind_jwt_authorization_as_api_token(self) -> None:
+        """GIVEN a Hydra JWT bearer WHEN a tool runs THEN do not bind it as API token."""
+        middleware = OAuthMiddleWare(
+            auth_handler=AuthContextHeaderHandler(secret_key="test-secret-key")
+        )
+        middleware_context = MagicMock()
+        middleware_context.fastmcp_context = MagicMock()
+        middleware_context.fastmcp_context.set_state = AsyncMock()
+        observed: dict[str, str | None] = {}
+
+        async def call_next(context: Any) -> ToolResult:
+            observed["during"] = get_current_datarobot_bearer_token()
+            return ToolResult(structured_content={"ok": True})
+
+        headers = {"authorization": "Bearer header.payload.signature"}
+        with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value=headers):
+            await middleware.on_call_tool(middleware_context, call_next)
+
+        assert observed["during"] is None
+        assert get_current_datarobot_bearer_token() is None
+
 
 class TestAuthlibTokenRetriever:
     """Tests for AuthlibTokenRetriever class."""

--- a/tests/core/utils/test_auth.py
+++ b/tests/core/utils/test_auth.py
@@ -30,7 +30,6 @@ from datarobot.auth.session import AuthCtx
 from datarobot.auth.users import User
 from datarobot.models.genai.agent.auth import ToolAuth
 from datarobot.models.genai.agent.auth import set_authorization_context
-from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.core.utils.auth import AsyncOAuthTokenProvider
 from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
@@ -877,7 +876,7 @@ class TestOAuthMiddlewareBearerContext:
         middleware_context.fastmcp_context.set_state = AsyncMock()
         observed: dict[str, str | None] = {}
 
-        async def failing_call_next(context: Any) -> ToolResult:
+        async def failing_call_next(context: Any) -> dict[str, bool]:
             observed["during"] = get_current_datarobot_bearer_token()
             raise RuntimeError("tool failed")
 
@@ -900,9 +899,9 @@ class TestOAuthMiddlewareBearerContext:
         middleware_context.fastmcp_context.set_state = AsyncMock()
         observed: dict[str, str | None] = {}
 
-        async def call_next(context: Any) -> ToolResult:
+        async def call_next(context: Any) -> dict[str, bool]:
             observed["during"] = get_current_datarobot_bearer_token()
-            return ToolResult(structured_content={"ok": True})
+            return {"ok": True}
 
         headers = {"authorization": "Bearer header.payload.signature"}
         with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value=headers):
@@ -910,6 +909,29 @@ class TestOAuthMiddlewareBearerContext:
 
         assert observed["during"] is None
         assert get_current_datarobot_bearer_token() is None
+
+    @pytest.mark.asyncio
+    async def test_on_call_tool_preserves_existing_bearer_when_no_api_token(self) -> None:
+        """GIVEN an outer bearer binding WHEN no API token resolves THEN preserve it."""
+        middleware = OAuthMiddleWare(
+            auth_handler=AuthContextHeaderHandler(secret_key="test-secret-key")
+        )
+        middleware_context = MagicMock()
+        middleware_context.fastmcp_context = MagicMock()
+        middleware_context.fastmcp_context.set_state = AsyncMock()
+        observed: dict[str, str | None] = {}
+        set_current_datarobot_bearer_token("outer-pat")
+
+        async def call_next(context: Any) -> dict[str, bool]:
+            observed["during"] = get_current_datarobot_bearer_token()
+            return {"ok": True}
+
+        headers = {"authorization": "Bearer header.payload.signature"}
+        with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value=headers):
+            await middleware.on_call_tool(middleware_context, call_next)
+
+        assert observed["during"] == "outer-pat"
+        assert get_current_datarobot_bearer_token() == "outer-pat"
 
 
 class TestAuthlibTokenRetriever:

--- a/tests/core/utils/test_auth.py
+++ b/tests/core/utils/test_auth.py
@@ -16,6 +16,7 @@ import os
 import random
 from typing import Any
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import aiohttp
@@ -29,6 +30,7 @@ from datarobot.auth.session import AuthCtx
 from datarobot.auth.users import User
 from datarobot.models.genai.agent.auth import ToolAuth
 from datarobot.models.genai.agent.auth import set_authorization_context
+from fastmcp.tools.tool import ToolResult
 
 from datarobot_genai.core.utils.auth import AsyncOAuthTokenProvider
 from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
@@ -36,6 +38,9 @@ from datarobot_genai.core.utils.auth import AuthlibTokenRetriever
 from datarobot_genai.core.utils.auth import DatarobotTokenRetriever
 from datarobot_genai.core.utils.auth import OAuthConfig
 from datarobot_genai.core.utils.auth import create_token_retriever
+from datarobot_genai.core.utils.auth import get_current_datarobot_bearer_token
+from datarobot_genai.core.utils.auth import set_current_datarobot_bearer_token
+from datarobot_genai.drtools.core.auth import OAuthMiddleWare
 
 
 @pytest.fixture
@@ -372,9 +377,14 @@ class TestAuthContextHeaderHandlerRoundtrip:
 
 
 @pytest.fixture
-def mock_datarobot_client():
+def mock_datarobot_client(monkeypatch: pytest.MonkeyPatch):
     # mock dr client, to avoid external calls
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "unit-test-token")
     with patch("datarobot_genai.core.utils.auth.DatarobotOAuthClient") as m:
+        instance = MagicMock()
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        m.return_value = instance
         yield m
 
 
@@ -787,6 +797,99 @@ class TestCreateTokenRetriever:
             create_token_retriever(config)
 
 
+class TestDatarobotTokenRetriever:
+    """Tests for DataRobot OAuth provider token refresh."""
+
+    @pytest.fixture(autouse=True)
+    def reset_bearer_context(self):
+        set_current_datarobot_bearer_token(None)
+        yield
+        set_current_datarobot_bearer_token(None)
+
+    @pytest.mark.asyncio
+    async def test_refresh_access_token_uses_contextvar_bearer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GIVEN an inbound MCP bearer WHEN refreshing THEN use that bearer."""
+        monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+        set_current_datarobot_bearer_token("pat-X")
+        identity = Identity(
+            id="identity-1",
+            provider_type="google",
+            type="oauth2",
+            provider_user_id="user@example.com",
+            provider_identity_id="authz-1",
+        )
+        token_data = MagicMock()
+        token_data.access_token = "google-token"
+
+        with patch("datarobot_genai.core.utils.auth.DatarobotOAuthClient") as client_cls:
+            client = MagicMock()
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            client.refresh_access_token = AsyncMock(return_value=token_data)
+            client_cls.return_value = client
+
+            token = await DatarobotTokenRetriever().refresh_access_token(identity)
+
+        assert token is token_data
+        client_cls.assert_called_once_with(datarobot_api_token="pat-X")
+        client.refresh_access_token.assert_awaited_once_with(identity_id="authz-1")
+
+    @pytest.mark.asyncio
+    async def test_refresh_access_token_raises_without_contextvar_or_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GIVEN no bearer or env token WHEN refreshing THEN fail explicitly."""
+        monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+        identity = Identity(
+            id="identity-1",
+            provider_type="google",
+            type="oauth2",
+            provider_user_id="user@example.com",
+            provider_identity_id="authz-1",
+        )
+
+        with patch("datarobot_genai.core.utils.auth.DatarobotOAuthClient") as client_cls:
+            with pytest.raises(ValueError, match="Set DATAROBOT_API_TOKEN"):
+                await DatarobotTokenRetriever().refresh_access_token(identity)
+
+        client_cls.assert_not_called()
+
+
+class TestOAuthMiddlewareBearerContext:
+    """Tests for request-scoped MCP bearer binding."""
+
+    @pytest.fixture(autouse=True)
+    def reset_bearer_context(self):
+        set_current_datarobot_bearer_token(None)
+        yield
+        set_current_datarobot_bearer_token(None)
+
+    @pytest.mark.asyncio
+    async def test_on_call_tool_clears_bearer_context_when_tool_raises(self) -> None:
+        """GIVEN an inbound bearer WHEN a tool fails THEN clear the scoped bearer."""
+        middleware = OAuthMiddleWare(
+            auth_handler=AuthContextHeaderHandler(secret_key="test-secret-key")
+        )
+        middleware_context = MagicMock()
+        middleware_context.fastmcp_context = MagicMock()
+        middleware_context.fastmcp_context.set_state = AsyncMock()
+        observed: dict[str, str | None] = {}
+
+        async def failing_call_next(context: Any) -> ToolResult:
+            observed["during"] = get_current_datarobot_bearer_token()
+            raise RuntimeError("tool failed")
+
+        headers = {"authorization": "Bearer pat-token"}
+        with patch("datarobot_genai.drtools.core.auth._get_http_headers", return_value=headers):
+            with pytest.raises(RuntimeError, match="tool failed"):
+                await middleware.on_call_tool(middleware_context, failing_call_next)
+
+        assert observed["during"] == "pat-token"
+        assert get_current_datarobot_bearer_token() is None
+
+
 class TestAuthlibTokenRetriever:
     """Tests for AuthlibTokenRetriever class."""
 
@@ -832,7 +935,7 @@ class TestAuthlibTokenRetriever:
             patch("aiohttp.ClientSession.post") as mock_post,
         ):
             mock_response = AsyncMock()
-            mock_response.raise_for_status = AsyncMock()
+            mock_response.raise_for_status = MagicMock()
             mock_response.json = AsyncMock(return_value=mock_response_data)
             mock_post.return_value.__aenter__.return_value = mock_response
 

--- a/tests/drmcp/unit/test_core_clients.py
+++ b/tests/drmcp/unit/test_core_clients.py
@@ -28,9 +28,15 @@ from datarobot_genai.drmcp.core.clients import (
     setup_and_return_dr_api_client_with_static_config_in_container,
 )
 from datarobot_genai.drmcp.core.routes_utils import prefix_mount_path
+from datarobot_genai.drtools.core.auth import _extract_datarobot_api_token_from_headers
+from datarobot_genai.drtools.core.auth import (
+    _extract_datarobot_api_token_from_headers_with_fallback,
+)
 from datarobot_genai.drtools.core.auth import _extract_token_from_auth_context
 from datarobot_genai.drtools.core.auth import _extract_token_from_headers
 from datarobot_genai.drtools.core.auth import _extract_token_from_headers_with_fallback
+from datarobot_genai.drtools.core.auth import resolve_datarobot_api_token_from_headers
+from datarobot_genai.drtools.core.auth import set_request_headers_for_context
 
 
 @pytest.fixture
@@ -280,6 +286,60 @@ class TestExtractTokenFromHeaders:
         }
         result = _extract_token_from_headers(headers)
         assert result == "user-api-key"
+
+
+class TestExtractDatarobotApiTokenFromHeaders:
+    """Test cases for DataRobot API-token extraction used by OAuth refresh."""
+
+    def test_extracts_non_jwt_authorization_bearer(self):
+        """GIVEN a non-JWT Authorization bearer WHEN extracting THEN return it."""
+        headers = {"authorization": "Bearer pat-token-123"}
+        result = _extract_datarobot_api_token_from_headers(headers)
+        assert result == "pat-token-123"
+
+    def test_skips_jwt_shaped_authorization_bearer(self):
+        """GIVEN a JWT-shaped Authorization bearer WHEN extracting THEN skip it."""
+        headers = {"authorization": "Bearer header.payload.signature"}
+        result = _extract_datarobot_api_token_from_headers(headers)
+        assert result is None
+
+    def test_explicit_api_token_header_can_be_jwt_shaped(self):
+        """GIVEN an explicit API token header WHEN extracting THEN return it as-is."""
+        headers = {"x-datarobot-api-token": "Bearer pat.with.dots"}
+        result = _extract_datarobot_api_token_from_headers(headers)
+        assert result == "pat.with.dots"
+
+    @patch("datarobot_genai.drtools.core.auth.AuthContextHeaderHandler")
+    def test_falls_back_to_auth_context_metadata(self, mock_handler_class):
+        """GIVEN no API token header WHEN AuthCtx metadata has api_key THEN return it."""
+        auth_ctx = AuthCtx(
+            user=User(id="test-user-123", email="test.user@example.com"),
+            identities=[],
+            metadata={"dr_ctx": {"api_key": "metadata-api-key"}},
+        )
+        mock_handler = Mock()
+        mock_handler.get_context.return_value = auth_ctx
+        mock_handler_class.return_value = mock_handler
+
+        result = _extract_datarobot_api_token_from_headers_with_fallback(
+            {"x-datarobot-authorization-context": "jwt-token"}
+        )
+
+        assert result == "metadata-api-key"
+
+    def test_resolve_uses_context_headers_when_framework_has_jwt_authorization(self):
+        """GIVEN framework JWT and ctx API token WHEN resolving THEN use ctx API token."""
+        set_request_headers_for_context({"x-datarobot-api-token": "ctx-api-token"})
+        try:
+            with patch(
+                "datarobot_genai.drtools.core.auth._get_http_headers",
+                return_value={"authorization": "Bearer header.payload.signature"},
+            ):
+                result = resolve_datarobot_api_token_from_headers()
+        finally:
+            set_request_headers_for_context({})
+
+        assert result == "ctx-api-token"
 
 
 class TestExtractTokenFromAuthContext:

--- a/tests/drmcp/unit/test_oauth_access_token_header_fallback.py
+++ b/tests/drmcp/unit/test_oauth_access_token_header_fallback.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
+from datarobot.auth.exceptions import OAuthValidationErr
 
 from datarobot_genai.drtools.core.auth import get_oauth_access_token_with_header_fallback
 from datarobot_genai.drtools.core.auth import oauth_access_token_header_name
@@ -207,3 +208,20 @@ class TestGetOauthAccessTokenWithHeaderFallback:
             )
         assert isinstance(out, ToolError)
         assert out.kind == ToolErrorKind.INTERNAL
+
+    @pytest.mark.asyncio
+    async def test_tool_error_authentication_on_oauth_validation_error(self) -> None:
+        with patch(
+            "datarobot_genai.drtools.core.auth.get_access_token",
+            new_callable=AsyncMock,
+            side_effect=OAuthValidationErr("No identity found for provider 'google'."),
+        ):
+            out = await get_oauth_access_token_with_header_fallback(
+                "google",
+                display_name="Google",
+                access_token_header_segment="google-drive",
+            )
+
+        assert isinstance(out, ToolError)
+        assert out.kind == ToolErrorKind.AUTHENTICATION
+        assert "x-datarobot-google-drive-access-token" in str(out)

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.88"
+version = "0.15.89"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.87"
+version = "0.15.88"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

Direct streamable HTTP MCP clients can authenticate to an external MCP server with a DataRobot bearer token, but datarobot-genai owns two important pieces of that flow:

- `MCPConfig(external_mcp_url=...)` builds client-side connections to external MCP servers.
- datarobot-genai drtools own the OAuth provider token refresh path used by tools such as Google Drive.

Global-mcp can resolve the DataRobot user and synthesize an `AuthCtx`, but a GDrive tool later calls `get_access_token("google")` inside datarobot-genai. That refresh must use the current request's DataRobot PAT/API-token, not an arbitrary bearer and not a process-global deploy-time token unless there is no request bearer available.

This PR separates generic bearer resolution from DataRobot PAT/API-token resolution and keeps the refresh token request-scoped for concurrent FastMCP tool calls.

# FLOW

1. A bearer-only MCP client calls an external MCP server such as global-mcp with `Authorization: Bearer <DataRobot PAT>`.
2. Global-mcp validates the bearer, resolves the user, lists authorized OAuth providers, and synthesizes an `AuthCtx` with the selected provider identity.
3. A GDrive drtool asks datarobot-genai for a Google provider token.
4. `OAuthMiddleWare` binds only a DataRobot PAT/API-token source for the lifetime of that FastMCP tool call.
5. `DatarobotTokenRetriever.refresh_access_token()` uses the request-scoped DataRobot bearer when constructing `DatarobotOAuthClient(...)`.
6. Google Drive receives the refreshed Google OAuth access token, not the DataRobot PAT.

# CHANGES

- Forward `Authorization: Bearer <DATAROBOT_API_TOKEN>` for `external_mcp_url` configs when an API token is configured.
- Split generic token header candidates from DataRobot API-token/PAT candidates.
- Add `resolve_datarobot_api_token_from_headers()` for SDK/OAuth refresh paths where Hydra JWTs must not be treated as PATs.
- Preserve generic `resolve_token_from_headers()` behavior for legacy callers that need any bearer.
- Bind only DataRobot API-token/PAT sources in `OAuthMiddleWare`; generic `Authorization` is accepted only when it is not JWT-shaped.
- Keep explicit DataRobot API-token headers authoritative, including JWT-shaped PAT values.
- Use request-local DataRobot bearer context in `DatarobotTokenRetriever.refresh_access_token()`, falling back to `DATAROBOT_API_TOKEN` only outside request-scoped contexts.
- Replace silent/no-op exception handling in the touched auth paths with logged warnings/errors and explicit fallbacks.
- Add focused unit coverage for JWT-shaped Authorization filtering, explicit API-token headers, AuthCtx metadata fallback, request-scoped bearer reset, and refresh via request PAT.
- Bump the package version to `0.15.89`.

# TESTING

Latest local validation after the final review pass:

- `uv run ruff check src/datarobot_genai/core/mcp/config.py src/datarobot_genai/core/utils/auth.py src/datarobot_genai/drtools/core/auth.py src/datarobot_genai/drtools/core/constants.py tests/core/mcp/test_common.py tests/core/utils/test_auth.py tests/drmcp/unit/test_core_clients.py tests/drmcp/unit/test_oauth_access_token_header_fallback.py` -> passed
- `uv run mypy src/datarobot_genai/core/mcp/config.py src/datarobot_genai/core/utils/auth.py src/datarobot_genai/drtools/core/auth.py src/datarobot_genai/drtools/core/constants.py` -> passed
- `uv run pytest tests/core/mcp/test_common.py tests/core/utils/test_auth.py tests/drmcp/unit/test_core_clients.py tests/drmcp/unit/test_oauth_access_token_header_fallback.py tests/drmcp/unit/test_auth.py -q` -> `198 passed, 30 warnings`
- `git diff --check src/datarobot_genai/core/mcp/config.py src/datarobot_genai/core/utils/auth.py src/datarobot_genai/drtools/core/auth.py src/datarobot_genai/drtools/core/constants.py tests/core/mcp/test_common.py tests/core/utils/test_auth.py tests/drmcp/unit/test_core_clients.py tests/drmcp/unit/test_oauth_access_token_header_fallback.py pyproject.toml uv.lock` -> passed

Curl validation through local global-mcp using this datarobot-genai checkout on `PYTHONPATH`:

- Server started with `DATAROBOT_API_TOKEN` intentionally empty so `DatarobotOAuthClient(...).refresh_access_token()` could only use the request-scoped PAT.
- `POST /mcp initialize` with `Authorization: Bearer <PAT>` -> HTTP `200`, server `global-mcp`, protocol `2024-11-05`.
- `tools/list` -> HTTP `200`, `42` tools, including `gdrive_find_contents` and `gdrive_read_content`.
- `tools/call gdrive_find_contents` with only the request PAT -> HTTP `200`, `isError=false`, returned 2 Google Drive files.
- Server logs showed `/account/info/` `200`, `/externalOAuth/authorizedProviders/` `200`, DataRobot OAuth provider token refresh `201`, then Google Drive files API `200`.

Notes: tests emit expected short JWT test-key warnings.

# RELATED

- MODEL-23408
- global-mcp PR: https://github.com/datarobot/global-mcp/pull/160
