### PR TITLE
Add AtlassianAuth with OAuth Bearer (HTTP) and API token Basic auth (config) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.108
+- `drtools` Atlassian (Jira/Confluence): added `AtlassianAuth` with OAuth Bearer (HTTP) and API token Basic auth (config). Config fields: `ATLASSIAN_API_TOKEN`, optional `ATLASSIAN_EMAIL` and `ATLASSIAN_SITE_URL` for Basic auth (cloud ID from `/_edge/tenant_info`); token alone is treated as a static OAuth Bearer token.
+- Docs: added `docs/drtools/auth-atlassian.md` for Atlassian config auth.
+- Tests: added Atlassian API token Basic auth tests for Jira/Confluence clients.
+
 ## 0.15.107
 - `drmcpbase`: MCP catalog transforms live in `datarobot_genai.drmcpbase.fastmcp_transforms` (`DataRobotMCPCatalogTransform`, `register_mcp_catalog_transform`). Removed `conditional_code_mode` and `mcp_catalog_transform` modules.
 - `drmcpbase`: in tools mode (`x-datarobot-mcp-mode=tools` or unset), optional header `x-datarobot-mcp-tools` (comma-separated tool names, exact match) filters `tools/list` and `tools/call` resolution; header names are matched case-insensitively; unknown tool names are logged and skipped.

--- a/docs/drtools/auth-atlassian.md
+++ b/docs/drtools/auth-atlassian.md
@@ -1,0 +1,34 @@
+# Atlassian (Jira / Confluence) auth
+
+Under **`AUTH_RESOLUTION_STRATEGY=http`**, Jira and Confluence use OAuth On-Behalf-Of (provider types
+`jira` / `confluence`) with header fallbacks `x-datarobot-jira-access-token` and
+`x-datarobot-confluence-access-token`. Cloud ID is resolved from
+`https://api.atlassian.com/oauth/token/accessible-resources`.
+
+Under **`AUTH_RESOLUTION_STRATEGY=config`**, set credentials on the server:
+
+> **Personal agents only:** `config` is for single-user, personal setups. Do not use it on shared or multi-tenant agents—every user would share the same server-side Atlassian and API tokens from env/config.
+
+| Variable | Required | Description |
+|---|---|---|
+| `ATLASSIAN_API_TOKEN` | Yes | OAuth access token **or** Atlassian API token |
+| `ATLASSIAN_EMAIL` | For API tokens | Account email; when set, enables API token Basic auth |
+| `ATLASSIAN_SITE_URL` | With email | Cloud site URL, e.g. `https://your-domain.atlassian.net` |
+
+**Auth mode detection (config only):**
+
+- **`ATLASSIAN_EMAIL` set** → API token Basic auth (`email:api_token`). Cloud ID comes from
+  `{ATLASSIAN_SITE_URL}/_edge/tenant_info`. REST calls use
+  `https://api.atlassian.com/ex/jira/{cloudId}/...` (or `/ex/confluence/{cloudId}/...`) with
+  `Authorization: Basic ...`.
+- **`ATLASSIAN_EMAIL` not set** → `ATLASSIAN_API_TOKEN` is treated as a static OAuth access token
+  (Bearer). Cloud ID comes from the OAuth accessible-resources endpoint.
+
+Example (API token for local scripts):
+
+```bash
+export AUTH_RESOLUTION_STRATEGY=config
+export ATLASSIAN_API_TOKEN=your-atlassian-api-token
+export ATLASSIAN_EMAIL=you@example.com
+export ATLASSIAN_SITE_URL=https://your-domain.atlassian.net
+```

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.107"
+version = "0.15.108"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.107"
+version = "0.15.108"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/core/clients/atlassian.py
+++ b/src/datarobot_genai/drtools/core/clients/atlassian.py
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Atlassian API client utilities for OAuth and cloud ID management."""
+"""Atlassian API client utilities for OAuth Bearer and API token Basic auth."""
 
+import base64
 import logging
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 from typing import Literal
 
 import httpx
 
 from datarobot_genai.drtools.core.auth import get_oauth_access_token_with_header_fallback
+from datarobot_genai.drtools.core.credentials import AuthResolutionStrategy
+from datarobot_genai.drtools.core.credentials import get_credentials
 from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 
 logger = logging.getLogger(__name__)
 
@@ -30,40 +36,149 @@ ATLASSIAN_API_BASE = "https://api.atlassian.com"
 
 # API endpoint paths
 OAUTH_ACCESSIBLE_RESOURCES_PATH = "/oauth/token/accessible-resources"
+TENANT_INFO_PATH = "/_edge/tenant_info"
 
 # Supported Atlassian service types
 AtlassianServiceType = Literal["jira", "confluence"]
 
 
-async def get_jira_access_token() -> str | ToolError:
-    """
-    OAuth access token for Jira Cloud API calls.
+class AtlassianAuthMode(StrEnum):
+    """How Atlassian REST calls are authenticated."""
 
