### PR TITLE
[MODEL-23708] Workload API | Settings and Observability Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.15.126
+- `drtools/workload`: PR3 — settings and observability tools.
+  - **New tools** (`observability_tools.py`): `workload_settings_get`, `workload_settings_update` (triggers rolling replacement via PATCH /settings), `workload_stats` (aggregated perf stats with quantile + slow-request controls), `workload_history` (artifact deployment history), `workload_events` (status-change and error events), `workload_promote` (lock running draft artifact), `workload_related` (linked artifacts and related entities).
+  - **Client additions** (`WorkloadApiClient`): `get_workload_settings`, `update_workload_settings`, `get_workload_stats`, `list_workload_history`, `list_workload_events`, `promote_workload_artifact`, `get_workload_related`.
+
 ## 0.15.125
 - `dragent/frontends/converters`: registered `convert_run_agent_input_to_chat_request_or_message` so plain `RunAgentInput` from the DRUM `NatAgent.invoke` / `streaming_memory_agent` passthrough boundary converts to NAT `ChatRequestOrMessage` for inner `per_user_tool_calling_agent` workflows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.15.127
-- `drtools/workload`: PR3 — settings and observability tools.
+- `drtools/workload`: settings and observability tools.
   - **New tools** (`observability_tools.py`): `workload_settings_get`, `workload_settings_update` (triggers rolling replacement via PATCH /settings), `workload_stats` (aggregated perf stats with quantile + slow-request controls), `workload_history` (artifact deployment history), `workload_events` (status-change and error events), `workload_promote` (lock running draft artifact), `workload_related` (linked artifacts and related entities).
   - **Client additions** (`WorkloadApiClient`): `get_workload_settings`, `update_workload_settings`, `get_workload_stats`, `list_workload_history`, `list_workload_events`, `promote_workload_artifact`, `get_workload_related`.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.126"
+version = "0.15.127"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.125"
+version = "0.15.126"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.125"
+version = "0.15.126"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.15.126"
+version = "0.15.127"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -138,3 +138,77 @@ class WorkloadApiClient:
                     f"'{target_status}'. Last status: {status}"
                 )
             await asyncio.sleep(poll_interval_seconds)
+
+    # ------------------------------------------------------------------ #
+    # Workloads — settings                                                 #
+    # ------------------------------------------------------------------ #
+
+    def get_workload_settings(self, workload_id: str) -> dict[str, Any]:
+        """GET /workloads/{id}/settings — returns WorkloadSettingsResponse."""
+        with request_user_dr_client() as client:
+            return client.get(f"workloads/{workload_id}/settings").json()
+
+    def update_workload_settings(self, workload_id: str, runtime: dict[str, Any]) -> dict[str, Any]:
+        """PATCH /workloads/{id}/settings — triggers rolling replacement (202)."""
+        with request_user_dr_client() as client:
+            return client.patch(
+                f"workloads/{workload_id}/settings", json={"runtime": runtime}
+            ).json()
+
+    # ------------------------------------------------------------------ #
+    # Workloads — observability                                            #
+    # ------------------------------------------------------------------ #
+
+    def get_workload_stats(
+        self,
+        workload_id: str,
+        *,
+        proton_id: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        response_time_quantile: float = 0.5,
+        slow_requests_threshold: int = 2000,
+    ) -> dict[str, Any]:
+        """GET /workloads/{id}/stats — aggregated performance statistics."""
+        params: dict[str, Any] = {
+            "responseTimeQuantile": response_time_quantile,
+            "slowRequestsThreshold": slow_requests_threshold,
+        }
+        if proton_id:
+            params["protonId"] = proton_id
+        if start_time:
+            params["startTime"] = start_time
+        if end_time:
+            params["endTime"] = end_time
+        with request_user_dr_client() as client:
+            return client.get(f"workloads/{workload_id}/stats", params=params).json()
+
+    def list_workload_history(
+        self, workload_id: str, *, limit: int = 10, offset: int = 0
+    ) -> dict[str, Any]:
+        """GET /workloads/{id}/history — artifact deployment history."""
+        with request_user_dr_client() as client:
+            return client.get(
+                f"workloads/{workload_id}/history",
+                params={"limit": limit, "offset": offset},
+            ).json()
+
+    def list_workload_events(
+        self, workload_id: str, *, limit: int = 10, offset: int = 0
+    ) -> dict[str, Any]:
+        """GET /workloads/{id}/events — status-change and error events."""
+        with request_user_dr_client() as client:
+            return client.get(
+                f"workloads/{workload_id}/events",
+                params={"limit": limit, "offset": offset},
+            ).json()
+
+    def promote_workload_artifact(self, workload_id: str) -> dict[str, Any]:
+        """POST /workloads/{id}/promote — lock the running draft artifact (202)."""
+        with request_user_dr_client() as client:
+            return client.post(f"workloads/{workload_id}/promote").json()
+
+    def get_workload_related(self, workload_id: str) -> dict[str, Any]:
+        """GET /workloads/{id}/related — linked artifacts and related entities."""
+        with request_user_dr_client() as client:
+            return client.get(f"workloads/{workload_id}/related").json()

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -206,7 +206,8 @@ class WorkloadApiClient:
     def promote_workload_artifact(self, workload_id: str) -> dict[str, Any]:
         """POST /workloads/{id}/promote — lock the running draft artifact (202)."""
         with request_user_dr_client() as client:
