### PR TITLE
BUZZOK-31124: feat: fold assistant reasoning into chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.1
+- `core/agents`: a prior-turn reasoning message is folded into the following assistant message's `content` as `<reasoning>…</reasoning>` text during history extraction, so chain-of-thought round-trips to the model across all agent frameworks and ingress paths (AG-UI `AssistantMessage` has no reasoning field). The text `{chat_history}` summary and the langgraph/llama_index structured converters both surface it; a reasoning turn with no following assistant turn is dropped. Consumer note: turns that carry reasoning now replay their full chain-of-thought into history, which adds tokens — tune `max_history_messages` if context budget is tight.
+
 ## 0.16.0
 - `core/agents/events.py`: `events_to_messages` folds an AG-UI event stream back into `Message` objects (assistant text + its tool calls on one `AssistantMessage`, paired `ToolMessage` results, reasoning) for replay as history — the Python port of the TS client's `defaultApplyEvents` (messages slice).
 - `llama_index`: tool-call events now carry `parent_message_id`, so a client folding the stream keeps a turn's text and tool calls on one assistant message.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.0"
+version = "0.16.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/agents/history.py
+++ b/src/datarobot_genai/core/agents/history.py
@@ -26,6 +26,8 @@ from typing import TypedDict
 
 from ag_ui.core import RunAgentInput
 
+from datarobot_genai.core.agents.reasoning import wrap_reasoning
+
 
 class _NormalizedHistoryMessageRequired(TypedDict):
     """Required fields for a normalized prior chat message."""
@@ -94,6 +96,51 @@ def _summarize_tool_calls(tool_calls: Any) -> str:
     return "[tool_calls]"
 
 
+def _fold_reasoning_messages(messages: list[Any]) -> list[Any]:
+    """Fold standalone ``reasoning`` messages into the following assistant turn.
+
+    AG-UI ``AssistantMessage`` has no reasoning field, so reasoning arrives as separate
+    ``role="reasoning"`` messages in history.
+    Reasoning precedes its answer, so each reasoning message is merged into the next
+    assistant message's content as ``<reasoning>...</reasoning>`` text; the standalone
+    reasoning message is then dropped. This makes the text summary and the structured
+    converters surface reasoning identically, without per-path handling.
+
+    Consecutive reasoning messages before one assistant are concatenated. Reasoning
+    with no following assistant turn (orphan) is dropped. A no-op when there are no
+    reasoning messages, so non-reasoning history is unchanged.
+    """
+    folded: list[Any] = []
+    pending: list[str] = []
+    for message in messages:
+        role = str(_get_message_field(message, "role") or "")
+        if role == "reasoning":
+            text = _get_message_field(message, "content")
+            if text:
+                pending.append(str(text))
+            continue
+        if pending and role == "assistant":
+            content = _get_message_field(message, "content")
+            folded.append(
+                {
+                    "role": "assistant",
+                    "content": wrap_reasoning(
+                        "\n".join(pending), str(content) if content is not None else ""
+                    ),
+                    "tool_calls": _get_message_field(message, "tool_calls"),
+                    "name": _get_message_field(message, "name"),
+                    "tool_call_id": _get_message_field(message, "tool_call_id"),
+                }
+            )
+            pending = []
+            continue
+        # Non-assistant turn (or assistant with no buffered reasoning): any buffered
+        # reasoning has no answer to attach to, so drop it.
+        pending = []
+        folded.append(message)
+    return folded
+
+
 def extract_history_messages(
     run_agent_input: RunAgentInput,
     max_history: int,
@@ -113,7 +160,9 @@ def extract_history_messages(
     - When ``max_history <= 0``, history is disabled and an empty list is returned.
       This matches the documented semantics where 0 means "no history".
     """
-    raw_messages = list(run_agent_input.messages)
+    # Fold standalone reasoning messages into their following assistant turn before
+    # any truncation, so reasoning travels with its answer and never consumes a slot.
+    raw_messages = _fold_reasoning_messages(list(run_agent_input.messages))
     if not raw_messages or max_history <= 0:
         return []
 

--- a/src/datarobot_genai/core/agents/reasoning.py
+++ b/src/datarobot_genai/core/agents/reasoning.py
@@ -96,9 +96,8 @@ def flatten_to_text(content: str | list[Any] | None) -> str:
 
 
 # AG-UI ``AssistantMessage`` has no reasoning field, so prior-turn reasoning is folded
-# into the assistant ``content`` as a plain-text sentinel block. The same format is used
-# wherever reasoning is folded (the OpenAI ingest field, and the AG-UI history message),
-# so it is defined once here.
+# into the assistant ``content`` as a plain-text sentinel block by ``wrap_reasoning``
+# (used during history extraction); the sentinels are defined once here.
 REASONING_OPEN = "<reasoning>"
 REASONING_CLOSE = "</reasoning>"
 

--- a/src/datarobot_genai/core/agents/reasoning.py
+++ b/src/datarobot_genai/core/agents/reasoning.py
@@ -93,3 +93,21 @@ def iter_content_blocks(
 def flatten_to_text(content: str | list[Any] | None) -> str:
     """Collapse any content shape to its text portion, dropping thinking blocks."""
     return "".join(delta for kind, delta in iter_content_blocks(content) if kind == "text")
+
+
+# AG-UI ``AssistantMessage`` has no reasoning field, so prior-turn reasoning is folded
+# into the assistant ``content`` as a plain-text sentinel block. The same format is used
+# wherever reasoning is folded (the OpenAI ingest field, and the AG-UI history message),
+# so it is defined once here.
+REASONING_OPEN = "<reasoning>"
+REASONING_CLOSE = "</reasoning>"
+
+
+def wrap_reasoning(reasoning: str, content: str | None) -> str:
+    """Prepend ``reasoning`` to ``content`` as a ``<reasoning>...</reasoning>`` block.
+
+    Returns the reasoning block followed by the answer text. ``content`` may be ``None``
+    or empty (e.g. a tool-call-only assistant turn), in which case only the reasoning
+    block remains (trailing whitespace stripped).
+    """
+    return f"{REASONING_OPEN}\n{reasoning}\n{REASONING_CLOSE}\n{content or ''}".rstrip()

--- a/src/datarobot_genai/langgraph/history.py
+++ b/src/datarobot_genai/langgraph/history.py
@@ -17,7 +17,8 @@ The default chat-history path flattens prior turns into the text ``{chat_history
 prompt variable, which drops tool calls. This converter rebuilds real
 ``HumanMessage`` / ``AIMessage(tool_calls=...)`` / ``ToolMessage`` so the model sees
 structured tool history. Reasoning, when carried, is already plain text in
-``content`` (folded at ingest), so it needs no special handling here.
+``content`` (folded into the assistant turn during history extraction), so it needs
+no special handling here.
 """
 
 from __future__ import annotations

--- a/tests/core/agents/test_history.py
+++ b/tests/core/agents/test_history.py
@@ -476,3 +476,23 @@ class TestReasoningFold:
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "hello"},
         ]
