### PR TITLE
[BUZZOK-29470] Instrument DR mem0 client for otel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.110
+- `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.
+
 ## 0.15.109
 - `drtools/sandbox`: added a `Sandbox` protocol and `DataRobotWorkloadSandbox` (workload-api backend) plus the `execute_code` function; credentials come from the request/config helpers (not `os.environ`), container stderr is surfaced from OTEL logs, and the security context is gated by `ENABLE_WORKLOAD_API_SECURITY_CONTEXT`.
 - `drtools.core.feature_flags`: added `is_tool_feature_enabled(flag, *, evaluator)`, the shared tool-gating policy reused by `drmcp` and global-mcp registries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.15.110
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.
 - `dragent/datarobot_otelcollector`: bridge NAT intermediate-step span context into the OTel SDK so memory and framework spans share the workflow trace instead of exporting as a separate tree. Falls back to NAT `workflow_trace_id` when the exporter bridge is unavailable.
+- `core/telemetry_nat_tracer`: patch the SDK `TracerProvider` installed by `bootstrap_otel_provider_for_datarobot()` so LangChain/LangGraph, HTTP client, and other auto-instrumentor spans join the active NAT workflow trace. Adds a single-active-run fallback when NAT `Context` is unavailable in framework worker threads.
 
 ## 0.15.109
 - `drtools/sandbox`: added a `Sandbox` protocol and `DataRobotWorkloadSandbox` (workload-api backend) plus the `execute_code` function; credentials come from the request/config helpers (not `os.environ`), container stderr is surfaced from OTEL logs, and the security context is gated by `ENABLE_WORKLOAD_API_SECURITY_CONTEXT`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.110
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.
+- `dragent/datarobot_otelcollector`: bridge NAT intermediate-step span context into the OTel SDK so memory and framework spans share the workflow trace instead of exporting as a separate tree. Falls back to NAT `workflow_trace_id` when the exporter bridge is unavailable.
 
 ## 0.15.109
 - `drtools/sandbox`: added a `Sandbox` protocol and `DataRobotWorkloadSandbox` (workload-api backend) plus the `execute_code` function; credentials come from the request/config helpers (not `os.environ`), container stderr is surfaced from OTEL logs, and the security context is gated by `ENABLE_WORKLOAD_API_SECURITY_CONTEXT`.

--- a/docs/dragent/tracing.md
+++ b/docs/dragent/tracing.md
@@ -26,7 +26,7 @@ Two independent span sources reach DataRobot, each wired through its own switch:
 - **Framework auto-instrumentor spans** — spans emitted by `opentelemetry-instrumentation-crewai`, `-langchain`, `-llamaindex`, and `-openai`. Enabled by calling `instrument(framework=...)` from your own code.
 - **Mem0 memory spans** — `update_memory`, `search_memory`, and `delete_memory` spans emitted by the `dr_mem0_memory` NAT provider when `streaming_memory_agent` / `auto_memory_agent` store or retrieve long-term memory. Enabled automatically once the OTel SDK bootstrap from `instrument()` is active (same env vars as above); no extra YAML config.
 
-When both the NAT exporter and SDK bootstrap are active, `datarobot_otelcollector` mirrors NAT span hierarchy into the OTel SDK context so memory spans nest under the active workflow trace instead of exporting as a separate tree.
+When both the NAT exporter and SDK bootstrap are active, `datarobot_otelcollector` mirrors NAT span hierarchy into the OTel SDK context and the SDK bootstrap wraps the global `TracerProvider` so framework, HTTP, and memory spans nest under the active workflow trace instead of exporting as separate trees.
 
 You generally want both NAT lifecycle and framework spans; mem0 spans appear automatically when memory is configured and tracing is enabled.
 
@@ -90,5 +90,5 @@ The repo ships a minimal reproducer at [`e2e-tests/dragent/base/workflow-tracing
 
 - **Data Exploration tab is empty**: Confirm the three environment variables in the table above are set in the deployment. Both sides silently skip when any is missing.
 - **NAT lifecycle spans appear but framework spans don't**: `instrument(framework=...)` was not called, or was called after the framework imported. Move the call to the top of `register.py`.
-- **Memory spans appear in a separate trace from workflow spans**: confirm `datarobot_otelcollector` is enabled in `workflow.yaml` and `instrument()` is called in `register.py`. The exporter bridges NAT context into the SDK; without it, memory spans only join the workflow trace via a best-effort `workflow_trace_id` fallback.
+- **Framework or memory spans appear in a separate trace from workflow spans**: confirm `datarobot_otelcollector` is enabled in `workflow.yaml` and `instrument()` is called in `register.py` before the framework imports. The exporter bridges NAT context into the SDK and the bootstrap wraps the global `TracerProvider` so LangChain/LangGraph, HTTP `POST`, and memory spans share the active workflow trace.
 - **`datarobot_entity_id must be of the form 'deployment-<id>'`**: You set `datarobot_entity_id` manually without the `deployment-` prefix. Either add the prefix or omit the field inside a deployment — it auto-derives from `MLOPS_DEPLOYMENT_ID`.

--- a/docs/dragent/tracing.md
+++ b/docs/dragent/tracing.md
@@ -26,6 +26,8 @@ Two independent span sources reach DataRobot, each wired through its own switch:
 - **Framework auto-instrumentor spans** — spans emitted by `opentelemetry-instrumentation-crewai`, `-langchain`, `-llamaindex`, and `-openai`. Enabled by calling `instrument(framework=...)` from your own code.
 - **Mem0 memory spans** — `update_memory`, `search_memory`, and `delete_memory` spans emitted by the `dr_mem0_memory` NAT provider when `streaming_memory_agent` / `auto_memory_agent` store or retrieve long-term memory. Enabled automatically once the OTel SDK bootstrap from `instrument()` is active (same env vars as above); no extra YAML config.
 
+When both the NAT exporter and SDK bootstrap are active, `datarobot_otelcollector` mirrors NAT span hierarchy into the OTel SDK context so memory spans nest under the active workflow trace instead of exporting as a separate tree.
+
 You generally want both NAT lifecycle and framework spans; mem0 spans appear automatically when memory is configured and tracing is enabled.
 
 ## `workflow.yaml`: enable the NAT exporter
