### PR TITLE
[MODEL-23717] Remove user MCP lineage feature flag checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.126
+- Removed user MCP lineage feature flag logic
+
 ## 0.15.125
 - `dragent/frontends/converters`: registered `convert_run_agent_input_to_chat_request_or_message` so plain `RunAgentInput` from the DRUM `NatAgent.invoke` / `streaming_memory_agent` passthrough boundary converts to NAT `ChatRequestOrMessage` for inner `per_user_tool_calling_agent` workflows.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.125"
+version = "0.15.126"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -27,7 +27,6 @@ from fastmcp.resources import Resource
 from fastmcp.tools import Tool
 from starlette.middleware import Middleware
 
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
 from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.middleware import initialize_oauth_middleware
@@ -222,17 +221,14 @@ class DataRobotMCPServer:
                 self._logger.info("Registering dynamic prompts from prompt management...")
                 asyncio.run(register_prompts_from_datarobot_prompt_management())
 
-            if asyncio.run(
-                FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user()
-            ):
-                try:
-                    linear_manager = LineageManager(self._mcp)
-                    asyncio.run(linear_manager.sync_mcp_tools())
-                    asyncio.run(linear_manager.sync_mcp_prompts())
-                    self._logger.info("Sync with MCP lineage")
-                except LRSEnvVarIsNotSetError as error:
-                    error_message = f"MCP item metadata is not sync. {str(error)}"
-                    self._logger.warning(error_message)
+            try:
+                linear_manager = LineageManager(self._mcp)
+                asyncio.run(linear_manager.sync_mcp_tools())
+                asyncio.run(linear_manager.sync_mcp_prompts())
+                self._logger.info("Sync with MCP lineage")
+            except LRSEnvVarIsNotSetError as error:
+                error_message = f"MCP item metadata is not sync. {str(error)}"
+                self._logger.warning(error_message)
 
             # Execute pre-server start actions
             asyncio.run(self._lifecycle.pre_server_start(self._mcp))

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
@@ -24,7 +24,6 @@ from datarobot_genai.drmcp.core.dynamic_prompts.register import (
     register_prompt_from_datarobot_prompt_management,
 )
 from datarobot_genai.drmcp.core.exceptions import DynamicPromptRegistrationError
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
 from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