+
+    def test_fold_runs_before_truncation(self) -> None:
+        # The reasoning fold must run BEFORE max_history truncation: reasoning travels
+        # with its assistant answer and never consumes a history slot. With max_history=2
+        # over [user, reasoning, assistant, user-boundary], BOTH the user turn and the
+        # folded assistant turn survive. If the fold ran AFTER the slice, reasoning would
+        # occupy a slot and push the user turn out (leaving only the assistant) -- this
+        # pins the ordering the fix depends on.
+        run_input = _make_run_agent_input(
+            [
+                UserMessage(id="u1", content="2+2?"),
+                ReasoningMessage(id="r1", content="adding two and two"),
+                AssistantMessage(id="a1", content="4"),
+                UserMessage(id="u2", content="thanks"),
+            ]
+        )
+        history = extract_history_messages(run_input, 2)
+        assert [m["role"] for m in history] == ["user", "assistant"]
+        assert history[0]["content"] == "2+2?"
+        assert history[1]["content"] == "<reasoning>\nadding two and two\n</reasoning>\n4"

--- a/tests/core/agents/test_history.py
+++ b/tests/core/agents/test_history.py
@@ -14,8 +14,12 @@
 
 
 from ag_ui.core import AssistantMessage
+from ag_ui.core import ReasoningMessage
 from ag_ui.core import RunAgentInput
+from ag_ui.core import ToolMessage
 from ag_ui.core import UserMessage
+from ag_ui.core.types import FunctionCall
+from ag_ui.core.types import ToolCall
 
 from datarobot_genai.core.agents.history import _summarize_tool_calls
 from datarobot_genai.core.agents.history import build_history_summary_from_messages
