### PR TITLE
Migrate the credentials config to DataRobotAppFrameworkBaseSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.101
+- `drtools`: refactored tool credentials to `ToolsAuthCredentials` and nested `DataRobotCredentials` using `DataRobotAppFrameworkBaseSettings` (env, runtime params, `.env`, file secrets, `pulumi_config.json`). Renamed fields to `datarobot_api_token` and `datarobot_endpoint` (`DATAROBOT_API_TOKEN`, `DATAROBOT_ENDPOINT`). Replaced `MCPServerCredentials`; added third-party config fields (`tavily_api_key`, `perplexity_api_key`, `atlassian_api_token`, `atlassian_email`, `atlassian_site_url`). Public export is `ToolsAuthCredentials`.
+
 ## 0.15.99
 - `dragent/workflow_paths`: added `discover_workflow_yaml()` and `publish_dragent_config_file_env()` to locate `workflow.yaml` and set `DRAGENT_CONFIG_FILE` (from the env var, `$CODE_DIR/workflow.yaml`, or a walk up from CWD). Wired into the DRAgent CLI, FastAPI frontend startup, and `load_workflow()` so middleware can resolve guard assets without relying on the process working directory.
 - `nat/datarobot_moderation_middleware`: default `model_dir` is now the directory containing `workflow.yaml` (via `DRAGENT_CONFIG_FILE`) instead of CWD, so `moderation_config.yaml` loads correctly in DataRobot custom-model deployments where CWD is not the agent code root. The middleware retries discovery on first use if `workflow.yaml` was not available at startup (e.g. gunicorn parent process).

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.101"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.101"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/__init__.py
+++ b/src/datarobot_genai/drmcp/__init__.py
@@ -35,7 +35,7 @@ from datarobot_genai.drtools.core.config_utils import (
 from datarobot_genai.drtools.core.config_utils import extract_datarobot_dict_runtime_param_payload
 from datarobot_genai.drtools.core.config_utils import extract_datarobot_runtime_param_payload
 from datarobot_genai.drtools.core.constants import RUNTIME_PARAM_ENV_VAR_NAME_PREFIX
-from datarobot_genai.drtools.core.credentials import MCPServerCredentials
+from datarobot_genai.drtools.core.credentials import ToolsAuthCredentials
 from datarobot_genai.drtools.core.credentials import get_credentials
 
 from .core.config import MCPServerConfig
@@ -59,7 +59,7 @@ __all__ = [
     "MCPServerConfig",
     # Credentials
     "get_credentials",
-    "MCPServerCredentials",
+    "ToolsAuthCredentials",
     # Constants
     "RUNTIME_PARAM_ENV_VAR_NAME_PREFIX",
     # User extensibility

--- a/src/datarobot_genai/drmcp/core/clients.py
+++ b/src/datarobot_genai/drmcp/core/clients.py
@@ -52,5 +52,6 @@ def setup_and_return_dr_api_client_with_static_config_in_container() -> RESTClie
     credentials = get_credentials()
 
     return dr.Client(
-        token=credentials.datarobot.application_api_token, endpoint=credentials.datarobot.endpoint
+        token=credentials.datarobot.datarobot_api_token,
+        endpoint=credentials.datarobot.datarobot_endpoint,
     )

--- a/src/datarobot_genai/drmcp/core/feature_flags.py
+++ b/src/datarobot_genai/drmcp/core/feature_flags.py
@@ -24,10 +24,8 @@ class FeatureFlag:
     @alru_cache(maxsize=1)
     async def is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user() -> bool:
         credentials = get_credentials()
-        dr_api_endpoint = credentials.datarobot.endpoint
-        dr_api_token_of_static_account_in_mcp_container = (
-            credentials.datarobot.application_api_token
-        )
+        dr_api_endpoint = credentials.datarobot.datarobot_endpoint
+        dr_api_token_of_static_account_in_mcp_container = credentials.datarobot.datarobot_api_token
 
         return await is_mcp_tools_gallery_support_enabled(
             dr_api_endpoint, dr_api_token_of_static_account_in_mcp_container

--- a/src/datarobot_genai/drmcp/core/telemetry.py
+++ b/src/datarobot_genai/drmcp/core/telemetry.py
@@ -174,7 +174,7 @@ def _setup_otel_env_variables() -> None:
     entity_id = config.otel_entity_id
 
     otlp_headers = (
-        f"X-DataRobot-Api-Key={credentials.datarobot.application_api_token},"
+        f"X-DataRobot-Api-Key={credentials.datarobot.datarobot_api_token},"
         f"X-DataRobot-Entity-Id={entity_id}"
     )
     os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = otlp_endpoint

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -37,6 +37,7 @@ from unittest.mock import Mock
 
 import datarobot as dr
 import datarobot_predict.deployment as _dr_predict_deployment
+from fastmcp.exceptions import ToolError
 
 from datarobot_genai.drmcp import create_mcp_server
 from datarobot_genai.drmcp.core.dynamic_prompts import register as prompt_register
@@ -120,10 +121,8 @@ def _get_datarobot_access_token_stdio_fallback(*, headers_auth_only: bool = True
     """Return DataRobot token from credentials for stdio (no headers)."""
     del headers_auth_only  # stdio has no headers; always use application credentials.
     creds = get_credentials()
-    token = creds.datarobot.application_api_token
+    token = creds.datarobot.datarobot_api_token
     if not token:
-        from fastmcp.exceptions import ToolError
-
         raise ToolError("DataRobot API token not available (stdio and no DATAROBOT_API_TOKEN).")
     return token
 

--- a/src/datarobot_genai/drtools/core/clients/datarobot.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot.py
@@ -62,7 +62,7 @@ def get_datarobot_access_token(*, headers_auth_only: bool = True) -> str:
                 "Please provide it via 'Authorization' (Bearer), 'x-datarobot-api-token' headers.",
                 kind=ToolErrorKind.AUTHENTICATION,
             )
-        token = get_credentials().datarobot.application_api_token
+        token = get_credentials().datarobot.datarobot_api_token
     return token
 
 
@@ -80,7 +80,7 @@ def request_user_dr_client(*, headers_auth_only: bool = True) -> Iterator[RESTCl
     concurrent requests.
     """
     token = get_datarobot_access_token(headers_auth_only=headers_auth_only)
-    endpoint = get_credentials().datarobot.endpoint
+    endpoint = get_credentials().datarobot.datarobot_endpoint
     with client_configuration(token=token, endpoint=endpoint):
         # Avoid use-case context from trafaret affecting tool calls.
         DRContext.use_case = None
@@ -100,7 +100,7 @@ def request_user_dr_sdk(*, headers_auth_only: bool = True) -> Iterator[Any]:
     :func:`request_user_dr_client`.
     """
     token = get_datarobot_access_token(headers_auth_only=headers_auth_only)
-    endpoint = get_credentials().datarobot.endpoint
+    endpoint = get_credentials().datarobot.datarobot_endpoint
     with client_configuration(token=token, endpoint=endpoint):
         DRContext.use_case = None
         yield dr
@@ -110,7 +110,7 @@ class ThreadSafeDataRobotClient:
     """Configure a per-request DataRobot SDK client from the caller's headers."""
 
     def __init__(self) -> None:
-        self.endpoint = get_credentials().datarobot.endpoint
+        self.endpoint = get_credentials().datarobot.datarobot_endpoint
 
     @contextmanager
     def request_user_client(self, *, headers_auth_only: bool = True) -> Iterator[RESTClientObject]:

--- a/src/datarobot_genai/drtools/core/credentials.py
+++ b/src/datarobot_genai/drtools/core/credentials.py
@@ -12,84 +12,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-
-from pydantic import AliasChoices
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from pydantic import Field
-from pydantic import field_validator
-from pydantic_settings import BaseSettings
-from pydantic_settings import SettingsConfigDict
 
-from .config_utils import extract_datarobot_runtime_param_payload
 from .constants import DEFAULT_DATAROBOT_ENDPOINT
-from .constants import RUNTIME_PARAM_ENV_VAR_NAME_PREFIX
 
 
-class DataRobotCredentials(BaseSettings):
-    """DataRobot API credentials."""
+class DataRobotCredentials(DataRobotAppFrameworkBaseSettings):
+    """DataRobot API credentials.
 
-    application_api_token: str = Field(
-        default="",
-        validation_alias=AliasChoices(
-            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "DATAROBOT_API_TOKEN",
-            "DATAROBOT_API_TOKEN",
-        ),
-        description="DataRobot API token",
-    )
-    endpoint: str = Field(
-        default=DEFAULT_DATAROBOT_ENDPOINT,
-        validation_alias=AliasChoices(
-            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "DATAROBOT_ENDPOINT",
-            "DATAROBOT_ENDPOINT",
-        ),
-        description="DataRobot API endpoint",
-    )
+    Loads from env vars (including MLOPS_RUNTIME_PARAM_*), .env, file secrets,
+    and pulumi_config.json. Fields map by name: ``datarobot_api_token`` reads
+    ``DATAROBOT_API_TOKEN``, ``datarobot_endpoint`` reads ``DATAROBOT_ENDPOINT``.
+    """
 
-    @field_validator(
-        "application_api_token",
-        "endpoint",
-        mode="before",
-    )
-    @classmethod
-    def validate_runtime_params(cls, v: Any) -> Any:
-        """Validate runtime parameters."""
-        return extract_datarobot_runtime_param_payload(v)
-
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        case_sensitive=False,
-        env_file_encoding="utf-8",
-        extra="ignore",
-    )
+    datarobot_api_token: str = ""
+    datarobot_endpoint: str = DEFAULT_DATAROBOT_ENDPOINT
 
 
-class MCPServerCredentials(BaseSettings):
-    """Application credentials for MCP server."""
+class ToolsAuthCredentials(DataRobotAppFrameworkBaseSettings):
+    """Application credentials for tools (DataRobot and third-party API keys)."""
 
     datarobot: DataRobotCredentials = Field(default_factory=DataRobotCredentials)
-
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        case_sensitive=False,
-        env_file_encoding="utf-8",
-        extra="ignore",
-    )
+    tavily_api_key: str = ""
+    perplexity_api_key: str = ""
+    atlassian_api_token: str = ""
+    atlassian_email: str = ""
+    atlassian_site_url: str = ""
 
     def has_datarobot_credentials(self) -> bool:
         """Check if DataRobot credentials are configured."""
-        return bool(self.datarobot.application_api_token)
+        return bool(self.datarobot.datarobot_api_token)
 
 
 # Global credentials instance
-_credentials: MCPServerCredentials | None = None
+_credentials: ToolsAuthCredentials | None = None
 
 
-def get_credentials() -> MCPServerCredentials:
+def get_credentials() -> ToolsAuthCredentials:
     """Get the global credentials instance."""
     # Use a local variable to avoid global statement warning
     credentials = _credentials
     if credentials is None:
-        credentials = MCPServerCredentials()
+        credentials = ToolsAuthCredentials()
         # Update the global variable
         globals()["_credentials"] = credentials
     return credentials

--- a/tests/drmcp/conftest.py
+++ b/tests/drmcp/conftest.py
@@ -65,7 +65,7 @@ def _make_dr_client() -> Any:
     elif not os.environ.get("DATAROBOT_API_TOKEN"):
         raise ValueError("Tests need DATAROBOT_API_TOKEN environment variable set.")
     creds = get_credentials()
-    token = creds.datarobot.application_api_token
+    token = creds.datarobot.datarobot_api_token
     if not token:
         raise ValueError("Integration tests need DATAROBOT_API_TOKEN environment variable set.")
     # Skip real API init when using stub token (CI/stub mode); dr.Client() would 401.
@@ -73,7 +73,7 @@ def _make_dr_client() -> Any:
     # etc.) check _is_stub_token() first and yield stub data without calling dr.*, so they
     # never hit the API when no client is configured.
     if token != STUB_DATAROBOT_API_TOKEN:
-        dr.Client(token=token, endpoint=creds.datarobot.endpoint)
+        dr.Client(token=token, endpoint=creds.datarobot.datarobot_endpoint)
     DRContext.use_case = None
     return dr
 

--- a/tests/drmcp/integration/test_dynamic_tools.py
+++ b/tests/drmcp/integration/test_dynamic_tools.py
@@ -194,7 +194,7 @@ def expected_input_schema() -> dict:
 
 @pytest.fixture
 def datarobot_endpoint() -> str:
-    return get_credentials().datarobot.endpoint
+    return get_credentials().datarobot.datarobot_endpoint
 
 
 @pytest.fixture

--- a/tests/drmcp/unit/core/test_feature_flags.py
+++ b/tests/drmcp/unit/core/test_feature_flags.py
@@ -50,7 +50,7 @@ class TestFeatureFlags:
         )
 
         mock_credentials = mock_get_credentials.return_value
-        mock_token = mock_credentials.datarobot.application_api_token
-        mock_endpoint = mock_credentials.datarobot.endpoint
+        mock_token = mock_credentials.datarobot.datarobot_api_token
+        mock_endpoint = mock_credentials.datarobot.datarobot_endpoint
         mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with(mock_endpoint, mock_token)
         assert output == mock_is_mcp_tools_gallery_support_enabled.return_value

--- a/tests/drmcp/unit/test_core_clients.py
+++ b/tests/drmcp/unit/test_core_clients.py
@@ -56,8 +56,8 @@ class TestDRAPIClientWithStaticConfigInContainer:
         mock_get_credentials.assert_called_once_with()
         mock_credentials = mock_get_credentials.return_value
         mock_dr_client_cls.assert_called_once_with(
-            token=mock_credentials.datarobot.application_api_token,
-            endpoint=mock_credentials.datarobot.endpoint,
+            token=mock_credentials.datarobot.datarobot_api_token,
+            endpoint=mock_credentials.datarobot.datarobot_endpoint,
         )
         assert output == mock_dr_client_cls.return_value
 

--- a/tests/drmcp/unit/test_credentials.py
+++ b/tests/drmcp/unit/test_credentials.py
@@ -36,7 +36,7 @@ def isolate_credentials(monkeypatch):
 
     # Apply to both credential classes
     monkeypatch.setattr(credentials.DataRobotCredentials, "model_config", config_without_env)
-    monkeypatch.setattr(credentials.MCPServerCredentials, "model_config", config_without_env)
+    monkeypatch.setattr(credentials.ToolsAuthCredentials, "model_config", config_without_env)
 
 
 def test_datarobot_credentials_default_endpoint() -> None:
@@ -46,11 +46,9 @@ def test_datarobot_credentials_default_endpoint() -> None:
     }
     with patch.dict("os.environ", env_vars, clear=True):  # Clear all env vars
         creds = credentials.DataRobotCredentials()