-    Uses DataRobot On-Behalf-Of (OBO) for OAuth provider type ``jira`` (matches
-    ``AppOauth`` / Authlib provider ids used by the agent application template).
+    OAUTH_BEARER = "oauth_bearer"
+    API_TOKEN_BASIC = "api_token_basic"
 
-    If OBO is unavailable, falls back to the ``x-datarobot-jira-access-token`` request header.
+
+@dataclass(frozen=True)
+class AtlassianAuth:
+    """Resolved Atlassian credentials for Jira/Confluence clients."""
+
+    mode: AtlassianAuthMode
+    token: str
+    email: str = ""
+    site_url: str = ""
+    cloud_id: str = ""
+
+    @classmethod
+    def oauth_bearer(cls, token: str, *, cloud_id: str = "") -> "AtlassianAuth":
+        return cls(mode=AtlassianAuthMode.OAUTH_BEARER, token=token, cloud_id=cloud_id)
+
+    @classmethod
+    def api_token_basic(
+        cls,
+        *,
+        email: str,
+        api_token: str,
+        site_url: str,
+        cloud_id: str = "",
+    ) -> "AtlassianAuth":
+        return cls(
+            mode=AtlassianAuthMode.API_TOKEN_BASIC,
+            token=api_token,
+            email=email,
+            site_url=site_url,
+            cloud_id=cloud_id,
+        )
+
+    def authorization_header(self) -> str:
+        if self.mode == AtlassianAuthMode.API_TOKEN_BASIC:
+            raw = f"{self.email}:{self.token}".encode()
+            encoded = base64.b64encode(raw).decode("ascii")
+            return f"Basic {encoded}"
+        return f"Bearer {self.token}"
+
+    def http_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": self.authorization_header(),
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+
+def normalize_atlassian_site_url(site_url: str) -> str:
+    """Normalize a Jira/Confluence Cloud site URL (``https://acme.atlassian.net``)."""
+    url = site_url.strip()
+    if not url:
+        return ""
+    if not url.startswith(("http://", "https://")):
+        url = f"https://{url}"
+    return url.rstrip("/")
+
+
+def resolve_config_atlassian_auth() -> AtlassianAuth | ToolError:
+    """Build Atlassian auth from config/env when ``auth_resolution_strategy=config``."""
+    creds = get_credentials()
+    api_token = creds.atlassian_api_token.strip()
+    if not api_token:
+        return ToolError(
+            "No Atlassian API token configured. Set ATLASSIAN_API_TOKEN.",
+            kind=ToolErrorKind.AUTHENTICATION,
+        )
+
+    email = creds.atlassian_email.strip()
+    if email:
+        site_url = normalize_atlassian_site_url(creds.atlassian_site_url)
+        if not site_url:
+            return ToolError(
+                "ATLASSIAN_SITE_URL is required when ATLASSIAN_EMAIL is set "
+                "(API token Basic auth). Example: https://your-domain.atlassian.net",
+                kind=ToolErrorKind.AUTHENTICATION,
+            )
+        return AtlassianAuth.api_token_basic(
+            email=email,
+            api_token=api_token,
+            site_url=site_url,
+        )
+
+    return AtlassianAuth.oauth_bearer(api_token)
+
+
+async def get_jira_access_token() -> AtlassianAuth | ToolError:
     """
-    return await get_oauth_access_token_with_header_fallback(
+    Resolve Jira Cloud credentials (OAuth Bearer or API token Basic in config mode).
+
+    HTTP strategy: DataRobot OBO for provider ``jira``, then
+    ``x-datarobot-jira-access-token`` header fallback.
+
+    Config strategy: ``ATLASSIAN_API_TOKEN`` with optional ``ATLASSIAN_EMAIL`` /
+    ``ATLASSIAN_SITE_URL`` for API token Basic auth; token alone is treated as a
+    static OAuth access token (Bearer).
+    """
+    creds = get_credentials()
+    if creds.auth_resolution_strategy == AuthResolutionStrategy.CONFIG:
+        return resolve_config_atlassian_auth()
+
+    token = await get_oauth_access_token_with_header_fallback(
         "jira",
         display_name="Jira",
         access_token_header_segment="jira",
     )
