### PR TITLE
Upgrade actions to 0.0.9 with improved slack notifications and better security

### DIFF
--- a/.github/workflows/workflow-pr-automation.yaml
+++ b/.github/workflows/workflow-pr-automation.yaml
@@ -15,7 +15,7 @@ jobs:
   # knows it has passed code review and is ready for the next step.
   mark-reviewed:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.8
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.9
     with:
       pr_number: ${{ github.event.pull_request.number }}
     permissions:
@@ -26,7 +26,7 @@ jobs:
   # so reviewers are alerted that the PR is ready for their attention.
   notify-ready-for-review:
     if: github.event_name == 'pull_request' && contains(github.event.label.name, 'ready for review')
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.8
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.9
     with:
       pr_number: ${{ github.event.pull_request.number }}
       pr_url: ${{ github.event.pull_request.html_url }}
@@ -45,7 +45,7 @@ jobs:
   # to the corresponding Jira issue in the PR description or as a comment.
   add-jira-link:
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'edited')
-    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.8
+    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.9
     with:
       pr_title: ${{ github.event.pull_request.title }}
       pr_number: ${{ github.event.pull_request.number }}
@@ -58,9 +58,10 @@ jobs:
   # that are still open and may need attention.
   notify-slack-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.8
+    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.9
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     permissions:
       contents: read
       pull-requests: read
+      checks: read

--- a/.github/workflows/workflow-pr-automation.yaml
+++ b/.github/workflows/workflow-pr-automation.yaml
@@ -15,7 +15,7 @@ jobs:
   # knows it has passed code review and is ready for the next step.
   mark-reviewed:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.5
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.8
     with:
       pr_number: ${{ github.event.pull_request.number }}
 
@@ -24,7 +24,7 @@ jobs:
   # so reviewers are alerted that the PR is ready for their attention.
   notify-ready-for-review:
     if: github.event_name == 'pull_request' && contains(github.event.label.name, 'ready for review')
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.5
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.8
     with:
       pr_number: ${{ github.event.pull_request.number }}
       pr_url: ${{ github.event.pull_request.html_url }}
@@ -41,7 +41,7 @@ jobs:
   # to the corresponding Jira issue in the PR description or as a comment.
   add-jira-link:
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'edited')
-    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.5
+    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.8
     with:
       pr_title: ${{ github.event.pull_request.title }}
       pr_number: ${{ github.event.pull_request.number }}
@@ -54,6 +54,6 @@ jobs:
   # that are still open and may need attention.
   notify-slack-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.5
+    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.8
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/workflow-pr-automation.yaml
+++ b/.github/workflows/workflow-pr-automation.yaml
@@ -18,6 +18,8 @@ jobs:
     uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.8
     with:
       pr_number: ${{ github.event.pull_request.number }}
+    permissions:
+      pull-requests: write
 
   # Triggered when the "ready for review" label is added to a PR.
   # Sends a Slack notification with PR metadata (title, author, diff size, URL)