-        assert creds.application_api_token == "test-token"
-        # The endpoint will be whatever is in the .env file or the default
-        # We just check that it's a valid endpoint
-        assert creds.endpoint is not None
-        assert creds.endpoint.startswith("https://")
+        assert creds.datarobot_api_token == "test-token"
+        assert creds.datarobot_endpoint is not None
+        assert creds.datarobot_endpoint.startswith("https://")
 
 
 def test_datarobot_credentials_custom_endpoint() -> None:
@@ -61,9 +59,8 @@ def test_datarobot_credentials_custom_endpoint() -> None:
     }
     with patch.dict("os.environ", env_vars, clear=True):
         creds = credentials.DataRobotCredentials()
-        assert creds.application_api_token == "test-token"
-        # The endpoint will be the custom one we set in env vars
-        assert creds.endpoint == "https://custom.endpoint.com/api/v2"
+        assert creds.datarobot_api_token == "test-token"
+        assert creds.datarobot_endpoint == "https://custom.endpoint.com/api/v2"
 
 
 def test_get_credentials_singleton() -> None:
@@ -77,7 +74,7 @@ def test_get_credentials_singleton() -> None:
 
         # First call should create new instance
         creds1 = credentials.get_credentials()
-        assert isinstance(creds1, credentials.MCPServerCredentials)
+        assert isinstance(creds1, credentials.ToolsAuthCredentials)
 
         # Second call should return same instance
         creds2 = credentials.get_credentials()
