### PR TITLE
[MODEL-23644] Rename MCP Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.100
+- Renamed MCP tools and updated unit, integration and acceptance tests
+
 ## 0.15.99
 - `dragent/workflow_paths`: added `discover_workflow_yaml()` and `publish_dragent_config_file_env()` to locate `workflow.yaml` and set `DRAGENT_CONFIG_FILE` (from the env var, `$CODE_DIR/workflow.yaml`, or a walk up from CWD). Wired into the DRAgent CLI, FastAPI frontend startup, and `load_workflow()` so middleware can resolve guard assets without relying on the process working directory.
 - `nat/datarobot_moderation_middleware`: default `model_dir` is now the directory containing `workflow.yaml` (via `DRAGENT_CONFIG_FILE`) instead of CWD, so `moderation_config.yaml` loads correctly in DataRobot custom-model deployments where CWD is not the agent code root. The middleware retries discovery on first use if `workflow.yaml` was not available at startup (e.g. gunicorn parent process).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.100"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/config.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/config.py
@@ -163,13 +163,13 @@ def _get_additional_prediction_instructions(deployment_id: str) -> str:
 Follow these steps in order:
 1. Get deployment info: Call tools with the deployment_id="{deployment_id}" to learn about
    features and requirements.
-2. Retrieve features: Use `get_deployment_features` to see all required and optional features
+2. Retrieve features: Use `deployment_get_features` to see all required and optional features
    with their importance scores.
-3. Prepare data: Use `generate_prediction_data_template` to create the correctly structured
+3. Prepare data: Use `deployment_generate_prediction_sample` to create the correctly structured
    CSV format.
 4. Consider feature importance: For high-importance features, always provide values (infer or
    ask). Low-importance features can be left blank.
-5. Validate: Run `validate_prediction_data` before submission to catch errors early.
+5. Validate: Run `deployment_validate_prediction_data` before submission to catch errors early.
 6. Time series note: Ensure `datetime_column` and `series_id_columns` are properly formatted
    if applicable.
 

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/schemas/drum_prediction_fallback_schema.json
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/schemas/drum_prediction_fallback_schema.json
@@ -3,7 +3,7 @@
   "properties": {
     "data": {
       "type": "string",
-      "description": "CSV-formatted data for prediction. Each row represents one prediction request. Column names must match the feature names from get_deployment_features tool."
+      "description": "CSV-formatted data for prediction. Each row represents one prediction request. Column names must match the feature names from deployment_get_features tool."
     }
   },
   "required": ["data"]

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -154,7 +154,7 @@ def _patch_datarobot_token_for_stdio() -> None:
 
 
 def _apply_predict_stubs() -> None:
-    """Patch datarobot_predict.deployment.predict so predict_realtime works with StubDeployment."""
+    """Patch datarobot_predict.deployment.predict for inline scoring with StubDeployment."""
     _dr_predict_deployment.predict = test_create_prediction_result
 
 

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -61,7 +61,7 @@ class StubModel:
     def request_predictions(
         self, dataset: Any = None, dataset_id: Any = None, **kwargs: Any
     ) -> MagicMock:
-        """Stub ``Model.request_predictions`` (used by score_dataset_with_model)."""
+        """Stub ``Model.request_predictions`` (used by modeling_score_dataset)."""
         return MagicMock(id=f"pred_job_{self.id}")
 
     def request_feature_impact(self) -> None:
@@ -84,7 +84,7 @@ class StubModel:
 
 
 class StubDatetimePartitioning:
-    """Stub datetime partitioning for get_deployment_info time_series_config."""
+    """Stub datetime partitioning for deployment_get_info time_series_config."""
 
     datetime_partition_column = "date"
     forecast_window_start = 1
@@ -113,7 +113,7 @@ class StubProject:
         return self._models[offset : offset + limit]
 
     def upload_dataset_from_catalog(self, dataset_id: str, **kwargs: Any) -> Any:
-        """Stub ``Project.upload_dataset_from_catalog`` (used by score_dataset_with_model)."""
+        """Stub ``Project.upload_dataset_from_catalog`` (used by modeling_score_dataset)."""
         return SimpleNamespace(id=f"prediction_dataset_for_{dataset_id}")
 
 
