### PR TITLE
Fix Jira payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.100
+- `drtools` Jira: `Issue` model tolerates real Jira payloads—optional `emailAddress`, optional unassigned `assignee`, and `as_flat_dict()` falls back to `displayName` or `accountId` when email is missing.
+
 ## 0.15.99
 - `dragent/workflow_paths`: added `discover_workflow_yaml()` and `publish_dragent_config_file_env()` to locate `workflow.yaml` and set `DRAGENT_CONFIG_FILE` (from the env var, `$CODE_DIR/workflow.yaml`, or a walk up from CWD). Wired into the DRAgent CLI, FastAPI frontend startup, and `load_workflow()` so middleware can resolve guard assets without relying on the process working directory.
 - `nat/datarobot_moderation_middleware`: default `model_dir` is now the directory containing `workflow.yaml` (via `DRAGENT_CONFIG_FILE`) instead of CWD, so `moderation_config.yaml` loads correctly in DataRobot custom-model deployments where CWD is not the agent code root. The middleware retries discovery on first use if `workflow.yaml` was not available at startup (e.g. gunicorn parent process).

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.100"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.100"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/core/clients/jira.py
+++ b/src/datarobot_genai/drtools/core/clients/jira.py
@@ -39,7 +39,13 @@ RESPONSE_JIRA_ISSUE_FIELDS_STR = ",".join(RESPONSE_JIRA_ISSUE_FIELDS)
 
 
 class _IssuePerson(BaseModel):
-    email_address: str = Field(alias="emailAddress")
+    email_address: str | None = Field(default=None, alias="emailAddress")
+    display_name: str | None = Field(default=None, alias="displayName")
+    account_id: str | None = Field(default=None, alias="accountId")
+
+    def contact_label(self) -> str | None:
+        """Best-effort user identifier when email is unavailable in the API payload."""
+        return self.email_address or self.display_name or self.account_id
 
 
 class _IssueStatus(BaseModel):
@@ -50,7 +56,7 @@ class _IssueFields(BaseModel):
     summary: str
     status: _IssueStatus
     reporter: _IssuePerson
-    assignee: _IssuePerson
+    assignee: _IssuePerson | None = None
     created: str
     updated: str
 
@@ -65,8 +71,10 @@ class Issue(BaseModel):
             "id": self.id,
             "key": self.key,
             "summary": self.fields.summary,
-            "reporterEmailAddress": self.fields.reporter.email_address,
-            "assigneeEmailAddress": self.fields.assignee.email_address,
+            "reporterEmailAddress": self.fields.reporter.contact_label(),
+            "assigneeEmailAddress": (
+                self.fields.assignee.contact_label() if self.fields.assignee else None
+            ),
             "created": self.fields.created,
             "updated": self.fields.updated,
             "status": self.fields.status.name,

--- a/tests/drmcp/unit/tool_clients/test_jira_client.py
+++ b/tests/drmcp/unit/tool_clients/test_jira_client.py
@@ -212,3 +212,55 @@ class TestJiraClient:
                 )
 
                 assert result == ["summary"]
+
+
+class TestIssueModel:
+    def _base_fields(self, **overrides: object) -> dict[str, object]:
+        fields: dict[str, object] = {
+            "summary": "Dummy summary",
+            "status": {"name": "In Progress"},
+            "updated": "2025-12-15T07:47:19.176-0500",
+            "created": "2025-12-11T09:01:58.944-0500",
+            "reporter": {"emailAddress": "dummy@reporter.com"},
+            "assignee": {"emailAddress": "dummy@assignee.com"},
+        }
+        fields.update(overrides)
+        return fields
+
+    def test_as_flat_dict_uses_display_name_when_email_missing(self) -> None:
+        issue = Issue(
+            id="123",
+            key="PROJ-123",
+            fields=self._base_fields(
+                reporter={"displayName": "Reporter User"},
+                assignee={"displayName": "Assignee User"},
+            ),
+        )
+
+        flat = issue.as_flat_dict()
+        assert flat["reporterEmailAddress"] == "Reporter User"
+        assert flat["assigneeEmailAddress"] == "Assignee User"
+
+    def test_as_flat_dict_uses_account_id_when_email_and_display_name_missing(self) -> None:
+        issue = Issue(
+            id="123",
+            key="PROJ-123",
+            fields=self._base_fields(
+                reporter={"accountId": "reporter-account-id"},
+                assignee={"accountId": "assignee-account-id"},
+            ),
+        )
+
+        flat = issue.as_flat_dict()
+        assert flat["reporterEmailAddress"] == "reporter-account-id"
+        assert flat["assigneeEmailAddress"] == "assignee-account-id"
+
+    def test_as_flat_dict_allows_unassigned_issue(self) -> None:
+        issue = Issue(
+            id="123",
+            key="PROJ-123",
+            fields=self._base_fields(assignee=None),
+        )
+
+        flat = issue.as_flat_dict()
+        assert flat["assigneeEmailAddress"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.100"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- `drtools` Jira: `Issue` model tolerates real Jira payloads—optional `emailAddress`, optional unassigned `assignee`, and `as_flat_dict()` falls back to `displayName` or `accountId` when email is missing.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Jira client model and flattening logic with new unit tests; no auth, security, or broad API surface changes.
> 
> **Overview**
> Relaxes the **`drtools` Jira `Issue` Pydantic models** so live Atlassian REST payloads parse instead of failing validation: person fields may omit `emailAddress`, **`assignee` may be unassigned (`null`)**, and optional `displayName` / `accountId` are accepted on reporter and assignee.
> 
> **`Issue.as_flat_dict()`** now exposes reporter/assignee via a **`contact_label()`** fallback chain (`emailAddress` → `displayName` → `accountId`) and sets **`assigneeEmailAddress` to `None`** when there is no assignee. The package is released as **0.15.100** with changelog and lockfile updates; unit tests cover display-name/account-id fallbacks and unassigned issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ee2db1f1cf4fb56e01e1063b5ca6498d63cc77. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->