@@ -85,19 +82,16 @@ def test_get_credentials_singleton() -> None:
 
 
 def test_has_datarobot_credentials() -> None:
-    """Test MCPServerCredentials.has_datarobot_credentials method."""
+    """Test ToolsAuthCredentials.has_datarobot_credentials method."""
     # Test with DataRobot credentials
     env_vars = {
         "DATAROBOT_API_TOKEN": "test-token",
     }
     with patch.dict("os.environ", env_vars, clear=True):
-        creds = credentials.MCPServerCredentials()
+        creds = credentials.ToolsAuthCredentials()
         assert creds.has_datarobot_credentials() is True
 
     # Test without DataRobot credentials
     with patch.dict("os.environ", {}, clear=True):
-        try:
-            credentials.MCPServerCredentials()
-            assert False, "Should raise ValidationError"
-        except Exception:
-            assert True
+        creds = credentials.ToolsAuthCredentials()
+        assert creds.has_datarobot_credentials() is False

--- a/tests/drmcp/unit/test_telemetry.py
+++ b/tests/drmcp/unit/test_telemetry.py
@@ -45,7 +45,7 @@ def test_setup_otel_env_variables() -> None:
     mock_config.otel_exporter_otlp_headers = ""
 
     mock_credentials = MagicMock()
