### PR TITLE
[BUZZOK-31122] Make streaming_memory_agent a passthrough when there's no memory back…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.116
+- `nat/datarobot_mem0_memory`: when no memory backend is configured (no `agent_memory_space_id` + `DATAROBOT_API_TOKEN`, and no `api_key` / `MEM0_API_KEY`), the provider yields an `UnconfiguredMemoryEditor` no-op instead of raising at startup. Workflows can declare `dr_mem0_memory` unconditionally and enable memory later via runtime parameters or env vars. The mutually-exclusive guardrail against setting both `agent_memory_space_id` and `api_key` is unchanged.
+- `dragent/plugins/streaming_memory_agent`: passes through to the inner agent when the referenced memory backend is unconfigured (`is_memory_editor_configured` returns false), so a fixed `memory_name` in `workflow.yaml` works with or without credentials wired at deploy time.
+
 ## 0.15.115
 - `drmcpbase`: added `class UserMCPProvider` to support user MCP proxy
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1121,12 +1121,12 @@ requires-dist = [
     { name = "datarobot-early-access", marker = "extra == 'langgraph'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'llamaindex'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", marker = "extra == 'nat'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.30,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.30,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.33,<12.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1361,11 +1361,12 @@ example-quickstart = [{ name = "datarobot-genai", extras = ["langgraph"], editab
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.30"
+version = "11.2.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "backoff" },
+    { name = "click" },
     { name = "numpy" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -1374,11 +1375,12 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "pydantic" },
+    { name = "requests" },
     { name = "rouge-score" },
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/ba/d594bdcb2a21817ca854f593302b31c7dd7c064db76873de73c686e5768b/datarobot_moderations-11.2.30-py3-none-any.whl", hash = "sha256:a31d5d80a946d664d6d267898d41b9041134a0eef4a02037bc31adfe01ed6f28", size = 123894, upload-time = "2026-05-19T16:20:45.444Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/26/763042a9b2ae2f6bcf10aee14a019d3a52d36becb9bb6091f8f40492d660/datarobot_moderations-11.2.33-py3-none-any.whl", hash = "sha256:1b835a8e53306b41407ff30dbd90631cbe0084cdbe5bb0bdb2b79999dc1adcf8", size = 149461, upload-time = "2026-06-03T13:33:56.177Z" },
 ]
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.114"
+version = "0.15.115"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.115"
+version = "0.15.116"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.115"
+version = "0.15.116"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
+++ b/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
@@ -40,7 +40,9 @@ The configuration surface (``memory_name``, ``inner_agent_name``,
 ``save_user_messages_to_memory``, ``retrieve_memory_for_every_response``,
 ``save_ai_messages_to_memory``, ``search_params``, ``add_params``) is inherited
 from upstream ``AutoMemoryAgentConfig`` so the two wrappers can be swapped
-without reauthoring ``workflow.yaml``.
+without reauthoring ``workflow.yaml``. When the referenced memory backend is
+unconfigured (``dr_mem0_memory`` with no credentials), the wrapper passthroughs
+to the inner agent without memory operations.
 """
 
 import os
@@ -68,6 +70,7 @@ from nat.plugins.langchain.agent.auto_memory_wrapper.register import AutoMemoryA
 from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
 from datarobot_genai.dragent.frontends.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.nat.datarobot_mem0_memory import is_memory_editor_configured
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +86,8 @@ class StreamingMemoryAgentConfig(  # type: ignore[call-arg, misc]
     ``save_ai_messages_to_memory``, ``search_params``, and ``add_params``
     from :class:`AutoMemoryAgentConfig`.  Only the ``_type`` discriminator
     differs, so a workflow can switch between the two by renaming ``_type``.
+    When the referenced memory backend is unconfigured, the wrapper passthroughs
+    to the inner agent without memory capture or retrieval.
     """
 
 
@@ -138,8 +143,33 @@ async def streaming_memory_agent(
     config: StreamingMemoryAgentConfig, builder: Builder
 ) -> AsyncGenerator[Any, None]:
     """Build the streaming memory agent workflow."""
-    memory_editor = await builder.get_memory_client(config.memory_name)
     inner_agent_fn = await builder.get_function(config.inner_agent_name)
+
+    async def _stream_to_str(
+        responses: AsyncGenerator[DRAgentEventResponse],
+    ) -> str:
+        aggregated = aggregate_dragent_event_responses([r async for r in responses])
+        return convert_dragent_event_response_to_str(aggregated)
+
+    memory_editor = await builder.get_memory_client(config.memory_name)
+
+    if not is_memory_editor_configured(memory_editor):
+
+        async def _passthrough_stream_fn(
+            input_message: RunAgentInput,
+        ) -> Annotated[
+            AsyncGenerator[DRAgentEventResponse, None],
+            Streaming(convert=aggregate_dragent_event_responses),
+        ]:
+            async for event_response in inner_agent_fn.astream(input_message):
+                yield event_response
+
+        yield FunctionInfo.create(
+            stream_fn=_passthrough_stream_fn,
+            stream_to_single_fn=_stream_to_str,
+            description=config.description,
+        )
+        return
 
     async def _stream_fn(
         input_message: RunAgentInput,
@@ -210,12 +240,6 @@ async def streaming_memory_agent(
                         )
                     except Exception as exc:  # noqa: BLE001
                         logger.warning("memory.add_items(assistant) failed: %s", exc)
-
-    async def _stream_to_str(
-        responses: AsyncGenerator[DRAgentEventResponse],
-    ) -> str:
-        aggregated = aggregate_dragent_event_responses([r async for r in responses])
-        return convert_dragent_event_response_to_str(aggregated)
 
     yield FunctionInfo.create(
         stream_fn=_stream_fn,

--- a/src/datarobot_genai/nat/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/nat/datarobot_mem0_memory.py
@@ -28,6 +28,11 @@ Backend selection is driven by config:
 
 Both routes share the same ``MemoryEditor`` adapter because the DR endpoint
 is API-compatible with mem0 — only the host and auth token differ.
+
+When neither route is configured (no ``agent_memory_space_id`` + token and no
+``api_key`` / ``MEM0_API_KEY``), the provider yields an
+:class:`UnconfiguredMemoryEditor` so workflows can declare ``dr_mem0_memory``
+unconditionally and enable memory later via runtime parameters or env vars.
 """
 
 import asyncio
@@ -189,6 +194,24 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
             "``AGENT_MEMORY_TTL_SECONDS`` env var."
         ),
     )
+
+
+class UnconfiguredMemoryEditor(MemoryEditor):  # type: ignore[misc]
+    """No-op memory backend returned when ``dr_mem0_memory`` has no credentials."""
+
+    async def add_items(self, items: list[MemoryItem], **kwargs: Any) -> None:
+        return
+
+    async def search(self, query: str, top_k: int = 5, **kwargs: Any) -> list[MemoryItem]:
+        return []
+
+    async def remove_items(self, **kwargs: Any) -> None:
+        return
+
+
+def is_memory_editor_configured(editor: MemoryEditor) -> bool:
+    """Return ``False`` when ``dr_mem0_memory`` yielded an unconfigured no-op editor."""
+    return not isinstance(editor, UnconfiguredMemoryEditor)
 
 
 class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
@@ -397,6 +420,22 @@ def _create_mem0_client(config: DRMem0MemoryClientConfig, api_key: str | None) -
     )
 
 
+def _resolve_memory_backend(
+    config: DRMem0MemoryClientConfig,
+) -> tuple[str, str, str | None] | None:
+    """Return ``(api_key, store_name, store_id)`` when configured, else ``None``."""
+    if config.agent_memory_space_id:
+        api_key = config.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
+        if not api_key:
+            return None
+        return (api_key, "datarobot-memory", config.agent_memory_space_id)
+
+    if config.api_key:
+        return (config.api_key, "mem0", config.project_id or config.org_id)
+
+    return None
+
+
 @register_memory(config_type=DRMem0MemoryClientConfig)
 async def dr_mem0_memory_client(
     config: DRMem0MemoryClientConfig, builder: Builder
@@ -414,27 +453,17 @@ async def dr_mem0_memory_client(
             "either unset it or pass api_key=None explicitly when using agent_memory_space_id."
         )
 
-    if config.agent_memory_space_id:
-        api_key = config.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
-        if not api_key:
-            raise RuntimeError(
-                "DataRobot API token is not set. Configure memory.datarobot_api_token "
-                "or DATAROBOT_API_TOKEN when using agent_memory_space_id."
-            )
-    elif config.api_key:
-        api_key = config.api_key
-    else:
-        raise RuntimeError(
-            "Mem0 API key is not set. Please configure memory.api_key or MEM0_API_KEY, "
-            "or set agent_memory_space_id to target the DataRobot mem0 endpoint."
+    resolved = _resolve_memory_backend(config)
+    if resolved is None:
+        logger.info(
+            "dr_mem0_memory: no memory backend configured "
+            "(set agent_memory_space_id + DATAROBOT_API_TOKEN, or api_key / MEM0_API_KEY); "
+            "memory operations are disabled"
         )
+        yield UnconfiguredMemoryEditor()
+        return
 
-    if config.agent_memory_space_id:
-        store_name = "datarobot-memory"
-        store_id: str | None = config.agent_memory_space_id
-    else:
-        store_name = "mem0"
-        store_id = config.project_id or config.org_id
+    api_key, store_name, store_id = resolved
 
     editor: MemoryEditor = DRMem0Editor(
         _create_mem0_client(config, api_key),

--- a/tests/dragent/plugins/test_streaming_memory_agent.py
+++ b/tests/dragent/plugins/test_streaming_memory_agent.py
@@ -39,6 +39,7 @@ from datarobot_genai.dragent.plugins.streaming_memory_agent import _last_user_te
 from datarobot_genai.dragent.plugins.streaming_memory_agent import _user_id_from_context
 from datarobot_genai.dragent.plugins.streaming_memory_agent import _with_memory_context
 from datarobot_genai.dragent.plugins.streaming_memory_agent import streaming_memory_agent
+from datarobot_genai.nat.datarobot_mem0_memory import UnconfiguredMemoryEditor
 
 _MODULE = "datarobot_genai.dragent.plugins.streaming_memory_agent"
 
@@ -341,6 +342,21 @@ class TestStreamingMemoryAgentFactory:
         builder.get_memory_client.assert_awaited_once_with("mem0")
         builder.get_function.assert_awaited_once_with("inner-agent")
 
+    async def test_passthroughs_when_memory_backend_unconfigured(self, context_user_id):
+        config = _make_config(memory_name="mem0")
+        chunks = [_chunk("Hello"), _chunk(" world")]
+        builder = _make_builder(
+            memory_editor=UnconfiguredMemoryEditor(),
+            inner_agent_chunks=chunks,
+        )
+
+        async with streaming_memory_agent(config, builder) as fn_info:
+            out = await _drain(fn_info.stream_fn(_input(_user("hi"))))
+
+        assert _content_deltas(out) == ["Hello", " world"]
+        builder.get_memory_client.assert_awaited_once_with("mem0")
+        builder.get_function.assert_awaited_once_with("inner-agent")
+
 
 # ---------------------------------------------------------------------------
 # streaming_memory_agent — stream_fn behavior
@@ -377,6 +393,43 @@ class TestStreamFnAllFlagsOff:
         # No memory side effects when every flag is off.
         memory_editor.add_items.assert_not_called()
         memory_editor.search.assert_not_called()
+
+
+class TestStreamFnPassthroughWithoutMemory:
+    """Unconfigured dr_mem0_memory → inner agent stream passes through unchanged."""
+
+    async def test_streams_inner_agent_without_memory_calls(self, context_user_id):
+        config = _make_config(memory_name="mem0")
+        chunks = [_chunk("Hello"), _chunk(" world")]
+        builder = _make_builder(
+            memory_editor=UnconfiguredMemoryEditor(),
+            inner_agent_chunks=chunks,
+        )
+
+        async with streaming_memory_agent(config, builder) as fn_info:
+            out = await _drain(fn_info.stream_fn(_input(_user("hi"))))
+
+        assert _content_deltas(out) == ["Hello", " world"]
+        builder.get_memory_client.assert_awaited_once_with("mem0")
+
+    async def test_forwards_input_unchanged(self, context_user_id):
+        config = _make_config(memory_name="mem0")
+        captured: dict = {}
+
+        async def _astream(inner_request, to_type=None):
+            captured["request"] = inner_request
+            captured["to_type"] = to_type
+            yield _chunk("ok")
+
+        builder = _make_builder(memory_editor=UnconfiguredMemoryEditor())
+        builder.get_function.return_value.astream = _astream
+
+        async with streaming_memory_agent(config, builder) as fn_info:
+            await _drain(fn_info.stream_fn(_input(_user("hi"))))
+
+        assert captured["to_type"] is None
+        assert isinstance(captured["request"], RunAgentInput)
+        assert [m.content for m in captured["request"].messages] == ["hi"]
 
 
 class TestStreamFnSavesUserMessage:

--- a/tests/nat/test_mem0_memory.py
+++ b/tests/nat/test_mem0_memory.py
@@ -32,6 +32,8 @@ from datarobot_genai.nat import datarobot_mem0_memory
 from datarobot_genai.nat.datarobot_mem0_memory import Config
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0Editor
 from datarobot_genai.nat.datarobot_mem0_memory import DRMem0MemoryClientConfig
+from datarobot_genai.nat.datarobot_mem0_memory import UnconfiguredMemoryEditor
+from datarobot_genai.nat.datarobot_mem0_memory import is_memory_editor_configured
 
 # Matches ``DataRobotMemoryClient.user_id`` (= ``sha256(api_key)``). The editor
 # falls back to this when no per-session user_id is supplied (e.g. direct calls
@@ -567,16 +569,23 @@ def test_memory_client_config_default_ttl_is_none_without_env(monkeypatch: Any) 
     assert config.default_ttl_seconds is None
 
 
-async def test_registered_memory_client_requires_api_key(monkeypatch: Any) -> None:
+async def test_registered_memory_client_yields_unconfigured_editor_without_api_key(
+    monkeypatch: Any,
+) -> None:
     # GIVEN neither memory.api_key nor MEM0_API_KEY is configured.
     monkeypatch.delenv("MEM0_API_KEY", raising=False)
+    monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
 
-    # WHEN NAT builds the memory client, THEN it raises a clear configuration error.
-    with pytest.raises(RuntimeError, match="MEM0_API_KEY"):
-        async with datarobot_mem0_memory.dr_mem0_memory_client(
-            DRMem0MemoryClientConfig(api_key=None), object()
-        ):
-            pass
+    # WHEN NAT builds the memory client, THEN it yields a no-op editor instead of failing.
+    async with datarobot_mem0_memory.dr_mem0_memory_client(
+        DRMem0MemoryClientConfig(api_key=None), object()
+    ) as editor:
+        assert isinstance(editor, UnconfiguredMemoryEditor)
+        assert not is_memory_editor_configured(editor)
+        await editor.add_items(
+            [MemoryItem(conversation=[{"role": "user", "content": "hi"}], user_id="u1")]
+        )
+        assert await editor.search("hi", user_id="u1") == []
 
 
 def test_dr_mem0_endpoint_builds_path_prefixed_url(monkeypatch: Any) -> None:
@@ -763,24 +772,22 @@ async def test_registered_memory_client_prefers_explicit_dr_token_over_env(
     assert created == [{"api_key": "explicit-token"}]
 
 
-async def test_registered_memory_client_requires_dr_token_when_agent_memory_space_id_set(
+async def test_registered_memory_client_yields_unconfigured_editor_without_dr_token(
     monkeypatch: Any,
 ) -> None:
     # GIVEN an agent_memory_space_id but neither datarobot_api_token nor DATAROBOT_API_TOKEN.
     monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
     monkeypatch.delenv("MEM0_API_KEY", raising=False)
 
-    # WHEN NAT builds the memory client, THEN it raises a DR-specific error so
-    # users know to set the DR token, not the Mem0 api_key.
-    with pytest.raises(RuntimeError, match="DATAROBOT_API_TOKEN"):
-        async with datarobot_mem0_memory.dr_mem0_memory_client(
-            DRMem0MemoryClientConfig(
-                agent_memory_space_id="space-42",
-                datarobot_endpoint="https://app.datarobot.com/api/v2",
-            ),
-            object(),
-        ):
-            pass
+    async with datarobot_mem0_memory.dr_mem0_memory_client(
+        DRMem0MemoryClientConfig(
+            agent_memory_space_id="space-42",
+            datarobot_endpoint="https://app.datarobot.com/api/v2",
+        ),
+        object(),
+    ) as editor:
+        assert isinstance(editor, UnconfiguredMemoryEditor)
+        assert not is_memory_editor_configured(editor)
 
 
 async def test_registered_memory_client_rejects_agent_memory_space_id_and_api_key_together(

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.115"
+version = "0.15.116"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
…end configured

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This allows a `workflow.yaml` like 
```
memory:
  mem0_memory:
    _type: dr_mem0_memory

workflow:
  _type: streaming_memory_agent
  inner_agent_name: langgraph_agent
  memory_name: mem0_memory
  llm_name: datarobot_llm
  description: LangGraph planner/writer agent with automatic memory capture and retrieval
```
to be used unconditionally. When the user opts into memory and MEM0_API_KEY is set or pulumi creates the AGENT_MEMORY_SPACE_ID then memory is used. If it's not set then `dr_mem0_memory` is a no-op memory editor and `streaming_memory_agent` is a passthrough.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow startup from fail-fast to silent no-op when memory creds are absent; agents run without memory until configured, which is intentional but alters prior error behavior.
> 
> **Overview**
> **Optional memory:** `dr_mem0_memory` no longer fails at build time when credentials are missing. It yields **`UnconfiguredMemoryEditor`** (no-op add/search/remove) and logs that memory is disabled, so `workflow.yaml` can always declare `dr_mem0_memory` and turn memory on later via `MEM0_API_KEY`, `AGENT_MEMORY_SPACE_ID`, or `DATAROBOT_API_TOKEN`.
> 
> **`streaming_memory_agent`** checks **`is_memory_editor_configured`**. If the backend is unconfigured, it streams the inner agent unchanged with no capture, retrieval, or persistence. Mutual exclusion of DR space id vs Mem0 `api_key` still raises.
> 
> E2e lockfile bumps **`datarobot-moderations`** to **11.2.33**. Tests cover unconfigured editor and passthrough streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c252c90950a4ba56fee82e6669b6dea5ee620e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->