### PR TITLE
[BUZZOK-31015] Fix DataRobotModerationMiddleware when response is blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.97
+- `nat/datarobot_moderation_middleware`: fixed moderated DRAgent streams that ended on a moderation `content_filter` without emitting `TEXT_MESSAGE_END` for open assistant text segments; the middleware now synthesizes those end events so AG-UI clients can close text messages cleanly.
+- `nat/datarobot_moderation_middleware`: closed upstream and moderation async generators when the consumer stopped early (e.g. client disconnect), avoiding leaked iterators during stream teardown.
 
 ## 0.15.96
 - Fix tool call sequense of ag-ui events for dragent+nat

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.95"
+version = "0.15.97"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.96"
+version = "0.15.97"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1008,6 +1008,44 @@ def skip_event_type(event: Event) -> bool:
     }
 
 
+def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
+    """Track assistant text segments that started or received content but did not end."""
+    if isinstance(event, TextMessageStartEvent):
+        open_message_ids.add(event.message_id)
+    elif isinstance(event, TextMessageEndEvent):
+        open_message_ids.discard(event.message_id)
+    elif isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
+        if event.message_id:
+            open_message_ids.add(event.message_id)
+
+
+def _synthetic_text_message_end_events(
+    open_message_ids: set[str],
+) -> list[TextMessageEndEvent]:
+    """Close dangling text segments when upstream ends the stream without TEXT_MESSAGE_END."""
+    end_events = [TextMessageEndEvent(message_id=message_id) for message_id in open_message_ids]
+    open_message_ids.clear()
+    return end_events
+
+
+def _synthetic_text_message_end_responses(
+    open_message_ids: set[str],
+) -> list[DRAgentEventResponse]:
+    """Wrap synthetic ``TEXT_MESSAGE_END`` events as ``DRAgentEventResponse`` batches."""
+    zero = default_usage_metrics()
+    return [
+        DRAgentEventResponse(events=[end_event], usage_metrics=zero)
+        for end_event in _synthetic_text_message_end_events(open_message_ids)
+    ]
+
+
+def _track_dragent_response_events(
+    open_message_ids: set[str], response: DRAgentEventResponse
+) -> None:
+    for event in response.events:
+        _track_open_text_message(open_message_ids, event)
+
+
 def _response_has_assistant_text_deltas(response: DRAgentEventResponse) -> bool:
     """Check if the payload includes assistant text AG-UI deltas
     (possibly after lifecycle events).
@@ -1095,6 +1133,7 @@ async def _moderated_dragent_stream(
     during peek-ahead are buffered and emitted after each moderated chunk.
     """
     stream_tool_index_map: dict[int, str] = {}
+    open_text_message_ids: set[str] = set()
     pending_deferred: list[DRAgentEventResponse] = []
     pending_pass_through: list[DRAgentEventResponse] = []
     moderation_source_responses: list[DRAgentEventResponse] = []
