### PR TITLE
Update memory_space_id naming to agent_memory_space_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-<<<<<<< HEAD
+## 0.15.113
+
 ## 0.15.112
 - Upgrade github actions to release 0.0.9
 
 ## 0.15.111
 - Bump `datarobot-moderations` to 11.2.33 to fix a bug with `ModerationIterator`
 =======
-## 0.15.111
->>>>>>> 88ce4399 (Update and add agent memory space id to configs)
+- `nat/datarobot_mem0_memory`: renamed the `memory_space_id` config field to `agent_memory_space_id` (endpoint path follows: `{datarobot_endpoint}/memory/{agent_memory_space_id}`), and added a default factory that reads `AGENT_MEMORY_SPACE_ID` from env via `DataRobotAppFrameworkBaseSettings`. This lets a minimal `workflow.yaml` memory block target the DataRobot Memory Service when the recipe's agent runtime wires the env var, without requiring an explicit field in YAML. Error messages, docstrings, and the mutually-exclusive guardrail against `api_key` were updated to reference the new field name.
+>>>>>>> 74b27607 (CHANGELOG update)
 
 ## 0.15.110
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+<<<<<<< HEAD
 ## 0.15.112
 - Upgrade github actions to release 0.0.9
 
 ## 0.15.111
 - Bump `datarobot-moderations` to 11.2.33 to fix a bug with `ModerationIterator`
+=======
+## 0.15.111
+>>>>>>> 88ce4399 (Update and add agent memory space id to configs)
 
 ## 0.15.110
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.113
+- `nat/datarobot_mem0_memory`: renamed the `memory_space_id` config field to `agent_memory_space_id` (endpoint path follows: `{datarobot_endpoint}/memory/{agent_memory_space_id}`), and added a default factory that reads `AGENT_MEMORY_SPACE_ID` from env via `DataRobotAppFrameworkBaseSettings`. This lets a minimal `workflow.yaml` memory block target the DataRobot Memory Service when the recipe's agent runtime wires the env var, without requiring an explicit field in YAML. Error messages, docstrings, and the mutually-exclusive guardrail against `api_key` were updated to reference the new field name.
 
 ## 0.15.112
 - Upgrade github actions to release 0.0.9
 
 ## 0.15.111
 - Bump `datarobot-moderations` to 11.2.33 to fix a bug with `ModerationIterator`
