### PR TITLE
Removed OAuth provider startup gating to cater for the config strategy

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -32,6 +32,7 @@ tasks:
       - |
         OTEL_ENABLED=false \
         OTEL_SDK_DISABLED=true \
+        ENABLE_PREDICTIVE_TOOLS=true \
         MCP_SERVER_PORT={{.PORT}} uv run tests/drmcp/acceptance/ete_test_server.py &
       - |
         for i in {1..30}; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.100
+- `drmcp`: removed OAuth provider startup gating (`IS_*_OAUTH_PROVIDER_CONFIGURED`, `is_*_oauth_configured`, and `oauth_check` in `tool_config`). Tool enablement is controlled only by `ENABLE_*_TOOLS` flags; OAuth tokens are resolved at request time.
+- `drmcp`: `enable_predictive_tools` default is now `false` (opt in via env, `MCP_CLI_CONFIGS`, or runtime params). Integration and acceptance test harnesses set `ENABLE_PREDICTIVE_TOOLS=true` so predictive tool suites keep running.
+- `drmcp`: `/metadata` tool config reports `enabled` only (dropped `oauth_required` / `oauth_configured`).
+
 ## 0.15.99
 - `dragent/workflow_paths`: added `discover_workflow_yaml()` and `publish_dragent_config_file_env()` to locate `workflow.yaml` and set `DRAGENT_CONFIG_FILE` (from the env var, `$CODE_DIR/workflow.yaml`, or a walk up from CWD). Wired into the DRAgent CLI, FastAPI frontend startup, and `load_workflow()` so middleware can resolve guard assets without relying on the process working directory.
 - `nat/datarobot_moderation_middleware`: default `model_dir` is now the directory containing `workflow.yaml` (via `DRAGENT_CONFIG_FILE`) instead of CWD, so `moderation_config.yaml` loads correctly in DataRobot custom-model deployments where CWD is not the agent code root. The middleware retries discovery on first use if `workflow.yaml` was not available at startup (e.g. gunicorn parent process).

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.103"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.103"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -39,7 +39,7 @@ class MCPToolConfig(BaseSettings):
     """Tool configuration for MCP server."""
 
     enable_predictive_tools: bool = Field(
-        default=True,
+        default=False,
         validation_alias=AliasChoices(
             RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "ENABLE_PREDICTIVE_TOOLS",
             "ENABLE_PREDICTIVE_TOOLS",
@@ -146,52 +146,6 @@ class MCPToolConfig(BaseSettings):
         description="Enable/disable vector database tools",
     )
 
-    is_atlassian_oauth_provider_configured: bool = Field(
-        default=False,
-        validation_alias=AliasChoices(
-            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "IS_ATLASSIAN_OAUTH_PROVIDER_CONFIGURED",
-            "IS_ATLASSIAN_OAUTH_PROVIDER_CONFIGURED",
-        ),
-        description="Whether Atlassian OAuth provider is configured for Atlassian integration",
-    )
-
-    @property
-    def is_atlassian_oauth_configured(self) -> bool:
-        """Check if Atlassian OAuth is configured via provider flag or environment variables."""
-        return self.is_atlassian_oauth_provider_configured or bool(
-            os.getenv("ATLASSIAN_CLIENT_ID") and os.getenv("ATLASSIAN_CLIENT_SECRET")
-        )
-
-    is_google_oauth_provider_configured: bool = Field(
-        default=False,
-        validation_alias=AliasChoices(
-            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "IS_GOOGLE_OAUTH_PROVIDER_CONFIGURED",
-            "IS_GOOGLE_OAUTH_PROVIDER_CONFIGURED",
-        ),
-        description="Whether Google OAuth provider is configured for Google integration",
-    )
-
-    @property
-    def is_google_oauth_configured(self) -> bool:
-        return self.is_google_oauth_provider_configured or bool(
-            os.getenv("GOOGLE_CLIENT_ID") and os.getenv("GOOGLE_CLIENT_SECRET")
-        )
-
-    is_microsoft_oauth_provider_configured: bool = Field(
-        default=False,
-        validation_alias=AliasChoices(
-            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "IS_MICROSOFT_OAUTH_PROVIDER_CONFIGURED",
-            "IS_MICROSOFT_OAUTH_PROVIDER_CONFIGURED",
-        ),
-        description="Whether Microsoft OAuth provider is configured for Microsoft integration",
-    )
-
-    @property
-    def is_microsoft_oauth_configured(self) -> bool:
-        return self.is_microsoft_oauth_provider_configured or bool(
-            os.getenv("MICROSOFT_CLIENT_ID") and os.getenv("MICROSOFT_CLIENT_SECRET")
-        )
-
     @field_validator(
         "enable_predictive_tools",
         "enable_jira_tools",
@@ -205,9 +159,6 @@ class MCPToolConfig(BaseSettings):
         "enable_code_execution_tools",
         "enable_optimization_tools",
         "enable_vdb_tools",
-        "is_atlassian_oauth_provider_configured",
-        "is_google_oauth_provider_configured",
-        "is_microsoft_oauth_provider_configured",
         mode="before",
     )
     @classmethod

--- a/src/datarobot_genai/drmcp/core/routes.py
+++ b/src/datarobot_genai/drmcp/core/routes.py
@@ -92,16 +92,9 @@ def register_routes(mcp: DataRobotMCP) -> None:
             for tool_type in ToolType:
                 tool_config = TOOL_CONFIGS[tool_type]
                 is_enabled = getattr(config.tool_config, tool_config["config_field_name"], False)
-                oauth_check_fn = tool_config["oauth_check"]
-                oauth_required = oauth_check_fn is not None
-                oauth_configured = None
-                if oauth_required and oauth_check_fn is not None:
-                    oauth_configured = oauth_check_fn(config)
 
                 tool_config_status[tool_type.value] = {
                     "enabled": is_enabled,
-                    "oauth_required": oauth_required,
-                    "oauth_configured": oauth_configured,
                 }
 
             # Safe config details (excluding sensitive information)

--- a/src/datarobot_genai/drmcp/core/tool_config.py
+++ b/src/datarobot_genai/drmcp/core/tool_config.py
@@ -14,7 +14,6 @@
 
 """Tool configuration and enablement logic."""
 
-from collections.abc import Callable
 from enum import StrEnum
 from typing import TYPE_CHECKING
 from typing import TypedDict
@@ -44,7 +43,6 @@ class ToolConfig(TypedDict):
     """Configuration for a tool type."""
 
     name: str
-    oauth_check: Callable[["MCPServerConfig"], bool] | None
     directory: str
     package_prefix: str
     config_field_name: str
@@ -54,84 +52,72 @@ class ToolConfig(TypedDict):
 TOOL_CONFIGS: dict[ToolType, ToolConfig] = {
     ToolType.PREDICTIVE: ToolConfig(
         name="predictive",
-        oauth_check=None,
         directory="predictive",
         package_prefix="datarobot_genai.drtools.predictive",
         config_field_name="enable_predictive_tools",
     ),
     ToolType.JIRA: ToolConfig(
         name="jira",
-        oauth_check=lambda config: config.tool_config.is_atlassian_oauth_configured,
         directory="jira",
         package_prefix="datarobot_genai.drtools.jira",
         config_field_name="enable_jira_tools",
     ),
     ToolType.CONFLUENCE: ToolConfig(
         name="confluence",
-        oauth_check=lambda config: config.tool_config.is_atlassian_oauth_configured,
         directory="confluence",
         package_prefix="datarobot_genai.drtools.confluence",
         config_field_name="enable_confluence_tools",
     ),
     ToolType.GDRIVE: ToolConfig(
         name="gdrive",
-        oauth_check=lambda config: config.tool_config.is_google_oauth_configured,
         directory="gdrive",
         package_prefix="datarobot_genai.drtools.gdrive",
         config_field_name="enable_gdrive_tools",
     ),
     ToolType.MICROSOFT_GRAPH: ToolConfig(
         name="microsoft_graph",
-        oauth_check=lambda config: config.tool_config.is_microsoft_oauth_configured,
         directory="microsoft_graph",
         package_prefix="datarobot_genai.drtools.microsoft_graph",
         config_field_name="enable_microsoft_graph_tools",
     ),
     ToolType.PERPLEXITY: ToolConfig(
         name="perplexity",
-        oauth_check=None,  # OAuth for Perplexity is not supported
         directory="perplexity",
         package_prefix="datarobot_genai.drtools.perplexity",
         config_field_name="enable_perplexity_tools",
     ),
     ToolType.TAVILY: ToolConfig(
         name="tavily",
-        oauth_check=None,
         directory="tavily",
         package_prefix="datarobot_genai.drtools.tavily",
         config_field_name="enable_tavily_tools",
     ),
     ToolType.DR_DOCS: ToolConfig(
         name="dr_docs",
-        oauth_check=None,
         directory="dr_docs",
         package_prefix="datarobot_genai.drtools.dr_docs",
         config_field_name="enable_dr_docs_tools",
     ),
     ToolType.USE_CASE: ToolConfig(
         name="use_case",
-        oauth_check=None,
         directory="use_case",
         package_prefix="datarobot_genai.drtools.use_case",
         config_field_name="enable_use_case_tools",
     ),
     ToolType.CODE_EXECUTION: ToolConfig(
         name="code_execution",
-        oauth_check=None,
         directory="code_execution",
         package_prefix="datarobot_genai.drtools.code_execution",
         config_field_name="enable_code_execution_tools",
     ),
     ToolType.OPTIMIZATION: ToolConfig(
         name="optimization",
-        oauth_check=None,
         directory="optimization",
         package_prefix="datarobot_genai.drtools.optimization",
         config_field_name="enable_optimization_tools",
     ),
     ToolType.VDB: ToolConfig(
         name="vdb",
-        oauth_check=None,
         directory="vdb",
         package_prefix="datarobot_genai.drtools.vdb",
         config_field_name="enable_vdb_tools",
@@ -145,23 +131,6 @@ def get_tool_enable_config_name(tool_type: ToolType) -> str:
 
 
 def is_tool_enabled(tool_type: ToolType, config: "MCPServerConfig") -> bool:
-    """
-    Check if a tool is enabled based on configuration.
-
-    Args:
-        tool_type: The type of tool to check
-        config: The server configuration
-
-    Returns
-    -------
-        True if the tool is enabled, False otherwise
-    """
-    tool_config_registry = TOOL_CONFIGS[tool_type]
-    enable_config_name = tool_config_registry["config_field_name"]
-    is_enabled = getattr(config.tool_config, enable_config_name)
-
-    # If tool is enabled, check OAuth requirements if needed
-    if is_enabled and tool_config_registry["oauth_check"] is not None:
-        return tool_config_registry["oauth_check"](config)
-
-    return is_enabled
+    """Return whether *tool_type* is enabled in *config*."""
+    enable_config_name = TOOL_CONFIGS[tool_type]["config_field_name"]
+    return bool(getattr(config.tool_config, enable_config_name))

--- a/src/datarobot_genai/drmcp/test_utils/mcp_utils_integration.py
+++ b/src/datarobot_genai/drmcp/test_utils/mcp_utils_integration.py
@@ -26,6 +26,11 @@ from mcp.client.stdio import stdio_client
 from datarobot_genai.drmcp.test_utils.stub_credentials import STUB_DATAROBOT_API_TOKEN
 from datarobot_genai.drmcp.test_utils.stub_credentials import STUB_DATAROBOT_ENDPOINT
 
+# Default tool groups enabled for integration/acceptance MCP servers (model default is off).
+_TEST_SUITE_ENABLED_TOOLS_ENV: dict[str, str] = {
+    "ENABLE_PREDICTIVE_TOOLS": "true",
+}
+
 
 def integration_test_mcp_server_params(use_stub: bool = True) -> StdioServerParameters:
     # When running with stubs, always use stub credentials so the subprocess never attempts
@@ -51,6 +56,7 @@ def integration_test_mcp_server_params(use_stub: bool = True) -> StdioServerPara
             "MCP_SERVER_REGISTER_DYNAMIC_PROMPTS_ON_STARTUP"
         )
         or "true",
+        **_TEST_SUITE_ENABLED_TOOLS_ENV,
     }
 
     script_dir = Path(__file__).resolve().parent

--- a/tests/drmcp/acceptance/test_routes.py
+++ b/tests/drmcp/acceptance/test_routes.py
@@ -249,14 +249,7 @@ class TestCustomRoutesE2E:
                 assert tool_type in tool_config
                 tool_type_config = tool_config[tool_type]
                 assert "enabled" in tool_type_config
-                assert "oauth_required" in tool_type_config
-                assert "oauth_configured" in tool_type_config
                 assert isinstance(tool_type_config["enabled"], bool)
-                assert isinstance(tool_type_config["oauth_required"], bool)
-                # oauth_configured can be None or bool
-                assert tool_type_config["oauth_configured"] is None or isinstance(
-                    tool_type_config["oauth_configured"], bool
-                )
 
     async def test_metadata_route_with_prompt_registration(self) -> None:
         """Test metadata route reflects prompt registration changes."""
@@ -352,10 +345,5 @@ class TestCustomRoutesE2E:
 
             # Verify tool config values are consistent
             tool_config = config["tool_config"]
-            for tool_type, tool_info in tool_config.items():
-                # If OAuth is not required, oauth_configured should be None
-                if not tool_info["oauth_required"]:
-                    assert tool_info["oauth_configured"] is None
-                # If OAuth is required, oauth_configured should be a bool
-                else:
-                    assert isinstance(tool_info["oauth_configured"], bool)
+            for _tool_type, tool_info in tool_config.items():
+                assert isinstance(tool_info["enabled"], bool)

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -54,7 +54,7 @@ def test_config_defaults() -> None:
         assert config.prompt_registration_duplicate_behavior == "warn"
 
         # Tool enablement defaults
-        assert config.tool_config.enable_predictive_tools is True
+        assert config.tool_config.enable_predictive_tools is False
         assert config.tool_config.enable_jira_tools is False
         assert config.tool_config.enable_confluence_tools is False
         assert config.tool_config.enable_microsoft_graph_tools is False
@@ -63,10 +63,6 @@ def test_config_defaults() -> None:
         assert config.tool_config.enable_vdb_tools is False
         assert config.tool_config.enable_code_execution_tools is False
         assert config.tool_config.enable_optimization_tools is False
-
-        # OAuth provider configuration defaults
-        assert config.tool_config.is_atlassian_oauth_provider_configured is False
-        assert config.tool_config.is_microsoft_oauth_provider_configured is False
 
         # Clean up the cached config after the test
         config_module._config = None
@@ -111,7 +107,7 @@ class TestDuplicateBehavior:
 
 
 class TestToolConfiguration:
-    """Test tool enablement and OAuth configuration."""
+    """Test tool enablement configuration."""
 
     def test_tool_enablement_defaults(self) -> None:
         """Test that tool enablement defaults are correct."""
@@ -119,7 +115,7 @@ class TestToolConfiguration:
             config_module._config = None
             config = MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
 
-            assert config.tool_config.enable_predictive_tools is True
+            assert config.tool_config.enable_predictive_tools is False
             assert config.tool_config.enable_jira_tools is False
             assert config.tool_config.enable_confluence_tools is False
             assert config.tool_config.enable_microsoft_graph_tools is False
@@ -155,100 +151,6 @@ class TestToolConfiguration:
         with patch.dict(os.environ, {env_var: "false"}, clear=False):
             config = MCPServerConfig()
             assert getattr(config.tool_config, tool_name) is False
-
-    def test_atlassian_oauth_configured_via_provider_flag(self) -> None:
-        """Test is_atlassian_oauth_configured when provider flag is set."""
-        with patch.dict(
-            os.environ, {"IS_ATLASSIAN_OAUTH_PROVIDER_CONFIGURED": "true"}, clear=False
-        ):
-            config = MCPServerConfig()
-            assert config.tool_config.is_atlassian_oauth_configured is True
-
-    def test_atlassian_oauth_configured_via_env_vars(self) -> None:
-        """Test is_atlassian_oauth_configured when env vars are set."""
-        with patch.dict(
-            os.environ,
-            {"ATLASSIAN_CLIENT_ID": "test_id", "ATLASSIAN_CLIENT_SECRET": "test_secret"},
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            assert config.tool_config.is_atlassian_oauth_configured is True
-
-    def test_atlassian_oauth_not_configured(self) -> None:
-        """Test is_atlassian_oauth_configured when not configured."""
-        with patch.dict(os.environ, clear=True):
-            config_module._config = None
-            config = MCPServerConfig(_env_file=None)
-            assert config.tool_config.is_atlassian_oauth_configured is False
-            config_module._config = None
-
-    def test_atlassian_oauth_partial_env_vars(self) -> None:
-        """Test is_atlassian_oauth_configured with only one env var set."""
-        with patch.dict(os.environ, {"ATLASSIAN_CLIENT_ID": "test_id"}, clear=False):
-            config = MCPServerConfig()
-            assert config.tool_config.is_atlassian_oauth_configured is False
-
-    def test_gdrive_oauth_configured_via_provider_flag(self) -> None:
-        """Test is_google_oauth_configured when provider flag is set."""
-        with patch.dict(os.environ, {"IS_GOOGLE_OAUTH_PROVIDER_CONFIGURED": "true"}, clear=False):
-            config = MCPServerConfig()
-            assert config.tool_config.is_google_oauth_configured is True
-
-    def test_gdrive_oauth_configured_via_env_vars(self) -> None:
-        """Test is_google_oauth_configured when env vars are set."""
-        with patch.dict(
-            os.environ,
-            {"GOOGLE_CLIENT_ID": "test_id", "GOOGLE_CLIENT_SECRET": "test_secret"},
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            assert config.tool_config.is_google_oauth_configured is True
-
-    def test_gdrive_oauth_not_configured(self) -> None:
-        """Test is_google_oauth_configured when not configured."""
-        with patch.dict(os.environ, clear=True):
-            config_module._config = None
-            config = MCPServerConfig(_env_file=None)
-            assert config.tool_config.is_google_oauth_configured is False
-            config_module._config = None
-
-    def test_gdrive_oauth_partial_env_vars(self) -> None:
-        """Test is_google_oauth_configured with only one env var set."""
-        with patch.dict(os.environ, {"GOOGLE_CLIENT_ID": "test_id"}, clear=False):
-            config = MCPServerConfig()
-            assert config.tool_config.is_google_oauth_configured is False
-
-    def test_microsoft_oauth_configured_via_provider_flag(self) -> None:
-        """Test is_microsoft_oauth_configured when provider flag is set."""
-        with patch.dict(
-            os.environ, {"IS_MICROSOFT_OAUTH_PROVIDER_CONFIGURED": "true"}, clear=False
-        ):
-            config = MCPServerConfig()
-            assert config.tool_config.is_microsoft_oauth_configured is True
-
-    def test_microsoft_oauth_configured_via_env_vars(self) -> None:
-        """Test is_microsoft_oauth_configured when env vars are set."""
-        with patch.dict(
-            os.environ,
-            {"MICROSOFT_CLIENT_ID": "test_id", "MICROSOFT_CLIENT_SECRET": "test_secret"},
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            assert config.tool_config.is_microsoft_oauth_configured is True
-
-    def test_microsoft_oauth_not_configured(self) -> None:
-        """Test is_microsoft_oauth_configured when not configured."""
-        with patch.dict(os.environ, clear=True):
-            config_module._config = None
-            config = MCPServerConfig(_env_file=None)
-            assert config.tool_config.is_microsoft_oauth_configured is False
-            config_module._config = None
-
-    def test_microsoft_oauth_partial_env_vars(self) -> None:
-        """Test is_microsoft_oauth_configured with only one env var set."""
-        with patch.dict(os.environ, {"MICROSOFT_CLIENT_ID": "test_id"}, clear=False):
-            config = MCPServerConfig()
-            assert config.tool_config.is_microsoft_oauth_configured is False
 
 
 class _MCPToolConfigNoEnvFile(MCPToolConfig):
@@ -289,7 +191,7 @@ class TestMCPCLIConfigs:
             assert config.mcp_cli_configs is None
             assert config.mcp_server_register_dynamic_tools_on_startup is False
             assert config.mcp_server_register_dynamic_prompts_on_startup is False
-            assert config.tool_config.enable_predictive_tools is True
+            assert config.tool_config.enable_predictive_tools is False
             assert config.tool_config.enable_gdrive_tools is False
             assert config.tool_config.enable_jira_tools is False
             assert config.tool_config.enable_confluence_tools is False
@@ -457,16 +359,16 @@ class TestMCPCLIConfigs:
             assert config.tool_config.enable_tavily_tools is False
             self._reset_config()
 
-    def test_predictive_tools_default_true_without_env_file(self) -> None:
-        """Regression: without loading .env, enable_predictive_tools keeps model default True."""
+    def test_predictive_tools_default_false_without_env_file(self) -> None:
+        """Regression: without loading .env, enable_predictive_tools keeps model default False."""
         with patch.dict(os.environ, {}, clear=True):
             self._reset_config()
             config = get_config()
-            assert config.tool_config.enable_predictive_tools is True
+            assert config.tool_config.enable_predictive_tools is False
             self._reset_config()
 
-    def test_predictive_default_true_stays_true_when_in_mcp_cli_configs(self) -> None:
-        """Predictive has default True; when in MCP_CLI_CONFIGS and no env, stays True."""
+    def test_predictive_enabled_when_in_mcp_cli_configs(self) -> None:
+        """Predictive has default False; when in MCP_CLI_CONFIGS and no env, becomes True."""
         with patch.dict(os.environ, {"MCP_CLI_CONFIGS": "predictive"}, clear=True):
             self._reset_config()
             config = get_config()

--- a/tests/drmcp/unit/test_routes.py
+++ b/tests/drmcp/unit/test_routes.py
@@ -631,9 +631,6 @@ class TestMetadataRoute:
         mock_tool_config.enable_code_execution_tools = False
         mock_tool_config.enable_optimization_tools = False
         mock_tool_config.enable_vdb_tools = False
-        mock_tool_config.is_atlassian_oauth_configured = False
-        mock_tool_config.is_google_oauth_configured = False
-        mock_tool_config.is_microsoft_oauth_configured = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config
@@ -742,9 +739,6 @@ class TestMetadataRoute:
         mock_tool_config.enable_code_execution_tools = False
         mock_tool_config.enable_optimization_tools = False
         mock_tool_config.enable_vdb_tools = False
-        mock_tool_config.is_atlassian_oauth_configured = False
-        mock_tool_config.is_google_oauth_configured = False
-        mock_tool_config.is_microsoft_oauth_configured = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config
@@ -770,20 +764,19 @@ class TestMetadataRoute:
     @patch("datarobot_genai.drmcp.core.routes.get_resource_tags")
     @patch("datarobot_genai.drmcp.core.routes.get_prompt_tags")
     @patch("datarobot_genai.drmcp.core.routes.get_tool_tags")
-    async def test_metadata_route_with_oauth_tools(
+    async def test_metadata_route_with_enabled_tools(
         self,
         mock_get_tool_tags: Mock,
         mock_get_prompt_tags: Mock,
         mock_get_resource_tags: Mock,
         mock_get_config: Mock,
     ):
-        """Test metadata route with OAuth-enabled tools."""
+        """Test metadata route reports enabled tool flags from config."""
         # Setup mocks with empty lists
         self.mock_mcp.list_tools = AsyncMock(return_value=[])
         self.mock_mcp.list_prompts = AsyncMock(return_value=[])
         self.mock_mcp.list_resources = AsyncMock(return_value=[])
 
-        # Create mock config with OAuth-enabled tools
         mock_config = Mock()
         mock_config.mcp_server_name = "test-server"
         mock_config.mcp_server_port = 8080
@@ -798,10 +791,10 @@ class TestMetadataRoute:
 
         mock_tool_config = Mock()
         mock_tool_config.enable_predictive_tools = False
-        mock_tool_config.enable_jira_tools = True  # OAuth required
-        mock_tool_config.enable_confluence_tools = True  # OAuth required
-        mock_tool_config.enable_gdrive_tools = True  # OAuth required
-        mock_tool_config.enable_microsoft_graph_tools = True  # OAuth required
+        mock_tool_config.enable_jira_tools = True
+        mock_tool_config.enable_confluence_tools = True
+        mock_tool_config.enable_gdrive_tools = True
+        mock_tool_config.enable_microsoft_graph_tools = True
         mock_tool_config.enable_perplexity_tools = False
         mock_tool_config.enable_tavily_tools = False
         mock_tool_config.enable_dr_docs_tools = False
@@ -809,9 +802,6 @@ class TestMetadataRoute:
         mock_tool_config.enable_code_execution_tools = False
         mock_tool_config.enable_optimization_tools = False
         mock_tool_config.enable_vdb_tools = False
-        mock_tool_config.is_atlassian_oauth_configured = True
-        mock_tool_config.is_google_oauth_configured = True
-        mock_tool_config.is_microsoft_oauth_configured = True
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config
@@ -824,20 +814,12 @@ class TestMetadataRoute:
         assert response.status_code == HTTPStatus.OK
         response_data = json.loads(response.body.decode("utf-8"))
 
-        # Verify OAuth tool configs (enabled from config; oauth_configured from OAuth check)
         tool_config = response_data["config"]["tool_config"]
         assert tool_config["jira"]["enabled"] is True
-        assert tool_config["jira"]["oauth_required"] is True
-        assert tool_config["jira"]["oauth_configured"] is True
         assert tool_config["confluence"]["enabled"] is True
-        assert tool_config["confluence"]["oauth_required"] is True
-        assert tool_config["confluence"]["oauth_configured"] is True
         assert tool_config["gdrive"]["enabled"] is True
-        assert tool_config["gdrive"]["oauth_required"] is True
-        assert tool_config["gdrive"]["oauth_configured"] is True
         assert tool_config["microsoft_graph"]["enabled"] is True
-        assert tool_config["microsoft_graph"]["oauth_required"] is True
-        assert tool_config["microsoft_graph"]["oauth_configured"] is True
+        assert tool_config["predictive"]["enabled"] is False
 
     @pytest.mark.asyncio
     async def test_metadata_route_error_scenario(self):
@@ -854,74 +836,3 @@ class TestMetadataRoute:
         response_data = json.loads(response.body.decode("utf-8"))
         assert "error" in response_data
         assert "Failed to retrieve metadata" in response_data["error"]
-
-    @pytest.mark.asyncio
-    @patch("datarobot_genai.drmcp.core.routes.get_config")
-    @patch("datarobot_genai.drmcp.core.routes.get_resource_tags")
-    @patch("datarobot_genai.drmcp.core.routes.get_prompt_tags")
-    @patch("datarobot_genai.drmcp.core.routes.get_tool_tags")
-    async def test_metadata_route_tool_config_oauth_not_configured(
-        self,
-        mock_get_tool_tags: Mock,
-        mock_get_prompt_tags: Mock,
-        mock_get_resource_tags: Mock,
-        mock_get_config: Mock,
-    ):
-        """Test metadata route with OAuth-required tools but OAuth not configured."""
-        # Setup mocks with empty lists
-        self.mock_mcp.list_tools = AsyncMock(return_value=[])
-        self.mock_mcp.list_prompts = AsyncMock(return_value=[])
-        self.mock_mcp.list_resources = AsyncMock(return_value=[])
-
-        # Create mock config with OAuth-required tools but OAuth not configured
-        mock_config = Mock()
-        mock_config.mcp_server_name = "test-server"
-        mock_config.mcp_server_port = 8080
-        mock_config.mcp_server_log_level = "INFO"
-        mock_config.app_log_level = "DEBUG"
-        mock_config.mount_path = "/"
-        mock_config.mcp_server_register_dynamic_tools_on_startup = False
-        mock_config.mcp_server_register_dynamic_prompts_on_startup = False
-        mock_config.tool_registration_allow_empty_schema = False
-        mock_config.tool_registration_duplicate_behavior = "warn"
-        mock_config.prompt_registration_duplicate_behavior = "warn"
-
-        mock_tool_config = Mock()
-        mock_tool_config.enable_predictive_tools = False
-        mock_tool_config.enable_jira_tools = True  # OAuth required but not configured
-        mock_tool_config.enable_confluence_tools = True  # OAuth required but not configured
-        mock_tool_config.enable_gdrive_tools = False
-        mock_tool_config.enable_microsoft_graph_tools = False
-        mock_tool_config.enable_perplexity_tools = False
-        mock_tool_config.enable_tavily_tools = False
-        mock_tool_config.enable_dr_docs_tools = False
-        mock_tool_config.enable_use_case_tools = False
-        mock_tool_config.enable_code_execution_tools = False
-        mock_tool_config.enable_optimization_tools = False
-        mock_tool_config.enable_vdb_tools = False
-        mock_tool_config.is_atlassian_oauth_configured = False  # OAuth not configured
-        mock_tool_config.is_google_oauth_configured = False
-        mock_tool_config.is_microsoft_oauth_configured = False
-
-        mock_config.tool_config = mock_tool_config
-        mock_get_config.return_value = mock_config
-
-        register_routes(self.mock_mcp)
-
-        metadata_handler = self.registered_routes["GET", "/metadata"]
-        response = await metadata_handler(self.mock_request)
-
-        assert response.status_code == HTTPStatus.OK
-        response_data = json.loads(response.body.decode("utf-8"))
-
-        # Verify tool config (enabled from config only; oauth_configured from OAuth check)
-        tool_config = response_data["config"]["tool_config"]
-        assert tool_config["jira"]["enabled"] is True
-        assert tool_config["jira"]["oauth_required"] is True
-        assert tool_config["jira"]["oauth_configured"] is False
-        assert tool_config["confluence"]["enabled"] is True
-        assert tool_config["confluence"]["oauth_required"] is True
-        assert tool_config["confluence"]["oauth_configured"] is False
-        assert tool_config["predictive"]["enabled"] is False
-        assert tool_config["predictive"]["oauth_required"] is False
-        assert tool_config["predictive"]["oauth_configured"] is None

--- a/tests/drmcp/unit/test_tool_config.py
+++ b/tests/drmcp/unit/test_tool_config.py
@@ -15,7 +15,6 @@
 """Tests for tool configuration and enablement logic."""
 
 import os
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from datarobot_genai.drmcp.core.config import MCPServerConfig
@@ -41,9 +40,7 @@ class TestToolType:
 
     def test_tool_type_is_string_enum(self) -> None:
         """Test that ToolType is a string enum."""
-        # ToolType inherits from str and Enum, so the value is a string
         assert ToolType.PREDICTIVE.value == "predictive"
-        # The enum member itself can be compared to string
         assert ToolType.PREDICTIVE == "predictive"
 
 
@@ -59,7 +56,6 @@ class TestToolConfigs:
         """Test predictive tool configuration."""
         config = TOOL_CONFIGS[ToolType.PREDICTIVE]
         assert config["name"] == "predictive"
-        assert config["oauth_check"] is None
         assert config["directory"] == "predictive"
         assert config["package_prefix"] == "datarobot_genai.drtools.predictive"
         assert config["config_field_name"] == "enable_predictive_tools"
@@ -68,7 +64,6 @@ class TestToolConfigs:
         """Test Jira tool configuration."""
         config = TOOL_CONFIGS[ToolType.JIRA]
         assert config["name"] == "jira"
-        assert config["oauth_check"] is not None
         assert config["directory"] == "jira"
         assert config["package_prefix"] == "datarobot_genai.drtools.jira"
         assert config["config_field_name"] == "enable_jira_tools"
@@ -77,7 +72,6 @@ class TestToolConfigs:
         """Test Confluence tool configuration."""
         config = TOOL_CONFIGS[ToolType.CONFLUENCE]
         assert config["name"] == "confluence"
-        assert config["oauth_check"] is not None
         assert config["directory"] == "confluence"
         assert config["package_prefix"] == "datarobot_genai.drtools.confluence"
         assert config["config_field_name"] == "enable_confluence_tools"
@@ -86,91 +80,9 @@ class TestToolConfigs:
         """Test Microsoft Graph tool configuration."""
         config = TOOL_CONFIGS[ToolType.MICROSOFT_GRAPH]
         assert config["name"] == "microsoft_graph"
-        assert config["oauth_check"] is not None
         assert config["directory"] == "microsoft_graph"
         assert config["package_prefix"] == "datarobot_genai.drtools.microsoft_graph"
         assert config["config_field_name"] == "enable_microsoft_graph_tools"
-
-    def test_use_case_tool_config(self) -> None:
-        """Test use case tool configuration."""
-        config = TOOL_CONFIGS[ToolType.USE_CASE]
-        assert config["name"] == "use_case"
-        assert config["oauth_check"] is None
-        assert config["directory"] == "use_case"
-        assert config["package_prefix"] == "datarobot_genai.drtools.use_case"
-        assert config["config_field_name"] == "enable_use_case_tools"
-
-    def test_vdb_tool_config(self) -> None:
-        """Test VDB tool configuration."""
-        config = TOOL_CONFIGS[ToolType.VDB]
-        assert config["name"] == "vdb"
-        assert config["oauth_check"] is None
-        assert config["directory"] == "vdb"
-        assert config["package_prefix"] == "datarobot_genai.drtools.vdb"
-        assert config["config_field_name"] == "enable_vdb_tools"
-
-    def test_code_execution_tool_config(self) -> None:
-        """Test code execution tool configuration."""
-        config = TOOL_CONFIGS[ToolType.CODE_EXECUTION]
-        assert config["name"] == "code_execution"
-        assert config["oauth_check"] is None
-        assert config["directory"] == "code_execution"
-        assert config["package_prefix"] == "datarobot_genai.drtools.code_execution"
-        assert config["config_field_name"] == "enable_code_execution_tools"
-
-    def test_optimization_tool_config(self) -> None:
-        """Test optimization tool configuration."""
-        config = TOOL_CONFIGS[ToolType.OPTIMIZATION]
-        assert config["name"] == "optimization"
-        assert config["oauth_check"] is None
-        assert config["directory"] == "optimization"
-        assert config["package_prefix"] == "datarobot_genai.drtools.optimization"
-        assert config["config_field_name"] == "enable_optimization_tools"
-
-    def test_jira_oauth_check_callable(self) -> None:
-        """Test that Jira OAuth check is a callable."""
-        config = TOOL_CONFIGS[ToolType.JIRA]
-        assert callable(config["oauth_check"])
-
-        # Test that it calls the config method
-        mock_config = MagicMock(spec=MCPServerConfig)
-        mock_tool_config = MagicMock()
-        mock_tool_config.is_atlassian_oauth_configured = True
-        mock_config.tool_config = mock_tool_config
-        assert config["oauth_check"](mock_config) is True
-
-        mock_tool_config.is_atlassian_oauth_configured = False
-        assert config["oauth_check"](mock_config) is False
-
-    def test_confluence_oauth_check_callable(self) -> None:
-        """Test that Confluence OAuth check is a callable."""
-        config = TOOL_CONFIGS[ToolType.CONFLUENCE]
-        assert callable(config["oauth_check"])
-
-        # Test that it calls the config method
-        mock_config = MagicMock(spec=MCPServerConfig)
-        mock_tool_config = MagicMock()
-        mock_tool_config.is_atlassian_oauth_configured = True
-        mock_config.tool_config = mock_tool_config
-        assert config["oauth_check"](mock_config) is True
-
-        mock_tool_config.is_atlassian_oauth_configured = False
-        assert config["oauth_check"](mock_config) is False
-
-    def test_microsoft_graph_oauth_check_callable(self) -> None:
-        """Test that Microsoft Graph OAuth check is a callable."""
-        config = TOOL_CONFIGS[ToolType.MICROSOFT_GRAPH]
-        assert callable(config["oauth_check"])
-
-        # Test that it calls the config method
-        mock_config = MagicMock(spec=MCPServerConfig)
-        mock_tool_config = MagicMock()
-        mock_tool_config.is_microsoft_oauth_configured = True
-        mock_config.tool_config = mock_tool_config
-        assert config["oauth_check"](mock_config) is True
-
-        mock_tool_config.is_microsoft_oauth_configured = False
-        assert config["oauth_check"](mock_config) is False
 
 
 class TestGetToolEnableConfigName:
@@ -210,152 +122,32 @@ class TestIsToolEnabled:
             config = MCPServerConfig()
             assert is_tool_enabled(ToolType.PREDICTIVE, config) is False
 
-    def test_predictive_tool_default_enabled(self) -> None:
-        """Test predictive tool default is enabled."""
+    def test_predictive_tool_default_disabled(self) -> None:
+        """Test predictive tool default is disabled."""
         with patch.dict(os.environ, clear=True):
             config = MCPServerConfig(_env_file=None)
-            assert is_tool_enabled(ToolType.PREDICTIVE, config) is True
+            assert is_tool_enabled(ToolType.PREDICTIVE, config) is False
 
-    def test_jira_tool_enabled_with_oauth(self) -> None:
-        """Test Jira tool when enabled and OAuth is configured."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_JIRA_TOOLS": "true",
-                "IS_ATLASSIAN_OAUTH_PROVIDER_CONFIGURED": "true",
-            },
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            assert is_tool_enabled(ToolType.JIRA, config) is True
-
-    def test_jira_tool_enabled_without_oauth(self) -> None:
-        """Test Jira tool when enabled but OAuth is not configured."""
+    def test_jira_tool_enabled(self) -> None:
+        """Test Jira tool when enabled."""
         with patch.dict(os.environ, {"ENABLE_JIRA_TOOLS": "true"}, clear=False):
-            config = MCPServerConfig()
-            # No OAuth configured
-            assert is_tool_enabled(ToolType.JIRA, config) is False
-
-    def test_jira_tool_enabled_with_env_vars(self) -> None:
-        """Test Jira tool when enabled and OAuth via env vars."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_JIRA_TOOLS": "true",
-                "ATLASSIAN_CLIENT_ID": "test_id",
-                "ATLASSIAN_CLIENT_SECRET": "test_secret",
-            },
-            clear=False,
-        ):
             config = MCPServerConfig()
             assert is_tool_enabled(ToolType.JIRA, config) is True
 
     def test_jira_tool_disabled(self) -> None:
         """Test Jira tool when disabled."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_JIRA_TOOLS": "false",
-                "IS_ATLASSIAN_OAUTH_PROVIDER_CONFIGURED": "true",
-            },
-            clear=False,
-        ):
+        with patch.dict(os.environ, {"ENABLE_JIRA_TOOLS": "false"}, clear=False):
             config = MCPServerConfig()
-            # Even with OAuth configured, tool should be disabled
             assert is_tool_enabled(ToolType.JIRA, config) is False
 
-    def test_confluence_tool_enabled_with_oauth(self) -> None:
-        """Test Confluence tool when enabled and OAuth is configured."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_CONFLUENCE_TOOLS": "true",
-                "IS_ATLASSIAN_OAUTH_PROVIDER_CONFIGURED": "true",
-            },
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            assert is_tool_enabled(ToolType.CONFLUENCE, config) is True
-
-    def test_confluence_tool_enabled_without_oauth(self) -> None:
-        """Test Confluence tool when enabled but OAuth is not configured."""
+    def test_confluence_tool_enabled(self) -> None:
+        """Test Confluence tool when enabled."""
         with patch.dict(os.environ, {"ENABLE_CONFLUENCE_TOOLS": "true"}, clear=False):
             config = MCPServerConfig()
-            # No OAuth configured
-            assert is_tool_enabled(ToolType.CONFLUENCE, config) is False
-
-    def test_confluence_tool_enabled_with_env_vars(self) -> None:
-        """Test Confluence tool when enabled and OAuth via env vars."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_CONFLUENCE_TOOLS": "true",
-                "ATLASSIAN_CLIENT_ID": "test_id",
-                "ATLASSIAN_CLIENT_SECRET": "test_secret",
-            },
-            clear=False,
-        ):
-            config = MCPServerConfig()
             assert is_tool_enabled(ToolType.CONFLUENCE, config) is True
 
-    def test_confluence_tool_disabled(self) -> None:
-        """Test Confluence tool when disabled."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_CONFLUENCE_TOOLS": "false",
-                "IS_ATLASSIAN_OAUTH_PROVIDER_CONFIGURED": "true",
-            },
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            # Even with OAuth configured, tool should be disabled
-            assert is_tool_enabled(ToolType.CONFLUENCE, config) is False
-
-    def test_microsoft_graph_tool_enabled_with_oauth(self) -> None:
-        """Test Microsoft Graph tool when enabled and OAuth is configured."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_MICROSOFT_GRAPH_TOOLS": "true",
-                "IS_MICROSOFT_OAUTH_PROVIDER_CONFIGURED": "true",
-            },
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            assert is_tool_enabled(ToolType.MICROSOFT_GRAPH, config) is True
-
-    def test_microsoft_graph_tool_enabled_without_oauth(self) -> None:
-        """Test Microsoft Graph tool when enabled but OAuth is not configured."""
+    def test_microsoft_graph_tool_enabled(self) -> None:
+        """Test Microsoft Graph tool when enabled."""
         with patch.dict(os.environ, {"ENABLE_MICROSOFT_GRAPH_TOOLS": "true"}, clear=False):
             config = MCPServerConfig()
-            # No OAuth configured
-            assert is_tool_enabled(ToolType.MICROSOFT_GRAPH, config) is False
-
-    def test_microsoft_graph_tool_enabled_with_env_vars(self) -> None:
-        """Test Microsoft Graph tool when enabled and OAuth via env vars."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_MICROSOFT_GRAPH_TOOLS": "true",
-                "MICROSOFT_CLIENT_ID": "test_id",
-                "MICROSOFT_CLIENT_SECRET": "test_secret",
-            },
-            clear=False,
-        ):
-            config = MCPServerConfig()
             assert is_tool_enabled(ToolType.MICROSOFT_GRAPH, config) is True