@@ -35,6 +37,8 @@ jobs:
       repo_name: ${{ github.event.repository.name }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    permissions:
+      pull-requests: write
 
   # Triggered when a PR is opened or its title/description is edited.
   # Parses the PR title or branch name for a Jira ticket ID and adds a link
@@ -57,3 +61,6 @@ jobs:
     uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.8
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    permissions:
+      contents: read
+      pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.112
+- Upgrade github actions to release 0.0.9
+
 ## 0.15.111
-<<<<<<< HEAD
 - Bump `datarobot-moderations` to 11.2.33 to fix a bug with `ModerationIterator`
 
-=======
-- Upgrade github actions to release 0.0.9
-- 
->>>>>>> d23f1294 (Update CHANGELOG.md)
 ## 0.15.110
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.
 - `dragent/datarobot_otelcollector`: bridge NAT intermediate-step span context into the OTel SDK so memory and framework spans share the workflow trace instead of exporting as a separate tree. Falls back to NAT `workflow_trace_id` when the exporter bridge is unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.111
+<<<<<<< HEAD
 - Bump `datarobot-moderations` to 11.2.33 to fix a bug with `ModerationIterator`
 
+=======
+- Upgrade github actions to release 0.0.9
+- 
+>>>>>>> d23f1294 (Update CHANGELOG.md)
 ## 0.15.110
-<<<<<<< HEAD
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.
 - `dragent/datarobot_otelcollector`: bridge NAT intermediate-step span context into the OTel SDK so memory and framework spans share the workflow trace instead of exporting as a separate tree. Falls back to NAT `workflow_trace_id` when the exporter bridge is unavailable.
 - `core/telemetry_nat_tracer`: patch the SDK `TracerProvider` installed by `bootstrap_otel_provider_for_datarobot()` so LangChain/LangGraph, HTTP client, and other auto-instrumentor spans join the active NAT workflow trace. Adds a single-active-run fallback when NAT `Context` is unavailable in framework worker threads.
-=======
-- Upgrade github actions to release 0.0.9
->>>>>>> 0865e7b1 (Bump versions)
 
 ## 0.15.109
 - `drtools/sandbox`: added a `Sandbox` protocol and `DataRobotWorkloadSandbox` (workload-api backend) plus the `execute_code` function; credentials come from the request/config helpers (not `os.environ`), container stderr is surfaced from OTEL logs, and the security context is gated by `ENABLE_WORKLOAD_API_SECURITY_CONTEXT`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Bump `datarobot-moderations` to 11.2.33 to fix a bug with `ModerationIterator`
 
 ## 0.15.110
+<<<<<<< HEAD
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.
 - `dragent/datarobot_otelcollector`: bridge NAT intermediate-step span context into the OTel SDK so memory and framework spans share the workflow trace instead of exporting as a separate tree. Falls back to NAT `workflow_trace_id` when the exporter bridge is unavailable.
 - `core/telemetry_nat_tracer`: patch the SDK `TracerProvider` installed by `bootstrap_otel_provider_for_datarobot()` so LangChain/LangGraph, HTTP client, and other auto-instrumentor spans join the active NAT workflow trace. Adds a single-active-run fallback when NAT `Context` is unavailable in framework worker threads.
+=======
+- Upgrade github actions to release 0.0.9
+>>>>>>> 0865e7b1 (Bump versions)
 
 ## 0.15.109
 - `drtools/sandbox`: added a `Sandbox` protocol and `DataRobotWorkloadSandbox` (workload-api backend) plus the `execute_code` function; credentials come from the request/config helpers (not `os.environ`), container stderr is surfaced from OTEL logs, and the security context is gated by `ENABLE_WORKLOAD_API_SECURITY_CONTEXT`.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.110"
+version = "0.15.111"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.111"
+version = "0.15.112"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.111"
+version = "0.15.112"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.111"
+version = "0.15.112"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Github actions are pretty out of date in this repo for slack updates. This upgrades them with all the latest fixes.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Fixes potential security vulnerabilities in github actions
- Fixes bugs in not notifying slack
- Improves slack notifications with more details and information

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions caller configuration; wrong scopes could break labels/notifications but do not affect application runtime or data paths.
> 
> **Overview**
> Tightens **PR Automation** by pinning all four reusable `datarobot-oss/github-actions` workflows from **@0.0.5** to **@0.0.8** and declaring explicit `permissions` on each caller job instead of relying on the default token scope.
> 
> **mark-reviewed** and **notify-ready-for-review** now request `pull-requests: write` (the latter in addition to its existing Slack secret). **notify-slack-scheduled** adds `contents: read` and `pull-requests: read` for the scheduled/dispatch Slack digest. **add-jira-link** only bumps the action ref; its `pull-requests: write` block was already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d29d95f7b6d8a1309242bebc07861a8718edee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->