### PR TITLE
[MODEL-23706] Added Workload API Support and Read Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.118
+- `drtools/workload`: add initial Workload API tool group — `workload_list`, `workload_search`, `workload_get`, `bundle_list` — backed by a new `WorkloadApiClient` using the per-request DataRobot REST client. Includes full MCP registration wiring (`ToolType.WORKLOAD`, `enable_workload_tools` config flag, `MCP_CLI_OPTS` entry). Enable with `ENABLE_WORKLOAD_TOOLS=true`. Canonical paths: `/api/v2/workloads/`, `/api/v2/mlops/compute/bundles`.
+
 ## 0.15.117
 - Initialize `_dask_client` to exit cleanly and not throw error during shutdown
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+
+## 0.15.119
+- `drtools/workload`: workload lifecycle tools — `workload_create_payload` (payload builder helper), `workload_create`, `workload_start`, `workload_stop` (with optional `wait_stopped` polling), `workload_delete`, `workload_update` (PATCH name/description/importance), and `workload_wait_for_status` (async polling with terminal-status detection and configurable timeout). Client gains `create_workload`, `start_workload`, `stop_workload`, `delete_workload`, `patch_workload` methods. Payload builder supports both existing-artifact (`artifactId`) and inline-artifact modes, fixed and autoscaling replica configurations, and resource bundle selection — following the source-of-truth `WorkloadRuntime.containerGroups` schema.
+
 ## 0.15.118
-- `drtools/workload`: add initial Workload API tool group — `workload_list`, `workload_search`, `workload_get`, `bundle_list` — backed by a new `WorkloadApiClient` using the per-request DataRobot REST client. Includes full MCP registration wiring (`ToolType.WORKLOAD`, `enable_workload_tools` config flag, `MCP_CLI_OPTS` entry). Enable with `ENABLE_WORKLOAD_TOOLS=true`. Canonical paths: `/api/v2/workloads/`, `/api/v2/mlops/compute/bundles`.
+- `eval`: migrated third-party dependent modules from `af-component-evaluation` into `datarobot_genai.eval` — `validation` (pyyaml), `generator` (anthropic), `judge` (nemo_evaluator). `judge` fixes a cross-provider incompatibility where NeMo always sends `temperature` + `top_p` together, which Anthropic/Bedrock Claude rejects. Judge sessions are now thread-local to be safe under `parallelism > 1`. Full test coverage added; `nemo_evaluator` is stubbed in `conftest.py` so tests run without flask.
 
 ## 0.15.117
 - Initialize `_dask_client` to exit cleanly and not throw error during shutdown

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.118"
+version = "0.15.119"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.117"
+version = "0.15.118"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1093,6 +1093,8 @@ requires-dist = [
     { name = "azure-ai-inference", marker = "extra == 'crewai'", specifier = ">=1.0.0b9,<2.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drmcp'", specifier = ">=4.12.0,<5.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'drtools'", specifier = ">=4.12.0,<5.0.0" },
+    { name = "cachetools", marker = "extra == 'drmcp'", specifier = ">=5.0.0,<8.0.0" },
+    { name = "cachetools", marker = "extra == 'drmcpbase'", specifier = ">=5.0.0,<8.0.0" },
     { name = "colorama", marker = "extra == 'core'", specifier = ">=0.4.6,<1.0.0" },
     { name = "colorama", marker = "extra == 'crewai'", specifier = ">=0.4.6,<1.0.0" },
     { name = "colorama", marker = "extra == 'dragent'", specifier = ">=0.4.6,<1.0.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.118"
+version = "0.15.119"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.117"
+version = "0.15.118"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -146,6 +146,15 @@ class MCPToolConfig(BaseSettings):
         description="Enable/disable vector database tools",
     )
 
+    enable_workload_tools: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            RUNTIME_PARAM_ENV_VAR_NAME_PREFIX + "ENABLE_WORKLOAD_TOOLS",
+            "ENABLE_WORKLOAD_TOOLS",
+        ),
+        description="Enable/disable DataRobot Workload API tools",
+    )
+
     @field_validator(
         "enable_predictive_tools",
         "enable_jira_tools",
@@ -159,6 +168,7 @@ class MCPToolConfig(BaseSettings):
         "enable_code_execution_tools",
         "enable_optimization_tools",
         "enable_vdb_tools",
+        "enable_workload_tools",
         mode="before",
     )
     @classmethod

--- a/src/datarobot_genai/drmcp/core/constants.py
+++ b/src/datarobot_genai/drmcp/core/constants.py
@@ -32,4 +32,5 @@ MCP_CLI_OPTS: list[tuple[str, str | None, str | None]] = [
     ("code_execution", None, "enable_code_execution_tools"),
     ("optimization", None, "enable_optimization_tools"),
     ("vdb", None, "enable_vdb_tools"),
+    ("workload", None, "enable_workload_tools"),
 ]