-    mock_credentials.datarobot.application_api_token = "test-app-token"
+    mock_credentials.datarobot.datarobot_api_token = "test-app-token"
 
     with (
         patch("datarobot_genai.drmcp.core.telemetry.get_config", return_value=mock_config),

--- a/tests/drmcp/unit/tool_clients/test_datarobot.py
+++ b/tests/drmcp/unit/tool_clients/test_datarobot.py
@@ -68,5 +68,5 @@ class TestGetDatarobotAccessToken:
                 "datarobot_genai.drtools.core.clients.datarobot.get_credentials",
             ) as mock_get_credentials,
         ):
-            mock_get_credentials.return_value.datarobot.application_api_token = "app-tok"
+            mock_get_credentials.return_value.datarobot.datarobot_api_token = "app-tok"
             assert get_datarobot_access_token(headers_auth_only=False) == "app-tok"

--- a/tests/drtools/unit/core/test_datarobot_sdk.py
+++ b/tests/drtools/unit/core/test_datarobot_sdk.py
@@ -37,7 +37,7 @@ class TestRequestUserDrSdk:
     ) -> None:
         mock_get_headers.return_value = {"authorization": "Bearer header-token"}
         mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "https://test.datarobot.com/api/v2"
+        mock_creds.datarobot.datarobot_endpoint = "https://test.datarobot.com/api/v2"
         mock_get_creds.return_value = mock_creds
 
         with request_user_dr_sdk(headers_auth_only=False) as sdk:
