### PR TITLE
[BUZZOK-31123] Auto-skip datarobot_moderation_middleware when running from drum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.122
+- `nat/helpers`: `NatAgent` (DRUM path) now strips `datarobot_moderation` middleware from the loaded `workflow.yaml` automatically. DRUM applies guardrails via `moderation_config.yaml` outside NAT; keeping the middleware in YAML for DRAgent deployments no longer requires a separate DRUM copy of the file. DRAgent entry points (`load_workflow` default, inline runner, CLI) are unchanged.
+
 ## 0.15.121
 - `drmcp/core/config`: `MCPServerConfig` assembles `otel_exporter_otlp_headers` dynamically from `OTEL_ENTITY_ID` + `DATAROBOT_API_TOKEN` when the header is not explicitly set, avoiding stale API tokens baked at `pulumi up` time.
 - `dragent/cli/commands`: `_bridge_pulumi_otel_env()` reads `OTEL_ENTITY_ID` from `pulumi_config.json` and assembles OTel headers with the live `DATAROBOT_API_TOKEN`.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.120"
+version = "0.15.122"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.121"
+version = "0.15.122"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/agent.py
+++ b/src/datarobot_genai/nat/agent.py
@@ -219,7 +219,11 @@ class NatAgent(BaseAgent[None]):
         message_id = str(uuid.uuid4())
         text_started = False
 
-        async with load_workflow(self.workflow_path, headers=self.forwarded_headers) as workflow:
+        async with load_workflow(
+            self.workflow_path,
+            headers=self.forwarded_headers,
+            disable_datarobot_moderation=True,
+        ) as workflow:
             async with workflow.session(user_id=thread_id) as session:
                 async with session.run(chat_request) as runner:
                     intermediate_future = pull_intermediate_structured()
@@ -299,7 +303,11 @@ class NatAgent(BaseAgent[None]):
             ChatResponse | str: The result from the NAT workflow
             list[IntermediateStep]: The list of intermediate steps
         """
-        async with load_workflow(workflow_path, headers=headers) as workflow:
+        async with load_workflow(
+            workflow_path,
+            headers=headers,
+            disable_datarobot_moderation=True,
+        ) as workflow:
             async with workflow.session(user_id=str(uuid.uuid4())) as session:
                 async with session.run(chat_request) as runner:
                     intermediate_future = pull_intermediate_structured()

--- a/src/datarobot_genai/nat/helpers.py
+++ b/src/datarobot_genai/nat/helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -31,8 +32,65 @@ from datarobot_genai.core.chat.auth import get_authorization_context_from_header
 from datarobot_genai.core.utils.auth import prepare_identity_header
 from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
 
+logger = logging.getLogger(__name__)
 
-def load_config(config_file: StrPath, headers: dict[str, str] | None = None) -> Config:
+DATAROBOT_MODERATION_MIDDLEWARE_TYPE = "datarobot_moderation"
+
+
+def remove_datarobot_moderation_middleware(config_yaml: dict[str, Any]) -> None:
+    """Remove ``datarobot_moderation`` middleware entries from a NAT workflow config.
+
+    DRUM applies LLM guardrails via ``moderation_config.yaml`` outside the NAT workflow.
+    When ``NatAgent`` loads a shared ``workflow.yaml`` through DRUM, strip the NAT
+    middleware so guardrails are not applied twice.
+    """
+    middleware_section = config_yaml.get("middleware")
+    if not isinstance(middleware_section, dict):
+        return
+
+    removed_names = [
+        name
+        for name, cfg in middleware_section.items()
+        if isinstance(cfg, dict) and cfg.get("_type") == DATAROBOT_MODERATION_MIDDLEWARE_TYPE
+    ]
+    if not removed_names:
+        return
+
+    for name in removed_names:
+        del middleware_section[name]
+    if not middleware_section:
+        config_yaml.pop("middleware", None)
+
+    removed = set(removed_names)
+    _strip_middleware_references(config_yaml, removed)
+    logger.info(
+        "Removed datarobot_moderation middleware for DRUM execution: %s",
+        ", ".join(sorted(removed)),
+    )
+
+
+def _strip_middleware_references(node: Any, removed: set[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in list(node.items()):
+            if key == "middleware" and isinstance(value, list):
+                filtered = [name for name in value if name not in removed]
+                if filtered:
+                    node[key] = filtered
+                else:
+                    del node[key]
+            else:
+                _strip_middleware_references(value, removed)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_middleware_references(item, removed)
+
+
+def load_config(
+    config_file: StrPath,
+    headers: dict[str, str] | None = None,
+    *,
+    disable_datarobot_moderation: bool = False,
+) -> Config:
     """
     Load a NAT configuration file with injected headers. It ensures that all plugins are
     loaded and then validates the configuration file against the Config schema.
