### PR TITLE
[-] CI: cache only uv download cache, not .venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,15 @@ jobs:
           version: ${{ env.TASK_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache uv and virtualenv
+      - name: Cache uv download cache
         uses: actions/cache@v4
         with:
-          path: |
-            .venv
-            ~/.cache/uv
+          # Cache only uv's content-addressed download cache, not .venv. Caching
+          # .venv across the shared key let a stale/cross-module environment be
+          # restored, which `uv sync` then reconciled incorrectly (e.g. the
+          # drmcpbase extra losing the datarobot SDK). The venv is rebuilt from
+          # this cache by `uv sync` on every run, which is fast and always correct.
+          path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-${{ matrix.python-version }}-
@@ -99,12 +102,15 @@ jobs:
           version: ${{ env.TASK_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache uv and virtualenv
+      - name: Cache uv download cache
         uses: actions/cache@v4
         with:
-          path: |
-            .venv
-            ~/.cache/uv
+          # Cache only uv's content-addressed download cache, not .venv. Caching
+          # .venv across the shared key let a stale/cross-module environment be
+          # restored, which `uv sync` then reconciled incorrectly (e.g. the
+          # drmcpbase extra losing the datarobot SDK). The venv is rebuilt from
+          # this cache by `uv sync` on every run, which is fast and always correct.
+          path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-${{ matrix.python-version }}-
@@ -153,12 +159,15 @@ jobs:
           version: ${{ env.TASK_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache uv and virtualenv
+      - name: Cache uv download cache
         uses: actions/cache@v4
         with:
-          path: |
-            .venv
-            ~/.cache/uv
+          # Cache only uv's content-addressed download cache, not .venv. Caching
+          # .venv across the shared key let a stale/cross-module environment be
+          # restored, which `uv sync` then reconciled incorrectly (e.g. the
+          # drmcpbase extra losing the datarobot SDK). The venv is rebuilt from
+          # this cache by `uv sync` on every run, which is fast and always correct.
+          path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-${{ matrix.python-version }}-
@@ -219,12 +228,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
-      - name: Cache uv and virtualenv
+      - name: Cache uv download cache
         uses: actions/cache@v4
         with:
-          path: |
-            .venv
-            ~/.cache/uv
+          # Cache only uv's content-addressed download cache, not .venv (see note above).
+          path: ~/.cache/uv
           key: uv-${{ runner.os }}-3.12-${{ hashFiles('uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-3.12-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.94
+- CI: cache only `~/.cache/uv`, not `.venv`, so each job rebuilds a clean venv. Caching `.venv` under a shared key could restore a stale environment, intermittently breaking the `drmcpbase` test job (`ModuleNotFoundError: No module named 'datarobot'`).
+
 ## 0.15.93
 - Per-user DataRobot API access (MODEL-23521): added `request_user_dr_client` and `request_user_dr_sdk` in `drtools.core.clients.datarobot`, both scoped via `client_configuration()` (ContextVar) instead of the global `dr.Client()`, so concurrent MCP tool requests do not share tokens.
 - Removed `drtools.core.rest_client`; consolidated token resolution into `get_datarobot_access_token(*, headers_auth_only=...)` alongside the new context managers.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.93"
+version = "0.15.94"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.93"
+version = "0.15.94"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.93"
+version = "0.15.94"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
A shared (non-module-specific) cache key plus loose restore-keys let a stale/cross-module .venv be restored; uv sync --extra <module> then reconciled it incorrectly, intermittently dropping the datarobot SDK from the drmcpbase test job (ModuleNotFoundError: No module named 'datarobot'). Cache only ~/.cache/uv and rebuild the venv each run. Bump 0.15.93 -> 0.15.94.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and release-metadata changes only; no application runtime or auth logic is modified.
> 
> **Overview**
> **CI caching** in `.github/workflows/ci.yml` no longer restores `.venv`—only `~/.cache/uv` is cached across the lint, per-module test, build-test, and security jobs. Each run still runs `uv sync`, but rebuilds the virtualenv from the download cache so matrix jobs with different extras (e.g. `drmcpbase` vs `core`) do not inherit a wrong environment from a shared cache key.
> 
> Release **0.15.94** documents the fix and updates lockfiles/version metadata accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2381ebe9c9a084378695b1febbca7d1b2dff8ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->