+    if isinstance(token, ToolError):
+        return token
+    return AtlassianAuth.oauth_bearer(token)
 
 
-async def get_confluence_access_token() -> str | ToolError:
+async def get_confluence_access_token() -> AtlassianAuth | ToolError:
     """
-    OAuth access token for Confluence Cloud API calls.
+    Resolve Confluence Cloud credentials (OAuth Bearer or API token Basic in config mode).
 
-    Uses DataRobot OBO for OAuth provider type ``confluence``.
+    HTTP strategy: DataRobot OBO for provider ``confluence``, then
+    ``x-datarobot-confluence-access-token`` header fallback.
 
-    If OBO is unavailable, falls back to the ``x-datarobot-confluence-access-token`` header.
+    Config strategy: same as :func:`get_jira_access_token` (shared Atlassian site credentials).
     """
-    return await get_oauth_access_token_with_header_fallback(
+    creds = get_credentials()
+    if creds.auth_resolution_strategy == AuthResolutionStrategy.CONFIG:
+        return resolve_config_atlassian_auth()
+
+    token = await get_oauth_access_token_with_header_fallback(
         "confluence",
         display_name="Confluence",
         access_token_header_segment="confluence",
     )
+    if isinstance(token, ToolError):
+        return token
+    return AtlassianAuth.oauth_bearer(token)
 
 
 def _find_resource_by_service(
@@ -109,39 +224,55 @@ def _find_first_resource_with_id(
     return None
 
 
-async def get_atlassian_cloud_id(
+async def get_atlassian_cloud_id_from_site(
     client: httpx.AsyncClient,
-    service_type: AtlassianServiceType | None = None,
+    site_url: str,
 ) -> str:
     """
-    Get the cloud ID for the authenticated Atlassian instance.
-
-    According to Atlassian OAuth 2.0 documentation, API calls should use:
-    https://api.atlassian.com/ex/{service}/{cloudId}/rest/api/3/...
+    Resolve cloud ID for API token auth via ``{site}/_edge/tenant_info``.
 
     Args:
-        client: HTTP client with authentication headers configured
-        service_type: Optional service type to filter by (e.g., "jira", "confluence").
-            If provided, will prioritize resources matching this service type.
+        client: HTTP client with Basic auth headers configured
+        site_url: Normalized site URL (e.g. ``https://acme.atlassian.net``)
 
     Returns
     -------
-        Cloud ID string for the Atlassian instance
+        Cloud ID string for the Atlassian Cloud site
 
     Raises
     ------
-        ValueError: If cloud ID cannot be retrieved due to:
-            - No accessible resources found
-            - No cloud ID found in resources
-            - Authentication failure (401)
-            - HTTP request failure
-
-    Example:
-        ```python
-        client = httpx.AsyncClient(headers={"Authorization": f"Bearer {token}"})
-        cloud_id = await get_atlassian_cloud_id(client, service_type="jira")
-        ```
+        ValueError: If cloud ID cannot be retrieved
     """
+    url = f"{site_url.rstrip('/')}{TENANT_INFO_PATH}"
+
+    try:
+        response = await client.get(url)
+        response.raise_for_status()
+        data = response.json()
+        cloud_id = data.get("cloudId") if isinstance(data, dict) else None
+        if not cloud_id:
+            raise ValueError("No cloudId in tenant_info response")
+        logger.debug("Resolved Atlassian cloud ID from tenant_info: %s", cloud_id)
+        return str(cloud_id)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 401:
+            raise ValueError(
+                "Authentication failed for Atlassian API token. "
+                "Check ATLASSIAN_EMAIL, ATLASSIAN_API_TOKEN, and ATLASSIAN_SITE_URL."
+            ) from e
+        logger.error("HTTP error getting cloud ID from tenant_info: %s", e.response.status_code)
+        raise ValueError(
+            f"Failed to get Atlassian cloud ID from tenant_info: HTTP {e.response.status_code}"
+        ) from e
+    except httpx.RequestError as e:
+        logger.error("Request error getting cloud ID from tenant_info: %s", e)
+        raise ValueError("Failed to get Atlassian cloud ID: Network error") from e
+
+
+async def _get_oauth_cloud_id(
+    client: httpx.AsyncClient,
+    service_type: AtlassianServiceType | None,
+) -> str:
     url = f"{ATLASSIAN_API_BASE}{OAUTH_ACCESSIBLE_RESOURCES_PATH}"
 
     try:
@@ -154,22 +285,21 @@ async def get_atlassian_cloud_id(
                 "No accessible resources found. Ensure OAuth token has required scopes."
             )
 
-        # If service_type is specified, try to find matching resource
         if service_type:
             resource = _find_resource_by_service(resources, service_type)
             if resource:
                 cloud_id = resource["id"]
-                logger.debug(f"Using {service_type} cloud ID: {cloud_id}")
+                logger.debug("Using %s cloud ID: %s", service_type, cloud_id)
                 return cloud_id
             logger.warning(
-                f"No {service_type} resource found, falling back to first available resource"
+                "No %s resource found, falling back to first available resource",
+                service_type,
             )
 
-        # Fallback: use the first resource with an ID
         resource = _find_first_resource_with_id(resources)
         if resource:
             cloud_id = resource["id"]
-            logger.debug(f"Using cloud ID (fallback): {cloud_id}")
+            logger.debug("Using cloud ID (fallback): %s", cloud_id)
             return cloud_id
 
         raise ValueError("No cloud ID found in accessible resources")
@@ -179,8 +309,48 @@ async def get_atlassian_cloud_id(
                 "Authentication failed. Token may be expired. "
                 "Complete OAuth flow again: GET /oauth/atlassian/authorize"
             ) from e
-        logger.error(f"HTTP error getting cloud ID: {e.response.status_code}")
+        logger.error("HTTP error getting cloud ID: %s", e.response.status_code)
         raise ValueError(f"Failed to get Atlassian cloud ID: HTTP {e.response.status_code}") from e
     except httpx.RequestError as e:
-        logger.error(f"Request error getting cloud ID: {e}")
+        logger.error("Request error getting cloud ID: %s", e)
         raise ValueError("Failed to get Atlassian cloud ID: Network error") from e
+
+
+async def get_atlassian_cloud_id(
+    client: httpx.AsyncClient,
+    service_type: AtlassianServiceType | None = None,
+    *,
+    auth: AtlassianAuth | None = None,
+) -> str:
+    """
+    Get the cloud ID for the authenticated Atlassian instance.
+
+    OAuth Bearer: ``https://api.atlassian.com/oauth/token/accessible-resources``
+
+    API token Basic: ``{site}/_edge/tenant_info``
+
+    According to Atlassian documentation, API calls use:
+    ``https://api.atlassian.com/ex/{service}/{cloudId}/...``
+
+    Args:
+        client: HTTP client with authentication headers configured
+        service_type: Optional service type to filter OAuth resources (e.g. ``jira``)
+        auth: Optional resolved auth; when mode is API token Basic, uses ``tenant_info``
+
+    Returns
+    -------
+        Cloud ID string for the Atlassian instance
+
+    Raises
+    ------
+        ValueError: If cloud ID cannot be retrieved
+    """
+    if auth and auth.cloud_id:
+        return auth.cloud_id
+
+    if auth and auth.mode == AtlassianAuthMode.API_TOKEN_BASIC:
+        if not auth.site_url:
+            raise ValueError("Atlassian site URL is required for API token cloud ID lookup")
+        return await get_atlassian_cloud_id_from_site(client, auth.site_url)
+
+    return await _get_oauth_cloud_id(client, service_type)

--- a/src/datarobot_genai/drtools/core/clients/confluence.py
+++ b/src/datarobot_genai/drtools/core/clients/confluence.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from .atlassian import ATLASSIAN_API_BASE
+from .atlassian import AtlassianAuth
 from .atlassian import get_atlassian_cloud_id
 
 logger = logging.getLogger(__name__)
@@ -115,23 +116,19 @@ class ConfluenceClient:
 
     EXPAND_FIELDS = "body.storage,space,version"
 
-    def __init__(self, access_token: str) -> None:
+    def __init__(self, auth: str | AtlassianAuth) -> None:
         """
-        Initialize Confluence client with access token.
+        Initialize Confluence client with OAuth Bearer or API token Basic auth.
 
         Args:
-            access_token: OAuth access token for Atlassian API
+            auth: :class:`AtlassianAuth` or a raw OAuth access token string (Bearer)
         """
-        self.access_token = access_token
+        self._auth = auth if isinstance(auth, AtlassianAuth) else AtlassianAuth.oauth_bearer(auth)
         self._client = httpx.AsyncClient(
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            headers=self._auth.http_headers(),
             timeout=30.0,
         )
-        self._cloud_id: str | None = None
+        self._cloud_id: str | None = self._auth.cloud_id or None
 
     async def _get_cloud_id(self) -> str:
         """
@@ -151,7 +148,9 @@ class ConfluenceClient:
         if self._cloud_id:
             return self._cloud_id
 
-        self._cloud_id = await get_atlassian_cloud_id(self._client, service_type="confluence")
+        self._cloud_id = await get_atlassian_cloud_id(
+            self._client, service_type="confluence", auth=self._auth
+        )
         return self._cloud_id
 
     def _parse_response(self, data: dict) -> ConfluencePage:

--- a/src/datarobot_genai/drtools/core/clients/jira.py
+++ b/src/datarobot_genai/drtools/core/clients/jira.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from .atlassian import ATLASSIAN_API_BASE
+from .atlassian import AtlassianAuth
 from .atlassian import get_atlassian_cloud_id
 
 logger = logging.getLogger(__name__)
@@ -88,23 +89,19 @@ class JiraClient:
     At the moment of creating this client, official Jira SDK is not supporting async.
     """
 
-    def __init__(self, access_token: str) -> None:
+    def __init__(self, auth: str | AtlassianAuth) -> None:
         """
-        Initialize Jira client with access token.
+        Initialize Jira client with OAuth Bearer or API token Basic auth.
 
         Args:
-            access_token: OAuth access token for Atlassian API
+            auth: :class:`AtlassianAuth` or a raw OAuth access token string (Bearer)
         """
-        self.access_token = access_token
+        self._auth = auth if isinstance(auth, AtlassianAuth) else AtlassianAuth.oauth_bearer(auth)
         self._client = httpx.AsyncClient(
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            headers=self._auth.http_headers(),
             timeout=30.0,
         )
-        self._cloud_id: str | None = None
+        self._cloud_id: str | None = self._auth.cloud_id or None
 
     async def _get_cloud_id(self) -> str:
         """
@@ -124,7 +121,9 @@ class JiraClient:
         if self._cloud_id:
             return self._cloud_id
 
-        self._cloud_id = await get_atlassian_cloud_id(self._client, service_type="jira")
+        self._cloud_id = await get_atlassian_cloud_id(
+            self._client, service_type="jira", auth=self._auth
+        )
         return self._cloud_id
 
     async def _get_full_url(self, path: str) -> str:

--- a/tests/drmcp/unit/tool_clients/test_atlassian.py
+++ b/tests/drmcp/unit/tool_clients/test_atlassian.py
@@ -14,6 +14,7 @@
 
 """Tests for Atlassian API client utilities."""
 
+import base64
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -25,13 +26,40 @@ from datarobot.auth.datarobot.exceptions import OAuthServiceClientErr
 from datarobot_genai.drtools.core.auth import set_request_headers
 from datarobot_genai.drtools.core.clients.atlassian import ATLASSIAN_API_BASE
 from datarobot_genai.drtools.core.clients.atlassian import OAUTH_ACCESSIBLE_RESOURCES_PATH
+from datarobot_genai.drtools.core.clients.atlassian import TENANT_INFO_PATH
+from datarobot_genai.drtools.core.clients.atlassian import AtlassianAuth
+from datarobot_genai.drtools.core.clients.atlassian import AtlassianAuthMode
 from datarobot_genai.drtools.core.clients.atlassian import _find_first_resource_with_id
 from datarobot_genai.drtools.core.clients.atlassian import _find_resource_by_service
 from datarobot_genai.drtools.core.clients.atlassian import get_atlassian_cloud_id
+from datarobot_genai.drtools.core.clients.atlassian import get_atlassian_cloud_id_from_site
 from datarobot_genai.drtools.core.clients.atlassian import get_confluence_access_token
 from datarobot_genai.drtools.core.clients.atlassian import get_jira_access_token
+from datarobot_genai.drtools.core.clients.atlassian import normalize_atlassian_site_url
+from datarobot_genai.drtools.core.clients.atlassian import resolve_config_atlassian_auth
+from datarobot_genai.drtools.core.credentials import AuthResolutionStrategy
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+
+
+def _mock_creds(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    strategy: AuthResolutionStrategy = AuthResolutionStrategy.HTTP,
+    api_key: str = "",
+    email: str = "",
+    site_url: str = "",
+) -> MagicMock:
+    mock_creds = MagicMock()
+    mock_creds.auth_resolution_strategy = strategy
+    mock_creds.atlassian_api_token = api_key
+    mock_creds.atlassian_email = email
+    mock_creds.atlassian_site_url = site_url
+    monkeypatch.setattr(
+        "datarobot_genai.drtools.core.clients.atlassian.get_credentials",
+        lambda: mock_creds,
+    )
+    return mock_creds
 
 
 @pytest.mark.parametrize(
@@ -62,7 +90,7 @@ class TestGetAtlassianServiceAccessToken:
         provider_type: str,
         access_token_header: str,
     ) -> None:
-        """Test successful access token retrieval."""
+        """Test successful OAuth Bearer access token retrieval."""
         mock_token = "test_access_token_123"
         mock_get_access_token = AsyncMock(return_value=mock_token)
         with patch(
@@ -70,7 +98,10 @@ class TestGetAtlassianServiceAccessToken:
             mock_get_access_token,
         ):
             result = await get_token()
-        assert result == mock_token
+        assert isinstance(result, AtlassianAuth)
+        assert result.mode == AtlassianAuthMode.OAUTH_BEARER
+        assert result.token == mock_token
+        assert result.authorization_header() == f"Bearer {mock_token}"
         mock_get_access_token.assert_awaited_once_with(provider_type)
 
     @pytest.mark.asyncio
@@ -86,7 +117,8 @@ class TestGetAtlassianServiceAccessToken:
             new_callable=AsyncMock,
             return_value="",
         ):
-            result = await get_token()
+            with patch("datarobot_genai.drtools.core.auth.get_request_headers", return_value={}):
+                result = await get_token()
         assert isinstance(result, ToolError)
         assert result.kind == ToolErrorKind.AUTHENTICATION
         assert "empty access token" in str(result).lower()
@@ -106,7 +138,8 @@ class TestGetAtlassianServiceAccessToken:
             new_callable=AsyncMock,
             side_effect=oauth_error,
         ):
-            result = await get_token()
+            with patch("datarobot_genai.drtools.core.auth.get_request_headers", return_value={}):
+                result = await get_token()
         assert isinstance(result, ToolError)
         assert "Could not obtain access token" in str(result)
         assert access_token_header in str(result)
@@ -145,7 +178,84 @@ class TestGetAtlassianServiceAccessToken:
         ):
             set_request_headers({access_token_header: "from-header"})
             result = await get_token()
-        assert result == "from-header"
+        assert isinstance(result, AtlassianAuth)
+        assert result.mode == AtlassianAuthMode.OAUTH_BEARER
+        assert result.token == "from-header"
+
+
+class TestResolveConfigAtlassianAuth:
+    def test_api_token_basic_when_email_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _mock_creds(
+            monkeypatch,
+            strategy=AuthResolutionStrategy.CONFIG,
+            api_key="atlassian-api-token",
+            email="user@example.com",
+            site_url="acme.atlassian.net",
+        )
+        auth = resolve_config_atlassian_auth()
+        assert isinstance(auth, AtlassianAuth)
+        assert auth.mode == AtlassianAuthMode.API_TOKEN_BASIC
+        assert auth.email == "user@example.com"
+        assert auth.token == "atlassian-api-token"
+        assert auth.site_url == "https://acme.atlassian.net"
+
+    def test_oauth_bearer_when_email_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _mock_creds(
+            monkeypatch,
+            strategy=AuthResolutionStrategy.CONFIG,
+            api_key="oauth-access-token",
+        )
+        auth = resolve_config_atlassian_auth()
+        assert isinstance(auth, AtlassianAuth)
+        assert auth.mode == AtlassianAuthMode.OAUTH_BEARER
+        assert auth.token == "oauth-access-token"
+
+    def test_missing_api_key_returns_tool_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _mock_creds(monkeypatch, strategy=AuthResolutionStrategy.CONFIG)
+        result = resolve_config_atlassian_auth()
+        assert isinstance(result, ToolError)
+        assert result.kind == ToolErrorKind.AUTHENTICATION
+
+    def test_email_without_site_url_returns_tool_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_creds(
+            monkeypatch,
+            strategy=AuthResolutionStrategy.CONFIG,
+            api_key="atlassian-api-token",
+            email="user@example.com",
+        )
+        result = resolve_config_atlassian_auth()
+        assert isinstance(result, ToolError)
+        assert "ATLASSIAN_SITE_URL" in str(result)
+
+    @pytest.mark.asyncio
+    async def test_config_strategy_uses_api_token_basic(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_creds(
+            monkeypatch,
+            strategy=AuthResolutionStrategy.CONFIG,
+            api_key="atlassian-api-token",
+            email="user@example.com",
+            site_url="https://acme.atlassian.net",
+        )
+        auth = await get_jira_access_token()
+        assert isinstance(auth, AtlassianAuth)
+        assert auth.mode == AtlassianAuthMode.API_TOKEN_BASIC
+        expected = base64.b64encode(b"user@example.com:atlassian-api-token").decode("ascii")
+        assert auth.authorization_header() == f"Basic {expected}"
+
+
+class TestAtlassianAuthHelpers:
+    def test_normalize_site_url_adds_https(self) -> None:
+        assert normalize_atlassian_site_url("acme.atlassian.net") == "https://acme.atlassian.net"
+
+    def test_normalize_site_url_strips_trailing_slash(self) -> None:
+        assert (
+            normalize_atlassian_site_url("https://acme.atlassian.net/")
+            == "https://acme.atlassian.net"
+        )
 
 
 class TestFindResourceByService:
@@ -240,6 +350,35 @@ class TestFindFirstResourceWithId:
         assert result is None
 
 
+class TestGetAtlassianCloudIdFromSite:
+    @pytest.mark.asyncio
+    async def test_resolves_cloud_id_from_tenant_info(self) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"cloudId": "tenant-cloud-789"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        cloud_id = await get_atlassian_cloud_id_from_site(mock_client, "https://acme.atlassian.net")
+        assert cloud_id == "tenant-cloud-789"
+        mock_client.get.assert_awaited_once_with(f"https://acme.atlassian.net{TENANT_INFO_PATH}")
+
+    @pytest.mark.asyncio
+    async def test_tenant_info_401(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Unauthorized", request=MagicMock(), response=mock_response
+        )
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(ValueError, match="Authentication failed for Atlassian API token"):
+            await get_atlassian_cloud_id_from_site(mock_client, "https://acme.atlassian.net")
+
+
 class TestGetAtlassianCloudId:
     """Test get_atlassian_cloud_id function."""
 
@@ -261,6 +400,24 @@ class TestGetAtlassianCloudId:
         assert cloud_id == "cloud-jira-123"
         mock_client.get.assert_awaited_once()
         assert ATLASSIAN_API_BASE in str(mock_client.get.call_args)
+
+    @pytest.mark.asyncio
+    async def test_get_cloud_id_api_token_uses_tenant_info(self) -> None:
+        auth = AtlassianAuth.api_token_basic(
+            email="user@example.com",
+            api_token="api-token",
+            site_url="https://acme.atlassian.net",
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"cloudId": "tenant-cloud-999"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        cloud_id = await get_atlassian_cloud_id(mock_client, service_type="jira", auth=auth)
+        assert cloud_id == "tenant-cloud-999"
+        mock_client.get.assert_awaited_once_with(f"https://acme.atlassian.net{TENANT_INFO_PATH}")
 
     @pytest.mark.asyncio
     async def test_get_cloud_id_without_service_type(self) -> None:
@@ -377,11 +534,9 @@ class TestGetAtlassianCloudId:
 
         await get_atlassian_cloud_id(mock_client)
 
-        # Verify the URL was constructed correctly
         mock_client.get.assert_awaited_once()
         call_args = mock_client.get.call_args
         assert call_args is not None
-        # httpx.AsyncClient.get() is called with URL as first positional argument
         url = call_args[0][0] if call_args[0] else None
         expected_url = f"{ATLASSIAN_API_BASE}{OAUTH_ACCESSIBLE_RESOURCES_PATH}"
         assert url == expected_url

--- a/tests/drmcp/unit/tool_clients/test_jira_client.py
+++ b/tests/drmcp/unit/tool_clients/test_jira_client.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from datarobot_genai.drtools.core.clients.atlassian import AtlassianAuth
 from datarobot_genai.drtools.core.clients.jira import Issue
 from datarobot_genai.drtools.core.clients.jira import JiraClient
 
@@ -212,6 +213,37 @@ class TestJiraClient:
                 )
 
                 assert result == ["summary"]
+
+    @pytest.mark.asyncio
+    async def test_api_token_basic_auth_headers_and_cloud_id_path(
+        self, mock_cloud_id: str, mock_issue_response: dict
+    ) -> None:
+        """API token Basic auth uses tenant_info cloud ID and Basic Authorization header."""
+        import base64
+
+        auth = AtlassianAuth.api_token_basic(
+            email="user@example.com",
+            api_token="api-token-secret",
+            site_url="https://acme.atlassian.net",
+        )
+        expected_basic = base64.b64encode(b"user@example.com:api-token-secret").decode("ascii")
+
+        with patch(
+            "datarobot_genai.drtools.core.clients.jira.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ) as mock_get_cloud_id:
+            async with JiraClient(auth) as client:
+                assert client._client.headers["Authorization"] == f"Basic {expected_basic}"
+
+                async def mock_get(url: str, params: dict | None = None) -> httpx.Response:
+                    return make_response(200, mock_issue_response, mock_cloud_id)
+
+                client._client.get = mock_get
+                await client.get_jira_issue("PROJ-123")
+
+                mock_get_cloud_id.assert_awaited_once()
+                assert mock_get_cloud_id.call_args.kwargs["auth"] == auth
 
 
 class TestIssueModel:

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.107"
+version = "0.15.108"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION


<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- `drtools` Atlassian (Jira/Confluence): added `AtlassianAuth` with OAuth Bearer (HTTP) and API token Basic auth (config). Config fields: `ATLASSIAN_API_TOKEN`, optional `ATLASSIAN_EMAIL` and `ATLASSIAN_SITE_URL` for Basic auth (cloud ID from `/_edge/tenant_info`); token alone is treated as a static OAuth Bearer token.
- Docs: added `docs/drtools/auth-atlassian.md` for Atlassian config auth.
- Tests: added Atlassian API token Basic auth tests for Jira/Confluence clients.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes third-party authentication and credential resolution; config strategy stores shared Atlassian tokens server-side (documented for personal use only), which is risky if misused on multi-tenant deployments.
> 
> **Overview**
> Introduces **`AtlassianAuth`** so Jira and Confluence clients support **OAuth Bearer** (existing HTTP/OBO + header fallbacks) and **API token Basic auth** when `AUTH_RESOLUTION_STRATEGY=config`.
> 
> In config mode, **`ATLASSIAN_API_TOKEN`** is required; with **`ATLASSIAN_EMAIL`** and **`ATLASSIAN_SITE_URL`**, auth uses Basic (`email:token`) and cloud ID is resolved from `{site}/_edge/tenant_info`. Without email, the token is treated as a static OAuth Bearer and cloud ID still comes from accessible-resources.
> 
> **`get_jira_access_token`** / **`get_confluence_access_token`** now return `AtlassianAuth` instead of raw strings; **`JiraClient`** and **`ConfluenceClient`** accept `AtlassianAuth` or a legacy Bearer string and build headers via `AtlassianAuth.http_headers()`. **`get_atlassian_cloud_id`** branches on auth mode (tenant_info vs OAuth resources).
> 
> Adds **`docs/drtools/auth-atlassian.md`**, unit tests for config resolution and API-token paths, and bumps version to **0.15.108**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aba81392d45d805f79480fc784d389f18d0c5f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->