### PR TITLE
[BUZZOK-29951] Add init for `_dask_client` to prevent error during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.114
+- Initialize `_dask_client` to exit cleanly and not throw error during shutdown
+
 ## 0.15.113
 - `nat/datarobot_mem0_memory`: renamed the `memory_space_id` config field to `agent_memory_space_id` (endpoint path follows: `{datarobot_endpoint}/memory/{agent_memory_space_id}`), and added a default factory that reads `AGENT_MEMORY_SPACE_ID` from env via `DataRobotAppFrameworkBaseSettings`. This lets a minimal `workflow.yaml` memory block target the DataRobot Memory Service when the recipe's agent runtime wires the env var, without requiring an explicit field in YAML. Error messages, docstrings, and the mutually-exclusive guardrail against `api_key` were updated to reference the new field name.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.112"
+version = "0.15.114"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1121,12 +1121,12 @@ requires-dist = [
     { name = "datarobot-early-access", marker = "extra == 'langgraph'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'llamaindex'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'nat'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.33,<12.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1361,11 +1361,12 @@ example-quickstart = [{ name = "datarobot-genai", extras = ["langgraph"], editab
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.30"
+version = "11.2.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "backoff" },
+    { name = "click" },
     { name = "numpy" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -1374,11 +1375,12 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "pydantic" },
+    { name = "requests" },
     { name = "rouge-score" },
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/ba/d594bdcb2a21817ca854f593302b31c7dd7c064db76873de73c686e5768b/datarobot_moderations-11.2.30-py3-none-any.whl", hash = "sha256:a31d5d80a946d664d6d267898d41b9041134a0eef4a02037bc31adfe01ed6f28", size = 123894, upload-time = "2026-05-19T16:20:45.444Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/26/763042a9b2ae2f6bcf10aee14a019d3a52d36becb9bb6091f8f40492d660/datarobot_moderations-11.2.33-py3-none-any.whl", hash = "sha256:1b835a8e53306b41407ff30dbd90631cbe0084cdbe5bb0bdb2b79999dc1adcf8", size = 149461, upload-time = "2026-06-03T13:33:56.177Z" },
 ]
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.113"
+version = "0.15.114"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -224,6 +224,13 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
 
 class DRAgentFastApiFrontEndPlugin(FastApiFrontEndPlugin):
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        # NAT's FastApiFrontEndPlugin.run() finally-block accesses self._dask_client
+        # directly, but that attribute is only set lazily by the dask_client property.
+        # When dask isn't installed it is never set, so shutdown raises AttributeError.
+        self._dask_client = None
+
     async def run(self) -> None:
         # Resolve ``workflow.yaml`` before NAT builds the app (gunicorn calls ``get_app()`` in
         # the parent process, which initializes middleware including datarobot_moderation).

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -742,3 +742,28 @@ class TestDRAgentFastApiFrontEndPlugin:
     def test_get_worker_class(self):
         plugin = DRAgentFastApiFrontEndPlugin(full_config=Config(general=GeneralConfig()))
         assert plugin.get_worker_class() is DRAgentFastApiFrontEndPluginWorker
+
+    def test_dask_client_initialized_to_none(self):
+        """NAT's run() finally-block reads self._dask_client directly; it must exist even
+        when dask is not installed so shutdown cleanup doesn't raise AttributeError.
+        """
+        plugin = DRAgentFastApiFrontEndPlugin(full_config=Config(general=GeneralConfig()))
+        assert plugin._dask_client is None
+
+    @pytest.mark.asyncio
+    async def test_run_shutdown_without_dask_does_not_raise(self):
+        """Simulate stopping the server (Ctrl+C) so NAT's run() finally-block runs its
+        dask cleanup. Without the _dask_client fix this raises AttributeError when dask
+        is not installed.
+        """
+        config = Config(general=GeneralConfig(front_end=DRAgentFastApiFrontEndConfig()))
+        plugin = DRAgentFastApiFrontEndPlugin(full_config=config)
+
+        async def fake_serve(_self):
+            raise KeyboardInterrupt
+
+        with (
+            patch("datarobot_genai.dragent.workflow_paths.publish_dragent_config_file_env"),
+            patch("uvicorn.Server.serve", fake_serve),
+        ):
+            await plugin.run()

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.113"
+version = "0.15.114"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Without `dask` installed, during shutdown NAT tries to access `_dask_client` and raises an `AttributeError`. 
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Creating an `__init__` and explicitly setting `_dask_client` to `None` to make it safe to access during shutdown
## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized startup/shutdown fix with tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **DRAgent FastAPI shutdown** when Dask is not installed: `DRAgentFastApiFrontEndPlugin` now defines `__init__` and sets **`_dask_client = None`** so NAT’s `FastApiFrontEndPlugin.run()` finally-block can read that attribute without raising **`AttributeError`** (the lazy `dask_client` property never created it when Dask is absent).
> 
> Adds unit coverage that the attribute exists and that **`run()`** completes cleanly on **`KeyboardInterrupt`**-style shutdown with Dask unavailable. Release **0.15.115** (changelog + version); lockfiles also bump **`datarobot-moderations`** to **11.2.33**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266bc5c4b2a191cb418ec22f425176056f50d0e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->