@@ -59,13 +58,12 @@ async def register_prompt_from_prompt_template_id_and_version(
         registered_prompt = await register_prompt_from_datarobot_prompt_management(
             prompt_template=prompt_template
         )
-        if await FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user():
-            try:
-                linear_manager = LineageManager(mcp)
-                await linear_manager.sync_mcp_prompts()
-            except LRSEnvVarIsNotSetError as error:
-                error_message = f"MCP item metadata is not sync. {str(error)}"
-                logger.warning(error_message)
+        try:
+            linear_manager = LineageManager(mcp)
+            await linear_manager.sync_mcp_prompts()
+        except LRSEnvVarIsNotSetError as error:
+            error_message = f"MCP item metadata is not sync. {str(error)}"
+            logger.warning(error_message)
         return registered_prompt
 
     prompt_template_version = get_datarobot_prompt_template_version(
@@ -80,13 +78,12 @@ async def register_prompt_from_prompt_template_id_and_version(
     registered_prompt = await register_prompt_from_datarobot_prompt_management(
         prompt_template=prompt_template, prompt_template_version=prompt_template_version
     )
-    if await FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_prompts()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
+    try:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_prompts()
+    except LRSEnvVarIsNotSetError as error:
+        error_message = f"MCP item metadata is not sync. {str(error)}"
+        logger.warning(error_message)
     return registered_prompt
 
 
@@ -103,13 +100,12 @@ async def delete_registered_prompt_template(prompt_template_id: str) -> bool:
         f"Deleted prompt name {prompt_name} for prompt template id {prompt_template_id}, "
         f"version {prompt_template_version_id}"
     )
-    if await FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_prompts()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
+    try:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_prompts()
+    except LRSEnvVarIsNotSetError as error:
+        error_message = f"MCP item metadata is not sync. {str(error)}"
+        logger.warning(error_message)
     return True
 
 
@@ -157,10 +153,9 @@ async def refresh_registered_prompt_template(headers_auth_only: bool = False) ->
             # We need to also delete prompt templates that are
             await mcp.remove_prompt_mapping(mcp_prompt_template_id, mcp_prompt_template_version_id)
 
-    if await FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_prompts()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
+    try:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_prompts()
+    except LRSEnvVarIsNotSetError as error:
+        error_message = f"MCP item metadata is not sync. {str(error)}"
+        logger.warning(error_message)

--- a/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_tools/deployment/controllers.py
@@ -20,7 +20,6 @@ from fastmcp.tools.tool import Tool
 from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
     register_tool_of_datarobot_deployment,
 )
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
 from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.mcp_instance import mcp
@@ -46,13 +45,12 @@ async def register_tool_for_deployment_id(deployment_id: str) -> Tool:
     with request_user_dr_sdk(headers_auth_only=True):
         deployment = dr.Deployment.get(deployment_id)
     registered_tool = await register_tool_of_datarobot_deployment(deployment)
-    if await FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_tools()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
+    try:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_tools()
+    except LRSEnvVarIsNotSetError as error:
+        error_message = f"MCP item metadata is not sync. {str(error)}"
+        logger.warning(error_message)
 
     return registered_tool
 
@@ -73,11 +71,10 @@ async def delete_registered_tool_deployment(deployment_id: str) -> bool:
     tool_name = deployments[deployment_id]
     await mcp.remove_deployment_mapping(deployment_id)
     logger.info(f"Deleted tool {tool_name} for deployment {deployment_id}")
-    if await FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user():
-        try:
-            linear_manager = LineageManager(mcp)
-            await linear_manager.sync_mcp_tools()
-        except LRSEnvVarIsNotSetError as error:
-            error_message = f"MCP item metadata is not sync. {str(error)}"
-            logger.warning(error_message)
+    try:
+        linear_manager = LineageManager(mcp)
+        await linear_manager.sync_mcp_tools()
+    except LRSEnvVarIsNotSetError as error:
+        error_message = f"MCP item metadata is not sync. {str(error)}"
+        logger.warning(error_message)
     return True

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -40,7 +40,6 @@ import datarobot_predict.deployment as _dr_predict_deployment
 
 from datarobot_genai.drmcp import create_mcp_server
 from datarobot_genai.drmcp.core.dynamic_prompts import register as prompt_register
-from datarobot_genai.drmcp.core.feature_flags import FeatureFlag
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import test_create_dr_client
 from datarobot_genai.drmcp.test_utils.stubs.prediction_result_stub import (
@@ -167,7 +166,6 @@ def apply_lineage_manager_stubs() -> None:
     LineageManager.__init__ = Mock(return_value=None)  # type: ignore[assignment]
     LineageManager.sync_mcp_tools = AsyncMock()  # type: ignore[assignment]
     LineageManager.sync_mcp_prompts = AsyncMock()  # type: ignore[assignment]
-    FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user = AsyncMock()  # type: ignore[assignment]
 
 
 def _apply_dr_sdk_stubs(stub_dr: Any, mock_rest: MagicMock) -> None:

--- a/tests/drmcp/unit/dynamic_prompts/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_controllers.py
@@ -150,7 +150,6 @@ class TestPromptTemplatesAdd:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -214,7 +213,6 @@ class TestPromptTemplatesAdd:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_registering_with_prompt_template_id(
         self,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_get_datarobot_prompt_template: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
@@ -228,14 +226,12 @@ class TestPromptTemplatesAdd:
         mock_register_prompt_from_datarobot_prompt_management.assert_called_once_with(
             prompt_template=mock_prompt_template,
         )
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_registering_with_prompt_template_and_version_ids(
         self,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_get_datarobot_prompt_template: Mock,
         mock_get_datarobot_prompt_template_version: Mock,
         mock_lineage_manager_init: Mock,
@@ -260,7 +256,6 @@ class TestPromptTemplatesAdd:
             prompt_template=mock_prompt_template,
             prompt_template_version=mock_prompt_template_version,
         )
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
 
@@ -298,7 +293,6 @@ class TestPromptTemplatesDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -334,7 +328,6 @@ class TestPromptTemplatesDeletion:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_deletion(
         self,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
         mcp_server: DataRobotMCP,
@@ -344,7 +337,6 @@ class TestPromptTemplatesDeletion:
 
         await delete_registered_prompt_template(prompt_id)
 
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()
 
@@ -368,7 +360,6 @@ class TestPromptTemplatesRefresh:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_prompts",
     )
@@ -405,13 +396,11 @@ class TestPromptTemplatesRefresh:
     )
     async def test_sync_mcp_metadata_after_refresh_prompts(
         self,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: Mock,
         mcp_server: DataRobotMCP,
     ) -> None:
         await refresh_registered_prompt_template()
 
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_prompts.assert_called_once_with()

--- a/tests/drmcp/unit/dynamic_tools/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_tools/test_controllers.py
@@ -138,7 +138,6 @@ class TestToolRegistration:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -171,7 +170,6 @@ class TestToolRegistration:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -213,7 +211,6 @@ class TestToolRegistration:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_registration(
         self,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_request_user_dr_sdk: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_tools: Mock,
@@ -231,7 +228,6 @@ class TestToolRegistration:
         mock_register_tool_of_datarobot_deployment.assert_called_once_with(
             mock_deployment_get.return_value
         )
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_tools.assert_called_once_with()
 
@@ -275,7 +271,6 @@ class TestDeploymentDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -311,7 +306,6 @@ class TestDeploymentDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -357,7 +351,6 @@ class TestDeploymentDeletion:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )
@@ -410,7 +403,6 @@ class TestDeploymentDeletion:
     @pytest.mark.asyncio
     async def test_sync_mcp_metadata_after_deletion(
         self,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_tools: Mock,
         mcp_server: DataRobotMCP,
@@ -420,7 +412,6 @@ class TestDeploymentDeletion:
 
         await delete_registered_tool_deployment(tool_id)
 
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mcp_server)
         mock_sync_mcp_tools.assert_called_once_with()
 
@@ -430,7 +421,6 @@ class TestIntegratedWorkflow:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
-        "mock_is_mcp_tools_gallery_support_enabled",
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
     )

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -101,7 +101,6 @@ class TestDataRobotMCPServer:
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
         "mock_sync_mcp_prompts",
-        "mock_is_mcp_tools_gallery_support_enabled",
     )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch(
@@ -188,7 +187,6 @@ class TestDataRobotMCPServer:
         mock_get_config: MagicMock,
         mock_mcp: MagicMock,
         mock_config: MagicMock,
-        mock_is_mcp_tools_gallery_support_enabled: Mock,
         mock_lineage_manager_init: Mock,
         mock_sync_mcp_prompts: AsyncMock,
         mock_sync_mcp_tools: AsyncMock,
@@ -217,7 +215,6 @@ class TestDataRobotMCPServer:
         mock_mcp.list_tools.assert_called_once()
 
         # Check MCP lineage
-        mock_is_mcp_tools_gallery_support_enabled.assert_called_once_with()
         mock_lineage_manager_init.assert_called_once_with(mock_mcp)
         mock_sync_mcp_prompts.assert_called_once_with()
         mock_sync_mcp_tools.assert_called_once_with()
@@ -226,7 +223,6 @@ class TestDataRobotMCPServer:
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
         "mock_sync_mcp_prompts",
-        "mock_is_mcp_tools_gallery_support_enabled",
     )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")
