### PR TITLE
[MODEL-23707] Workload API Lifecycle Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.123
+- `drtools/workload`: PR2 — workload lifecycle tools.
+  - **New tools**: `workload_create_payload` (builds and validates a create payload without an API call; supports both existing `artifactId` and inline artifact via `artifact_name`, `image_uri`, `port`, `cpu`, `memory_bytes`), `workload_create`, `workload_start`, `workload_stop` (with optional `wait_stopped` polling), `workload_delete`, `workload_update` (PATCH name/description/importance), `workload_wait_for_status`.
+  - **Client additions** (`WorkloadApiClient`): `create_workload`, `start_workload`, `stop_workload`, `delete_workload`, `patch_workload`, and `wait_for_workload_status` polling method (raises `RuntimeError` on `errored`, `TimeoutError` on deadline).
+  - Runtime payload uses the canonical `runtime.containerGroups[].resourceBundles` schema from the OpenAPI spec.
+
 ## 0.15.122
 - `nat/helpers`: `NatAgent` (DRUM path) now strips `datarobot_moderation` middleware from the loaded `workflow.yaml` automatically. DRUM applies guardrails via `moderation_config.yaml` outside NAT; keeping the middleware in YAML for DRAgent deployments no longer requires a separate DRUM copy of the file. DRAgent entry points (`load_workflow` default, inline runner, CLI) are unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.123
-- `drtools/workload`: PR2 — workload lifecycle tools.
+- `drtools/workload`: lifecycle tools.
   - **New tools**: `workload_create_payload` (builds and validates a create payload without an API call; supports both existing `artifactId` and inline artifact via `artifact_name`, `image_uri`, `port`, `cpu`, `memory_bytes`), `workload_create`, `workload_start`, `workload_stop` (with optional `wait_stopped` polling), `workload_delete`, `workload_update` (PATCH name/description/importance), `workload_wait_for_status`.
   - **Client additions** (`WorkloadApiClient`): `create_workload`, `start_workload`, `stop_workload`, `delete_workload`, `patch_workload`, and `wait_for_workload_status` polling method (raises `RuntimeError` on `errored`, `TimeoutError` on deadline).
   - Runtime payload uses the canonical `runtime.containerGroups[].resourceBundles` schema from the OpenAPI spec.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.122"
+version = "0.15.123"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.122"
+version = "0.15.123"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
+import time
 from typing import Any
 
 from datarobot_genai.drtools.core.clients.datarobot import request_user_dr_client
@@ -97,7 +99,7 @@ class WorkloadApiClient:
     # Workloads — polling                                                  #
     # ------------------------------------------------------------------ #
 
