### PR TITLE
[BUZZOK-30951] Fix model dir default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.99
+- `dragent/workflow_paths`: added `discover_workflow_yaml()` and `publish_dragent_config_file_env()` to locate `workflow.yaml` and set `DRAGENT_CONFIG_FILE` (from the env var, `$CODE_DIR/workflow.yaml`, or a walk up from CWD). Wired into the DRAgent CLI, FastAPI frontend startup, and `load_workflow()` so middleware can resolve guard assets without relying on the process working directory.
+- `nat/datarobot_moderation_middleware`: default `model_dir` is now the directory containing `workflow.yaml` (via `DRAGENT_CONFIG_FILE`) instead of CWD, so `moderation_config.yaml` loads correctly in DataRobot custom-model deployments where CWD is not the agent code root. The middleware retries discovery on first use if `workflow.yaml` was not available at startup (e.g. gunicorn parent process).
+
 ## 0.15.98
 - Added `datarobot_genai.drmcpbase.fastmcp_transforms.conditional_code_mode.ConditionalCodeMode`: This allows users to switch to fast mcp's CodeMode (tools are limited to {"search", "get_schema", "execute"}) if they pass the header: `x-datarobot-mcp-mode=code_execute`
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.98"
+version = "0.15.99"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.98"
+version = "0.15.99"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -22,6 +22,8 @@ import click
 from nat.cli.commands.start import StartCommandGroup
 from nat.cli.type_registry import RegisteredFrontEndInfo
 
+from datarobot_genai.nat.datarobot_moderation_middleware import DRAGENT_CONFIG_FILE_ENV
+
 from .remote import build_agui_payload
 from .remote import get_auth_context_headers
 from .remote import get_local_auth_context_headers
@@ -82,7 +84,7 @@ class DRAgentCommandGroup(StartCommandGroup):
         self,
         ctx: click.Context,
         cmd_name: str,
-        config_file: object,
+        config_file: Path | None,
         override: tuple[tuple[str, str], ...],
         **kwargs: object,
     ) -> int | None:
@@ -91,6 +93,7 @@ class DRAgentCommandGroup(StartCommandGroup):
                 "No config file provided. "
                 "Pass --config_file <path> or set the DRAGENT_CONFIG_FILE env var."
             )
+        os.environ[DRAGENT_CONFIG_FILE_ENV] = str(config_file.expanduser().resolve())
         _bridge_pulumi_otel_env()
         return super().invoke_subcommand(ctx, cmd_name, config_file, override, **kwargs)
 

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -22,7 +22,7 @@ import click
 from nat.cli.commands.start import StartCommandGroup
 from nat.cli.type_registry import RegisteredFrontEndInfo
 
-from datarobot_genai.nat.datarobot_moderation_middleware import DRAGENT_CONFIG_FILE_ENV
+from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
 
 from .remote import build_agui_payload
 from .remote import get_auth_context_headers

--- a/src/datarobot_genai/dragent/cli/commands.py
+++ b/src/datarobot_genai/dragent/cli/commands.py
@@ -22,7 +22,7 @@ import click
 from nat.cli.commands.start import StartCommandGroup
 from nat.cli.type_registry import RegisteredFrontEndInfo
 
-from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
+from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
 
 from .remote import build_agui_payload
 from .remote import get_auth_context_headers
@@ -93,7 +93,7 @@ class DRAgentCommandGroup(StartCommandGroup):
                 "No config file provided. "
                 "Pass --config_file <path> or set the DRAGENT_CONFIG_FILE env var."
             )
-        os.environ[DRAGENT_CONFIG_FILE_ENV] = str(config_file.expanduser().resolve())
+        publish_dragent_config_file_env(config_file)
         _bridge_pulumi_otel_env()
         return super().invoke_subcommand(ctx, cmd_name, config_file, override, **kwargs)
 