@@ -260,7 +256,6 @@ class TestDataRobotMCPServer:
         "mock_lineage_manager_init",
         "mock_sync_mcp_tools",
         "mock_sync_mcp_prompts",
-        "mock_is_mcp_tools_gallery_support_enabled",
     )
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.get_config")
     @patch("datarobot_genai.drmcp.core.dr_mcp_server.asyncio")


### PR DESCRIPTION
# RATIONALE
User MCP lineage feature was signed off. This PR removed the feature flag logic around it.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lineage sync now runs on every startup and dynamic tool/prompt mutation; environments without LRS configured will hit the existing warning path more often, but behavior is unchanged when lineage is properly configured.
> 
> **Overview**
> **MCP lineage sync is always on** now that user MCP lineage has shipped—`ENABLE_MCP_TOOLS_GALLERY_SUPPORT` gating via `FeatureFlag.is_mcp_tools_gallery_support_enabled_for_static_mcp_container_user()` is removed from server startup and dynamic tool/prompt controllers.
> 
> `LineageManager.sync_mcp_tools()` / `sync_mcp_prompts()` run unconditionally (still wrapped in `try`/`except LRSEnvVarIsNotSetError` with a warning). The same applies on register, delete, and refresh for deployment tools and prompt templates.
> 
> Tests and integration stubs drop feature-flag mocks and assertions; lineage behavior tests now expect sync without checking the flag first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5df5fc923a0f65f3575d4cf008f8676924e05003. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->