@@ -54,7 +54,7 @@ class TestRequestUserDrSdk:
     ) -> None:
         mock_get_headers.return_value = {}
         mock_creds = MagicMock()
-        mock_creds.datarobot.application_api_token = "credential-token"
+        mock_creds.datarobot.datarobot_api_token = "credential-token"
         mock_get_creds.return_value = mock_creds
 
         with pytest.raises(ToolError, match="DataRobot API token not found"):
@@ -64,13 +64,13 @@ class TestRequestUserDrSdk:
     @patch(f"{_MODULE}.client_configuration")
     @patch(f"{_MODULE}.get_credentials")
     @patch("datarobot_genai.drtools.core.auth._get_http_headers")
-    def test_uses_application_api_token_when_no_headers(
+    def test_uses_datarobot_api_token_when_no_headers(
         self, mock_get_headers, mock_get_creds, mock_client_configuration
     ) -> None:
         mock_get_headers.return_value = {}
         mock_creds = MagicMock()
-        mock_creds.datarobot.application_api_token = "env-api-token"
-        mock_creds.datarobot.endpoint = "https://app.datarobot.com/api/v2"
+        mock_creds.datarobot.datarobot_api_token = "env-api-token"
+        mock_creds.datarobot.datarobot_endpoint = "https://app.datarobot.com/api/v2"
         mock_get_creds.return_value = mock_creds
 
         with request_user_dr_sdk(headers_auth_only=False) as sdk:
@@ -88,7 +88,7 @@ class TestRequestUserDrSdk:
     ) -> None:
         with patch(f"{_MODULE}.resolve_token_from_headers", return_value="tok"):
             mock_creds = MagicMock()
-            mock_creds.datarobot.endpoint = "https://test.datarobot.com/api/v2"
+            mock_creds.datarobot.datarobot_endpoint = "https://test.datarobot.com/api/v2"
             mock_get_creds.return_value = mock_creds
             mock_dr_context.use_case = "some-use-case"
 
@@ -134,7 +134,7 @@ class TestRequestUserDrSdk:
         jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
         mock_get_headers.return_value = {"x-datarobot-authorization-context": jwt}
         mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "https://app.datarobot.com/api/v2"
+        mock_creds.datarobot.datarobot_endpoint = "https://app.datarobot.com/api/v2"
         mock_get_creds.return_value = mock_creds
 
         with request_user_dr_sdk(headers_auth_only=False):