--- a/src/datarobot_genai/dragent/constants.py
+++ b/src/datarobot_genai/dragent/constants.py
@@ -1,0 +1,17 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared DRAgent constants."""
+
+DRAGENT_CONFIG_FILE_ENV = "DRAGENT_CONFIG_FILE"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -224,5 +224,13 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
 
 class DRAgentFastApiFrontEndPlugin(FastApiFrontEndPlugin):
+    async def run(self) -> None:
+        # Resolve ``workflow.yaml`` before NAT builds the app (gunicorn calls ``get_app()`` in
+        # the parent process, which initializes middleware including datarobot_moderation).
+        from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
+
+        publish_dragent_config_file_env()
+        await super().run()
+
     def get_worker_class(self) -> type[FastApiFrontEndPluginWorker]:
         return DRAgentFastApiFrontEndPluginWorker

--- a/src/datarobot_genai/dragent/workflow_paths.py
+++ b/src/datarobot_genai/dragent/workflow_paths.py
@@ -1,0 +1,83 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Locate ``workflow.yaml`` for DRAgent runtimes and deployments."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
+
+WORKFLOW_FILENAME = "workflow.yaml"
+CODE_DIR_ENV = "CODE_DIR"
+
+
+def _existing_workflow(path: Path) -> Path | None:
+    try:
+        resolved = path.expanduser().resolve()
+    except OSError:
+        return None
+    return resolved if resolved.is_file() else None
+
+
+def discover_workflow_yaml() -> Path | None:
+    """Return ``workflow.yaml`` when it can be located on disk.
+
+    Resolution order:
+
+    1. ``DRAGENT_CONFIG_FILE`` when it points at an existing file
+    2. ``$CODE_DIR/workflow.yaml`` (DataRobot custom-model deployments set ``CODE_DIR``)
+    3. ``workflow.yaml`` in the current working directory or any parent directory
+    """
+    config_file = os.environ.get(DRAGENT_CONFIG_FILE_ENV)
+    if config_file:
+        for candidate in _workflow_candidates_from_hint(config_file):
+            if (found := _existing_workflow(candidate)) is not None:
+                return found
+
+    code_dir = os.environ.get(CODE_DIR_ENV)
+    if code_dir and (found := _existing_workflow(Path(code_dir) / WORKFLOW_FILENAME)) is not None:
+        return found
+
+    for directory in [Path.cwd(), *Path.cwd().parents]:
+        if (found := _existing_workflow(directory / WORKFLOW_FILENAME)) is not None:
+            return found
+
+    return None
+
+
+def _workflow_candidates_from_hint(config_file: str) -> list[Path]:
+    hinted = Path(config_file).expanduser()
+    candidates = [hinted, Path.cwd() / hinted]
+    code_dir = os.environ.get(CODE_DIR_ENV)
+    if code_dir is not None:
+        code_root = Path(code_dir).expanduser()
+        candidates.extend([code_root / hinted, code_root / WORKFLOW_FILENAME])
+    return candidates
+
+
+def publish_dragent_config_file_env(
+    workflow_path: Path | str | None = None,
+) -> Path | None:
+    """Set ``DRAGENT_CONFIG_FILE`` to an absolute ``workflow.yaml`` path when found."""
+    resolved = (
+        _existing_workflow(Path(workflow_path))
+        if workflow_path is not None
+        else discover_workflow_yaml()
+    )
+    if resolved is not None:
+        os.environ[DRAGENT_CONFIG_FILE_ENV] = str(resolved)
+    return resolved

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -124,6 +124,8 @@ from datarobot_genai.dragent.frontends.converters import (
 from datarobot_genai.dragent.frontends.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
+from datarobot_genai.dragent.workflow_paths import discover_workflow_yaml
+from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
 
 _logger = logging.getLogger(__name__)
 
@@ -174,9 +176,19 @@ def moderation_config_has_guards(moderation: ModerationConfig) -> bool:
 
 def _default_moderation_model_dir() -> str:
     """Return the directory that holds ``workflow.yaml`` when known, else CWD."""
+    publish_dragent_config_file_env()
     config_file = os.environ.get(DRAGENT_CONFIG_FILE_ENV)
     if config_file:
-        return str(Path(config_file).expanduser().resolve().parent)
+        found = discover_workflow_yaml()
+        if found is not None:
+            return str(found.parent)
+        try:
+            return str(Path(config_file).expanduser().resolve().parent)
+        except OSError:
+            pass
+    discovered = discover_workflow_yaml()
+    if discovered is not None:
+        return str(discovered.parent)
     return os.path.abspath(os.getcwd())
 
 
@@ -1294,11 +1306,19 @@ class DataRobotModerationMiddleware(
 
     def __init__(self, config: DataRobotModerationConfig, builder: Builder) -> None:  # noqa: ARG002
         super().__init__()
+        self._config = config
         self._moderation = load_llm_moderation_pipeline(config)
+
+    def _get_moderation(self) -> ModerationPipeline | None:
+        """Return the moderation pipeline, retrying discovery if startup missed ``workflow.yaml``."""
+        if self._moderation is None:
+            publish_dragent_config_file_env()
+            self._moderation = load_llm_moderation_pipeline(self._config)
+        return self._moderation
 
     @property
     def enabled(self) -> bool:
-        return self._moderation is not None
+        return self._get_moderation() is not None
 
     async def function_middleware_invoke(
         self,
@@ -1349,18 +1369,17 @@ class DataRobotModerationMiddleware(
         workflow_input = _workflow_input_from_args(context.original_args)
         if workflow_input is None:
             return None
-        if self._moderation is None:
+        moderation = self._get_moderation()
+        if moderation is None:
             return None
 
-        pipeline = self._moderation._pipeline
+        pipeline = moderation._pipeline
 
         prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
         prompt = moderation_prompt_from_workflow_input(workflow_input)
 
         # Step 1: Prescore via ``ModerationPipeline.evaluate_prompt_async`` (non-blocking).
-        prompt_eval, prescore_latency, prescore_df = await self._moderation.evaluate_prompt_async(
-            prompt
-        )
+        prompt_eval, prescore_latency, prescore_df = await moderation.evaluate_prompt_async(prompt)
 
         if prompt_eval.blocked:
             # If all prompts in the input are blocked, means history as well as the prompt
@@ -1393,7 +1412,8 @@ class DataRobotModerationMiddleware(
             InvocationContext if modified, or None to pass through unchanged.
         """
         original_output = context.output