-=======
-- `nat/datarobot_mem0_memory`: renamed the `memory_space_id` config field to `agent_memory_space_id` (endpoint path follows: `{datarobot_endpoint}/memory/{agent_memory_space_id}`), and added a default factory that reads `AGENT_MEMORY_SPACE_ID` from env via `DataRobotAppFrameworkBaseSettings`. This lets a minimal `workflow.yaml` memory block target the DataRobot Memory Service when the recipe's agent runtime wires the env var, without requiring an explicit field in YAML. Error messages, docstrings, and the mutually-exclusive guardrail against `api_key` were updated to reference the new field name.
->>>>>>> 74b27607 (CHANGELOG update)
 
 ## 0.15.110
 - `nat/datarobot_mem0_memory`: emit OpenTelemetry GenAI memory spans (`update_memory`, `search_memory`, `delete_memory`) for Mem0/DataRobot Memory Service access through `DRMem0Editor`, with `gen_ai.memory.store.*`, query/result counts, and per-user scope attributes. Spans export through the same OTel SDK bootstrap used by `instrument()` in `register.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-<<<<<<< HEAD
-version = "0.15.112"
-=======
-version = "0.15.111"
->>>>>>> 88ce4399 (Update and add agent memory space id to configs)
+version = "0.15.113"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
+<<<<<<< HEAD
 version = "0.15.112"
+=======
+version = "0.15.111"
+>>>>>>> 88ce4399 (Update and add agent memory space id to configs)
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -19,18 +19,16 @@ interface so ``auto_memory_agent`` can store and retrieve long-term memory.
 
 Backend selection is driven by config:
 
-* ``memory_space_id`` → the DataRobot Memory Service's mem0-compatible API,
-  reached at ``{DATAROBOT_ENDPOINT}/memory/{memory_space_id}/`` and
+* ``agent_memory_space_id`` → the DataRobot Memory Service's mem0-compatible API,
+  reached at ``{DATAROBOT_ENDPOINT}/memory/{agent_memory_space_id}/`` and
   authenticated with the DataRobot API token. See PBMP-7431 ("Agentic Memory
   Service"), section "Connect to DataRobot memory" / "API Layout".
 * ``api_key`` (or ``MEM0_API_KEY``) → Mem0's hosted SaaS at
-  ``https://api.mem0.ai``. Used when no ``memory_space_id`` is configured.
+  ``https://api.mem0.ai``. Used when no ``agent_memory_space_id`` is configured.
 
 Both routes share the same ``MemoryEditor`` adapter because the DR endpoint
 is API-compatible with mem0 — only the host and auth token differ.
 """
-
-from __future__ import annotations
 
 import asyncio
 import logging
@@ -66,11 +64,23 @@ class Config(DataRobotAppFrameworkBaseSettings):
     """
 
     mem0_api_key: str | None = None
+    agent_memory_space_id: str | None = None
     agent_memory_ttl_seconds: int | None = None
 
 
-def _get_default_mem0_api_key() -> str | None:
-    return Config().mem0_api_key
+def _get_default_memory_backend_config() -> Config:
+    return Config()
+
+
+def _get_default_mem0_api_key_for_memory_backend() -> str | None:
+    config = _get_default_memory_backend_config()
+    if config.agent_memory_space_id:
+        return None
+    return config.mem0_api_key
+
+
+def _get_default_agent_memory_space_id() -> str | None:
+    return _get_default_memory_backend_config().agent_memory_space_id
 
 
 def _get_default_ttl_seconds() -> int | None:
@@ -122,28 +132,28 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
 
     Backend selection:
 
-    * If ``memory_space_id`` is set, requests go to the DataRobot Memory
+    * If ``agent_memory_space_id`` is set, requests go to the DataRobot Memory
       Service's mem0-compatible endpoint at
-      ``{datarobot_endpoint}/memory/{memory_space_id}/`` authenticated with
+      ``{datarobot_endpoint}/memory/{agent_memory_space_id}/`` authenticated with
       ``datarobot_api_token`` (or ``DATAROBOT_API_TOKEN``).
     * Otherwise, ``api_key`` (or ``MEM0_API_KEY``) is used against Mem0's
       hosted SaaS (``host`` defaults to ``https://api.mem0.ai``).
     """
 
     api_key: str | None = Field(
-        default_factory=_get_default_mem0_api_key,
+        default_factory=_get_default_mem0_api_key_for_memory_backend,
         description="Mem0 API key used when targeting Mem0's hosted SaaS.",
     )
     host: str | None = Field(
         default=None,
         description=(
-            "Mem0 base URL for the SaaS backend. Ignored when ``memory_space_id`` is set."
+            "Mem0 base URL for the SaaS backend. Ignored when ``agent_memory_space_id`` is set."
         ),
     )
     org_id: str | None = None
     project_id: str | None = None
-    memory_space_id: str | None = Field(
-        default=None,
+    agent_memory_space_id: str | None = Field(
+        default_factory=_get_default_agent_memory_space_id,
         description=(
             "DataRobot MemorySpace ID. When set, the editor uses the DataRobot "
             "Memory Service's mem0-compatible endpoint instead of Mem0 SaaS. "
@@ -154,14 +164,14 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
         default=None,
         description=(
             "DataRobot API base URL used to build the mem0 endpoint when "
-            "``memory_space_id`` is set (e.g. ``https://app.datarobot.com/api/v2``). "
+            "``agent_memory_space_id`` is set (e.g. ``https://app.datarobot.com/api/v2``). "
             "Defaults to the ``DATAROBOT_ENDPOINT`` env var."
         ),
     )
     datarobot_api_token: str | None = Field(
         default=None,
         description=(
-            "DataRobot API token used when ``memory_space_id`` is set. "
+            "DataRobot API token used when ``agent_memory_space_id`` is set. "
             "Defaults to the ``DATAROBOT_API_TOKEN`` env var."
         ),
     )
@@ -348,10 +358,10 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
 
 
 def _dr_mem0_endpoint(config: DRMem0MemoryClientConfig) -> str:
-    """Build the DataRobot Memory Service mem0 endpoint for a memory space.
+    """Build the DataRobot Memory Service mem0 endpoint for an agent memory space.
 
     Per PBMP-7431 ("API Layout"), the DR memory service exposes a
-    mem0-compatible API at ``{DATAROBOT_ENDPOINT}/memory/{memory_space_id}``.
+    mem0-compatible API at ``{DATAROBOT_ENDPOINT}/memory/{agent_memory_space_id}``.
 
     No trailing slash: mem0's ``AsyncMemoryClient._validate_api_key`` builds
     its ping URL as ``f"{host}/v1/ping/"`` via raw string concat (it does not
@@ -362,9 +372,9 @@ def _dr_mem0_endpoint(config: DRMem0MemoryClientConfig) -> str:
     if not base:
         raise RuntimeError(
             "DataRobot endpoint is not set. Configure memory.datarobot_endpoint "
-            "or DATAROBOT_ENDPOINT when using memory_space_id."
+            "or DATAROBOT_ENDPOINT when using agent_memory_space_id."
         )
-    return f"{base.rstrip('/')}/memory/{config.memory_space_id}"
+    return f"{base.rstrip('/')}/memory/{config.agent_memory_space_id}"
 
 
 def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -> Any:
@@ -378,7 +388,7 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -
             'Install it with `pip install "datarobot-genai[nat,memory]"`.'
         ) from exc
 
-    host = _dr_mem0_endpoint(config) if config.memory_space_id else config.host
+    host = _dr_mem0_endpoint(config) if config.agent_memory_space_id else config.host
     return Mem0Client(
         api_key=api_key,
         host=host,
@@ -391,32 +401,32 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -
 async def dr_mem0_memory_client(
     config: DRMem0MemoryClientConfig, builder: Builder
 ) -> AsyncGenerator[MemoryEditor]:
-    if config.memory_space_id and config.api_key:
+    if config.agent_memory_space_id and config.api_key:
         # These point at different services with different tokens. Silently
         # picking one masks misconfiguration — e.g. a config copied from a
         # Mem0-SaaS deployment that left ``api_key`` populated, or a stray
         # ``MEM0_API_KEY`` in env hydrating ``api_key`` via its default
         # factory. Force the caller to disambiguate.
         raise RuntimeError(
-            "memory_space_id and api_key are mutually exclusive: they target "
+            "agent_memory_space_id and api_key are mutually exclusive: they target "
             "different services (DataRobot Memory Service vs. Mem0 SaaS) with "
             "different auth tokens. Set exactly one. If MEM0_API_KEY is in env, "
-            "either unset it or pass api_key=None explicitly when using memory_space_id."
+            "either unset it or pass api_key=None explicitly when using agent_memory_space_id."
         )
 
-    if config.memory_space_id:
+    if config.agent_memory_space_id:
         api_key = config.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
         if not api_key:
             raise RuntimeError(
                 "DataRobot API token is not set. Configure memory.datarobot_api_token "
-                "or DATAROBOT_API_TOKEN when using memory_space_id."
+                "or DATAROBOT_API_TOKEN when using agent_memory_space_id."
             )
     elif config.api_key:
         api_key = config.api_key
     else:
         raise RuntimeError(
             "Mem0 API key is not set. Please configure memory.api_key or MEM0_API_KEY, "
-            "or set memory_space_id to target the DataRobot mem0 endpoint."
+            "or set agent_memory_space_id to target the DataRobot mem0 endpoint."
         )
 
     if config.memory_space_id:

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -429,9 +429,9 @@ async def dr_mem0_memory_client(
             "or set agent_memory_space_id to target the DataRobot mem0 endpoint."
         )
 
-    if config.memory_space_id:
+    if config.agent_memory_space_id:
         store_name = "datarobot-memory"
-        store_id: str | None = config.memory_space_id
+        store_id: str | None = config.agent_memory_space_id
     else:
         store_name = "mem0"
         store_id = config.project_id or config.org_id

--- a/tests/nat/integration/test_dr_mem0_integration.py
+++ b/tests/nat/integration/test_dr_mem0_integration.py
@@ -19,11 +19,11 @@ Two backends are exercised against their real services:
 * **DataRobot Memory Service** — a real ``MemorySpace`` is created via the
   DataRobot SDK (``datarobot.models.memory.MemorySpace``, see
   ``public_api_client``'s ``datarobot/models/memory.py``), the provider is
-  built with ``memory_space_id=<that id>``, and add/search/remove round-trip
+  built with ``agent_memory_space_id=<that id>``, and add/search/remove round-trip
   through the path-prefixed mem0-compatible endpoint at
-  ``{DATAROBOT_ENDPOINT}/memory/{memory_space_id}/``. The space is deleted in
+  ``{DATAROBOT_ENDPOINT}/memory/{agent_memory_space_id}/``. The space is deleted in
   a finalizer so we never leak resources across runs.
-* **Mem0 SaaS** — same provider, no ``memory_space_id``, just a ``MEM0_API_KEY``.
+* **Mem0 SaaS** — same provider, no ``agent_memory_space_id``, just a ``MEM0_API_KEY``.
   Confirms the existing SaaS path still works after the routing changes.
 
 All tests skip when the required credentials aren't in the environment so
@@ -163,12 +163,12 @@ def dr_memory_space(_dr_client: Any) -> Any:
 async def test_dr_mem0_endpoint_add_search_round_trip(
     dr_memory_space: Any,
 ) -> None:
-    # GIVEN a real DR memory space and the unified provider configured to
-    # route through the path-prefixed DR mem0 endpoint (memory_space_id set,
+    # GIVEN a real DR agent memory space and the unified provider configured to
+    # route through the path-prefixed DR mem0 endpoint (agent_memory_space_id set,
     # DR token used as the auth credential).
     config = DRMem0MemoryClientConfig(
         api_key=None,
-        memory_space_id=dr_memory_space.id,
+        agent_memory_space_id=dr_memory_space.id,
         datarobot_endpoint=os.environ["DATAROBOT_ENDPOINT"],
         datarobot_api_token=os.environ["DATAROBOT_API_TOKEN"],
     )
@@ -217,11 +217,11 @@ async def test_dr_mem0_endpoint_add_search_round_trip(
 async def test_dr_mem0_endpoint_isolates_memories_per_user(
     dr_memory_space: Any,
 ) -> None:
-    # GIVEN the provider pointed at the same DR memory space, and two
+    # GIVEN the provider pointed at the same DR agent memory space, and two
     # distinct users.
     config = DRMem0MemoryClientConfig(
         api_key=None,
-        memory_space_id=dr_memory_space.id,
+        agent_memory_space_id=dr_memory_space.id,
         datarobot_endpoint=os.environ["DATAROBOT_ENDPOINT"],
         datarobot_api_token=os.environ["DATAROBOT_API_TOKEN"],
     )
@@ -272,7 +272,7 @@ async def test_dr_mem0_endpoint_isolates_memories_per_user(
 # --------------------------------------------------------------------------- #
 @skip_unless_mem0
 async def test_mem0_saas_add_search_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
-    # GIVEN the unified provider configured *without* memory_space_id — it
+    # GIVEN the unified provider configured *without* agent_memory_space_id — it
     # must fall through to the Mem0 SaaS endpoint and use MEM0_API_KEY.
     # We also ensure no stale DR creds steer the router elsewhere.
     monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
@@ -280,7 +280,7 @@ async def test_mem0_saas_add_search_round_trip(monkeypatch: pytest.MonkeyPatch) 
 
     config = DRMem0MemoryClientConfig(
         api_key=os.environ["MEM0_API_KEY"],
-        memory_space_id=None,
+        agent_memory_space_id=None,
     )
     user_id = f"nat-int-{uuid.uuid4().hex[:12]}"
     secret = f"MEM0-SAAS-INT-{uuid.uuid4().hex[:12]}"
@@ -322,7 +322,9 @@ async def test_mem0_saas_validates_credentials_on_init(
     # GIVEN a deliberately invalid Mem0 API key.
     monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
     monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
-    config = DRMem0MemoryClientConfig(api_key="m0-this-key-does-not-exist", memory_space_id=None)
+    config = DRMem0MemoryClientConfig(
+        api_key="m0-this-key-does-not-exist", agent_memory_space_id=None
+    )
 
     # WHEN we try to build the client, THEN Mem0's _validate_api_key surfaces
     # the auth failure as ValueError (it wraps the HTTPError). This proves

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -500,6 +500,33 @@ def test_memory_client_config_uses_settings_mem0_api_key(monkeypatch: Any) -> No
     assert config.api_key == "settings-key"
 
 
+def test_memory_client_config_uses_settings_default_agent_memory_space_id(
+    monkeypatch: Any,
+) -> None:
+    # GIVEN AGENT_MEMORY_SPACE_ID is set in the env by the recipe's agent runtime
+    # parameter wiring.
+    monkeypatch.setenv("AGENT_MEMORY_SPACE_ID", "space-from-runtime")
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+
+    # WHEN the NAT memory config is created without an explicit agent_memory_space_id.
+    config = DRMem0MemoryClientConfig(api_key=None)
+
+    # THEN the agent_memory_space_id defaults from settings, so minimal workflow.yaml
+    # memory blocks can still target the DataRobot Memory Service.
+    assert Config().agent_memory_space_id == "space-from-runtime"
+    assert config.agent_memory_space_id == "space-from-runtime"
+
+
+def test_memory_client_config_explicit_agent_memory_space_id_beats_env(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("AGENT_MEMORY_SPACE_ID", "space-from-runtime")
+
+    config = DRMem0MemoryClientConfig(api_key=None, agent_memory_space_id="space-explicit")
+
+    assert config.agent_memory_space_id == "space-explicit"
+
+
 def test_memory_client_config_uses_settings_default_ttl(monkeypatch: Any) -> None:
     # GIVEN AGENT_MEMORY_TTL_SECONDS is set in the env (e.g. by infra/agent.py's
     # runtime parameter), exposing the recipe's configured retention to the
@@ -553,14 +580,14 @@ async def test_registered_memory_client_requires_api_key(monkeypatch: Any) -> No
 
 
 def test_dr_mem0_endpoint_builds_path_prefixed_url(monkeypatch: Any) -> None:
-    # GIVEN a memory_space_id and an explicit datarobot_endpoint.
+    # GIVEN an agent_memory_space_id and an explicit datarobot_endpoint.
     # WHEN the endpoint URL is built.
     # THEN it follows PBMP-7431's "API Layout": {endpoint}/memory/{id}, with no
     # trailing slash (mem0's _validate_api_key uses raw f"{host}/v1/ping/"
     # concat, so a trailing slash would produce a double slash). Any
     # caller-supplied trailing slash on the base is collapsed.
     config = DRMem0MemoryClientConfig(
-        memory_space_id="space-123",
+        agent_memory_space_id="space-123",
         datarobot_endpoint="https://app.datarobot.com/api/v2/",
     )
     assert (
@@ -572,7 +599,7 @@ def test_dr_mem0_endpoint_builds_path_prefixed_url(monkeypatch: Any) -> None:
 def test_dr_mem0_endpoint_falls_back_to_datarobot_endpoint_env(monkeypatch: Any) -> None:
     # GIVEN no explicit datarobot_endpoint on the config but DATAROBOT_ENDPOINT in env.
     monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://staging.datarobot.com/api/v2")
-    config = DRMem0MemoryClientConfig(memory_space_id="space-xyz")
+    config = DRMem0MemoryClientConfig(agent_memory_space_id="space-xyz")
 
     # THEN the env var is used as the base.
     assert (
@@ -584,7 +611,7 @@ def test_dr_mem0_endpoint_falls_back_to_datarobot_endpoint_env(monkeypatch: Any)
 def test_dr_mem0_endpoint_requires_a_base_url(monkeypatch: Any) -> None:
     # GIVEN no datarobot_endpoint configured and no env var.
     monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
-    config = DRMem0MemoryClientConfig(memory_space_id="space-xyz")
+    config = DRMem0MemoryClientConfig(agent_memory_space_id="space-xyz")
 
     # THEN the builder refuses to fabricate a URL — better to fail loud than to
     # point at a wrong host.
@@ -592,10 +619,10 @@ def test_dr_mem0_endpoint_requires_a_base_url(monkeypatch: Any) -> None:
         datarobot_mem0_memory._dr_mem0_endpoint(config)
 
 
-def test_create_mem0_client_routes_to_dr_endpoint_when_memory_space_id_set(
+def test_create_mem0_client_routes_to_dr_endpoint_when_agent_memory_space_id_set(
     monkeypatch: Any,
 ) -> None:
-    # GIVEN a memory_space_id and a DR endpoint. This test exercises the real
+    # GIVEN an agent_memory_space_id and a DR endpoint. This test exercises the real
     # ``_create_mem0_client`` body (host computation), which transitively
     # imports ``mem0``. Skip on minimal installs (the ``nat`` test module in
     # CI doesn't include the ``[memory]`` extra) — the factory-level tests
@@ -622,7 +649,7 @@ def test_create_mem0_client_routes_to_dr_endpoint_when_memory_space_id_set(
     monkeypatch.setattr(mem0client_module, "Mem0Client", FakeMem0Client)
 
     config = DRMem0MemoryClientConfig(
-        memory_space_id="space-42",
+        agent_memory_space_id="space-42",
         datarobot_endpoint="https://app.datarobot.com/api/v2",
         org_id="org-1",
         project_id="proj-1",
@@ -641,10 +668,10 @@ def test_create_mem0_client_routes_to_dr_endpoint_when_memory_space_id_set(
     }
 
 
-def test_create_mem0_client_uses_config_host_when_no_memory_space_id(
+def test_create_mem0_client_uses_config_host_when_no_agent_memory_space_id(
     monkeypatch: Any,
 ) -> None:
-    # GIVEN no memory_space_id (Mem0 SaaS path) and an explicit host override.
+    # GIVEN no agent_memory_space_id (Mem0 SaaS path) and an explicit host override.
     # Same skip rationale as ``..._routes_to_dr_endpoint...``: this hits the
     # real ``_create_mem0_client`` body which imports ``mem0``.
     pytest.importorskip("mem0")
@@ -673,10 +700,10 @@ def test_create_mem0_client_uses_config_host_when_no_memory_space_id(
     assert captured == {"api_key": "mem0-key", "host": "https://mem0.example.com"}
 
 
-async def test_registered_memory_client_uses_dr_token_when_memory_space_id_set(
+async def test_registered_memory_client_uses_dr_token_when_agent_memory_space_id_set(
     monkeypatch: Any,
 ) -> None:
-    # GIVEN a memory_space_id config and a DATAROBOT_API_TOKEN in env.
+    # GIVEN an agent_memory_space_id config and a DATAROBOT_API_TOKEN in env.
     monkeypatch.setenv("DATAROBOT_API_TOKEN", "dr-secret-token")
     monkeypatch.delenv("MEM0_API_KEY", raising=False)
 
@@ -691,7 +718,7 @@ async def test_registered_memory_client_uses_dr_token_when_memory_space_id_set(
 
     config = DRMem0MemoryClientConfig(
         api_key=None,
-        memory_space_id="space-42",
+        agent_memory_space_id="space-42",
         datarobot_endpoint="https://app.datarobot.com/api/v2",
     )
 
@@ -723,7 +750,7 @@ async def test_registered_memory_client_prefers_explicit_dr_token_over_env(
     monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
 
     config = DRMem0MemoryClientConfig(
-        memory_space_id="space-42",
+        agent_memory_space_id="space-42",
         datarobot_endpoint="https://app.datarobot.com/api/v2",
         datarobot_api_token="explicit-token",
     )
@@ -736,10 +763,10 @@ async def test_registered_memory_client_prefers_explicit_dr_token_over_env(
     assert created == [{"api_key": "explicit-token"}]
 
 
-async def test_registered_memory_client_requires_dr_token_when_memory_space_id_set(
+async def test_registered_memory_client_requires_dr_token_when_agent_memory_space_id_set(
     monkeypatch: Any,
 ) -> None:
-    # GIVEN a memory_space_id but neither datarobot_api_token nor DATAROBOT_API_TOKEN.
+    # GIVEN an agent_memory_space_id but neither datarobot_api_token nor DATAROBOT_API_TOKEN.
     monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
     monkeypatch.delenv("MEM0_API_KEY", raising=False)
 
@@ -748,7 +775,7 @@ async def test_registered_memory_client_requires_dr_token_when_memory_space_id_s
     with pytest.raises(RuntimeError, match="DATAROBOT_API_TOKEN"):
         async with datarobot_mem0_memory.dr_mem0_memory_client(
             DRMem0MemoryClientConfig(
-                memory_space_id="space-42",
+                agent_memory_space_id="space-42",
                 datarobot_endpoint="https://app.datarobot.com/api/v2",
             ),
             object(),
@@ -756,10 +783,10 @@ async def test_registered_memory_client_requires_dr_token_when_memory_space_id_s
             pass
 
 
-async def test_registered_memory_client_rejects_memory_space_id_and_api_key_together(
+async def test_registered_memory_client_rejects_agent_memory_space_id_and_api_key_together(
     monkeypatch: Any,
 ) -> None:
-    # GIVEN both memory_space_id and api_key set (e.g. a config copied from a
+    # GIVEN both agent_memory_space_id and api_key set (e.g. a config copied from a
     # Mem0-SaaS deployment that forgot to clear api_key after switching to DR,
     # or a stray MEM0_API_KEY in env hydrating api_key via its default factory).
     # The two fields point at different services with different auth tokens,
@@ -771,7 +798,7 @@ async def test_registered_memory_client_rejects_memory_space_id_and_api_key_toge
         async with datarobot_mem0_memory.dr_mem0_memory_client(
             DRMem0MemoryClientConfig(
                 api_key="mem0-saas-key",
-                memory_space_id="space-42",
+                agent_memory_space_id="space-42",
                 datarobot_endpoint="https://app.datarobot.com/api/v2",
                 datarobot_api_token="dr-token",
             ),
@@ -780,16 +807,16 @@ async def test_registered_memory_client_rejects_memory_space_id_and_api_key_toge
             pass
 
 
-async def test_registered_memory_client_rejects_memory_space_id_with_env_mem0_key(
+async def test_registered_memory_client_rejects_agent_memory_space_id_with_env_mem0_key(
     monkeypatch: Any,
 ) -> None:
     # GIVEN MEM0_API_KEY contamination in env (e.g. another tool set it) and
-    # an explicit memory_space_id config. The default_factory will pick up
+    # an explicit agent_memory_space_id config. The default_factory will pick up
     # MEM0_API_KEY and populate api_key, creating an ambiguous config.
     monkeypatch.setenv("MEM0_API_KEY", "stray-env-key")
     monkeypatch.setenv("DATAROBOT_API_TOKEN", "dr-token")
 
-    config = DRMem0MemoryClientConfig(memory_space_id="space-42")
+    config = DRMem0MemoryClientConfig(agent_memory_space_id="space-42")
     # Confirm the env did hydrate api_key — this is the exact ambiguity the
     # guardrail exists to catch.
     assert config.api_key == "stray-env-key"
@@ -802,7 +829,7 @@ async def test_registered_memory_client_rejects_memory_space_id_with_env_mem0_ke
             pass
 
 
-async def test_registered_memory_client_allows_memory_space_id_with_explicit_null_api_key(
+async def test_registered_memory_client_allows_agent_memory_space_id_with_explicit_null_api_key(
     monkeypatch: Any,
 ) -> None:
     # GIVEN MEM0_API_KEY in env but the caller explicitly passes api_key=None
@@ -815,7 +842,7 @@ async def test_registered_memory_client_allows_memory_space_id_with_explicit_nul
 
     config = DRMem0MemoryClientConfig(
         api_key=None,  # explicit override beats the env default_factory
-        memory_space_id="space-42",
+        agent_memory_space_id="space-42",
         datarobot_endpoint="https://app.datarobot.com/api/v2",
         datarobot_api_token="dr-token",
     )

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -862,7 +862,7 @@ async def test_registered_memory_client_sets_store_metadata_for_dr_route(
     monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
 
     config = DRMem0MemoryClientConfig(
-        memory_space_id="space-42",
+        agent_memory_space_id="space-42",
         datarobot_endpoint="https://app.datarobot.com/api/v2",
         datarobot_api_token="dr-token",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,11 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
+<<<<<<< HEAD
 version = "0.15.112"
+=======
+version = "0.15.111"
+>>>>>>> 88ce4399 (Update and add agent memory space id to configs)
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,11 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-<<<<<<< HEAD
-version = "0.15.112"
-=======
-version = "0.15.111"
->>>>>>> 88ce4399 (Update and add agent memory space id to configs)
+version = "0.15.113"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking rename for any `workflow.yaml` still using `memory_space_id`; the factory still branches on `config.memory_space_id` for OTel store metadata, which would break the DR memory route at runtime until aligned with `agent_memory_space_id`.
> 
> **Overview**
> Releases **0.15.111** and renames the NAT `dr_mem0_memory` config field **`memory_space_id` → `agent_memory_space_id`** everywhere routing, docs, errors, and tests reference the DataRobot Memory Service path (`{datarobot_endpoint}/memory/{id}`).
> 
> **`agent_memory_space_id`** now defaults from **`AGENT_MEMORY_SPACE_ID`** via `DataRobotAppFrameworkBaseSettings`, so deployments can use a minimal `workflow.yaml` memory block when the agent runtime injects that env var. The **`api_key`** default factory skips **`MEM0_API_KEY`** when an agent memory space is configured, preserving the existing mutually-exclusive guard against mixing DR and Mem0 SaaS credentials.
> 
> Integration and unit tests were updated for the new field name; new tests cover env-based defaults and explicit YAML overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74b2760704aa2d63ff8b61426f0cae526ab7ea95. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->