@@ -362,3 +366,113 @@ class TestDropUnpairedBoundaryToolTurns:
             {"role": "tool", "content": "18C", "tool_call_id": "c1"},
         ]
         assert drop_unpaired_boundary_tool_turns(history) == history
+
+
+# ---------------------------------------------------------------------------
+# reasoning folding: standalone `reasoning` messages -> assistant content
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningFold:
+    def test_folds_reasoning_into_next_assistant(self) -> None:
+        run_input = _make_run_agent_input(
+            [
+                UserMessage(id="u1", content="2+2?"),
+                ReasoningMessage(id="r1", content="adding two and two"),
+                AssistantMessage(id="a1", content="4"),
+                UserMessage(id="u2", content="thanks"),
+            ]
+        )
+        history = extract_history_messages(run_input, 50)
+        # The standalone reasoning message is gone; it is folded into the assistant turn.
+        assert [m["role"] for m in history] == ["user", "assistant"]
+        assert history[1]["content"] == "<reasoning>\nadding two and two\n</reasoning>\n4"
+
+    def test_concatenates_consecutive_reasoning(self) -> None:
+        run_input = _make_run_agent_input(
+            [
+                ReasoningMessage(id="r1", content="first"),
+                ReasoningMessage(id="r2", content="second"),
+                AssistantMessage(id="a1", content="done"),
+                UserMessage(id="u2", content="ok"),
+            ]
+        )
+        history = extract_history_messages(run_input, 50)
+        assert history[0]["content"] == "<reasoning>\nfirst\nsecond\n</reasoning>\ndone"
+
+    def test_folds_into_tool_call_turn_and_preserves_tool_calls(self) -> None:
+        run_input = _make_run_agent_input(
+            [
+                ReasoningMessage(id="r1", content="need the weather tool"),
+                AssistantMessage(
+                    id="a1",
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="c1",
+                            type="function",
+                            function=FunctionCall(
+                                name="get_weather", arguments='{"city": "Paris"}'
+                            ),
+                        )
+                    ],
+                ),
+                ToolMessage(id="t1", content="18C", tool_call_id="c1"),
+                UserMessage(id="u2", content="thanks"),
+            ]
+        )
+        history = extract_history_messages(run_input, 50)
+        assistant = next(m for m in history if m["role"] == "assistant")
+        # Reasoning folds into the (empty) content; the tool call rides alongside it.
+        assert assistant["content"] == "<reasoning>\nneed the weather tool\n</reasoning>"
+        assert assistant.get("tool_calls") is not None
+
+    def test_drops_orphan_reasoning_with_no_following_assistant(self) -> None:
+        run_input = _make_run_agent_input(
+            [
+                UserMessage(id="u1", content="hi"),
+                ReasoningMessage(id="r1", content="orphan thought"),
+                UserMessage(id="u2", content="still there"),
+            ]
+        )
+        history = extract_history_messages(run_input, 50)
+        assert all(m["role"] != "reasoning" for m in history)
+        assert all("orphan thought" not in m["content"] for m in history)
+
+    def test_ignores_empty_reasoning(self) -> None:
+        run_input = _make_run_agent_input(
+            [
+                ReasoningMessage(id="r1", content=""),
+                AssistantMessage(id="a1", content="answer"),
+                UserMessage(id="u2", content="ok"),
+            ]
+        )
+        history = extract_history_messages(run_input, 50)
+        assert history[0]["content"] == "answer"
+
+    def test_summary_folds_reasoning_into_assistant_line(self) -> None:
+        run_input = _make_run_agent_input(
+            [
+                UserMessage(id="u1", content="2+2?"),
+                ReasoningMessage(id="r1", content="adding"),
+                AssistantMessage(id="a1", content="4"),
+                UserMessage(id="u2", content="thx"),
+            ]
+        )
+        summary = build_history_summary_from_messages(run_input, 50)
+        # One assistant line carrying the reasoning, not a separate `reasoning:` line.
+        assert summary == "user: 2+2?\nassistant: <reasoning>\nadding\n</reasoning>\n4"
+
+    def test_no_reasoning_history_is_unchanged(self) -> None:
+        run_input = _make_run_agent_input(
+            [
+                UserMessage(id="u1", content="hi"),
+                AssistantMessage(id="a1", content="hello"),
+                UserMessage(id="u2", content="bye"),
+            ]
+        )
+        history = extract_history_messages(run_input, 50)
+        assert history == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]