-    def wait_for_workload_status(
+    async def wait_for_workload_status(
         self,
         workload_id: str,
         target_status: str,
@@ -105,7 +107,9 @@ class WorkloadApiClient:
         timeout_seconds: int = 600,
         poll_interval_seconds: int = 1,
     ) -> dict[str, Any]:
-        """Block until the workload reaches *target_status*, enters errored, or times out.
+        """Poll until the workload reaches *target_status*, enters errored, or times out.
+
+        Uses :func:`asyncio.sleep` between polls so async callers do not block the event loop.
 
         Raises
         ------
@@ -114,8 +118,6 @@ class WorkloadApiClient:
         TimeoutError
             When *timeout_seconds* elapses before reaching *target_status*.
         """
-        import time
-
         deadline = time.monotonic() + timeout_seconds
         last_status: str | None = None
         while True:
@@ -135,4 +137,4 @@ class WorkloadApiClient:
                     f"Timeout waiting for workload {workload_id} to reach "
                     f"'{target_status}'. Last status: {status}"
                 )
-            time.sleep(poll_interval_seconds)
+            await asyncio.sleep(poll_interval_seconds)

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -61,3 +61,78 @@ class WorkloadApiClient:
         """GET /mlops/compute/bundles — available CPU/GPU resource bundles."""
         with request_user_dr_client() as client:
             return client.get("mlops/compute/bundles").json()
+
+    # ------------------------------------------------------------------ #
+    # Workloads — write                                                    #
+    # ------------------------------------------------------------------ #
+
+    def create_workload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST /workloads/ — returns the created WorkloadFormatted (201)."""
+        with request_user_dr_client() as client:
+            return client.post("workloads/", json=payload).json()
+
+    def start_workload(self, workload_id: str) -> dict[str, Any]:
+        """POST /workloads/{id}/start — returns WorkloadOperationResponse (202)."""
+        with request_user_dr_client() as client:
+            resp = client.post(f"workloads/{workload_id}/start")
+            return resp.json() if resp.content else {}
+
+    def stop_workload(self, workload_id: str) -> dict[str, Any]:
+        """POST /workloads/{id}/stop — returns WorkloadOperationResponse (202)."""
+        with request_user_dr_client() as client:
+            resp = client.post(f"workloads/{workload_id}/stop")
+            return resp.json() if resp.content else {}
+
+    def delete_workload(self, workload_id: str) -> None:
+        """DELETE /workloads/{id} — 204 No Content on success."""
+        with request_user_dr_client() as client:
+            client.delete(f"workloads/{workload_id}")
+
+    def patch_workload(self, workload_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """PATCH /workloads/{id} — partial update of name / description / importance."""
+        with request_user_dr_client() as client:
+            return client.patch(f"workloads/{workload_id}", json=payload).json()
+
+    # ------------------------------------------------------------------ #
+    # Workloads — polling                                                  #
+    # ------------------------------------------------------------------ #
+
+    def wait_for_workload_status(
+        self,
+        workload_id: str,
+        target_status: str,
+        *,
+        timeout_seconds: int = 600,
+        poll_interval_seconds: int = 1,
+    ) -> dict[str, Any]:
+        """Block until the workload reaches *target_status*, enters errored, or times out.
+
+        Raises
+        ------
+        RuntimeError
+            When the workload enters ``errored`` before reaching *target_status*.
+        TimeoutError
+            When *timeout_seconds* elapses before reaching *target_status*.
+        """
+        import time
+
+        deadline = time.monotonic() + timeout_seconds
+        last_status: str | None = None
+        while True:
+            obj = self.get_workload(workload_id)
+            status = obj.get("status")
+            if status != last_status:
+                logger.info("Workload %s status: %s", workload_id, status)
+                last_status = status
+            if status == target_status:
+                return obj
+            if status == "errored":
+                raise RuntimeError(
+                    f"Workload {workload_id} errored while waiting for '{target_status}'"
+                )
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Timeout waiting for workload {workload_id} to reach "
+                    f"'{target_status}'. Last status: {status}"
+                )
+            time.sleep(poll_interval_seconds)

--- a/src/datarobot_genai/drtools/workload/constants.py
+++ b/src/datarobot_genai/drtools/workload/constants.py
@@ -1,0 +1,15 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMPORTANCE_VALUES = ("low", "moderate", "high", "critical")

--- a/src/datarobot_genai/drtools/workload/lifecycle_tools.py
+++ b/src/datarobot_genai/drtools/workload/lifecycle_tools.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from typing import Annotated
 from typing import Any
 
@@ -22,123 +21,8 @@ from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
-from datarobot_genai.drtools.pagination import clamp_limit
-from datarobot_genai.drtools.pagination import merge_pagination_metadata
 from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
 from datarobot_genai.drtools.workload.constants import IMPORTANCE_VALUES
-
-logger = logging.getLogger(__name__)
-
-
-# ------------------------------------------------------------------ #
-# Workload tools — read                                                #
-# ------------------------------------------------------------------ #
-
-
-@tool_metadata(
-    tags={"workload", "datarobot", "list", "search"},
-    description=(
-        "[Workload—list] Use to discover workloads: returns id, name, status, "
-        "artifactId, importance, and runtime for each workload. "
-        "Not for a single known workload id (workload_get), not for artifacts "
-        "(artifact_list).\n\n"
-        "Example: workload_list(limit=50) or workload_list(search='my-app', limit=20)."
-    ),
-)
-async def workload_list(
-    *,
-    search: Annotated[
-        str | None,
-        "Optional server-side filter; matches workload name or id.",
-    ] = None,
-    limit: Annotated[
-        int,
-        "Maximum workloads to return (1–100). Default 100.",
-    ] = 100,
-    offset: Annotated[
-        int,
-        "Number of workloads to skip for pagination. Default 0.",
-    ] = 0,
-) -> dict[str, Any]:
-    if offset < 0:
-        raise ToolError(
-            "Argument validation error: 'offset' must be >= 0.",
-            kind=ToolErrorKind.VALIDATION,
-        )
-
-    clamped_limit, note = clamp_limit(limit)
-
-    try:
-        result = WorkloadApiClient().list_workloads(
-            limit=clamped_limit, offset=offset, search=search
-        )
-    except ClientError as exc:
-        raise_tool_error_for_client_error(exc)
-
-    data = result.get("data", []) or []
-    return merge_pagination_metadata(
-        {"workloads": data, "count": len(data)},
-        result,
-        note,
-        offset=offset,
-        limit=clamped_limit,
-    )
-
-
-@tool_metadata(
-    tags={"workload", "datarobot", "get"},
-    description=(
-        "[Workload—get] Use when you have an exact workload id and need the "
-        "full record: status, runtime, artifact reference, endpoint URL, "
-        "creator, and timestamps. Not for discovery (workload_list), not for "
-        "debugging pod conditions (proton_status_details).\n\n"
-        "Example: workload_get(workload_id='wkld-abc123')."
-    ),
-)
-async def workload_get(
-    *,
-    workload_id: Annotated[
-        str,
-        "The unique id of the workload (from workload_list or workload_create).",
-    ],
-) -> dict[str, Any]:
-    if not workload_id or not workload_id.strip():
-        raise ToolError(
-            "Argument validation error: 'workload_id' cannot be empty.",
-            kind=ToolErrorKind.VALIDATION,
-        )
-
-    try:
-        return WorkloadApiClient().get_workload(workload_id.strip())
-    except ClientError as exc:
-        raise_tool_error_for_client_error(exc)
-
-
-# ------------------------------------------------------------------ #
-# Bundle tools                                                         #
-# ------------------------------------------------------------------ #
-
-
-@tool_metadata(
-    tags={"workload", "bundle", "datarobot", "list"},
-    description=(
-        "[Workload—bundle list] Use to discover available compute resource "
-        "bundles (CPU count, memory, GPU type and VRAM). GPU type and VRAM "
-        "are always determined by the bundle — there is no separate gpuType "
-        "parameter. Use the bundle id when creating or updating a workload.\n\n"
-        "Example: bundle_list()."
-    ),
-)
-async def bundle_list() -> dict[str, Any]:
-    try:
-        return WorkloadApiClient().list_bundles()
-    except ClientError as exc:
-        raise_tool_error_for_client_error(exc)
-
-
-# ------------------------------------------------------------------ #
-# Workload tools — lifecycle                                           #
-# ------------------------------------------------------------------ #
 
 
 @tool_metadata(

--- a/src/datarobot_genai/drtools/workload/read_tools.py
+++ b/src/datarobot_genai/drtools/workload/read_tools.py
@@ -1,0 +1,122 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+from typing import Any
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "list", "search"},
+    description=(
+        "[Workload—list] Use to discover workloads: returns id, name, status, "
+        "artifactId, importance, and runtime for each workload. "
+        "Not for a single known workload id (workload_get), not for artifacts "
+        "(artifact_list).\n\n"
+        "Example: workload_list(limit=50) or workload_list(search='my-app', limit=20)."
+    ),
+)
+async def workload_list(
+    *,
+    search: Annotated[
+        str | None,
+        "Optional server-side filter; matches workload name or id.",
+    ] = None,
+    limit: Annotated[
+        int,
+        "Maximum workloads to return (1–100). Default 100.",
+    ] = 100,
+    offset: Annotated[
+        int,
+        "Number of workloads to skip for pagination. Default 0.",
+    ] = 0,
+) -> dict[str, Any]:
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    clamped_limit, note = clamp_limit(limit)
+
+    try:
+        result = WorkloadApiClient().list_workloads(
+            limit=clamped_limit, offset=offset, search=search
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"workloads": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "get"},
+    description=(
+        "[Workload—get] Use when you have an exact workload id and need the "
+        "full record: status, runtime, artifact reference, endpoint URL, "
+        "creator, and timestamps. Not for discovery (workload_list), not for "
+        "debugging pod conditions (proton_status_details).\n\n"
+        "Example: workload_get(workload_id='wkld-abc123')."
+    ),
+)
+async def workload_get(
+    *,
+    workload_id: Annotated[
+        str,
+        "The unique id of the workload (from workload_list or workload_create).",
+    ],
+) -> dict[str, Any]:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    try:
+        return WorkloadApiClient().get_workload(workload_id.strip())
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+@tool_metadata(
+    tags={"workload", "bundle", "datarobot", "list"},
+    description=(
+        "[Workload—bundle list] Use to discover available compute resource "
+        "bundles (CPU count, memory, GPU type and VRAM). GPU type and VRAM "
+        "are always determined by the bundle — there is no separate gpuType "
+        "parameter. Use the bundle id when creating or updating a workload.\n\n"
+        "Example: bundle_list()."
+    ),
+)
+async def bundle_list() -> dict[str, Any]:
+    try:
+        return WorkloadApiClient().list_bundles()
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)