@@ -41,6 +99,9 @@ def load_config(config_file: StrPath, headers: dict[str, str] | None = None) -> 
     ----------
     config_file : StrPath
         The path to the configuration file
+    disable_datarobot_moderation : bool, optional
+        When ``True``, strip ``datarobot_moderation`` middleware from the loaded config.
+        Used by ``NatAgent`` on the DRUM path where guardrails are applied externally.
 
     Returns
     -------
@@ -51,6 +112,9 @@ def load_config(config_file: StrPath, headers: dict[str, str] | None = None) -> 
     discover_and_register_plugins(PluginTypes.CONFIG_OBJECT)
 
     config_yaml = yaml_load(config_file)
+
+    if disable_datarobot_moderation:
+        remove_datarobot_moderation_middleware(config_yaml)
 
     add_headers_to_datarobot_mcp_auth(config_yaml, headers)
     add_headers_to_datarobot_llm_deployment(config_yaml, headers)
@@ -96,7 +160,11 @@ def add_headers_to_datarobot_llm_deployment(
 
 @asynccontextmanager
 async def load_workflow(
-    config_file: StrPath, max_concurrency: int = -1, headers: dict[str, str] | None = None
+    config_file: StrPath,
+    max_concurrency: int = -1,
+    headers: dict[str, str] | None = None,
+    *,
+    disable_datarobot_moderation: bool = False,
 ) -> AsyncGenerator[Workflow, None]:
     """
     Load the NAT configuration file and create a Runner object. This is the primary entry point for
@@ -109,13 +177,20 @@ async def load_workflow(
     max_concurrency : int, optional
         The maximum number of parallel workflow invocations to support. Specifying 0 or -1 will
         allow an unlimited count, by default -1
+    disable_datarobot_moderation : bool, optional
+        When ``True``, strip ``datarobot_moderation`` middleware from the loaded config.
+        Used by ``NatAgent`` on the DRUM path where guardrails are applied externally.
     """
     # Publish the workflow path so middleware (e.g. datarobot_moderation) can locate
     # ``moderation_config.yaml`` next to ``workflow.yaml`` without relying on CWD.
     publish_dragent_config_file_env(config_file)
 
     # Load the config object
-    config = load_config(config_file, headers=headers)
+    config = load_config(
+        config_file,
+        headers=headers,
+        disable_datarobot_moderation=disable_datarobot_moderation,
+    )
 
     # Must yield the workflow function otherwise it cleans up
     async with WorkflowBuilder.from_config(config=config) as builder:

--- a/tests/nat/test_agent.py
+++ b/tests/nat/test_agent.py
@@ -503,4 +503,5 @@ async def test_streaming_mcp_headers(
     mock_load_workflow.assert_called_once_with(
         workflow_path,
         headers=expected_headers,
+        disable_datarobot_moderation=True,
     )

--- a/tests/nat/test_helpers.py
+++ b/tests/nat/test_helpers.py
@@ -32,6 +32,7 @@ from datarobot_genai.nat.helpers import extract_datarobot_headers_from_context
 from datarobot_genai.nat.helpers import extract_headers_from_context
 from datarobot_genai.nat.helpers import load_config
 from datarobot_genai.nat.helpers import load_workflow
+from datarobot_genai.nat.helpers import remove_datarobot_moderation_middleware
 
 
 @pytest.mark.parametrize(
@@ -267,6 +268,93 @@ def test_load_config(config_yaml, headers, should_have_headers):
         assert not dr_auth_config.headers
 
 
+def test_remove_datarobot_moderation_middleware_strips_definitions_and_references() -> None:
+    config_yaml = {
+        "middleware": {
+            "datarobot_guardrails": {
+                "_type": "datarobot_moderation",
+                "moderation": {"guards": []},
+            },
+            "other_middleware": {"_type": "some_other"},
+        },
+        "workflow": {
+            "_type": "react_agent",
+            "middleware": ["datarobot_guardrails", "other_middleware"],
+        },
+    }
+
+    remove_datarobot_moderation_middleware(config_yaml)
+
+    assert config_yaml == {
+        "middleware": {"other_middleware": {"_type": "some_other"}},
+        "workflow": {"_type": "react_agent", "middleware": ["other_middleware"]},
+    }
+
+
+def test_remove_datarobot_moderation_middleware_noop_when_absent() -> None:
+    config_yaml = {
+        "middleware": {"other_middleware": {"_type": "some_other"}},
+        "workflow": {"_type": "react_agent"},
+    }
+
+    remove_datarobot_moderation_middleware(config_yaml)
+
+    assert config_yaml == {
+        "middleware": {"other_middleware": {"_type": "some_other"}},
+        "workflow": {"_type": "react_agent"},
+    }
+
+
+@pytest.mark.parametrize(
+    "disable_datarobot_moderation, expected_middleware",
+    [
+        (
+            True,
+            {"other_middleware": {"_type": "some_other"}},
+        ),
+        (
+            False,
+            {
+                "datarobot_guardrails": {"_type": "datarobot_moderation"},
+                "other_middleware": {"_type": "some_other"},
+            },
+        ),
+    ],
+)
+def test_load_config_can_disable_datarobot_moderation(
+    disable_datarobot_moderation, expected_middleware
+) -> None:
+    config_yaml = {
+        "middleware": {
+            "datarobot_guardrails": {"_type": "datarobot_moderation"},
+            "other_middleware": {"_type": "some_other"},
+        },
+        "workflow": {
+            "_type": "react_agent",
+            "middleware": ["datarobot_guardrails", "other_middleware"],
+        },
+        "llms": {"llm": {"_type": "test"}},
+    }
+    with (
+        patch("datarobot_genai.nat.helpers.yaml_load", return_value=config_yaml),
+        patch("datarobot_genai.nat.helpers.validate_schema", side_effect=lambda cfg, _: cfg),
+        patch("datarobot_genai.nat.helpers.discover_and_register_plugins"),
+    ):
+        load_config(
+            "some_path",
+            disable_datarobot_moderation=disable_datarobot_moderation,
+        )
+
+    assert config_yaml["middleware"] == expected_middleware
+    if disable_datarobot_moderation:
+        assert config_yaml["workflow"]["middleware"] == ["other_middleware"]
+    else:
+        assert config_yaml["workflow"]["middleware"] == [
+            "datarobot_guardrails",
+            "other_middleware",
+        ]
+
+
 async def test_load_workflow():
     with patch("datarobot_genai.nat.helpers.WorkflowBuilder"):
         with patch("datarobot_genai.nat.helpers.SessionManager") as mock_session_manager:
@@ -276,7 +364,11 @@ async def test_load_workflow():
                 headers = {"h1": "v1"}
                 async with load_workflow(path, headers=headers) as workflow:
                     assert workflow
-                    mock_load_config.assert_called_once_with("some_path", headers=headers)
+                    mock_load_config.assert_called_once_with(
+                        "some_path",
+                        headers=headers,
+                        disable_datarobot_moderation=False,
+                    )
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.120"
+version = "0.15.122"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Drum runs moderations outside of the workflow. When running a NAT agent from drum we do not want to also include the `datarobot_moderation_middleware` that would run moderations in the workflow. And we want to ship a single `workflow.yaml` that does not need to be edited to include/remove `datarobot_moderation_middleware` depending whether drum or dragent is used.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
When loading the `workflow.yaml` in the drum flow remove `datarobot_moderation_middleware`.

I tested that it works with the NAT agent created from https://github.com/datarobot/recipe-datarobot-agent-application with the dev build of `datarobot-genai` using drum and dragent.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when LLM guardrails run on the DRUM path; misconfiguration could skip in-workflow moderation if the flag were used outside NatAgent, but scope is limited to DRUM entry points with tests covering strip behavior.
> 
> **Overview**
> **NatAgent (DRUM)** now loads `workflow.yaml` with `disable_datarobot_moderation=True`, so `datarobot_moderation` middleware is removed from the parsed config before the workflow runs. DRUM already applies guardrails via `moderation_config.yaml`; this avoids double moderation while keeping one shared YAML for DRUM and DRAgent.
> 
> `nat/helpers` adds `remove_datarobot_moderation_middleware` (drops `_type: datarobot_moderation` entries and scrubs workflow `middleware` name lists) and threads the opt-in flag through `load_config` / `load_workflow`. **DRAgent** call sites that use the default `load_workflow` behavior are unchanged.
> 
> Release **0.15.117** with changelog and tests for stripping, `load_config` flag behavior, and NatAgent `load_workflow` arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a27b37ef68aed4fc16bdce34df57735c0ad6d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->