--- a/tests/drtools/unit/core/test_rest_client.py
+++ b/tests/drtools/unit/core/test_rest_client.py
@@ -35,7 +35,7 @@ class TestGetDatarobotAccessTokenExtended:
 
     def test_falls_back_to_app_token_when_headers_auth_only_false(self) -> None:
         mock_creds = MagicMock()
-        mock_creds.datarobot.application_api_token = "app-tok"
+        mock_creds.datarobot.datarobot_api_token = "app-tok"
         with (
             patch(f"{_MODULE}.resolve_token_from_headers", return_value=None),
             patch(f"{_MODULE}.get_credentials", return_value=mock_creds),
@@ -54,7 +54,7 @@ class TestGetDatarobotAccessTokenExtended:
 class TestRequestUserDrClient:
     def test_scopes_client_to_resolved_token_and_yields_it(self) -> None:
         mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "https://x.example/api/v2"
+        mock_creds.datarobot.datarobot_endpoint = "https://x.example/api/v2"
         with (
             patch(f"{_MODULE}.resolve_token_from_headers", return_value="user-tok"),
             patch(f"{_MODULE}.get_credentials", return_value=mock_creds),
@@ -86,7 +86,7 @@ class TestRequestUserDrClient:
 class TestRequestUserDrSdk:
     def test_scopes_sdk_via_client_configuration(self) -> None:
         mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "https://x.example/api/v2"
+        mock_creds.datarobot.datarobot_endpoint = "https://x.example/api/v2"
         with (
             patch(f"{_MODULE}.resolve_token_from_headers", return_value="user-tok"),
             patch(f"{_MODULE}.get_credentials", return_value=mock_creds),
@@ -103,7 +103,7 @@ class TestRequestUserDrSdk:
 class TestThreadSafeDataRobotClientRequestUserClient:
     def test_delegates_to_same_client_configuration(self) -> None:
         mock_creds = MagicMock()
-        mock_creds.datarobot.endpoint = "https://x.example/api/v2"
+        mock_creds.datarobot.datarobot_endpoint = "https://x.example/api/v2"
         with (
             patch(f"{_MODULE}.resolve_token_from_headers", return_value="user-tok"),
             patch(f"{_MODULE}.get_credentials", return_value=mock_creds),

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.101"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- `drtools`: refactored tool credentials to `ToolsAuthCredentials` and nested `DataRobotCredentials` using `DataRobotAppFrameworkBaseSettings` (env, runtime params, `.env`, file secrets, `pulumi_config.json`). Renamed fields to `datarobot_api_token` and `datarobot_endpoint` (`DATAROBOT_API_TOKEN`, `DATAROBOT_ENDPOINT`). Replaced `MCPServerCredentials`; added third-party config fields (`tavily_api_key`, `perplexity_api_key`, `atlassian_api_token`, `atlassian_email`, `atlassian_site_url`). Public export is `ToolsAuthCredentials`.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming MCPServerCredentials and credential attribute paths is a breaking change for any code or deployments still using application_api_token/endpoint; auth and OTel wiring depend on the new settings loader behaving like the old env/runtime-param paths.
> 
> **Overview**
> **drtools** credentials are refactored onto `DataRobotAppFrameworkBaseSettings`: `MCPServerCredentials` becomes **`ToolsAuthCredentials`**, with nested **`DataRobotCredentials`** loading from env (including `MLOPS_RUNTIME_PARAM_*`), `.env`, file secrets, and `pulumi_config.json` instead of custom runtime-param validators.
> 
> DataRobot fields are renamed to **`datarobot_api_token`** and **`datarobot_endpoint`** (still `DATAROBOT_API_TOKEN` / `DATAROBOT_ENDPOINT` via settings naming). Call sites in **drmcp** (static container client, OTel headers, feature flags), **drtools** per-request clients, tests, and the public **`drmcp`** export are updated accordingly.
> 
> **`ToolsAuthCredentials`** also adds optional third-party keys: `tavily_api_key`, `perplexity_api_key`, and Atlassian (`atlassian_api_token`, `atlassian_email`, `atlassian_site_url`). Package version is bumped to **0.15.101** with changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5782b73d12498b80d6f6c0fb6235089fe47432. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->