--- a/src/datarobot_genai/drtools/workload/tools.py
+++ b/src/datarobot_genai/drtools/workload/tools.py
@@ -133,3 +133,379 @@ async def bundle_list() -> dict[str, Any]:
         return WorkloadApiClient().list_bundles()
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# Workload tools — lifecycle                                           #
+# ------------------------------------------------------------------ #
+
+_IMPORTANCE_VALUES = ("low", "moderate", "high", "critical")
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "payload", "helper"},
+    description=(
+        "[Workload—build create payload] Build a valid workload create payload "
+        "without making an API call. Pass the returned payload dict to "
+        "workload_create. Two modes — pick exactly one:\n"
+        "  (1) existing artifact: set artifact_id.\n"
+        "  (2) inline artifact: set artifact_name, image_uri, port, cpu, memory_bytes.\n\n"
+        "Example (existing): workload_create_payload(name='my-wl', artifact_id='art-xyz')\n"
+        "Example (inline):   workload_create_payload(name='echo', artifact_name='echo', "
+        "image_uri='hashicorp/http-echo:0.2.3', port=8080, cpu=1, memory_bytes=134217728)"
+    ),
+)
+async def workload_create_payload(
+    *,
+    name: Annotated[str, "Workload display name. Required."],
+    artifact_id: Annotated[
+        str | None,
+        "ID of an existing artifact to deploy. Use this OR inline fields, not both.",
+    ] = None,
+    description: Annotated[str | None, "Optional workload description."] = None,
+    importance: Annotated[
+        str | None,
+        "Importance level: 'low' | 'moderate' | 'high' | 'critical'. Default 'low'.",
+    ] = "low",
+    resource_bundle_id: Annotated[
+        str | None,
+        "Bundle id from bundle_list. Sets runtime.containerGroups[0].resourceBundles.",
+    ] = None,
+    replica_count: Annotated[int | None, "Fixed replica count (>= 1). Default 1."] = 1,
+    artifact_name: Annotated[
+        str | None,
+        "Inline artifact name. Required when artifact_id is not provided.",
+    ] = None,
+    artifact_description: Annotated[str | None, "Inline artifact description."] = None,
+    image_uri: Annotated[
+        str | None,
+        "Docker image URI (e.g. nginx:latest). Required for inline artifact.",
+    ] = None,
+    port: Annotated[
+        int | None,
+        "Primary container port (1024–65535). Required for inline artifact.",
+    ] = None,
+    cpu: Annotated[int | None, "CPU cores (>= 1). Required for inline artifact."] = None,
+    memory_bytes: Annotated[
+        int | None,
+        "Memory in bytes (e.g. 134217728 = 128 MiB). Required for inline artifact.",
+    ] = None,
+    gpu: Annotated[int | None, "GPU count. Default 0."] = 0,
+    environment_vars: Annotated[
+        list[dict[str, str]] | None,
+        "Env vars as [{name, value}, ...] for the inline artifact container.",
+    ] = None,
+) -> dict[str, Any]:
+    use_existing = bool(artifact_id and str(artifact_id).strip())
+    inline_required = [artifact_name, image_uri, port, cpu, memory_bytes]
+    use_inline = all(v is not None for v in inline_required) and all(
+        str(v).strip() for v in [artifact_name, image_uri]
+    )
+
+    if use_existing and use_inline:
+        raise ToolError(
+            "Argument validation error: provide either artifact_id or inline fields, not both.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if not use_existing and not use_inline:
+        raise ToolError(
+            "Argument validation error: provide either artifact_id or all inline fields "
+            "(artifact_name, image_uri, port, cpu, memory_bytes).",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if not name or not str(name).strip():
+        raise ToolError(
+            "Argument validation error: 'name' is required.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if importance and importance.lower() not in _IMPORTANCE_VALUES:
+        raise ToolError(
+            f"Argument validation error: 'importance' must be one of {_IMPORTANCE_VALUES}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if use_inline:
+        if port is not None and not (1024 <= port <= 65535):
+            raise ToolError(
+                "Argument validation error: 'port' must be between 1024 and 65535.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+        if cpu is not None and cpu < 1:
+            raise ToolError(
+                "Argument validation error: 'cpu' must be >= 1.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+        if memory_bytes is not None and memory_bytes < 0:
+            raise ToolError(
+                "Argument validation error: 'memory_bytes' must be >= 0.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+    if replica_count is not None and replica_count < 1:
+        raise ToolError(
+            "Argument validation error: 'replica_count' must be >= 1.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    payload: dict[str, Any] = {"name": name.strip()}
+    if description:
+        payload["description"] = description.strip()
+    payload["importance"] = (importance or "low").lower()
+
+    if use_existing:
+        assert artifact_id is not None
+        payload["artifactId"] = artifact_id.strip()
+    else:
+        assert image_uri is not None
+        assert artifact_name is not None
+        container: dict[str, Any] = {
+            "name": "main",
+            "imageUri": image_uri.strip(),
+            "primary": True,
+            "port": port,
+            "resourceRequest": {"cpu": cpu, "memory": memory_bytes, "gpu": gpu or 0},
+        }
+        if environment_vars:
+            container["environmentVars"] = [
+                {"name": str(e.get("name", "")), "value": str(e.get("value", ""))}
+                for e in environment_vars
+                if isinstance(e, dict)
+            ]
+        artifact: dict[str, Any] = {
+            "name": artifact_name.strip(),
+            "spec": {"type": "service", "containerGroups": [{"containers": [container]}]},
+        }
+        if artifact_description:
+            artifact["description"] = artifact_description.strip()
+        payload["artifact"] = artifact
+
+    group_runtime: dict[str, Any] = {"name": "default", "replicaCount": replica_count or 1}
+    if resource_bundle_id and str(resource_bundle_id).strip():
+        group_runtime["resourceBundles"] = [resource_bundle_id.strip()]
+    payload["runtime"] = {"containerGroups": [group_runtime]}
+
+    return {"payload": payload, "usage": "Pass payload to workload_create(payload=...)."}
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "create"},
+    description=(
+        "[Workload—create] Create a new workload from a payload dict. "
+        "Use workload_create_payload to build the payload first. "
+        "The payload must contain 'name' and exactly one of 'artifactId' or 'artifact'.\n\n"
+        "Example: workload_create(payload=workload_create_payload(...)['payload'])"
+    ),
+)
+async def workload_create(
+    *,
+    payload: Annotated[
+        dict[str, Any],
+        "Create payload with 'name' and one of 'artifactId' or 'artifact'. "
+        "Build with workload_create_payload.",
+    ],
+) -> dict[str, Any]:
+    if not payload or not isinstance(payload, dict):
+        raise ToolError(
+            "Argument validation error: 'payload' must be a non-empty object.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if not (payload.get("name") or "").strip():
+        raise ToolError(
+            "Argument validation error: payload must contain a non-empty 'name'.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if bool(payload.get("artifactId")) == bool(payload.get("artifact")):
+        raise ToolError(
+            "Argument validation error: payload must contain exactly one of "
+            "'artifactId' or 'artifact'.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    try:
+        return WorkloadApiClient().create_workload(payload)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "start"},
+    description=(
+        "[Workload—start] Start a stopped workload. Returns immediately after the "
+        "request is accepted (202). Use workload_wait_for_status with "
+        "target_status='running' to block until live.\n\n"
+        "Example: workload_start(workload_id='wkld-abc')"
+    ),
+)
+async def workload_start(
+    *,
+    workload_id: Annotated[str, "Id of the workload to start."],
+) -> dict[str, Any]:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    try:
+        return WorkloadApiClient().start_workload(workload_id.strip())
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "stop"},
+    description=(
+        "[Workload—stop] Stop a running workload. By default waits until the "
+        "workload reaches 'stopped' status (up to timeout_seconds). Set "
+        "wait_stopped=False to return immediately after the stop request.\n\n"
+        "Example: workload_stop(workload_id='wkld-abc')"
+    ),
+)
+async def workload_stop(
+    *,
+    workload_id: Annotated[str, "Id of the workload to stop."],
+    wait_stopped: Annotated[bool, "Poll until status is 'stopped'. Default true."] = True,
+    timeout_seconds: Annotated[
+        int, "Max seconds to wait when wait_stopped is true. Default 120."
+    ] = 120,
+) -> dict[str, Any]:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if timeout_seconds < 1:
+        raise ToolError(
+            "Argument validation error: 'timeout_seconds' must be >= 1.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    client = WorkloadApiClient()
+    try:
+        result = client.stop_workload(workload_id.strip())
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    if wait_stopped:
+        try:
+            result = client.wait_for_workload_status(
+                workload_id.strip(), "stopped", timeout_seconds=timeout_seconds
+            )
+        except (RuntimeError, TimeoutError) as exc:
+            raise ToolError(str(exc), kind=ToolErrorKind.UPSTREAM) from exc
+
+    return result
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "delete"},
+    description=(
+        "[Workload—delete] Permanently delete a workload. The workload must be "
+        "stopped first — use workload_stop then workload_delete.\n\n"
+        "Example: workload_delete(workload_id='wkld-abc')"
+    ),
+)
+async def workload_delete(
+    *,
+    workload_id: Annotated[str, "Id of the workload to delete."],
+) -> dict[str, Any]:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    try:
+        WorkloadApiClient().delete_workload(workload_id.strip())
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    return {"deleted": True, "workload_id": workload_id.strip()}
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "update"},
+    description=(
+        "[Workload—update] Partially update a workload's name, description, or "
+        "importance. Only supplied fields are changed. At least one field is required.\n\n"
+        "Example: workload_update(workload_id='wkld-abc', name='new-name', importance='high')"
+    ),
+)
+async def workload_update(
+    *,
+    workload_id: Annotated[str, "Id of the workload to update."],
+    name: Annotated[str | None, "New workload name."] = None,
+    description: Annotated[str | None, "New workload description."] = None,
+    importance: Annotated[
+        str | None, "New importance: 'low' | 'moderate' | 'high' | 'critical'."
+    ] = None,
+) -> dict[str, Any]:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if not any([name, description, importance]):
+        raise ToolError(
+            "Argument validation error: at least one of name, description, or importance must be set.",  # noqa: E501
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if importance and importance.lower() not in _IMPORTANCE_VALUES:
+        raise ToolError(
+            f"Argument validation error: 'importance' must be one of {_IMPORTANCE_VALUES}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    patch: dict[str, Any] = {}
+    if name is not None:
+        patch["name"] = name.strip()
+    if description is not None:
+        patch["description"] = description.strip()
+    if importance is not None:
+        patch["importance"] = importance.lower()
+
+    try:
+        return WorkloadApiClient().patch_workload(workload_id.strip(), patch)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "wait"},
+    description=(
+        "[Workload—wait for status] Poll a workload until it reaches a target "
+        "status, raises if it enters 'errored', or times out. "
+        "Common targets: 'running' (after start), 'stopped' (after stop).\n\n"
+        "Example: workload_wait_for_status(workload_id='wkld-abc', target_status='running')"
+    ),
+)
+async def workload_wait_for_status(
+    *,
+    workload_id: Annotated[str, "Id of the workload to poll."],
+    target_status: Annotated[str, "Status to wait for, e.g. 'running', 'stopped', 'initializing'."],
+    timeout_seconds: Annotated[
+        int, "Max seconds to wait before raising a timeout error. Default 600."
+    ] = 600,
+) -> dict[str, Any]:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if not target_status or not target_status.strip():
+        raise ToolError(
+            "Argument validation error: 'target_status' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if timeout_seconds < 1:
+        raise ToolError(
+            "Argument validation error: 'timeout_seconds' must be >= 1.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    try:
+        return WorkloadApiClient().wait_for_workload_status(
+            workload_id.strip(),
+            target_status.strip(),
+            timeout_seconds=timeout_seconds,
+        )
+    except (RuntimeError, TimeoutError) as exc:
+        raise ToolError(str(exc), kind=ToolErrorKind.UPSTREAM) from exc
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)

--- a/src/datarobot_genai/drtools/workload/tools.py
+++ b/src/datarobot_genai/drtools/workload/tools.py
@@ -25,6 +25,7 @@ from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.pagination import clamp_limit
 from datarobot_genai.drtools.pagination import merge_pagination_metadata
 from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drtools.workload.constants import IMPORTANCE_VALUES
 
 logger = logging.getLogger(__name__)
 
@@ -139,8 +140,6 @@ async def bundle_list() -> dict[str, Any]:
 # Workload tools — lifecycle                                           #
 # ------------------------------------------------------------------ #
 
-_IMPORTANCE_VALUES = ("low", "moderate", "high", "critical")
-
 
 @tool_metadata(
     tags={"workload", "datarobot", "payload", "helper"},
@@ -218,9 +217,9 @@ async def workload_create_payload(
             "Argument validation error: 'name' is required.",
             kind=ToolErrorKind.VALIDATION,
         )
-    if importance and importance.lower() not in _IMPORTANCE_VALUES:
+    if importance and importance.lower() not in IMPORTANCE_VALUES:
         raise ToolError(
-            f"Argument validation error: 'importance' must be one of {_IMPORTANCE_VALUES}.",
+            f"Argument validation error: 'importance' must be one of {IMPORTANCE_VALUES}.",
             kind=ToolErrorKind.VALIDATION,
         )
     if use_inline:
@@ -385,11 +384,13 @@ async def workload_stop(
 
     if wait_stopped:
         try:
-            result = client.wait_for_workload_status(
+            result = await client.wait_for_workload_status(
                 workload_id.strip(), "stopped", timeout_seconds=timeout_seconds
             )
         except (RuntimeError, TimeoutError) as exc:
             raise ToolError(str(exc), kind=ToolErrorKind.UPSTREAM) from exc
+        except ClientError as exc:
+            raise_tool_error_for_client_error(exc)
 
     return result
 
@@ -446,9 +447,9 @@ async def workload_update(
             "Argument validation error: at least one of name, description, or importance must be set.",  # noqa: E501
             kind=ToolErrorKind.VALIDATION,
         )
-    if importance and importance.lower() not in _IMPORTANCE_VALUES:
+    if importance and importance.lower() not in IMPORTANCE_VALUES:
         raise ToolError(
-            f"Argument validation error: 'importance' must be one of {_IMPORTANCE_VALUES}.",
+            f"Argument validation error: 'importance' must be one of {IMPORTANCE_VALUES}.",
             kind=ToolErrorKind.VALIDATION,
         )
 
@@ -500,7 +501,7 @@ async def workload_wait_for_status(
         )
 
     try:
-        return WorkloadApiClient().wait_for_workload_status(
+        return await WorkloadApiClient().wait_for_workload_status(
             workload_id.strip(),
             target_status.strip(),
             timeout_seconds=timeout_seconds,

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -23,7 +23,8 @@ from datarobot.errors import ClientError
 
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
-from datarobot_genai.drtools.workload import tools
+from datarobot_genai.drtools.workload import lifecycle_tools
+from datarobot_genai.drtools.workload import read_tools
 
 # ------------------------------------------------------------------ #
 # Shared fixtures                                                       #
@@ -65,7 +66,7 @@ async def test_workload_list_success(patched_dr_client: MagicMock) -> None:
         }
     )
 
-    result = await tools.workload_list()
+    result = await read_tools.workload_list()
 
     assert result["count"] == 2
     assert result["total_count"] == 2
@@ -80,7 +81,7 @@ async def test_workload_list_with_search(patched_dr_client: MagicMock) -> None:
         json=lambda: {"data": [{"id": "wkld-1", "name": "my-app"}], "count": 1}
     )
 
-    result = await tools.workload_list(search="my-app", limit=10, offset=5)
+    result = await read_tools.workload_list(search="my-app", limit=10, offset=5)
 
     patched_dr_client.get.assert_called_once_with(
         "workloads/", params={"limit": 10, "offset": 5, "search": "my-app"}
@@ -94,7 +95,7 @@ async def test_workload_list_with_search(patched_dr_client: MagicMock) -> None:
 async def test_workload_list_clamps_limit(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": [], "count": 0})
 
-    result = await tools.workload_list(limit=500)
+    result = await read_tools.workload_list(limit=500)
 
     # limit clamped to 100
     patched_dr_client.get.assert_called_once_with("workloads/", params={"limit": 100, "offset": 0})
@@ -105,7 +106,7 @@ async def test_workload_list_clamps_limit(patched_dr_client: MagicMock) -> None:
 @pytest.mark.asyncio
 async def test_workload_list_negative_offset_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_list(offset=-1)
+        await read_tools.workload_list(offset=-1)
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
@@ -116,7 +117,7 @@ async def test_workload_list_client_error(patched_dr_client: MagicMock) -> None:
     )
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_list()
+        await read_tools.workload_list()
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
@@ -125,7 +126,7 @@ async def test_workload_list_404_raises_not_found(patched_dr_client: MagicMock) 
     patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_list()
+        await read_tools.workload_list()
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
 
 
@@ -145,7 +146,7 @@ async def test_workload_get_success(patched_dr_client: MagicMock) -> None:
         }
     )
 
-    result = await tools.workload_get(workload_id="wkld-abc")
+    result = await read_tools.workload_get(workload_id="wkld-abc")
 
     patched_dr_client.get.assert_called_once_with("workloads/wkld-abc")
     assert result["id"] == "wkld-abc"
@@ -156,7 +157,7 @@ async def test_workload_get_success(patched_dr_client: MagicMock) -> None:
 async def test_workload_get_strips_whitespace(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.return_value = MagicMock(json=lambda: {"id": "wkld-abc"})
 
-    await tools.workload_get(workload_id="  wkld-abc  ")
+    await read_tools.workload_get(workload_id="  wkld-abc  ")
 
     patched_dr_client.get.assert_called_once_with("workloads/wkld-abc")
 
@@ -164,7 +165,7 @@ async def test_workload_get_strips_whitespace(patched_dr_client: MagicMock) -> N
 @pytest.mark.asyncio
 async def test_workload_get_empty_id_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_get(workload_id="")
+        await read_tools.workload_get(workload_id="")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
@@ -173,7 +174,7 @@ async def test_workload_get_not_found(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_get(workload_id="wkld-missing")
+        await read_tools.workload_get(workload_id="wkld-missing")
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
 
 
@@ -192,7 +193,7 @@ async def test_bundle_list_success(patched_dr_client: MagicMock) -> None:
     }
     patched_dr_client.get.return_value = MagicMock(json=lambda: bundles_payload)
 
-    result = await tools.bundle_list()
+    result = await read_tools.bundle_list()
 
     patched_dr_client.get.assert_called_once_with("mlops/compute/bundles")
     assert result == bundles_payload
@@ -205,7 +206,7 @@ async def test_bundle_list_client_error(patched_dr_client: MagicMock) -> None:
     )
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.bundle_list()
+        await read_tools.bundle_list()
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
@@ -216,7 +217,7 @@ async def test_bundle_list_client_error(patched_dr_client: MagicMock) -> None:
 
 @pytest.mark.asyncio
 async def test_create_payload_existing_artifact() -> None:
-    result = await tools.workload_create_payload(name="my-wl", artifact_id="art-abc")
+    result = await lifecycle_tools.workload_create_payload(name="my-wl", artifact_id="art-abc")
     p = result["payload"]
     assert p["name"] == "my-wl"
     assert p["artifactId"] == "art-abc"
@@ -227,7 +228,7 @@ async def test_create_payload_existing_artifact() -> None:
 
 @pytest.mark.asyncio
 async def test_create_payload_inline_artifact() -> None:
-    result = await tools.workload_create_payload(
+    result = await lifecycle_tools.workload_create_payload(
         name="test-echo",
         artifact_name="echo",
         image_uri="hashicorp/http-echo:0.2.3",
@@ -251,7 +252,7 @@ async def test_create_payload_inline_artifact() -> None:
 @pytest.mark.asyncio
 async def test_create_payload_both_modes_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create_payload(
+        await lifecycle_tools.workload_create_payload(
             name="x",
             artifact_id="art-abc",
             artifact_name="echo",
@@ -266,21 +267,23 @@ async def test_create_payload_both_modes_raises() -> None:
 @pytest.mark.asyncio
 async def test_create_payload_neither_mode_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create_payload(name="x")
+        await lifecycle_tools.workload_create_payload(name="x")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
 async def test_create_payload_invalid_importance_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create_payload(name="wl", artifact_id="art-1", importance="ultra")
+        await lifecycle_tools.workload_create_payload(
+            name="wl", artifact_id="art-1", importance="ultra"
+        )
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
 async def test_create_payload_invalid_port_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create_payload(
+        await lifecycle_tools.workload_create_payload(
             name="wl", artifact_name="x", image_uri="x:1", port=80, cpu=1, memory_bytes=1
         )
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
@@ -288,7 +291,7 @@ async def test_create_payload_invalid_port_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_create_payload_env_vars() -> None:
-    result = await tools.workload_create_payload(
+    result = await lifecycle_tools.workload_create_payload(
         name="app-wl",
         artifact_name="app",
         image_uri="my-image:latest",
@@ -312,7 +315,7 @@ async def test_workload_create_success(patched_dr_client: MagicMock) -> None:
         json=lambda: {"id": "wkld-new", "name": "my-wl", "status": "initializing"}
     )
 
-    result = await tools.workload_create(
+    result = await lifecycle_tools.workload_create(
         payload={"name": "my-wl", "artifactId": "art-abc", "runtime": {}}
     )
 
@@ -325,21 +328,21 @@ async def test_workload_create_success(patched_dr_client: MagicMock) -> None:
 @pytest.mark.asyncio
 async def test_workload_create_empty_payload_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create(payload={})
+        await lifecycle_tools.workload_create(payload={})
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
 async def test_workload_create_missing_name_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create(payload={"artifactId": "art-1"})
+        await lifecycle_tools.workload_create(payload={"artifactId": "art-1"})
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
 async def test_workload_create_both_artifact_fields_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create(
+        await lifecycle_tools.workload_create(
             payload={"name": "wl", "artifactId": "art-1", "artifact": {"name": "x"}}
         )
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
@@ -349,7 +352,7 @@ async def test_workload_create_both_artifact_fields_raises() -> None:
 async def test_workload_create_client_error(patched_dr_client: MagicMock) -> None:
     patched_dr_client.post.side_effect = ClientError("422", status_code=422, json={})
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_create(payload={"name": "wl", "artifactId": "art-1"})
+        await lifecycle_tools.workload_create(payload={"name": "wl", "artifactId": "art-1"})
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
@@ -364,7 +367,7 @@ async def test_workload_start_success(patched_dr_client: MagicMock) -> None:
         content=b'{"accepted":true}', json=lambda: {"accepted": True}
     )
 
-    result = await tools.workload_start(workload_id="wkld-abc")
+    result = await lifecycle_tools.workload_start(workload_id="wkld-abc")
 
     patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/start")
     assert result == {"accepted": True}
@@ -373,7 +376,7 @@ async def test_workload_start_success(patched_dr_client: MagicMock) -> None:
 @pytest.mark.asyncio
 async def test_workload_start_empty_id_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_start(workload_id="")
+        await lifecycle_tools.workload_start(workload_id="")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
@@ -388,7 +391,7 @@ async def test_workload_stop_no_wait(patched_dr_client: MagicMock) -> None:
         content=b'{"accepted":true}', json=lambda: {"accepted": True}
     )
 
-    result = await tools.workload_stop(workload_id="wkld-abc", wait_stopped=False)
+    result = await lifecycle_tools.workload_stop(workload_id="wkld-abc", wait_stopped=False)
 
     patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/stop")
     assert result == {"accepted": True}
@@ -401,7 +404,7 @@ async def test_workload_stop_with_wait(patched_dr_client: MagicMock) -> None:
         json=lambda: {"id": "wkld-abc", "status": "stopped"}
     )
 
-    result = await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
+    result = await lifecycle_tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
 
     assert result["status"] == "stopped"
 
@@ -414,7 +417,9 @@ async def test_workload_stop_timeout_raises(patched_dr_client: MagicMock) -> Non
     )
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True, timeout_seconds=1)
+        await lifecycle_tools.workload_stop(
+            workload_id="wkld-abc", wait_stopped=True, timeout_seconds=1
+        )
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
@@ -426,7 +431,9 @@ async def test_workload_stop_errored_raises(patched_dr_client: MagicMock) -> Non
     )
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True, timeout_seconds=30)
+        await lifecycle_tools.workload_stop(
+            workload_id="wkld-abc", wait_stopped=True, timeout_seconds=30
+        )
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
@@ -436,7 +443,7 @@ async def test_workload_stop_wait_client_error(patched_dr_client: MagicMock) -> 
     patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
+        await lifecycle_tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
 
 
@@ -449,7 +456,7 @@ async def test_workload_stop_wait_client_error(patched_dr_client: MagicMock) -> 
 async def test_workload_delete_success(patched_dr_client: MagicMock) -> None:
     patched_dr_client.delete.return_value = MagicMock()
 
-    result = await tools.workload_delete(workload_id="wkld-abc")
+    result = await lifecycle_tools.workload_delete(workload_id="wkld-abc")
 
     patched_dr_client.delete.assert_called_once_with("workloads/wkld-abc")
     assert result == {"deleted": True, "workload_id": "wkld-abc"}
@@ -458,7 +465,7 @@ async def test_workload_delete_success(patched_dr_client: MagicMock) -> None:
 @pytest.mark.asyncio
 async def test_workload_delete_empty_id_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_delete(workload_id="")
+        await lifecycle_tools.workload_delete(workload_id="")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
@@ -473,7 +480,7 @@ async def test_workload_update_name(patched_dr_client: MagicMock) -> None:
         json=lambda: {"id": "wkld-abc", "name": "new-name"}
     )
 
-    result = await tools.workload_update(workload_id="wkld-abc", name="new-name")
+    result = await lifecycle_tools.workload_update(workload_id="wkld-abc", name="new-name")
 
     patched_dr_client.patch.assert_called_once_with("workloads/wkld-abc", json={"name": "new-name"})
     assert result["name"] == "new-name"
@@ -483,7 +490,7 @@ async def test_workload_update_name(patched_dr_client: MagicMock) -> None:
 async def test_workload_update_multiple_fields(patched_dr_client: MagicMock) -> None:
     patched_dr_client.patch.return_value = MagicMock(json=lambda: {"id": "wkld-abc"})
 
-    await tools.workload_update(
+    await lifecycle_tools.workload_update(
         workload_id="wkld-abc", name="x", description="desc", importance="high"
     )
 
@@ -495,14 +502,14 @@ async def test_workload_update_multiple_fields(patched_dr_client: MagicMock) -> 
 @pytest.mark.asyncio
 async def test_workload_update_no_fields_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_update(workload_id="wkld-abc")
+        await lifecycle_tools.workload_update(workload_id="wkld-abc")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
 async def test_workload_update_invalid_importance_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_update(workload_id="wkld-abc", importance="ultra")
+        await lifecycle_tools.workload_update(workload_id="wkld-abc", importance="ultra")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
@@ -517,7 +524,9 @@ async def test_workload_wait_for_status_immediate(patched_dr_client: MagicMock) 
         json=lambda: {"id": "wkld-abc", "status": "running"}
     )
 
-    result = await tools.workload_wait_for_status(workload_id="wkld-abc", target_status="running")
+    result = await lifecycle_tools.workload_wait_for_status(
+        workload_id="wkld-abc", target_status="running"
+    )
 
     assert result["status"] == "running"
 
@@ -529,21 +538,23 @@ async def test_workload_wait_for_status_errored_raises(patched_dr_client: MagicM
     )
 
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_wait_for_status(workload_id="wkld-abc", target_status="running")
+        await lifecycle_tools.workload_wait_for_status(
+            workload_id="wkld-abc", target_status="running"
+        )
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
 @pytest.mark.asyncio
 async def test_workload_wait_for_status_empty_target_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_wait_for_status(workload_id="wkld-abc", target_status="")
+        await lifecycle_tools.workload_wait_for_status(workload_id="wkld-abc", target_status="")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
 async def test_workload_wait_for_status_zero_timeout_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await tools.workload_wait_for_status(
+        await lifecycle_tools.workload_wait_for_status(
             workload_id="wkld-abc", target_status="running", timeout_seconds=0
         )
     assert exc_info.value.kind is ToolErrorKind.VALIDATION

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -430,6 +430,16 @@ async def test_workload_stop_errored_raises(patched_dr_client: MagicMock) -> Non
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
+@pytest.mark.asyncio
+async def test_workload_stop_wait_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
+    patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
 # ------------------------------------------------------------------ #
 # workload_delete                                                       #
 # ------------------------------------------------------------------ #

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -207,3 +207,333 @@ async def test_bundle_list_client_error(patched_dr_client: MagicMock) -> None:
     with pytest.raises(ToolError) as exc_info:
         await tools.bundle_list()
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# workload_create_payload                                              #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_create_payload_existing_artifact() -> None:
+    result = await tools.workload_create_payload(name="my-wl", artifact_id="art-abc")
+    p = result["payload"]
+    assert p["name"] == "my-wl"
+    assert p["artifactId"] == "art-abc"
+    assert "artifact" not in p
+    assert p["importance"] == "low"
+    assert p["runtime"]["containerGroups"][0]["replicaCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_payload_inline_artifact() -> None:
+    result = await tools.workload_create_payload(
+        name="test-echo",
+        artifact_name="echo",
+        image_uri="hashicorp/http-echo:0.2.3",
+        port=8080,
+        cpu=1,
+        memory_bytes=134217728,
+        importance="high",
+        resource_bundle_id="cpu.small",
+    )
+    p = result["payload"]
+    assert p["name"] == "test-echo"
+    assert p["importance"] == "high"
+    assert "artifactId" not in p
+    container = p["artifact"]["spec"]["containerGroups"][0]["containers"][0]
+    assert container["imageUri"] == "hashicorp/http-echo:0.2.3"
+    assert container["port"] == 8080
+    assert container["resourceRequest"]["cpu"] == 1
+    assert p["runtime"]["containerGroups"][0]["resourceBundles"] == ["cpu.small"]
+
+
+@pytest.mark.asyncio
+async def test_create_payload_both_modes_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create_payload(
+            name="x",
+            artifact_id="art-abc",
+            artifact_name="echo",
+            image_uri="nginx:latest",
+            port=8080,
+            cpu=1,
+            memory_bytes=134217728,
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_create_payload_neither_mode_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create_payload(name="x")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_create_payload_invalid_importance_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create_payload(name="wl", artifact_id="art-1", importance="ultra")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_create_payload_invalid_port_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create_payload(
+            name="wl", artifact_name="x", image_uri="x:1", port=80, cpu=1, memory_bytes=1
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_create_payload_env_vars() -> None:
+    result = await tools.workload_create_payload(
+        name="app-wl",
+        artifact_name="app",
+        image_uri="my-image:latest",
+        port=8080,
+        cpu=2,
+        memory_bytes=268435456,
+        environment_vars=[{"name": "FOO", "value": "bar"}],
+    )
+    container = result["payload"]["artifact"]["spec"]["containerGroups"][0]["containers"][0]
+    assert container["environmentVars"] == [{"name": "FOO", "value": "bar"}]
+
+
+# ------------------------------------------------------------------ #
+# workload_create                                                      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_create_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(
+        json=lambda: {"id": "wkld-new", "name": "my-wl", "status": "initializing"}
+    )
+
+    result = await tools.workload_create(
+        payload={"name": "my-wl", "artifactId": "art-abc", "runtime": {}}
+    )
+
+    patched_dr_client.post.assert_called_once_with(
+        "workloads/", json={"name": "my-wl", "artifactId": "art-abc", "runtime": {}}
+    )
+    assert result["id"] == "wkld-new"
+
+
+@pytest.mark.asyncio
+async def test_workload_create_empty_payload_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create(payload={})
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_create_missing_name_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create(payload={"artifactId": "art-1"})
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_create_both_artifact_fields_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create(
+            payload={"name": "wl", "artifactId": "art-1", "artifact": {"name": "x"}}
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_create_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.side_effect = ClientError("422", status_code=422, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_create(payload={"name": "wl", "artifactId": "art-1"})
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# workload_start                                                        #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_start_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(
+        content=b'{"accepted":true}', json=lambda: {"accepted": True}
+    )
+
+    result = await tools.workload_start(workload_id="wkld-abc")
+
+    patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/start")
+    assert result == {"accepted": True}
+
+
+@pytest.mark.asyncio
+async def test_workload_start_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_start(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# workload_stop                                                         #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_stop_no_wait(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(
+        content=b'{"accepted":true}', json=lambda: {"accepted": True}
+    )
+
+    result = await tools.workload_stop(workload_id="wkld-abc", wait_stopped=False)
+
+    patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/stop")
+    assert result == {"accepted": True}
+
+
+@pytest.mark.asyncio
+async def test_workload_stop_with_wait(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "stopped"}
+    )
+
+    result = await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
+
+    assert result["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_workload_stop_timeout_raises(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "running"}
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True, timeout_seconds=1)
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+@pytest.mark.asyncio
+async def test_workload_stop_errored_raises(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "errored"}
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_stop(workload_id="wkld-abc", wait_stopped=True, timeout_seconds=30)
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# workload_delete                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_delete_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.return_value = MagicMock()
+
+    result = await tools.workload_delete(workload_id="wkld-abc")
+
+    patched_dr_client.delete.assert_called_once_with("workloads/wkld-abc")
+    assert result == {"deleted": True, "workload_id": "wkld-abc"}
+
+
+@pytest.mark.asyncio
+async def test_workload_delete_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_delete(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# workload_update                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_update_name(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.patch.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "name": "new-name"}
+    )
+
+    result = await tools.workload_update(workload_id="wkld-abc", name="new-name")
+
+    patched_dr_client.patch.assert_called_once_with("workloads/wkld-abc", json={"name": "new-name"})
+    assert result["name"] == "new-name"
+
+
+@pytest.mark.asyncio
+async def test_workload_update_multiple_fields(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.patch.return_value = MagicMock(json=lambda: {"id": "wkld-abc"})
+
+    await tools.workload_update(
+        workload_id="wkld-abc", name="x", description="desc", importance="high"
+    )
+
+    patched_dr_client.patch.assert_called_once_with(
+        "workloads/wkld-abc", json={"name": "x", "description": "desc", "importance": "high"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_workload_update_no_fields_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_update(workload_id="wkld-abc")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_update_invalid_importance_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_update(workload_id="wkld-abc", importance="ultra")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# workload_wait_for_status                                             #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_wait_for_status_immediate(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "running"}
+    )
+
+    result = await tools.workload_wait_for_status(workload_id="wkld-abc", target_status="running")
+
+    assert result["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_workload_wait_for_status_errored_raises(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "errored"}
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_wait_for_status(workload_id="wkld-abc", target_status="running")
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+@pytest.mark.asyncio
+async def test_workload_wait_for_status_empty_target_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_wait_for_status(workload_id="wkld-abc", target_status="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_wait_for_status_zero_timeout_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await tools.workload_wait_for_status(
+            workload_id="wkld-abc", target_status="running", timeout_seconds=0
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.122"
+version = "0.15.123"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Created workload api lifecycle write tools 
- Created unit tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces destructive workload operations (delete, stop) and long-running polling against the Workload API; mitigated by validation and per-request user-scoped clients, but agents can still mutate real infrastructure when tools are enabled.
> 
> **Overview**
> Adds **DataRobot Workload API lifecycle** support for MCP agents on top of the existing read-only workload tools, bumping the package to **0.15.123**.
> 
> **`WorkloadApiClient`** gains write and polling helpers: create, start/stop, delete, PATCH metadata, and `wait_for_workload_status` (fails on `errored`, times out with `TimeoutError`).
> 
> **New `drtools/workload` tools** expose the full flow: `workload_create_payload` (validates existing `artifactId` vs inline container spec, bundles via `runtime.containerGroups[].resourceBundles`), then `workload_create`, `workload_start`, `workload_stop` (optional wait until stopped), `workload_delete`, `workload_update`, and `workload_wait_for_status`. Inputs are validated client-side; API errors map to `ToolError`.
> 
> **Tests** add broad unit coverage in `tests/drmcp/unit/workload_tools/test_tools.py`; the PR does not add integration/acceptance tests called out in the project checklist for new `drtools` tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5890179d04d8f92c7b78b08c71c41c9878e87fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->