--- a/src/datarobot_genai/drmcp/core/tool_config.py
+++ b/src/datarobot_genai/drmcp/core/tool_config.py
@@ -37,6 +37,7 @@ class ToolType(StrEnum):
     CODE_EXECUTION = "code_execution"
     OPTIMIZATION = "optimization"
     VDB = "vdb"
+    WORKLOAD = "workload"
 
 
 class ToolConfig(TypedDict):
@@ -121,6 +122,12 @@ TOOL_CONFIGS: dict[ToolType, ToolConfig] = {
         directory="vdb",
         package_prefix="datarobot_genai.drtools.vdb",
         config_field_name="enable_vdb_tools",
+    ),
+    ToolType.WORKLOAD: ToolConfig(
+        name="workload",
+        directory="workload",
+        package_prefix="datarobot_genai.drtools.workload",
+        config_field_name="enable_workload_tools",
     ),
 }
 

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -15,27 +15,20 @@
 import logging
 from typing import Any
 
-from datarobot.rest import RESTClientObject
+from datarobot_genai.drtools.core.clients.datarobot import request_user_dr_client
 
 logger = logging.getLogger(__name__)
 
 
 class WorkloadApiClient:
-    """Workload API methods backed by the DataRobot REST client.
+    """Workload API methods backed by the per-request DataRobot REST client.
 
-    Instantiate inside a
-    :func:`~datarobot_genai.drtools.core.clients.datarobot.request_user_dr_client`
-    (or :meth:`ThreadSafeDataRobotClient.request_user_client`) context so the
-    underlying client carries the correct per-user credentials::
+    Each call runs inside :func:`request_user_dr_client` so credentials come from
+    the requesting user's headers::
 