@@ -88,4 +90,5 @@ The repo ships a minimal reproducer at [`e2e-tests/dragent/base/workflow-tracing
 
 - **Data Exploration tab is empty**: Confirm the three environment variables in the table above are set in the deployment. Both sides silently skip when any is missing.
 - **NAT lifecycle spans appear but framework spans don't**: `instrument(framework=...)` was not called, or was called after the framework imported. Move the call to the top of `register.py`.
+- **Memory spans appear in a separate trace from workflow spans**: confirm `datarobot_otelcollector` is enabled in `workflow.yaml` and `instrument()` is called in `register.py`. The exporter bridges NAT context into the SDK; without it, memory spans only join the workflow trace via a best-effort `workflow_trace_id` fallback.
 - **`datarobot_entity_id must be of the form 'deployment-<id>'`**: You set `datarobot_entity_id` manually without the `deployment-` prefix. Either add the prefix or omit the field inside a deployment — it auto-derives from `MLOPS_DEPLOYMENT_ID`.

--- a/docs/dragent/tracing.md
+++ b/docs/dragent/tracing.md
@@ -24,8 +24,9 @@ Two independent span sources reach DataRobot, each wired through its own switch:
 
 - **NAT lifecycle spans** — workflow runs, tool calls, and other `IntermediateStep`-derived events NAT emits as your `workflow.yaml` executes. Enabled by a block in `workflow.yaml` (see below).
 - **Framework auto-instrumentor spans** — spans emitted by `opentelemetry-instrumentation-crewai`, `-langchain`, `-llamaindex`, and `-openai`. Enabled by calling `instrument(framework=...)` from your own code.
+- **Mem0 memory spans** — `update_memory`, `search_memory`, and `delete_memory` spans emitted by the `dr_mem0_memory` NAT provider when `streaming_memory_agent` / `auto_memory_agent` store or retrieve long-term memory. Enabled automatically once the OTel SDK bootstrap from `instrument()` is active (same env vars as above); no extra YAML config.
 
-You generally want both: wire the YAML side for NAT lifecycle and the Python side for framework internals.
+You generally want both NAT lifecycle and framework spans; mem0 spans appear automatically when memory is configured and tracing is enabled.
 
 ## `workflow.yaml`: enable the NAT exporter
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.109"
+version = "0.15.110"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.109"
+version = "0.15.110"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/datarobot_otel.py
+++ b/src/datarobot_genai/core/datarobot_otel.py
@@ -167,6 +167,8 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
         )
         processor = BatchSpanProcessor(exporter)
 
+        from datarobot_genai.core.telemetry_nat_tracer import wrap_sdk_tracer_provider
+
         if isinstance(current, ProxyTracerProvider):
             sdk_version = _get_opentelemetry_sdk_version()
             resource = Resource.create(
@@ -177,12 +179,13 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
                     "service.name": _resolve_service_name(),
                 }
             )
-            provider = TracerProvider(resource=resource)
+            provider = wrap_sdk_tracer_provider(TracerProvider(resource=resource))
             provider.add_span_processor(processor)
             trace.set_tracer_provider(provider)
             action = "installed"
         else:  # SDK TracerProvider already installed — attach to it.
-            current.add_span_processor(processor)
+            provider = wrap_sdk_tracer_provider(current)
+            provider.add_span_processor(processor)
             action = "attached"
     except Exception:
         # Never let telemetry setup take down the agent. Log with traceback so

--- a/src/datarobot_genai/core/memory/datarobot_memory_client.py
+++ b/src/datarobot_genai/core/memory/datarobot_memory_client.py
@@ -16,6 +16,10 @@ import hashlib
 import os
 
 import httpx
+
+# Mem0 reads MEM0_TELEMETRY at import time; disable PostHog before loading mem0.
+os.environ["MEM0_TELEMETRY"] = "False"
+
 from mem0 import AsyncMemoryClient
 from mem0.client.project import AsyncProject
 from mem0.memory.telemetry import capture_client_event

--- a/src/datarobot_genai/core/telemetry_memory.py
+++ b/src/datarobot_genai/core/telemetry_memory.py
@@ -27,6 +27,8 @@ from opentelemetry.trace import SpanKind
 from opentelemetry.trace import Status
 from opentelemetry.trace import StatusCode
 
+from datarobot_genai.core.telemetry_nat_context import use_nat_workflow_trace_context
+
 _tracer = trace.get_tracer(__name__)
 
 MemoryOperationName = Literal["update_memory", "search_memory", "delete_memory"]
@@ -58,23 +60,24 @@ def trace_memory_operation(
     attributes: dict[str, Any] | None = None,
 ) -> Iterator[Span]:
     """Create a GenAI memory span following OTel semantic conventions."""
-    with _tracer.start_as_current_span(
-        operation_name,
-        kind=SpanKind.CLIENT,
-    ) as span:
-        attrs = {
-            "gen_ai.operation.name": operation_name,
-            "gen_ai.memory.store.name": store_name,
-            **(attributes or {}),
-        }
-        if store_id:
-            attrs["gen_ai.memory.store.id"] = store_id
-        _set_span_attributes(span, attrs)
-        try:
-            yield span
-            span.set_status(Status(StatusCode.OK))
-        except Exception as exc:
-            span.set_attribute("error.type", type(exc).__name__)
-            span.set_status(Status(StatusCode.ERROR, str(exc)))
-            span.record_exception(exc)
-            raise
+    with use_nat_workflow_trace_context():
+        with _tracer.start_as_current_span(
+            operation_name,
+            kind=SpanKind.CLIENT,
+        ) as span:
+            attrs = {
+                "gen_ai.operation.name": operation_name,
+                "gen_ai.memory.store.name": store_name,
+                **(attributes or {}),
+            }
+            if store_id:
+                attrs["gen_ai.memory.store.id"] = store_id
+            _set_span_attributes(span, attrs)
+            try:
+                yield span
+                span.set_status(Status(StatusCode.OK))
+            except Exception as exc:
+                span.set_attribute("error.type", type(exc).__name__)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+                raise

--- a/src/datarobot_genai/core/telemetry_memory.py
+++ b/src/datarobot_genai/core/telemetry_memory.py
@@ -1,0 +1,80 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenTelemetry helpers for GenAI memory operations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from typing import Literal
+
+from opentelemetry import trace
+from opentelemetry.trace import Span
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace import Status
+from opentelemetry.trace import StatusCode
+
+_tracer = trace.get_tracer(__name__)
+
+MemoryOperationName = Literal["update_memory", "search_memory", "delete_memory"]
+
+_MAX_QUERY_LEN = 512
+
+
+def truncate_memory_text(value: str, limit: int = _MAX_QUERY_LEN) -> str:
+    """Truncate long memory query text for span attributes."""
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3] + "..."
+
+
+def _set_span_attributes(span: Span, attributes: dict[str, Any]) -> None:
+    for key, value in attributes.items():
+        if value is None:
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            span.set_attribute(key, value)
+
+
+@contextmanager
+def trace_memory_operation(
+    operation_name: MemoryOperationName,
+    *,
+    store_name: str,
+    store_id: str | None = None,
+    attributes: dict[str, Any] | None = None,
+) -> Iterator[Span]:
+    """Create a GenAI memory span following OTel semantic conventions."""
+    with _tracer.start_as_current_span(
+        operation_name,
+        kind=SpanKind.CLIENT,
+    ) as span:
+        attrs = {
+            "gen_ai.operation.name": operation_name,
+            "gen_ai.memory.store.name": store_name,
+            **(attributes or {}),
+        }
+        if store_id:
+            attrs["gen_ai.memory.store.id"] = store_id
+        _set_span_attributes(span, attrs)
+        try:
+            yield span
+            span.set_status(Status(StatusCode.OK))
+        except Exception as exc:
+            span.set_attribute("error.type", type(exc).__name__)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
+            raise

--- a/src/datarobot_genai/core/telemetry_nat_context.py
+++ b/src/datarobot_genai/core/telemetry_nat_context.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -33,34 +34,90 @@ logger = logging.getLogger(__name__)
 
 NatSpanRef = tuple[int, int]
 
-# Track NAT span hierarchy without mutating OTel context in the exporter callback.
-# SDK spans attach this parent locally inside use_nat_workflow_trace_context().
-_nat_parent_stack: ContextVar[list[NatSpanRef]] = ContextVar("nat_parent_stack", default=[])
+_lock = threading.Lock()
+# NAT exporter callbacks and memory ops can run in different asyncio tasks.
+# Key stacks by workflow_run_id so both sides see the same active NAT span.
+_run_parent_stacks: dict[str, list[NatSpanRef]] = {}
+
+# Fallback for unit tests that push/pop without a NAT workflow run id.
+_local_parent_stack: ContextVar[list[NatSpanRef]] = ContextVar("nat_local_parent_stack", default=[])
 
 
-def push_nat_span_context(*, trace_id: int, span_id: int) -> None:
-    """Record the active NAT span as the SDK parent for this execution context."""
-    stack = list(_nat_parent_stack.get())
+def _workflow_run_id_from_nat() -> str | None:
+    try:
+        from nat.builder.context import Context
+
+        return Context.get().workflow_run_id
+    except Exception:
+        logger.debug("Unable to read NAT workflow run id", exc_info=True)
+        return None
+
+
+def _stack_for_run(run_id: str | None) -> list[NatSpanRef] | None:
+    if not run_id:
+        return None
+    with _lock:
+        return _run_parent_stacks.setdefault(run_id, [])
+
+
+def push_nat_span_context(
+    *,
+    trace_id: int,
+    span_id: int,
+    run_id: str | None = None,
+) -> None:
+    """Record the active NAT span as the SDK parent for a workflow run."""
+    key = run_id or _workflow_run_id_from_nat()
+    if key:
+        stack = _stack_for_run(key)
+        assert stack is not None
+        stack.append((trace_id, span_id))
+        return
+
+    stack = list(_local_parent_stack.get())
     stack.append((trace_id, span_id))
-    _nat_parent_stack.set(stack)
+    _local_parent_stack.set(stack)
 
 
-def pop_nat_span_context() -> None:
-    """Remove one NAT span level from the current execution context."""
-    stack = list(_nat_parent_stack.get())
+def pop_nat_span_context(*, run_id: str | None = None) -> None:
+    """Remove one NAT span level for a workflow run."""
+    key = run_id or _workflow_run_id_from_nat()
+    if key:
+        with _lock:
+            stack = _run_parent_stacks.get(key)
+            if not stack:
+                return
+            stack.pop()
+            if not stack:
+                _run_parent_stacks.pop(key, None)
+        return
+
+    stack = list(_local_parent_stack.get())
     if not stack:
         return
     stack.pop()
-    _nat_parent_stack.set(stack)
+    _local_parent_stack.set(stack)
 
 
-def reset_nat_span_context() -> None:
-    """Clear any remaining NAT span levels for the current execution context."""
-    _nat_parent_stack.set([])
+def reset_nat_span_context(*, run_id: str | None = None) -> None:
+    """Clear NAT span levels for one workflow run (or the local fallback stack)."""
+    key = run_id or _workflow_run_id_from_nat()
+    if key:
+        with _lock:
+            _run_parent_stacks.pop(key, None)
+        return
+    _local_parent_stack.set([])
 
 
 def _current_nat_parent_span_context() -> SpanContext | None:
-    stack = _nat_parent_stack.get()
+    key = _workflow_run_id_from_nat()
+    stack: list[NatSpanRef] | None
+    if key:
+        with _lock:
+            stack = list(_run_parent_stacks.get(key, ()))
+    else:
+        stack = list(_local_parent_stack.get())
+
     if not stack:
         return None
     trace_id, span_id = stack[-1]
@@ -96,41 +153,42 @@ def _attach_span_context(span_context: SpanContext) -> Any:
     return otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_context)))
 
 
-@contextmanager
-def use_nat_workflow_trace_context() -> Iterator[None]:
-    """Ensure SDK spans join the active NAT workflow trace when possible.
-
-    When ``datarobot_otelcollector`` is active it keeps a NAT span stack aligned
-    with intermediate steps. This helper attaches that parent (or falls back to
-    ``workflow_trace_id``) only for the duration of the caller's scope so OTel
-    context tokens are not leaked across async boundaries.
-    """
-    current = trace.get_current_span()
-    if current.get_span_context().is_valid:
-        yield
-        return
-
+def _resolve_workflow_parent_context() -> SpanContext | None:
     parent_context = _current_nat_parent_span_context()
     if parent_context is not None:
-        token = _attach_span_context(parent_context)
-        try:
-            yield
-        finally:
-            _safe_detach(token)
-        return
+        return parent_context
 
     trace_id = _workflow_trace_id_from_nat()
     if trace_id is None:
-        yield
-        return
+        return None
 
-    fallback_context = SpanContext(
+    return SpanContext(
         trace_id=trace_id,
         span_id=uuid.uuid4().int >> 64,
         is_remote=True,
         trace_flags=TraceFlags(TraceFlags.SAMPLED),
     )
-    token = _attach_span_context(fallback_context)
+
+
+@contextmanager
+def use_nat_workflow_trace_context() -> Iterator[None]:
+    """Ensure SDK spans join the active NAT workflow trace when possible.
+
+    When ``datarobot_otelcollector`` is active it keeps a per-run NAT span stack
+    aligned with intermediate steps. This helper attaches that parent (or falls
+    back to ``workflow_trace_id``) only for the duration of the caller's scope.
+    """
+    parent_context = _resolve_workflow_parent_context()
+    if parent_context is None:
+        yield
+        return
+
+    current = trace.get_current_span().get_span_context()
+    if current.is_valid and current.trace_id == parent_context.trace_id:
+        yield
+        return
+
+    token = _attach_span_context(parent_context)
     try:
         yield
     finally:

--- a/src/datarobot_genai/core/telemetry_nat_context.py
+++ b/src/datarobot_genai/core/telemetry_nat_context.py
@@ -1,0 +1,107 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bridge NAT workflow trace context into the OpenTelemetry SDK context."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan
+from opentelemetry.trace import SpanContext
+from opentelemetry.trace import TraceFlags
+
+logger = logging.getLogger(__name__)
+
+# Attach tokens for NonRecordingSpan parents pushed by the NAT exporter bridge.
+_otel_context_tokens: ContextVar[list[Any]] = ContextVar("nat_otel_context_tokens", default=[])
+
+
+def push_nat_span_context(*, trace_id: int, span_id: int) -> None:
+    """Attach a NonRecordingSpan so SDK spans share NAT's trace and parent."""
+    span_context = SpanContext(
+        trace_id=trace_id,
+        span_id=span_id,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    ctx = trace.set_span_in_context(NonRecordingSpan(span_context))
+    token = otel_context.attach(ctx)
+    stack = list(_otel_context_tokens.get())
+    stack.append(token)
+    _otel_context_tokens.set(stack)
+
+
+def pop_nat_span_context() -> None:
+    """Pop one NAT-bridged OTel context level."""
+    stack = list(_otel_context_tokens.get())
+    if not stack:
+        return
+    token = stack.pop()
+    _otel_context_tokens.set(stack)
+    otel_context.detach(token)
+
+
+def reset_nat_span_context() -> None:
+    """Detach any remaining bridged OTel context levels."""
+    while _otel_context_tokens.get():
+        pop_nat_span_context()
+
+
+def _workflow_trace_id_from_nat() -> int | None:
+    try:
+        from nat.builder.context import Context
+
+        return Context.get().workflow_trace_id
+    except Exception:
+        logger.debug("Unable to read NAT workflow trace id", exc_info=True)
+        return None
+
+
+@contextmanager
+def use_nat_workflow_trace_context() -> Iterator[None]:
+    """Ensure SDK spans join the active NAT workflow trace when possible.
+
+    When ``datarobot_otelcollector`` is active it keeps the OTel SDK context
+    aligned with NAT intermediate steps. This fallback covers the gap when
+    only ``instrument()`` is configured or the exporter bridge is unavailable.
+    """
+    current = trace.get_current_span()
+    if current.get_span_context().is_valid:
+        yield
+        return
+
+    trace_id = _workflow_trace_id_from_nat()
+    if trace_id is None:
+        yield
+        return
+
+    span_context = SpanContext(
+        trace_id=trace_id,
+        span_id=uuid.uuid4().int >> 64,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_context)))
+    try:
+        yield
+    finally:
+        otel_context.detach(token)

--- a/src/datarobot_genai/core/telemetry_nat_context.py
+++ b/src/datarobot_genai/core/telemetry_nat_context.py
@@ -109,14 +109,21 @@ def reset_nat_span_context(*, run_id: str | None = None) -> None:
     _local_parent_stack.set([])
 
 
-def _current_nat_parent_span_context() -> SpanContext | None:
+def _stack_for_current_run() -> list[NatSpanRef]:
     key = _workflow_run_id_from_nat()
-    stack: list[NatSpanRef] | None
     if key:
         with _lock:
-            stack = list(_run_parent_stacks.get(key, ()))
-    else:
-        stack = list(_local_parent_stack.get())
+            return list(_run_parent_stacks.get(key, ()))
+
+    with _lock:
+        if len(_run_parent_stacks) == 1:
+            return list(next(iter(_run_parent_stacks.values())))
+
+    return list(_local_parent_stack.get())
+
+
+def _current_nat_parent_span_context() -> SpanContext | None:
+    stack = _stack_for_current_run()
 
     if not stack:
         return None

--- a/src/datarobot_genai/core/telemetry_nat_context.py
+++ b/src/datarobot_genai/core/telemetry_nat_context.py
@@ -31,39 +31,55 @@ from opentelemetry.trace import TraceFlags
 
 logger = logging.getLogger(__name__)
 
-# Attach tokens for NonRecordingSpan parents pushed by the NAT exporter bridge.
-_otel_context_tokens: ContextVar[list[Any]] = ContextVar("nat_otel_context_tokens", default=[])
+NatSpanRef = tuple[int, int]
+
+# Track NAT span hierarchy without mutating OTel context in the exporter callback.
+# SDK spans attach this parent locally inside use_nat_workflow_trace_context().
+_nat_parent_stack: ContextVar[list[NatSpanRef]] = ContextVar("nat_parent_stack", default=[])
 
 
 def push_nat_span_context(*, trace_id: int, span_id: int) -> None:
-    """Attach a NonRecordingSpan so SDK spans share NAT's trace and parent."""
-    span_context = SpanContext(
+    """Record the active NAT span as the SDK parent for this execution context."""
+    stack = list(_nat_parent_stack.get())
+    stack.append((trace_id, span_id))
+    _nat_parent_stack.set(stack)
+
+
+def pop_nat_span_context() -> None:
+    """Remove one NAT span level from the current execution context."""
+    stack = list(_nat_parent_stack.get())
+    if not stack:
+        return
+    stack.pop()
+    _nat_parent_stack.set(stack)
+
+
+def reset_nat_span_context() -> None:
+    """Clear any remaining NAT span levels for the current execution context."""
+    _nat_parent_stack.set([])
+
+
+def _current_nat_parent_span_context() -> SpanContext | None:
+    stack = _nat_parent_stack.get()
+    if not stack:
+        return None
+    trace_id, span_id = stack[-1]
+    return SpanContext(
         trace_id=trace_id,
         span_id=span_id,
         is_remote=False,
         trace_flags=TraceFlags(TraceFlags.SAMPLED),
     )
-    ctx = trace.set_span_in_context(NonRecordingSpan(span_context))
-    token = otel_context.attach(ctx)
-    stack = list(_otel_context_tokens.get())
-    stack.append(token)
-    _otel_context_tokens.set(stack)
 
 
-def pop_nat_span_context() -> None:
-    """Pop one NAT-bridged OTel context level."""
-    stack = list(_otel_context_tokens.get())
-    if not stack:
-        return
-    token = stack.pop()
-    _otel_context_tokens.set(stack)
-    otel_context.detach(token)
-
-
-def reset_nat_span_context() -> None:
-    """Detach any remaining bridged OTel context levels."""
-    while _otel_context_tokens.get():
-        pop_nat_span_context()
+def _safe_detach(token: object) -> None:
+    try:
+        otel_context.detach(token)
+    except ValueError:
+        logger.debug(
+            "Skipping OTel context detach for token from a different execution context",
+            exc_info=True,
+        )
 
 
 def _workflow_trace_id_from_nat() -> int | None:
@@ -76,17 +92,31 @@ def _workflow_trace_id_from_nat() -> int | None:
         return None
 
 
+def _attach_span_context(span_context: SpanContext) -> Any:
+    return otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_context)))
+
+
 @contextmanager
 def use_nat_workflow_trace_context() -> Iterator[None]:
     """Ensure SDK spans join the active NAT workflow trace when possible.
 
-    When ``datarobot_otelcollector`` is active it keeps the OTel SDK context
-    aligned with NAT intermediate steps. This fallback covers the gap when
-    only ``instrument()`` is configured or the exporter bridge is unavailable.
+    When ``datarobot_otelcollector`` is active it keeps a NAT span stack aligned
+    with intermediate steps. This helper attaches that parent (or falls back to
+    ``workflow_trace_id``) only for the duration of the caller's scope so OTel
+    context tokens are not leaked across async boundaries.
     """
     current = trace.get_current_span()
     if current.get_span_context().is_valid:
         yield
+        return
+
+    parent_context = _current_nat_parent_span_context()
+    if parent_context is not None:
+        token = _attach_span_context(parent_context)
+        try:
+            yield
+        finally:
+            _safe_detach(token)
         return
 
     trace_id = _workflow_trace_id_from_nat()
@@ -94,14 +124,14 @@ def use_nat_workflow_trace_context() -> Iterator[None]:
         yield
         return
 
-    span_context = SpanContext(
+    fallback_context = SpanContext(
         trace_id=trace_id,
         span_id=uuid.uuid4().int >> 64,
         is_remote=True,
         trace_flags=TraceFlags(TraceFlags.SAMPLED),
     )
-    token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_context)))
+    token = _attach_span_context(fallback_context)
     try:
         yield
     finally:
-        otel_context.detach(token)
+        _safe_detach(token)

--- a/src/datarobot_genai/core/telemetry_nat_tracer.py
+++ b/src/datarobot_genai/core/telemetry_nat_tracer.py
@@ -1,0 +1,134 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TracerProvider wrapper that parents SDK spans under the active NAT workflow trace."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import Any
+
+from opentelemetry import context as otel_context
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.trace import Link
+from opentelemetry.trace import Span
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace import Tracer
+from opentelemetry.util.types import Attributes
+
+from datarobot_genai.core.telemetry_nat_context import use_nat_workflow_trace_context
+
+
+class NatWorkflowTracer(Tracer):
+    """Tracer that joins SDK spans to the active NAT workflow trace when possible."""
+
+    def __init__(self, delegate: Tracer) -> None:
+        self._delegate = delegate
+
+    def start_span(
+        self,
+        name: str,
+        context: otel_context.Context | None = None,
+        kind: SpanKind = SpanKind.INTERNAL,
+        attributes: Attributes = None,
+        links: Link | None = None,
+        start_time: int | None = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+    ) -> Span:
+        with use_nat_workflow_trace_context():
+            return self._delegate.start_span(
+                name,
+                context=context,
+                kind=kind,
+                attributes=attributes,
+                links=links,
+                start_time=start_time,
+                record_exception=record_exception,
+                set_status_on_exception=set_status_on_exception,
+            )
+
+    def start_as_current_span(
+        self,
+        name: str,
+        context: otel_context.Context | None = None,
+        kind: SpanKind = SpanKind.INTERNAL,
+        attributes: Attributes = None,
+        links: Link | None = None,
+        start_time: int | None = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+        end_on_exit: bool = True,
+    ) -> AbstractContextManager[Span]:
+        return _NatWorkflowSpanContextManager(
+            self._delegate.start_as_current_span(
+                name,
+                context=context,
+                kind=kind,
+                attributes=attributes,
+                links=links,
+                start_time=start_time,
+                record_exception=record_exception,
+                set_status_on_exception=set_status_on_exception,
+                end_on_exit=end_on_exit,
+            )
+        )
+
+
+class _NatWorkflowSpanContextManager(AbstractContextManager[Span]):
+    def __init__(self, delegate: AbstractContextManager[Span]) -> None:
+        self._delegate = delegate
+        self._nat_context: AbstractContextManager[None] | None = None
+
+    def __enter__(self) -> Span:
+        self._nat_context = use_nat_workflow_trace_context()
+        self._nat_context.__enter__()
+        return self._delegate.__enter__()
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool | None:
+        try:
+            return self._delegate.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            if self._nat_context is not None:
+                self._nat_context.__exit__(exc_type, exc_val, exc_tb)
+
+
+_NAT_TRACER_WRAPPED_ATTR = "_nat_workflow_tracer_wrapped"
+
+
+def wrap_sdk_tracer_provider(provider: SDKTracerProvider) -> SDKTracerProvider:
+    """Patch an SDK provider so every tracer joins the NAT workflow trace."""
+    if getattr(provider, _NAT_TRACER_WRAPPED_ATTR, False):
+        return provider
+
+    original_get_tracer = provider.get_tracer
+
+    def get_tracer(
+        instrumenting_module_name: str,
+        instrumenting_library_version: str | None = None,
+        schema_url: str | None = None,
+        attributes: Attributes = None,
+    ) -> Tracer:
+        return NatWorkflowTracer(
+            original_get_tracer(
+                instrumenting_module_name,
+                instrumenting_library_version,
+                schema_url,
+                attributes,
+            )
+        )
+
+    provider.get_tracer = get_tracer  # type: ignore[method-assign]
+    setattr(provider, _NAT_TRACER_WRAPPED_ATTR, True)
+    return provider

--- a/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
@@ -85,15 +85,23 @@ class DataRobotOTLPSpanAdapterExporter(OTLPSpanAdapterExporter):
     workflow span.
     """
 
+    @staticmethod
+    def _span_has_bridge_context(span: object | None) -> bool:
+        context = getattr(span, "context", None)
+        return bool(context and context.trace_id and context.span_id)
+
     def _process_start_event(self, event: IntermediateStep) -> None:
         super()._process_start_event(event)
         span = self._span_stack.get(event.UUID)
-        if span and span.context:
+        if self._span_has_bridge_context(span):
             push_nat_span_context(trace_id=span.context.trace_id, span_id=span.context.span_id)
 
     def _process_end_event(self, event: IntermediateStep) -> None:
-        pop_nat_span_context()
+        span = self._span_stack.get(event.UUID)
+        should_pop = self._span_has_bridge_context(span)
         super()._process_end_event(event)
+        if should_pop:
+            pop_nat_span_context()
 
     def on_complete(self) -> None:
         reset_nat_span_context()

--- a/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
@@ -56,6 +56,7 @@ from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_telemetry_exporter
 from nat.data_models.common import SerializableSecretStr
 from nat.data_models.common import get_secret_value
+from nat.data_models.intermediate_step import IntermediateStep
 from nat.data_models.telemetry_exporter import TelemetryExporterBaseConfig
 from nat.observability.mixin.batch_config_mixin import BatchConfigMixin
 from nat.observability.mixin.collector_config_mixin import CollectorConfigMixin
@@ -68,8 +69,35 @@ from datarobot_genai.core.datarobot_otel import ENTITY_ID_PREFIX
 from datarobot_genai.core.datarobot_otel import resolve_api_key_from_env
 from datarobot_genai.core.datarobot_otel import resolve_entity_id_from_env
 from datarobot_genai.core.datarobot_otel import resolve_otel_endpoint_from_env
+from datarobot_genai.core.telemetry_nat_context import pop_nat_span_context
+from datarobot_genai.core.telemetry_nat_context import push_nat_span_context
+from datarobot_genai.core.telemetry_nat_context import reset_nat_span_context
 
 logger = logging.getLogger(__name__)
+
+
+class DataRobotOTLPSpanAdapterExporter(OTLPSpanAdapterExporter):
+    """OTLP exporter that mirrors NAT span hierarchy into the OTel SDK context.
+
+    NAT lifecycle spans and SDK spans (memory, framework auto-instrumentors)
+    otherwise export as separate trace trees. This bridge keeps the SDK context
+    aligned with NAT intermediate steps so memory spans nest under the active
+    workflow span.
+    """
+
+    def _process_start_event(self, event: IntermediateStep) -> None:
+        super()._process_start_event(event)
+        span = self._span_stack.get(event.UUID)
+        if span and span.context:
+            push_nat_span_context(trace_id=span.context.trace_id, span_id=span.context.span_id)
+
+    def _process_end_event(self, event: IntermediateStep) -> None:
+        pop_nat_span_context()
+        super()._process_end_event(event)
+
+    def on_complete(self) -> None:
+        reset_nat_span_context()
+        super().on_complete()
 
 
 class DataRobotOtelCollectorTelemetryExporter(  # type: ignore[call-arg]
@@ -148,7 +176,7 @@ class DataRobotOtelCollectorTelemetryExporter(  # type: ignore[call-arg]
 async def datarobot_otelcollector_telemetry_exporter(
     config: DataRobotOtelCollectorTelemetryExporter,
     builder: Builder,
-) -> AsyncGenerator[OTLPSpanAdapterExporter, None]:
+) -> AsyncGenerator[DataRobotOTLPSpanAdapterExporter]:
     """Yield an OTLP span exporter pointed at the DataRobot OTel collector."""
     headers: dict[str, str] = {
         "X-DataRobot-Api-Key": get_secret_value(config.datarobot_api_key),
@@ -180,7 +208,7 @@ async def datarobot_otelcollector_telemetry_exporter(
         sorted(headers.keys()),
     )
 
-    yield OTLPSpanAdapterExporter(
+    yield DataRobotOTLPSpanAdapterExporter(
         endpoint=config.endpoint,
         headers=headers,
         resource_attributes=merged_resource_attributes,

--- a/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
@@ -85,6 +85,13 @@ class DataRobotOTLPSpanAdapterExporter(OTLPSpanAdapterExporter):
     workflow span.
     """
 
+    def _workflow_run_id(self) -> str | None:
+        try:
+            return self._context_state.workflow_run_id.get()
+        except Exception:
+            logger.debug("Unable to read workflow run id for NAT span bridge", exc_info=True)
+            return None
+
     @staticmethod
     def _span_has_bridge_context(span: object | None) -> bool:
         context = getattr(span, "context", None)
@@ -92,19 +99,27 @@ class DataRobotOTLPSpanAdapterExporter(OTLPSpanAdapterExporter):
 
     def _process_start_event(self, event: IntermediateStep) -> None:
         super()._process_start_event(event)
+        run_id = self._workflow_run_id()
         span = self._span_stack.get(event.UUID)
-        if self._span_has_bridge_context(span):
-            push_nat_span_context(trace_id=span.context.trace_id, span_id=span.context.span_id)
+        if run_id and self._span_has_bridge_context(span):
+            push_nat_span_context(
+                trace_id=span.context.trace_id,
+                span_id=span.context.span_id,
+                run_id=run_id,
+            )
 
     def _process_end_event(self, event: IntermediateStep) -> None:
+        run_id = self._workflow_run_id()
         span = self._span_stack.get(event.UUID)
-        should_pop = self._span_has_bridge_context(span)
+        should_pop = bool(run_id and self._span_has_bridge_context(span))
         super()._process_end_event(event)
         if should_pop:
-            pop_nat_span_context()
+            pop_nat_span_context(run_id=run_id)
 
     def on_complete(self) -> None:
-        reset_nat_span_context()
+        run_id = self._workflow_run_id()
+        if run_id:
+            reset_nat_span_context(run_id=run_id)
         super().on_complete()
 
 

--- a/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
+++ b/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
@@ -43,6 +43,11 @@ from upstream ``AutoMemoryAgentConfig`` so the two wrappers can be swapped
 without reauthoring ``workflow.yaml``.
 """
 
+import os
+
+# Mem0 reads MEM0_TELEMETRY at import time; set before any transitive mem0 import.
+os.environ["MEM0_TELEMETRY"] = "False"
+
 import logging
 import uuid
 from collections.abc import AsyncGenerator

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -368,6 +368,8 @@ def _dr_mem0_endpoint(config: DRMem0MemoryClientConfig) -> str:
 
 
 def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:
+    # Belt-and-suspenders: mem0 reads MEM0_TELEMETRY at import time.
+    os.environ["MEM0_TELEMETRY"] = "False"
     try:
         from datarobot_genai.core.memory.mem0client import Mem0Client
     except ImportError as exc:

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -318,11 +318,12 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         return memories
 
     async def remove_items(self, **kwargs: Any) -> None:
-        memory_id = kwargs.get("memory_id")
+        has_memory_id = "memory_id" in kwargs
         user_id = kwargs.get("user_id")
-        if not memory_id and not user_id:
+        if not has_memory_id and not user_id:
             return
 
+        memory_id = kwargs.get("memory_id") if has_memory_id else None
         with trace_memory_operation(
             "delete_memory",
             store_name=self._store_name,
@@ -331,7 +332,7 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
                 user_id=user_id,
                 extra={
                     **({"gen_ai.memory.record.id": memory_id} if memory_id else {}),
-                    **({"memory.delete_all": True} if user_id and not memory_id else {}),
+                    **({"memory.delete_all": True} if user_id and not has_memory_id else {}),
                 },
             ),
         ):

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -52,6 +52,9 @@ from nat.memory.models import MemoryItem
 from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 from pydantic import Field
 
+from datarobot_genai.core.telemetry_memory import trace_memory_operation
+from datarobot_genai.core.telemetry_memory import truncate_memory_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -181,12 +184,51 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
 class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
     """Adapt ``Mem0Client`` to NAT's ``MemoryEditor`` interface."""
 
-    def __init__(self, client: Any, ttl_seconds: int | None = None) -> None:
+    def __init__(
+        self,
+        client: Any,
+        ttl_seconds: int | None = None,
+        *,
+        store_name: str = "mem0",
+        store_id: str | None = None,
+    ) -> None:
         self._client = client
         self._mem0 = client._memory
         self._ttl_seconds = ttl_seconds
+        self._store_name = store_name
+        self._store_id = store_id
+
+    def _memory_span_attributes(
+        self,
+        *,
+        user_id: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        attrs: dict[str, Any] = dict(extra or {})
+        if user_id:
+            attrs["gen_ai.memory.scope"] = "user"
+            attrs["memory.user_id"] = user_id
+        return attrs
 
     async def add_items(self, items: list[MemoryItem], **kwargs: Any) -> None:
+        configured_user_id = kwargs.get("user_id")
+        resolved_user_ids = {
+            item.user_id or configured_user_id or self._mem0.user_id for item in items
+        }
+        user_id = next(iter(resolved_user_ids)) if len(resolved_user_ids) == 1 else None
+
+        with trace_memory_operation(
+            "update_memory",
+            store_name=self._store_name,
+            store_id=self._store_id,
+            attributes=self._memory_span_attributes(
+                user_id=user_id,
+                extra={"memory.item_count": len(items)},
+            ),
+        ):
+            await self._add_items_impl(items, **kwargs)
+
+    async def _add_items_impl(self, items: list[MemoryItem], **kwargs: Any) -> None:
         add_kwargs = dict(kwargs)
         output_format = add_kwargs.pop("output_format", "v1.1")
         configured_run_id = add_kwargs.pop("run_id", None)
@@ -220,6 +262,24 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
             await asyncio.gather(*coroutines)
 
     async def search(self, query: str, top_k: int = 5, **kwargs: Any) -> list[MemoryItem]:
+        user_id = kwargs.get("user_id") or self._mem0.user_id
+        with trace_memory_operation(
+            "search_memory",
+            store_name=self._store_name,
+            store_id=self._store_id,
+            attributes=self._memory_span_attributes(
+                user_id=user_id,
+                extra={
+                    "gen_ai.memory.query.text": truncate_memory_text(query),
+                    "memory.top_k": top_k,
+                },
+            ),
+        ) as span:
+            memories = await self._search_impl(query, top_k=top_k, **kwargs)
+            span.set_attribute("gen_ai.memory.search.result.count", len(memories))
+            return memories
+
+    async def _search_impl(self, query: str, top_k: int = 5, **kwargs: Any) -> list[MemoryItem]:
         user_id = kwargs.pop("user_id", None) or self._mem0.user_id
         conditions: list[dict[str, Any]] = [{"user_id": user_id}]
         for key in ("run_id", "agent_id", "app_id"):
@@ -258,6 +318,26 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         return memories
 
     async def remove_items(self, **kwargs: Any) -> None:
+        memory_id = kwargs.get("memory_id")
+        user_id = kwargs.get("user_id")
+        if not memory_id and not user_id:
+            return
+
+        with trace_memory_operation(
+            "delete_memory",
+            store_name=self._store_name,
+            store_id=self._store_id,
+            attributes=self._memory_span_attributes(
+                user_id=user_id,
+                extra={
+                    **({"gen_ai.memory.record.id": memory_id} if memory_id else {}),
+                    **({"memory.delete_all": True} if user_id and not memory_id else {}),
+                },
+            ),
+        ):
+            await self._remove_items_impl(**kwargs)
+
+    async def _remove_items_impl(self, **kwargs: Any) -> None:
         if "memory_id" in kwargs:
             await self._mem0.delete(kwargs.pop("memory_id"))
             return
@@ -336,9 +416,18 @@ async def dr_mem0_memory_client(
             "or set memory_space_id to target the DataRobot mem0 endpoint."
         )
 
+    if config.memory_space_id:
+        store_name = "datarobot-memory"
+        store_id: str | None = config.memory_space_id
+    else:
+        store_name = "mem0"
+        store_id = config.project_id or config.org_id
+
     editor: MemoryEditor = DRMem0Editor(
         _create_mem0_client(config, api_key),
         ttl_seconds=config.default_ttl_seconds,
+        store_name=store_name,
+        store_id=store_id,
     )
     if isinstance(config, RetryMixin):
         editor = patch_with_retry(

--- a/tests/core/test_datarobot_otel.py
+++ b/tests/core/test_datarobot_otel.py
@@ -23,6 +23,7 @@ from opentelemetry.trace import ProxyTracerProvider
 from opentelemetry.util._once import Once
 
 from datarobot_genai.core import datarobot_otel
+from datarobot_genai.core.telemetry_nat_tracer import _NAT_TRACER_WRAPPED_ATTR
 
 _ENV_VARS = (
     "DATAROBOT_API_TOKEN",
@@ -106,6 +107,7 @@ class TestBootstrapOtelProvider:
 
         provider = trace.get_tracer_provider()
         assert isinstance(provider, TracerProvider)
+        assert getattr(provider, _NAT_TRACER_WRAPPED_ATTR, False)
 
         # Resource attributes include service.name derived from MLOPS_DEPLOYMENT_ID.
         attrs = provider.resource.attributes
@@ -189,8 +191,9 @@ class TestBootstrapOtelProvider:
         self._set_full_env(clean_env)
         assert datarobot_otel.bootstrap_otel_provider_for_datarobot() is True
 
-        # Provider was kept (not replaced); sentinel resource attrs survive.
+        # SDK provider was kept (not replaced); get_tracer is patched for NAT joins.
         assert trace.get_tracer_provider() is pre_existing
+        assert getattr(pre_existing, _NAT_TRACER_WRAPPED_ATTR, False)
         assert pre_existing.resource.attributes["test.sentinel"] == "yes"
         assert pre_existing.resource.attributes["service.name"] == "preexisting-service"
 

--- a/tests/core/test_telemetry_memory.py
+++ b/tests/core/test_telemetry_memory.py
@@ -1,0 +1,91 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+from opentelemetry.util._once import Once
+
+from datarobot_genai.core import telemetry_memory
+
+
+@pytest.fixture
+def memory_span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER", None)
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER_SET_ONCE", Once())
+    trace.set_tracer_provider(provider)
+    monkeypatch.setattr(
+        telemetry_memory,
+        "_tracer",
+        trace.get_tracer("test.telemetry_memory"),
+    )
+    yield exporter
+    exporter.clear()
+
+
+def test_trace_memory_operation_emits_gen_ai_attributes(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    with telemetry_memory.trace_memory_operation(
+        "search_memory",
+        store_name="mem0",
+        store_id="project-123",
+        attributes={
+            "gen_ai.memory.query.text": "hello",
+            "memory.top_k": 3,
+        },
+    ):
+        pass
+
+    spans = memory_span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "search_memory"
+    assert span.kind == SpanKind.CLIENT
+    assert span.attributes["gen_ai.operation.name"] == "search_memory"
+    assert span.attributes["gen_ai.memory.store.name"] == "mem0"
+    assert span.attributes["gen_ai.memory.store.id"] == "project-123"
+    assert span.attributes["gen_ai.memory.query.text"] == "hello"
+    assert span.attributes["memory.top_k"] == 3
+
+
+def test_trace_memory_operation_records_exception(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    with pytest.raises(RuntimeError, match="boom"):
+        with telemetry_memory.trace_memory_operation(
+            "update_memory",
+            store_name="datarobot-memory",
+        ):
+            raise RuntimeError("boom")
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.attributes["error.type"] == "RuntimeError"
+    assert span.status.status_code.name == "ERROR"
+
+
+def test_truncate_memory_text() -> None:
+    assert telemetry_memory.truncate_memory_text("short") == "short"
+    long_text = "x" * 600
+    truncated = telemetry_memory.truncate_memory_text(long_text)
+    assert len(truncated) == 512
+    assert truncated.endswith("...")

--- a/tests/core/test_telemetry_nat_context.py
+++ b/tests/core/test_telemetry_nat_context.py
@@ -53,8 +53,9 @@ def test_push_and_pop_nat_span_context_nests_sdk_spans(
 
     telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=parent_span_id)
     telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=child_span_id)
-    with trace.get_tracer("test").start_as_current_span("search_memory"):
-        pass
+    with telemetry_nat_context.use_nat_workflow_trace_context():
+        with trace.get_tracer("test").start_as_current_span("search_memory"):
+            pass
     telemetry_nat_context.pop_nat_span_context()
     telemetry_nat_context.pop_nat_span_context()
 
@@ -63,11 +64,30 @@ def test_push_and_pop_nat_span_context_nests_sdk_spans(
     assert span.parent.span_id == child_span_id
 
 
-def test_reset_nat_span_context_clears_stack() -> None:
-    trace_id = uuid.uuid4().int
-    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=uuid.uuid4().int >> 64)
+def test_pop_without_push_is_safe() -> None:
+    telemetry_nat_context.pop_nat_span_context()
     telemetry_nat_context.reset_nat_span_context()
-    assert trace.get_current_span().get_span_context().is_valid is False
+
+
+def test_reset_nat_span_context_clears_stack(
+    memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_trace_id_from_nat",
+        lambda: None,
+    )
+    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=parent_span_id)
+    telemetry_nat_context.reset_nat_span_context()
+
+    with telemetry_memory.trace_memory_operation("search_memory", store_name="mem0"):
+        pass
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id != trace_id
 
 
 def test_use_nat_workflow_trace_context_joins_workflow_trace(

--- a/tests/core/test_telemetry_nat_context.py
+++ b/tests/core/test_telemetry_nat_context.py
@@ -143,3 +143,58 @@ def test_trace_memory_operation_fallback_uses_workflow_trace_id(
 
     span = memory_span_exporter.get_finished_spans()[0]
     assert span.context.trace_id == workflow_trace_id
+
+
+def test_run_id_stack_is_visible_from_memory_context(
+    memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "run-123"
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_run_id_from_nat",
+        lambda: run_id,
+    )
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_trace_id_from_nat",
+        lambda: None,
+    )
+
+    telemetry_nat_context.push_nat_span_context(
+        trace_id=trace_id,
+        span_id=parent_span_id,
+        run_id=run_id,
+    )
+    try:
+        with telemetry_memory.trace_memory_operation("delete_memory", store_name="mem0"):
+            pass
+    finally:
+        telemetry_nat_context.pop_nat_span_context(run_id=run_id)
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id == trace_id
+    assert span.parent.span_id == parent_span_id
+
+
+def test_use_nat_workflow_trace_context_overrides_unrelated_active_span(
+    memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_trace_id = uuid.uuid4().int
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_trace_id_from_nat",
+        lambda: workflow_trace_id,
+    )
+
+    with trace.get_tracer("other").start_as_current_span("framework-span"):
+        with telemetry_nat_context.use_nat_workflow_trace_context():
+            with trace.get_tracer("test").start_as_current_span("search_memory"):
+                pass
+
+    spans = {span.name: span for span in memory_span_exporter.get_finished_spans()}
+    span = spans["search_memory"]
+    assert span.context.trace_id == workflow_trace_id

--- a/tests/core/test_telemetry_nat_context.py
+++ b/tests/core/test_telemetry_nat_context.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import uuid
 
 import pytest
-from nat.builder.context import Context
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -119,9 +118,8 @@ def test_trace_memory_operation_fallback_uses_workflow_trace_id(
         lambda: workflow_trace_id,
     )
 
-    with Context.scope(workflow_trace_id=workflow_trace_id):
-        with telemetry_memory.trace_memory_operation("search_memory", store_name="mem0"):
-            pass
+    with telemetry_memory.trace_memory_operation("search_memory", store_name="mem0"):
+        pass
 
     span = memory_span_exporter.get_finished_spans()[0]
     assert span.context.trace_id == workflow_trace_id

--- a/tests/core/test_telemetry_nat_context.py
+++ b/tests/core/test_telemetry_nat_context.py
@@ -1,0 +1,127 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from nat.builder.context import Context
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._once import Once
+
+from datarobot_genai.core import telemetry_memory
+from datarobot_genai.core import telemetry_nat_context
+
+
+@pytest.fixture
+def memory_span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER", None)
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER_SET_ONCE", Once())
+    trace.set_tracer_provider(provider)
+    monkeypatch.setattr(
+        telemetry_memory,
+        "_tracer",
+        trace.get_tracer("test.telemetry_nat_context"),
+    )
+    yield exporter
+    exporter.clear()
+
+
+def test_push_and_pop_nat_span_context_nests_sdk_spans(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+    child_span_id = uuid.uuid4().int >> 64
+
+    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=parent_span_id)
+    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=child_span_id)
+    with trace.get_tracer("test").start_as_current_span("search_memory"):
+        pass
+    telemetry_nat_context.pop_nat_span_context()
+    telemetry_nat_context.pop_nat_span_context()
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id == trace_id
+    assert span.parent.span_id == child_span_id
+
+
+def test_reset_nat_span_context_clears_stack() -> None:
+    trace_id = uuid.uuid4().int
+    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=uuid.uuid4().int >> 64)
+    telemetry_nat_context.reset_nat_span_context()
+    assert trace.get_current_span().get_span_context().is_valid is False
+
+
+def test_use_nat_workflow_trace_context_joins_workflow_trace(
+    memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_trace_id = uuid.uuid4().int
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_trace_id_from_nat",
+        lambda: workflow_trace_id,
+    )
+
+    with telemetry_nat_context.use_nat_workflow_trace_context():
+        with trace.get_tracer("test").start_as_current_span("update_memory"):
+            pass
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id == workflow_trace_id
+
+
+def test_trace_memory_operation_uses_existing_nat_context(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+
+    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=parent_span_id)
+    try:
+        with telemetry_memory.trace_memory_operation("delete_memory", store_name="mem0"):
+            pass
+    finally:
+        telemetry_nat_context.pop_nat_span_context()
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id == trace_id
+    assert span.parent.span_id == parent_span_id
+
+
+def test_trace_memory_operation_fallback_uses_workflow_trace_id(
+    memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_trace_id = uuid.uuid4().int
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_trace_id_from_nat",
+        lambda: workflow_trace_id,
+    )
+
+    with Context.scope(workflow_trace_id=workflow_trace_id):
+        with telemetry_memory.trace_memory_operation("search_memory", store_name="mem0"):
+            pass
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id == workflow_trace_id

--- a/tests/core/test_telemetry_nat_context.py
+++ b/tests/core/test_telemetry_nat_context.py
@@ -145,6 +145,40 @@ def test_trace_memory_operation_fallback_uses_workflow_trace_id(
     assert span.context.trace_id == workflow_trace_id
 
 
+def test_single_active_run_fallback_without_nat_context(
+    memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "run-only"
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_run_id_from_nat",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        telemetry_nat_context,
+        "_workflow_trace_id_from_nat",
+        lambda: None,
+    )
+
+    telemetry_nat_context.push_nat_span_context(
+        trace_id=trace_id,
+        span_id=parent_span_id,
+        run_id=run_id,
+    )
+    try:
+        with telemetry_memory.trace_memory_operation("search_memory", store_name="mem0"):
+            pass
+    finally:
+        telemetry_nat_context.pop_nat_span_context(run_id=run_id)
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id == trace_id
+    assert span.parent.span_id == parent_span_id
+
+
 def test_run_id_stack_is_visible_from_memory_context(
     memory_span_exporter: InMemorySpanExporter,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/test_telemetry_nat_tracer.py
+++ b/tests/core/test_telemetry_nat_tracer.py
@@ -1,0 +1,104 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._once import Once
+
+from datarobot_genai.core import telemetry_nat_context
+from datarobot_genai.core.telemetry_nat_tracer import wrap_sdk_tracer_provider
+
+
+@pytest.fixture
+def memory_span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    wrap_sdk_tracer_provider(provider)
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER", None)
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER_SET_ONCE", Once())
+    trace.set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
+
+
+def test_wrapped_tracer_joins_pushed_nat_parent(memory_span_exporter: InMemorySpanExporter) -> None:
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+
+    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=parent_span_id)
+    try:
+        with trace.get_tracer("test.framework").start_as_current_span("invoke_agent LangGraph"):
+            pass
+    finally:
+        telemetry_nat_context.pop_nat_span_context()
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.name == "invoke_agent LangGraph"
+    assert span.context.trace_id == trace_id
+    assert span.parent.span_id == parent_span_id
+
+
+def test_wrapped_tracer_start_span_joins_nat_parent(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+
+    telemetry_nat_context.push_nat_span_context(trace_id=trace_id, span_id=parent_span_id)
+    try:
+        span = trace.get_tracer("test.http").start_span("POST")
+        span.end()
+    finally:
+        telemetry_nat_context.pop_nat_span_context()
+
+    finished = memory_span_exporter.get_finished_spans()[0]
+    assert finished.name == "POST"
+    assert finished.context.trace_id == trace_id
+    assert finished.parent.span_id == parent_span_id
+
+
+def test_single_active_run_fallback_without_nat_context(
+    memory_span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "run-only"
+    trace_id = uuid.uuid4().int
+    parent_span_id = uuid.uuid4().int >> 64
+    monkeypatch.setattr(telemetry_nat_context, "_workflow_run_id_from_nat", lambda: None)
+    monkeypatch.setattr(telemetry_nat_context, "_workflow_trace_id_from_nat", lambda: None)
+
+    telemetry_nat_context.push_nat_span_context(
+        trace_id=trace_id,
+        span_id=parent_span_id,
+        run_id=run_id,
+    )
+    try:
+        with trace.get_tracer("test.langchain").start_as_current_span(
+            "ChatPromptTemplate.workflow"
+        ):
+            pass
+    finally:
+        telemetry_nat_context.pop_nat_span_context(run_id=run_id)
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.context.trace_id == trace_id
+    assert span.parent.span_id == parent_span_id

--- a/tests/dragent/plugins/test_datarobot_otelcollector.py
+++ b/tests/dragent/plugins/test_datarobot_otelcollector.py
@@ -165,7 +165,7 @@ class TestExporterFactory:
     async def test_emits_both_datarobot_headers(self):
         cfg = _make_config()
         with patch(
-            "datarobot_genai.dragent.plugins.datarobot_otelcollector.OTLPSpanAdapterExporter"
+            "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"
         ) as mock_exporter:
             async with datarobot_otelcollector_telemetry_exporter(cfg, builder=MagicMock()):
                 pass
@@ -184,7 +184,7 @@ class TestExporterFactory:
             },
         )
         with patch(
-            "datarobot_genai.dragent.plugins.datarobot_otelcollector.OTLPSpanAdapterExporter"
+            "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"
         ) as mock_exporter:
             async with datarobot_otelcollector_telemetry_exporter(cfg, builder=MagicMock()):
                 pass
@@ -200,7 +200,7 @@ class TestExporterFactory:
         # SecretStr wrapper — OTLP exporter expects str values.
         cfg = _make_config()
         with patch(
-            "datarobot_genai.dragent.plugins.datarobot_otelcollector.OTLPSpanAdapterExporter"
+            "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"
         ) as mock_exporter:
             async with datarobot_otelcollector_telemetry_exporter(cfg, builder=MagicMock()):
                 pass
@@ -215,7 +215,7 @@ class TestExporterFactory:
         # otelcollector exporter.
         cfg = _make_config(project="my-agent")
         with patch(
-            "datarobot_genai.dragent.plugins.datarobot_otelcollector.OTLPSpanAdapterExporter"
+            "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"
         ) as mock_exporter:
             async with datarobot_otelcollector_telemetry_exporter(cfg, builder=MagicMock()):
                 pass
@@ -234,7 +234,7 @@ class TestExporterFactory:
             resource_attributes={"service.name": "override-name", "env": "prod"},
         )
         with patch(
-            "datarobot_genai.dragent.plugins.datarobot_otelcollector.OTLPSpanAdapterExporter"
+            "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"
         ) as mock_exporter:
             async with datarobot_otelcollector_telemetry_exporter(cfg, builder=MagicMock()):
                 pass

--- a/tests/dragent/plugins/test_streaming_memory_agent.py
+++ b/tests/dragent/plugins/test_streaming_memory_agent.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -128,6 +129,9 @@ async def _drain(gen: AsyncGenerator) -> list:
 
 
 class TestStreamingMemoryAgentConfig:
+    def test_disables_mem0_posthog_telemetry_on_import(self):
+        assert os.environ.get("MEM0_TELEMETRY") == "False"
+
     def test_is_subclass_of_auto_memory_agent_config(self):
         # Inheriting from upstream lets workflows swap _type between the two
         # wrappers without restating any other field.

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -20,7 +20,14 @@ from typing import Any
 import pytest
 from nat.builder.context import Context
 from nat.memory.models import MemoryItem
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+from opentelemetry.util._once import Once
 
+from datarobot_genai.core import telemetry_memory
 from datarobot_genai.nat import datarobot_mem0_memory
 from datarobot_genai.nat.datarobot_mem0_memory import Config
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
@@ -30,6 +37,23 @@ from datarobot_genai.nat.datarobot_mem0_memory import DRMem0MemoryClientConfig
 # falls back to this when no per-session user_id is supplied (e.g. direct calls
 # outside the auto-memory wrapper).
 FAKE_API_KEY_USER_ID = "fake-api-key-sha256"
+
+
+@pytest.fixture
+def memory_span_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER", None)
+    monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER_SET_ONCE", Once())
+    trace.set_tracer_provider(provider)
+    monkeypatch.setattr(
+        telemetry_memory,
+        "_tracer",
+        trace.get_tracer("test.nat_mem0_memory"),
+    )
+    yield exporter
+    exporter.clear()
 
 
 class FakeMem0Api:
@@ -789,3 +813,118 @@ async def test_registered_memory_client_allows_memory_space_id_with_explicit_nul
     # the explicit None signals the caller knows what they want.
     async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
         assert isinstance(editor, DRMem0Editor)
+
+
+async def test_registered_memory_client_sets_store_metadata_for_dr_route(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(
+        datarobot_mem0_memory, "_create_mem0_client", lambda *_a, **_k: FakeMem0Client()
+    )
+    monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
+
+    config = DRMem0MemoryClientConfig(
+        memory_space_id="space-42",
+        datarobot_endpoint="https://app.datarobot.com/api/v2",
+        datarobot_api_token="dr-token",
+    )
+
+    async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
+        assert editor._store_name == "datarobot-memory"
+        assert editor._store_id == "space-42"
+
+
+async def test_registered_memory_client_sets_store_metadata_for_mem0_saas(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(
+        datarobot_mem0_memory, "_create_mem0_client", lambda *_a, **_k: FakeMem0Client()
+    )
+    monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
+
+    config = DRMem0MemoryClientConfig(
+        api_key="secret-key",
+        org_id="org-123",
+        project_id="project-456",
+    )
+
+    async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
+        assert editor._store_name == "mem0"
+        assert editor._store_id == "project-456"
+
+
+async def test_add_items_emits_update_memory_span(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(
+        FakeMem0Client(mem0),
+        store_name="datarobot-memory",
+        store_id="space-42",
+    )
+    item = MemoryItem(
+        conversation=[{"role": "user", "content": "remember Python"}],
+        user_id="session-user-123",
+    )
+
+    await editor.add_items([item])
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.name == "update_memory"
+    assert span.kind == SpanKind.CLIENT
+    assert span.attributes["gen_ai.operation.name"] == "update_memory"
+    assert span.attributes["gen_ai.memory.store.name"] == "datarobot-memory"
+    assert span.attributes["gen_ai.memory.store.id"] == "space-42"
+    assert span.attributes["memory.item_count"] == 1
+    assert span.attributes["memory.user_id"] == "session-user-123"
+
+
+async def test_search_emits_search_memory_span(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    mem0 = FakeMem0Api()
+    mem0.search_result = {
+        "results": [
+            {
+                "input": [{"role": "user", "content": "I prefer Python"}],
+                "memory": "User prefers Python.",
+                "categories": ["preference"],
+                "metadata": {},
+            }
+        ]
+    }
+    editor = DRMem0Editor(FakeMem0Client(mem0), store_name="mem0")
+
+    await editor.search("language", top_k=2, user_id="session-user-123")
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.name == "search_memory"
+    assert span.attributes["gen_ai.operation.name"] == "search_memory"
+    assert span.attributes["gen_ai.memory.query.text"] == "language"
+    assert span.attributes["gen_ai.memory.search.result.count"] == 1
+    assert span.attributes["memory.user_id"] == "session-user-123"
+
+
+async def test_remove_items_emits_delete_memory_span(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0), store_name="mem0")
+
+    await editor.remove_items(memory_id="memory-123")
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.name == "delete_memory"
+    assert span.attributes["gen_ai.operation.name"] == "delete_memory"
+    assert span.attributes["gen_ai.memory.record.id"] == "memory-123"
+
+
+async def test_remove_items_without_target_emits_no_span(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0), store_name="mem0")
+
+    await editor.remove_items()
+
+    assert not memory_span_exporter.get_finished_spans()

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -414,6 +414,17 @@ async def test_remove_items_without_memory_id_or_user_id_is_a_noop() -> None:
     assert mem0.delete_all_calls == []
 
 
+@pytest.mark.parametrize("memory_id", [None, ""])
+async def test_remove_items_with_falsy_memory_id_still_deletes(memory_id: Any) -> None:
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0))
+
+    await editor.remove_items(memory_id=memory_id)
+
+    assert mem0.delete_calls == [memory_id]
+    assert mem0.delete_all_calls == []
+
+
 async def test_registered_memory_client_forwards_default_ttl_to_editor(
     monkeypatch: Any,
 ) -> None:
@@ -928,3 +939,16 @@ async def test_remove_items_without_target_emits_no_span(
     await editor.remove_items()
 
     assert not memory_span_exporter.get_finished_spans()
+
+
+async def test_remove_items_with_falsy_memory_id_emits_delete_span_without_record_id(
+    memory_span_exporter: InMemorySpanExporter,
+) -> None:
+    mem0 = FakeMem0Api()
+    editor = DRMem0Editor(FakeMem0Client(mem0), store_name="mem0")
+
+    await editor.remove_items(memory_id="")
+
+    span = memory_span_exporter.get_finished_spans()[0]
+    assert span.name == "delete_memory"
+    assert "gen_ai.memory.record.id" not in span.attributes

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.109"
+version = "0.15.110"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
We want tracing for mem0 operations when using dragent.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Instrument the DR mem0 client for otel. Bridge the NAT and otel SDK traces so they are grouped by the workflow.

It works using the recipe with the most recent dev build below:
<img width="1362" height="550" alt="Screenshot 2026-06-04 at 11 35 09 PM" src="https://github.com/user-attachments/assets/21c178a0-de36-452b-ac34-4ff39f5cb8e9" />


## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only wrapping around existing memory APIs; no auth or data-path changes beyond span attributes (truncated queries, user ids).
> 
> **Overview**
> Adds **OpenTelemetry GenAI memory tracing** for the NAT `dr_mem0_memory` provider so Mem0 / DataRobot Memory Service calls show up in deployment tracing alongside existing NAT and framework spans.
> 
> A new `telemetry_memory` module provides `trace_memory_operation` (CLIENT spans for `update_memory`, `search_memory`, `delete_memory`) with `gen_ai.memory.store.*` attributes, truncated query text, result counts, and optional per-user scope. **`DRMem0Editor`** wraps add/search/delete in those spans (no span when delete has no target) and the factory sets **`store_name` / `store_id`** from `memory_space_id` vs Mem0 SaaS. Version **0.15.106**, changelog, and **`docs/dragent/tracing.md`** document the automatic mem0 span source when `instrument()` is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485447a4133545b023572b125769498180703245. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->