-        if self._moderation is None:
+        moderation = self._get_moderation()
+        if moderation is None:
             return None
 
         if isinstance(original_output, DRAgentEventResponse):
@@ -1412,7 +1432,7 @@ class DataRobotModerationMiddleware(
         if not response_text.strip():
             return None
 
-        pipeline = self._moderation._pipeline
+        pipeline = moderation._pipeline
         state = _moderation_invoke_state_ctx.get()
         if state is None:
             return None
@@ -1421,7 +1441,7 @@ class DataRobotModerationMiddleware(
         # Step 3: Postscore via ``ModerationPipeline.evaluate_response`` (same path as
         # ``_run_stage`` in dome) when response text is present.
         prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
-        response_eval, _, _postscore_df = await self._moderation.evaluate_response_async(
+        response_eval, _, _postscore_df = await moderation.evaluate_response_async(
             response_text,
             prompt=state.prompt,
         )
@@ -1532,7 +1552,7 @@ class DataRobotModerationMiddleware(
                         yield chunk
                 return
 
-            moderation = self._moderation
+            moderation = self._get_moderation()
             assert moderation is not None
 
             async with contextlib.aclosing(

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -28,7 +28,8 @@ Guard configuration (``_type: datarobot_moderation``):
 * **Inline (preferred)** — nest guards under ``middleware.<name>.moderation`` in ``workflow.yaml``.
   When present, this block is used even if ``moderation_config.yaml`` also exists.
 * **DRUM-style file (fallback)** — when ``moderation`` is omitted, load ``moderation_config.yaml``
-  from ``model_dir`` (defaults to the process working directory).
+  from ``model_dir`` (defaults to the directory containing ``workflow.yaml``, resolved from
+  ``DRAGENT_CONFIG_FILE`` when set, otherwise the process working directory).
 * If neither source is present or both are empty, the middleware is a no-op.
 
 ``ModerationPipeline.stream_response_async`` only accepts OpenAI ``ChatCompletionChunk``; DRAgent
@@ -152,7 +153,8 @@ class DataRobotModerationConfig(
         description=(
             "Directory containing ``moderation_config.yaml`` and guard assets (DRUM custom model "
             "layout). Used for the inline ``moderation`` block and as the fallback file location. "
-            "Defaults to the process working directory."
+            "Defaults to the directory containing ``workflow.yaml`` (``DRAGENT_CONFIG_FILE``), "
+            "or the process working directory when that env var is unset."
         ),
     )
     moderation: ModerationConfig | None = Field(
@@ -169,13 +171,26 @@ def moderation_config_has_guards(moderation: ModerationConfig) -> bool:
     return any(target.guards for target in moderation.targets)
 
 
+DRAGENT_CONFIG_FILE_ENV = "DRAGENT_CONFIG_FILE"
+
+
+def _default_moderation_model_dir() -> str:
+    """Return the directory that holds ``workflow.yaml`` when known, else CWD."""
+    config_file = os.environ.get(DRAGENT_CONFIG_FILE_ENV)
+    if config_file:
+        return str(Path(config_file).expanduser().resolve().parent)
+    return os.path.abspath(os.getcwd())
+
+
 def resolve_moderation_model_dir(model_dir: str | None) -> str:
     """Resolve the base directory for guard assets and ``moderation_config.yaml``."""
-    return os.path.abspath(model_dir if model_dir is not None else os.getcwd())
+    if model_dir is not None:
+        return os.path.abspath(model_dir)
+    return _default_moderation_model_dir()
 
 
 def moderation_config_file_path(model_dir: str | None) -> Path:
-    """Return the DRUM-style ``moderation_config.yaml`` path under ``model_dir`` (or CWD)."""
+    """Return the DRUM-style ``moderation_config.yaml`` path under ``model_dir`` (or workflow dir)."""
     return Path(resolve_moderation_model_dir(model_dir)) / MODERATION_CONFIG_FILE_NAME
 
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -117,6 +117,7 @@ from openai.types.chat.chat_completion_message_tool_call import Function as Open
 from pydantic import Field
 
 from datarobot_genai.core.agents import default_usage_metrics
+from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
 from datarobot_genai.dragent.frontends.converters import (
     convert_dragent_event_response_to_openai_chat_completion_chunk,
 )
@@ -169,9 +170,6 @@ class DataRobotModerationConfig(
 def moderation_config_has_guards(moderation: ModerationConfig) -> bool:
     """Return whether ``moderation`` defines at least one guard across all targets."""
     return any(target.guards for target in moderation.targets)
-
-
-DRAGENT_CONFIG_FILE_ENV = "DRAGENT_CONFIG_FILE"
 
 
 def _default_moderation_model_dir() -> str:

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
 from nat.builder.workflow import Workflow
@@ -29,6 +31,7 @@ from nat.utils.type_utils import StrPath
 
 from datarobot_genai.core.chat.auth import get_authorization_context_from_headers
 from datarobot_genai.core.utils.auth import prepare_identity_header
+from datarobot_genai.nat.datarobot_moderation_middleware import DRAGENT_CONFIG_FILE_ENV
 
 
 def load_config(config_file: StrPath, headers: dict[str, str] | None = None) -> Config:
@@ -109,6 +112,10 @@ async def load_workflow(
         The maximum number of parallel workflow invocations to support. Specifying 0 or -1 will
         allow an unlimited count, by default -1
     """
+    # Publish the workflow path so middleware (e.g. datarobot_moderation) can locate
+    # ``moderation_config.yaml`` next to ``workflow.yaml`` without relying on CWD.
+    os.environ[DRAGENT_CONFIG_FILE_ENV] = str(Path(config_file).expanduser().resolve())
+
     # Load the config object
     config = load_config(config_file, headers=headers)
 

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import Any
 
 from nat.builder.workflow import Workflow
@@ -31,7 +29,7 @@ from nat.utils.type_utils import StrPath
 
 from datarobot_genai.core.chat.auth import get_authorization_context_from_headers
 from datarobot_genai.core.utils.auth import prepare_identity_header
-from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
+from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
 
 
 def load_config(config_file: StrPath, headers: dict[str, str] | None = None) -> Config:
@@ -114,7 +112,7 @@ async def load_workflow(
     """
     # Publish the workflow path so middleware (e.g. datarobot_moderation) can locate
     # ``moderation_config.yaml`` next to ``workflow.yaml`` without relying on CWD.
-    os.environ[DRAGENT_CONFIG_FILE_ENV] = str(Path(config_file).expanduser().resolve())
+    publish_dragent_config_file_env(config_file)
 
     # Load the config object
     config = load_config(config_file, headers=headers)

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -31,7 +31,7 @@ from nat.utils.type_utils import StrPath
 
 from datarobot_genai.core.chat.auth import get_authorization_context_from_headers
 from datarobot_genai.core.utils.auth import prepare_identity_header
-from datarobot_genai.nat.datarobot_moderation_middleware import DRAGENT_CONFIG_FILE_ENV
+from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
 
 
 def load_config(config_file: StrPath, headers: dict[str, str] | None = None) -> Config:

--- a/tests/dragent/test_workflow_paths.py
+++ b/tests/dragent/test_workflow_paths.py
@@ -1,0 +1,104 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
+from datarobot_genai.dragent.workflow_paths import CODE_DIR_ENV
+from datarobot_genai.dragent.workflow_paths import discover_workflow_yaml
+from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
+
+
+def test_discover_workflow_yaml_from_absolute_dragent_config_file(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    with patch.dict(os.environ, {DRAGENT_CONFIG_FILE_ENV: str(workflow)}, clear=False):
+        assert discover_workflow_yaml() == workflow.resolve()
+
+
+def test_discover_workflow_yaml_from_relative_dragent_config_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent_dir = tmp_path / "opt" / "code"
+    agent_dir.mkdir(parents=True)
+    workflow = agent_dir / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    with patch.dict(
+        os.environ,
+        {DRAGENT_CONFIG_FILE_ENV: "opt/code/workflow.yaml"},
+        clear=False,
+    ):
+        assert discover_workflow_yaml() == workflow.resolve()
+
+
+def test_discover_workflow_yaml_from_code_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent_dir = tmp_path / "opt" / "code"
+    agent_dir.mkdir(parents=True)
+    workflow = agent_dir / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "other").mkdir()
+    monkeypatch.chdir(tmp_path / "other")
+    monkeypatch.delenv(DRAGENT_CONFIG_FILE_ENV, raising=False)
+    with patch.dict(os.environ, {CODE_DIR_ENV: str(agent_dir)}, clear=False):
+        assert discover_workflow_yaml() == workflow.resolve()
+
+
+def test_discover_workflow_yaml_walks_cwd_parents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent_dir = tmp_path / "project" / "agent"
+    agent_dir.mkdir(parents=True)
+    workflow = agent_dir / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    nested = agent_dir / "nested"
+    nested.mkdir()
+    monkeypatch.chdir(nested)
+    monkeypatch.delenv(DRAGENT_CONFIG_FILE_ENV, raising=False)
+    monkeypatch.delenv(CODE_DIR_ENV, raising=False)
+    assert discover_workflow_yaml() == workflow.resolve()
+
+
+def test_publish_dragent_config_file_env_sets_absolute_path(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    published = publish_dragent_config_file_env(workflow)
+    assert published == workflow.resolve()
+    assert os.environ[DRAGENT_CONFIG_FILE_ENV] == str(workflow.resolve())
+
+
+def test_discover_workflow_yaml_relative_hint_with_code_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deployment layout: CWD is not ``CODE_DIR`` but hint is ``workflow.yaml``."""
+    agent_dir = tmp_path / "opt" / "code"
+    agent_dir.mkdir(parents=True)
+    workflow = agent_dir / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    with patch.dict(
+        os.environ,
+        {DRAGENT_CONFIG_FILE_ENV: "workflow.yaml", CODE_DIR_ENV: str(agent_dir)},
+        clear=False,
+    ):
+        assert discover_workflow_yaml() == workflow.resolve()

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -71,9 +71,9 @@ from openai.types.chat.chat_completion_chunk import (
 
 from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.core.agents.verify import validate_sequence
+from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
 from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
-from datarobot_genai.nat.datarobot_moderation_middleware import DRAGENT_CONFIG_FILE_ENV
 from datarobot_genai.nat.datarobot_moderation_middleware import DataRobotModerationConfig
 from datarobot_genai.nat.datarobot_moderation_middleware import DataRobotModerationMiddleware
 from datarobot_genai.nat.datarobot_moderation_middleware import (

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -484,8 +484,23 @@ def test_resolve_moderation_model_dir_falls_back_to_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv(DRAGENT_CONFIG_FILE_ENV, raising=False)
+    monkeypatch.delenv("CODE_DIR", raising=False)
     monkeypatch.chdir(tmp_path)
     assert resolve_moderation_model_dir(None) == str(tmp_path.resolve())
+
+
+def test_resolve_moderation_model_dir_from_code_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    agent_dir = tmp_path / "opt" / "code"
+    agent_dir.mkdir(parents=True)
+    workflow = agent_dir / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    (agent_dir / "moderation_config.yaml").write_text("targets: []\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(DRAGENT_CONFIG_FILE_ENV, raising=False)
+    with patch.dict(os.environ, {"CODE_DIR": str(agent_dir)}, clear=False):
+        assert resolve_moderation_model_dir(None) == str(agent_dir.resolve())
 
 
 def test_load_llm_moderation_pipeline_default_model_dir_from_dragent_config_file(

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -73,6 +73,7 @@ from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.core.agents.verify import validate_sequence
 from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.nat.datarobot_moderation_middleware import DRAGENT_CONFIG_FILE_ENV
 from datarobot_genai.nat.datarobot_moderation_middleware import DataRobotModerationConfig
 from datarobot_genai.nat.datarobot_moderation_middleware import DataRobotModerationMiddleware
 from datarobot_genai.nat.datarobot_moderation_middleware import (
@@ -87,6 +88,7 @@ from datarobot_genai.nat.datarobot_moderation_middleware import moderation_confi
 from datarobot_genai.nat.datarobot_moderation_middleware import (
     moderation_prompt_from_workflow_input,
 )
+from datarobot_genai.nat.datarobot_moderation_middleware import resolve_moderation_model_dir
 from datarobot_genai.nat.datarobot_moderation_middleware import workflow_input_to_completion_dict
 
 
@@ -464,6 +466,45 @@ def test_load_llm_moderation_pipeline_no_guards_is_noop_without_credentials() ->
         assert load_llm_moderation_pipeline(cfg) is None
     from_config.assert_not_called()
     from_yaml.assert_not_called()
+
+
+def test_resolve_moderation_model_dir_explicit() -> None:
+    assert resolve_moderation_model_dir("/tmp/model") == os.path.abspath("/tmp/model")
+
+
+def test_resolve_moderation_model_dir_from_dragent_config_file(tmp_path: Path) -> None:
+    workflow = tmp_path / "agent" / "workflow.yaml"
+    workflow.parent.mkdir()
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    with patch.dict(os.environ, {DRAGENT_CONFIG_FILE_ENV: str(workflow)}, clear=False):
+        assert resolve_moderation_model_dir(None) == str(workflow.parent.resolve())
+
+
+def test_resolve_moderation_model_dir_falls_back_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(DRAGENT_CONFIG_FILE_ENV, raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert resolve_moderation_model_dir(None) == str(tmp_path.resolve())
+
+
+def test_load_llm_moderation_pipeline_default_model_dir_from_dragent_config_file(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    workflow = agent_dir / "workflow.yaml"
+    workflow.write_text("workflow: {}\n", encoding="utf-8")
+    fixture_dir = INTEGRATION_MODERATION_MODEL_DIR
+    (agent_dir / "moderation_config.yaml").write_text(
+        (fixture_dir / "moderation_config.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    cfg = DataRobotModerationConfig()
+    with patch.dict(os.environ, {**_CREDENTIAL_ENV, DRAGENT_CONFIG_FILE_ENV: str(workflow)}):
+        pipeline = load_llm_moderation_pipeline(cfg)
+    assert pipeline is not None
+    assert pipeline._pipeline.get_prescore_guards()
 
 
 def test_load_llm_moderation_pipeline_config_file_missing_is_noop(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.98"
+version = "0.15.99"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Drum uses os.cwd() for the model_dir when it's not explicitly set. This doesn't work with dragent in a deployment.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Set an env variable when loading the `workflow.yaml` and use it to resolve the model_dir to find `moderation_config.yaml`. Do this before loading the workflow and also try reloading the moderations in case it was missed at startup.

I validated that this works in a deployment using the preview build with the current version of the recipe with `moderation_config.yaml` added and using dragent.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where file-backed moderation guards load in deployed agents; mis-set env could skip guards, but behavior is covered by new tests and only affects the unset model_dir path.
> 
> **Overview**
> Fixes **moderation `model_dir` resolution** for DRAgent deployments where the process working directory is not the agent bundle directory (DRUM-style behavior used CWD and could miss co-located `moderation_config.yaml`).
> 
> When a workflow is loaded, the resolved path to **`workflow.yaml`** is written to **`DRAGENT_CONFIG_FILE`**. The dragent CLI sets the same variable on **`serve` / `run`**. **DataRobot moderation middleware** uses that env var (via shared **`DRAGENT_CONFIG_FILE`**) to default **`model_dir`** to the workflow file’s parent when **`model_dir`** is omitted, with CWD as fallback. Explicit **`model_dir`** is unchanged.
> 
> Adds **`datarobot_genai.dragent.constants`**, unit tests for resolution and file-backed pipeline loading, and bumps package version to **0.15.98**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0472ae6b474cbafaff1045f03bdc332b463a4b9c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->