-        with ThreadSafeDataRobotClient().request_user_client():
-            rest_client = dr.client.get_client()
-            client = WorkloadApiClient(rest_client)
-            result = client.list_workloads(limit=50)
+        client = WorkloadApiClient()
+        result = client.list_workloads(limit=50)
     """
-
-    def __init__(self, rest_client: RESTClientObject) -> None:
-        self._client = rest_client
 
     # ------------------------------------------------------------------ #
     # Workloads — read                                                     #
@@ -52,7 +45,8 @@ class WorkloadApiClient:
         params: dict[str, Any] = {"limit": limit, "offset": offset}
         if search:
             params["search"] = search
-        return self._client.get("workloads/", params=params).json()
+        with request_user_dr_client() as client:
+            return client.get("workloads/", params=params).json()
 
     def get_workload(self, workload_id: str) -> dict[str, Any]:
         """GET /workloads/{workload_id}."""
@@ -64,4 +58,5 @@ class WorkloadApiClient:
 
     def list_bundles(self) -> dict[str, Any]:
         """GET /mlops/compute/bundles — available CPU/GPU resource bundles."""
-        return self._client.get("mlops/compute/bundles").json()
+        with request_user_dr_client() as client:
+            return client.get("mlops/compute/bundles").json()

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -50,7 +50,8 @@ class WorkloadApiClient:
 
     def get_workload(self, workload_id: str) -> dict[str, Any]:
         """GET /workloads/{workload_id}."""
-        return self._client.get(f"workloads/{workload_id}").json()
+        with request_user_dr_client() as client:
+            return client.get(f"workloads/{workload_id}").json()
 
     # ------------------------------------------------------------------ #
     # Compute bundles                                                      #

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -1,0 +1,67 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any
+
+from datarobot.rest import RESTClientObject
+
+logger = logging.getLogger(__name__)
+
+
+class WorkloadApiClient:
+    """Workload API methods backed by the DataRobot REST client.
+
+    Instantiate inside a
+    :func:`~datarobot_genai.drtools.core.clients.datarobot.request_user_dr_client`
+    (or :meth:`ThreadSafeDataRobotClient.request_user_client`) context so the
+    underlying client carries the correct per-user credentials::
+
+        with ThreadSafeDataRobotClient().request_user_client():
+            rest_client = dr.client.get_client()
+            client = WorkloadApiClient(rest_client)
+            result = client.list_workloads(limit=50)
+    """
+
+    def __init__(self, rest_client: RESTClientObject) -> None:
+        self._client = rest_client
+
+    # ------------------------------------------------------------------ #
+    # Workloads — read                                                     #
+    # ------------------------------------------------------------------ #
+
+    def list_workloads(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /workloads/ with optional server-side search and pagination."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if search:
+            params["search"] = search
+        return self._client.get("workloads/", params=params).json()
+
+    def get_workload(self, workload_id: str) -> dict[str, Any]:
+        """GET /workloads/{workload_id}."""
+        return self._client.get(f"workloads/{workload_id}").json()
+
+    # ------------------------------------------------------------------ #
+    # Compute bundles                                                      #
+    # ------------------------------------------------------------------ #
+
+    def list_bundles(self) -> dict[str, Any]:
+        """GET /mlops/compute/bundles — available CPU/GPU resource bundles."""
+        return self._client.get("mlops/compute/bundles").json()

--- a/src/datarobot_genai/drtools/pagination.py
+++ b/src/datarobot_genai/drtools/pagination.py
@@ -53,7 +53,7 @@ def merge_pagination_metadata(
         for key in ("next", "previous"):
             if key in api_response and api_response[key] is not None:
                 final_results[key] = api_response[key]
-        for total_key in ("total_count", "total"):
+        for total_key in ("total_count", "totalCount", "total"):
             if total_key in api_response and api_response[total_key] is not None:
                 final_results["total_count"] = api_response[total_key]
                 break

--- a/src/datarobot_genai/drtools/workload/__init__.py
+++ b/src/datarobot_genai/drtools/workload/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/datarobot_genai/drtools/workload/tools.py
+++ b/src/datarobot_genai/drtools/workload/tools.py
@@ -1,0 +1,201 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Annotated
+from typing import Any
+
+import datarobot as dr
+from datarobot.errors import ClientError
+
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot import ThreadSafeDataRobotClient
+from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
+
+logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------ #
+# Workload tools — read                                                #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "list"},
+    description=(
+        "[Workload—list] Use to discover workloads: returns id, name, status, "
+        "artifactId, importance, and runtime for each workload. Supports "
+        "pagination (limit/offset) and an optional server-side search filter. "
+        "Not for a single known workload id (workload_get), not for artifacts "
+        "(artifact_list).\n\n"
+        "Example: workload_list(limit=50) or workload_list(search='my-app', limit=20)."
+    ),
+)
+async def workload_list(
+    *,
+    search: Annotated[
+        str | None,
+        "Optional server-side filter; matches workload name or id.",
+    ] = None,
+    limit: Annotated[
+        int,
+        "Maximum workloads to return (1–100). Default 100.",
+    ] = 100,
+    offset: Annotated[
+        int,
+        "Number of workloads to skip for pagination. Default 0.",
+    ] = 0,
+) -> dict[str, Any]:
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    clamped_limit, note = clamp_limit(limit)
+
+    try:
+        with ThreadSafeDataRobotClient().request_user_client():
+            rest_client = dr.client.get_client()
+            client = WorkloadApiClient(rest_client)
+            result = client.list_workloads(limit=clamped_limit, offset=offset, search=search)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"workloads": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "search"},
+    description=(
+        "[Workload—search] Use when you have a partial workload name or id to "
+        "search for. Performs a server-side search and returns matching "
+        "workloads. Use workload_list when you want all workloads without a "
+        "filter, or workload_get when you already have the exact id.\n\n"
+        "Example: workload_search(query='mcp-server', limit=10)."
+    ),
+)
+async def workload_search(
+    *,
+    query: Annotated[
+        str,
+        "Search string matched server-side against workload name and id.",
+    ],
+    limit: Annotated[
+        int,
+        "Maximum workloads to return (1–100). Default 20.",
+    ] = 20,
+    offset: Annotated[
+        int,
+        "Number of results to skip for pagination. Default 0.",
+    ] = 0,
+) -> dict[str, Any]:
+    if not query or not query.strip():
+        raise ToolError(
+            "Argument validation error: 'query' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    clamped_limit, note = clamp_limit(limit)
+
+    try:
+        with ThreadSafeDataRobotClient().request_user_client():
+            rest_client = dr.client.get_client()
+            client = WorkloadApiClient(rest_client)
+            result = client.list_workloads(limit=clamped_limit, offset=offset, search=query.strip())
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"workloads": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "get"},
+    description=(
+        "[Workload—get] Use when you have an exact workload id and need the "
+        "full record: status, runtime, artifact reference, endpoint URL, "
+        "creator, and timestamps. Not for discovery (workload_list), not for "
+        "debugging pod conditions (proton_status_details).\n\n"
+        "Example: workload_get(workload_id='wkld-abc123')."
+    ),
+)
+async def workload_get(
+    *,
+    workload_id: Annotated[
+        str,
+        "The unique id of the workload (from workload_list or workload_create).",
+    ],
+) -> dict[str, Any]:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    try:
+        with ThreadSafeDataRobotClient().request_user_client():
+            rest_client = dr.client.get_client()
+            client = WorkloadApiClient(rest_client)
+            return client.get_workload(workload_id.strip())
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# Bundle tools                                                         #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "bundle", "datarobot", "list"},
+    description=(
+        "[Workload—bundle list] Use to discover available compute resource "
+        "bundles (CPU count, memory, GPU type and VRAM). GPU type and VRAM "
+        "are always determined by the bundle — there is no separate gpuType "
+        "parameter. Use the bundle id when creating or updating a workload.\n\n"
+        "Example: bundle_list()."
+    ),
+)
+async def bundle_list() -> dict[str, Any]:
+    try:
+        with ThreadSafeDataRobotClient().request_user_client():
+            rest_client = dr.client.get_client()
+            client = WorkloadApiClient(rest_client)
+            return client.list_bundles()
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)

--- a/src/datarobot_genai/drtools/workload/tools.py
+++ b/src/datarobot_genai/drtools/workload/tools.py
@@ -16,11 +16,9 @@ import logging
 from typing import Annotated
 from typing import Any
 
-import datarobot as dr
 from datarobot.errors import ClientError
 
 from datarobot_genai.drtools.core import tool_metadata
-from datarobot_genai.drtools.core.clients.datarobot import ThreadSafeDataRobotClient
 from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
@@ -70,10 +68,9 @@ async def workload_list(
     clamped_limit, note = clamp_limit(limit)
 
     try:
-        with ThreadSafeDataRobotClient().request_user_client():
-            rest_client = dr.client.get_client()
-            client = WorkloadApiClient(rest_client)
-            result = client.list_workloads(limit=clamped_limit, offset=offset, search=search)
+        result = WorkloadApiClient().list_workloads(
+            limit=clamped_limit, offset=offset, search=search
+        )
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
 
@@ -111,10 +108,7 @@ async def workload_get(
         )
 
     try:
-        with ThreadSafeDataRobotClient().request_user_client():
-            rest_client = dr.client.get_client()
-            client = WorkloadApiClient(rest_client)
-            return client.get_workload(workload_id.strip())
+        return WorkloadApiClient().get_workload(workload_id.strip())
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
 
@@ -136,9 +130,6 @@ async def workload_get(
 )
 async def bundle_list() -> dict[str, Any]:
     try:
-        with ThreadSafeDataRobotClient().request_user_client():
-            rest_client = dr.client.get_client()
-            client = WorkloadApiClient(rest_client)
-            return client.list_bundles()
+        return WorkloadApiClient().list_bundles()
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)

--- a/src/datarobot_genai/drtools/workload/tools.py
+++ b/src/datarobot_genai/drtools/workload/tools.py
@@ -37,11 +37,10 @@ logger = logging.getLogger(__name__)
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "list"},
+    tags={"workload", "datarobot", "list", "search"},
     description=(
         "[Workload—list] Use to discover workloads: returns id, name, status, "
         "artifactId, importance, and runtime for each workload. Supports "
-        "pagination (limit/offset) and an optional server-side search filter. "
         "Not for a single known workload id (workload_get), not for artifacts "
         "(artifact_list).\n\n"
         "Example: workload_list(limit=50) or workload_list(search='my-app', limit=20)."
@@ -75,62 +74,6 @@ async def workload_list(
             rest_client = dr.client.get_client()
             client = WorkloadApiClient(rest_client)
             result = client.list_workloads(limit=clamped_limit, offset=offset, search=search)
-    except ClientError as exc:
-        raise_tool_error_for_client_error(exc)
-
-    data = result.get("data", []) or []
-    return merge_pagination_metadata(
-        {"workloads": data, "count": len(data)},
-        result,
-        note,
-        offset=offset,
-        limit=clamped_limit,
-    )
-
-
-@tool_metadata(
-    tags={"workload", "datarobot", "search"},
-    description=(
-        "[Workload—search] Use when you have a partial workload name or id to "
-        "search for. Performs a server-side search and returns matching "
-        "workloads. Use workload_list when you want all workloads without a "
-        "filter, or workload_get when you already have the exact id.\n\n"
-        "Example: workload_search(query='mcp-server', limit=10)."
-    ),
-)
-async def workload_search(
-    *,
-    query: Annotated[
-        str,
-        "Search string matched server-side against workload name and id.",
-    ],
-    limit: Annotated[
-        int,
-        "Maximum workloads to return (1–100). Default 20.",
-    ] = 20,
-    offset: Annotated[
-        int,
-        "Number of results to skip for pagination. Default 0.",
-    ] = 0,
-) -> dict[str, Any]:
-    if not query or not query.strip():
-        raise ToolError(
-            "Argument validation error: 'query' cannot be empty.",
-            kind=ToolErrorKind.VALIDATION,
-        )
-    if offset < 0:
-        raise ToolError(
-            "Argument validation error: 'offset' must be >= 0.",
-            kind=ToolErrorKind.VALIDATION,
-        )
-
-    clamped_limit, note = clamp_limit(limit)
-
-    try:
-        with ThreadSafeDataRobotClient().request_user_client():
-            rest_client = dr.client.get_client()
-            client = WorkloadApiClient(rest_client)
-            result = client.list_workloads(limit=clamped_limit, offset=offset, search=query.strip())
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
 

--- a/src/datarobot_genai/drtools/workload/tools.py
+++ b/src/datarobot_genai/drtools/workload/tools.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
     tags={"workload", "datarobot", "list", "search"},
     description=(
         "[Workload—list] Use to discover workloads: returns id, name, status, "
-        "artifactId, importance, and runtime for each workload. Supports "
+        "artifactId, importance, and runtime for each workload. "
         "Not for a single known workload id (workload_get), not for artifacts "
         "(artifact_list).\n\n"
         "Example: workload_list(limit=50) or workload_list(search='my-app', limit=20)."

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -52,6 +52,23 @@ def test_merge_pagination_metadata_total_count_wins_over_total() -> None:
     assert out["total_count"] == 7
 
 
+def test_merge_pagination_metadata_total_count_from_total_count_camel_case() -> None:
+    """DataRobot list responses often expose totalCount instead of total or total_count."""
+    base: dict = {"workloads": []}
+    body = {"totalCount": 42, "next": "https://example/api?offset=100"}
+    out = data.merge_pagination_metadata(base, body, offset=100, limit=100)
+    assert out["total_count"] == 42
+    assert out["next"] == "https://example/api?offset=100"
+
+
+def test_merge_pagination_metadata_total_count_wins_over_total_count_camel_case() -> None:
+    """Explicit total_count takes precedence over totalCount."""
+    base: dict = {"x": 1}
+    body = {"total_count": 7, "totalCount": 99}
+    out = data.merge_pagination_metadata(base, body)
+    assert out["total_count"] == 7
+
+
 def test_merge_pagination_metadata_list_body_ignored() -> None:
     """Non-dict body does not add next/previous/total (browse/query edge cases)."""
     base: dict = {"k": 1}

--- a/tests/drmcp/unit/test_routes.py
+++ b/tests/drmcp/unit/test_routes.py
@@ -631,6 +631,7 @@ class TestMetadataRoute:
         mock_tool_config.enable_code_execution_tools = False
         mock_tool_config.enable_optimization_tools = False
         mock_tool_config.enable_vdb_tools = False
+        mock_tool_config.enable_workload_tools = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config
@@ -739,6 +740,7 @@ class TestMetadataRoute:
         mock_tool_config.enable_code_execution_tools = False
         mock_tool_config.enable_optimization_tools = False
         mock_tool_config.enable_vdb_tools = False
+        mock_tool_config.enable_workload_tools = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config
@@ -802,6 +804,7 @@ class TestMetadataRoute:
         mock_tool_config.enable_code_execution_tools = False
         mock_tool_config.enable_optimization_tools = False
         mock_tool_config.enable_vdb_tools = False
+        mock_tool_config.enable_workload_tools = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config

--- a/tests/drmcp/unit/test_tool_config.py
+++ b/tests/drmcp/unit/test_tool_config.py
@@ -18,6 +18,7 @@ import os
 from unittest.mock import patch
 
 from datarobot_genai.drmcp.core.config import MCPServerConfig
+from datarobot_genai.drmcp.core.config import MCPToolConfig
 from datarobot_genai.drmcp.core.tool_config import TOOL_CONFIGS
 from datarobot_genai.drmcp.core.tool_config import ToolType
 from datarobot_genai.drmcp.core.tool_config import get_tool_enable_config_name
@@ -138,7 +139,7 @@ class TestIsToolEnabled:
     def test_predictive_tool_default_disabled(self) -> None:
         """Test predictive tool default is disabled."""
         with patch.dict(os.environ, clear=True):
-            config = MCPServerConfig(_env_file=None)
+            config = MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
             assert is_tool_enabled(ToolType.PREDICTIVE, config) is False
 
     def test_jira_tool_enabled(self) -> None:
@@ -180,5 +181,5 @@ class TestIsToolEnabled:
     def test_workload_tool_default_disabled(self) -> None:
         """Test workload tool default is disabled."""
         with patch.dict(os.environ, clear=True):
-            config = MCPServerConfig(_env_file=None)
+            config = MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
             assert is_tool_enabled(ToolType.WORKLOAD, config) is False

--- a/tests/drmcp/unit/test_tool_config.py
+++ b/tests/drmcp/unit/test_tool_config.py
@@ -37,6 +37,7 @@ class TestToolType:
         assert ToolType.VDB.value == "vdb"
         assert ToolType.CODE_EXECUTION.value == "code_execution"
         assert ToolType.OPTIMIZATION.value == "optimization"
+        assert ToolType.WORKLOAD.value == "workload"
 
     def test_tool_type_is_string_enum(self) -> None:
         """Test that ToolType is a string enum."""
@@ -84,6 +85,14 @@ class TestToolConfigs:
         assert config["package_prefix"] == "datarobot_genai.drtools.microsoft_graph"
         assert config["config_field_name"] == "enable_microsoft_graph_tools"
 
+    def test_workload_tool_config(self) -> None:
+        """Test workload tool configuration."""
+        config = TOOL_CONFIGS[ToolType.WORKLOAD]
+        assert config["name"] == "workload"
+        assert config["directory"] == "workload"
+        assert config["package_prefix"] == "datarobot_genai.drtools.workload"
+        assert config["config_field_name"] == "enable_workload_tools"
+
 
 class TestGetToolEnableConfigName:
     """Test get_tool_enable_config_name function."""
@@ -105,6 +114,10 @@ class TestGetToolEnableConfigName:
         assert (
             get_tool_enable_config_name(ToolType.MICROSOFT_GRAPH) == "enable_microsoft_graph_tools"
         )
+
+    def test_workload_config_name(self) -> None:
+        """Test config name for workload tools."""
+        assert get_tool_enable_config_name(ToolType.WORKLOAD) == "enable_workload_tools"
 
 
 class TestIsToolEnabled:
@@ -151,3 +164,21 @@ class TestIsToolEnabled:
         with patch.dict(os.environ, {"ENABLE_MICROSOFT_GRAPH_TOOLS": "true"}, clear=False):
             config = MCPServerConfig()
             assert is_tool_enabled(ToolType.MICROSOFT_GRAPH, config) is True
+
+    def test_workload_tool_enabled(self) -> None:
+        """Test workload tool when enabled."""
+        with patch.dict(os.environ, {"ENABLE_WORKLOAD_TOOLS": "true"}, clear=False):
+            config = MCPServerConfig()
+            assert is_tool_enabled(ToolType.WORKLOAD, config) is True
+
+    def test_workload_tool_disabled(self) -> None:
+        """Test workload tool when disabled."""
+        with patch.dict(os.environ, {"ENABLE_WORKLOAD_TOOLS": "false"}, clear=False):
+            config = MCPServerConfig()
+            assert is_tool_enabled(ToolType.WORKLOAD, config) is False
+
+    def test_workload_tool_default_disabled(self) -> None:
+        """Test workload tool default is disabled."""
+        with patch.dict(os.environ, clear=True):
+            config = MCPServerConfig(_env_file=None)
+            assert is_tool_enabled(ToolType.WORKLOAD, config) is False

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -16,14 +16,11 @@
 
 from collections.abc import Iterator
 from unittest.mock import MagicMock
-from unittest.mock import Mock
 from unittest.mock import patch
 
-import datarobot as dr
 import pytest
 from datarobot.errors import ClientError
 
-from datarobot_genai.drtools.core.clients.datarobot import ThreadSafeDataRobotClient
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.workload import tools
@@ -34,22 +31,17 @@ from datarobot_genai.drtools.workload import tools
 
 
 @pytest.fixture
-def mock_request_user_client() -> Iterator[Mock]:
-    with patch.object(ThreadSafeDataRobotClient, "request_user_client") as mock_cm:
-        yield mock_cm
-
-
-@pytest.fixture
 def mock_rest_client() -> MagicMock:
     return MagicMock()
 
 
 @pytest.fixture
-def patched_dr_client(
-    mock_request_user_client: Mock,  # noqa: ARG001 — activates the context manager patch
-    mock_rest_client: MagicMock,
-) -> Iterator[MagicMock]:
-    with patch.object(dr.client, "get_client", return_value=mock_rest_client):
+def patched_dr_client(mock_rest_client: MagicMock) -> Iterator[MagicMock]:
+    with patch(
+        "datarobot_genai.drtools.core.clients.datarobot_workload.request_user_dr_client"
+    ) as mock_cm:
+        mock_cm.return_value.__enter__.return_value = mock_rest_client
+        mock_cm.return_value.__exit__.return_value = False
         yield mock_rest_client
 
 
@@ -76,6 +68,7 @@ async def test_workload_list_success(patched_dr_client: MagicMock) -> None:
     result = await tools.workload_list()
 
     assert result["count"] == 2
+    assert result["total_count"] == 2
     assert result["workloads"][0]["id"] == "wkld-1"
     assert result["workloads"][1]["name"] == "Beta"
     patched_dr_client.get.assert_called_once_with("workloads/", params={"limit": 100, "offset": 0})
@@ -134,61 +127,6 @@ async def test_workload_list_404_raises_not_found(patched_dr_client: MagicMock) 
     with pytest.raises(ToolError) as exc_info:
         await tools.workload_list()
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
-
-
-# ------------------------------------------------------------------ #
-# workload_search                                                       #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_workload_search_success(patched_dr_client: MagicMock) -> None:
-    patched_dr_client.get.return_value = MagicMock(
-        json=lambda: {
-            "data": [{"id": "wkld-1", "name": "mcp-server"}],
-            "count": 1,
-        }
-    )
-
-    result = await tools.workload_search(query="mcp-server")
-
-    patched_dr_client.get.assert_called_once_with(
-        "workloads/", params={"limit": 20, "offset": 0, "search": "mcp-server"}
-    )
-    assert result["count"] == 1
-    assert result["workloads"][0]["id"] == "wkld-1"
-
-
-@pytest.mark.asyncio
-async def test_workload_search_empty_query_raises() -> None:
-    with pytest.raises(ToolError) as exc_info:
-        await tools.workload_search(query="")
-    assert exc_info.value.kind is ToolErrorKind.VALIDATION
-
-
-@pytest.mark.asyncio
-async def test_workload_search_whitespace_query_raises() -> None:
-    with pytest.raises(ToolError) as exc_info:
-        await tools.workload_search(query="   ")
-    assert exc_info.value.kind is ToolErrorKind.VALIDATION
-
-
-@pytest.mark.asyncio
-async def test_workload_search_negative_offset_raises() -> None:
-    with pytest.raises(ToolError) as exc_info:
-        await tools.workload_search(query="anything", offset=-5)
-    assert exc_info.value.kind is ToolErrorKind.VALIDATION
-
-
-@pytest.mark.asyncio
-async def test_workload_search_client_error(patched_dr_client: MagicMock) -> None:
-    patched_dr_client.get.side_effect = ClientError(
-        "503 Service Unavailable", status_code=503, json={}
-    )
-
-    with pytest.raises(ToolError) as exc_info:
-        await tools.workload_search(query="foo")
-    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
 # ------------------------------------------------------------------ #

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -1,0 +1,271 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for workload tools (PR1 — read-only surface)."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import datarobot as dr
+import pytest
+from datarobot.errors import ClientError
+
+from datarobot_genai.drtools.core.clients.datarobot import ThreadSafeDataRobotClient
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.workload import tools
+
+# ------------------------------------------------------------------ #
+# Shared fixtures                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def mock_request_user_client() -> Iterator[Mock]:
+    with patch.object(ThreadSafeDataRobotClient, "request_user_client") as mock_cm:
+        yield mock_cm
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def patched_dr_client(
+    mock_request_user_client: Mock,  # noqa: ARG001 — activates the context manager patch
+    mock_rest_client: MagicMock,
+) -> Iterator[MagicMock]:
+    with patch.object(dr.client, "get_client", return_value=mock_rest_client):
+        yield mock_rest_client
+
+
+# ------------------------------------------------------------------ #
+# workload_list                                                         #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_list_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "data": [
+                {"id": "wkld-1", "name": "Alpha", "status": "running"},
+                {"id": "wkld-2", "name": "Beta", "status": "stopped"},
+            ],
+            "count": 2,
+            "totalCount": 2,
+            "next": None,
+            "previous": None,
+        }
+    )
+
+    result = await tools.workload_list()
+
+    assert result["count"] == 2
+    assert result["workloads"][0]["id"] == "wkld-1"
+    assert result["workloads"][1]["name"] == "Beta"
+    patched_dr_client.get.assert_called_once_with("workloads/", params={"limit": 100, "offset": 0})
+
+
+@pytest.mark.asyncio
+async def test_workload_list_with_search(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"data": [{"id": "wkld-1", "name": "my-app"}], "count": 1}
+    )
+
+    result = await tools.workload_list(search="my-app", limit=10, offset=5)
+
+    patched_dr_client.get.assert_called_once_with(
+        "workloads/", params={"limit": 10, "offset": 5, "search": "my-app"}
+    )
+    assert result["count"] == 1
+    assert result["offset"] == 5
+    assert result["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_workload_list_clamps_limit(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": [], "count": 0})
+
+    result = await tools.workload_list(limit=500)
+
+    # limit clamped to 100
+    patched_dr_client.get.assert_called_once_with("workloads/", params={"limit": 100, "offset": 0})
+    assert result["limit"] == 100
+    assert "note" in result
+
+
+@pytest.mark.asyncio
+async def test_workload_list_negative_offset_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_list(offset=-1)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_list_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError(
+        "500 Internal Server Error", status_code=500, json={}
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_list()
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+@pytest.mark.asyncio
+async def test_workload_list_404_raises_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_list()
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# workload_search                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_search_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "data": [{"id": "wkld-1", "name": "mcp-server"}],
+            "count": 1,
+        }
+    )
+
+    result = await tools.workload_search(query="mcp-server")
+
+    patched_dr_client.get.assert_called_once_with(
+        "workloads/", params={"limit": 20, "offset": 0, "search": "mcp-server"}
+    )
+    assert result["count"] == 1
+    assert result["workloads"][0]["id"] == "wkld-1"
+
+
+@pytest.mark.asyncio
+async def test_workload_search_empty_query_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_search(query="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_search_whitespace_query_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_search(query="   ")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_search_negative_offset_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_search(query="anything", offset=-5)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_search_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError(
+        "503 Service Unavailable", status_code=503, json={}
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_search(query="foo")
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# workload_get                                                          #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_get_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "id": "wkld-abc",
+            "name": "my-workload",
+            "status": "running",
+            "artifactId": "art-xyz",
+        }
+    )
+
+    result = await tools.workload_get(workload_id="wkld-abc")
+
+    patched_dr_client.get.assert_called_once_with("workloads/wkld-abc")
+    assert result["id"] == "wkld-abc"
+    assert result["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_workload_get_strips_whitespace(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"id": "wkld-abc"})
+
+    await tools.workload_get(workload_id="  wkld-abc  ")
+
+    patched_dr_client.get.assert_called_once_with("workloads/wkld-abc")
+
+
+@pytest.mark.asyncio
+async def test_workload_get_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_get(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_get_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_get(workload_id="wkld-missing")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# bundle_list                                                           #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_bundle_list_success(patched_dr_client: MagicMock) -> None:
+    bundles_payload = {
+        "data": [
+            {"id": "cpu.small", "cpuCount": 1, "memoryBytes": 2147483648, "gpuCount": 0},
+            {"id": "gpu.l4.small", "cpuCount": 4, "memoryBytes": 17179869184, "gpuCount": 1},
+        ]
+    }
+    patched_dr_client.get.return_value = MagicMock(json=lambda: bundles_payload)
+
+    result = await tools.bundle_list()
+
+    patched_dr_client.get.assert_called_once_with("mlops/compute/bundles")
+    assert result == bundles_payload
+
+
+@pytest.mark.asyncio
+async def test_bundle_list_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError(
+        "500 Internal Server Error", status_code=500, json={}
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.bundle_list()
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.118"
+version = "0.15.119"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.117"
+version = "0.15.118"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Added workload API support
- Added read tools - `workload_list`, `workload_get`, `bundle_list`
- Added config for workload api
- Created unit tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

## TESTING
<img width="581" height="356" alt="Screenshot 2026-06-08 at 2 32 07 PM" src="https://github.com/user-attachments/assets/2bc888de-f3ba-4a73-825f-4383bed111be" />

<img width="578" height="764" alt="Screenshot 2026-06-08 at 2 32 43 PM" src="https://github.com/user-attachments/assets/9a052b1b-eb2d-44d9-9eb0-d9476e0aaef6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only, disabled-by-default tools that reuse established per-user REST client and error-handling patterns; no mutating workload APIs in this change.
> 
> **Overview**
> Adds an opt-in **Workload** MCP tool group (version **0.15.118**) so agents can read DataRobot workloads and compute bundles via the REST API.
> 
> Introduces `WorkloadApiClient` and four read-only tools—`workload_list`, `workload_search`, `workload_get`, and `bundle_list`—using `ThreadSafeDataRobotClient().request_user_client()` for per-user credentials, shared pagination/validation, and `ClientError` → `ToolError` handling. MCP registration follows the existing pattern: `ToolType.WORKLOAD`, `enable_workload_tools` / `ENABLE_WORKLOAD_TOOLS` (default off), and a `workload` entry in `MCP_CLI_OPTS`.
> 
> Unit tests cover the new tools and config enablement; the PR checklist still calls out missing integration/acceptance tests for `drtools/workload`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72c8d9f69eb82cfb0e23a0a7e0002de80ea776d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->