@@ -1127,6 +1166,7 @@ async def _moderated_dragent_stream(
         if response.events and not skip_event_type(response.events[0]):
             first_text = response
             break
+        _track_dragent_response_events(open_text_message_ids, response)
         yield response
     if first_text is None:
         return
@@ -1138,19 +1178,27 @@ async def _moderated_dragent_stream(
         prescore_latency=stream_state.latency_so_far,
     ):
         source_response = moderation_source_responses.pop(0)
-        yield dome_chunk_to_dragent_event_response(
+        moderated_response = dome_chunk_to_dragent_event_response(
             moderated,
             source_ag_ui_events=source_response.events,
             stream_tool_index_map=stream_tool_index_map,
         )
+        _track_dragent_response_events(open_text_message_ids, moderated_response)
+        yield moderated_response
         for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
+            _track_dragent_response_events(open_text_message_ids, item)
             yield item
         finish = moderated.choices[0].finish_reason if moderated.choices else None
         if finish == "content_filter":
+            for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
+                yield end_response
             return
 
     for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
+        _track_dragent_response_events(open_text_message_ids, item)
         yield item
+    for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
+        yield end_response
 
 
 @dataclass

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -38,11 +38,13 @@ boundary, then reverses to AG-UI on the way out.
 
 from __future__ import annotations
 
+import contextlib
 import contextvars
 import logging
 import math
 import os
 import uuid
+from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import UTC
@@ -1120,12 +1122,20 @@ def _drain_pending_after_moderated_chunk(
     return ordered
 
 
+async def _aclose_async_iterator(iterator: AsyncGenerator[Any]) -> None:
+    """Close an async generator, ignoring errors from double-close or partial consumption."""
+    try:
+        await iterator.aclose()
+    except Exception:
+        _logger.debug("Error closing async iterator during stream teardown", exc_info=True)
+
+
 async def _moderated_dragent_stream(
-    upstream: AsyncIterator[DRAgentEventResponse],
+    upstream: AsyncGenerator[DRAgentEventResponse],
     *,
     moderation: ModerationPipeline,
     stream_state: _ModerationInvokeState,
-) -> AsyncIterator[DRAgentEventResponse]:
+) -> AsyncGenerator[DRAgentEventResponse]:
     """Yield DRAgent stream chunks with AG-UI-safe ordering around moderated text deltas.
 
     Non-text upstream events pass through immediately until the first text delta. Text deltas are
@@ -1137,6 +1147,7 @@ async def _moderated_dragent_stream(
     pending_deferred: list[DRAgentEventResponse] = []
     pending_pass_through: list[DRAgentEventResponse] = []
     moderation_source_responses: list[DRAgentEventResponse] = []
+    stopped_for_content_filter = False
 
     def buffer_passthrough(response: DRAgentEventResponse) -> None:
         if response.events and _defer_until_after_moderated_chunk(response.events[0]):
@@ -1162,43 +1173,57 @@ async def _moderated_dragent_stream(
             current = await next_text_response()
 
     first_text: DRAgentEventResponse | None = None
-    async for response in upstream:
-        if response.events and not skip_event_type(response.events[0]):
-            first_text = response
-            break
-        _track_dragent_response_events(open_text_message_ids, response)
-        yield response
-    if first_text is None:
-        return
-
-    async for moderated in moderation.stream_response_async(
-        completion_chunks(first_text),
-        prompt=stream_state.prompt,
-        prescore_df=stream_state.prescore_df,
-        prescore_latency=stream_state.latency_so_far,
-    ):
-        source_response = moderation_source_responses.pop(0)
-        moderated_response = dome_chunk_to_dragent_event_response(
-            moderated,
-            source_ag_ui_events=source_response.events,
-            stream_tool_index_map=stream_tool_index_map,
-        )
-        _track_dragent_response_events(open_text_message_ids, moderated_response)
-        yield moderated_response
-        for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
-            _track_dragent_response_events(open_text_message_ids, item)
-            yield item
-        finish = moderated.choices[0].finish_reason if moderated.choices else None
-        if finish == "content_filter":
-            for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
-                yield end_response
+    try:
+        async for response in upstream:
+            if response.events and not skip_event_type(response.events[0]):
+                first_text = response
+                break
+            _track_dragent_response_events(open_text_message_ids, response)
+            yield response
+        if first_text is None:
             return
 
-    for item in _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through):
-        _track_dragent_response_events(open_text_message_ids, item)
-        yield item
-    for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
-        yield end_response
+        async with contextlib.aclosing(
+            moderation.stream_response_async(
+                completion_chunks(first_text),
+                prompt=stream_state.prompt,
+                prescore_df=stream_state.prescore_df,
+                prescore_latency=stream_state.latency_so_far,
+            )
+        ) as moderation_stream:
+            async for moderated in moderation_stream:
+                source_response = moderation_source_responses.pop(0)
+                moderated_response = dome_chunk_to_dragent_event_response(
+                    moderated,
+                    source_ag_ui_events=source_response.events,
+                    stream_tool_index_map=stream_tool_index_map,
+                )
+                _track_dragent_response_events(open_text_message_ids, moderated_response)
+                yield moderated_response
+                for item in _drain_pending_after_moderated_chunk(
+                    pending_deferred, pending_pass_through
+                ):
+                    _track_dragent_response_events(open_text_message_ids, item)
+                    yield item
+                finish = moderated.choices[0].finish_reason if moderated.choices else None
+                if finish == "content_filter":
+                    for end_response in _synthetic_text_message_end_responses(
+                        open_text_message_ids
+                    ):
+                        yield end_response
+                    stopped_for_content_filter = True
+                    break
+
+        if not stopped_for_content_filter:
+            for item in _drain_pending_after_moderated_chunk(
+                pending_deferred, pending_pass_through
+            ):
+                _track_dragent_response_events(open_text_message_ids, item)
+                yield item
+            for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
+                yield end_response
+    finally:
+        await _aclose_async_iterator(upstream)
 
 
 @dataclass
@@ -1484,19 +1509,31 @@ class DataRobotModerationMiddleware(
             # workflow input / prescore skipped), pass the stream through unchanged.
             stream_state = _moderation_invoke_state_ctx.get()
             if stream_state is None:
-                async for chunk in call_next(*ctx.modified_args, **ctx.modified_kwargs):
-                    yield chunk
+                async with contextlib.aclosing(
+                    cast(
+                        AsyncGenerator[DRAgentEventResponse, None],
+                        call_next(*ctx.modified_args, **ctx.modified_kwargs),
+                    )
+                ) as upstream:
+                    async for chunk in upstream:
+                        yield chunk
                 return
 
             moderation = self._moderation
             assert moderation is not None
 
-            async for response in _moderated_dragent_stream(
-                call_next(*ctx.modified_args, **ctx.modified_kwargs),
-                moderation=moderation,
-                stream_state=stream_state,
-            ):
-                yield response
+            async with contextlib.aclosing(
+                _moderated_dragent_stream(
+                    cast(
+                        AsyncGenerator[DRAgentEventResponse, None],
+                        call_next(*ctx.modified_args, **ctx.modified_kwargs),
+                    ),
+                    moderation=moderation,
+                    stream_state=stream_state,
+                )
+            ) as moderated_stream:
+                async for response in moderated_stream:
+                    yield response
         finally:
             _clear_moderation_invoke_state_if_set()
 

--- a/tests/nat/integration/fixtures/moderation_real_credentials/moderation_config.yaml
+++ b/tests/nat/integration/fixtures/moderation_real_credentials/moderation_config.yaml
@@ -68,6 +68,12 @@ guards:
     type: ootb
     llm_type: llmGateway
     llm_gateway_model_id: azure/gpt-4o-2024-11-20
+    intervention:
+      action: block
+      message: "Agent did not complete the requested task."
+      conditions:
+        - comparator: lessThan
+          comparand: 0.5
   - name: Goal Accuracy (gateway)
     description: Goal accuracy
     ootb_type: agent_goal_accuracy

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2025,6 +2025,46 @@ async def test_function_middleware_stream_synthesizes_text_message_end_on_conten
     )
 
 
+async def test_function_middleware_stream_closes_generators_on_early_consumer_exit(
+    builder_mock: MagicMock,
+) -> None:
+    """Closing the consumer must aclose moderation and upstream iterators."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hi")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+
+    async def upstream():
+        yield _text_response("delta-one")
+        yield _text_response("delta-two")
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with (
+        patch(
+            "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+            return_value=moderation,
+        ),
+        patch(
+            "datarobot_genai.nat.datarobot_moderation_middleware._aclose_async_iterator",
+            new_callable=AsyncMock,
+        ) as aclose_mock,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        stream = mw.function_middleware_stream(
+            _make_run_input("hi"),
+            call_next=stream_next,
+            context=_fn_context(),
+        )
+        agen = stream.__aiter__()
+        first = await agen.__anext__()
+        assert isinstance(first, DRAgentEventResponse)
+        await agen.aclose()
+
+    aclose_mock.assert_awaited()
+
+
 async def test_function_middleware_stream_passthrough_when_no_run_agent_input(
     builder_mock: MagicMock,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -310,6 +310,39 @@ async def _passthrough_stream_response_async(
         current = peek
 
 
+async def _content_filter_on_last_stream_response_async(
+    completion: Any,
+    **kwargs: Any,
+) -> Any:
+    """Echo streamed chunks; mark the final chunk with ``finish_reason=content_filter``."""
+    aiter = completion.__aiter__()
+    try:
+        current = await aiter.__anext__()
+    except StopAsyncIteration:
+        return
+    while True:
+        try:
+            peek = await aiter.__anext__()
+        except StopAsyncIteration:
+            choice = current.choices[0]
+            yield ChatCompletionChunk(
+                id=current.id,
+                choices=[
+                    OpenAIChunkChoice(
+                        index=0,
+                        delta=choice.delta,
+                        finish_reason="content_filter",
+                    )
+                ],
+                created=current.created,
+                model=current.model,
+                object="chat.completion.chunk",
+            )
+            return
+        yield current
+        current = peek
+
+
 def _prescore_df_blocked(prompt: str, blocked_message: str) -> pd.DataFrame:
     return pd.DataFrame(
         {
@@ -1576,7 +1609,9 @@ async def test_function_middleware_stream_response_token_limit_blocks(
         ]
 
     stream_next.assert_called_once()
-    assert len(chunks) == 1
+    assert len(chunks) >= 1
+    flat = [ev for resp in chunks for ev in resp.events]
+    assert any(ev.type == EventType.TEXT_MESSAGE_END for ev in flat)
     chunk = chunks[0]
     assert isinstance(chunk, DRAgentEventResponse)
     assert _assistant_text_joined_from_dragent_response(chunk) == _RESPONSE_TOKEN_CAP_BLOCK_MESSAGE
@@ -1717,8 +1752,14 @@ async def test_function_middleware_stream_prompt_replace(
     stream_next.assert_called_once()
     assert predict_inputs
     assert run_input.messages[-1].content == _MODEL_PROMPT_REPLACEMENT
-    assert len(chunks) == 1
-    assert _assistant_text_joined_from_dragent_response(chunks[0]) == "streamed-model-out"
+    flat = [ev for resp in chunks for ev in resp.events]
+    assert any(ev.type == EventType.TEXT_MESSAGE_END for ev in flat)
+    assert (
+        _assistant_text_joined_from_dragent_response(
+            DRAgentEventResponse(events=flat, usage_metrics=default_usage_metrics())
+        )
+        == "streamed-model-out"
+    )
 
 
 async def test_function_middleware_invoke_response_replace(
@@ -1847,8 +1888,14 @@ async def test_function_middleware_stream_response_replace(
 
     stream_next.assert_called_once()
     assert predict_inputs
-    assert len(chunks) == 1
-    assert _assistant_text_joined_from_dragent_response(chunks[0]) == _MODEL_RESPONSE_REPLACEMENT
+    flat = [ev for resp in chunks for ev in resp.events]
+    assert any(ev.type == EventType.TEXT_MESSAGE_END for ev in flat)
+    assert (
+        _assistant_text_joined_from_dragent_response(
+            DRAgentEventResponse(events=flat, usage_metrics=default_usage_metrics())
+        )
+        == _MODEL_RESPONSE_REPLACEMENT
+    )
 
 
 async def test_function_middleware_stream_yields_blocked_pre_invoke(
@@ -1916,10 +1963,66 @@ async def test_function_middleware_stream_echoes_single_text_chunk(builder_mock:
             )
         ]
 
-    assert len(chunks) == 1
+    assert len(chunks) == 2
     assert isinstance(chunks[0], DRAgentEventResponse)
-    deltas = "".join(ev.delta for ev in chunks[0].events if isinstance(ev, TextMessageContentEvent))
+    assert isinstance(chunks[1], DRAgentEventResponse)
+    deltas = "".join(
+        ev.delta for resp in chunks for ev in resp.events if isinstance(ev, TextMessageContentEvent)
+    )
     assert deltas == "delta-one"
+    assert any(ev.type == EventType.TEXT_MESSAGE_END for resp in chunks for ev in resp.events)
+
+
+async def test_function_middleware_stream_synthesizes_text_message_end_on_content_filter(
+    builder_mock: MagicMock,
+) -> None:
+    """Moderation content_filter can end the stream without upstream TEXT_MESSAGE_END."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    moderation.stream_response_async = _content_filter_on_last_stream_response_async
+    prescore_df = _prescore_df_ok("hi")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    msg_id = "msg-blocked"
+    zero = default_usage_metrics()
+    blocked_text = "Agent did not complete the requested task."
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=msg_id, role="assistant")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=msg_id, delta=blocked_text)],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    assert any(isinstance(ev, TextMessageEndEvent) and ev.message_id == msg_id for ev in flat), (
+        f"expected TEXT_MESSAGE_END for {msg_id!r}, got {[e.type for e in flat]}"
+    )
+    assert (
+        _assistant_text_joined_from_dragent_response(
+            DRAgentEventResponse(events=flat, usage_metrics=zero)
+        )
+        == blocked_text
+    )
 
 
 async def test_function_middleware_stream_passthrough_when_no_run_agent_input(

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.96"
+version = "0.15.97"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Using
```
- name: Task Adherence
  type: ootb
  ootb_type: task_adherence
  stage: response
  llm_type: llmGateway
  llm_gateway_model_id: azure/gpt-5-2-2025-12-11
  intervention:
    action: block
    message: "Agent did not complete the requested task."
    conditions: 
      - comparator: lessThan
```
in the recipe revealed that there are errors in the console output related to unclosed generators and the expected blocked message did not appear in the UI until a refresh.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Synthesize TEXT_MESSAGE_END_EVENT and close the generators when the response is blocked.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming lifecycle and AG-UI event ordering in moderation middleware—a sensitive path for blocked responses and client rendering—but scope is focused with new unit tests.
> 
> **Overview**
> Fixes **DataRobot moderation streaming** when response-stage guards **block** the assistant (e.g. task adherence with `intervention.action: block`). The moderated stream could stop on `content_filter` **without** upstream `TEXT_MESSAGE_END`, which broke AG-UI and hid the block message until refresh; logs also showed **unclosed async generators**.
> 
> The middleware now **tracks open assistant text segments**, emits **synthetic `TEXT_MESSAGE_END`** when moderation blocks or when the stream ends with dangling text, and wraps upstream/moderation iterators in **`contextlib.aclosing`** plus **`finally`** teardown via `_aclose_async_iterator`. Passthrough and moderated paths use the same closing pattern.
> 
> **Tests** cover content-filter synthesis, early consumer `aclose`, and stricter stream expectations; the real-credentials moderation fixture adds a **blocking Task Adherence** guard. Package version **0.15.91 → 0.15.92**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4380c692aa808646d9963746453a611988cfbc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->