@@ -132,7 +132,7 @@ class StubDeployment:
         """
         Stub get_features;
         returns: list of feature dicts
-        (must include feature_type for generate_prediction_data_template).
+        (must include feature_type for deployment_generate_prediction_sample).
         """
         return [
             {"name": "text_review", "importance": 1, "feature_type": "text"},
@@ -364,7 +364,7 @@ def test_create_dr_client() -> StubDRClient:
     """Create a stub DataRobot client with test project and models."""
     client = StubDRClient()
 
-    # Metrics shape: get_best_model expects metrics[metric].get("validation")
+    # Metrics shape: models_get_bestmodel expects metrics[metric].get("validation")
     def _metrics(auc: float, logloss: float) -> dict:
         return {
             "AUC": {"validation": auc},
@@ -440,7 +440,7 @@ def test_create_dr_client() -> StubDRClient:
         ]
 
     def iterate_datasets(offset: int = 0, limit: int | None = None) -> Any:
-        """Stub ``Dataset.iterate``; supports offset/limit for ``list_ai_catalog_items``."""
+        """Stub ``Dataset.iterate``; supports offset/limit for ``catalog_list_datasets``."""
         items = _catalog_stub_datasets()[offset:]
         if limit is not None:
             items = items[:limit]
@@ -530,7 +530,7 @@ def test_create_dr_client() -> StubDRClient:
     def stub_post(url: str, json: dict | None = None, **kwargs: Any) -> StubRestResponse:
         """Stub for rest_client.post() REST calls."""
         if "deployments" in url and "predictions" in url:
-            # query_vector_database calls POST deployments/{id}/predictions/
+            # vdb_query calls POST deployments/{id}/predictions/
             return StubRestResponse(
                 {
                     "data": [

--- a/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
@@ -30,7 +30,7 @@ class ToolCallTestExpectations(BaseModel):
         default_factory=list,
         description=(
             "Logical tool names treated as equivalent for this step (same parameters/result "
-            "checks). Example: get_deployment_features vs get_deployment_info for deployment "
+            "checks). Example: deployment_get_features vs deployment_get_info for deployment "
             "scoring metadata."
         ),
     )
@@ -45,7 +45,7 @@ class ETETestExpectations(BaseModel):
     """Class to store test expectations for ETE tests.
 
     By default ``allow_unexpected_tool_calls`` is True so models may call extra tools
-    (e.g. list_projects after an error, get_dataset_details after resolving an id).
+    (e.g. modeling_list_projects after an error, catalog_get_preview after resolving an id).
     Set it to False when a test must assert an exact tool-call count and order with
     no additional calls.
     """
@@ -90,7 +90,7 @@ def _normalize_tool_name(tool_name: str, expected_tool_name: str | None = None) 
             return expected_tool_name
 
     # Some environments expose names as `<server>_mcp_<tool_name>`
-    # (e.g. `global_mcp_upload_dataset_to_ai_catalog`). Strip that server prefix.
+    # (e.g. `global_mcp_catalog_upload_dataset`). Strip that server prefix.
     if "_mcp_" in tool_name:
         _, suffix = tool_name.split("_mcp_", 1)
         if suffix:
@@ -298,7 +298,7 @@ class ToolBaseE2E:
                 - llm_response_content_contains_expectations: Expected content in the LLM response
             openai_llm_client: The OpenAI LLM client
             mcp_session: The test session
-            test_name: The name of the test (e.g. test_get_best_model_success)
+            test_name: The name of the test (e.g. test_models_get_bestmodel_success)
         """
         # Get the test file name from the class name
         file_name = self.__class__.__name__.lower().replace("e2e", "").replace("test", "")

--- a/src/datarobot_genai/drtools/confluence/tools.py
+++ b/src/datarobot_genai/drtools/confluence/tools.py
@@ -42,7 +42,7 @@ _FOOTER_COMMENTS_DOCS = (
     description=(
         "[Confluence—get page] Use when you have a numeric page id, or an exact page title plus "
         "space_key, and need the page body (storage HTML). Not CQL multi-page search "
-        "(confluence_search), not Jira (jira_get_issue).\n\n"
+        "(confluence_search_space), not Jira (jira_get_issue).\n\n"
         'Examples: By ID: page_id_or_title="856391684". By title: '
         'page_id_or_title="Meeting Notes", space_key="TEAM" (space_key is required when '
         "using a title).\n\n"
@@ -181,7 +181,7 @@ async def confluence_add_comment(
         f"Reference (CQL): {_CQL_DOCS}"
     ),
 )
-async def confluence_search(
+async def confluence_search_space(
     *,
     cql_query: Annotated[
         str,

--- a/src/datarobot_genai/drtools/core/utils.py
+++ b/src/datarobot_genai/drtools/core/utils.py
@@ -47,7 +47,8 @@ def predictions_result_response(df: Any, show_explanations: bool = False) -> Pre
     raise ToolError(
         f"Prediction CSV is {encoded_len} bytes, which exceeds the inline limit "
         f"of {MAX_INLINE_SIZE} bytes. "
-        "Use batch prediction (for example predict_by_ai_catalog) for large outputs, "
+        "Use batch prediction (for example predict_batch_predictions_from_dataset) "
+        "for large outputs, "
         "or reduce rows or explanations.",
         kind=ToolErrorKind.VALIDATION,
     )

--- a/src/datarobot_genai/drtools/dr_docs/tools.py
+++ b/src/datarobot_genai/drtools/dr_docs/tools.py
@@ -55,8 +55,8 @@ logger = logging.getLogger(__name__)
     description=(
         "[DR docs—search] Use when the user asks about DataRobot agentic AI product behavior, "
         "setup, or APIs covered on the public agentic-AI documentation site. Returns page titles "
-        "and URLs (then fetch_datarobot_doc_page for full text). Not Confluence, not general web "
-        "(tavily_search / perplexity_search)."
+        "and URLs (then datarobot_docs_fetch_page for full text). Not Confluence, not general web "
+        "(tavily_search_web / perplexity_search)."
     ),
 )
 async def search_datarobot_agentic_docs(
@@ -109,7 +109,7 @@ async def search_datarobot_agentic_docs(
         "agentic docs index (search_datarobot_agentic_docs)."
     ),
 )
-async def fetch_datarobot_doc_page(
+async def datarobot_docs_fetch_page(
     *,
     url: Annotated[
         str,

--- a/src/datarobot_genai/drtools/gdrive/tools.py
+++ b/src/datarobot_genai/drtools/gdrive/tools.py
@@ -43,7 +43,7 @@ _DRIVE_PERMISSIONS_DOCS = "https://developers.google.com/drive/api/guides/manage
     description=(
         "[GDrive—find files] Use when the user needs Google Drive file names and ids with "
         "optional folder scope, Drive query string, and pagination. Not file body text "
-        "(gdrive_read_content), not SharePoint (microsoft_graph_search_content).\n\n"
+        "(gdrive_read_and_export_content), not SharePoint (microsoft_graph_search_content).\n\n"
         f"limit must be >= page_size and a multiple of page_size (page_size max {MAX_PAGE_SIZE}, "
         f"limit max {LIMIT}). Examples: page_size=10, limit=50; page_size=3, limit=3; "
         "page_size=12, limit=36.\n\n"
@@ -117,7 +117,7 @@ async def gdrive_find_contents(
         f"Reference (export MIME types): {_DRIVE_EXPORT_DOCS}"
     ),
 )
-async def gdrive_read_content(
+async def gdrive_read_and_export_content(
     *,
     file_id: Annotated[str, "The ID of the file to read."],
     target_format: Annotated[
@@ -200,7 +200,8 @@ async def gdrive_create_file(
     enabled=False,
     description=(
         "[GDrive—metadata] Use when renaming, starring, or trashing an existing file by id. "
-        "Not reading content (gdrive_read_content), not ACL changes (gdrive_manage_access).\n\n"
+        "Not reading content (gdrive_read_and_export_content), "
+        "not ACL changes (gdrive_manage_access).\n\n"
         "Examples: new_name only; starred=True/False; trash=True/restore False; combine fields. "
         "At least one of new_name, starred, or trash is required.\n\n"
         f"Reference: {_DRIVE_FILES_UPDATE_DOCS}"

--- a/src/datarobot_genai/drtools/jira/tools.py
+++ b/src/datarobot_genai/drtools/jira/tools.py
@@ -39,7 +39,7 @@ _JIRA_ISSUES_REST = "https://developer.atlassian.com/cloud/jira/platform/rest/v3
     description=(
         "[Jira—search issues] Use when filtering many issues with JQL (project, status, text, "
         "dates, assignee, etc.). Returns matching issues as summaries. Not one known issue key "
-        "(jira_get_issue), not Confluence (confluence_search).\n\n"
+        "(jira_get_issue), not Confluence (confluence_search_space).\n\n"
         'Example: jql_query="project = PROJ AND status = Open", max_results=50.\n\n'
         "JQL references: "
         f"{_JQL_FUNCTIONS} {_JQL_FIELDS} {_JQL_KEYWORDS} {_JQL_OPERATORS}"

--- a/src/datarobot_genai/drtools/microsoft_graph/tools.py
+++ b/src/datarobot_genai/drtools/microsoft_graph/tools.py
@@ -233,14 +233,14 @@ async def microsoft_graph_share_item(
     description=(
         "[M365—create text file] Use when the user wants a new plain-text file in personal "
         "OneDrive or a SharePoint library (library id from search). Not metadata updates "
-        "(microsoft_update_metadata), not sharing (microsoft_graph_share_item).\n\n"
+        "(microsoft_graph_update_metadata), not sharing (microsoft_graph_share_item).\n\n"
         "Personal OneDrive: file_name + content_text only (saves to root). SharePoint: set "
         "document_library_id from microsoft_graph_search_content (documentLibraryId). "
         "Duplicate names are auto-renamed (e.g. report (1).txt).\n\n"
         f"References: {_MS_DRIVEITEM} {_MS_DRIVEITEM_PATCH}"
     ),
 )
-async def microsoft_create_file(
+async def microsoft_graph_create_file(
     *,
     file_name: Annotated[str, "The name of the file to create (e.g., 'report.txt')."],
     content_text: Annotated[str, "The raw text content to be stored in the file."],
@@ -304,7 +304,7 @@ async def microsoft_create_file(
         f"References: {_MS_DRIVEITEM} {_MS_DRIVEITEM_PATCH}"
     ),
 )
-async def microsoft_update_metadata(
+async def microsoft_graph_update_metadata(
     *,
     item_id: Annotated[str, "The ID of the file or list item to update."],
     fields_to_update: Annotated[

--- a/src/datarobot_genai/drtools/perplexity/tools.py
+++ b/src/datarobot_genai/drtools/perplexity/tools.py
@@ -42,9 +42,9 @@ _PPLX_STRUCTURED = "https://docs.perplexity.ai/guides/structured-outputs"
     description=(
         "[Perplexity—web search] Use when the user needs ranked web sources/snippets for a "
         "question or multi-part research (string or list of sub-queries), with optional domain "
-        "allow/deny and recency. Not long-form single narrative answers (perplexity_think), not "
+        "allow/deny and recency. Not long-form single narrative answers (perplexity_sonar), not "
         "DataRobot docs (search_datarobot_agentic_docs), not raw URL extraction "
-        "(tavily_extract).\n\n"
+        "(tavily_extract_text).\n\n"
         f"query may be a string or up to {MAX_QUERIES} strings; tune max_results (1-{MAX_RESULTS}) "
         f"and max_tokens_per_page (1-{MAX_TOKENS_PER_PAGE}).\n\n"
         f"Reference: {_PPLX_SEARCH_GUIDE}"
@@ -173,7 +173,7 @@ async def perplexity_search(
         f"Reference: {_PPLX_STRUCTURED}"
     ),
 )
-async def perplexity_think(
+async def perplexity_sonar(
     *,
     prompt: Annotated[str, "The research prompt or instruction."],
     model: Annotated[

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -57,10 +57,10 @@ def _serialize_datastore_params(params: Any) -> dict[str, Any]:
         "and needs a new AI Catalog dataset_id (nothing registered yet). Exactly one of "
         "base64 file content or file_url. Returns dataset id, version id, and name for "
         "Autopilot, scoring, or inspection. Not for listing existing items "
-        "(list_ai_catalog_items), not external DB browsing (list_datastores)."
+        "(catalog_list_datasets), not external DB browsing (catalog_list_datastores)."
     ),
 )
-async def upload_dataset_to_ai_catalog(
+async def catalog_upload_dataset(
     *,
     file_content_base64: Annotated[
         str,
@@ -140,11 +140,12 @@ async def upload_dataset_to_ai_catalog(
     description=(
         "[Catalog—list datasets] Use when the user needs catalog datasets they already have "
         "as id-to-name map. Read-only. Not project-attached datasets "
-        "(get_project_dataset_by_name), not modeling projects (list_projects). Follow with "
-        "get_dataset_details or scoring tools that take dataset_id."
+        "(modeling_get_project_dataset), not modeling projects (modeling_list_projects). "
+        "Follow with "
+        "catalog_get_preview or scoring tools that take dataset_id."
     ),
 )
-async def list_ai_catalog_items(
+async def catalog_list_datasets(
     offset: Annotated[
         int | None,
         "Skip this many catalog items (0-based). Example: page 2 with page size 3 uses offset=3.",
@@ -203,13 +204,13 @@ async def list_ai_catalog_items(
     description=(
         "[Catalog—one dataset metadata] Use when you already have catalog dataset_id and "
         "need name, row count, timestamps, optional column list and sample rows. Read-only. "
-        "Lighter than full EDA (analyze_dataset / get_exploratory_insights); not datastore "
-        "SQL (query_datastore)."
+        "Lighter than full EDA (catalog_analyze_dataset / catalog_get_eda_insights); not datastore "
+        "SQL (catalog_query_datastore)."
     ),
 )
-async def get_dataset_details(
+async def catalog_get_preview(
     *,
-    dataset_id: Annotated[str, "AI Catalog dataset id (from list_ai_catalog_items or upload)."]
+    dataset_id: Annotated[str, "AI Catalog dataset id (from catalog_list_datasets or upload)."]
     | None = None,
     include_sample: Annotated[
         bool, "If true, include columns and up to sample_rows example rows."
@@ -247,11 +248,12 @@ async def get_dataset_details(
     description=(
         "[Datastore—list connections] Use when the user works with saved external connections "
         "(DB, warehouse, bucket, etc.) and needs datastore ids. Read-only. Not AI Catalog "
-        "datasets (list_ai_catalog_items), not modeling projects. Next step: browse_datastore "
-        "or query_datastore."
+        "datasets (catalog_list_datasets), not modeling projects. "
+        "Next step: catalog_browse_datastore "
+        "or catalog_query_datastore."
     ),
 )
-async def list_datastores(
+async def catalog_list_datastores(
     offset: Annotated[
         int | None,
         "Skip this many datastores (0-based). Use with limit for paged listing; omit for all.",
@@ -308,14 +310,14 @@ async def list_datastores(
 @tool_metadata(
     tags={"predictive", "data", "read", "datastore", "browse", "daria"},
     description=(
-        "[Datastore—browse objects] Use after list_datastores when the user needs schemas, "
+        "[Datastore—browse objects] Use after catalog_list_datastores when the user needs schemas, "
         "tables, or folders inside one connection. Read-only; optional path, search filter, "
-        "pagination. Not SQL execution (query_datastore), not catalog dataset listing."
+        "pagination. Not SQL execution (catalog_query_datastore), not catalog dataset listing."
     ),
 )
-async def browse_datastore(
+async def catalog_browse_datastore(
     *,
-    datastore_id: Annotated[str, "Connection id from list_datastores."] | None = None,
+    datastore_id: Annotated[str, "Connection id from catalog_list_datastores."] | None = None,
     path: Annotated[str, "Path within the connection (e.g. schema or folder); omit for root."]
     | None = None,
     offset: Annotated[int, "Pagination offset."] = 0,
@@ -372,14 +374,15 @@ async def browse_datastore(
     tags={"predictive", "data", "read", "write", "delete", "datastore", "query", "sql", "daria"},
     description=(
         "[Datastore—run SQL] Use when the user wants to execute SQL (SELECT or DML) against "
-        "one saved external connection. Requires datastore_id from list_datastores; returns "
+        "one saved external connection. Requires datastore_id from catalog_list_datastores; "
+        "returns "
         "rows, columns, and row count up to limit. Not DataRobot catalog inspection "
-        "(get_dataset_details), not browsing without SQL (browse_datastore)."
+        "(catalog_get_preview), not browsing without SQL (catalog_browse_datastore)."
     ),
 )
-async def query_datastore(
+async def catalog_query_datastore(
     *,
-    datastore_id: Annotated[str, "Connection id from list_datastores."] | None = None,
+    datastore_id: Annotated[str, "Connection id from catalog_list_datastores."] | None = None,
     sql: Annotated[str, "SQL statement to run against that connection."] | None = None,
     offset: Annotated[int, "Number of rows to skip (0-based) for pagination"] = 0,
     limit: Annotated[

--- a/src/datarobot_genai/drtools/predictive/deployment.py
+++ b/src/datarobot_genai/drtools/predictive/deployment.py
@@ -37,12 +37,12 @@ logger = logging.getLogger(__name__)
     tags={"predictive", "deployment", "read", "management", "list", "daria"},
     description=(
         "[Deploy—discover deployments] Use when the user needs their MLOps deployments as "
-        "id-to-label map. Read-only. Not modeling projects (list_projects), not logged "
-        "prediction rows (get_prediction_history), not scoring payloads "
-        "(predict_* / get_deployment_info)."
+        "id-to-label map. Read-only. Not modeling projects (modeling_list_projects), not logged "
+        "prediction rows (deployment_get_prediction_history), not scoring payloads "
+        "(predict_* / deployment_get_info)."
     ),
 )
-async def list_deployments() -> dict[str, Any]:
+async def deployment_get_list() -> dict[str, Any]:
     with ThreadSafeDataRobotClient().request_user_client():
         deployments = dr.Deployment.list()
         if not deployments:
@@ -56,11 +56,11 @@ async def list_deployments() -> dict[str, Any]:
     description=(
         "[Deploy—model linkage] Use when the user wants the model record attached to a deployment "
         "(model id, project linkage). Read-only and narrow. For input feature names, types, and "
-        "prediction contract, use get_deployment_info instead; for training leaderboard details, "
-        "use get_model_details with project_id + model_id."
+        "prediction contract, use deployment_get_info instead; for training leaderboard details, "
+        "use modeling_get_modeldetails with project_id + model_id."
     ),
 )
-async def get_model_info_from_deployment(
+async def deployment_get_model_info(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
 ) -> dict[str, Any]:
@@ -78,15 +78,16 @@ async def get_model_info_from_deployment(
     tags={"predictive", "deployment", "write", "model", "create", "daria"},
     description=(
         "[Deploy—from leaderboard model] Use when the user wants a new live MLOps deployment "
-        "from an existing trained leaderboard model_id (from list_models / get_best_model). "
+        "from an existing trained leaderboard model_id "
+        "(from modeling_list_models / models_get_bestmodel). "
         "Returns deployment id and label. Not batch or realtime scoring by itself, not custom "
         "folder deploy (deploy_custom_model when enabled), not listing deployments "
-        "(list_deployments)."
+        "(deployment_get_list)."
     ),
 )
-async def deploy_model(
+async def deployment_create_deployment(
     *,
-    model_id: Annotated[str, "Trained model id from list_models / leaderboard."],
+    model_id: Annotated[str, "Trained model id from modeling_list_models / leaderboard."],
     label: Annotated[str, "Human-readable deployment name shown in the UI."],
     description: Annotated[str, "Optional longer description for operators."] | None = None,
 ) -> dict[str, Any]:
@@ -201,11 +202,11 @@ async def deploy_custom_model(
     description=(
         "[Deploy—prediction audit log] Use when the user asks for historical prediction rows "
         "already logged for a deployment (monitoring, audit). Read-only pagination; does not run "
-        "new scores. For fresh scoring use predict_realtime, predict_by_ai_catalog, "
-        "predict_from_project_data, etc."
+        "new scores. For fresh scoring use predict_score_inline_realtime, "
+        "predict_batch_predictions_from_dataset, predict_batch_predictions_from_partition, etc."
     ),
 )
-async def get_prediction_history(
+async def deployment_get_prediction_history(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     limit: Annotated[int, "Max rows in this page."] = 100,

--- a/src/datarobot_genai/drtools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drtools/predictive/deployment_info.py
@@ -54,13 +54,13 @@ def _feature_importance_value(feature: Any) -> float:
         "[Deploy—scoring contract] Use first when building or validating payloads for a "
         "deployment: target name/type, model family, all input features (name, type, "
         "importance), plus time-series settings when relevant. Read-only. Narrower feature-only "
-        "view is get_deployment_features; model training diagnostics stay on the project "
-        "(get_model_details)."
+        "view is deployment_get_features; model training diagnostics stay on the project "
+        "(modeling_get_modeldetails)."
     ),
 )
-async def get_deployment_info(
+async def deployment_get_info(
     *,
-    deployment_id: Annotated[str, "MLOps deployment id (from list_deployments or product UI)."],
+    deployment_id: Annotated[str, "MLOps deployment id (from deployment_get_list or product UI)."],
 ) -> dict[str, Any]:
     if not deployment_id:
         raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
@@ -129,11 +129,12 @@ async def get_deployment_info(
     description=(
         "[Deploy—sample prediction rows] Use when the user needs example rows with correct "
         "column names and types for one deployment (placeholder values only). Read-only. "
-        "Pair with get_deployment_info for semantics; output is meant as a skeleton for "
-        "predict_realtime CSV/JSON, not for batch catalog jobs or project model scoring."
+        "Pair with deployment_get_info for semantics; output is meant as a skeleton for "
+        "predict_score_inline_realtime CSV/JSON, not for batch catalog jobs "
+        "or project model scoring."
     ),
 )
-async def generate_prediction_data_template(
+async def deployment_generate_prediction_sample(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     n_rows: Annotated[int, "How many identical-length template rows to generate (≥1)."] = 1,
@@ -144,7 +145,7 @@ async def generate_prediction_data_template(
         n_rows = 1
 
     # Get feature information
-    features_info = await get_deployment_features(deployment_id=deployment_id)
+    features_info = await deployment_get_features(deployment_id=deployment_id)
     # Check if we got a valid result
     if not isinstance(features_info, dict) or "features" not in features_info:
         raise ToolError(
@@ -229,15 +230,17 @@ async def generate_prediction_data_template(
         "[Deploy—validate CSV only] Use when the user has inline CSV text and wants a schema "
         "check against one deployment before scoring (columns, basic types, time-series "
         "datetime and series id columns). Does not score; returns valid/invalid plus "
-        "errors/warnings. Same csv_string shape as predict_realtime dataset when CSV; not for "
+        "errors/warnings. Same csv_string shape as predict_score_inline_realtime "
+        "dataset when CSV; not for "
         "catalog dataset_id flows or JSON-only payloads."
     ),
 )
-async def validate_prediction_data(
+async def deployment_validate_prediction_data(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     csv_string: Annotated[
-        str, "Single CSV document (header + rows), same shape as predict_realtime dataset."
+        str,
+        "Single CSV document (header + rows), same shape as predict_score_inline_realtime dataset.",
     ],
 ) -> dict[str, Any]:
     if not csv_string or not csv_string.strip():
@@ -258,7 +261,7 @@ async def validate_prediction_data(
     if not deployment_id:
         raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
     # Get deployment features
-    features_info = await get_deployment_features(deployment_id=deployment_id)
+    features_info = await deployment_get_features(deployment_id=deployment_id)
 
     validation_report: dict[str, Any] = {
         "status": "valid",
@@ -372,18 +375,18 @@ async def validate_prediction_data(
     description=(
         "[Deploy—features slice] Use when you only need feature list, target summary, and "
         "optional time_series_config for a deployment without the full scoring contract "
-        "narrative. Read-only; subset of get_deployment_info (which remains the default first "
-        "call for predict_realtime prep)."
+        "narrative. Read-only; subset of deployment_get_info (which remains the default first "
+        "call for predict_score_inline_realtime prep)."
     ),
 )
-async def get_deployment_features(
+async def deployment_get_features(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
 ) -> dict[str, Any]:
     if not deployment_id:
         raise ToolError("Deployment ID must be provided", kind=ToolErrorKind.VALIDATION)
 
-    info = await get_deployment_info(deployment_id=deployment_id)
+    info = await deployment_get_info(deployment_id=deployment_id)
     # Only keep features, time_series_config, and total_features
     result = {
         "features": info.get("features", []),

--- a/src/datarobot_genai/drtools/predictive/model.py
+++ b/src/datarobot_genai/drtools/predictive/model.py
@@ -41,7 +41,7 @@ _MAX_NULL_RATE_FOR_ELIGIBILITY = 0.3
 # Below this fraction, `:.0%` rounds to "0%", so render as "<1%" instead.
 _MIN_DISPLAYABLE_GAP_PCT = 0.01
 
-# Cadence / gap inference helpers for is_eligible_for_timeseries_training.
+# Cadence / gap inference helpers for catalog_check_timeseries_eligibility.
 # Adapted from datarobot-ts-helpers (MIT, Bultema et al.):
 # https://github.com/jarredbultema/ts_helpers_package — specifically
 # `time_steps_gap_check` and the `median_timestep` derivation in
@@ -130,7 +130,7 @@ def _compute_cadence(
 
 @dataclass
 class ModelInsights:
-    """DTO for model detail information returned by get_model_details."""
+    """DTO for model detail information returned by modeling_get_modeldetails."""
 
     model_id: str
     project_id: str
@@ -178,11 +178,12 @@ class ModelEncoder(json.JSONEncoder):
         "[Project—pick best model] Use when the user wants the top leaderboard model for one "
         "modeling project, optionally ranked by a validation metric (e.g. AUC, LogLoss). "
         "Read-only; returns project_id plus best model id, type, and metrics. Not for listing "
-        "every model (list_models), not deployment scoring metadata (get_deployment_info), "
-        "not full diagnostics (get_model_details)."
+        "every model (modeling_list_models), not deployment scoring metadata "
+        "(deployment_get_info), "
+        "not full diagnostics (modeling_get_modeldetails)."
     ),
 )
-async def get_best_model(
+async def models_get_bestmodel(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
     metric: Annotated[
@@ -248,15 +249,17 @@ async def get_best_model(
     description=(
         "[Project—model vs catalog] Use when the user wants to score an AI Catalog dataset with a "
         "specific leaderboard model inside a modeling project (they give project_id, model_id, and "
-        "catalog dataset_id). This is not deployment batch scoring (see predict_by_ai_catalog) and "
-        "not inline CSV in chat (see predict_realtime). Starts an async project scoring job; "
+        "catalog dataset_id). This is not deployment batch scoring "
+        "(see predict_batch_predictions_from_dataset) and "
+        "not inline CSV in chat (see predict_score_inline_realtime). "
+        "Starts an async project scoring job; "
         "returns scoring_job_id and related dataset ids, not prediction rows."
     ),
 )
-async def score_dataset_with_model(
+async def modeling_score_dataset(
     *,
     project_id: Annotated[str, "Modeling project that owns the model."],
-    model_id: Annotated[str, "Leaderboard model id from list_models."],
+    model_id: Annotated[str, "Leaderboard model id from modeling_list_models."],
     dataset_id: Annotated[str, "AI Catalog dataset id to score (tabular)."],
 ) -> dict[str, Any]:
     if not project_id:
@@ -291,12 +294,14 @@ async def score_dataset_with_model(
     description=(
         "[Project—list models] Use when the user needs trained leaderboard models for a "
         "project (ids, types, metrics), with optional offset/limit pagination. Read-only. Not "
-        "the same as picking only the best model (get_best_model). When may_have_more is true, "
-        "call again with offset increased by the prior limit. Follow with get_model_details, "
-        "deploy_model, or score_dataset_with_model using a chosen model_id."
+        "the same as picking only the best model (models_get_bestmodel). "
+        "When may_have_more is true, "
+        "call again with offset increased by the prior limit. Follow with "
+        "modeling_get_modeldetails, "
+        "deployment_create_deployment, or modeling_score_dataset using a chosen model_id."
     ),
 )
-async def list_models(
+async def modeling_list_models(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
     offset: Annotated[
@@ -350,11 +355,11 @@ async def list_models(
         "[Project—model diagnostics] Use when the user asks for training-time detail on one "
         "leaderboard model: target, project metric, validation metrics, optional feature impact "
         "and ROC. Read-only. For MLOps deployment input columns and prediction contract, use "
-        "get_deployment_info instead. For ROC-only or lift-only charts with explicit source "
-        "fold, see get_model_roc_curve / get_model_lift_chart."
+        "deployment_get_info instead. For ROC-only or lift-only charts with explicit source "
+        "fold, see modeling_get_model_roc / modeling_get_model_lift_chart."
     ),
 )
-async def get_model_details(
+async def modeling_get_modeldetails(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
     model_id: Annotated[str, "Leaderboard model id."],
@@ -408,11 +413,11 @@ async def get_model_details(
         "[Catalog—time series readiness] Use before starting time-series Autopilot: checks an "
         "AI Catalog dataset for row count, parsable datetime column, target null rate, optional "
         "multiseries id column. Read-only; returns ELIGIBLE or NOT_ELIGIBLE with reasons; does "
-        "not train. Not general EDA (get_exploratory_insights / analyze_dataset) and not "
-        "tabular-only Autopilot start (start_autopilot without TS-specific checks)."
+        "not train. Not general EDA (catalog_get_eda_insights / catalog_analyze_dataset) and not "
+        "tabular-only Autopilot start (modeling_start_autopilot without TS-specific checks)."
     ),
 )
-async def is_eligible_for_timeseries_training(
+async def catalog_check_timeseries_eligibility(
     *,
     dataset_id: Annotated[str, "AI Catalog dataset id."],
     datetime_column: Annotated[str, "Column name with timestamps."],

--- a/src/datarobot_genai/drtools/predictive/predict.py
+++ b/src/datarobot_genai/drtools/predictive/predict.py
@@ -75,9 +75,9 @@ def _batch_job_submitted_payload(job: Any, deployment_id: str, input_desc: str) 
         "name": f"Predictions for {deployment_id}",
         "mime_type": "text/csv",
         "note": (
-            "This tool only submits the batch job. You MUST poll get_batch_prediction_job_status "
+            "This tool only submits the batch job. You MUST poll predict_get_batch_job_status "
             "with job_id until batch_job_status is COMPLETED and url is present (retry every few "
-            "seconds while RUNNING or INITIALIZING). Then call get_batch_prediction_results for "
+            "seconds while RUNNING or INITIALIZING). Then call predict_get_batch_results for "
             "inline CSV if small enough, or fetch url with DataRobot API authentication."
         ),
     }
@@ -89,14 +89,15 @@ def _batch_job_submitted_payload(job: Any, deployment_id: str, input_desc: str) 
         "[Predict—deployment + catalog dataset] Submits batch scoring of one AI Catalog tabular "
         "dataset through an MLOps deployment (deployment_id + dataset_id). Returns immediately "
         "with job_id and initial batch_job_status; does NOT wait for completion. Required "
-        "follow-up: poll get_batch_prediction_job_status until COMPLETED and url is set, then "
-        "get_batch_prediction_results or authenticated download of url. Not leaderboard scoring "
-        "(score_dataset_with_model), not project splits (predict_from_project_data), not inline "
-        "rows (predict_realtime). For synchronous small catalog scoring use "
-        "predict_by_ai_catalog_rt."
+        "follow-up: poll predict_get_batch_job_status until COMPLETED and url is set, then "
+        "predict_get_batch_results or authenticated download of url. Not leaderboard scoring "
+        "(modeling_score_dataset), not project splits "
+        "(predict_batch_predictions_from_partition), not inline "
+        "rows (predict_score_inline_realtime). For synchronous small catalog scoring use "
+        "predict_score_catalog_realtime."
     ),
 )
-async def predict_by_ai_catalog(
+async def predict_batch_predictions_from_dataset(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     dataset_id: Annotated[str, "AI Catalog dataset id to score."],
@@ -133,13 +134,14 @@ async def predict_by_ai_catalog(
     description=(
         "[Predict—deployment + project splits] Submits batch predictions from a deployment using "
         "project data: training, holdout, validation, or allBacktest (partition), optional "
-        "catalog dataset_id. Returns immediately with job_id like predict_by_ai_catalog; does NOT "
-        "wait. Required follow-up: poll get_batch_prediction_job_status until COMPLETED and url, "
-        "then get_batch_prediction_results or download url. Not catalog-only scoring without "
+        "catalog dataset_id. Returns immediately with job_id like "
+        "predict_batch_predictions_from_dataset; does NOT "
+        "wait. Required follow-up: poll predict_get_batch_job_status until COMPLETED and url, "
+        "then predict_get_batch_results or download url. Not catalog-only scoring without "
         "project context, not inline CSV in chat."
     ),
 )
-async def predict_from_project_data(
+async def predict_batch_predictions_from_partition(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     project_id: Annotated[str, "DataRobot project id that supplies training/holdout data."],
@@ -197,19 +199,22 @@ async def predict_from_project_data(
 @tool_metadata(
     tags={"predictive", "prediction", "read", "scoring", "batch"},
     description=(
-        "[Predict—batch job status] REQUIRED polling step after predict_by_ai_catalog or "
-        "predict_from_project_data. Pass job_id from the submit response. Returns "
+        "[Predict—batch job status] REQUIRED polling step after "
+        "predict_batch_predictions_from_dataset or "
+        "predict_batch_predictions_from_partition. Pass job_id from the submit response. "
+        "Returns "
         "batch_job_status, optional url when the scored file is ready, and progress fields. "
         "Poll every few seconds until batch_job_status is COMPLETED and url is non-null, then "
-        "get_batch_prediction_results or download url. Lightweight (no CSV body). Raises on "
-        "terminal failure. Not for score_dataset_with_model jobs."
+        "predict_get_batch_results or download url. Lightweight (no CSV body). Raises on "
+        "terminal failure. Not for modeling_score_dataset jobs."
     ),
 )
-async def get_batch_prediction_job_status(
+async def predict_get_batch_job_status(
     *,
     job_id: Annotated[
         str,
-        "Batch prediction job id from predict_by_ai_catalog or predict_from_project_data.",
+        "Batch prediction job id from predict_batch_predictions_from_dataset "
+        "or predict_batch_predictions_from_partition.",
     ],
 ) -> dict[str, Any]:
     if not job_id or not job_id.strip():
@@ -252,17 +257,18 @@ async def get_batch_prediction_job_status(
 @tool_metadata(
     tags={"predictive", "prediction", "read", "scoring", "batch"},
     description=(
-        "[Predict—fetch batch CSV] After get_batch_prediction_job_status shows COMPLETED and "
+        "[Predict—fetch batch CSV] After predict_get_batch_job_status shows COMPLETED and "
         "url, returns scored CSV text inline for job_id when under the inline size cap. If too "
         "large, the error includes the download url—fetch with API authentication. Does not start "
-        "scoring; not for score_dataset_with_model jobs."
+        "scoring; not for modeling_score_dataset jobs."
     ),
 )
-async def get_batch_prediction_results(
+async def predict_get_batch_results(
     *,
     job_id: Annotated[
         str,
-        "job_id from predict_by_ai_catalog or predict_from_project_data (same as status polling).",
+        "job_id from predict_batch_predictions_from_dataset "
+        "or predict_batch_predictions_from_partition (same as status polling).",
     ],
     download_timeout: Annotated[int, "Seconds to wait for the download to become ready."] = 120,
     download_read_timeout: Annotated[int, "Seconds allowed for streaming the CSV body."] = 660,

--- a/src/datarobot_genai/drtools/predictive/predict_realtime.py
+++ b/src/datarobot_genai/drtools/predictive/predict_realtime.py
@@ -50,11 +50,12 @@ def _parse_datetime(value: str) -> datetime:
         "[Predict—deployment + catalog, synchronous rows] Use when the user already has an AI "
         "Catalog dataset_id and wants realtime-style scoring through a deployment with rows "
         "returned in one response (moderate size). Not for pasted inline CSV/JSON "
-        "(predict_realtime), not for async batch CSV submit-and-poll (predict_by_ai_catalog plus "
-        "get_batch_prediction_job_status), not project-partition batch (predict_from_project_data)."
+        "(predict_score_inline_realtime), not for async batch CSV submit-and-poll "
+        "(predict_batch_predictions_from_dataset plus predict_get_batch_job_status), "
+        "not project-partition batch (predict_batch_predictions_from_partition)."
     ),
 )
-async def predict_by_ai_catalog_rt(
+async def predict_score_catalog_realtime(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     dataset_id: Annotated[str, "AI Catalog dataset id (tabular)."],
@@ -125,14 +126,15 @@ async def predict_by_ai_catalog_rt(
         "in the conversation: a CSV snippet (header + rows) or a JSON array of row objects in "
         "the dataset argument, plus deployment_id. Immediate synchronous scoring; results return "
         "in the tool response. Do not use for catalog dataset_id only (use "
-        "predict_by_ai_catalog_rt or batch predict_by_ai_catalog), not for project holdout "
-        "batch jobs (predict_from_project_data), and not for leaderboard model scoring jobs "
-        "(score_dataset_with_model). Match feature columns to get_deployment_info. Time series: "
+        "predict_score_catalog_realtime or batch predict_batch_predictions_from_dataset), "
+        "not for project holdout batch jobs (predict_batch_predictions_from_partition), "
+        "and not for leaderboard model scoring jobs "
+        "(modeling_score_dataset). Match feature columns to deployment_get_info. Time series: "
         "forecast_point or forecast_range_start+end, plus series_id_column if multiseries. "
-        "validate_prediction_data can sanity-check CSV shape first."
+        "deployment_validate_prediction_data can sanity-check CSV shape first."
     ),
 )
-async def predict_realtime(
+async def predict_score_inline_realtime(
     *,
     deployment_id: Annotated[str, "MLOps deployment id."],
     dataset: Annotated[

--- a/src/datarobot_genai/drtools/predictive/project.py
+++ b/src/datarobot_genai/drtools/predictive/project.py
@@ -33,11 +33,11 @@ logger = logging.getLogger(__name__)
     description=(
         "[Project—discover ids] Use when the user needs their modeling projects as id-to-name "
         "map (no single project_id yet). Read-only. Not for datasets inside one project "
-        "(get_project_dataset_by_name), not catalog datasets (list_ai_catalog_items), not "
-        "deployments (list_deployments)."
+        "(modeling_get_project_dataset), not catalog datasets (catalog_list_datasets), not "
+        "deployments (deployment_get_list)."
     ),
 )
-async def list_projects() -> dict[str, Any]:
+async def modeling_list_projects() -> dict[str, Any]:
     with ThreadSafeDataRobotClient().request_user_client():
         projects = dr.Project.list()
         projects = {p.id: p.project_name for p in projects}
@@ -53,10 +53,10 @@ async def list_projects() -> dict[str, Any]:
         "X') and you need its dataset_id: pass project_id plus dataset_name as a case-insensitive "
         "substring of the dataset display name. Read-only. Returns dataset_id and whether it is "
         "the project source or a prediction upload. Not for listing all projects "
-        "(list_projects) or arbitrary catalog lookup."
+        "(modeling_list_projects) or arbitrary catalog lookup."
     ),
 )
-async def get_project_dataset_by_name(
+async def modeling_get_project_dataset(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
     dataset_name: Annotated[str, "Substring to match against dataset display names."],

--- a/src/datarobot_genai/drtools/predictive/training.py
+++ b/src/datarobot_genai/drtools/predictive/training.py
@@ -199,11 +199,12 @@ def _build_dataset_insights(df: pd.DataFrame) -> dict[str, Any]:
         "[Catalog—quick profile] Use for a fast structural overview of one AI Catalog dataset: "
         "row/column counts, inferred kinds (numeric, categorical, datetime, text), missingness, "
         "heuristic candidate targets. Read-only; does not train. Lighter than "
-        "get_exploratory_insights; does not rank ML use-case ideas (suggest_use_cases calls this "
+        "catalog_get_eda_insights; does not rank ML use-case ideas "
+        "(catalog_suggest_ml_problems calls this "
         "internally)."
     ),
 )
-async def analyze_dataset(
+async def catalog_analyze_dataset(
     *,
     dataset_id: Annotated[str, "AI Catalog dataset id."],
 ) -> dict[str, Any]:
@@ -220,11 +221,12 @@ async def analyze_dataset(
     description=(
         "[Catalog—use-case ideas] Use when the user wants ranked ML problem suggestions from one "
         "catalog dataset (name, suggested target, problem type, confidence). Read-only. Builds on "
-        "dataset profiling; not the same as starting Autopilot (start_autopilot) or deep EDA "
-        "(get_exploratory_insights)."
+        "dataset profiling; not the same as starting Autopilot (modeling_start_autopilot) "
+        "or deep EDA "
+        "(catalog_get_eda_insights)."
     ),
 )
-async def suggest_use_cases(
+async def catalog_suggest_ml_problems(
     *,
     dataset_id: Annotated[str, "AI Catalog dataset id."],
 ) -> dict[str, Any]:
@@ -254,11 +256,11 @@ async def suggest_use_cases(
         "and numeric correlations. For averages/min/max/median/std on a specific column, set "
         "feature_col to use DataRobot catalog feature metadata (allFeaturesDetails; EDA sample "
         "per platform), optionally with include_feature_histogram. Read-only; does not train or "
-        "upload data. Heavier than analyze_dataset; not time-series eligibility "
-        "(is_eligible_for_timeseries_training)."
+        "upload data. Heavier than catalog_analyze_dataset; not time-series eligibility "
+        "(catalog_check_timeseries_eligibility)."
     ),
 )
-async def get_exploratory_insights(
+async def catalog_get_eda_insights(
     *,
     dataset_id: Annotated[str, "AI Catalog dataset id."],
     target_col: Annotated[
@@ -606,11 +608,11 @@ def _analyze_target_for_use_cases(df: pd.DataFrame, target_col: str) -> list[Use
         "existing project via project_id. mode must be string 'quick', 'comprehensive', or "
         "'manual' (default 'quick'). Returns "
         "project_id and status—not finished leaderboard models yet. Not deployment creation "
-        "(deploy_model), not batch scoring (predict_*), not dataset upload "
-        "(upload_dataset_to_ai_catalog) unless they already registered data."
+        "(deployment_create_deployment), not batch scoring (predict_*), not dataset upload "
+        "(catalog_upload_dataset) unless they already registered data."
     ),
 )
-async def start_autopilot(
+async def modeling_start_autopilot(
     *,
     target: Annotated[str, "Column name in the training table to predict."],
     project_id: Annotated[
@@ -698,11 +700,12 @@ async def start_autopilot(
         "[Project—ROC only] Use when the user wants ROC curve points for one binary classification "
         "leaderboard model; source must be string 'validation', 'holdout', or 'crossValidation'. "
         "Read-only. Not "
-        "for regression-only models, not full model card (get_model_details), not deployment "
-        "monitoring (get_prediction_history)."
+        "for regression-only models, not full model card (modeling_get_modeldetails), "
+        "not deployment "
+        "monitoring (deployment_get_prediction_history)."
     ),
 )
-async def get_model_roc_curve(
+async def modeling_get_model_roc(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
     model_id: Annotated[str, "Leaderboard model id."],
@@ -762,11 +765,12 @@ async def get_model_roc_curve(
     description=(
         "[Project—global feature impact] Use for training-time global feature impact on one "
         "leaderboard model (may wait while impact is computed). Read-only. Not per-row SHAP from "
-        "live deployment predictions (those come from predict_realtime explanation flags), not "
-        "lift chart bins (get_model_lift_chart)."
+        "live deployment predictions "
+        "(those come from predict_score_inline_realtime explanation flags), not "
+        "lift chart bins (modeling_get_model_lift_chart)."
     ),
 )
-async def get_model_feature_impact(
+async def modeling_get_model_feature_impact(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
     model_id: Annotated[str, "Leaderboard model id."],
@@ -794,12 +798,12 @@ async def get_model_feature_impact(
     description=(
         "[Project—lift chart] Use for lift chart bins on one classification leaderboard model "
         "(actual vs predicted by score bucket); source must be 'validation', 'holdout', or "
-        "'crossValidation'. Read-only. Not ROC points (get_model_roc_curve), not general model "
+        "'crossValidation'. Read-only. Not ROC points (modeling_get_model_roc), not general model "
         "metrics dump "
-        "(get_model_details)."
+        "(modeling_get_modeldetails)."
     ),
 )
-async def get_model_lift_chart(
+async def modeling_get_model_lift_chart(
     *,
     project_id: Annotated[str, "DataRobot modeling project id."],
     model_id: Annotated[str, "Leaderboard model id."],

--- a/src/datarobot_genai/drtools/tavily/tools.py
+++ b/src/datarobot_genai/drtools/tavily/tools.py
@@ -43,15 +43,16 @@ _TAVILY_CRAWL_API = "https://docs.tavily.com/documentation/api-reference/endpoin
         "[Tavily—web search] Use when the user needs fresh facts from the public web by keyword "
         "(optional topic string: 'general', 'news', or 'finance'). Returns ranked snippets and "
         "optional short answer. "
-        "Not for reading full pages when you already have URLs (tavily_extract), not site link "
-        "discovery (tavily_map), not multi-page site harvest (tavily_crawl).\n\n"
-        'Examples: tavily_search(query="Python best practices 2026"); '
+        "Not for reading full pages when you already have URLs (tavily_extract_text), "
+        "not site link discovery (tavily_list_links), "
+        "not multi-page site harvest (tavily_crawl_site).\n\n"
+        'Examples: tavily_search_web(query="Python best practices 2026"); '
         'topic="news", time_range="week"; topic="finance"; search_depth="advanced", '
         "include_answer=True. Advanced depth uses more credits.\n\n"
         f"Reference: {_TAVILY_SEARCH_API}"
     ),
 )
-async def tavily_search(
+async def tavily_search_web(
     *,
     query: Annotated[str, "The search query to execute."],
     topic: Annotated[
@@ -119,13 +120,13 @@ async def tavily_search(
     description=(
         "[Tavily—read URLs] Use when you already have one or more page URLs and need cleaned "
         "body text or reranked chunks (optional query for relevance). Not broad keyword web "
-        "search (tavily_search), not crawling an entire site (tavily_crawl).\n\n"
-        'Examples: single url string; list of urls; tavily_extract(urls="...", query="...", '
+        "search (tavily_search_web), not crawling an entire site (tavily_crawl_site).\n\n"
+        'Examples: single url string; list of urls; tavily_extract_text(urls="...", query="...", '
         'chunks_per_source=5); extract_depth="advanced". Up to 20 URLs; chunks_per_source 1-5.\n\n'
         f"Reference: {_TAVILY_EXTRACT_API}"
     ),
 )
-async def tavily_extract(
+async def tavily_extract_text(
     *,
     urls: Annotated[
         str | list[str],
@@ -191,13 +192,15 @@ async def tavily_extract(
     description=(
         "[Tavily—site map] Use when you need a structured list of links under one root URL "
         "(find sections or docs paths before reading). Optional instructions steer which branches "
-        "matter. Not keyword web search (tavily_search), not full page text (tavily_extract), "
-        "not deep multi-hop crawl (tavily_crawl).\n\n"
-        'Example: tavily_map(url="https://docs.example.com", instructions="API sections").\n\n'
+        "matter. Not keyword web search (tavily_search_web), "
+        "not full page text (tavily_extract_text), "
+        "not deep multi-hop crawl (tavily_crawl_site).\n\n"
+        'Example: tavily_list_links(url="https://docs.example.com", '
+        'instructions="API sections").\n\n'
         f"Reference: {_TAVILY_MAP_API}"
     ),
 )
-async def tavily_map(
+async def tavily_list_links(
     *,
     url: Annotated[str, "The root URL to begin mapping."],
     instructions: Annotated[
@@ -234,14 +237,14 @@ async def tavily_map(
     description=(
         "[Tavily—site crawl] Use when you need many related pages from one site guided by "
         "natural-language instructions (breadth/depth limits). Not single-URL read "
-        "(tavily_extract), not link-only outline (tavily_map), not global keyword search "
-        "(tavily_search).\n\n"
+        "(tavily_extract_text), not link-only outline (tavily_list_links), "
+        "not global keyword search (tavily_search_web).\n\n"
         "Examples: basic crawl on docs root; instructions to filter topics; max_depth and limit "
         "up to API max; exclude_paths regex list. Higher depth/limit uses more credits.\n\n"
         f"Reference: {_TAVILY_CRAWL_API}"
     ),
 )
-async def tavily_crawl(
+async def tavily_crawl_site(
     *,
     url: Annotated[str, "The root URL to begin the traversal."],
     instructions: Annotated[

--- a/src/datarobot_genai/drtools/use_case/tools.py
+++ b/src/datarobot_genai/drtools/use_case/tools.py
@@ -35,11 +35,12 @@ logger = logging.getLogger(__name__)
     description=(
         "[Use case—list] Use when the user needs DataRobot use cases (workspace bundles) as "
         "id+name, optionally filtered by name search. Read-only. Not assets inside a known case "
-        "(list_use_case_assets), not modeling project ids (list_projects), not deployments alone "
-        "(list_deployments)."
+        "(usecases_list_assets), not modeling project ids (modeling_list_projects), "
+        "not deployments alone "
+        "(deployment_get_list)."
     ),
 )
-async def list_use_cases(
+async def datarobot_usecases_list(
     *,
     search: Annotated[str | None, "Optional search filter for use case names"] = None,
     limit: Annotated[int, "Maximum number of use cases to return"] = 100,
@@ -72,10 +73,10 @@ async def list_use_cases(
     description=(
         "[Use case—assets] Use when you have one or more use_case_id values and need what is "
         "linked: datasets, deployments, and experiments as id+name per case. Read-only. Not "
-        "discovering use case ids (list_use_cases), not Jira/Confluence content."
+        "discovering use case ids (datarobot_usecases_list), not Jira/Confluence content."
     ),
 )
-async def list_use_case_assets(
+async def usecases_list_assets(
     *,
     use_case_id: Annotated[str | None, "The ID of a single DataRobot use case"] = None,
     use_case_ids: Annotated[list[str] | None, "List of use case IDs to fetch assets for"] = None,

--- a/src/datarobot_genai/drtools/vdb/tools.py
+++ b/src/datarobot_genai/drtools/vdb/tools.py
@@ -38,11 +38,11 @@ logger = logging.getLogger(__name__)
     description=(
         "[VDB—discover deployments] Use when the user needs deployed Vector Databases (VDBs) as "
         "id/label/status records. Read-only. Filters DataRobot deployments to "
-        "modelTargetType=VectorDatabase. Not predictive deployments (list_deployments), not "
-        "AI Catalog datasets (list_ai_catalog_items). Next step: query_vector_database."
+        "modelTargetType=VectorDatabase. Not predictive deployments (deployment_get_list), not "
+        "AI Catalog datasets (catalog_list_datasets). Next step: vdb_query."
     ),
 )
-async def list_vector_databases(
+async def vdb_list(
     *,
     offset: Annotated[
         int | None,
@@ -97,12 +97,12 @@ async def list_vector_databases(
     tags={"vdb", "read", "query", "search", "daria"},
     description=(
         "[VDB—semantic search] Use when the user wants to retrieve documents from a deployed "
-        "Vector Database via semantic similarity (deployment_id from list_vector_databases). "
+        "Vector Database via semantic similarity (deployment_id from vdb_list). "
         "Returns matched documents with metadata. Read-only. Not deployment metadata "
-        "(get_deployment_info), not predictive scoring (predict_*)."
+        "(deployment_get_info), not predictive scoring (predict_*)."
     ),
 )
-async def query_vector_database(
+async def vdb_query(
     *,
     deployment_id: Annotated[str, "The deployment ID of the Vector Database"] | None = None,
     query: Annotated[str, "The search query"] | None = None,

--- a/tests/drmcp/acceptance/test_confluence_tools.py
+++ b/tests/drmcp/acceptance/test_confluence_tools.py
@@ -131,7 +131,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_confluence_search_success(
+    async def test_confluence_search_space_success(
         self,
         llm_client: Any,
     ) -> None:
@@ -140,7 +140,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="confluence_search",
+                    name="confluence_search_space",
                     parameters={
                         "cql_query": cql_query,
                     },
@@ -159,7 +159,7 @@ class TestConfluenceToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_confluence_search_success"
+            test_name = frame.f_code.co_name if frame else "test_confluence_search_space_success"
             await self._run_test_with_expectations(
                 prompt,
                 expectations,

--- a/tests/drmcp/acceptance/test_data.py
+++ b/tests/drmcp/acceptance/test_data.py
@@ -29,11 +29,11 @@ TINY_UPLOAD_CSV_BASE64 = base64.b64encode(_TINY_UPLOAD_CSV.encode("utf-8")).deco
 
 
 @pytest.fixture(scope="session")
-def expectations_for_upload_dataset_to_ai_catalog_success_from_base64() -> ETETestExpectations:
+def expectations_for_catalog_upload_dataset_success_from_base64() -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="upload_dataset_to_ai_catalog",
+                name="catalog_upload_dataset",
                 parameters={
                     "file_content_base64": TINY_UPLOAD_CSV_BASE64,
                     "dataset_filename": "ete_tiny.csv",
@@ -56,11 +56,11 @@ def expectations_for_upload_dataset_to_ai_catalog_success_from_base64() -> ETETe
 
 
 @pytest.fixture(scope="session")
-def expectations_for_upload_dataset_to_ai_catalog_success_from_url() -> ETETestExpectations:
+def expectations_for_catalog_upload_dataset_success_from_url() -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="upload_dataset_to_ai_catalog",
+                name="catalog_upload_dataset",
                 parameters={
                     "file_url": "https://s3.amazonaws.com/datarobot_public_datasets/10k_diabetes.csv"
                 },
@@ -79,11 +79,11 @@ def expectations_for_upload_dataset_to_ai_catalog_success_from_url() -> ETETestE
 
 
 @pytest.fixture(scope="session")
-def expectations_for_list_ai_catalog_items_success() -> ETETestExpectations:
+def expectations_for_catalog_list_datasets_success() -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_ai_catalog_items",
+                name="catalog_list_datasets",
                 parameters={},
                 result={"datasets": {}, "count": 0},
             )
@@ -109,10 +109,10 @@ class TestDataE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_upload_dataset_to_ai_catalog_success_from_url(
+    async def test_catalog_upload_dataset_success_from_url(
         self,
         llm_client: Any,
-        expectations_for_upload_dataset_to_ai_catalog_success_from_url: ETETestExpectations,
+        expectations_for_catalog_upload_dataset_success_from_url: ETETestExpectations,
         prompt_template: str,
     ) -> None:
         prompt = prompt_template.format(
@@ -121,13 +121,13 @@ class TestDataE2E(ToolBaseE2E):
         async with ete_test_mcp_session() as session:
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_upload_dataset_to_ai_catalog_success_from_url,
+                expectations_for_catalog_upload_dataset_success_from_url,
                 llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
                     if inspect.currentframe()
-                    else "test_upload_dataset_to_ai_catalog_success_from_url"
+                    else "test_catalog_upload_dataset_success_from_url"
                 ),
             )
 
@@ -142,23 +142,23 @@ class TestDataE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_upload_dataset_to_ai_catalog_success_from_base64(
+    async def test_catalog_upload_dataset_success_from_base64(
         self,
         llm_client: Any,
-        expectations_for_upload_dataset_to_ai_catalog_success_from_base64: ETETestExpectations,
+        expectations_for_catalog_upload_dataset_success_from_base64: ETETestExpectations,
         prompt_template: str,
     ) -> None:
         prompt = prompt_template.format(b64=TINY_UPLOAD_CSV_BASE64)
         async with ete_test_mcp_session() as session:
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_upload_dataset_to_ai_catalog_success_from_base64,
+                expectations_for_catalog_upload_dataset_success_from_base64,
                 llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
                     if inspect.currentframe()
-                    else "test_upload_dataset_to_ai_catalog_success_from_base64"
+                    else "test_catalog_upload_dataset_success_from_base64"
                 ),
             )
 
@@ -172,21 +172,21 @@ class TestDataE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_list_ai_catalog_items_success(
+    async def test_catalog_list_datasets_success(
         self,
         llm_client: Any,
-        expectations_for_list_ai_catalog_items_success: ETETestExpectations,
+        expectations_for_catalog_list_datasets_success: ETETestExpectations,
         prompt: str,
     ) -> None:
         async with ete_test_mcp_session() as session:
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_list_ai_catalog_items_success,
+                expectations_for_catalog_list_datasets_success,
                 llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
                     if inspect.currentframe()
-                    else "test_list_ai_catalog_items_success"
+                    else "test_catalog_list_datasets_success"
                 ),
             )

--- a/tests/drmcp/acceptance/test_data_tools.py
+++ b/tests/drmcp/acceptance/test_data_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Acceptance tests for new data tools (get_dataset_details, list_datastores, browse_datastore, query_datastore)."""  # noqa: E501
+"""Acceptance tests for new data tools (catalog_get_preview, catalog_list_datastores, catalog_browse_datastore, catalog_query_datastore)."""  # noqa: E501
 
 import inspect
 from typing import Any
@@ -27,13 +27,13 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_dataset_details(
+def expectations_for_catalog_get_preview(
     classification_dataset_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_dataset_details",
+                name="catalog_get_preview",
                 parameters={"dataset_id": classification_dataset_id},
                 result={"id": classification_dataset_id, "name": ""},
             ),
@@ -46,11 +46,11 @@ def expectations_for_get_dataset_details(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_list_datastores() -> ETETestExpectations:
+def expectations_for_catalog_list_datastores() -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_datastores",
+                name="catalog_list_datastores",
                 parameters={},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -66,44 +66,44 @@ def expectations_for_list_datastores() -> ETETestExpectations:
 class TestDataToolsE2E(ToolBaseE2E):
     """Acceptance tests for data tools."""
 
-    async def test_get_dataset_details(
+    async def test_catalog_get_preview(
         self,
         llm_client: Any,
-        expectations_for_get_dataset_details: ETETestExpectations,
+        expectations_for_catalog_get_preview: ETETestExpectations,
         classification_dataset_id: str,
     ) -> None:
-        """Test LLM can use get_dataset_details to retrieve dataset metadata."""
+        """Test LLM can use catalog_get_preview to retrieve dataset metadata."""
         prompt = (
             f"I have a dataset with ID '{classification_dataset_id}' in the DataRobot AI Catalog. "
             "Can you get the details about this dataset including columns and sample rows?"
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_dataset_details"
+            test_name = frame.f_code.co_name if frame else "test_catalog_get_preview"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_dataset_details,
+                expectations_for_catalog_get_preview,
                 llm_client,
                 session,
                 test_name,
             )
 
-    async def test_list_datastores(
+    async def test_catalog_list_datastores(
         self,
         llm_client: Any,
-        expectations_for_list_datastores: ETETestExpectations,
+        expectations_for_catalog_list_datastores: ETETestExpectations,
     ) -> None:
-        """Test LLM can use list_datastores to show available data connections."""
+        """Test LLM can use catalog_list_datastores to show available data connections."""
         prompt = (
             "Can you list all available data connections (datastores) in my DataRobot environment? "
             "I need to see what databases are connected."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_list_datastores"
+            test_name = frame.f_code.co_name if frame else "test_catalog_list_datastores"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_list_datastores,
+                expectations_for_catalog_list_datastores,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_deployment.py
+++ b/tests/drmcp/acceptance/test_deployment.py
@@ -25,11 +25,11 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectati
 
 
 @pytest.fixture(scope="session")
-def expectations_for_list_deployments_success() -> ETETestExpectations:
+def expectations_for_deployment_get_list_success() -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_deployments",
+                name="deployment_get_list",
                 parameters={},
                 result={"deployments": {}},
             ),
@@ -43,13 +43,13 @@ def expectations_for_list_deployments_success() -> ETETestExpectations:
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_model_info_from_deployment_success(
+def expectations_for_deployment_get_model_info_success(
     deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_model_info_from_deployment",
+                name="deployment_get_model_info",
                 parameters={"deployment_id": deployment_id},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -59,13 +59,13 @@ def expectations_for_get_model_info_from_deployment_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_model_info_from_deployment_failure(
+def expectations_for_deployment_get_model_info_failure(
     nonexistent_deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_model_info_from_deployment",
+                name="deployment_get_model_info",
                 parameters={"deployment_id": nonexistent_deployment_id},
                 result="[not_found] DataRobot API error (404):",
             ),
@@ -94,22 +94,22 @@ class TestDeploymentE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_list_deployments_success(
+    async def test_deployment_get_list_success(
         self,
         llm_client: Any,
-        expectations_for_list_deployments_success: ETETestExpectations,
+        expectations_for_deployment_get_list_success: ETETestExpectations,
         prompt: str,
     ) -> None:
         async with ete_test_mcp_session() as session:
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_list_deployments_success,
+                expectations_for_deployment_get_list_success,
                 llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
                     if inspect.currentframe()
-                    else "test_list_deployments_success"
+                    else "test_deployment_get_list_success"
                 ),
             )
 
@@ -123,10 +123,10 @@ class TestDeploymentE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_model_info_from_deployment_success(
+    async def test_deployment_get_model_info_success(
         self,
         llm_client: Any,
-        expectations_for_get_model_info_from_deployment_success: ETETestExpectations,
+        expectations_for_deployment_get_model_info_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
@@ -135,13 +135,13 @@ class TestDeploymentE2E(ToolBaseE2E):
         async with ete_test_mcp_session() as session:
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_model_info_from_deployment_success,
+                expectations_for_deployment_get_model_info_success,
                 llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
                     if inspect.currentframe()
-                    else "test_get_model_info_from_deployment_success"
+                    else "test_deployment_get_model_info_success"
                 ),
             )
 
@@ -155,10 +155,10 @@ class TestDeploymentE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_model_info_from_deployment_failure(
+    async def test_deployment_get_model_info_failure(
         self,
         llm_client: Any,
-        expectations_for_get_model_info_from_deployment_failure: ETETestExpectations,
+        expectations_for_deployment_get_model_info_failure: ETETestExpectations,
         nonexistent_deployment_id: str,
         prompt_template: str,
     ) -> None:
@@ -167,12 +167,12 @@ class TestDeploymentE2E(ToolBaseE2E):
         async with ete_test_mcp_session() as session:
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_model_info_from_deployment_failure,
+                expectations_for_deployment_get_model_info_failure,
                 llm_client,
                 session,
                 (
                     inspect.currentframe().f_code.co_name  # type: ignore[union-attr]
                     if inspect.currentframe()
-                    else "test_get_model_info_from_deployment_failure"
+                    else "test_deployment_get_model_info_failure"
                 ),
             )

--- a/tests/drmcp/acceptance/test_deployment_info.py
+++ b/tests/drmcp/acceptance/test_deployment_info.py
@@ -30,13 +30,13 @@ INLINE_CSV_FOR_VALIDATE = "text_review,product_category\nhello world,electronics
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_deployment_features_success(
+def expectations_for_deployment_get_features_success(
     deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_deployment_features",
+                name="deployment_get_features",
                 parameters={"deployment_id": deployment_id},
                 result={"total_features": 0, "features": []},
             ),
@@ -52,13 +52,13 @@ def expectations_for_get_deployment_features_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_generate_prediction_data_template_success(
+def expectations_for_deployment_generate_prediction_sample_success(
     deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="generate_prediction_data_template",
+                name="deployment_generate_prediction_sample",
                 parameters={"deployment_id": deployment_id},
                 result={
                     "deployment_id": "",
@@ -80,7 +80,7 @@ def expectations_for_generate_prediction_data_template_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_validate_prediction_data_success(
+def expectations_for_deployment_validate_prediction_data_success(
     deployment_id: str,
     diabetes_scoring_small_file_path: str,
 ) -> ETETestExpectations:
@@ -88,7 +88,7 @@ def expectations_for_validate_prediction_data_success(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="validate_prediction_data",
+                name="deployment_validate_prediction_data",
                 parameters={
                     "deployment_id": deployment_id,
                     "csv_string": csv_string,
@@ -106,13 +106,13 @@ def expectations_for_validate_prediction_data_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_validate_prediction_data_inline_csv(
+def expectations_for_deployment_validate_prediction_data_inline_csv(
     deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="validate_prediction_data",
+                name="deployment_validate_prediction_data",
                 parameters={
                     "deployment_id": deployment_id,
                     "csv_string": ANY_NONEMPTY_STRING,
@@ -130,13 +130,13 @@ def expectations_for_validate_prediction_data_inline_csv(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_validate_prediction_data_failure(
+def expectations_for_deployment_validate_prediction_data_failure(
     deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="validate_prediction_data",
+                name="deployment_validate_prediction_data",
                 parameters={
                     "deployment_id": deployment_id,
                     "csv_string": "",
@@ -166,10 +166,10 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             """
         ],
     )
-    async def test_get_deployment_features_success(
+    async def test_deployment_get_features_success(
         self,
         llm_client: Any,
-        expectations_for_get_deployment_features_success: ETETestExpectations,
+        expectations_for_deployment_get_features_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
@@ -177,10 +177,10 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_deployment_features_success"
+            test_name = frame.f_code.co_name if frame else "test_deployment_get_features_success"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_deployment_features_success,
+                expectations_for_deployment_get_features_success,
                 llm_client,
                 session,
                 test_name,
@@ -196,10 +196,10 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             """
         ],
     )
-    async def test_generate_prediction_data_template_success(
+    async def test_deployment_generate_prediction_sample_success(
         self,
         llm_client: Any,
-        expectations_for_generate_prediction_data_template_success: ETETestExpectations,
+        expectations_for_deployment_generate_prediction_sample_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
@@ -208,11 +208,13 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
             test_name = (
-                frame.f_code.co_name if frame else "test_generate_prediction_data_template_success"
+                frame.f_code.co_name
+                if frame
+                else "test_deployment_generate_prediction_sample_success"
             )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_generate_prediction_data_template_success,
+                expectations_for_deployment_generate_prediction_sample_success,
                 llm_client,
                 session,
                 test_name,
@@ -230,10 +232,10 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             """
         ],
     )
-    async def test_validate_prediction_data_inline_csv_success(
+    async def test_deployment_validate_prediction_data_inline_csv_success(
         self,
         llm_client: Any,
-        expectations_for_validate_prediction_data_inline_csv: ETETestExpectations,
+        expectations_for_deployment_validate_prediction_data_inline_csv: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
@@ -246,11 +248,11 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             test_name = (
                 frame.f_code.co_name
                 if frame
-                else "test_validate_prediction_data_inline_csv_success"
+                else "test_deployment_validate_prediction_data_inline_csv_success"
             )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_validate_prediction_data_inline_csv,
+                expectations_for_deployment_validate_prediction_data_inline_csv,
                 llm_client,
                 session,
                 test_name,
@@ -272,10 +274,10 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             """
         ],
     )
-    async def test_validate_prediction_data_success(
+    async def test_deployment_validate_prediction_data_success(
         self,
         llm_client: Any,
-        expectations_for_validate_prediction_data_success: ETETestExpectations,
+        expectations_for_deployment_validate_prediction_data_success: ETETestExpectations,
         deployment_id: str,
         diabetes_scoring_small_file_path: str,
         prompt_template: str,
@@ -287,10 +289,14 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_validate_prediction_data_success"
+            test_name = (
+                frame.f_code.co_name
+                if frame
+                else "test_deployment_validate_prediction_data_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_validate_prediction_data_success,
+                expectations_for_deployment_validate_prediction_data_success,
                 llm_client,
                 session,
                 test_name,
@@ -307,10 +313,10 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
             """
         ],
     )
-    async def test_validate_prediction_data_failure(
+    async def test_deployment_validate_prediction_data_failure(
         self,
         llm_client: Any,
-        expectations_for_validate_prediction_data_failure: ETETestExpectations,
+        expectations_for_deployment_validate_prediction_data_failure: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
@@ -318,10 +324,14 @@ class TestDeploymentInfoE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_validate_prediction_data_failure"
+            test_name = (
+                frame.f_code.co_name
+                if frame
+                else "test_deployment_validate_prediction_data_failure"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_validate_prediction_data_failure,
+                expectations_for_deployment_validate_prediction_data_failure,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_deployment_tools.py
+++ b/tests/drmcp/acceptance/test_deployment_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Acceptance tests for deployment MCP tools (list_deployments, deploy_model, deploy_custom_model)."""  # noqa: E501
+"""Acceptance tests for deployment MCP tools (deployment_get_list, deployment_create_deployment, deploy_custom_model)."""  # noqa: E501
 
 import inspect
 from pathlib import Path

--- a/tests/drmcp/acceptance/test_dr_docs_tools.py
+++ b/tests/drmcp/acceptance/test_dr_docs_tools.py
@@ -56,13 +56,13 @@ class TestDrDocsToolsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_fetch_datarobot_doc_page_success(self, llm_client: Any) -> None:
+    async def test_datarobot_docs_fetch_page_success(self, llm_client: Any) -> None:
         """Test fetching a specific DataRobot agentic-ai documentation page."""
         _url = "https://docs.datarobot.com/en/docs/agentic-ai/agentic-glossary.html"
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="fetch_datarobot_doc_page",
+                    name="datarobot_docs_fetch_page",
                     parameters={"url": _url},
                     result=SHOULD_NOT_BE_EMPTY,
                 ),
@@ -72,7 +72,7 @@ class TestDrDocsToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_fetch_datarobot_doc_page_success"
+            test_name = frame.f_code.co_name if frame else "test_datarobot_docs_fetch_page_success"
             await self._run_test_with_expectations(
                 f"Fetch the content from '{_url}' and summarize what you find.",
                 expectations,
@@ -91,7 +91,7 @@ class TestDrDocsToolsE2E(ToolBaseE2E):
                     result=SHOULD_NOT_BE_EMPTY,
                 ),
                 ToolCallTestExpectations(
-                    name="fetch_datarobot_doc_page",
+                    name="datarobot_docs_fetch_page",
                     parameters={
                         "url": "https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-authentication.html"
                     },

--- a/tests/drmcp/acceptance/test_gdrive_tools.py
+++ b/tests/drmcp/acceptance/test_gdrive_tools.py
@@ -67,13 +67,13 @@ def expectations_for_gdrive_list_files_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_gdrive_read_content_success(
+def expectations_for_gdrive_read_and_export_content_success(
     gdrive_pdf_file_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="gdrive_read_content",
+                name="gdrive_read_and_export_content",
                 parameters={
                     "file_id": gdrive_pdf_file_id,
                 },
@@ -128,10 +128,10 @@ class TestGdriveToolsE2E(ToolBaseE2E):
             "and tell me what the document is about."
         ],
     )
-    async def test_gdrive_read_content_success(
+    async def test_gdrive_read_and_export_content_success(
         self,
         llm_client: Any,
-        expectations_for_gdrive_read_content_success: ETETestExpectations,
+        expectations_for_gdrive_read_and_export_content_success: ETETestExpectations,
         gdrive_pdf_file_id: str,
         prompt_template: str,
     ) -> None:
@@ -139,10 +139,12 @@ class TestGdriveToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_gdrive_read_content_success"
+            test_name = (
+                frame.f_code.co_name if frame else "test_gdrive_read_and_export_content_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_gdrive_read_content_success,
+                expectations_for_gdrive_read_and_export_content_success,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_microsoft_graph_tools.py
+++ b/tests/drmcp/acceptance/test_microsoft_graph_tools.py
@@ -74,7 +74,7 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
             )
 
     @pytest.mark.skip(reason="Creates real files in OneDrive without cleanup - run manually")
-    async def test_microsoft_create_file_success(
+    async def test_microsoft_graph_create_file_success(
         self,
         openai_llm_client: Any,
     ) -> None:
@@ -90,7 +90,7 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="microsoft_create_file",
+                    name="microsoft_graph_create_file",
                     parameters={
                         "file_name": unique_filename,
                         "content_text": content,
@@ -108,7 +108,9 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_microsoft_create_file_success"
+            test_name = (
+                frame.f_code.co_name if frame else "test_microsoft_graph_create_file_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
@@ -176,7 +178,7 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
             )
 
     @pytest.mark.skip(reason="Modifies real data in SharePoint/OneDrive - run manually")
-    async def test_microsoft_update_metadata_success(
+    async def test_microsoft_graph_update_metadata_success(
         self,
         openai_llm_client: Any,
     ) -> None:
@@ -194,7 +196,7 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="microsoft_update_metadata",
+                    name="microsoft_graph_update_metadata",
                     parameters={
                         "item_id": test_item_id,
                         "fields_to_update": {"description": new_description},
@@ -215,7 +217,9 @@ class TestMicrosoftGraphToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_microsoft_update_metadata_success"
+            test_name = (
+                frame.f_code.co_name if frame else "test_microsoft_graph_update_metadata_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
                 expectations,

--- a/tests/drmcp/acceptance/test_model.py
+++ b/tests/drmcp/acceptance/test_model.py
@@ -25,13 +25,13 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectati
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_best_model_success(
+def expectations_for_models_get_bestmodel_success(
     classification_project_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_best_model",
+                name="models_get_bestmodel",
                 parameters={"project_id": classification_project_id},
                 result={
                     "project_id": "",
@@ -51,13 +51,13 @@ def expectations_for_get_best_model_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_best_model_failure(
+def expectations_for_models_get_bestmodel_failure(
     nonexistent_project_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_best_model",
+                name="models_get_bestmodel",
                 parameters={"project_id": nonexistent_project_id},
                 result="[not_found] DataRobot API error (404):",
             ),
@@ -74,7 +74,7 @@ def expectations_for_get_best_model_failure(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_score_dataset_with_model_success(
+def expectations_for_modeling_score_dataset_success(
     classification_project_id: str,
     model_id: str,
     classification_predict_dataset: Any,
@@ -82,7 +82,7 @@ def expectations_for_score_dataset_with_model_success(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="score_dataset_with_model",
+                name="modeling_score_dataset",
                 parameters={
                     "project_id": classification_project_id,
                     "model_id": model_id,
@@ -102,7 +102,7 @@ def expectations_for_score_dataset_with_model_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_score_dataset_with_model_failure(
+def expectations_for_modeling_score_dataset_failure(
     classification_project_id: str,
     nonexistent_model_id: str,
     classification_predict_dataset: Any,
@@ -110,7 +110,7 @@ def expectations_for_score_dataset_with_model_failure(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="score_dataset_with_model",
+                name="modeling_score_dataset",
                 parameters={
                     "project_id": classification_project_id,
                     "model_id": nonexistent_model_id,
@@ -146,10 +146,10 @@ class TestModelE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_best_model_success(
+    async def test_models_get_bestmodel_success(
         self,
         llm_client: Any,
-        expectations_for_get_best_model_success: ETETestExpectations,
+        expectations_for_models_get_bestmodel_success: ETETestExpectations,
         classification_project_id: str,
         prompt_template: str,
     ) -> None:
@@ -157,10 +157,10 @@ class TestModelE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_best_model_success"
+            test_name = frame.f_code.co_name if frame else "test_models_get_bestmodel_success"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_best_model_success,
+                expectations_for_models_get_bestmodel_success,
                 llm_client,
                 session,
                 test_name,
@@ -176,10 +176,10 @@ class TestModelE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_best_model_failure(
+    async def test_models_get_bestmodel_failure(
         self,
         llm_client: Any,
-        expectations_for_get_best_model_failure: ETETestExpectations,
+        expectations_for_models_get_bestmodel_failure: ETETestExpectations,
         nonexistent_project_id: str,
         prompt_template: str,
     ) -> None:
@@ -187,10 +187,10 @@ class TestModelE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_best_model_failure"
+            test_name = frame.f_code.co_name if frame else "test_models_get_bestmodel_failure"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_best_model_failure,
+                expectations_for_models_get_bestmodel_failure,
                 llm_client,
                 session,
                 test_name,
@@ -207,10 +207,10 @@ class TestModelE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_score_dataset_with_model_success(
+    async def test_modeling_score_dataset_success(
         self,
         llm_client: Any,
-        expectations_for_score_dataset_with_model_success: ETETestExpectations,
+        expectations_for_modeling_score_dataset_success: ETETestExpectations,
         classification_project_id: str,
         model_id: str,
         classification_predict_dataset: Any,
@@ -224,10 +224,10 @@ class TestModelE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_score_dataset_with_model_success"
+            test_name = frame.f_code.co_name if frame else "test_modeling_score_dataset_success"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_score_dataset_with_model_success,
+                expectations_for_modeling_score_dataset_success,
                 llm_client,
                 session,
                 test_name,
@@ -243,10 +243,10 @@ class TestModelE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_score_dataset_with_model_failure(
+    async def test_modeling_score_dataset_failure(
         self,
         llm_client: Any,
-        expectations_for_score_dataset_with_model_failure: ETETestExpectations,
+        expectations_for_modeling_score_dataset_failure: ETETestExpectations,
         classification_project_id: str,
         nonexistent_model_id: str,
         classification_predict_dataset: Any,
@@ -260,10 +260,10 @@ class TestModelE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_score_dataset_with_model_failure"
+            test_name = frame.f_code.co_name if frame else "test_modeling_score_dataset_failure"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_score_dataset_with_model_failure,
+                expectations_for_modeling_score_dataset_failure,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_model_tools.py
+++ b/tests/drmcp/acceptance/test_model_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Acceptance tests for get_model_details, is_eligible_for_timeseries_training tools."""
+"""Acceptance tests for modeling_get_modeldetails, catalog_check_timeseries_eligibility tools."""
 
 import inspect
 from typing import Any
@@ -29,19 +29,19 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
 @pytest.mark.skip(reason="MODEL-22978 - TODO: Fix tests")
 @pytest.mark.asyncio
 class TestGetModelDetailsE2E(ToolBaseE2E):
-    """End-to-end acceptance tests for get_model_details tool."""
+    """End-to-end acceptance tests for modeling_get_modeldetails tool."""
 
-    async def test_get_model_details_callable(
+    async def test_modeling_get_modeldetails_callable(
         self,
         llm_client: Any,
         classification_project_id: str,
         model_id: str,
     ) -> None:
-        """Smoke test: LLM calls get_model_details and returns model info."""
+        """Smoke test: LLM calls modeling_get_modeldetails and returns model info."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="get_model_details",
+                    name="modeling_get_modeldetails",
                     parameters={
                         "project_id": classification_project_id,
                         "model_id": model_id,
@@ -58,7 +58,7 @@ class TestGetModelDetailsE2E(ToolBaseE2E):
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_model_details_callable"
+            test_name = frame.f_code.co_name if frame else "test_modeling_get_modeldetails_callable"
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
@@ -67,17 +67,17 @@ class TestGetModelDetailsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_get_model_details_with_roc_curve(
+    async def test_modeling_get_modeldetails_with_roc_curve(
         self,
         llm_client: Any,
         classification_project_id: str,
         model_id: str,
     ) -> None:
-        """LLM calls get_model_details with ROC curve and returns curve data."""
+        """LLM calls modeling_get_modeldetails with ROC curve and returns curve data."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="get_model_details",
+                    name="modeling_get_modeldetails",
                     parameters={
                         "project_id": classification_project_id,
                         "model_id": model_id,
@@ -95,7 +95,9 @@ class TestGetModelDetailsE2E(ToolBaseE2E):
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_model_details_with_roc_curve"
+            test_name = (
+                frame.f_code.co_name if frame else "test_modeling_get_modeldetails_with_roc_curve"
+            )
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
@@ -107,18 +109,18 @@ class TestGetModelDetailsE2E(ToolBaseE2E):
 
 @pytest.mark.asyncio
 class TestIsEligibleForTimeseriesTrainingE2E(ToolBaseE2E):
-    """End-to-end acceptance tests for is_eligible_for_timeseries_training tool."""
+    """End-to-end acceptance tests for catalog_check_timeseries_eligibility tool."""
 
     async def test_timeseries_eligibility_check(
         self,
         llm_client: Any,
         classification_dataset_id: str,
     ) -> None:
-        """LLM calls is_eligible_for_timeseries_training and reports eligibility."""
+        """LLM calls catalog_check_timeseries_eligibility and reports eligibility."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="is_eligible_for_timeseries_training",
+                    name="catalog_check_timeseries_eligibility",
                     parameters={
                         "dataset_id": classification_dataset_id,
                         "datetime_column": "date",

--- a/tests/drmcp/acceptance/test_perplexity_tools.py
+++ b/tests/drmcp/acceptance/test_perplexity_tools.py
@@ -75,13 +75,13 @@ def expectations_for_perplexity_search_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_perplexity_think_success(
+def expectations_for_perplexity_sonar_success(
     research_prompt: str, research_model: int
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="perplexity_think",
+                name="perplexity_sonar",
                 parameters={"prompt": research_prompt, "model": research_model},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -139,10 +139,10 @@ class TestPerplexityToolsE2E(ToolBaseE2E):
             "Use model '{model}'."
         ],
     )
-    async def test_perplexity_think_success(
+    async def test_perplexity_sonar_success(
         self,
         llm_client: Any,
-        expectations_for_perplexity_think_success: ETETestExpectations,
+        expectations_for_perplexity_sonar_success: ETETestExpectations,
         research_prompt: str,
         research_model: str,
         prompt_template: str,
@@ -151,10 +151,10 @@ class TestPerplexityToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_perplexity_think_success"
+            test_name = frame.f_code.co_name if frame else "test_perplexity_sonar_success"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_perplexity_think_success,
+                expectations_for_perplexity_sonar_success,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_predict.py
+++ b/tests/drmcp/acceptance/test_predict.py
@@ -26,14 +26,14 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectati
 
 
 @pytest.fixture(scope="session")
-def expectations_for_predict_by_ai_catalog_success(
+def expectations_for_predict_batch_predictions_from_dataset_success(
     deployment_id: str,
     classification_predict_dataset: Any,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="predict_by_ai_catalog",
+                name="predict_batch_predictions_from_dataset",
                 parameters={
                     "deployment_id": deployment_id,
                     "dataset_id": classification_predict_dataset["dataset_id"],
@@ -41,12 +41,12 @@ def expectations_for_predict_by_ai_catalog_success(
                 result=SHOULD_NOT_BE_EMPTY,
             ),
             ToolCallTestExpectations(
-                name="get_batch_prediction_job_status",
+                name="predict_get_batch_job_status",
                 parameters={"job_id": ANY_NONEMPTY_STRING},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
             ToolCallTestExpectations(
-                name="get_batch_prediction_results",
+                name="predict_get_batch_results",
                 parameters={"job_id": ANY_NONEMPTY_STRING},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -58,13 +58,13 @@ def expectations_for_predict_by_ai_catalog_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_predict_from_project_data_success(
+def expectations_for_predict_batch_predictions_from_partition_success(
     deployment_id: str, classification_project_id: str
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="predict_from_project_data",
+                name="predict_batch_predictions_from_partition",
                 parameters={
                     "deployment_id": deployment_id,
                     "project_id": classification_project_id,
@@ -73,12 +73,12 @@ def expectations_for_predict_from_project_data_success(
                 result=SHOULD_NOT_BE_EMPTY,
             ),
             ToolCallTestExpectations(
-                name="get_batch_prediction_job_status",
+                name="predict_get_batch_job_status",
                 parameters={"job_id": ANY_NONEMPTY_STRING},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
             ToolCallTestExpectations(
-                name="get_batch_prediction_results",
+                name="predict_get_batch_results",
                 parameters={"job_id": ANY_NONEMPTY_STRING},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -97,7 +97,7 @@ def expectations_for_batch_predict_then_get_batch_results_success(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="predict_by_ai_catalog",
+                name="predict_batch_predictions_from_dataset",
                 parameters={
                     "deployment_id": deployment_id,
                     "dataset_id": classification_predict_dataset["dataset_id"],
@@ -105,12 +105,12 @@ def expectations_for_batch_predict_then_get_batch_results_success(
                 result=SHOULD_NOT_BE_EMPTY,
             ),
             ToolCallTestExpectations(
-                name="get_batch_prediction_job_status",
+                name="predict_get_batch_job_status",
                 parameters={"job_id": ANY_NONEMPTY_STRING},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
             ToolCallTestExpectations(
-                name="get_batch_prediction_results",
+                name="predict_get_batch_results",
                 parameters={"job_id": ANY_NONEMPTY_STRING},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -157,16 +157,16 @@ class TestPredictE2E(ToolBaseE2E):
         I have a DataRobot deployment with ID '{deployment_id}'.
         Run batch predictions using the AI Catalog dataset with ID '{dataset_id}'.
         The batch submit tool returns immediately with a job_id: you must call
-        get_batch_prediction_job_status with that job_id until the job is COMPLETED and a
-        download url exists, then call get_batch_prediction_results with the same job_id to
+        predict_get_batch_job_status with that job_id until the job is COMPLETED and a
+        download url exists, then call predict_get_batch_results with the same job_id to
         retrieve the scored CSV. Summarize the prediction outcome.
         """
         ],
     )
-    async def test_predict_by_ai_catalog_success(
+    async def test_predict_batch_predictions_from_dataset_success(
         self,
         llm_client: Any,
-        expectations_for_predict_by_ai_catalog_success: ETETestExpectations,
+        expectations_for_predict_batch_predictions_from_dataset_success: ETETestExpectations,
         deployment_id: str,
         classification_project_id: str,
         classification_predict_dataset: Any,
@@ -180,10 +180,14 @@ class TestPredictE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_predict_by_ai_catalog_success"
+            test_name = (
+                frame.f_code.co_name
+                if frame
+                else "test_predict_batch_predictions_from_dataset_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_predict_by_ai_catalog_success,
+                expectations_for_predict_batch_predictions_from_dataset_success,
                 llm_client,
                 session,
                 test_name,
@@ -196,15 +200,15 @@ class TestPredictE2E(ToolBaseE2E):
         The MCP server has no access to my laptop files. Deployment ID is '{deployment_id}'.
         Run batch scoring using only the AI Catalog dataset id '{dataset_id}' as the input source.
         Do not use local file paths or upload from this machine.
-        After submit, poll get_batch_prediction_job_status until COMPLETED with a url, then
-        get_batch_prediction_results for the CSV and describe the predictions.
+        After submit, poll predict_get_batch_job_status until COMPLETED with a url, then
+        predict_get_batch_results for the CSV and describe the predictions.
         """
         ],
     )
-    async def test_predict_by_ai_catalog_catalog_id_only_prompt(
+    async def test_predict_batch_predictions_from_dataset_catalog_id_only_prompt(
         self,
         llm_client: Any,
-        expectations_for_predict_by_ai_catalog_success: ETETestExpectations,
+        expectations_for_predict_batch_predictions_from_dataset_success: ETETestExpectations,
         deployment_id: str,
         classification_project_id: str,
         classification_predict_dataset: Any,
@@ -220,11 +224,11 @@ class TestPredictE2E(ToolBaseE2E):
             test_name = (
                 frame.f_code.co_name
                 if frame
-                else "test_predict_by_ai_catalog_catalog_id_only_prompt"
+                else "test_predict_batch_predictions_from_dataset_catalog_id_only_prompt"
             )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_predict_by_ai_catalog_success,
+                expectations_for_predict_batch_predictions_from_dataset_success,
                 llm_client,
                 session,
                 test_name,
@@ -236,15 +240,15 @@ class TestPredictE2E(ToolBaseE2E):
             """
         I have a DataRobot deployment with ID '{deployment_id}' and project ID '{project_id}'.
         Run batch predictions on the holdout partition. After submit returns job_id, poll
-        get_batch_prediction_job_status until COMPLETED with url, then get_batch_prediction_results
+        predict_get_batch_job_status until COMPLETED with url, then predict_get_batch_results
         and summarize predictions.
         """
         ],
     )
-    async def test_predict_from_project_data_success(
+    async def test_predict_batch_predictions_from_partition_success(
         self,
         llm_client: Any,
-        expectations_for_predict_from_project_data_success: ETETestExpectations,
+        expectations_for_predict_batch_predictions_from_partition_success: ETETestExpectations,
         deployment_id: str,
         classification_project_id: str,
         prompt_template: str,
@@ -255,10 +259,14 @@ class TestPredictE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_predict_from_project_data_success"
+            test_name = (
+                frame.f_code.co_name
+                if frame
+                else "test_predict_batch_predictions_from_partition_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_predict_from_project_data_success,
+                expectations_for_predict_batch_predictions_from_partition_success,
                 llm_client,
                 session,
                 test_name,
@@ -269,12 +277,12 @@ class TestPredictE2E(ToolBaseE2E):
         [
             """
         Run batch scoring on deployment '{deployment_id}' using AI Catalog dataset '{dataset_id}'.
-        Use the job_id from submit: call get_batch_prediction_job_status until COMPLETED and url
-        is set, then get_batch_prediction_results for the CSV. Summarize the prediction results.
+        Use the job_id from submit: call predict_get_batch_job_status until COMPLETED and url
+        is set, then predict_get_batch_results for the CSV. Summarize the prediction results.
         """
         ],
     )
-    async def test_batch_predict_then_get_batch_prediction_results(
+    async def test_batch_predict_then_predict_get_batch_results(
         self,
         llm_client: Any,
         expectations_for_batch_predict_then_get_batch_results_success: ETETestExpectations,
@@ -291,7 +299,7 @@ class TestPredictE2E(ToolBaseE2E):
             test_name = (
                 frame.f_code.co_name
                 if frame
-                else "test_batch_predict_then_get_batch_prediction_results"
+                else "test_batch_predict_then_predict_get_batch_results"
             )
             await self._run_test_with_expectations(
                 prompt,

--- a/tests/drmcp/acceptance/test_predict_realtime.py
+++ b/tests/drmcp/acceptance/test_predict_realtime.py
@@ -38,13 +38,13 @@ INLINE_JSON_DATASET = (
 
 
 @pytest.fixture(scope="session")
-def expectations_for_predict_by_ai_catalog_rt_success(
+def expectations_for_predict_score_catalog_realtime_success(
     deployment_id: str, classification_predict_dataset: Any
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="predict_by_ai_catalog_rt",
+                name="predict_score_catalog_realtime",
                 parameters={
                     "deployment_id": deployment_id,
                     "dataset_id": classification_predict_dataset["dataset_id"],
@@ -65,7 +65,7 @@ def expectations_for_predict_realtime_dataset_string_success(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="predict_realtime",
+                name="predict_score_inline_realtime",
                 parameters={
                     "deployment_id": deployment_id,
                     "dataset": INLINE_CSV_DATASET,
@@ -80,12 +80,12 @@ def expectations_for_predict_realtime_dataset_string_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_deployment_info_success(deployment_id: str) -> ETETestExpectations:
+def expectations_for_deployment_get_info_success(deployment_id: str) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_deployment_info",
-                acceptable_tool_names=["get_deployment_features"],
+                name="deployment_get_info",
+                acceptable_tool_names=["deployment_get_features"],
                 parameters={"deployment_id": deployment_id},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -99,11 +99,11 @@ def expectations_for_get_deployment_info_success(deployment_id: str) -> ETETestE
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_deployment_features_success(deployment_id: str) -> ETETestExpectations:
+def expectations_for_deployment_get_features_success(deployment_id: str) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_deployment_features",
+                name="deployment_get_features",
                 parameters={"deployment_id": deployment_id},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -116,13 +116,13 @@ def expectations_for_get_deployment_features_success(deployment_id: str) -> ETET
 
 
 @pytest.fixture(scope="session")
-def expectations_for_generate_prediction_data_template_success(
+def expectations_for_deployment_generate_prediction_sample_success(
     deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="generate_prediction_data_template",
+                name="deployment_generate_prediction_sample",
                 parameters={"deployment_id": deployment_id},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -136,13 +136,13 @@ def expectations_for_generate_prediction_data_template_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_validate_prediction_data_success(
+def expectations_for_deployment_validate_prediction_data_success(
     deployment_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="validate_prediction_data",
+                name="deployment_validate_prediction_data",
                 parameters={
                     "deployment_id": deployment_id,
                     "csv_string": INLINE_CSV_DATASET,
@@ -166,7 +166,7 @@ def expectations_for_predict_realtime_json_dataset_success(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="predict_realtime",
+                name="predict_score_inline_realtime",
                 parameters={
                     "deployment_id": deployment_id,
                     "dataset": ANY_NONEMPTY_STRING,
@@ -193,10 +193,10 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_predict_by_ai_catalog_rt_success(
+    async def test_predict_score_catalog_realtime_success(
         self,
         llm_client: Any,
-        expectations_for_predict_by_ai_catalog_rt_success: ETETestExpectations,
+        expectations_for_predict_score_catalog_realtime_success: ETETestExpectations,
         deployment_id: str,
         classification_predict_dataset: Any,
         prompt_template: str,
@@ -208,10 +208,12 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_predict_by_ai_catalog_rt_success"
+            test_name = (
+                frame.f_code.co_name if frame else "test_predict_score_catalog_realtime_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_predict_by_ai_catalog_rt_success,
+                expectations_for_predict_score_catalog_realtime_success,
                 llm_client,
                 session,
                 test_name,
@@ -298,20 +300,20 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_deployment_info_success(
+    async def test_deployment_get_info_success(
         self,
         llm_client: Any,
-        expectations_for_get_deployment_info_success: ETETestExpectations,
+        expectations_for_deployment_get_info_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
         prompt = prompt_template.format(deployment_id=deployment_id)
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_deployment_info_success"
+            test_name = frame.f_code.co_name if frame else "test_deployment_get_info_success"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_deployment_info_success,
+                expectations_for_deployment_get_info_success,
                 llm_client,
                 session,
                 test_name,
@@ -326,20 +328,20 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_deployment_features_success(
+    async def test_deployment_get_features_success(
         self,
         llm_client: Any,
-        expectations_for_get_deployment_features_success: ETETestExpectations,
+        expectations_for_deployment_get_features_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
         prompt = prompt_template.format(deployment_id=deployment_id)
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_get_deployment_features_success"
+            test_name = frame.f_code.co_name if frame else "test_deployment_get_features_success"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_deployment_features_success,
+                expectations_for_deployment_get_features_success,
                 llm_client,
                 session,
                 test_name,
@@ -354,10 +356,10 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_generate_prediction_data_template_success(
+    async def test_deployment_generate_prediction_sample_success(
         self,
         llm_client: Any,
-        expectations_for_generate_prediction_data_template_success: ETETestExpectations,
+        expectations_for_deployment_generate_prediction_sample_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
@@ -365,11 +367,13 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
             test_name = (
-                frame.f_code.co_name if frame else "test_generate_prediction_data_template_success"
+                frame.f_code.co_name
+                if frame
+                else "test_deployment_generate_prediction_sample_success"
             )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_generate_prediction_data_template_success,
+                expectations_for_deployment_generate_prediction_sample_success,
                 llm_client,
                 session,
                 test_name,
@@ -386,20 +390,24 @@ class TestPredictRealtimeE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_validate_prediction_data_success(
+    async def test_deployment_validate_prediction_data_success(
         self,
         llm_client: Any,
-        expectations_for_validate_prediction_data_success: ETETestExpectations,
+        expectations_for_deployment_validate_prediction_data_success: ETETestExpectations,
         deployment_id: str,
         prompt_template: str,
     ) -> None:
         prompt = prompt_template.format(deployment_id=deployment_id, csv=INLINE_CSV_DATASET)
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_validate_prediction_data_success"
+            test_name = (
+                frame.f_code.co_name
+                if frame
+                else "test_deployment_validate_prediction_data_success"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_validate_prediction_data_success,
+                expectations_for_deployment_validate_prediction_data_success,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_projects.py
+++ b/tests/drmcp/acceptance/test_projects.py
@@ -24,14 +24,14 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectati
 
 
 @pytest.fixture(scope="session")
-def expectations_for_list_projects_success(
+def expectations_for_modeling_list_projects_success(
     classification_project_id: str,
     classification_project_name: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_projects",
+                name="modeling_list_projects",
                 parameters={},
                 result=f'"{classification_project_id}": "{classification_project_name}"',
             ),
@@ -44,7 +44,7 @@ def expectations_for_list_projects_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_project_dataset_by_name_success(
+def expectations_for_modeling_get_project_dataset_success(
     classification_project_id: str,
     classification_dataset_name: str,
     classification_dataset_id: str,
@@ -52,7 +52,7 @@ def expectations_for_get_project_dataset_by_name_success(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_project_dataset_by_name",
+                name="modeling_get_project_dataset",
                 parameters={
                     "project_id": classification_project_id,
                     "dataset_name": classification_dataset_name,
@@ -71,13 +71,13 @@ def expectations_for_get_project_dataset_by_name_success(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_project_dataset_by_name_failure(
+def expectations_for_modeling_get_project_dataset_failure(
     classification_project_id: str, nonexistent_dataset_name: str
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="get_project_dataset_by_name",
+                name="modeling_get_project_dataset",
                 parameters={
                     "project_id": classification_project_id,
                     "dataset_name": nonexistent_dataset_name,
@@ -100,7 +100,7 @@ def expectations_for_get_project_dataset_by_name_failure(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_get_project_dataset_by_name_success_with_multiple_calls(
+def expectations_for_modeling_get_project_dataset_success_with_multiple_calls(
     classification_project_name: str,
     classification_dataset_name: str,
     classification_project_id: str,
@@ -109,12 +109,12 @@ def expectations_for_get_project_dataset_by_name_success_with_multiple_calls(
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_projects",
+                name="modeling_list_projects",
                 parameters={},
                 result=f'"{classification_project_id}": "{classification_project_name}"',
             ),
             ToolCallTestExpectations(
-                name="get_project_dataset_by_name",
+                name="modeling_get_project_dataset",
                 parameters={
                     "project_id": classification_project_id,
                     "dataset_name": classification_dataset_name,
@@ -147,18 +147,18 @@ class TestProjectsE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_list_projects_success(
+    async def test_modeling_list_projects_success(
         self,
         llm_client: Any,
-        expectations_for_list_projects_success: ETETestExpectations,
+        expectations_for_modeling_list_projects_success: ETETestExpectations,
         prompt: str,
     ) -> None:
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_list_projects_success"
+            test_name = frame.f_code.co_name if frame else "test_modeling_list_projects_success"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_list_projects_success,
+                expectations_for_modeling_list_projects_success,
                 llm_client,
                 session,
                 test_name,
@@ -173,10 +173,10 @@ class TestProjectsE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_project_dataset_by_name_success(
+    async def test_modeling_get_project_dataset_success(
         self,
         llm_client: Any,
-        expectations_for_get_project_dataset_by_name_success: ETETestExpectations,
+        expectations_for_modeling_get_project_dataset_success: ETETestExpectations,
         classification_project_id: str,
         classification_dataset_name: str,
         prompt_template: str,
@@ -189,11 +189,11 @@ class TestProjectsE2E(ToolBaseE2E):
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
             test_name = (
-                frame.f_code.co_name if frame else "test_get_project_dataset_by_name_success"
+                frame.f_code.co_name if frame else "test_modeling_get_project_dataset_success"
             )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_project_dataset_by_name_success,
+                expectations_for_modeling_get_project_dataset_success,
                 llm_client,
                 session,
                 test_name,
@@ -208,10 +208,10 @@ class TestProjectsE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_project_dataset_by_name_failure(
+    async def test_modeling_get_project_dataset_failure(
         self,
         llm_client: Any,
-        expectations_for_get_project_dataset_by_name_failure: ETETestExpectations,
+        expectations_for_modeling_get_project_dataset_failure: ETETestExpectations,
         classification_project_id: str,
         nonexistent_dataset_name: str,
         prompt_template: str,
@@ -223,11 +223,11 @@ class TestProjectsE2E(ToolBaseE2E):
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
             test_name = (
-                frame.f_code.co_name if frame else "test_get_project_dataset_by_name_failure"
+                frame.f_code.co_name if frame else "test_modeling_get_project_dataset_failure"
             )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_project_dataset_by_name_failure,
+                expectations_for_modeling_get_project_dataset_failure,
                 llm_client,
                 session,
                 test_name,
@@ -241,8 +241,8 @@ class TestProjectsE2E(ToolBaseE2E):
         I need the dataset '{dataset_name}' from that project.
 
         Use tools before answering:
-        1. Call list_projects to find the project id for '{project_name}'.
-        2. Call get_project_dataset_by_name with that project id and dataset name
+        1. Call modeling_list_projects to find the project id for '{project_name}'.
+        2. Call modeling_get_project_dataset with that project id and dataset name
            '{dataset_name}'.
 
         You may call both tools in the same assistant turn. Do not reply with a final
@@ -250,10 +250,10 @@ class TestProjectsE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_get_project_dataset_by_name_success_with_multiple_calls(
+    async def test_modeling_get_project_dataset_success_with_multiple_calls(
         self,
         llm_client: Any,
-        expectations_for_get_project_dataset_by_name_success_with_multiple_calls: (
+        expectations_for_modeling_get_project_dataset_success_with_multiple_calls: (
             ETETestExpectations
         ),
         classification_project_name: str,
@@ -270,11 +270,11 @@ class TestProjectsE2E(ToolBaseE2E):
             test_name = (
                 frame.f_code.co_name
                 if frame
-                else "test_get_project_dataset_by_name_success_with_multiple_calls"
+                else "test_modeling_get_project_dataset_success_with_multiple_calls"
             )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_get_project_dataset_by_name_success_with_multiple_calls,
+                expectations_for_modeling_get_project_dataset_success_with_multiple_calls,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_tavily_tools.py
+++ b/tests/drmcp/acceptance/test_tavily_tools.py
@@ -30,12 +30,12 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
 class TestTavilyToolsE2E(ToolBaseE2E):
     """End-to-end tests for Tavily search tools."""
 
-    async def test_tavily_search_success(self, llm_client: Any) -> None:
+    async def test_tavily_search_web_success(self, llm_client: Any) -> None:
         """Test basic Tavily search."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="tavily_search",
+                    name="tavily_search_web",
                     parameters={"query": "DataRobot machine learning"},
                     result=SHOULD_NOT_BE_EMPTY,
                 ),
@@ -45,7 +45,7 @@ class TestTavilyToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_tavily_search_success"
+            test_name = frame.f_code.co_name if frame else "test_tavily_search_web_success"
             await self._run_test_with_expectations(
                 "Search the web for 'DataRobot machine learning' and summarize what you find.",
                 expectations,
@@ -54,12 +54,12 @@ class TestTavilyToolsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_tavily_extract_success(self, llm_client: Any) -> None:
+    async def test_tavily_extract_text_success(self, llm_client: Any) -> None:
         """Test basic Tavily extract."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="tavily_extract",
+                    name="tavily_extract_text",
                     parameters={"urls": "https://docs.datarobot.com"},
                     result=SHOULD_NOT_BE_EMPTY,
                 ),
@@ -69,7 +69,7 @@ class TestTavilyToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_tavily_extract_success"
+            test_name = frame.f_code.co_name if frame else "test_tavily_extract_text_success"
             await self._run_test_with_expectations(
                 "Extract content from 'https://docs.datarobot.com' and summarize what you find.",
                 expectations,
@@ -78,12 +78,12 @@ class TestTavilyToolsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_tavily_map_success(self, llm_client: Any) -> None:
+    async def test_tavily_list_links_success(self, llm_client: Any) -> None:
         """Test basic Tavily map."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="tavily_map",
+                    name="tavily_list_links",
                     parameters={"url": "https://docs.datarobot.com", "limit": 5},
                     result=SHOULD_NOT_BE_EMPTY,
                 ),
@@ -93,7 +93,7 @@ class TestTavilyToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_tavily_map_success"
+            test_name = frame.f_code.co_name if frame else "test_tavily_list_links_success"
             await self._run_test_with_expectations(
                 "Map 'https://docs.datarobot.com' website. Limit to 5 results.",
                 expectations,
@@ -102,12 +102,12 @@ class TestTavilyToolsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_tavily_crawl_success(self, llm_client: Any) -> None:
+    async def test_tavily_crawl_site_success(self, llm_client: Any) -> None:
         """Test basic Tavily crawl."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="tavily_crawl",
+                    name="tavily_crawl_site",
                     parameters={"url": "https://docs.datarobot.com"},
                     result=SHOULD_NOT_BE_EMPTY,
                 ),
@@ -117,7 +117,7 @@ class TestTavilyToolsE2E(ToolBaseE2E):
 
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_tavily_crawl_success"
+            test_name = frame.f_code.co_name if frame else "test_tavily_crawl_site_success"
             await self._run_test_with_expectations(
                 "Crawl 'https://docs.datarobot.com' and summarize what pages you find.",
                 expectations,

--- a/tests/drmcp/acceptance/test_use_case_tools.py
+++ b/tests/drmcp/acceptance/test_use_case_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Acceptance tests for use case MCP tools (list_use_cases, list_use_case_assets)."""
+"""Acceptance tests for use case MCP tools (datarobot_usecases_list, usecases_list_assets)."""
 
 import inspect
 from typing import Any
@@ -27,11 +27,11 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
 
 
 @pytest.fixture(scope="session")
-def expectations_for_list_use_cases_success() -> ETETestExpectations:
+def expectations_for_datarobot_usecases_list_success() -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_use_cases",
+                name="datarobot_usecases_list",
                 parameters={},
                 result={"use_cases": {}},
             ),
@@ -45,11 +45,11 @@ def expectations_for_list_use_cases_success() -> ETETestExpectations:
 
 
 @pytest.fixture(scope="session")
-def expectations_for_list_use_cases_with_search_success() -> ETETestExpectations:
+def expectations_for_datarobot_usecases_list_with_search_success() -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_use_cases",
+                name="datarobot_usecases_list",
                 parameters={"search": "fraud"},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -63,13 +63,13 @@ def expectations_for_list_use_cases_with_search_success() -> ETETestExpectations
 
 
 @pytest.fixture(scope="session")
-def expectations_for_list_use_case_assets_success(
+def expectations_for_usecases_list_assets_success(
     use_case_id: str,
 ) -> ETETestExpectations:
     return ETETestExpectations(
         tool_calls_expected=[
             ToolCallTestExpectations(
-                name="list_use_case_assets",
+                name="usecases_list_assets",
                 parameters={"use_case_id": use_case_id},
                 result=SHOULD_NOT_BE_EMPTY,
             ),
@@ -95,7 +95,7 @@ def use_case_id() -> str:
 @pytest.mark.skip(reason="MODEL-22978 - TODO: Fix tests")
 @pytest.mark.asyncio
 class TestUseCaseToolsE2E(ToolBaseE2E):
-    """End-to-end tests for use case tools (list_use_cases, list_use_case_assets)."""
+    """End-to-end tests for use case tools (datarobot_usecases_list, usecases_list_assets)."""
 
     @pytest.mark.parametrize(
         "prompt",
@@ -106,19 +106,19 @@ class TestUseCaseToolsE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_list_use_cases(
+    async def test_datarobot_usecases_list(
         self,
         llm_client: Any,
-        expectations_for_list_use_cases_success: ETETestExpectations,
+        expectations_for_datarobot_usecases_list_success: ETETestExpectations,
         prompt: str,
     ) -> None:
-        """E2E test: LLM lists all use cases via list_use_cases tool."""
+        """E2E test: LLM lists all use cases via datarobot_usecases_list tool."""
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_list_use_cases"
+            test_name = frame.f_code.co_name if frame else "test_datarobot_usecases_list"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_list_use_cases_success,
+                expectations_for_datarobot_usecases_list_success,
                 llm_client,
                 session,
                 test_name,
@@ -128,23 +128,25 @@ class TestUseCaseToolsE2E(ToolBaseE2E):
         "search_term",
         ["fraud"],
     )
-    async def test_list_use_cases_with_search(
+    async def test_datarobot_usecases_list_with_search(
         self,
         llm_client: Any,
-        expectations_for_list_use_cases_with_search_success: ETETestExpectations,
+        expectations_for_datarobot_usecases_list_with_search_success: ETETestExpectations,
         search_term: str,
     ) -> None:
-        """E2E test: LLM searches for use cases matching a keyword via list_use_cases tool."""
+        """E2E test: LLM searches use cases by keyword via datarobot_usecases_list."""
         prompt = (
             f"I need to find DataRobot use cases related to '{search_term}'. "
             f"Can you search for use cases containing '{search_term}' in their name?"
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_list_use_cases_with_search"
+            test_name = (
+                frame.f_code.co_name if frame else "test_datarobot_usecases_list_with_search"
+            )
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_list_use_cases_with_search_success,
+                expectations_for_datarobot_usecases_list_with_search_success,
                 llm_client,
                 session,
                 test_name,
@@ -159,21 +161,21 @@ class TestUseCaseToolsE2E(ToolBaseE2E):
         """
         ],
     )
-    async def test_list_use_case_assets(
+    async def test_usecases_list_assets(
         self,
         llm_client: Any,
-        expectations_for_list_use_case_assets_success: ETETestExpectations,
+        expectations_for_usecases_list_assets_success: ETETestExpectations,
         use_case_id: str,
         prompt_template: str,
     ) -> None:
-        """E2E test: LLM lists assets in a use case via list_use_case_assets tool."""
+        """E2E test: LLM lists assets in a use case via usecases_list_assets tool."""
         prompt = prompt_template.format(use_case_id=use_case_id)
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_list_use_case_assets"
+            test_name = frame.f_code.co_name if frame else "test_usecases_list_assets"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_list_use_case_assets_success,
+                expectations_for_usecases_list_assets_success,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_vdb_tools.py
+++ b/tests/drmcp/acceptance/test_vdb_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Acceptance tests for VDB MCP tools (list_vector_databases, query_vector_database)."""
+"""Acceptance tests for VDB MCP tools (vdb_list, vdb_query)."""
 
 import inspect
 from typing import Any
@@ -39,12 +39,12 @@ def vdb_deployment_id() -> str:
 class TestVDBToolsE2E(ToolBaseE2E):
     """End-to-end acceptance tests for VDB MCP tools."""
 
-    async def test_list_vector_databases_callable(self, llm_client: Any) -> None:
+    async def test_vdb_list_callable(self, llm_client: Any) -> None:
         """Smoke test: LLM is prompted to list VDBs; expect tool use and valid response."""
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="list_vector_databases",
+                    name="vdb_list",
                     parameters={},
                     result=SHOULD_NOT_BE_EMPTY,
                 ),
@@ -52,12 +52,11 @@ class TestVDBToolsE2E(ToolBaseE2E):
             llm_response_content_contains_expectations=["vector database", "VDB", "deployment"],
         )
         prompt = (
-            "Please list all Vector Databases (VDBs) available in DataRobot. "
-            "Use the list_vector_databases tool."
+            "Please list all Vector Databases (VDBs) available in DataRobot. Use the vdb_list tool."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_list_vector_databases_callable"
+            test_name = frame.f_code.co_name if frame else "test_vdb_list_callable"
             await self._run_test_with_expectations(
                 prompt,
                 expectations,
@@ -66,7 +65,7 @@ class TestVDBToolsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_query_vector_database_callable(
+    async def test_vdb_query_callable(
         self,
         llm_client: Any,
         vdb_deployment_id: str,
@@ -75,7 +74,7 @@ class TestVDBToolsE2E(ToolBaseE2E):
         expectations = ETETestExpectations(
             tool_calls_expected=[
                 ToolCallTestExpectations(
-                    name="query_vector_database",
+                    name="vdb_query",
                     parameters={
                         "deployment_id": vdb_deployment_id,
                         "query": "What is DataRobot?",
@@ -87,11 +86,11 @@ class TestVDBToolsE2E(ToolBaseE2E):
         )
         prompt = (
             f"Please query the Vector Database deployment with ID '{vdb_deployment_id}' "
-            "for 'What is DataRobot?' using the query_vector_database tool."
+            "for 'What is DataRobot?' using the vdb_query tool."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_query_vector_database_callable"
+            test_name = frame.f_code.co_name if frame else "test_vdb_query_callable"
             await self._run_test_with_expectations(
                 prompt,
                 expectations,

--- a/tests/drmcp/integration/test_batch_predict.py
+++ b/tests/drmcp/integration/test_batch_predict.py
@@ -30,26 +30,26 @@ from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import STUB_PROJECT_
 
 @pytest.mark.asyncio
 class TestBatchPredictToolsIntegration:
-    """MCP integration tests for predict_by_ai_catalog, status, and results (stdio stub server)."""
+    """Integration tests for batch predict tools: submit, status, and results (stdio stub)."""
 
     async def test_batch_predict_tools_registered(self) -> None:
         """Batch prediction tools are registered with predictive tools enabled."""
         async with integration_test_mcp_session() as session:
             listed = await session.list_tools()
             tool_names = [t.name for t in listed.tools]
-            assert "predict_by_ai_catalog" in tool_names
-            assert "predict_from_project_data" in tool_names
-            assert "get_batch_prediction_job_status" in tool_names
-            assert "get_batch_prediction_results" in tool_names
+            assert "predict_batch_predictions_from_dataset" in tool_names
+            assert "predict_batch_predictions_from_partition" in tool_names
+            assert "predict_get_batch_job_status" in tool_names
+            assert "predict_get_batch_results" in tool_names
 
-    async def test_predict_by_ai_catalog_submit_status_and_results(
+    async def test_predict_batch_predictions_from_dataset_submit_status_and_results(
         self, classification_project: dict[str, Any]
     ) -> None:
         """Submit batch scoring from catalog, poll status, and read inline CSV (stub job)."""
         deployment_id = classification_project["deployment_id"]
         async with integration_test_mcp_session() as session:
             submit = await session.call_tool(
-                "predict_by_ai_catalog",
+                "predict_batch_predictions_from_dataset",
                 {
                     "deployment_id": deployment_id,
                     "dataset_id": STUB_PREDICT_CATALOG_DATASET_ID,
@@ -62,10 +62,10 @@ class TestBatchPredictToolsIntegration:
             assert payload["deployment_id"] == deployment_id
             assert payload["batch_job_status"] == "COMPLETED"
             assert payload.get("url")
-            assert "get_batch_prediction_job_status" in payload["note"]
+            assert "predict_get_batch_job_status" in payload["note"]
 
             status = await session.call_tool(
-                "get_batch_prediction_job_status",
+                "predict_get_batch_job_status",
                 {"job_id": STUB_BATCH_PREDICTION_JOB_ID},
             )
             assert not status.isError
@@ -75,7 +75,7 @@ class TestBatchPredictToolsIntegration:
             assert st.get("url")
 
             results = await session.call_tool(
-                "get_batch_prediction_results",
+                "predict_get_batch_results",
                 {"job_id": STUB_BATCH_PREDICTION_JOB_ID},
             )
             assert not results.isError
@@ -87,14 +87,14 @@ class TestBatchPredictToolsIntegration:
             df = pd.read_csv(StringIO(body["data"]))
             assert len(df) >= 1
 
-    async def test_predict_from_project_data_submit_status_and_results(
+    async def test_predict_batch_predictions_from_partition_submit_status_and_results(
         self, classification_project: dict[str, Any]
     ) -> None:
         """Submit batch scoring from project holdout, poll, and download stub CSV."""
         deployment_id = classification_project["deployment_id"]
         async with integration_test_mcp_session() as session:
             submit = await session.call_tool(
-                "predict_from_project_data",
+                "predict_batch_predictions_from_partition",
                 {
                     "deployment_id": deployment_id,
                     "project_id": STUB_PROJECT_ID,
@@ -106,24 +106,26 @@ class TestBatchPredictToolsIntegration:
             assert payload["job_id"] == STUB_BATCH_PREDICTION_JOB_ID
 
             status = await session.call_tool(
-                "get_batch_prediction_job_status",
+                "predict_get_batch_job_status",
                 {"job_id": payload["job_id"]},
             )
             assert not status.isError
 
             results = await session.call_tool(
-                "get_batch_prediction_results",
+                "predict_get_batch_results",
                 {"job_id": payload["job_id"]},
             )
             assert not results.isError
             body = json.loads(results.content[0].text)
             assert "data" in body
 
-    async def test_predict_by_ai_catalog_empty_deployment_id_validation(self) -> None:
+    async def test_predict_batch_predictions_from_dataset_empty_deployment_id_validation(
+        self,
+    ) -> None:
         """Empty deployment_id returns a tool validation error."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "predict_by_ai_catalog",
+                "predict_batch_predictions_from_dataset",
                 {
                     "deployment_id": "   ",
                     "dataset_id": STUB_PREDICT_CATALOG_DATASET_ID,

--- a/tests/drmcp/integration/test_data.py
+++ b/tests/drmcp/integration/test_data.py
@@ -29,16 +29,16 @@ class TestMCPDataToolsIntegration:
         async with integration_test_mcp_session() as session:
             result = await session.list_tools()
             tool_names = [t.name for t in result.tools]
-            assert "get_dataset_details" in tool_names
-            assert "list_datastores" in tool_names
-            assert "browse_datastore" in tool_names
-            assert "query_datastore" in tool_names
+            assert "catalog_get_preview" in tool_names
+            assert "catalog_list_datastores" in tool_names
+            assert "catalog_browse_datastore" in tool_names
+            assert "catalog_query_datastore" in tool_names
 
-    async def test_get_dataset_details_success(self) -> None:
-        """Test get_dataset_details returns metadata and sample rows."""
+    async def test_catalog_get_preview_success(self) -> None:
+        """Test catalog_get_preview returns metadata and sample rows."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_dataset_details",
+                "catalog_get_preview",
                 {"dataset_id": "stub_dataset_id"},
             )
             assert not result.isError
@@ -51,32 +51,32 @@ class TestMCPDataToolsIntegration:
             assert "sample" in data
             assert len(data["sample"]) > 0
 
-    async def test_get_dataset_details_not_found(self) -> None:
-        """Test get_dataset_details with nonexistent dataset."""
+    async def test_catalog_get_preview_not_found(self) -> None:
+        """Test catalog_get_preview with nonexistent dataset."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_dataset_details",
+                "catalog_get_preview",
                 {"dataset_id": "nonexistent_dataset"},
             )
             assert result.isError
             result_text = result.content[0].text  # type: ignore[union-attr]
             assert "not found" in result_text.lower() or "error" in result_text.lower()
 
-    async def test_get_dataset_details_missing_id(self) -> None:
-        """Test get_dataset_details with no dataset_id."""
+    async def test_catalog_get_preview_missing_id(self) -> None:
+        """Test catalog_get_preview with no dataset_id."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_dataset_details",
+                "catalog_get_preview",
                 {},
             )
             assert result.isError
             result_text = result.content[0].text  # type: ignore[union-attr]
             assert "Dataset ID must be provided" in result_text
 
-    async def test_list_datastores_success(self) -> None:
-        """Test list_datastores returns available data connections."""
+    async def test_catalog_list_datastores_success(self) -> None:
+        """Test catalog_list_datastores returns available data connections."""
         async with integration_test_mcp_session() as session:
-            result = await session.call_tool("list_datastores", {})
+            result = await session.call_tool("catalog_list_datastores", {})
             assert not result.isError
             assert isinstance(result.content[0], TextContent)
             data = json.loads(result.content[0].text)
@@ -86,11 +86,11 @@ class TestMCPDataToolsIntegration:
             assert data["datastores"][0]["id"] == "stub_datastore_id"
             assert data["datastores"][0]["canonical_name"] == "Test PostgreSQL"
 
-    async def test_browse_datastore_success(self) -> None:
-        """Test browse_datastore returns table listings."""
+    async def test_catalog_browse_datastore_success(self) -> None:
+        """Test catalog_browse_datastore returns table listings."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "browse_datastore",
+                "catalog_browse_datastore",
                 {"datastore_id": "stub_datastore_id"},
             )
             assert not result.isError
@@ -100,19 +100,19 @@ class TestMCPDataToolsIntegration:
             assert "items" in data
             assert data["count"] >= 1
 
-    async def test_browse_datastore_missing_id(self) -> None:
-        """Test browse_datastore with no datastore_id."""
+    async def test_catalog_browse_datastore_missing_id(self) -> None:
+        """Test catalog_browse_datastore with no datastore_id."""
         async with integration_test_mcp_session() as session:
-            result = await session.call_tool("browse_datastore", {})
+            result = await session.call_tool("catalog_browse_datastore", {})
             assert result.isError
             result_text = result.content[0].text  # type: ignore[union-attr]
             assert "Datastore ID must be provided" in result_text
 
-    async def test_query_datastore_success(self) -> None:
-        """Test query_datastore executes SQL and returns results."""
+    async def test_catalog_query_datastore_success(self) -> None:
+        """Test catalog_query_datastore executes SQL and returns results."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "query_datastore",
+                "catalog_query_datastore",
                 {
                     "datastore_id": "stub_datastore_id",
                     "sql": "SELECT * FROM users LIMIT 10",
@@ -125,12 +125,12 @@ class TestMCPDataToolsIntegration:
             assert "columns" in data
             assert data["row_count"] >= 1
 
-    async def test_query_datastore_missing_params(self) -> None:
-        """Test query_datastore with missing required parameters."""
+    async def test_catalog_query_datastore_missing_params(self) -> None:
+        """Test catalog_query_datastore with missing required parameters."""
         async with integration_test_mcp_session() as session:
             # Missing sql
             result = await session.call_tool(
-                "query_datastore",
+                "catalog_query_datastore",
                 {"datastore_id": "stub_datastore_id"},
             )
             assert result.isError
@@ -139,7 +139,7 @@ class TestMCPDataToolsIntegration:
 
             # Missing datastore_id
             result = await session.call_tool(
-                "query_datastore",
+                "catalog_query_datastore",
                 {"sql": "SELECT 1"},
             )
             assert result.isError

--- a/tests/drmcp/integration/test_deployment_info.py
+++ b/tests/drmcp/integration/test_deployment_info.py
@@ -25,33 +25,33 @@ from datarobot_genai.drmcp.test_utils.mcp_utils_integration import integration_t
 class TestMCPDeploymentInfoIntegration:
     """Integration tests for MCP deployment info tools (multiclass project)."""
 
-    async def test_get_deployment_features_and_template(
+    async def test_deployment_get_features_and_template(
         self, classification_project: dict[str, Any]
     ) -> None:
-        """Integration test for get_deployment_features and generate_prediction_data_template
+        """Integration test for deployment_get_features and deployment_generate_prediction_sample
         on a multiclass deployment.
         """
         async with integration_test_mcp_session() as session:
             deployment_id = classification_project["deployment_id"]
-            # Test get_deployment_features
+            # Test deployment_get_features
             result = await session.call_tool(
-                "get_deployment_features",
+                "deployment_get_features",
                 {"deployment_id": deployment_id},
             )
             assert not result.isError, (
-                f"get_deployment_features failed: {result.content[0].text}"  # type: ignore[union-attr]
+                f"deployment_get_features failed: {result.content[0].text}"  # type: ignore[union-attr]
             )
             result_content = result.content[0]
             assert isinstance(result_content, TextContent)
             assert "error" not in result_content.text.lower()
 
-            # Test generate_prediction_data_template (returns JSON structured content)
+            # Test deployment_generate_prediction_sample (returns JSON structured content)
             result = await session.call_tool(
-                "generate_prediction_data_template",
+                "deployment_generate_prediction_sample",
                 {"deployment_id": deployment_id, "n_rows": 3},
             )
             assert not result.isError, (
-                f"generate_prediction_data_template failed: {result.content[0].text}"  # type: ignore[union-attr]
+                f"deployment_generate_prediction_sample failed: {result.content[0].text}"  # type: ignore[union-attr]
             )
             result_content = result.content[0]
             assert isinstance(result_content, TextContent)
@@ -65,19 +65,19 @@ class TestMCPDeploymentInfoIntegration:
             assert "text_review" in data["template_data"][0]
             assert "product_category" in data["template_data"][0]
 
-    async def test_validate_prediction_data_valid(
+    async def test_deployment_validate_prediction_data_valid(
         self, classification_project: dict[str, Any], test_data_dir: Any
     ) -> None:
-        """Integration test for validate_prediction_data with valid scoring file."""
+        """Integration test for deployment_validate_prediction_data with valid scoring file."""
         async with integration_test_mcp_session() as session:
             deployment_id = classification_project["deployment_id"]
             predict_file = test_data_dir / "text_classification_predict.csv"
             result = await session.call_tool(
-                "validate_prediction_data",
+                "deployment_validate_prediction_data",
                 {"deployment_id": deployment_id, "csv_string": predict_file.read_text()},
             )
             assert not result.isError, (
-                f"validate_prediction_data failed: {result.content[0].text}"  # type: ignore[union-attr]
+                f"deployment_validate_prediction_data failed: {result.content[0].text}"  # type: ignore[union-attr]
             )
             result_content = result.content[0]
             assert isinstance(result_content, TextContent)
@@ -88,14 +88,14 @@ class TestMCPDeploymentInfoIntegration:
             assert data["summary"]["rows"] > 0
             assert data["summary"]["columns"] > 0
 
-    async def test_validate_prediction_data_empty_csv(
+    async def test_deployment_validate_prediction_data_empty_csv(
         self, classification_project: dict[str, Any]
     ) -> None:
-        """Integration test for validate_prediction_data with empty csv_string."""
+        """Integration test for deployment_validate_prediction_data with empty csv_string."""
         async with integration_test_mcp_session() as session:
             deployment_id = classification_project["deployment_id"]
             result = await session.call_tool(
-                "validate_prediction_data",
+                "deployment_validate_prediction_data",
                 {
                     "deployment_id": deployment_id,
                     "csv_string": "   ",

--- a/tests/drmcp/integration/test_deployment_tools.py
+++ b/tests/drmcp/integration/test_deployment_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for get_prediction_history deployment tool."""
+"""Integration tests for deployment_get_prediction_history deployment tool."""
 
 import json
 
@@ -26,13 +26,13 @@ STUB_DEPLOYMENT_ID = "stub_deployment_id"
 
 @pytest.mark.asyncio
 class TestGetPredictionHistoryIntegration:
-    """Integration tests for the get_prediction_history MCP tool."""
+    """Integration tests for the deployment_get_prediction_history MCP tool."""
 
-    async def test_get_prediction_history_basic(self) -> None:
-        """get_prediction_history returns prediction rows for a valid deployment."""
+    async def test_deployment_get_prediction_history_basic(self) -> None:
+        """deployment_get_prediction_history returns prediction rows for a valid deployment."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_prediction_history",
+                "deployment_get_prediction_history",
                 {
                     "deployment_id": STUB_DEPLOYMENT_ID,
                     "limit": 10,
@@ -49,11 +49,11 @@ class TestGetPredictionHistoryIntegration:
             assert "rows" in data
             assert isinstance(data["rows"], list)
 
-    async def test_get_prediction_history_returns_rows(self) -> None:
-        """get_prediction_history returns the expected stub prediction rows."""
+    async def test_deployment_get_prediction_history_returns_rows(self) -> None:
+        """deployment_get_prediction_history returns the expected stub prediction rows."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_prediction_history",
+                "deployment_get_prediction_history",
                 {
                     "deployment_id": STUB_DEPLOYMENT_ID,
                     "limit": 5,
@@ -71,11 +71,11 @@ class TestGetPredictionHistoryIntegration:
             assert "predictionValue" in first_row
             assert "timestamp" in first_row
 
-    async def test_get_prediction_history_with_time_filters(self) -> None:
-        """get_prediction_history passes time filters without error."""
+    async def test_deployment_get_prediction_history_with_time_filters(self) -> None:
+        """deployment_get_prediction_history passes time filters without error."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_prediction_history",
+                "deployment_get_prediction_history",
                 {
                     "deployment_id": STUB_DEPLOYMENT_ID,
                     "limit": 10,
@@ -89,11 +89,11 @@ class TestGetPredictionHistoryIntegration:
             assert data["deployment_id"] == STUB_DEPLOYMENT_ID
             assert "rows" in data
 
-    async def test_get_prediction_history_default_limit(self) -> None:
-        """get_prediction_history uses the default limit of 100."""
+    async def test_deployment_get_prediction_history_default_limit(self) -> None:
+        """deployment_get_prediction_history uses the default limit of 100."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_prediction_history",
+                "deployment_get_prediction_history",
                 {
                     "deployment_id": STUB_DEPLOYMENT_ID,
                 },
@@ -104,11 +104,11 @@ class TestGetPredictionHistoryIntegration:
             # stub returns min(100, 5) = 5 rows with default limit
             assert data["row_count"] >= 0
 
-    async def test_get_prediction_history_missing_deployment_id(self) -> None:
-        """get_prediction_history returns an error when deployment_id is not provided."""
+    async def test_deployment_get_prediction_history_missing_deployment_id(self) -> None:
+        """deployment_get_prediction_history returns an error when deployment_id is not provided."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_prediction_history",
+                "deployment_get_prediction_history",
                 {"limit": 10},
             )
 
@@ -116,9 +116,9 @@ class TestGetPredictionHistoryIntegration:
             text = result.content[0].text.lower()
             assert "deployment_id" in text or "error" in text
 
-    async def test_get_prediction_history_tool_registered(self) -> None:
-        """Verify get_prediction_history is registered in the MCP session."""
+    async def test_deployment_get_prediction_history_tool_registered(self) -> None:
+        """Verify deployment_get_prediction_history is registered in the MCP session."""
         async with integration_test_mcp_session() as session:
             tools_result = await session.list_tools()
             tool_names = [t.name for t in tools_result.tools]
-            assert "get_prediction_history" in tool_names
+            assert "deployment_get_prediction_history" in tool_names

--- a/tests/drmcp/integration/test_model.py
+++ b/tests/drmcp/integration/test_model.py
@@ -37,12 +37,12 @@ class TestMCPToolsIntegration:
             tools_result: ListToolsResult = await session.list_tools()
             tool_names = [tool.name for tool in tools_result.tools]
 
-            assert "get_best_model" in tool_names
-            assert "score_dataset_with_model" in tool_names
+            assert "models_get_bestmodel" in tool_names
+            assert "modeling_score_dataset" in tool_names
 
             # 2 Test getting best model with specified metric
             result: CallToolResult = await session.call_tool(
-                "get_best_model",
+                "models_get_bestmodel",
                 {
                     "project_id": project_id,
                     "metric": "AUC",
@@ -69,7 +69,7 @@ class TestMCPToolsIntegration:
 
             # 3 Test getting best model without specifying metric
             result = await session.call_tool(
-                "get_best_model",
+                "models_get_bestmodel",
                 {"project_id": project_id},
             )
 
@@ -88,7 +88,7 @@ class TestMCPToolsIntegration:
 
             # 4 Test error handling for nonexistent project
             result = await session.call_tool(
-                "get_best_model", {"project_id": "nonexistent_project"}
+                "models_get_bestmodel", {"project_id": "nonexistent_project"}
             )
 
             assert result.isError
@@ -103,7 +103,7 @@ class TestMCPToolsIntegration:
 
             # 5 Test metric-based sorting of models
             result = await session.call_tool(
-                "get_best_model",
+                "models_get_bestmodel",
                 {"project_id": project_id, "metric": "LogLoss"},
             )
 
@@ -122,7 +122,7 @@ class TestMCPToolsIntegration:
 
             # 6 Test scoring: unknown AI Catalog dataset id (stub Dataset.get raises)
             result = await session.call_tool(
-                "score_dataset_with_model",
+                "modeling_score_dataset",
                 {
                     "project_id": project_id,
                     "model_id": "standalone_model",
@@ -136,5 +136,5 @@ class TestMCPToolsIntegration:
                 if hasattr(result.content[0], "text")
                 else str(result.content[0])
             )
-            assert "Error in score_dataset_with_model" in result_text
+            assert "Error in modeling_score_dataset" in result_text
             assert "Not Found" in result_text or "404" in result_text

--- a/tests/drmcp/integration/test_model_tools.py
+++ b/tests/drmcp/integration/test_model_tools.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for get_model_details and is_eligible_for_timeseries_training tools."""
+"""Integration tests for modeling_get_modeldetails and catalog_check_timeseries_eligibility."""
 
 import json
 
@@ -26,13 +26,13 @@ from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import STUB_PROJECT_
 
 @pytest.mark.asyncio
 class TestGetModelDetailsIntegration:
-    """Integration tests for the get_model_details MCP tool."""
+    """Integration tests for the modeling_get_modeldetails MCP tool."""
 
-    async def test_get_model_details_basic(self) -> None:
-        """get_model_details returns model info without optional fields."""
+    async def test_modeling_get_modeldetails_basic(self) -> None:
+        """modeling_get_modeldetails returns model info without optional fields."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_model_details",
+                "modeling_get_modeldetails",
                 {
                     "project_id": STUB_PROJECT_ID,
                     "model_id": "model_1",
@@ -57,11 +57,11 @@ class TestGetModelDetailsIntegration:
             assert "feature_impact" not in data
             assert "roc_curve" not in data
 
-    async def test_get_model_details_with_feature_impact(self) -> None:
-        """get_model_details includes feature impact when requested."""
+    async def test_modeling_get_modeldetails_with_feature_impact(self) -> None:
+        """modeling_get_modeldetails includes feature impact when requested."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_model_details",
+                "modeling_get_modeldetails",
                 {
                     "project_id": STUB_PROJECT_ID,
                     "model_id": "model_1",
@@ -79,11 +79,11 @@ class TestGetModelDetailsIntegration:
             feature_names = [f["featureName"] for f in fi]
             assert "text_review" in feature_names
 
-    async def test_get_model_details_with_roc_curve(self) -> None:
-        """get_model_details includes ROC curve when requested."""
+    async def test_modeling_get_modeldetails_with_roc_curve(self) -> None:
+        """modeling_get_modeldetails includes ROC curve when requested."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_model_details",
+                "modeling_get_modeldetails",
                 {
                     "project_id": STUB_PROJECT_ID,
                     "model_id": "model_1",
@@ -100,11 +100,11 @@ class TestGetModelDetailsIntegration:
             assert isinstance(roc["roc_points"], list)
             assert len(roc["roc_points"]) > 0
 
-    async def test_get_model_details_with_all_optional_fields(self) -> None:
-        """get_model_details returns all fields when both optional flags are True."""
+    async def test_modeling_get_modeldetails_with_all_optional_fields(self) -> None:
+        """modeling_get_modeldetails returns all fields when both optional flags are True."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_model_details",
+                "modeling_get_modeldetails",
                 {
                     "project_id": STUB_PROJECT_ID,
                     "model_id": "model_2",
@@ -120,11 +120,11 @@ class TestGetModelDetailsIntegration:
             assert "feature_impact" in data
             assert "roc_curve" in data
 
-    async def test_get_model_details_missing_project_id(self) -> None:
-        """get_model_details returns an error when project_id is not provided."""
+    async def test_modeling_get_modeldetails_missing_project_id(self) -> None:
+        """modeling_get_modeldetails returns an error when project_id is not provided."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_model_details",
+                "modeling_get_modeldetails",
                 {"model_id": "model_1"},
             )
 
@@ -132,34 +132,34 @@ class TestGetModelDetailsIntegration:
             text = result.content[0].text.lower()
             assert "project_id" in text or "error" in text
 
-    async def test_get_model_details_missing_model_id(self) -> None:
-        """get_model_details returns an error when model_id is not provided."""
+    async def test_modeling_get_modeldetails_missing_model_id(self) -> None:
+        """modeling_get_modeldetails returns an error when model_id is not provided."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_model_details",
+                "modeling_get_modeldetails",
                 {"project_id": STUB_PROJECT_ID},
             )
 
             assert result.isError
             assert "model_id" in result.content[0].text.lower() or "Error" in result.content[0].text
 
-    async def test_get_model_details_tool_registered(self) -> None:
-        """Verify get_model_details is registered in the MCP session."""
+    async def test_modeling_get_modeldetails_tool_registered(self) -> None:
+        """Verify modeling_get_modeldetails is registered in the MCP session."""
         async with integration_test_mcp_session() as session:
             tools_result = await session.list_tools()
             tool_names = [t.name for t in tools_result.tools]
-            assert "get_model_details" in tool_names
+            assert "modeling_get_modeldetails" in tool_names
 
 
 @pytest.mark.asyncio
 class TestIsEligibleForTimeseriesTrainingIntegration:
-    """Integration tests for the is_eligible_for_timeseries_training MCP tool."""
+    """Integration tests for the catalog_check_timeseries_eligibility MCP tool."""
 
     async def test_eligible_dataset(self) -> None:
-        """is_eligible_for_timeseries_training returns ELIGIBLE for a valid dataset."""
+        """catalog_check_timeseries_eligibility returns ELIGIBLE for a valid dataset."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "is_eligible_for_timeseries_training",
+                "catalog_check_timeseries_eligibility",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "datetime_column": "date",
@@ -174,10 +174,10 @@ class TestIsEligibleForTimeseriesTrainingIntegration:
             assert any("Row count" in info for info in data["info"])
 
     async def test_eligible_dataset_with_series_id(self) -> None:
-        """is_eligible_for_timeseries_training returns ELIGIBLE with optional series_id_column."""
+        """catalog_check_timeseries_eligibility returns ELIGIBLE with optional series_id_column."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "is_eligible_for_timeseries_training",
+                "catalog_check_timeseries_eligibility",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "datetime_column": "date",
@@ -192,10 +192,10 @@ class TestIsEligibleForTimeseriesTrainingIntegration:
             assert data["errors"] == []
 
     async def test_not_eligible_missing_datetime_column(self) -> None:
-        """is_eligible_for_timeseries_training returns NOT_ELIGIBLE when datetime column missing."""
+        """catalog_check_timeseries_eligibility is NOT_ELIGIBLE without datetime column."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "is_eligible_for_timeseries_training",
+                "catalog_check_timeseries_eligibility",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "datetime_column": "nonexistent_date_col",
@@ -209,10 +209,10 @@ class TestIsEligibleForTimeseriesTrainingIntegration:
             assert any("nonexistent_date_col" in err for err in data["errors"])
 
     async def test_not_eligible_missing_target_column(self) -> None:
-        """is_eligible_for_timeseries_training returns NOT_ELIGIBLE when target column missing."""
+        """catalog_check_timeseries_eligibility returns NOT_ELIGIBLE when target column missing."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "is_eligible_for_timeseries_training",
+                "catalog_check_timeseries_eligibility",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "datetime_column": "date",
@@ -226,10 +226,10 @@ class TestIsEligibleForTimeseriesTrainingIntegration:
             assert any("nonexistent_target" in err for err in data["errors"])
 
     async def test_missing_dataset_id(self) -> None:
-        """is_eligible_for_timeseries_training returns an error when dataset_id is missing."""
+        """catalog_check_timeseries_eligibility returns an error when dataset_id is missing."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "is_eligible_for_timeseries_training",
+                "catalog_check_timeseries_eligibility",
                 {
                     "datetime_column": "date",
                     "target_column": "sales",
@@ -239,10 +239,10 @@ class TestIsEligibleForTimeseriesTrainingIntegration:
             assert result.isError
 
     async def test_missing_datetime_column(self) -> None:
-        """is_eligible_for_timeseries_training returns an error when datetime_column is missing."""
+        """catalog_check_timeseries_eligibility returns an error when datetime_column is missing."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "is_eligible_for_timeseries_training",
+                "catalog_check_timeseries_eligibility",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "target_column": "sales",
@@ -252,10 +252,10 @@ class TestIsEligibleForTimeseriesTrainingIntegration:
             assert result.isError
 
     async def test_missing_target_column(self) -> None:
-        """is_eligible_for_timeseries_training returns an error when target_column is missing."""
+        """catalog_check_timeseries_eligibility returns an error when target_column is missing."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "is_eligible_for_timeseries_training",
+                "catalog_check_timeseries_eligibility",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "datetime_column": "date",
@@ -265,8 +265,8 @@ class TestIsEligibleForTimeseriesTrainingIntegration:
             assert result.isError
 
     async def test_tool_registered(self) -> None:
-        """Verify is_eligible_for_timeseries_training is registered in the MCP session."""
+        """Verify catalog_check_timeseries_eligibility is registered in the MCP session."""
         async with integration_test_mcp_session() as session:
             tools_result = await session.list_tools()
             tool_names = [t.name for t in tools_result.tools]
-            assert "is_eligible_for_timeseries_training" in tool_names
+            assert "catalog_check_timeseries_eligibility" in tool_names

--- a/tests/drmcp/integration/test_predict_realtime.py
+++ b/tests/drmcp/integration/test_predict_realtime.py
@@ -54,7 +54,7 @@ class TestMCPRealtimePredictToolsIntegration:
                 dataset_str = f.read()
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": dataset_str,
@@ -89,7 +89,7 @@ class TestMCPRealtimePredictToolsIntegration:
             predict_file = test_data_dir / "timeseries_regression_predict.csv"
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -122,7 +122,7 @@ class TestMCPRealtimePredictToolsIntegration:
             predict_file = test_data_dir / "multiseries_regression_predict.csv"
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -155,7 +155,7 @@ class TestMCPRealtimePredictToolsIntegration:
 
             # Use the unified predict_realtime function for regular (non-time series) predictions
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -182,7 +182,7 @@ class TestMCPRealtimePredictToolsIntegration:
 
             # Test with invalid series_id_column
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -194,7 +194,7 @@ class TestMCPRealtimePredictToolsIntegration:
             assert result.isError
             assert (
                 result.content[0].text  # type: ignore[union-attr]
-                == "[internal] Error in predict_realtime: "
+                == "[internal] Error in predict_score_inline_realtime: "
                 "ValueError: series_id_column 'invalid_column' not found in input data."
             )
 
@@ -232,7 +232,7 @@ class TestMCPRealtimePredictToolsIntegration:
             predict_file = test_data_dir / "timeseries_regression_predict.csv"
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -278,7 +278,7 @@ class TestMCPRealtimePredictToolsIntegration:
             predict_file = test_data_dir / "timeseries_regression_predict.csv"
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -329,7 +329,7 @@ class TestMCPRealtimePredictToolsIntegration:
             predict_file = test_data_dir / "text_classification_predict.csv"
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -368,7 +368,7 @@ class TestMCPRealtimePredictToolsIntegration:
             predict_file = test_data_dir / "timeseries_regression_predict.csv"
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -425,7 +425,7 @@ class TestMCPRealtimePredictToolsIntegration:
             input_columns = {col.strip() for col in input_df.columns}
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),
@@ -473,7 +473,7 @@ class TestMCPRealtimePredictToolsIntegration:
             predict_file = test_data_dir / "timeseries_regression_predict.csv"
 
             result = await session.call_tool(
-                "predict_realtime",
+                "predict_score_inline_realtime",
                 {
                     "deployment_id": deployment_id,
                     "dataset": predict_file.read_text(),

--- a/tests/drmcp/integration/test_training_eda.py
+++ b/tests/drmcp/integration/test_training_eda.py
@@ -25,20 +25,20 @@ from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import STUB_DATASET_
 
 @pytest.mark.asyncio
 class TestGetExploratoryInsightsIntegration:
-    """MCP integration tests for ``get_exploratory_insights`` including catalog API profile."""
+    """MCP integration tests for ``catalog_get_eda_insights`` including catalog API profile."""
 
-    async def test_get_exploratory_insights_registered(self) -> None:
-        """``get_exploratory_insights`` is registered when predictive tools load."""
+    async def test_catalog_get_eda_insights_registered(self) -> None:
+        """``catalog_get_eda_insights`` is registered when predictive tools load."""
         async with integration_test_mcp_session() as session:
             listed = await session.list_tools()
             tool_names = [t.name for t in listed.tools]
-            assert "get_exploratory_insights" in tool_names
+            assert "catalog_get_eda_insights" in tool_names
 
-    async def test_get_exploratory_insights_with_catalog_feature_profile(self) -> None:
+    async def test_catalog_get_eda_insights_with_catalog_feature_profile(self) -> None:
         """``feature_col`` returns DataRobot catalog-style stats and optional histogram."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_exploratory_insights",
+                "catalog_get_eda_insights",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "feature_col": "sales",
@@ -61,11 +61,11 @@ class TestGetExploratoryInsightsIntegration:
             assert "histogram" in profile
             assert profile["histogram"]["plot"][0]["label"] == "stub-bin"
 
-    async def test_get_exploratory_insights_invalid_feature_col(self) -> None:
+    async def test_catalog_get_eda_insights_invalid_feature_col(self) -> None:
         """Unknown ``feature_col`` yields a tool error."""
         async with integration_test_mcp_session() as session:
             result = await session.call_tool(
-                "get_exploratory_insights",
+                "catalog_get_eda_insights",
                 {
                     "dataset_id": STUB_DATASET_ID,
                     "feature_col": "not_a_column",

--- a/tests/drmcp/integration/test_use_case.py
+++ b/tests/drmcp/integration/test_use_case.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for use case MCP tools (list_use_cases, list_use_case_assets)."""
+"""Integration tests for use case MCP tools (datarobot_usecases_list, usecases_list_assets)."""
 
 import json
 
@@ -36,17 +36,17 @@ class TestMCPUseCaseToolsIntegration:
     """Integration tests for MCP use case tools via stub DataRobot client."""
 
     async def test_tools_registered(self) -> None:
-        """Verify list_use_cases and list_use_case_assets are registered in the MCP server."""
+        """Verify use case list tools are registered in the MCP server."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
             result = await session.list_tools()
             tool_names = [t.name for t in result.tools]
-            assert "list_use_cases" in tool_names
-            assert "list_use_case_assets" in tool_names
+            assert "datarobot_usecases_list" in tool_names
+            assert "usecases_list_assets" in tool_names
 
-    async def test_list_use_cases_success(self) -> None:
-        """list_use_cases returns a list of use cases from the stub."""
+    async def test_datarobot_usecases_list_success(self) -> None:
+        """datarobot_usecases_list returns a list of use cases from the stub."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
-            result = await session.call_tool("list_use_cases", {})
+            result = await session.call_tool("datarobot_usecases_list", {})
             assert not result.isError
             assert len(result.content) > 0
             assert isinstance(result.content[0], TextContent)
@@ -57,10 +57,10 @@ class TestMCPUseCaseToolsIntegration:
             use_case_ids = [uc["id"] for uc in data["use_cases"]]
             assert STUB_USE_CASE_ID in use_case_ids
 
-    async def test_list_use_cases_with_search_filter(self) -> None:
-        """list_use_cases with a search filter narrows the results."""
+    async def test_datarobot_usecases_list_with_search_filter(self) -> None:
+        """datarobot_usecases_list with a search filter narrows the results."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
-            result = await session.call_tool("list_use_cases", {"search": "Stub"})
+            result = await session.call_tool("datarobot_usecases_list", {"search": "Stub"})
             assert not result.isError
             data = json.loads(result.content[0].text)
             assert "use_cases" in data
@@ -68,28 +68,30 @@ class TestMCPUseCaseToolsIntegration:
             for uc in data["use_cases"]:
                 assert "stub" in uc["name"].lower()
 
-    async def test_list_use_cases_with_search_no_results(self) -> None:
-        """list_use_cases with a non-matching search filter returns empty list."""
+    async def test_datarobot_usecases_list_with_search_no_results(self) -> None:
+        """datarobot_usecases_list with a non-matching search filter returns empty list."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
-            result = await session.call_tool("list_use_cases", {"search": "zzz_nonexistent_zzz"})
+            result = await session.call_tool(
+                "datarobot_usecases_list", {"search": "zzz_nonexistent_zzz"}
+            )
             assert not result.isError
             data = json.loads(result.content[0].text)
             assert data["use_cases"] == []
             assert data["count"] == 0
 
-    async def test_list_use_cases_with_limit(self) -> None:
-        """list_use_cases respects the limit parameter."""
+    async def test_datarobot_usecases_list_with_limit(self) -> None:
+        """datarobot_usecases_list respects the limit parameter."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
-            result = await session.call_tool("list_use_cases", {"limit": 1})
+            result = await session.call_tool("datarobot_usecases_list", {"limit": 1})
             assert not result.isError
             data = json.loads(result.content[0].text)
             assert "use_cases" in data
 
-    async def test_list_use_case_assets_success(self) -> None:
-        """list_use_case_assets returns datasets, deployments, and experiments for a use case."""
+    async def test_usecases_list_assets_success(self) -> None:
+        """usecases_list_assets returns datasets, deployments, and experiments for a use case."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
             result = await session.call_tool(
-                "list_use_case_assets", {"use_case_id": STUB_USE_CASE_ID}
+                "usecases_list_assets", {"use_case_id": STUB_USE_CASE_ID}
             )
             assert not result.isError
             assert len(result.content) > 0
@@ -105,11 +107,11 @@ class TestMCPUseCaseToolsIntegration:
             assert "deployments" in use_case or "deployments_error" in use_case
             assert "experiments" in use_case or "experiments_error" in use_case
 
-    async def test_list_use_case_assets_has_datasets(self) -> None:
-        """list_use_case_assets includes datasets list from stub."""
+    async def test_usecases_list_assets_has_datasets(self) -> None:
+        """usecases_list_assets includes datasets list from stub."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
             result = await session.call_tool(
-                "list_use_case_assets", {"use_case_id": STUB_USE_CASE_ID}
+                "usecases_list_assets", {"use_case_id": STUB_USE_CASE_ID}
             )
             assert not result.isError
             data = json.loads(result.content[0].text)
@@ -120,11 +122,11 @@ class TestMCPUseCaseToolsIntegration:
             assert "id" in use_case["datasets"][0]
             assert "name" in use_case["datasets"][0]
 
-    async def test_list_use_case_assets_has_deployments(self) -> None:
-        """list_use_case_assets includes deployments list from stub."""
+    async def test_usecases_list_assets_has_deployments(self) -> None:
+        """usecases_list_assets includes deployments list from stub."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
             result = await session.call_tool(
-                "list_use_case_assets", {"use_case_id": STUB_USE_CASE_ID}
+                "usecases_list_assets", {"use_case_id": STUB_USE_CASE_ID}
             )
             assert not result.isError
             data = json.loads(result.content[0].text)
@@ -134,11 +136,11 @@ class TestMCPUseCaseToolsIntegration:
             assert len(use_case["deployments"]) >= 1
             assert "id" in use_case["deployments"][0]
 
-    async def test_list_use_case_assets_has_experiments(self) -> None:
-        """list_use_case_assets includes experiments list from stub."""
+    async def test_usecases_list_assets_has_experiments(self) -> None:
+        """usecases_list_assets includes experiments list from stub."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
             result = await session.call_tool(
-                "list_use_case_assets", {"use_case_id": STUB_USE_CASE_ID}
+                "usecases_list_assets", {"use_case_id": STUB_USE_CASE_ID}
             )
             assert not result.isError
             data = json.loads(result.content[0].text)
@@ -149,10 +151,10 @@ class TestMCPUseCaseToolsIntegration:
             assert "id" in use_case["experiments"][0]
             assert "name" in use_case["experiments"][0]
 
-    async def test_list_use_case_assets_missing_use_case_id(self) -> None:
-        """list_use_case_assets raises ToolError when use_case_id is not provided."""
+    async def test_usecases_list_assets_missing_use_case_id(self) -> None:
+        """usecases_list_assets raises ToolError when use_case_id is not provided."""
         async with integration_test_mcp_session(server_params=_use_case_server_params()) as session:
-            result = await session.call_tool("list_use_case_assets", {})
+            result = await session.call_tool("usecases_list_assets", {})
             assert result.isError
             assert len(result.content) > 0
             error_text = (

--- a/tests/drmcp/integration/test_vdb.py
+++ b/tests/drmcp/integration/test_vdb.py
@@ -33,24 +33,23 @@ def _vdb_server_params():
 
 @pytest.mark.asyncio
 class TestMCPVDBToolsIntegration:
-    """Integration tests for MCP VDB tools (list_vector_databases, query_vector_database)."""
+    """Integration tests for MCP VDB tools (vdb_list, vdb_query)."""
 
     async def test_tools_registered(self) -> None:
         """Verify that VDB tools are registered and visible in the MCP session."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
             result = await session.list_tools()
             tool_names = [t.name for t in result.tools]
-            assert "list_vector_databases" in tool_names
-            assert "query_vector_database" in tool_names
+            assert "vdb_list" in tool_names
+            assert "vdb_query" in tool_names
 
-    async def test_list_vector_databases_returns_vdbs(self) -> None:
-        """list_vector_databases should return only VDB-capable deployments."""
+    async def test_vdb_list_returns_vdbs(self) -> None:
+        """vdb_list should return only VDB-capable deployments."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
-            result = await session.call_tool("list_vector_databases", {})
+            result = await session.call_tool("vdb_list", {})
 
             assert not result.isError, (
-                f"list_vector_databases failed: "
-                f"{result.content[0].text if result.content else 'no content'}"  # type: ignore[union-attr]
+                f"vdb_list failed: {result.content[0].text if result.content else 'no content'}"  # type: ignore[union-attr]
             )
             assert len(result.content) > 0
             assert isinstance(result.content[0], TextContent)
@@ -67,10 +66,10 @@ class TestMCPVDBToolsIntegration:
             assert vdb["label"] == "Stub VDB Deployment"
             assert vdb["status"] == "active"
 
-    async def test_list_vector_databases_structure(self) -> None:
-        """list_vector_databases result must have the expected keys per VDB entry."""
+    async def test_vdb_list_structure(self) -> None:
+        """vdb_list result must have the expected keys per VDB entry."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
-            result = await session.call_tool("list_vector_databases", {})
+            result = await session.call_tool("vdb_list", {})
 
             assert not result.isError
             data = json.loads(result.content[0].text)  # type: ignore[union-attr]
@@ -80,11 +79,11 @@ class TestMCPVDBToolsIntegration:
                 assert "label" in vdb
                 assert "status" in vdb
 
-    async def test_query_vector_database_returns_documents(self) -> None:
-        """query_vector_database should return a list of matching documents."""
+    async def test_vdb_query_returns_documents(self) -> None:
+        """vdb_query should return a list of matching documents."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
             result = await session.call_tool(
-                "query_vector_database",
+                "vdb_query",
                 {
                     "deployment_id": STUB_VDB_DEPLOYMENT_ID,
                     "query": "What is DataRobot?",
@@ -93,8 +92,7 @@ class TestMCPVDBToolsIntegration:
             )
 
             assert not result.isError, (
-                f"query_vector_database failed: "
-                f"{result.content[0].text if result.content else 'no content'}"  # type: ignore[union-attr]
+                f"vdb_query failed: {result.content[0].text if result.content else 'no content'}"  # type: ignore[union-attr]
             )
             assert len(result.content) > 0
             assert isinstance(result.content[0], TextContent)
@@ -107,11 +105,11 @@ class TestMCPVDBToolsIntegration:
             assert data["count"] == 2
             assert len(data["documents"]) == 2
 
-    async def test_query_vector_database_document_structure(self) -> None:
+    async def test_vdb_query_document_structure(self) -> None:
         """Returned documents should include page_content and metadata fields."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
             result = await session.call_tool(
-                "query_vector_database",
+                "vdb_query",
                 {
                     "deployment_id": STUB_VDB_DEPLOYMENT_ID,
                     "query": "AutoML",
@@ -126,11 +124,11 @@ class TestMCPVDBToolsIntegration:
             assert "page_content" in doc
             assert "metadata" in doc
 
-    async def test_query_vector_database_missing_deployment_id(self) -> None:
-        """query_vector_database without deployment_id must return an error."""
+    async def test_vdb_query_missing_deployment_id(self) -> None:
+        """vdb_query without deployment_id must return an error."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
             result = await session.call_tool(
-                "query_vector_database",
+                "vdb_query",
                 {"query": "What is DataRobot?"},
             )
 
@@ -139,11 +137,11 @@ class TestMCPVDBToolsIntegration:
             error_text = result.content[0].text  # type: ignore[union-attr]
             assert "Deployment ID" in error_text or "deployment_id" in error_text.lower()
 
-    async def test_query_vector_database_missing_query(self) -> None:
-        """query_vector_database without a query string must return an error."""
+    async def test_vdb_query_missing_query(self) -> None:
+        """vdb_query without a query string must return an error."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
             result = await session.call_tool(
-                "query_vector_database",
+                "vdb_query",
                 {"deployment_id": STUB_VDB_DEPLOYMENT_ID},
             )
 
@@ -152,11 +150,11 @@ class TestMCPVDBToolsIntegration:
             error_text = result.content[0].text  # type: ignore[union-attr]
             assert "Query" in error_text or "query" in error_text.lower()
 
-    async def test_query_vector_database_with_retrieval_mode(self) -> None:
-        """query_vector_database should accept retrieval_mode parameter."""
+    async def test_vdb_query_with_retrieval_mode(self) -> None:
+        """vdb_query should accept retrieval_mode parameter."""
         async with integration_test_mcp_session(server_params=_vdb_server_params()) as session:
             result = await session.call_tool(
-                "query_vector_database",
+                "vdb_query",
                 {
                     "deployment_id": STUB_VDB_DEPLOYMENT_ID,
                     "query": "machine learning",

--- a/tests/drmcp/unit/confluence_tools/test_tools.py
+++ b/tests/drmcp/unit/confluence_tools/test_tools.py
@@ -18,7 +18,7 @@ import pytest
 
 from datarobot_genai.drtools.confluence.tools import confluence_add_comment
 from datarobot_genai.drtools.confluence.tools import confluence_get_page
-from datarobot_genai.drtools.confluence.tools import confluence_search
+from datarobot_genai.drtools.confluence.tools import confluence_search_space
 from datarobot_genai.drtools.confluence.tools import confluence_update_page
 from datarobot_genai.drtools.core.clients.confluence import ConfluenceComment
 from datarobot_genai.drtools.core.clients.confluence import ConfluenceError
@@ -279,7 +279,7 @@ class TestConfluenceSearch:
     """Confluence search tool tests."""
 
     @pytest.mark.asyncio
-    async def test_confluence_search_happy_path(
+    async def test_confluence_search_space_happy_path(
         self,
         get_atlassian_access_token_mock: None,
         confluence_client_search_mock: list[ContentSearchResult],
@@ -287,7 +287,7 @@ class TestConfluenceSearch:
         """Confluence search -- happy path."""
         cql_query = "type=page AND space=TEST"
 
-        tool_result = await confluence_search(cql_query=cql_query)
+        tool_result = await confluence_search_space(cql_query=cql_query)
 
         content = tool_result
         expected = {
@@ -319,38 +319,38 @@ class TestConfluenceSearch:
         assert content == expected
 
     @pytest.mark.asyncio
-    async def test_confluence_search_when_error_in_client(
+    async def test_confluence_search_space_when_error_in_client(
         self, get_atlassian_access_token_mock: None, confluence_client_search_error_mock: None
     ) -> None:
         """Confluence search -- error in client."""
         cql_query = "type=page AND space=TEST"
 
         with pytest.raises(ConfluenceError, match="Search failed"):
-            await confluence_search(cql_query=cql_query)
+            await confluence_search_space(cql_query=cql_query)
 
     @pytest.mark.asyncio
-    async def test_confluence_search_empty_query(
+    async def test_confluence_search_space_empty_query(
         self, get_atlassian_access_token_mock: None
     ) -> None:
         """Confluence search -- empty query validation."""
         with pytest.raises(ToolError, match="cannot be empty"):
-            await confluence_search(cql_query="")
+            await confluence_search_space(cql_query="")
 
     @pytest.mark.asyncio
-    async def test_confluence_search_max_results_too_low(
+    async def test_confluence_search_space_max_results_too_low(
         self, get_atlassian_access_token_mock: None
     ) -> None:
         """Confluence search -- max_results below 1 should raise error."""
         with pytest.raises(ToolError, match="max_results.*must be between 1 and 100"):
-            await confluence_search(cql_query="type=page", max_results=0)
+            await confluence_search_space(cql_query="type=page", max_results=0)
 
     @pytest.mark.asyncio
-    async def test_confluence_search_max_results_too_high(
+    async def test_confluence_search_space_max_results_too_high(
         self, get_atlassian_access_token_mock: None
     ) -> None:
         """Confluence search -- max_results above 100 should raise error."""
         with pytest.raises(ToolError, match="max_results.*must be between 1 and 100"):
-            await confluence_search(cql_query="type=page", max_results=101)
+            await confluence_search_space(cql_query="type=page", max_results=101)
 
 
 @pytest.fixture
@@ -374,7 +374,7 @@ class TestConfluenceSearchIncludeBody:
     """Confluence search with include_body parameter tests."""
 
     @pytest.mark.asyncio
-    async def test_confluence_search_with_include_body(
+    async def test_confluence_search_space_with_include_body(
         self,
         get_atlassian_access_token_mock: None,
         confluence_client_search_mock: list[ContentSearchResult],
@@ -383,7 +383,7 @@ class TestConfluenceSearchIncludeBody:
         """Confluence search with include_body=True fetches full page content."""
         cql_query = "type=page AND space=TEST"
 
-        tool_result = await confluence_search(cql_query=cql_query, include_body=True)
+        tool_result = await confluence_search_space(cql_query=cql_query, include_body=True)
 
         content = tool_result
         assert content["count"] == 2
@@ -393,7 +393,7 @@ class TestConfluenceSearchIncludeBody:
         assert content["data"][0]["excerpt"] == "<p>Content</p>"
 
     @pytest.mark.asyncio
-    async def test_confluence_search_without_include_body(
+    async def test_confluence_search_space_without_include_body(
         self,
         get_atlassian_access_token_mock: None,
         confluence_client_search_mock: list[ContentSearchResult],
@@ -401,7 +401,7 @@ class TestConfluenceSearchIncludeBody:
         """Confluence search without include_body does not have body field."""
         cql_query = "type=page AND space=TEST"
 
-        tool_result = await confluence_search(cql_query=cql_query, include_body=False)
+        tool_result = await confluence_search_space(cql_query=cql_query, include_body=False)
 
         content = tool_result
         # body field should NOT be present when include_body=False

--- a/tests/drmcp/unit/dr_docs_tools/test_tools.py
+++ b/tests/drmcp/unit/dr_docs_tools/test_tools.py
@@ -15,7 +15,7 @@
 from unittest.mock import AsyncMock
 from unittest.mock import patch
 
-from datarobot_genai.drtools.dr_docs.tools import fetch_datarobot_doc_page
+from datarobot_genai.drtools.dr_docs.tools import datarobot_docs_fetch_page
 from datarobot_genai.drtools.dr_docs.tools import search_datarobot_agentic_docs
 
 
@@ -81,7 +81,7 @@ class TestSearchDatarobotAgenticDocs:
 
 
 class TestFetchDatarobotDocPage:
-    """Tests for fetch_datarobot_doc_page MCP tool."""
+    """Tests for datarobot_docs_fetch_page MCP tool."""
 
     async def test_fetch_returns_page_content(self) -> None:
         """Test that fetch returns page content on success."""
@@ -97,7 +97,7 @@ class TestFetchDatarobotDocPage:
         ) as mock_fetch:
             mock_fetch.return_value = mock_content
 
-            result = await fetch_datarobot_doc_page(
+            result = await datarobot_docs_fetch_page(
                 url="https://docs.datarobot.com/en/docs/agentic-ai/agentic-glossary.html"
             )
 
@@ -124,7 +124,7 @@ class TestFetchDatarobotDocPage:
         ) as mock_fetch:
             mock_fetch.return_value = mock_error
 
-            result = await fetch_datarobot_doc_page(url="https://example.com/not-docs/")
+            result = await datarobot_docs_fetch_page(url="https://example.com/not-docs/")
 
             content = result
             assert content["title"] == "Error"
@@ -145,7 +145,7 @@ class TestFetchDatarobotDocPage:
         ) as mock_fetch:
             mock_fetch.return_value = mock_error
 
-            result = await fetch_datarobot_doc_page(url=_url)
+            result = await datarobot_docs_fetch_page(url=_url)
 
             content = result
             assert content["title"] == "Error"

--- a/tests/drmcp/unit/gdrive_tools/test_tools.py
+++ b/tests/drmcp/unit/gdrive_tools/test_tools.py
@@ -25,7 +25,7 @@ from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.gdrive.tools import gdrive_create_file
 from datarobot_genai.drtools.gdrive.tools import gdrive_find_contents
 from datarobot_genai.drtools.gdrive.tools import gdrive_manage_access
-from datarobot_genai.drtools.gdrive.tools import gdrive_read_content
+from datarobot_genai.drtools.gdrive.tools import gdrive_read_and_export_content
 from datarobot_genai.drtools.gdrive.tools import gdrive_update_metadata
 
 
@@ -137,14 +137,14 @@ class TestGdriveReadContent:
             yield gdrive_file_content
 
     @pytest.mark.asyncio
-    async def test_gdrive_read_content_happy_path(
+    async def test_gdrive_read_and_export_content_happy_path(
         self,
         get_gdrive_access_token_mock: None,
         gdrive_file_content: GoogleDriveFileContent,
         gdrive_client_read_file_content_mock: GoogleDriveFileContent,
     ) -> None:
         """Gdrive read content -- happy path."""
-        result = await gdrive_read_content(file_id="doc123")
+        result = await gdrive_read_and_export_content(file_id="doc123")
         content = result
         assert content["id"] == "doc123"
         assert content["mimeType"] == "text/markdown"
@@ -159,7 +159,7 @@ class TestGdriveReadContent:
         assert content["wasExported"] is True
 
     @pytest.mark.asyncio
-    async def test_gdrive_read_content_csv_file(
+    async def test_gdrive_read_and_export_content_csv_file(
         self,
         get_gdrive_access_token_mock: None,
     ) -> None:
@@ -177,14 +177,14 @@ class TestGdriveReadContent:
             "datarobot_genai.drtools.core.clients.gdrive.GoogleDriveClient.read_file_content"
         ) as mock:
             mock.return_value = csv_content
-            result = await gdrive_read_content(file_id="sheet123")
+            result = await gdrive_read_and_export_content(file_id="sheet123")
         content = result
         assert content["mimeType"] == "text/csv"
         assert content["content"] == "Name,Age\nAlice,30"
         assert content["wasExported"] is True
 
     @pytest.mark.asyncio
-    async def test_gdrive_read_content_regular_text_file(
+    async def test_gdrive_read_and_export_content_regular_text_file(
         self,
         get_gdrive_access_token_mock: None,
     ) -> None:
@@ -202,31 +202,31 @@ class TestGdriveReadContent:
             "datarobot_genai.drtools.core.clients.gdrive.GoogleDriveClient.read_file_content"
         ) as mock:
             mock.return_value = text_content
-            result = await gdrive_read_content(file_id="txt123")
+            result = await gdrive_read_and_export_content(file_id="txt123")
         content = result
         assert content["wasExported"] is False
         assert content["wasExported"] is False
 
     @pytest.mark.asyncio
-    async def test_gdrive_read_content_empty_file_id(
+    async def test_gdrive_read_and_export_content_empty_file_id(
         self,
         get_gdrive_access_token_mock: None,
     ) -> None:
         """Gdrive read content -- empty file_id raises error."""
         with pytest.raises(ToolError, match="file_id.*cannot be empty"):
-            await gdrive_read_content(file_id="")
+            await gdrive_read_and_export_content(file_id="")
 
     @pytest.mark.asyncio
-    async def test_gdrive_read_content_whitespace_file_id(
+    async def test_gdrive_read_and_export_content_whitespace_file_id(
         self,
         get_gdrive_access_token_mock: None,
     ) -> None:
         """Gdrive read content -- whitespace file_id raises error."""
         with pytest.raises(ToolError, match="file_id.*cannot be empty"):
-            await gdrive_read_content(file_id="   ")
+            await gdrive_read_and_export_content(file_id="   ")
 
     @pytest.mark.asyncio
-    async def test_gdrive_read_content_file_not_found(
+    async def test_gdrive_read_and_export_content_file_not_found(
         self,
         get_gdrive_access_token_mock: None,
     ) -> None:
@@ -236,10 +236,10 @@ class TestGdriveReadContent:
         ) as mock:
             mock.side_effect = GoogleDriveError("File with ID 'nonexistent' not found.")
             with pytest.raises(GoogleDriveError, match="not found"):
-                await gdrive_read_content(file_id="nonexistent")
+                await gdrive_read_and_export_content(file_id="nonexistent")
 
     @pytest.mark.asyncio
-    async def test_gdrive_read_content_binary_file_error(
+    async def test_gdrive_read_and_export_content_binary_file_error(
         self,
         get_gdrive_access_token_mock: None,
     ) -> None:
@@ -252,7 +252,7 @@ class TestGdriveReadContent:
                 "File 'photo.jpg' has MIME type 'image/jpeg'."
             )
             with pytest.raises(GoogleDriveError, match="Binary files are not supported"):
-                await gdrive_read_content(file_id="img123")
+                await gdrive_read_and_export_content(file_id="img123")
 
 
 class TestGdriveCreateFile:

--- a/tests/drmcp/unit/microsoft_graph_tools/test_tools.py
+++ b/tests/drmcp/unit/microsoft_graph_tools/test_tools.py
@@ -21,7 +21,7 @@ import pytest
 from datarobot_genai.drtools.core.clients.microsoft_graph import MicrosoftGraphError
 from datarobot_genai.drtools.core.clients.microsoft_graph import MicrosoftGraphItem
 from datarobot_genai.drtools.core.exceptions import ToolError
-from datarobot_genai.drtools.microsoft_graph.tools import microsoft_create_file
+from datarobot_genai.drtools.microsoft_graph.tools import microsoft_graph_create_file
 from datarobot_genai.drtools.microsoft_graph.tools import microsoft_graph_search_content
 from datarobot_genai.drtools.microsoft_graph.tools import microsoft_graph_share_item
 
@@ -391,7 +391,7 @@ class TestMicrosoftGraphShareItem:
 
 
 class TestMicrosoftCreateFile:
-    """Test microsoft_create_file tool."""
+    """Test microsoft_graph_create_file tool."""
 
     @pytest.fixture
     def mock_created_file(self) -> MicrosoftGraphItem:
@@ -432,7 +432,7 @@ class TestMicrosoftCreateFile:
         mock_client_create_success: AsyncMock,
     ) -> None:
         """Test file creation in SharePoint with explicit document_library_id."""
-        result = await microsoft_create_file(
+        result = await microsoft_graph_create_file(
             file_name="report.txt",
             content_text="Content",
             document_library_id="drive123",
@@ -451,7 +451,7 @@ class TestMicrosoftCreateFile:
         mock_client_create_success: AsyncMock,
     ) -> None:
         """Test file creation in personal OneDrive when no library specified."""
-        result = await microsoft_create_file(
+        result = await microsoft_graph_create_file(
             file_name="notes.txt",
             content_text="My notes",
         )
@@ -470,10 +470,10 @@ class TestMicrosoftCreateFile:
     ) -> None:
         """Test validation errors for missing required fields."""
         with pytest.raises(ToolError, match="file_name is required"):
-            await microsoft_create_file(file_name="", content_text="Content")
+            await microsoft_graph_create_file(file_name="", content_text="Content")
 
         with pytest.raises(ToolError, match="content_text is required"):
-            await microsoft_create_file(file_name="test.txt", content_text="")
+            await microsoft_graph_create_file(file_name="test.txt", content_text="")
 
     @pytest.mark.asyncio
     async def test_create_file_client_error(
@@ -493,7 +493,7 @@ class TestMicrosoftCreateFile:
             mock_client_class.return_value = mock_client
 
             with pytest.raises(MicrosoftGraphError, match="[Pp]ermission denied"):
-                await microsoft_create_file(
+                await microsoft_graph_create_file(
                     file_name="report.txt",
                     content_text="Content",
                     document_library_id="drive123",

--- a/tests/drmcp/unit/perplexity_tools/test_tools.py
+++ b/tests/drmcp/unit/perplexity_tools/test_tools.py
@@ -23,7 +23,7 @@ from datarobot_genai.drtools.core.clients.perplexity import PerplexitySearchResu
 from datarobot_genai.drtools.core.clients.perplexity import PerplexityThinkResult
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.perplexity.tools import perplexity_search
-from datarobot_genai.drtools.perplexity.tools import perplexity_think
+from datarobot_genai.drtools.perplexity.tools import perplexity_sonar
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ def mock_perplexity_search_results() -> list[PerplexitySearchResult]:
 
 
 @pytest.fixture
-def mock_perplexity_think_results() -> PerplexityThinkResult:
+def mock_perplexity_sonar_results() -> PerplexityThinkResult:
     """Mock Perplexity Think Results."""
     return PerplexityThinkResult(
         **{
@@ -90,14 +90,14 @@ def mock_client_search_success(
 
 @pytest.fixture
 def mock_client_think_success(
-    mock_perplexity_think_results: PerplexityThinkResult,
+    mock_perplexity_sonar_results: PerplexityThinkResult,
 ) -> Iterator[AsyncMock]:
     """Mock successful client think."""
     with patch("datarobot_genai.drtools.perplexity.tools.PerplexityClient") as mock_client_class:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client.think = AsyncMock(return_value=mock_perplexity_think_results)
+        mock_client.think = AsyncMock(return_value=mock_perplexity_sonar_results)
         mock_client_class.return_value = mock_client
         yield mock_client
 
@@ -261,17 +261,17 @@ class TestPerplexitySearch:
 
 
 class TestPerplexityThink:
-    """Test perplexity_think tool."""
+    """Test perplexity_sonar tool."""
 
     @pytest.mark.asyncio
     async def test_think_success(
         self,
         get_perplexity_access_token_mock: None,
         mock_client_think_success: AsyncMock,
-        mock_perplexity_think_results: PerplexityThinkResult,
+        mock_perplexity_sonar_results: PerplexityThinkResult,
     ) -> None:
         """Test successful think."""
-        result = await perplexity_think(prompt="test prompt")
+        result = await perplexity_sonar(prompt="test prompt")
 
         assert result["model"] == "sonar"
         assert len(result["citations"]) == 2
@@ -294,7 +294,7 @@ class TestPerplexityThink:
     ) -> None:
         """Test think -- input validation."""
         with pytest.raises(ToolError, match=error_message):
-            await perplexity_think(**function_kwargs)
+            await perplexity_sonar(**function_kwargs)
 
     @pytest.mark.asyncio
     async def test_think_oauth_error(self) -> None:
@@ -304,7 +304,7 @@ class TestPerplexityThink:
             return_value=ToolError("OAuth error"),
         ):
             with pytest.raises(ToolError) as exc_info:
-                await perplexity_think(prompt="test prompt")
+                await perplexity_sonar(prompt="test prompt")
             assert "oauth" in str(exc_info.value).lower() or "error" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
@@ -323,7 +323,7 @@ class TestPerplexityThink:
             mock_client_class.return_value = mock_client
 
             with pytest.raises(PerplexityError) as exc_info:
-                await perplexity_think(prompt="test prompt")
+                await perplexity_sonar(prompt="test prompt")
             assert "client error" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
@@ -342,5 +342,5 @@ class TestPerplexityThink:
             mock_client_class.return_value = mock_client
 
             with pytest.raises(Exception) as exc_info:
-                await perplexity_think(prompt="test prompt")
+                await perplexity_sonar(prompt="test prompt")
             assert "unexpected error" in str(exc_info.value).lower()

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -64,7 +64,7 @@ def test_merge_pagination_metadata_list_body_ignored() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_success_from_bytes() -> None:
+async def test_catalog_upload_dataset_success_from_bytes() -> None:
     raw = b"a,b\n1,2\n"
     b64 = base64.b64encode(raw).decode("ascii")
     mock_catalog_item = MagicMock()
@@ -75,7 +75,7 @@ async def test_upload_dataset_to_ai_catalog_success_from_bytes() -> None:
     with patch.object(
         dr.Dataset, "create_from_file", return_value=mock_catalog_item
     ) as mock_create:
-        result = await data.upload_dataset_to_ai_catalog(
+        result = await data.catalog_upload_dataset(
             file_content_base64=b64, dataset_filename="somefile.csv"
         )
         mock_create.assert_called_once()
@@ -92,15 +92,13 @@ async def test_upload_dataset_to_ai_catalog_success_from_bytes() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_success_with_url() -> None:
+async def test_catalog_upload_dataset_success_with_url() -> None:
     mock_catalog_item = MagicMock()
     mock_catalog_item.id = "12345"
     mock_catalog_item.version_id = None
     mock_catalog_item.name = "somefile.csv"
     with patch.object(dr.Dataset, "create_from_url", return_value=mock_catalog_item) as mock_create:
-        result = await data.upload_dataset_to_ai_catalog(
-            file_url="https://example.com/somefile.csv"
-        )
+        result = await data.catalog_upload_dataset(file_url="https://example.com/somefile.csv")
         mock_create.assert_called_once_with("https://example.com/somefile.csv")
         assert isinstance(result, dict)
         assert result == {
@@ -112,7 +110,7 @@ async def test_upload_dataset_to_ai_catalog_success_with_url() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_error_with_url() -> None:
+async def test_catalog_upload_dataset_error_with_url() -> None:
     mock_catalog_item = MagicMock()
     mock_catalog_item.id = "12345"
     mock_catalog_item.version_id = None
@@ -122,27 +120,27 @@ async def test_upload_dataset_to_ai_catalog_error_with_url() -> None:
             ToolError,
             match="Invalid file URL: https:notavalidurl/somefile.csv",
         ):
-            await data.upload_dataset_to_ai_catalog(file_url="https:notavalidurl/somefile.csv")
+            await data.catalog_upload_dataset(file_url="https:notavalidurl/somefile.csv")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_error_no_content_or_url() -> None:
+async def test_catalog_upload_dataset_error_no_content_or_url() -> None:
     with pytest.raises(
         ToolError,
         match="Either file_content_base64 or file_url must be provided.",
     ):
-        await data.upload_dataset_to_ai_catalog()
+        await data.catalog_upload_dataset()
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_error_both_base64_and_url() -> None:
+async def test_catalog_upload_dataset_error_both_base64_and_url() -> None:
     with pytest.raises(
         ToolError,
         match="Please provide either file_content_base64 or file_url, not both.",
     ):
-        await data.upload_dataset_to_ai_catalog(
+        await data.catalog_upload_dataset(
             file_content_base64=base64.b64encode(b"x").decode("ascii"),
             file_url="https://example.com/somefile.csv",
         )
@@ -150,24 +148,24 @@ async def test_upload_dataset_to_ai_catalog_error_both_base64_and_url() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_invalid_base64() -> None:
+async def test_catalog_upload_dataset_invalid_base64() -> None:
     with pytest.raises(ToolError, match="Invalid base64"):
-        await data.upload_dataset_to_ai_catalog(file_content_base64="not-valid-base64!!!")
+        await data.catalog_upload_dataset(file_content_base64="not-valid-base64!!!")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_base64_whitespace_only() -> None:
+async def test_catalog_upload_dataset_base64_whitespace_only() -> None:
     with pytest.raises(ToolError, match="file_content_base64"):
-        await data.upload_dataset_to_ai_catalog(file_content_base64="   ")
+        await data.catalog_upload_dataset(file_content_base64="   ")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_upload_dataset_to_ai_catalog_error() -> None:
+async def test_catalog_upload_dataset_error() -> None:
     with patch.object(dr.Dataset, "create_from_file", side_effect=Exception("fail")):
         with pytest.raises(Exception) as exc_info:
-            await data.upload_dataset_to_ai_catalog(
+            await data.catalog_upload_dataset(
                 file_content_base64=base64.b64encode(b"x").decode("ascii")
             )
         assert "fail" in str(exc_info.value)
@@ -175,7 +173,7 @@ async def test_upload_dataset_to_ai_catalog_error() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_success() -> None:
+async def test_catalog_list_datasets_success() -> None:
     mock_ds1 = MagicMock()
     mock_ds1.id = "1"
     mock_ds1.name = "ds1"
@@ -183,7 +181,7 @@ async def test_list_ai_catalog_items_success() -> None:
     mock_ds2.id = "2"
     mock_ds2.name = "ds2"
     with patch.object(dr.Dataset, "iterate", return_value=iter([mock_ds1, mock_ds2])) as mock_iter:
-        result = await data.list_ai_catalog_items()
+        result = await data.catalog_list_datasets()
         assert result["count"] == 2
         # datasets is now a dict mapping id to name
         assert result["datasets"]["1"] == "ds1"
@@ -195,7 +193,7 @@ async def test_list_ai_catalog_items_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_pagination_respects_limit() -> None:
+async def test_catalog_list_datasets_pagination_respects_limit() -> None:
     """``limit`` caps items per call even if the iterator would yield more (SDK pages)."""
     row_mocks = []
     for i in range(5):
@@ -205,7 +203,7 @@ async def test_list_ai_catalog_items_pagination_respects_limit() -> None:
         row_mocks.append(m)
     # Simulate a generator that would keep going (e.g. multiple server pages)
     with patch.object(dr.Dataset, "iterate", return_value=iter(row_mocks[1:])) as mock_iter:
-        result = await data.list_ai_catalog_items(offset=1, limit=3)
+        result = await data.catalog_list_datasets(offset=1, limit=3)
 
         assert result["count"] == 3
         assert set(result["datasets"].keys()) == {"1", "2", "3"}
@@ -216,17 +214,17 @@ async def test_list_ai_catalog_items_pagination_respects_limit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_ai_catalog_items_rejects_negative_offset() -> None:
+async def test_catalog_list_datasets_rejects_negative_offset() -> None:
     with pytest.raises(ToolError, match="offset must be non-negative"):
-        await data.list_ai_catalog_items(offset=-1)
+        await data.catalog_list_datasets(offset=-1)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_clamps_invalid_limit_below_one() -> None:
+async def test_catalog_list_datasets_clamps_invalid_limit_below_one() -> None:
     """limit<1 is clamped to 100; response includes a note; iterate uses limit 100."""
     with patch.object(dr.Dataset, "iterate", return_value=iter([])) as mock_iter:
-        result = await data.list_ai_catalog_items(limit=0)
+        result = await data.catalog_list_datasets(limit=0)
         assert result["limit"] == 100
         assert "Limit must be at least 1" in (result.get("note") or "")
         mock_iter.assert_called_once_with(offset=0, limit=100)
@@ -234,9 +232,9 @@ async def test_list_ai_catalog_items_clamps_invalid_limit_below_one() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_clamps_limit_above_max() -> None:
+async def test_catalog_list_datasets_clamps_limit_above_max() -> None:
     with patch.object(dr.Dataset, "iterate", return_value=iter([])) as mock_iter:
-        result = await data.list_ai_catalog_items(limit=1001)
+        result = await data.catalog_list_datasets(limit=1001)
         assert result["limit"] == 100
         assert "Limit cannot exceed 100" in (result.get("note") or "")
         mock_iter.assert_called_once_with(offset=0, limit=100)
@@ -244,7 +242,7 @@ async def test_list_ai_catalog_items_clamps_limit_above_max() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_uses_default_limit() -> None:
+async def test_catalog_list_datasets_uses_default_limit() -> None:
     """Default limit 100 is passed to iterate and echoed in the result when not overridden."""
     mocks = []
     for i in range(3, 6):
@@ -253,7 +251,7 @@ async def test_list_ai_catalog_items_uses_default_limit() -> None:
         m.name = f"ds{i}"
         mocks.append(m)
     with patch.object(dr.Dataset, "iterate", return_value=iter(mocks)) as mock_iter:
-        result = await data.list_ai_catalog_items(offset=2)
+        result = await data.catalog_list_datasets(offset=2)
         assert result["count"] == 3
         assert set(result["datasets"].keys()) == {"3", "4", "5"}
         assert result["offset"] == 2
@@ -264,9 +262,9 @@ async def test_list_ai_catalog_items_uses_default_limit() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_empty() -> None:
+async def test_catalog_list_datasets_empty() -> None:
     with patch.object(dr.Dataset, "iterate", return_value=iter([])):
-        result = await data.list_ai_catalog_items()
+        result = await data.catalog_list_datasets()
         assert result["datasets"] == {}
         assert result["count"] == 0
         assert "offset" not in result
@@ -275,9 +273,9 @@ async def test_list_ai_catalog_items_empty() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_empty_paged_includes_count_and_pagination_echo() -> None:
+async def test_catalog_list_datasets_empty_paged_includes_count_and_pagination_echo() -> None:
     with patch.object(dr.Dataset, "iterate", return_value=iter([])):
-        result = await data.list_ai_catalog_items(offset=10, limit=5)
+        result = await data.catalog_list_datasets(offset=10, limit=5)
         assert result["datasets"] == {}
         assert result["count"] == 0
         assert result["offset"] == 10
@@ -292,14 +290,14 @@ async def test_list_ai_catalog_may_have_more_false_when_page_not_full() -> None:
     m1.id, m1.name = "a", "A"
     m2.id, m2.name = "b", "B"
     with patch.object(dr.Dataset, "iterate", return_value=iter([m1, m2])):
-        result = await data.list_ai_catalog_items(offset=0, limit=5)
+        result = await data.catalog_list_datasets(offset=0, limit=5)
         assert result["count"] == 2
         assert result["may_have_more"] is False
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_dataset_details_success() -> None:
+async def test_catalog_get_preview_success() -> None:
     mock_dataset = MagicMock()
     mock_dataset.id = "ds1"
     mock_dataset.name = "Test Dataset"
@@ -309,7 +307,7 @@ async def test_get_dataset_details_success() -> None:
     mock_df = pl.DataFrame({"a": [1, 2], "b": [3, 4]}).to_pandas()
     mock_dataset.get_raw_sample_data.return_value = mock_df
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await data.get_dataset_details(dataset_id="ds1")
+        result = await data.catalog_get_preview(dataset_id="ds1")
         assert isinstance(result, dict)
         assert result["id"] == "ds1"
         assert result["name"] == "Test Dataset"
@@ -320,7 +318,7 @@ async def test_get_dataset_details_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_dataset_details_respects_sample_rows() -> None:
+async def test_catalog_get_preview_respects_sample_rows() -> None:
     """sample_rows caps how many leading rows are returned (head)."""
     mock_dataset = MagicMock()
     mock_dataset.id = "ds1"
@@ -330,7 +328,7 @@ async def test_get_dataset_details_respects_sample_rows() -> None:
     mock_df = pl.DataFrame({"a": list(range(5)), "b": list(range(5, 10))}).to_pandas()
     mock_dataset.get_raw_sample_data.return_value = mock_df
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await data.get_dataset_details(dataset_id="ds1", sample_rows=2)
+        result = await data.catalog_get_preview(dataset_id="ds1", sample_rows=2)
         assert result["sample"] == [
             {"a": 0, "b": 5},
             {"a": 1, "b": 6},
@@ -339,7 +337,7 @@ async def test_get_dataset_details_respects_sample_rows() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_dataset_details_sample_rows_zero_returns_no_rows() -> None:
+async def test_catalog_get_preview_sample_rows_zero_returns_no_rows() -> None:
     mock_dataset = MagicMock()
     mock_dataset.id = "ds1"
     mock_dataset.name = "S"
@@ -347,13 +345,13 @@ async def test_get_dataset_details_sample_rows_zero_returns_no_rows() -> None:
     mock_df = pl.DataFrame({"a": [0]}).to_pandas()
     mock_dataset.get_raw_sample_data.return_value = mock_df
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await data.get_dataset_details(dataset_id="ds1", sample_rows=0)
+        result = await data.catalog_get_preview(dataset_id="ds1", sample_rows=0)
         assert result["sample"] == []
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_dataset_details_large_sample_rows_returns_full_frame() -> None:
+async def test_catalog_get_preview_large_sample_rows_returns_full_frame() -> None:
     """head(sample_rows) is bounded by the preview frame; unrelated to catalog pagination max."""
     mock_dataset = MagicMock()
     mock_dataset.id = "ds1"
@@ -362,32 +360,32 @@ async def test_get_dataset_details_large_sample_rows_returns_full_frame() -> Non
     mock_df = pl.DataFrame({"a": list(range(10))}).to_pandas()
     mock_dataset.get_raw_sample_data.return_value = mock_df
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await data.get_dataset_details(dataset_id="ds1", sample_rows=5000)
+        result = await data.catalog_get_preview(dataset_id="ds1", sample_rows=5000)
         assert len(result["sample"]) == 10
 
 
 @pytest.mark.asyncio
-async def test_get_dataset_details_missing_id() -> None:
+async def test_catalog_get_preview_missing_id() -> None:
     with pytest.raises(ToolError, match="Dataset ID must be provided"):
-        await data.get_dataset_details()
+        await data.catalog_get_preview()
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_dataset_details_no_sample() -> None:
+async def test_catalog_get_preview_no_sample() -> None:
     mock_dataset = MagicMock()
     mock_dataset.id = "ds1"
     mock_dataset.name = "Test"
     mock_dataset.created_at = "2025-01-01"
     mock_dataset.row_count = 50
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await data.get_dataset_details(dataset_id="ds1", include_sample=False)
+        result = await data.catalog_get_preview(dataset_id="ds1", include_sample=False)
         assert "sample" not in result
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_datastores_success() -> None:
+async def test_catalog_list_datastores_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": [
@@ -403,7 +401,7 @@ async def test_list_datastores_success() -> None:
     mock_rest = MagicMock()
     mock_rest.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        result = await data.list_datastores(offset=0, limit=10)
+        result = await data.catalog_list_datastores(offset=0, limit=10)
         assert isinstance(result, dict)
         assert result["count"] == 1
         assert result["datastores"][0]["id"] == "store1"
@@ -417,7 +415,7 @@ async def test_list_datastores_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_datastores_serializes_params_from_response() -> None:
+async def test_catalog_list_datastores_serializes_params_from_response() -> None:
     """API `params` may be plain dicts; _serialize_datastore_params keeps output JSON-friendly."""
     params = DataStoreParameters(
         driver_id="pg",
@@ -443,7 +441,7 @@ async def test_list_datastores_serializes_params_from_response() -> None:
     mock_rest = MagicMock()
     mock_rest.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        result = await data.list_datastores()
+        result = await data.catalog_list_datastores()
         assert data._serialize_datastore_params(params) == expected
         assert result["datastores"][0]["params"] == expected
         assert "offset" not in result
@@ -453,7 +451,7 @@ async def test_list_datastores_serializes_params_from_response() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_datastores_pagination_total_count_from_api() -> None:
+async def test_catalog_list_datastores_pagination_total_count_from_api() -> None:
     """API may return total_count; merge exposes it as total_count on the tool result."""
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -471,7 +469,7 @@ async def test_list_datastores_pagination_total_count_from_api() -> None:
     mock_rest = MagicMock()
     mock_rest.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        result = await data.list_datastores(offset=5, limit=1)
+        result = await data.catalog_list_datastores(offset=5, limit=1)
         assert result["count"] == 1
         assert result["offset"] == 5
         assert result["limit"] == 1
@@ -484,13 +482,13 @@ async def test_list_datastores_pagination_total_count_from_api() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_datastores_clamps_limit_above_max() -> None:
+async def test_catalog_list_datastores_clamps_limit_above_max() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": []}
     mock_rest = MagicMock()
     mock_rest.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        result = await data.list_datastores(limit=1001)
+        result = await data.catalog_list_datastores(limit=1001)
         assert result["limit"] == 100
         assert "Limit cannot exceed 100" in (result.get("note") or "")
         mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 100})
@@ -498,13 +496,13 @@ async def test_list_datastores_clamps_limit_above_max() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_browse_datastore_success() -> None:
+async def test_catalog_browse_datastore_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": ["table1", "table2"]}
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await data.browse_datastore(datastore_id="store1", path="/schema1")
+        result = await data.catalog_browse_datastore(datastore_id="store1", path="/schema1")
         assert isinstance(result, dict)
         assert result["count"] == 2
         assert result["datastore_id"] == "store1"
@@ -514,7 +512,7 @@ async def test_browse_datastore_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_browse_datastore_pagination_from_api_response() -> None:
+async def test_catalog_browse_datastore_pagination_from_api_response() -> None:
     """Browse passes offset/limit to the API and forwards next/total from the response body."""
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -525,7 +523,7 @@ async def test_browse_datastore_pagination_from_api_response() -> None:
     mock_rest = MagicMock()
     mock_rest.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        result = await data.browse_datastore(
+        result = await data.catalog_browse_datastore(
             datastore_id="store1",
             path="/s",
             offset=10,
@@ -543,20 +541,20 @@ async def test_browse_datastore_pagination_from_api_response() -> None:
 
 
 @pytest.mark.asyncio
-async def test_browse_datastore_missing_id() -> None:
+async def test_catalog_browse_datastore_missing_id() -> None:
     with pytest.raises(ToolError, match="Datastore ID must be provided"):
-        await data.browse_datastore()
+        await data.catalog_browse_datastore()
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_browse_datastore_clamps_limit_above_max() -> None:
+async def test_catalog_browse_datastore_clamps_limit_above_max() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": []}
     mock_rest = MagicMock()
     mock_rest.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        result = await data.browse_datastore(datastore_id="s1", limit=2000)
+        result = await data.catalog_browse_datastore(datastore_id="s1", limit=2000)
         assert result["limit"] == 100
         assert "Limit cannot exceed 100" in (result.get("note") or "")
         mock_rest.get.assert_called_once_with(
@@ -566,7 +564,7 @@ async def test_browse_datastore_clamps_limit_above_max() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_query_datastore_success() -> None:
+async def test_catalog_query_datastore_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": [{"id": 1, "val": "a"}],
@@ -575,7 +573,7 @@ async def test_query_datastore_success() -> None:
     mock_rest_client = MagicMock()
     mock_rest_client.post.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await data.query_datastore(datastore_id="store1", sql="SELECT * FROM t")
+        result = await data.catalog_query_datastore(datastore_id="store1", sql="SELECT * FROM t")
         assert isinstance(result, dict)
         assert result["row_count"] == 1
         assert result["columns"] == ["id", "val"]
@@ -585,13 +583,13 @@ async def test_query_datastore_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_query_datastore_clamps_limit_above_max() -> None:
+async def test_catalog_query_datastore_clamps_limit_above_max() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": [], "columns": []}
     mock_rest = MagicMock()
     mock_rest.post.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        out = await data.query_datastore(datastore_id="ds1", sql="SELECT 1", limit=2000)
+        out = await data.catalog_query_datastore(datastore_id="ds1", sql="SELECT 1", limit=2000)
         assert out["limit"] == 100
         assert "Limit cannot exceed 100" in (out.get("note") or "")
         mock_rest.post.assert_called_once_with(
@@ -602,7 +600,7 @@ async def test_query_datastore_clamps_limit_above_max() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_query_datastore_pagination_offset_limit_and_response_metadata() -> None:
+async def test_catalog_query_datastore_pagination_offset_limit_and_response_metadata() -> None:
     """Query sends offset/limit in the JSON body and merges pagination fields from the response."""
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -614,7 +612,7 @@ async def test_query_datastore_pagination_offset_limit_and_response_metadata() -
     mock_rest = MagicMock()
     mock_rest.post.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest):
-        result = await data.query_datastore(
+        result = await data.catalog_query_datastore(
             datastore_id="ds99",
             sql="SELECT 1",
             offset=50,
@@ -632,29 +630,29 @@ async def test_query_datastore_pagination_offset_limit_and_response_metadata() -
 
 
 @pytest.mark.asyncio
-async def test_query_datastore_missing_id() -> None:
+async def test_catalog_query_datastore_missing_id() -> None:
     with pytest.raises(ToolError, match="Datastore ID must be provided"):
-        await data.query_datastore(sql="SELECT 1")
+        await data.catalog_query_datastore(sql="SELECT 1")
 
 
 @pytest.mark.asyncio
-async def test_query_datastore_missing_sql() -> None:
+async def test_catalog_query_datastore_missing_sql() -> None:
     with pytest.raises(ToolError, match="SQL query must be provided"):
-        await data.query_datastore(datastore_id="store1")
+        await data.catalog_query_datastore(datastore_id="store1")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_error() -> None:
+async def test_catalog_list_datasets_error() -> None:
     with patch.object(dr.Dataset, "iterate", side_effect=Exception("fail")):
         with pytest.raises(Exception) as exc_info:
-            await data.list_ai_catalog_items()
+            await data.catalog_list_datasets()
         assert "fail" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_ai_catalog_items_client_error_during_lazy_iteration() -> None:
+async def test_catalog_list_datasets_client_error_during_lazy_iteration() -> None:
 
     def _gen_raises_on_consume():
         raise ClientError(
@@ -666,6 +664,6 @@ async def test_list_ai_catalog_items_client_error_during_lazy_iteration() -> Non
 
     with patch.object(dr.Dataset, "iterate", return_value=_gen_raises_on_consume()):
         with pytest.raises(ToolError) as exc_info:
-            await data.list_ai_catalog_items()
+            await data.catalog_list_datasets()
         assert exc_info.value.kind is ToolErrorKind.UPSTREAM
         assert "500" in str(exc_info.value)

--- a/tests/drmcp/unit/predictive_tools/test_deployment.py
+++ b/tests/drmcp/unit/predictive_tools/test_deployment.py
@@ -37,42 +37,42 @@ def test_load_dotenv() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_list_deployments_success() -> None:
+async def test_deployment_get_list_success() -> None:
     mock_dep1 = MagicMock(id="1", label="dep1")
     mock_dep2 = MagicMock(id="2", label="dep2")
     with patch.object(dr.Deployment, "list", return_value=[mock_dep1, mock_dep2]):
-        result = await deployment.list_deployments()
+        result = await deployment.deployment_get_list()
         assert result["deployments"]["1"] == "dep1"
         assert result["deployments"]["2"] == "dep2"
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_list_deployments_empty() -> None:
+async def test_deployment_get_list_empty() -> None:
     with patch.object(dr.Deployment, "list", return_value=[]):
-        result = await deployment.list_deployments()
+        result = await deployment.deployment_get_list()
         assert result["deployments"] == []
 
 
 @pytest.mark.asyncio
-async def test_list_deployments_error() -> None:
+async def test_deployment_get_list_error() -> None:
     with patch.object(
         ThreadSafeDataRobotClient,
         "request_user_client",
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:
-            await deployment.list_deployments()
+            await deployment.deployment_get_list()
         assert "fail" == str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_model_info_from_deployment_success() -> None:
+async def test_deployment_get_model_info_success() -> None:
     mock_deployment = MagicMock()
     mock_deployment.model = {"project_id": "pid", "model_id": "mid"}
     with patch.object(dr.Deployment, "get", return_value=mock_deployment) as mock_dep_get:
-        result = await deployment.get_model_info_from_deployment(deployment_id="dep_id")
+        result = await deployment.deployment_get_model_info(deployment_id="dep_id")
         mock_dep_get.assert_called_once_with("dep_id")
         assert result["project_id"] == "pid"
         assert result["model_id"] == "mid"
@@ -80,7 +80,7 @@ async def test_get_model_info_from_deployment_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_model_info_from_deployment_not_found() -> None:
+async def test_deployment_get_model_info_not_found() -> None:
     with patch.object(
         dr.Deployment,
         "get",
@@ -91,33 +91,33 @@ async def test_get_model_info_from_deployment_not_found() -> None:
         ),
     ):
         with pytest.raises(ToolError) as exc_info:
-            await deployment.get_model_info_from_deployment(deployment_id="dep_id")
+            await deployment.deployment_get_model_info(deployment_id="dep_id")
         assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
         assert "404" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_get_model_info_from_deployment_error() -> None:
+async def test_deployment_get_model_info_error() -> None:
     with patch.object(
         ThreadSafeDataRobotClient,
         "request_user_client",
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:
-            await deployment.get_model_info_from_deployment(deployment_id="dep_id")
+            await deployment.deployment_get_model_info(deployment_id="dep_id")
         assert "fail" == str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_deploy_model_success() -> None:
+async def test_deployment_create_deployment_success() -> None:
     mock_server = MagicMock(id="srv1")
     mock_dep = MagicMock(id="dep123")
     with (
         patch.object(dr.PredictionServer, "list", return_value=[mock_server]),
         patch.object(dr.Deployment, "create_from_learning_model", return_value=mock_dep),
     ):
-        result = await deployment.deploy_model(
+        result = await deployment.deployment_create_deployment(
             model_id="model123", label="Test Deployment", description="desc"
         )
         assert result["deployment_id"] == "dep123"
@@ -126,25 +126,29 @@ async def test_deploy_model_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_deploy_model_no_prediction_servers() -> None:
+async def test_deployment_create_deployment_no_prediction_servers() -> None:
     with patch.object(dr.PredictionServer, "list", return_value=[]):
         with pytest.raises(ToolError) as exc_info:
-            await deployment.deploy_model(model_id="model123", label="Test Deployment")
+            await deployment.deployment_create_deployment(
+                model_id="model123", label="Test Deployment"
+            )
         assert "No prediction servers available" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_deploy_model_error() -> None:
+async def test_deployment_create_deployment_error() -> None:
     with patch.object(dr.PredictionServer, "list", side_effect=Exception("fail servers")):
         with pytest.raises(Exception) as exc_info:
-            await deployment.deploy_model(model_id="model123", label="Test Deployment")
+            await deployment.deployment_create_deployment(
+                model_id="model123", label="Test Deployment"
+            )
         assert "fail servers" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_prediction_history_success() -> None:
+async def test_deployment_get_prediction_history_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": [
@@ -155,26 +159,26 @@ async def test_get_prediction_history_success() -> None:
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await deployment.get_prediction_history(deployment_id="dep1")
+        result = await deployment.deployment_get_prediction_history(deployment_id="dep1")
         assert result["deployment_id"] == "dep1"
         assert result["row_count"] == 2
 
 
 @pytest.mark.asyncio
-async def test_get_prediction_history_missing_id() -> None:
+async def test_deployment_get_prediction_history_missing_id() -> None:
     with pytest.raises(TypeError, match="deployment_id"):
-        await deployment.get_prediction_history()
+        await deployment.deployment_get_prediction_history()
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_prediction_history_with_time_range() -> None:
+async def test_deployment_get_prediction_history_with_time_range() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": []}
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await deployment.get_prediction_history(
+        result = await deployment.deployment_get_prediction_history(
             deployment_id="dep1",
             start_time="2025-01-01T00:00:00Z",
             end_time="2025-01-31T00:00:00Z",

--- a/tests/drmcp/unit/predictive_tools/test_deployment_info.py
+++ b/tests/drmcp/unit/predictive_tools/test_deployment_info.py
@@ -25,10 +25,10 @@ from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 
 from datarobot_genai.drtools.core.exceptions import ToolError
-from datarobot_genai.drtools.predictive.deployment_info import generate_prediction_data_template
-from datarobot_genai.drtools.predictive.deployment_info import get_deployment_features
-from datarobot_genai.drtools.predictive.deployment_info import get_deployment_info
-from datarobot_genai.drtools.predictive.deployment_info import validate_prediction_data
+from datarobot_genai.drtools.predictive.deployment_info import deployment_generate_prediction_sample
+from datarobot_genai.drtools.predictive.deployment_info import deployment_get_features
+from datarobot_genai.drtools.predictive.deployment_info import deployment_get_info
+from datarobot_genai.drtools.predictive.deployment_info import deployment_validate_prediction_data
 
 IMPORTANCE_THRESHOLD_TEST = 0.8
 
@@ -47,7 +47,7 @@ def _extract_content(result_obj: dict | ToolResult | ToolError) -> str:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_deployment_info_success() -> None:
+async def test_deployment_get_info_success() -> None:
     """Test successful retrieval of deployment features."""
     # Setup mocks
     mock_deployment = MagicMock()
@@ -90,11 +90,11 @@ async def test_get_deployment_info_success() -> None:
         patch.object(dr.Model, "get", return_value=mock_model),
         patch.object(dr.Project, "get", return_value=mock_project),
     ):
-        result = await get_deployment_info(deployment_id="dep123")
+        result = await deployment_get_info(deployment_id="dep123")
 
     # Handle potential error response
     if isinstance(result, ToolError):
-        pytest.fail(f"get_deployment_info returned error: {result}")
+        pytest.fail(f"deployment_get_info returned error: {result}")
 
     # Result should be a dictionary now
     result_json = result
@@ -116,11 +116,11 @@ async def test_get_deployment_info_success() -> None:
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template(
+async def test_deployment_generate_prediction_sample(
     mock_get_features: Any,
 ) -> None:
     """Test generating prediction data template."""
@@ -167,7 +167,7 @@ async def test_generate_prediction_data_template(
     mock_get_features.return_value = features_info
 
     # Test
-    result_obj = await generate_prediction_data_template(deployment_id="dep123", n_rows=3)
+    result_obj = await deployment_generate_prediction_sample(deployment_id="dep123", n_rows=3)
     result = _extract_content(result_obj)
     result_json = json.loads(result)
 
@@ -186,11 +186,11 @@ async def test_generate_prediction_data_template(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_valid(
+async def test_deployment_validate_prediction_data_valid(
     mock_get_features: Any,
     tmp_path: Any,
 ) -> None:
@@ -239,7 +239,7 @@ async def test_validate_prediction_data_valid(
     mock_get_features.return_value = features_info
 
     # Test
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="dep123", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -254,11 +254,11 @@ async def test_validate_prediction_data_valid(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_missing_important_feature(
+async def test_deployment_validate_prediction_data_missing_important_feature(
     mock_get_features: Any,
     tmp_path: Any,
 ) -> None:
@@ -276,7 +276,7 @@ async def test_validate_prediction_data_missing_important_feature(
     # Only notimp present
     pl.DataFrame({"notimp": ["", ""]}).write_csv(tmp_path / "test3.csv")
     test_file = tmp_path / "test3.csv"
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -285,7 +285,7 @@ async def test_validate_prediction_data_missing_important_feature(
     # If present but all missing, info not warning
     pl.DataFrame({"imp": [None, None], "notimp": ["", ""]}).write_csv(tmp_path / "test4.csv")
     test_file2 = tmp_path / "test4.csv"
-    result_obj2 = await validate_prediction_data(
+    result_obj2 = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file2.read_text()
     )
     result2 = _extract_content(result_obj2)
@@ -293,7 +293,7 @@ async def test_validate_prediction_data_missing_important_feature(
     # If present and not all missing, type check applies
     pl.DataFrame({"imp": ["bad", "bad"], "notimp": ["", ""]}).write_csv(tmp_path / "test5.csv")
     test_file3 = tmp_path / "test5.csv"
-    result_obj3 = await validate_prediction_data(
+    result_obj3 = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file3.read_text()
     )
     result3 = _extract_content(result_obj3)
@@ -302,23 +302,23 @@ async def test_validate_prediction_data_missing_important_feature(
 
 # Additional tests for coverage
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_error(mock_get_features: Any) -> None:
+async def test_deployment_generate_prediction_sample_error(mock_get_features: Any) -> None:
     mock_get_features.return_value = {"error": "something went wrong"}
     with pytest.raises(ToolError) as exc_info:
-        await generate_prediction_data_template(deployment_id="bad_id")
+        await deployment_generate_prediction_sample(deployment_id="bad_id")
     assert "Invalid feature information received" in str(exc_info.value)
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_empty_features(
+async def test_deployment_generate_prediction_sample_empty_features(
     mock_get_features: Any,
 ) -> None:
     mock_get_features.return_value = {
@@ -328,17 +328,17 @@ async def test_generate_prediction_data_template_empty_features(
         "target_type": "",
         "total_features": 0,
     }
-    result = await generate_prediction_data_template(deployment_id="empty_id")
+    result = await deployment_generate_prediction_sample(deployment_id="empty_id")
     assert result["total_features"] == 0
     assert result["template_data"] == []
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_unknown_type(
+async def test_deployment_generate_prediction_sample_unknown_type(
     mock_get_features: Any,
 ) -> None:
     features_info = {
@@ -349,17 +349,17 @@ async def test_generate_prediction_data_template_unknown_type(
         "total_features": 1,
     }
     mock_get_features.return_value = features_info
-    result_obj = await generate_prediction_data_template(deployment_id="id", n_rows=2)
+    result_obj = await deployment_generate_prediction_sample(deployment_id="id", n_rows=2)
     result = _extract_content(result_obj)
     assert '""' in result
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_none_min_max(
+async def test_deployment_generate_prediction_sample_none_min_max(
     mock_get_features: Any,
 ) -> None:
     features_info = {
@@ -373,17 +373,17 @@ async def test_generate_prediction_data_template_none_min_max(
         "total_features": 2,
     }
     mock_get_features.return_value = features_info
-    result_obj = await generate_prediction_data_template(deployment_id="id")
+    result_obj = await deployment_generate_prediction_sample(deployment_id="id")
     result = _extract_content(result_obj)
     assert "num" in result and "dt" in result
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_key_summary(
+async def test_deployment_generate_prediction_sample_key_summary(
     mock_get_features: Any,
 ) -> None:
     features_info = {
@@ -400,17 +400,17 @@ async def test_generate_prediction_data_template_key_summary(
         "total_features": 1,
     }
     mock_get_features.return_value = features_info
-    result_obj = await generate_prediction_data_template(deployment_id="id")
+    result_obj = await deployment_generate_prediction_sample(deployment_id="id")
     result = _extract_content(result_obj)
     assert "cat" in result
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_multiseries(
+async def test_deployment_generate_prediction_sample_multiseries(
     mock_get_features: Any,
 ) -> None:
     features_info = {
@@ -427,29 +427,29 @@ async def test_generate_prediction_data_template_multiseries(
         },
     }
     mock_get_features.return_value = features_info
-    result_obj = await generate_prediction_data_template(deployment_id="id")
+    result_obj = await deployment_generate_prediction_sample(deployment_id="id")
     result = _extract_content(result_obj)
     assert "dt_col" in result and "series_id" in result
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_error(mock_get_features: Any) -> None:
+async def test_deployment_validate_prediction_data_error(mock_get_features: Any) -> None:
     mock_get_features.return_value = {"error": "bad deployment"}
     with pytest.raises((ToolError, KeyError)) as exc_info:
-        await validate_prediction_data(deployment_id="bad_id", csv_string="a,b\n1,2\n")
+        await deployment_validate_prediction_data(deployment_id="bad_id", csv_string="a,b\n1,2\n")
     assert "features" in str(exc_info.value)
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_missing_feature(
+async def test_deployment_validate_prediction_data_missing_feature(
     mock_get_features: Any, tmp_path: Any
 ) -> None:
     features_info = {
@@ -466,7 +466,7 @@ async def test_validate_prediction_data_missing_feature(
     mock_get_features.return_value = features_info
     test_file = tmp_path / "test.csv"
     pl.DataFrame({"bar": [1, 2]}).write_csv(test_file)
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -474,11 +474,11 @@ async def test_validate_prediction_data_missing_feature(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_extra_columns(
+async def test_deployment_validate_prediction_data_extra_columns(
     mock_get_features: Any, tmp_path: Any
 ) -> None:
     features_info = {
@@ -495,7 +495,7 @@ async def test_validate_prediction_data_extra_columns(
     mock_get_features.return_value = features_info
     test_file = tmp_path / "test.csv"
     pl.DataFrame({"foo": [1, 2], "extra": [3, 4]}).write_csv(test_file)
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -503,11 +503,11 @@ async def test_validate_prediction_data_extra_columns(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_type_mismatch(
+async def test_deployment_validate_prediction_data_type_mismatch(
     mock_get_features: Any, tmp_path: Any
 ) -> None:
     features_info = {
@@ -524,7 +524,7 @@ async def test_validate_prediction_data_type_mismatch(
     mock_get_features.return_value = features_info
     test_file = tmp_path / "test.csv"
     pl.DataFrame({"foo": ["a", "b"]}).write_csv(test_file)
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -532,11 +532,11 @@ async def test_validate_prediction_data_type_mismatch(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_time_series_missing(
+async def test_deployment_validate_prediction_data_time_series_missing(
     mock_get_features: Any, tmp_path: Any
 ) -> None:
     features_info = {
@@ -559,7 +559,7 @@ async def test_validate_prediction_data_time_series_missing(
     mock_get_features.return_value = features_info
     test_file = tmp_path / "test.csv"
     pl.DataFrame({"foo": [1, 2]}).write_csv(test_file)
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -567,11 +567,11 @@ async def test_validate_prediction_data_time_series_missing(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_time_series_parse_error(
+async def test_deployment_validate_prediction_data_time_series_parse_error(
     mock_get_features: Any, tmp_path: Any
 ) -> None:
     features_info = {
@@ -600,7 +600,7 @@ async def test_validate_prediction_data_time_series_parse_error(
     mock_get_features.return_value = features_info
     test_file = tmp_path / "test.csv"
     pl.DataFrame({"foo": [1, 2], "dt_col": ["bad", "bad"]}).write_csv(test_file)
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -608,19 +608,19 @@ async def test_validate_prediction_data_time_series_parse_error(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_info", new_callable=AsyncMock
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_info", new_callable=AsyncMock
 )
 @pytest.mark.asyncio
-async def test_get_deployment_features_missing_fields(mock_get_info: Any) -> None:
+async def test_deployment_get_features_missing_fields(mock_get_info: Any) -> None:
     mock_get_info.return_value = {}
 
-    result = await get_deployment_features(deployment_id="id")
+    result = await deployment_get_features(deployment_id="id")
     assert "features" in result and "total_features" in result
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_deployment_info_custom_model() -> None:
+async def test_deployment_get_info_custom_model() -> None:
     class DummyDeployment:
         model: dict[str, Any] = {}
 
@@ -631,7 +631,7 @@ async def test_get_deployment_info_custom_model() -> None:
             pass
 
     with patch.object(dr.Deployment, "get", return_value=DummyDeployment()):
-        result = await get_deployment_info(deployment_id="custom_id")
+        result = await deployment_get_info(deployment_id="custom_id")
         assert result["model_type"] == "custom"
         assert result["target"] == ""
         assert result["target_type"] == ""
@@ -639,11 +639,11 @@ async def test_get_deployment_info_custom_model() -> None:
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_categorical_defaults(
+async def test_deployment_generate_prediction_sample_categorical_defaults(
     mock_get_features: Any,
 ) -> None:
     features_info = {
@@ -658,7 +658,7 @@ async def test_generate_prediction_data_template_categorical_defaults(
         "total_features": 3,
     }
     mock_get_features.return_value = features_info
-    result_obj = await generate_prediction_data_template(deployment_id="id", n_rows=2)
+    result_obj = await deployment_generate_prediction_sample(deployment_id="id", n_rows=2)
     result = _extract_content(result_obj)
     result_json = json.loads(result)
     # All categorical/text columns should be empty string
@@ -667,52 +667,52 @@ async def test_generate_prediction_data_template_categorical_defaults(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_exception(
+async def test_deployment_generate_prediction_sample_exception(
     mock_get_features: Any,
 ) -> None:
     mock_get_features.side_effect = Exception("fail")
     with pytest.raises(Exception) as exc_info:
-        await generate_prediction_data_template(deployment_id="id")
+        await deployment_generate_prediction_sample(deployment_id="id")
     assert "fail" == str(exc_info.value)
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_empty_csv_string(mock_get_features: Any) -> None:
+async def test_deployment_validate_prediction_data_empty_csv_string(mock_get_features: Any) -> None:
     mock_get_features.return_value = {"features": [], "model_type": "Test"}
     with pytest.raises(ToolError, match="csv_string"):
-        await validate_prediction_data(deployment_id="id", csv_string="")
+        await deployment_validate_prediction_data(deployment_id="id", csv_string="")
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_info", new_callable=AsyncMock
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_info", new_callable=AsyncMock
 )
 @pytest.mark.asyncio
-async def test_get_deployment_features_error_string(mock_get_info: Any) -> None:
-    """When get_deployment_info returns error dict,
-    get_deployment_features returns empty features.
+async def test_deployment_get_features_error_string(mock_get_info: Any) -> None:
+    """When deployment_get_info returns error dict,
+    deployment_get_features returns empty features.
     """
     mock_get_info.return_value = {"error": "not found"}
-    result = await get_deployment_features(deployment_id="id")
+    result = await deployment_get_features(deployment_id="id")
     assert result["features"] == []
     assert result["total_features"] == 0
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_info", new_callable=AsyncMock
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_info", new_callable=AsyncMock
 )
 @pytest.mark.asyncio
-async def test_get_deployment_features_optional_fields(mock_get_info: Any) -> None:
+async def test_deployment_get_features_optional_fields(mock_get_info: Any) -> None:
     base = {"features": [], "total_features": 0}
     mock_get_info.return_value = base
-    result = await get_deployment_features(deployment_id="id")
+    result = await deployment_get_features(deployment_id="id")
     assert "features" in result and "total_features" in result
     base.update(
         {
@@ -728,7 +728,7 @@ async def test_get_deployment_features_optional_fields(mock_get_info: Any) -> No
         }
     )
     mock_get_info.return_value = base
-    result = await get_deployment_features(deployment_id="id")
+    result = await deployment_get_features(deployment_id="id")
     assert result["model_type"] == "XGB"
     assert result["target"] == "y"
     assert result["target_type"] == "regression"
@@ -736,11 +736,11 @@ async def test_get_deployment_features_optional_fields(mock_get_info: Any) -> No
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_generate_prediction_data_template_frequent_values(
+async def test_deployment_generate_prediction_sample_frequent_values(
     mock_get_features: Any,
 ) -> None:
     features_info = {
@@ -759,17 +759,17 @@ async def test_generate_prediction_data_template_frequent_values(
         "total_features": 3,
     }
     mock_get_features.return_value = features_info
-    result = await generate_prediction_data_template(deployment_id="id", n_rows=2)
+    result = await deployment_generate_prediction_sample(deployment_id="id", n_rows=2)
     # cat should use 'A' (first frequent value), num and txt empty/null
     assert result["template_data"][0]["cat"] == "A"
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_missing_values(
+async def test_deployment_validate_prediction_data_missing_values(
     mock_get_features: Any,
     tmp_path: Any,
 ) -> None:
@@ -790,7 +790,7 @@ async def test_validate_prediction_data_missing_values(
         tmp_path / "test.csv"
     )
     test_file = tmp_path / "test.csv"
-    result_obj = await validate_prediction_data(
+    result_obj = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file.read_text()
     )
     result = _extract_content(result_obj)
@@ -798,7 +798,7 @@ async def test_validate_prediction_data_missing_values(
     # One column present, one missing
     pl.DataFrame({"cat": ["A", "B"]}).write_csv(tmp_path / "test2.csv")
     test_file2 = tmp_path / "test2.csv"
-    result_obj2 = await validate_prediction_data(
+    result_obj2 = await deployment_validate_prediction_data(
         deployment_id="id", csv_string=test_file2.read_text()
     )
     result2 = _extract_content(result_obj2)
@@ -809,11 +809,11 @@ async def test_validate_prediction_data_missing_values(
 
 
 @patch(
-    "datarobot_genai.drtools.predictive.deployment_info.get_deployment_features",
+    "datarobot_genai.drtools.predictive.deployment_info.deployment_get_features",
     new_callable=AsyncMock,
 )
 @pytest.mark.asyncio
-async def test_validate_prediction_data_with_csv_string(
+async def test_deployment_validate_prediction_data_with_csv_string(
     mock_get_features: Any,
 ) -> None:
     features_info = {
@@ -829,12 +829,12 @@ async def test_validate_prediction_data_with_csv_string(
     mock_get_features.return_value = features_info
     # CSV string with only 'cat' column
     csv_str = "cat\nA\nB\n"
-    result_obj = await validate_prediction_data(deployment_id="id", csv_string=csv_str)
+    result_obj = await deployment_validate_prediction_data(deployment_id="id", csv_string=csv_str)
     result = _extract_content(result_obj)
     assert "Missing feature column: num" in result
     assert "status" in result and "invalid" not in result
     # CSV string with both columns
     csv_str2 = "cat,num\nA,1\nB,2\n"
-    result_obj2 = await validate_prediction_data(deployment_id="id", csv_string=csv_str2)
+    result_obj2 = await deployment_validate_prediction_data(deployment_id="id", csv_string=csv_str2)
     result2 = _extract_content(result_obj2)
     assert "status" in result2 and "invalid" not in result2

--- a/tests/drmcp/unit/predictive_tools/test_model.py
+++ b/tests/drmcp/unit/predictive_tools/test_model.py
@@ -32,7 +32,7 @@ from datarobot_genai.drtools.predictive.model import model_to_dict
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_best_model_success() -> None:
+async def test_models_get_bestmodel_success() -> None:
     mock_project = MagicMock()
     mock_model1 = MagicMock(id="m1", model_type="XGBoost", metrics={"AUC": {"validation": 0.9}})
     mock_model2 = MagicMock(
@@ -40,7 +40,7 @@ async def test_get_best_model_success() -> None:
     )
     mock_project.get_models.return_value = [mock_model1, mock_model2]
     with patch.object(dr.Project, "get", return_value=mock_project):
-        result = await model.get_best_model(project_id="pid", metric="AUC")
+        result = await model.models_get_bestmodel(project_id="pid", metric="AUC")
     assert isinstance(result, dict)
     assert result["project_id"] == "pid"
     assert result["best_model"]["model_type"] == "XGBoost"
@@ -50,25 +50,25 @@ async def test_get_best_model_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_best_model_no_models() -> None:
+async def test_models_get_bestmodel_no_models() -> None:
     mock_project = MagicMock()
     mock_project.get_models.return_value = []
     with patch.object(dr.Project, "get", return_value=mock_project):
         with pytest.raises(ToolError, match="No models found for this project."):
-            await model.get_best_model(project_id="pid", metric="AUC")
+            await model.models_get_bestmodel(project_id="pid", metric="AUC")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_best_model_project_not_found() -> None:
+async def test_models_get_bestmodel_project_not_found() -> None:
     with patch.object(dr.Project, "get", return_value=None):
         with pytest.raises(ToolError, match="Project with ID pid not found."):
-            await model.get_best_model(project_id="pid", metric="AUC")
+            await model.models_get_bestmodel(project_id="pid", metric="AUC")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_best_model_project_client_error_404() -> None:
+async def test_models_get_bestmodel_project_client_error_404() -> None:
     with patch.object(
         dr.Project,
         "get",
@@ -79,26 +79,26 @@ async def test_get_best_model_project_client_error_404() -> None:
         ),
     ):
         with pytest.raises(ToolError) as exc_info:
-            await model.get_best_model(project_id="missing-proj", metric="AUC")
+            await model.models_get_bestmodel(project_id="missing-proj", metric="AUC")
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
     assert "404" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_get_best_model_error() -> None:
+async def test_models_get_bestmodel_error() -> None:
     with patch.object(
         ThreadSafeDataRobotClient,
         "request_user_client",
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:
-            await model.get_best_model(project_id="pid", metric="AUC")
+            await model.models_get_bestmodel(project_id="pid", metric="AUC")
         assert "fail" == str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_list_models_success() -> None:
+async def test_modeling_list_models_success() -> None:
     mock_project = MagicMock()
     mock_model1 = MagicMock(id="m1", model_type="XGBoost", metrics={"AUC": {"validation": 0.9}})
     mock_model2 = MagicMock(
@@ -106,7 +106,7 @@ async def test_list_models_success() -> None:
     )
     mock_project.get_model_records.return_value = [mock_model1, mock_model2]
     with patch.object(dr.Project, "get", return_value=mock_project):
-        result = await model.list_models(project_id="pid")
+        result = await model.modeling_list_models(project_id="pid")
     mock_project.get_model_records.assert_called_once_with(limit=100, offset=0)
     assert result["project_id"] == "pid"
     assert result["count"] == 2
@@ -118,11 +118,11 @@ async def test_list_models_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_list_models_pagination_offset_limit() -> None:
+async def test_modeling_list_models_pagination_offset_limit() -> None:
     mock_project = MagicMock()
     mock_project.get_model_records.return_value = []
     with patch.object(dr.Project, "get", return_value=mock_project):
-        result = await model.list_models(project_id="pid", offset=25, limit=10)
+        result = await model.modeling_list_models(project_id="pid", offset=25, limit=10)
     mock_project.get_model_records.assert_called_once_with(limit=10, offset=25)
     assert result["offset"] == 25
     assert result["limit"] == 10
@@ -131,18 +131,18 @@ async def test_list_models_pagination_offset_limit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_models_negative_offset() -> None:
+async def test_modeling_list_models_negative_offset() -> None:
     with pytest.raises(ToolError, match="offset must be non-negative"):
-        await model.list_models(project_id="pid", offset=-1)
+        await model.modeling_list_models(project_id="pid", offset=-1)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_list_models_clamp_limit_applies_note() -> None:
+async def test_modeling_list_models_clamp_limit_applies_note() -> None:
     mock_project = MagicMock()
     mock_project.get_model_records.return_value = [MagicMock(id="m1", model_type="T", metrics={})]
     with patch.object(dr.Project, "get", return_value=mock_project):
-        result = await model.list_models(project_id="pid", limit=500)
+        result = await model.modeling_list_models(project_id="pid", limit=500)
     mock_project.get_model_records.assert_called_once_with(limit=100, offset=0)
     assert result["limit"] == 100
     assert "note" in result
@@ -151,7 +151,7 @@ async def test_list_models_clamp_limit_applies_note() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_score_dataset_with_model_success() -> None:
+async def test_modeling_score_dataset_success() -> None:
     mock_project = MagicMock()
     mock_dr_model = MagicMock()
     mock_job = MagicMock(id="jobid")
@@ -169,7 +169,7 @@ async def test_score_dataset_with_model_success() -> None:
         patch.object(dr.Model, "get", return_value=mock_dr_model) as mock_model_get,
         patch.object(dr.Dataset, "get", return_value=mock_catalog_ds) as mock_dataset_get,
     ):
-        result = await model.score_dataset_with_model(
+        result = await model.modeling_score_dataset(
             project_id="pid", model_id="mid", dataset_id=ds_id
         )
     mock_project_get.assert_called_once_with("pid")
@@ -184,9 +184,9 @@ async def test_score_dataset_with_model_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_score_dataset_with_model_empty_dataset_id() -> None:
+async def test_modeling_score_dataset_empty_dataset_id() -> None:
     with pytest.raises(ToolError, match="Dataset ID must be provided"):
-        await model.score_dataset_with_model(
+        await model.modeling_score_dataset(
             project_id="pid",
             model_id="mid",
             dataset_id="   ",
@@ -195,7 +195,7 @@ async def test_score_dataset_with_model_empty_dataset_id() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_score_dataset_with_model_project_not_found() -> None:
+async def test_modeling_score_dataset_project_not_found() -> None:
     project_id = "pid"
     with patch.object(
         dr.Project,
@@ -207,7 +207,7 @@ async def test_score_dataset_with_model_project_not_found() -> None:
         ),
     ):
         with pytest.raises(ToolError) as exc_info:
-            await model.score_dataset_with_model(
+            await model.modeling_score_dataset(
                 project_id=project_id,
                 model_id="mid",
                 dataset_id="dsid",
@@ -218,7 +218,7 @@ async def test_score_dataset_with_model_project_not_found() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_score_dataset_with_model_model_not_found() -> None:
+async def test_modeling_score_dataset_model_not_found() -> None:
     mock_project = MagicMock()
     mock_project.get_models.return_value = []
     with (
@@ -234,7 +234,7 @@ async def test_score_dataset_with_model_model_not_found() -> None:
         ),
     ):
         with pytest.raises(ToolError) as exc_info:
-            await model.score_dataset_with_model(
+            await model.modeling_score_dataset(
                 project_id="pid",
                 model_id="mid",
                 dataset_id="dsid",
@@ -244,7 +244,7 @@ async def test_score_dataset_with_model_model_not_found() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_score_dataset_with_model_client_error_non_404_is_upstream() -> None:
+async def test_modeling_score_dataset_client_error_non_404_is_upstream() -> None:
     with patch.object(
         dr.Project,
         "get",
@@ -255,7 +255,7 @@ async def test_score_dataset_with_model_client_error_non_404_is_upstream() -> No
         ),
     ):
         with pytest.raises(ToolError) as exc_info:
-            await model.score_dataset_with_model(
+            await model.modeling_score_dataset(
                 project_id="pid",
                 model_id="mid",
                 dataset_id="dsid",
@@ -264,14 +264,14 @@ async def test_score_dataset_with_model_client_error_non_404_is_upstream() -> No
 
 
 @pytest.mark.asyncio
-async def test_score_dataset_with_model_error() -> None:
+async def test_modeling_score_dataset_error() -> None:
     with patch.object(
         ThreadSafeDataRobotClient,
         "request_user_client",
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:
-            await model.score_dataset_with_model(
+            await model.modeling_score_dataset(
                 project_id="pid",
                 model_id="mid",
                 dataset_id="dsid",
@@ -281,7 +281,7 @@ async def test_score_dataset_with_model_error() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_model_details_success() -> None:
+async def test_modeling_get_modeldetails_success() -> None:
     mock_project = MagicMock()
     mock_project.target = "target_col"
     mock_project.metric = "AUC"
@@ -297,7 +297,7 @@ async def test_get_model_details_success() -> None:
         patch.object(dr.Project, "get", return_value=mock_project),
         patch.object(dr.Model, "get", return_value=mock_model),
     ):
-        result = await model.get_model_details(project_id="pid", model_id="mid")
+        result = await model.modeling_get_modeldetails(project_id="pid", model_id="mid")
     assert isinstance(result, dict)
     assert result["model_id"] == "mid"
     assert result["model_type"] == "XGBoost"
@@ -305,22 +305,22 @@ async def test_get_model_details_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_model_details_missing_project_id() -> None:
+async def test_modeling_get_modeldetails_missing_project_id() -> None:
     """Required param project_id is enforced by signature (wrapped as ToolError)."""
     with pytest.raises(TypeError, match="project_id"):
-        await model.get_model_details(model_id="mid")
+        await model.modeling_get_modeldetails(model_id="mid")
 
 
 @pytest.mark.asyncio
-async def test_get_model_details_missing_model_id() -> None:
+async def test_modeling_get_modeldetails_missing_model_id() -> None:
     """Required param model_id is enforced by signature (wrapped as ToolError)."""
     with pytest.raises(TypeError, match="model_id"):
-        await model.get_model_details(project_id="pid")
+        await model.modeling_get_modeldetails(project_id="pid")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_model_details_feature_impact_error() -> None:
+async def test_modeling_get_modeldetails_feature_impact_error() -> None:
     mock_project = MagicMock()
     mock_project.target = "target_col"
     mock_project.metric = "AUC"
@@ -330,7 +330,7 @@ async def test_get_model_details_feature_impact_error() -> None:
         patch.object(dr.Project, "get", return_value=mock_project),
         patch.object(dr.Model, "get", return_value=mock_model),
     ):
-        result = await model.get_model_details(
+        result = await model.modeling_get_modeldetails(
             project_id="pid", model_id="mid", include_feature_impact=True
         )
     assert "feature_impact_error" in result
@@ -338,7 +338,7 @@ async def test_get_model_details_feature_impact_error() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_is_eligible_for_timeseries_training_success() -> None:
+async def test_catalog_check_timeseries_eligibility_success() -> None:
     mock_dataset = MagicMock()
     # Build with polars, convert to pandas at boundary (SDK returns pandas)
     dates = pl.date_range(
@@ -353,7 +353,7 @@ async def test_is_eligible_for_timeseries_training_success() -> None:
     ).to_pandas()
     mock_dataset.get_as_dataframe.return_value = pandas_df
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await model.is_eligible_for_timeseries_training(
+        result = await model.catalog_check_timeseries_eligibility(
             dataset_id="ds1", datetime_column="date", target_column="target"
         )
     assert result["status"] == "ELIGIBLE"
@@ -362,7 +362,7 @@ async def test_is_eligible_for_timeseries_training_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_is_eligible_for_timeseries_training_too_few_rows() -> None:
+async def test_catalog_check_timeseries_eligibility_too_few_rows() -> None:
     mock_dataset = MagicMock()
     # Build with polars, convert to pandas at boundary (SDK returns pandas)
     dates = pl.date_range(
@@ -376,7 +376,7 @@ async def test_is_eligible_for_timeseries_training_too_few_rows() -> None:
     ).to_pandas()
     mock_dataset.get_as_dataframe.return_value = pandas_df
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await model.is_eligible_for_timeseries_training(
+        result = await model.catalog_check_timeseries_eligibility(
             dataset_id="ds1", datetime_column="date", target_column="target"
         )
     assert result["status"] == "NOT_ELIGIBLE"
@@ -384,9 +384,9 @@ async def test_is_eligible_for_timeseries_training_too_few_rows() -> None:
 
 
 @pytest.mark.asyncio
-async def test_is_eligible_for_timeseries_training_missing_params() -> None:
+async def test_catalog_check_timeseries_eligibility_missing_params() -> None:
     with pytest.raises(TypeError, match="dataset_id"):
-        await model.is_eligible_for_timeseries_training(
+        await model.catalog_check_timeseries_eligibility(
             datetime_column="date", target_column="target"
         )
 
@@ -403,7 +403,7 @@ async def _run_eligibility(
     mock_dataset = _build_dataset_mock(pandas_df)
     with patch.object(ThreadSafeDataRobotClient, "request_user_client"):
         with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-            return await model.is_eligible_for_timeseries_training(
+            return await model.catalog_check_timeseries_eligibility(
                 dataset_id="ds1",
                 datetime_column=datetime_column,
                 target_column=target_column,

--- a/tests/drmcp/unit/predictive_tools/test_predict.py
+++ b/tests/drmcp/unit/predictive_tools/test_predict.py
@@ -44,7 +44,7 @@ def mock_batch_prediction_job() -> MagicMock:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_predict_by_ai_catalog(mock_batch_prediction_job: MagicMock) -> None:
+async def test_predict_batch_predictions_from_dataset(mock_batch_prediction_job: MagicMock) -> None:
     mock_job = _running_job()
     mock_batch_prediction_job.score.return_value = mock_job
     mock_dataset = MagicMock()
@@ -52,7 +52,9 @@ async def test_predict_by_ai_catalog(mock_batch_prediction_job: MagicMock) -> No
         patch.object(dr.Dataset, "get", return_value=mock_dataset),
         patch.object(dr.BatchPredictionJob, "score", mock_batch_prediction_job.score),
     ):
-        result = await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+        result = await predict.predict_batch_predictions_from_dataset(
+            deployment_id="dep", dataset_id="dsid"
+        )
         mock_batch_prediction_job.score.assert_called_once_with(
             deployment="dep",
             intake_settings={"type": "dataset", "dataset": mock_dataset},
@@ -64,13 +66,13 @@ async def test_predict_by_ai_catalog(mock_batch_prediction_job: MagicMock) -> No
         assert "Scoring dataset dsid" in result["input_desc"]
         assert result["batch_job_status"] == "RUNNING"
         assert result["url"] is None
-        assert "get_batch_prediction_job_status" in result["note"]
+        assert "predict_get_batch_job_status" in result["note"]
         mock_job.wait_for_completion.assert_not_called()
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_predict_by_ai_catalog_submit_returns_url_when_ready(
+async def test_predict_batch_predictions_from_dataset_submit_returns_url_when_ready(
     mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
@@ -86,14 +88,16 @@ async def test_predict_by_ai_catalog_submit_returns_url_when_ready(
         patch.object(dr.Dataset, "get", return_value=mock_dataset),
         patch.object(dr.BatchPredictionJob, "score", mock_batch_prediction_job.score),
     ):
-        result = await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+        result = await predict.predict_batch_predictions_from_dataset(
+            deployment_id="dep", dataset_id="dsid"
+        )
     assert result["url"] == DOWNLOAD_URL
     assert result["batch_job_status"] == "COMPLETED"
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_predict_by_ai_catalog_immediate_failure(
+async def test_predict_batch_predictions_from_dataset_immediate_failure(
     mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
@@ -110,12 +114,14 @@ async def test_predict_by_ai_catalog_immediate_failure(
         patch.object(dr.BatchPredictionJob, "score", mock_batch_prediction_job.score),
     ):
         with pytest.raises(ToolError, match="FAILED"):
-            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+            await predict.predict_batch_predictions_from_dataset(
+                deployment_id="dep", dataset_id="dsid"
+            )
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_predict_by_ai_catalog_non_local_file_output_raises(
+async def test_predict_batch_predictions_from_dataset_non_local_file_output_raises(
     mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
@@ -132,16 +138,20 @@ async def test_predict_by_ai_catalog_non_local_file_output_raises(
         patch.object(dr.BatchPredictionJob, "score", mock_batch_prediction_job.score),
     ):
         with pytest.raises(ToolError, match="not local file streaming"):
-            await predict.predict_by_ai_catalog(deployment_id="dep", dataset_id="dsid")
+            await predict.predict_batch_predictions_from_dataset(
+                deployment_id="dep", dataset_id="dsid"
+            )
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_predict_from_project_data(mock_batch_prediction_job: MagicMock) -> None:
+async def test_predict_batch_predictions_from_partition(
+    mock_batch_prediction_job: MagicMock,
+) -> None:
     mock_job = _running_job()
     mock_batch_prediction_job.score.return_value = mock_job
     with patch.object(dr.BatchPredictionJob, "score", mock_batch_prediction_job.score):
-        result = await predict.predict_from_project_data(
+        result = await predict.predict_batch_predictions_from_partition(
             deployment_id="dep",
             project_id="pid",
             dataset_id="dsid",
@@ -166,7 +176,7 @@ async def test_predict_from_project_data(mock_batch_prediction_job: MagicMock) -
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_batch_prediction_job_status(mock_batch_prediction_job: MagicMock) -> None:
+async def test_predict_get_batch_job_status(mock_batch_prediction_job: MagicMock) -> None:
     mock_job = MagicMock()
     mock_job.id = "jid"
     mock_job.get_status.return_value = {
@@ -179,7 +189,7 @@ async def test_get_batch_prediction_job_status(mock_batch_prediction_job: MagicM
     }
     mock_batch_prediction_job.get.return_value = mock_job
     with patch.object(dr.BatchPredictionJob, "get", mock_batch_prediction_job.get):
-        result = await predict.get_batch_prediction_job_status(job_id="jid")
+        result = await predict.predict_get_batch_job_status(job_id="jid")
     assert result["job_id"] == "jid"
     assert result["batch_job_status"] == "COMPLETED"
     assert result["url"] == "https://example.com/dl"
@@ -188,7 +198,7 @@ async def test_get_batch_prediction_job_status(mock_batch_prediction_job: MagicM
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_batch_prediction_job_status_non_local_file_raises(
+async def test_predict_get_batch_job_status_non_local_file_raises(
     mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
@@ -201,12 +211,12 @@ async def test_get_batch_prediction_job_status_non_local_file_raises(
     mock_batch_prediction_job.get.return_value = mock_job
     with patch.object(dr.BatchPredictionJob, "get", mock_batch_prediction_job.get):
         with pytest.raises(ToolError, match="not local file streaming"):
-            await predict.get_batch_prediction_job_status(job_id="jid")
+            await predict.predict_get_batch_job_status(job_id="jid")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_batch_prediction_job_status_terminal(
+async def test_predict_get_batch_job_status_terminal(
     mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
@@ -219,18 +229,18 @@ async def test_get_batch_prediction_job_status_terminal(
     mock_batch_prediction_job.get.return_value = mock_job
     with patch.object(dr.BatchPredictionJob, "get", mock_batch_prediction_job.get):
         with pytest.raises(ToolError, match="FAILED"):
-            await predict.get_batch_prediction_job_status(job_id="jid")
+            await predict.predict_get_batch_job_status(job_id="jid")
 
 
 @pytest.mark.asyncio
-async def test_get_batch_prediction_job_status_empty_job_id() -> None:
+async def test_predict_get_batch_job_status_empty_job_id() -> None:
     with pytest.raises(ToolError, match="job_id"):
-        await predict.get_batch_prediction_job_status(job_id="  ")
+        await predict.predict_get_batch_job_status(job_id="  ")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_batch_prediction_results_success(mock_batch_prediction_job: MagicMock) -> None:
+async def test_predict_get_batch_results_success(mock_batch_prediction_job: MagicMock) -> None:
     mock_job = MagicMock()
     mock_job.id = "abc123"
 
@@ -240,7 +250,7 @@ async def test_get_batch_prediction_results_success(mock_batch_prediction_job: M
     mock_job.download.side_effect = _download
     mock_batch_prediction_job.get.return_value = mock_job
     with patch.object(dr.BatchPredictionJob, "get", mock_batch_prediction_job.get):
-        result = await predict.get_batch_prediction_results(job_id="abc123")
+        result = await predict.predict_get_batch_results(job_id="abc123")
     assert result["job_id"] == "abc123"
     assert result["mime_type"] == "text/csv"
     assert result["data"] == "x,y\n1,2\n"
@@ -249,14 +259,14 @@ async def test_get_batch_prediction_results_success(mock_batch_prediction_job: M
 
 
 @pytest.mark.asyncio
-async def test_get_batch_prediction_results_empty_job_id() -> None:
+async def test_predict_get_batch_results_empty_job_id() -> None:
     with pytest.raises(ToolError, match="job_id"):
-        await predict.get_batch_prediction_results(job_id="   ")
+        await predict.predict_get_batch_results(job_id="   ")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_batch_prediction_results_too_large(mock_batch_prediction_job: MagicMock) -> None:
+async def test_predict_get_batch_results_too_large(mock_batch_prediction_job: MagicMock) -> None:
     mock_job = MagicMock()
     mock_job.id = "jid"
     mock_job.get_status.return_value = {"links": {"download": "https://example.com/batch/dl"}}
@@ -268,13 +278,13 @@ async def test_get_batch_prediction_results_too_large(mock_batch_prediction_job:
     mock_batch_prediction_job.get.return_value = mock_job
     with patch.object(dr.BatchPredictionJob, "get", mock_batch_prediction_job.get):
         with pytest.raises(ToolError, match="exceeding the inline limit") as exc:
-            await predict.get_batch_prediction_results(job_id="jid")
+            await predict.predict_get_batch_results(job_id="jid")
         assert "https://example.com/batch/dl" in str(exc.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_batch_prediction_results_download_runtime_error(
+async def test_predict_get_batch_results_download_runtime_error(
     mock_batch_prediction_job: MagicMock,
 ) -> None:
     mock_job = MagicMock()
@@ -284,5 +294,5 @@ async def test_get_batch_prediction_results_download_runtime_error(
     mock_batch_prediction_job.get.return_value = mock_job
     with patch.object(dr.BatchPredictionJob, "get", mock_batch_prediction_job.get):
         with pytest.raises(ToolError, match="queue full") as exc:
-            await predict.get_batch_prediction_results(job_id="jid")
+            await predict.predict_get_batch_results(job_id="jid")
         assert "https://example.com/batch/dl2" in str(exc.value)

--- a/tests/drmcp/unit/predictive_tools/test_predict_realtime.py
+++ b/tests/drmcp/unit/predictive_tools/test_predict_realtime.py
@@ -29,7 +29,7 @@ from datarobot_genai.drtools.core.clients.datarobot import ThreadSafeDataRobotCl
 from datarobot_genai.drtools.core.constants import MAX_INLINE_SIZE
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.predictive import predict_realtime
-from datarobot_genai.drtools.predictive.predict_realtime import predict_by_ai_catalog_rt
+from datarobot_genai.drtools.predictive.predict_realtime import predict_score_catalog_realtime
 
 THRESHOLD_HIGH = 0.8
 THRESHOLD_LOW = 0.2
@@ -60,7 +60,7 @@ async def test_predict_realtime_forecast_point(
     mock_result = MagicMock()
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="dep",
         dataset="file.csv",
         forecast_point="2024-06-01",
@@ -90,7 +90,7 @@ async def test_predict_realtime_forecast_range_oversize_raises(
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
     with pytest.raises(ToolError, match="exceeds the inline limit"):
-        await predict_realtime.predict_realtime(
+        await predict_realtime.predict_score_inline_realtime(
             deployment_id="dep",
             dataset="file.csv",
             forecast_range_start="2024-06-01",
@@ -144,7 +144,7 @@ async def test_predict_timeseries_regression_forecast_point_with_intervals(
     mock_result = MagicMock()
     mock_result.dataframe = regression_predictions
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="regression_dep_123",
         dataset="regression_data.csv",
         forecast_point="2024-06-01",
@@ -200,7 +200,7 @@ async def test_predict_timeseries_regression_historical_range(
     mock_result = MagicMock()
     mock_result.dataframe = regression_predictions
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="regression_dep_456",
         dataset="historical_regression_data.csv",
         forecast_range_start="2024-05-01",
@@ -259,7 +259,7 @@ async def test_predict_timeseries_regression_multiseries(
     mock_result = MagicMock()
     mock_result.dataframe = regression_predictions
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="multiseries_regression_dep",
         dataset="multiseries_data.csv",
         forecast_point="2024-06-01",
@@ -314,7 +314,7 @@ async def test_predict_timeseries_regression_large_dataset_raises(
     mock_result.dataframe = large_predictions
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
     with pytest.raises(ToolError, match="exceeds the inline limit"):
-        await predict_realtime.predict_realtime(
+        await predict_realtime.predict_score_inline_realtime(
             deployment_id="large_regression_dep",
             dataset="large_regression_data.csv",
             forecast_point="2024-06-01",
@@ -343,7 +343,7 @@ async def test_predict_timeseries_regression_series_id_validation_error(
 
     # Test with non-existent series_id_column
     with pytest.raises(ValueError) as exc_info:
-        await predict_realtime.predict_realtime(
+        await predict_realtime.predict_score_inline_realtime(
             deployment_id="regression_dep",
             dataset="data.csv",
             forecast_point="2024-06-01",
@@ -378,7 +378,7 @@ async def test_predict_timeseries_regression_no_prediction_intervals(
     mock_result = MagicMock()
     mock_result.dataframe = regression_predictions
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="regression_dep",
         dataset="data.csv",
         forecast_point="2024-06-01",
@@ -411,7 +411,7 @@ async def test_predict_realtime_with_all_explanation_parameters(
     mock_result = MagicMock()
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="text_dep",
         dataset="text_data.csv",
         max_explanations=10,
@@ -450,7 +450,7 @@ async def test_predict_realtime_with_passthrough_columns_all(
     mock_result = MagicMock()
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    await predict_realtime.predict_realtime(
+    await predict_realtime.predict_score_inline_realtime(
         deployment_id="dep",
         dataset="data.csv",
         passthrough_columns="all",
@@ -473,7 +473,7 @@ async def test_predict_realtime_with_passthrough_columns_specific(
     mock_result = MagicMock()
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    await predict_realtime.predict_realtime(
+    await predict_realtime.predict_score_inline_realtime(
         deployment_id="dep",
         dataset="data.csv",
         passthrough_columns="id,feature1",
@@ -497,7 +497,7 @@ async def test_predict_realtime_with_custom_endpoint(
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
     custom_endpoint = "https://custom-prediction-server.com/predict"
-    await predict_realtime.predict_realtime(
+    await predict_realtime.predict_score_inline_realtime(
         deployment_id="dep",
         dataset="data.csv",
         prediction_endpoint=custom_endpoint,
@@ -520,7 +520,7 @@ async def test_predict_realtime_regular_prediction_no_time_series_params(
     mock_result = MagicMock()
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    await predict_realtime.predict_realtime(
+    await predict_realtime.predict_score_inline_realtime(
         deployment_id="dep",
         dataset="data.csv",
         max_explanations=5,
@@ -549,7 +549,7 @@ async def test_predict_realtime_with_dataset_csv(
     mock_result = MagicMock()
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="dep",
         dataset=csv_str,
         timeout=5,
@@ -579,7 +579,7 @@ async def test_predict_realtime_with_dataset_json(
     mock_result = MagicMock()
     mock_result.dataframe = df
     patch_realtime_dependencies["mock_dr_predict"].return_value = mock_result
-    result = await predict_realtime.predict_realtime(
+    result = await predict_realtime.predict_score_inline_realtime(
         deployment_id="dep",
         dataset=json_str,
         timeout=5,
@@ -599,17 +599,17 @@ async def test_predict_realtime_with_dataset_json(
 
 
 class TestPredictByAiCatalogRt:
-    """Test cases for predict_by_ai_catalog_rt function."""
+    """Test cases for predict_score_catalog_realtime function."""
 
     @pytest.mark.asyncio
     @patch("datarobot_genai.drtools.predictive.predict_realtime.predictions_result_response")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.dr_predict")
-    async def test_predict_by_ai_catalog_rt_with_get_as_dataframe(
+    async def test_predict_score_catalog_realtime_with_get_as_dataframe(
         self,
         mock_dr_predict,
         mock_predictions_result_response,
     ):
-        """Test predict_by_ai_catalog_rt with get_as_dataframe method."""
+        """Test predict_score_catalog_realtime with get_as_dataframe method."""
         # Setup mocks
         mock_dataset = Mock()
         mock_dataset.get_as_dataframe.return_value = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
@@ -627,7 +627,7 @@ class TestPredictByAiCatalogRt:
             patch.object(dr.Deployment, "get", return_value=mock_deployment) as mock_dep_get,
         ):
             # Call function
-            result = await predict_by_ai_catalog_rt(
+            result = await predict_score_catalog_realtime(
                 deployment_id="deployment123", dataset_id="dataset123"
             )
 
@@ -651,13 +651,13 @@ class TestPredictByAiCatalogRt:
     @patch("datarobot_genai.drtools.predictive.predict_realtime.predictions_result_response")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.dr_predict")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.pl.read_csv")
-    async def test_predict_by_ai_catalog_rt_with_download(
+    async def test_predict_score_catalog_realtime_with_download(
         self,
         mock_read_csv,
         mock_dr_predict,
         mock_predictions_result_response,
     ):
-        """Test predict_by_ai_catalog_rt with download method."""
+        """Test predict_score_catalog_realtime with download method."""
         # Setup mocks
         mock_dataset = Mock()
         # Remove get_as_dataframe attribute entirely
@@ -680,7 +680,7 @@ class TestPredictByAiCatalogRt:
             patch.object(dr.Deployment, "get", return_value=mock_deployment) as mock_dep_get,
         ):
             # Call function
-            result = await predict_by_ai_catalog_rt(
+            result = await predict_score_catalog_realtime(
                 deployment_id="deployment123", dataset_id="dataset123"
             )
 
@@ -706,13 +706,13 @@ class TestPredictByAiCatalogRt:
     @patch("datarobot_genai.drtools.predictive.predict_realtime.predictions_result_response")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.dr_predict")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.pl.read_csv")
-    async def test_predict_by_ai_catalog_rt_with_get_file(
+    async def test_predict_score_catalog_realtime_with_get_file(
         self,
         mock_read_csv,
         mock_dr_predict,
         mock_predictions_result_response,
     ):
-        """Test predict_by_ai_catalog_rt with get_file method."""
+        """Test predict_score_catalog_realtime with get_file method."""
         mock_dataset = Mock()
         del mock_dataset.get_as_dataframe
         del mock_dataset.download
@@ -733,7 +733,7 @@ class TestPredictByAiCatalogRt:
             patch.object(dr.Dataset, "get", return_value=mock_dataset) as mock_ds_get,
             patch.object(dr.Deployment, "get", return_value=mock_deployment) as mock_dep_get,
         ):
-            result = await predict_by_ai_catalog_rt(
+            result = await predict_score_catalog_realtime(
                 deployment_id="deployment123", dataset_id="dataset123"
             )
 
@@ -758,13 +758,13 @@ class TestPredictByAiCatalogRt:
     @patch("datarobot_genai.drtools.predictive.predict_realtime.predictions_result_response")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.dr_predict")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.pl.read_csv")
-    async def test_predict_by_ai_catalog_rt_with_get_bytes(
+    async def test_predict_score_catalog_realtime_with_get_bytes(
         self,
         mock_read_csv,
         mock_dr_predict,
         mock_predictions_result_response,
     ):
-        """Test predict_by_ai_catalog_rt with get_bytes method."""
+        """Test predict_score_catalog_realtime with get_bytes method."""
         # Setup mocks
         mock_dataset = Mock()
         # Remove get_as_dataframe, download, and get_file attributes entirely
@@ -789,7 +789,7 @@ class TestPredictByAiCatalogRt:
             patch.object(dr.Deployment, "get", return_value=mock_deployment) as mock_dep_get,
         ):
             # Call function
-            result = await predict_by_ai_catalog_rt(
+            result = await predict_score_catalog_realtime(
                 deployment_id="deployment123", dataset_id="dataset123"
             )
 
@@ -814,13 +814,13 @@ class TestPredictByAiCatalogRt:
     @patch("datarobot_genai.drtools.predictive.predict_realtime.predictions_result_response")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.dr_predict")
     @patch("datarobot_genai.drtools.predictive.predict_realtime.pl.read_csv")
-    async def test_predict_by_ai_catalog_rt_with_url_fallback(
+    async def test_predict_score_catalog_realtime_with_url_fallback(
         self,
         mock_read_csv,
         mock_dr_predict,
         mock_predictions_result_response,
     ):
-        """Test predict_by_ai_catalog_rt with URL fallback."""
+        """Test predict_score_catalog_realtime with URL fallback."""
         # Setup mocks
         mock_dataset = Mock()
         # Remove get_as_dataframe, download, get_file, and get_bytes attributes entirely
@@ -846,7 +846,7 @@ class TestPredictByAiCatalogRt:
             patch.object(dr.Deployment, "get", return_value=mock_deployment) as mock_dep_get,
         ):
             # Call function
-            result = await predict_by_ai_catalog_rt(
+            result = await predict_score_catalog_realtime(
                 deployment_id="deployment123", dataset_id="dataset123"
             )
 

--- a/tests/drmcp/unit/predictive_tools/test_project.py
+++ b/tests/drmcp/unit/predictive_tools/test_project.py
@@ -25,11 +25,11 @@ from datarobot_genai.drtools.predictive import project
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_list_projects_success() -> None:
+async def test_modeling_list_projects_success() -> None:
     mock_proj1 = MagicMock(id="1", project_name="proj1")
     mock_proj2 = MagicMock(id="2", project_name="proj2")
     with patch.object(dr.Project, "list", return_value=[mock_proj1, mock_proj2]):
-        result = await project.list_projects()
+        result = await project.modeling_list_projects()
     assert isinstance(result, dict)
     projects_dict = result
     assert "1" in projects_dict
@@ -40,28 +40,28 @@ async def test_list_projects_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_list_projects_empty() -> None:
+async def test_modeling_list_projects_empty() -> None:
     with patch.object(dr.Project, "list", return_value=[]):
-        result = await project.list_projects()
+        result = await project.modeling_list_projects()
     assert isinstance(result, dict)
     assert result == {}
 
 
 @pytest.mark.asyncio
-async def test_list_projects_error() -> None:
+async def test_modeling_list_projects_error() -> None:
     with patch.object(
         ThreadSafeDataRobotClient,
         "request_user_client",
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:
-            await project.list_projects()
+            await project.modeling_list_projects()
         assert "fail" == str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_project_dataset_by_name_success() -> None:
+async def test_modeling_get_project_dataset_success() -> None:
     mock_project = MagicMock()
     mock_ds1 = MagicMock()
     mock_ds1.name = "training_data"
@@ -69,7 +69,7 @@ async def test_get_project_dataset_by_name_success() -> None:
     mock_project.get_datasets.return_value = [mock_ds1]
     mock_project.get_dataset.return_value = None
     with patch.object(dr.Project, "get", return_value=mock_project) as mock_proj_get:
-        result = await project.get_project_dataset_by_name(
+        result = await project.modeling_get_project_dataset(
             project_id="pid", dataset_name="training"
         )
     mock_proj_get.assert_called_once_with("pid")
@@ -79,25 +79,25 @@ async def test_get_project_dataset_by_name_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_request_user_client")
-async def test_get_project_dataset_by_name_not_found() -> None:
+async def test_modeling_get_project_dataset_not_found() -> None:
     mock_project = MagicMock()
     mock_project.get_datasets.return_value = []
     mock_project.get_dataset.return_value = None
     with patch.object(dr.Project, "get", return_value=mock_project):
         with pytest.raises(ToolError) as exc_info:
-            await project.get_project_dataset_by_name(project_id="pid", dataset_name="training")
+            await project.modeling_get_project_dataset(project_id="pid", dataset_name="training")
     assert (
         str(exc_info.value) == "Dataset with name containing 'training' not found in project pid."
     )
 
 
 @pytest.mark.asyncio
-async def test_get_project_dataset_by_name_error() -> None:
+async def test_modeling_get_project_dataset_error() -> None:
     with patch.object(
         ThreadSafeDataRobotClient,
         "request_user_client",
         side_effect=Exception("fail"),
     ):
         with pytest.raises(Exception) as exc_info:
-            await project.get_project_dataset_by_name(project_id="pid", dataset_name="training")
+            await project.modeling_get_project_dataset(project_id="pid", dataset_name="training")
         assert "fail" == str(exc_info.value)

--- a/tests/drmcp/unit/predictive_tools/test_training.py
+++ b/tests/drmcp/unit/predictive_tools/test_training.py
@@ -25,7 +25,7 @@ from datarobot_genai.drtools.predictive import training
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_analyze_dataset() -> None:
+async def test_catalog_analyze_dataset() -> None:
     mock_dataset = MagicMock()
     mock_df = pd.DataFrame(
         {
@@ -39,7 +39,7 @@ async def test_analyze_dataset() -> None:
     mock_dataset.get_as_dataframe.return_value = mock_df
 
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await training.analyze_dataset(dataset_id="test_dataset_id")
+        result = await training.catalog_analyze_dataset(dataset_id="test_dataset_id")
         assert isinstance(result, dict)
         insights = result
 
@@ -54,7 +54,7 @@ async def test_analyze_dataset() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_suggest_use_cases() -> None:
+async def test_catalog_suggest_ml_problems() -> None:
     mock_dataset = MagicMock()
     mock_df = pd.DataFrame(
         {
@@ -67,7 +67,7 @@ async def test_suggest_use_cases() -> None:
     mock_dataset.get_as_dataframe.return_value = mock_df
 
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await training.suggest_use_cases(dataset_id="test_dataset_id")
+        result = await training.catalog_suggest_ml_problems(dataset_id="test_dataset_id")
         assert isinstance(result, dict)
         suggestions = result["use_case_suggestions"]
 
@@ -79,13 +79,13 @@ async def test_suggest_use_cases() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_exploratory_insights() -> None:
+async def test_catalog_get_eda_insights() -> None:
     mock_dataset = MagicMock()
     mock_df = pd.DataFrame({"features": [1, 2, 3], "target": [0, 1, 0]})
     mock_dataset.get_as_dataframe.return_value = mock_df
 
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await training.get_exploratory_insights(
+        result = await training.catalog_get_eda_insights(
             dataset_id="test_dataset_id", target_col="target"
         )
         assert isinstance(result, dict)
@@ -100,7 +100,7 @@ async def test_get_exploratory_insights() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_exploratory_insights_catalog_feature_profile() -> None:
+async def test_catalog_get_eda_insights_catalog_feature_profile() -> None:
     mock_dataset = MagicMock()
     mock_df = pd.DataFrame({"features": [1, 2, 3], "target": [0, 1, 0]})
     mock_dataset.get_as_dataframe.return_value = mock_df
@@ -125,7 +125,7 @@ async def test_get_exploratory_insights_catalog_feature_profile() -> None:
     mock_dataset.iterate_all_features.return_value = iter([mock_api_feat, MagicMock(name="other")])
 
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
-        result = await training.get_exploratory_insights(
+        result = await training.catalog_get_eda_insights(
             dataset_id="test_dataset_id",
             feature_col="features",
             include_feature_histogram=True,
@@ -142,14 +142,14 @@ async def test_get_exploratory_insights_catalog_feature_profile() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_exploratory_insights_feature_col_unknown_column() -> None:
+async def test_catalog_get_eda_insights_feature_col_unknown_column() -> None:
     mock_dataset = MagicMock()
     mock_df = pd.DataFrame({"a": [1]})
     mock_dataset.get_as_dataframe.return_value = mock_df
 
     with patch.object(dr.Dataset, "get", return_value=mock_dataset):
         with pytest.raises(ToolError, match="feature_col"):
-            await training.get_exploratory_insights(
+            await training.catalog_get_eda_insights(
                 dataset_id="test_dataset_id",
                 feature_col="missing",
             )
@@ -157,7 +157,7 @@ async def test_get_exploratory_insights_feature_col_unknown_column() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_start_autopilot_new_project() -> None:
+async def test_modeling_start_autopilot_new_project() -> None:
     mock_dataset = MagicMock()
     mock_dataset.id = "test_dataset_id"
     mock_project = MagicMock()
@@ -169,7 +169,7 @@ async def test_start_autopilot_new_project() -> None:
         patch.object(dr.Dataset, "create_from_url", return_value=mock_dataset),
         patch.object(dr.Project, "create_from_dataset", return_value=mock_project),
     ):
-        result = await training.start_autopilot(
+        result = await training.modeling_start_autopilot(
             target="target",
             dataset_url="http://test.com/data.csv",
             project_name="Test Project",
@@ -185,14 +185,14 @@ async def test_start_autopilot_new_project() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_start_autopilot_existing_project() -> None:
+async def test_modeling_start_autopilot_existing_project() -> None:
     mock_project = MagicMock()
     mock_project.id = "test_project_id"
     mock_project.get_status.return_value = "running"
     mock_project.use_case_id = None
 
     with patch.object(dr.Project, "get", return_value=mock_project):
-        result = await training.start_autopilot(
+        result = await training.modeling_start_autopilot(
             target="target", project_id="test_project_id", mode="comprehensive"
         )
         assert isinstance(result, dict)
@@ -206,7 +206,7 @@ async def test_start_autopilot_existing_project() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_model_roc_curve() -> None:
+async def test_modeling_get_model_roc() -> None:
     mock_project = MagicMock()
     mock_model = MagicMock()
     mock_roc_curve = MagicMock()
@@ -227,7 +227,7 @@ async def test_get_model_roc_curve() -> None:
         patch.object(dr.Project, "get", return_value=mock_project),
         patch.object(dr.Model, "get", return_value=mock_model),
     ):
-        result = await training.get_model_roc_curve(
+        result = await training.modeling_get_model_roc(
             project_id="test_project_id", model_id="test_model_id"
         )
         assert isinstance(result, dict)
@@ -240,7 +240,7 @@ async def test_get_model_roc_curve() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_model_feature_impact() -> None:
+async def test_modeling_get_model_feature_impact() -> None:
     mock_project = MagicMock()
     mock_model = MagicMock()
     mock_feature_impact = [
@@ -253,7 +253,7 @@ async def test_get_model_feature_impact() -> None:
         patch.object(dr.Project, "get", return_value=mock_project),
         patch.object(dr.Model, "get", return_value=mock_model),
     ):
-        result = await training.get_model_feature_impact(
+        result = await training.modeling_get_model_feature_impact(
             project_id="test_project_id", model_id="test_model_id"
         )
         assert isinstance(result, dict)
@@ -265,7 +265,7 @@ async def test_get_model_feature_impact() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_get_model_lift_chart() -> None:
+async def test_modeling_get_model_lift_chart() -> None:
     mock_project = MagicMock()
     mock_model = MagicMock()
     mock_lift_chart = MagicMock()
@@ -281,7 +281,7 @@ async def test_get_model_lift_chart() -> None:
         patch.object(dr.Project, "get", return_value=mock_project),
         patch.object(dr.Model, "get", return_value=mock_model),
     ):
-        result = await training.get_model_lift_chart(
+        result = await training.modeling_get_model_lift_chart(
             project_id="test_project_id", model_id="test_model_id"
         )
         assert isinstance(result, dict)
@@ -294,21 +294,21 @@ async def test_get_model_lift_chart() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_start_autopilot_validation() -> None:
-    """Test validation of input parameters for start_autopilot."""
+async def test_modeling_start_autopilot_validation() -> None:
+    """Test validation of input parameters for modeling_start_autopilot."""
     # Test missing dataset info for new project
     with pytest.raises(
         ToolError,
         match="Either dataset_url or dataset_id must be provided",
     ):
-        await training.start_autopilot(target="target")
+        await training.modeling_start_autopilot(target="target")
 
     # Test conflicting dataset inputs
     with pytest.raises(
         ToolError,
         match="Please provide either dataset_url or dataset_id, not both",
     ):
-        await training.start_autopilot(
+        await training.modeling_start_autopilot(
             target="target",
             dataset_url="http://test.com/data.csv",
             dataset_id="test_dataset_id",
@@ -319,13 +319,13 @@ async def test_start_autopilot_validation() -> None:
         ToolError,
         match="Target variable must be specified",
     ):
-        await training.start_autopilot(target="", dataset_url="http://test.com/data.csv")
+        await training.modeling_start_autopilot(target="", dataset_url="http://test.com/data.csv")
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_suggest_use_cases_dataset_not_found() -> None:
-    """Test that suggest_use_cases provides a clear error message when dataset is not found."""
+async def test_catalog_suggest_ml_problems_dataset_not_found() -> None:
+    """catalog_suggest_ml_problems raises a clear error when the dataset is not found."""
 
     # Create a mock ClientError that matches the DataRobot SDK error format
     class MockClientError(Exception):
@@ -343,4 +343,4 @@ async def test_suggest_use_cases_dataset_not_found() -> None:
             ToolError,
             match=r"Dataset 'nonexistent_dataset_id' not found",
         ):
-            await training.suggest_use_cases(dataset_id="nonexistent_dataset_id")
+            await training.catalog_suggest_ml_problems(dataset_id="nonexistent_dataset_id")

--- a/tests/drmcp/unit/tavily_tools/test_tools.py
+++ b/tests/drmcp/unit/tavily_tools/test_tools.py
@@ -20,9 +20,9 @@ import pytest
 from datarobot_genai.drtools.core.clients.tavily import TavilyCrawlResults
 from datarobot_genai.drtools.core.clients.tavily import TavilyMapResults
 from datarobot_genai.drtools.core.clients.tavily import TavilySearchResults
-from datarobot_genai.drtools.tavily.tools import tavily_crawl
-from datarobot_genai.drtools.tavily.tools import tavily_map
-from datarobot_genai.drtools.tavily.tools import tavily_search
+from datarobot_genai.drtools.tavily.tools import tavily_crawl_site
+from datarobot_genai.drtools.tavily.tools import tavily_list_links
+from datarobot_genai.drtools.tavily.tools import tavily_search_web
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ def mock_tavily_auth() -> Iterator[None]:
 
 
 class TestTavilySearch:
-    """Tests for tavily_search tool."""
+    """Tests for tavily_search_web tool."""
 
     @pytest.mark.asyncio
     async def test_basic_search(self, mock_tavily_auth: None) -> None:
@@ -56,7 +56,7 @@ class TestTavilySearch:
 
         with patch("datarobot_genai.drtools.core.clients.tavily.TavilyClient.search") as mock:
             mock.return_value = mock_response
-            result = await tavily_search(query="test query")
+            result = await tavily_search_web(query="test query")
 
         assert result["resultCount"] == 1
 
@@ -74,14 +74,14 @@ class TestTavilySearch:
 
         with patch("datarobot_genai.drtools.core.clients.tavily.TavilyClient.search") as mock:
             mock.return_value = mock_response
-            result = await tavily_search(query="test", include_images=True, include_answer=True)
+            result = await tavily_search_web(query="test", include_images=True, include_answer=True)
 
         assert result["answer"] == "AI summary"
         assert len(result["images"]) == 1
 
 
 class TestTavilyMap:
-    """Tests for tavily_map tool."""
+    """Tests for tavily_list_links tool."""
 
     @pytest.mark.asyncio
     async def test_map_default(self, mock_tavily_auth: None) -> None:
@@ -92,7 +92,7 @@ class TestTavilyMap:
 
         with patch("datarobot_genai.drtools.core.clients.tavily.TavilyClient.map_") as mock:
             mock.return_value = mock_response
-            result = await tavily_map(url="https://example.com", include_usage=True)
+            result = await tavily_list_links(url="https://example.com", include_usage=True)
 
         assert result["count"] == 2
         assert len(result["results"]) == 2
@@ -107,7 +107,7 @@ class TestTavilyMap:
 
         with patch("datarobot_genai.drtools.core.clients.tavily.TavilyClient.map_") as mock:
             mock.return_value = mock_response
-            result = await tavily_map(url="https://example.com", include_usage=True)
+            result = await tavily_list_links(url="https://example.com", include_usage=True)
 
         assert result["count"] == 2
         assert len(result["results"]) == 2
@@ -115,7 +115,7 @@ class TestTavilyMap:
 
 
 class TestTavilyCrawl:
-    """Tests for tavily_crawl tool."""
+    """Tests for tavily_crawl_site tool."""
 
     @pytest.mark.asyncio
     async def test_basic_crawl(self, mock_tavily_auth: None) -> None:
@@ -135,7 +135,7 @@ class TestTavilyCrawl:
 
         with patch("datarobot_genai.drtools.core.clients.tavily.TavilyClient.crawl") as mock:
             mock.return_value = mock_response
-            result = await tavily_crawl(url="https://example.com")
+            result = await tavily_crawl_site(url="https://example.com")
 
         assert result["baseUrl"] == "https://example.com"
         assert result["resultCount"] == 1

--- a/tests/drmcp/unit/test_tool_base_ete.py
+++ b/tests/drmcp/unit/test_tool_base_ete.py
@@ -58,26 +58,26 @@ class TestToolCallTestExpectations:
 
 class TestCanonicalToolNameForExpectation:
     def test_matches_primary_name(self) -> None:
-        call = ToolCallTestExpectations(name="get_deployment_info", parameters={}, result="")
+        call = ToolCallTestExpectations(name="deployment_get_info", parameters={}, result="")
         assert (
-            _canonical_tool_name_for_expectation("get_deployment_info", call)
-            == "get_deployment_info"
+            _canonical_tool_name_for_expectation("deployment_get_info", call)
+            == "deployment_get_info"
         )
 
     def test_matches_acceptable_alternative(self) -> None:
         call = ToolCallTestExpectations(
-            name="get_deployment_info",
-            acceptable_tool_names=["get_deployment_features"],
+            name="deployment_get_info",
+            acceptable_tool_names=["deployment_get_features"],
             parameters={},
             result="",
         )
         assert (
-            _canonical_tool_name_for_expectation("get_deployment_features", call)
-            == "get_deployment_features"
+            _canonical_tool_name_for_expectation("deployment_get_features", call)
+            == "deployment_get_features"
         )
 
     def test_no_match(self) -> None:
-        call = ToolCallTestExpectations(name="get_deployment_info", parameters={}, result="")
+        call = ToolCallTestExpectations(name="deployment_get_info", parameters={}, result="")
         assert _canonical_tool_name_for_expectation("other_tool", call) is None
 
 

--- a/tests/drmcp/unit/use_case_tools/test_tools.py
+++ b/tests/drmcp/unit/use_case_tools/test_tools.py
@@ -42,7 +42,7 @@ def mock_get_client_context_with_token_from_request_header(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_cases_success() -> None:
+async def test_datarobot_usecases_list_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": [
@@ -53,7 +53,7 @@ async def test_list_use_cases_success() -> None:
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await tools.list_use_cases()
+        result = await tools.datarobot_usecases_list()
         assert isinstance(result, dict)
         assert result["count"] == 2
         assert result["use_cases"][0]["id"] == "uc1"
@@ -61,13 +61,13 @@ async def test_list_use_cases_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_cases_with_search() -> None:
+async def test_datarobot_usecases_list_with_search() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": [{"id": "uc1", "name": "Matching Case"}]}
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await tools.list_use_cases(search="Matching")
+        result = await tools.datarobot_usecases_list(search="Matching")
         mock_rest_client.get.assert_called_once_with(
             "useCases/", params={"limit": 100, "search": "Matching"}
         )
@@ -76,20 +76,20 @@ async def test_list_use_cases_with_search() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_cases_empty() -> None:
+async def test_datarobot_usecases_list_empty() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": []}
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await tools.list_use_cases()
+        result = await tools.datarobot_usecases_list()
         assert result["count"] == 0
         assert result["use_cases"] == []
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_case_assets_success() -> None:
+async def test_usecases_list_assets_success() -> None:
     mock_use_case = MagicMock()
     mock_use_case.name = "Test UC"
 
@@ -103,7 +103,7 @@ async def test_list_use_case_assets_success() -> None:
     mock_use_case.list_projects.return_value = [mock_proj]
 
     with patch.object(dr.UseCase, "get", return_value=mock_use_case):
-        result = await tools.list_use_case_assets(use_case_id="uc1")
+        result = await tools.usecases_list_assets(use_case_id="uc1")
         assert isinstance(result, dict)
         assert result["count"] == 1
         use_case_data = result["use_cases"][0]
@@ -115,7 +115,7 @@ async def test_list_use_case_assets_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_case_assets_multiple_ids() -> None:
+async def test_usecases_list_assets_multiple_ids() -> None:
     mock_uc1 = MagicMock()
     mock_uc1.name = "UC 1"
     mock_uc1.list_datasets.return_value = [MagicMock(id="ds1", name="DS 1")]
@@ -131,7 +131,7 @@ async def test_list_use_case_assets_multiple_ids() -> None:
     with patch.object(
         dr.UseCase, "get", side_effect=lambda uid: {"uc1": mock_uc1, "uc2": mock_uc2}[uid]
     ):
-        result = await tools.list_use_case_assets(use_case_ids=["uc1", "uc2"])
+        result = await tools.usecases_list_assets(use_case_ids=["uc1", "uc2"])
         assert isinstance(result, dict)
         assert result["count"] == 2
         assert result["use_cases"][0]["name"] == "UC 1"
@@ -139,14 +139,14 @@ async def test_list_use_case_assets_multiple_ids() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_use_case_assets_missing_id() -> None:
+async def test_usecases_list_assets_missing_id() -> None:
     with pytest.raises(ToolError, match="use_case_id.*or.*use_case_ids.*must be provided"):
-        await tools.list_use_case_assets()
+        await tools.usecases_list_assets()
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_cases_client_error_404() -> None:
+async def test_datarobot_usecases_list_client_error_404() -> None:
     mock_rest_client = MagicMock()
     mock_rest_client.get.side_effect = ClientError(
         "404 client error: {'message': 'Not Found'}",
@@ -155,14 +155,14 @@ async def test_list_use_cases_client_error_404() -> None:
     )
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
         with pytest.raises(ToolError) as exc_info:
-            await tools.list_use_cases()
+            await tools.datarobot_usecases_list()
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
     assert "404" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_case_assets_client_error_404() -> None:
+async def test_usecases_list_assets_client_error_404() -> None:
     with patch.object(
         dr.UseCase,
         "get",
@@ -172,7 +172,7 @@ async def test_list_use_case_assets_client_error_404() -> None:
             json={"message": "Not Found"},
         ),
     ):
-        result = await tools.list_use_case_assets(use_case_id="missing-uc")
+        result = await tools.usecases_list_assets(use_case_id="missing-uc")
 
     assert result["count"] == 1
     use_case_data = result["use_cases"][0]
@@ -183,7 +183,7 @@ async def test_list_use_case_assets_client_error_404() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_use_case_assets_partial_error() -> None:
+async def test_usecases_list_assets_partial_error() -> None:
     mock_use_case = MagicMock()
     mock_use_case.name = "Test UC"
 
@@ -192,7 +192,7 @@ async def test_list_use_case_assets_partial_error() -> None:
     mock_use_case.list_projects.return_value = []
 
     with patch.object(dr.UseCase, "get", return_value=mock_use_case):
-        result = await tools.list_use_case_assets(use_case_id="uc1")
+        result = await tools.usecases_list_assets(use_case_id="uc1")
         use_case_data = result["use_cases"][0]
         assert "datasets_error" in use_case_data
         assert use_case_data["deployments"] == []

--- a/tests/drmcp/unit/vdb_tools/test_tools.py
+++ b/tests/drmcp/unit/vdb_tools/test_tools.py
@@ -42,7 +42,7 @@ def mock_get_client_context_with_token_from_request_header(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_vector_databases_success() -> None:
+async def test_vdb_list_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": [
@@ -58,7 +58,7 @@ async def test_list_vector_databases_success() -> None:
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await tools.list_vector_databases()
+        result = await tools.vdb_list()
         assert isinstance(result, dict)
         assert result["count"] == 1
         assert result["vector_databases"][0]["deployment_id"] == "dep1"
@@ -70,13 +70,13 @@ async def test_list_vector_databases_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_vector_databases_pagination_params() -> None:
+async def test_vdb_list_pagination_params() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": [], "next": "url", "total_count": 7}
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await tools.list_vector_databases(offset=10, limit=25)
+        result = await tools.vdb_list(offset=10, limit=25)
         mock_rest_client.get.assert_called_once_with(
             "deployments/",
             params={"limit": 25, "modelTargetType": "VectorDatabase", "offset": 10},
@@ -88,33 +88,33 @@ async def test_list_vector_databases_pagination_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_vector_databases_negative_offset_validation() -> None:
+async def test_vdb_list_negative_offset_validation() -> None:
     with pytest.raises(ToolError, match="offset must be non-negative"):
-        await tools.list_vector_databases(offset=-1)
+        await tools.vdb_list(offset=-1)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_vector_databases_empty() -> None:
+async def test_vdb_list_empty() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": []}
     mock_rest_client = MagicMock()
     mock_rest_client.get.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await tools.list_vector_databases()
+        result = await tools.vdb_list()
         assert result["count"] == 0
         assert result["vector_databases"] == []
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_query_vector_database_success() -> None:
+async def test_vdb_query_success() -> None:
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": [{"content": "doc1", "metadata": {}}]}
     mock_rest_client = MagicMock()
     mock_rest_client.post.return_value = mock_response
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
-        result = await tools.query_vector_database(deployment_id="dep1", query="test query")
+        result = await tools.vdb_query(deployment_id="dep1", query="test query")
         assert isinstance(result, dict)
         assert result["count"] == 1
         assert result["deployment_id"] == "dep1"
@@ -122,7 +122,7 @@ async def test_query_vector_database_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_list_vector_databases_client_error_404() -> None:
+async def test_vdb_list_client_error_404() -> None:
     mock_rest_client = MagicMock()
     mock_rest_client.get.side_effect = ClientError(
         "404 client error: {'message': 'Not Found'}",
@@ -131,14 +131,14 @@ async def test_list_vector_databases_client_error_404() -> None:
     )
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
         with pytest.raises(ToolError) as exc_info:
-            await tools.list_vector_databases()
+            await tools.vdb_list()
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
     assert "404" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
-async def test_query_vector_database_client_error_404() -> None:
+async def test_vdb_query_client_error_404() -> None:
     mock_rest_client = MagicMock()
     mock_rest_client.post.side_effect = ClientError(
         "404 client error: {'message': 'Not Found'}",
@@ -147,18 +147,18 @@ async def test_query_vector_database_client_error_404() -> None:
     )
     with patch.object(dr.client, "get_client", return_value=mock_rest_client):
         with pytest.raises(ToolError) as exc_info:
-            await tools.query_vector_database(deployment_id="missing-dep", query="test")
+            await tools.vdb_query(deployment_id="missing-dep", query="test")
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
     assert "404" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_query_vector_database_missing_deployment_id() -> None:
+async def test_vdb_query_missing_deployment_id() -> None:
     with pytest.raises(ToolError, match="Deployment ID must be provided"):
-        await tools.query_vector_database(query="test")
+        await tools.vdb_query(query="test")
 
 
 @pytest.mark.asyncio
-async def test_query_vector_database_missing_query() -> None:
+async def test_vdb_query_missing_query() -> None:
     with pytest.raises(ToolError, match="Query must be provided"):
-        await tools.query_vector_database(deployment_id="dep1")
+        await tools.vdb_query(deployment_id="dep1")


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Renamed MCP tools based on the doc https://docs.google.com/document/d/1dntBsxcH18_bz2OlXqETe3tuQh-HRWRuZhFcUhxGxPI/edit?tab=t.0
- Updated unit, integration and acceptance tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change for any MCP clients, prompts, or agents hard-coded to old tool names; wide rename across the entire tool API with no aliases in the diff.
> 
> **Overview**
> This release (**0.15.100**) renames the public MCP tool surface across `drtools` and related packages to a **domain-prefixed** naming scheme (e.g. `catalog_*`, `deployment_*`, `modeling_*`, `predict_*`, `vdb_*`, `tavily_*`, `microsoft_graph_*`). Tool **implementations are renamed in place** (Python function names and MCP-exposed names); cross-references in `@tool_metadata` descriptions, dynamic deployment prediction instructions/schemas, and error messages are updated to match.
> 
> **Predictive / DataRobot:** Examples include `upload_dataset_to_ai_catalog` → `catalog_upload_dataset`, `list_deployments` → `deployment_get_list`, `get_deployment_features` → `deployment_get_features`, `predict_realtime` → `predict_score_inline_realtime`, `predict_by_ai_catalog` → `predict_batch_predictions_from_dataset`, `get_best_model` → `models_get_bestmodel`, `start_autopilot` → `modeling_start_autopilot`, `list_vector_databases` / `query_vector_database` → `vdb_list` / `vdb_query`.
> 
> **Integrations:** Confluence `confluence_search` → `confluence_search_space`; GDrive `gdrive_read_content` → `gdrive_read_and_export_content`; Microsoft `microsoft_create_file` / `microsoft_update_metadata` → `microsoft_graph_*`; Perplexity `perplexity_think` → `perplexity_sonar`; Tavily tools split into `tavily_search_web`, `tavily_extract_text`, `tavily_list_links`, `tavily_crawl_site`; DR docs `fetch_datarobot_doc_page` → `datarobot_docs_fetch_page`; use cases `list_use_cases` → `datarobot_usecases_list`, etc.
> 
> **Tests:** Unit/integration stubs, ETE helpers, and acceptance tests are aligned with the new names (fixtures, expected tool call names, and test method renames). No separate backward-compat aliases for old tool names appear in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffbe62f03a70e21d082e560e27413058d37fff7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->