-            return client.post(f"workloads/{workload_id}/promote").json()
+            resp = client.post(f"workloads/{workload_id}/promote")
+            return resp.json() if resp.content else {}
 
     def get_workload_related(self, workload_id: str) -> dict[str, Any]:
         """GET /workloads/{id}/related — linked artifacts and related entities."""

--- a/src/datarobot_genai/drtools/workload/observability_tools.py
+++ b/src/datarobot_genai/drtools/workload/observability_tools.py
@@ -1,0 +1,288 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+from typing import Any
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
+from datarobot_genai.drtools.core.exceptions import ToolError
+from datarobot_genai.drtools.core.exceptions import ToolErrorKind
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+from datarobot_genai.drtools.predictive.client_exceptions import raise_tool_error_for_client_error
+
+
+def _require_workload_id(workload_id: str) -> str:
+    if not workload_id or not workload_id.strip():
+        raise ToolError(
+            "Argument validation error: 'workload_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    return workload_id.strip()
+
+
+# ------------------------------------------------------------------ #
+# Settings                                                             #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "settings", "get"},
+    description=(
+        "[Workload—settings get] Retrieve the current runtime settings for a "
+        "workload (containerGroups, replicaCount, resourceBundles). Use before "
+        "calling workload_settings_update to inspect the current configuration.\n\n"
+        "Example: workload_settings_get(workload_id='wkld-abc')"
+    ),
+)
+async def workload_settings_get(
+    *,
+    workload_id: Annotated[str, "Id of the workload."],
+) -> dict[str, Any]:
+    wid = _require_workload_id(workload_id)
+    try:
+        return WorkloadApiClient().get_workload_settings(wid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "settings", "update"},
+    description=(
+        "[Workload—settings update] Update a workload's runtime settings by "
+        "triggering a rolling replacement with the current artifact. Pass a "
+        "runtime dict matching WorkloadRuntime: "
+        '{"containerGroups": [{"name": "default", "replicaCount": 2, '
+        '"resourceBundles": ["gpu.l4.small"]}]}. '
+        "Returns the in-progress Replacement object (202).\n\n"
+        "Example: workload_settings_update(workload_id='wkld-abc', "
+        'runtime={"containerGroups": [{"name": "default", "replicaCount": 2}]})'
+    ),
+)
+async def workload_settings_update(
+    *,
+    workload_id: Annotated[str, "Id of the workload."],
+    runtime: Annotated[
+        dict[str, Any],
+        "WorkloadRuntime dict. Must contain 'containerGroups' list. "
+        "Each group may have name, replicaCount, resourceBundles.",
+    ],
+) -> dict[str, Any]:
+    wid = _require_workload_id(workload_id)
+    if not runtime or not isinstance(runtime, dict):
+        raise ToolError(
+            "Argument validation error: 'runtime' must be a non-empty object.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if "containerGroups" not in runtime:
+        raise ToolError(
+            "Argument validation error: 'runtime' must contain 'containerGroups'.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    try:
+        return WorkloadApiClient().update_workload_settings(wid, runtime)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# Stats                                                                #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "stats"},
+    description=(
+        "[Workload—stats] Get aggregated performance statistics for a workload: "
+        "request count, error rate, response time quantile, slow requests. "
+        "Optionally scope to a proton or time window.\n\n"
+        "Example: workload_stats(workload_id='wkld-abc')\n"
+        "Example: workload_stats(workload_id='wkld-abc', response_time_quantile=0.95)"
+    ),
+)
+async def workload_stats(
+    *,
+    workload_id: Annotated[str, "Id of the workload."],
+    proton_id: Annotated[
+        str | None, "Scope stats to a specific proton id. Defaults to current proton."
+    ] = None,
+    start_time: Annotated[
+        str | None, "ISO-8601 start of the stats window (e.g. '2026-01-01T00:00:00Z')."
+    ] = None,
+    end_time: Annotated[str | None, "ISO-8601 end of the stats window."] = None,
+    response_time_quantile: Annotated[
+        float, "Quantile for response time (0–1). Default 0.5 (median)."
+    ] = 0.5,
+    slow_requests_threshold: Annotated[
+        int, "Threshold in ms above which a request is 'slow'. Default 2000."
+    ] = 2000,
+) -> dict[str, Any]:
+    wid = _require_workload_id(workload_id)
+    if not (0.0 <= response_time_quantile <= 1.0):
+        raise ToolError(
+            "Argument validation error: 'response_time_quantile' must be between 0 and 1.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if slow_requests_threshold < 0:
+        raise ToolError(
+            "Argument validation error: 'slow_requests_threshold' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    try:
+        return WorkloadApiClient().get_workload_stats(
+            wid,
+            proton_id=proton_id,
+            start_time=start_time,
+            end_time=end_time,
+            response_time_quantile=response_time_quantile,
+            slow_requests_threshold=slow_requests_threshold,
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# History                                                              #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "history"},
+    description=(
+        "[Workload—history] List the artifact deployment history for a workload: "
+        "each entry shows which artifact version was deployed, when, and by whom.\n\n"
+        "Example: workload_history(workload_id='wkld-abc')"
+    ),
+)
+async def workload_history(
+    *,
+    workload_id: Annotated[str, "Id of the workload."],
+    limit: Annotated[int, "Max records to return (1–100). Default 20."] = 20,
+    offset: Annotated[int, "Records to skip for pagination. Default 0."] = 0,
+) -> dict[str, Any]:
+    wid = _require_workload_id(workload_id)
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    clamped_limit, note = clamp_limit(limit)
+    try:
+        result = WorkloadApiClient().list_workload_history(wid, limit=clamped_limit, offset=offset)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"history": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+# ------------------------------------------------------------------ #
+# Events                                                               #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "events"},
+    description=(
+        "[Workload—events] List status-change and error events for a workload. "
+        "Useful for diagnosing why a workload failed to start or is in an "
+        "unexpected state.\n\n"
+        "Example: workload_events(workload_id='wkld-abc')"
+    ),
+)
+async def workload_events(
+    *,
+    workload_id: Annotated[str, "Id of the workload."],
+    limit: Annotated[int, "Max events to return (1–100). Default 20."] = 20,
+    offset: Annotated[int, "Events to skip for pagination. Default 0."] = 0,
+) -> dict[str, Any]:
+    wid = _require_workload_id(workload_id)
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    clamped_limit, note = clamp_limit(limit)
+    try:
+        result = WorkloadApiClient().list_workload_events(wid, limit=clamped_limit, offset=offset)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"events": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+# ------------------------------------------------------------------ #
+# Promote                                                              #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "promote"},
+    description=(
+        "[Workload—promote] Lock the draft artifact currently running on a "
+        "workload. The workload keeps running the same artifact; it is promoted "
+        "from draft to locked and assigned a version number. Workload stats are "
+        "reset and the event is recorded in history.\n\n"
+        "Example: workload_promote(workload_id='wkld-abc')"
+    ),
+)
+async def workload_promote(
+    *,
+    workload_id: Annotated[str, "Id of the workload whose artifact to promote."],
+) -> dict[str, Any]:
+    wid = _require_workload_id(workload_id)
+    try:
+        return WorkloadApiClient().promote_workload_artifact(wid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# Related                                                              #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "datarobot", "related"},
+    description=(
+        "[Workload—related] List entities related to a workload, such as linked "
+        "artifacts, repositories, and other connected resources.\n\n"
+        "Example: workload_related(workload_id='wkld-abc')"
+    ),
+)
+async def workload_related(
+    *,
+    workload_id: Annotated[str, "Id of the workload."],
+) -> dict[str, Any]:
+    wid = _require_workload_id(workload_id)
+    try:
+        return WorkloadApiClient().get_workload_related(wid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -758,13 +758,24 @@ async def test_workload_events_client_error(patched_dr_client: MagicMock) -> Non
 @pytest.mark.asyncio
 async def test_workload_promote_success(patched_dr_client: MagicMock) -> None:
     patched_dr_client.post.return_value = MagicMock(
-        json=lambda: {"id": "wkld-abc", "status": "running", "artifactId": "art-locked"}
+        content=b'{"id":"wkld-abc","status":"running","artifactId":"art-locked"}',
+        json=lambda: {"id": "wkld-abc", "status": "running", "artifactId": "art-locked"},
     )
 
     result = await observability_tools.workload_promote(workload_id="wkld-abc")
 
     patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/promote")
     assert result["artifactId"] == "art-locked"
+
+
+@pytest.mark.asyncio
+async def test_workload_promote_empty_body(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(content=b"", json=lambda: {})
+
+    result = await observability_tools.workload_promote(workload_id="wkld-abc")
+
+    patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/promote")
+    assert result == {}
 
 
 @pytest.mark.asyncio

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -24,6 +24,7 @@ from datarobot.errors import ClientError
 from datarobot_genai.drtools.core.exceptions import ToolError
 from datarobot_genai.drtools.core.exceptions import ToolErrorKind
 from datarobot_genai.drtools.workload import lifecycle_tools
+from datarobot_genai.drtools.workload import observability_tools
 from datarobot_genai.drtools.workload import read_tools
 
 # ------------------------------------------------------------------ #
@@ -557,4 +558,248 @@ async def test_workload_wait_for_status_zero_timeout_raises() -> None:
         await lifecycle_tools.workload_wait_for_status(
             workload_id="wkld-abc", target_status="running", timeout_seconds=0
         )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ================================================================== #
+# PR3 — settings + observability                                       #
+# ================================================================== #
+
+# ------------------------------------------------------------------ #
+# workload_settings_get                                                #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_settings_get_success(patched_dr_client: MagicMock) -> None:
+    payload = {"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1}]}}
+    patched_dr_client.get.return_value = MagicMock(json=lambda: payload)
+
+    result = await observability_tools.workload_settings_get(workload_id="wkld-abc")
+
+    patched_dr_client.get.assert_called_once_with("workloads/wkld-abc/settings")
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_workload_settings_get_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_settings_get(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_settings_get_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_settings_get(workload_id="wkld-abc")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# workload_settings_update                                             #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_settings_update_success(patched_dr_client: MagicMock) -> None:
+    replacement = {"id": "repl-1", "status": "in_progress"}
+    patched_dr_client.patch.return_value = MagicMock(json=lambda: replacement)
+    runtime = {"containerGroups": [{"name": "default", "replicaCount": 2}]}
+
+    result = await observability_tools.workload_settings_update(
+        workload_id="wkld-abc", runtime=runtime
+    )
+
+    patched_dr_client.patch.assert_called_once_with(
+        "workloads/wkld-abc/settings", json={"runtime": runtime}
+    )
+    assert result == replacement
+
+
+@pytest.mark.asyncio
+async def test_workload_settings_update_missing_container_groups_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_settings_update(
+            workload_id="wkld-abc", runtime={"replicaCount": 2}
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_settings_update_empty_runtime_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_settings_update(workload_id="wkld-abc", runtime={})
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# workload_stats                                                        #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_stats_success(patched_dr_client: MagicMock) -> None:
+    stats = {"requestCount": 100, "errorRate": 0.01, "responseTimeMs": 42.0}
+    patched_dr_client.get.return_value = MagicMock(json=lambda: stats)
+
+    result = await observability_tools.workload_stats(workload_id="wkld-abc")
+
+    patched_dr_client.get.assert_called_once_with(
+        "workloads/wkld-abc/stats",
+        params={
+            "responseTimeQuantile": 0.5,
+            "slowRequestsThreshold": 2000,
+        },
+    )
+    assert result == stats
+
+
+@pytest.mark.asyncio
+async def test_workload_stats_with_options(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {})
+
+    await observability_tools.workload_stats(
+        workload_id="wkld-abc",
+        proton_id="ptn-1",
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-02T00:00:00Z",
+        response_time_quantile=0.95,
+        slow_requests_threshold=1000,
+    )
+
+    patched_dr_client.get.assert_called_once_with(
+        "workloads/wkld-abc/stats",
+        params={
+            "responseTimeQuantile": 0.95,
+            "slowRequestsThreshold": 1000,
+            "protonId": "ptn-1",
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-02T00:00:00Z",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_workload_stats_invalid_quantile_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_stats(workload_id="wkld-abc", response_time_quantile=1.5)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# workload_history                                                      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_history_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "data": [{"artifactId": "art-1", "deployedAt": "2026-01-01T00:00:00Z"}],
+            "count": 1,
+            "totalCount": 1,
+        }
+    )
+
+    result = await observability_tools.workload_history(workload_id="wkld-abc")
+
+    patched_dr_client.get.assert_called_once_with(
+        "workloads/wkld-abc/history", params={"limit": 20, "offset": 0}
+    )
+    assert result["count"] == 1
+    assert result["history"][0]["artifactId"] == "art-1"
+
+
+@pytest.mark.asyncio
+async def test_workload_history_negative_offset_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_history(workload_id="wkld-abc", offset=-1)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# workload_events                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_events_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "data": [{"type": "status_change", "status": "running"}],
+            "count": 1,
+            "totalCount": 1,
+        }
+    )
+
+    result = await observability_tools.workload_events(workload_id="wkld-abc")
+
+    patched_dr_client.get.assert_called_once_with(
+        "workloads/wkld-abc/events", params={"limit": 20, "offset": 0}
+    )
+    assert result["count"] == 1
+    assert result["events"][0]["type"] == "status_change"
+
+
+@pytest.mark.asyncio
+async def test_workload_events_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_events(workload_id="wkld-abc")
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# workload_promote                                                      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_promote_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "running", "artifactId": "art-locked"}
+    )
+
+    result = await observability_tools.workload_promote(workload_id="wkld-abc")
+
+    patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/promote")
+    assert result["artifactId"] == "art-locked"
+
+
+@pytest.mark.asyncio
+async def test_workload_promote_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_promote(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_promote_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.side_effect = ClientError("422", status_code=422, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_promote(workload_id="wkld-abc")
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# workload_related                                                      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_related_success(patched_dr_client: MagicMock) -> None:
+    payload = {"artifacts": [{"id": "art-1", "name": "my-artifact"}]}
+    patched_dr_client.get.return_value = MagicMock(json=lambda: payload)
+
+    result = await observability_tools.workload_related(workload_id="wkld-abc")
+
+    patched_dr_client.get.assert_called_once_with("workloads/wkld-abc/related")
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_workload_related_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await observability_tools.workload_related(workload_id="")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.126"
+version = "0.15.127"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.15.125"
+version = "0.15.126"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Created workload api settings and observability tools
- Created unit tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `workload_settings_update` and `workload_promote` trigger rolling replacements and artifact locking on live workloads; mistakes could cause unintended deploys, though inputs are validated and APIs use per-user credentials.
> 
> **Overview**
> **Workload settings and observability MCP tools (PR3)** extend `drtools/workload` so agents can inspect and operate on deployed workloads beyond lifecycle APIs.
> 
> `WorkloadApiClient` gains REST wrappers for settings (`GET`/`PATCH` `/settings`), stats, history, events, promote, and related entities. New module `observability_tools.py` exposes seven async tools—`workload_settings_get`, `workload_settings_update` (rolling replacement via runtime `containerGroups`), `workload_stats` (quantile and slow-request thresholds), paginated `workload_history` / `workload_events`, `workload_promote`, and `workload_related`—with the same validation and `ClientError` → `ToolError` patterns as existing workload tools.
> 
> Unit coverage was added in `tests/drmcp/unit/workload_tools/test_tools.py`. Package version is **0.15.127** with changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0818beeb1ca57b39592a9821371df5a6465d966. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->