-
-    def test_microsoft_graph_tool_disabled(self) -> None:
-        """Test Microsoft Graph tool when disabled."""
-        with patch.dict(
-            os.environ,
-            {
-                "ENABLE_MICROSOFT_GRAPH_TOOLS": "false",
-                "IS_MICROSOFT_OAUTH_PROVIDER_CONFIGURED": "true",
-            },
-            clear=False,
-        ):
-            config = MCPServerConfig()
-            # Even with OAuth configured, tool should be disabled
-            assert is_tool_enabled(ToolType.MICROSOFT_GRAPH, config) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1083,7 +1083,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.99"
+version = "0.15.103"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- `drmcp`: removed OAuth provider startup gating (`IS_*_OAUTH_PROVIDER_CONFIGURED`, `is_*_oauth_configured`, and `oauth_check` in `tool_config`). Tool enablement is controlled only by `ENABLE_*_TOOLS` flags; OAuth tokens are resolved at request time.
- `drmcp`: `enable_predictive_tools` default is now `false` (opt in via env, `MCP_CLI_CONFIGS`, or runtime params). Integration and acceptance test harnesses set `ENABLE_PREDICTIVE_TOOLS=true` so predictive tool suites keep running.
- `drmcp`: `/metadata` tool config reports `enabled` only (dropped `oauth_required` / `oauth_configured`).

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: integration tools can register without OAuth pre-checks (failures move to runtime), predictive tools are off by default, and /metadata consumers lose oauth_* fields.
> 
> **Overview**
> **drmcp** tool enablement is simplified: only `ENABLE_*_TOOLS` (and `MCP_CLI_CONFIGS`) decide whether tool groups load at startup. OAuth provider flags, `is_*_oauth_configured` helpers, and per-tool `oauth_check` gating are removed—integrations like Jira/GDrive can be enabled without proving OAuth is configured up front; tokens are expected at request time.
> 
> **Predictive tools** default to **off** (`enable_predictive_tools` default `false`). Opt in via env, `MCP_CLI_CONFIGS`, or runtime params. Integration/acceptance harnesses and the local drmcp task set `ENABLE_PREDICTIVE_TOOLS=true` so existing predictive test suites keep running.
> 
> **GET `/metadata`** `tool_config` entries now expose only `enabled` (no `oauth_required` / `oauth_configured`). Tests and changelog updated; package version bumped to **0.15.103**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6189cffc22b8f0fd90866805d4ca5fe49af522. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->