--- a/tests/langgraph/test_history.py
+++ b/tests/langgraph/test_history.py
@@ -98,3 +98,14 @@ def test_parallel_tool_calls_in_one_turn_all_mapped() -> None:
     assert [tc["id"] for tc in tool_calls] == ["c1", "c2"]
     assert [tc["name"] for tc in tool_calls] == ["get_weather", "log_event"]
     assert tool_calls[0]["args"] == {"city": "Paris"}
+
+
+def test_carries_folded_reasoning_in_assistant_content() -> None:
+    # extract_history_messages folds standalone reasoning into the assistant content;
+    # the converter must carry that <reasoning> text through to the model (it would
+    # otherwise drop a standalone reasoning-role message).
+    history = [{"role": "assistant", "content": "<reasoning>\nadded 2+2\n</reasoning>\n4"}]
+    msgs = ag_ui_history_to_langchain(history)
+    assert isinstance(msgs[0], AIMessage)
+    assert "<reasoning>" in msgs[0].content
+    assert "added 2+2" in msgs[0].content

--- a/tests/llamaindex/test_history.py
+++ b/tests/llamaindex/test_history.py
@@ -114,3 +114,14 @@ def test_converted_history_serializes_to_openai_without_crashing() -> None:
     assert assistant["tool_calls"][0]["function"]["name"] == "get_weather"
     tool = next(d for d in dicts if d["role"] == "tool")
     assert tool["tool_call_id"] == "c1"
+
+
+def test_carries_folded_reasoning_in_assistant_content() -> None:
+    # extract_history_messages folds standalone reasoning into the assistant content;
+    # the converter must carry that <reasoning> text through to the model (it would
+    # otherwise drop a standalone reasoning-role message).
+    history = [{"role": "assistant", "content": "<reasoning>\nadded 2+2\n</reasoning>\n4"}]
+    msgs = ag_ui_history_to_chat_messages(history)
+    assert msgs[0].role == "assistant"
+    assert "<reasoning>" in msgs[0].content
+    assert "added 2+2" in msgs[0].content

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## RATIONALE

Reasoning models (Claude extended thinking, etc.) emit their chain-of-thought separately from the answer. AG-UI's `AssistantMessage` has no reasoning field, so reasoning arrives as standalone `role="reasoning"` messages in history (e.g. when a streamed run is folded back into messages). The structured langgraph/llama_index converters drop those messages and the text `{chat_history}` summary ignored them — so across turns the model lost the rationale behind its earlier answers, even though tool calls and text were preserved.

This folds each standalone reasoning message into the **following** assistant turn's `content` as `<reasoning>…</reasoning>` text, during history extraction (before `max_history` truncation, so reasoning rides with its answer and never consumes a slot). Prior-turn reasoning then round-trips to the model on **every** framework — through both the text `{chat_history}` summary and the structured converters. It's intentionally lossy (plain text, not signed thinking blocks), which keeps re-send safe. No-op when a turn carries no reasoning; consecutive reasoning is concatenated; reasoning with no following assistant turn is dropped.

### Before / after

Prior turns: a reasoning message *"17×20=340, 17×3=51, sum 391"* followed by the assistant answer *"It's 391."*

**Before** — reasoning dropped (structured converters skip `role="reasoning"`; the text summary ignored it):
```
assistant: It's 391.
```

**After** — folded into the following assistant turn (both the text summary and the langgraph/llama_index structured path):
```
assistant: <reasoning>
17×20=340, 17×3=51, sum 391
</reasoning>
It's 391.
```

> Stacked on #430 (tool-call history). Base will auto-retarget to `main` once #430 merges.

## Checklist
- [x] Reviewed guideline
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require integration/acceptance tests — N/A (no new tools)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change at the shared chat-completion ingest path with no-op when reasoning is absent; plain-text folding avoids signed-thinking resend issues.
> 
> **Overview**
> Assistant turns from chat-completion requests now preserve **reasoning** on ingest: `reasoning_content` or `reasoning` is merged into `AssistantMessage.content` as `<reasoning>…</reasoning>` plus the normal answer text via new helper `fold_reasoning_into_content` in `core/chat/completions.py`, wired in `convert_chat_completion_params_to_run_agent_input`.
> 
> That fixes multi-turn loss of chain-of-thought where AG-UI has no separate reasoning field. Messages without reasoning are unchanged. Release **0.15.119** with unit tests for folding and conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08efcc81a49b9804d2c3b14d6be6ae75a009d9c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
