### PR TITLE
[BUZZOK-30616] fix: FinalAnswerMiddleware for reasoning-model dead ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.2
+- `langgraph`: new `FinalAnswerMiddleware` (`datarobot_genai.langgraph.middleware`) for `create_agent` — when a reasoning model (e.g. gpt-oss) ends a turn with no tool calls and no answer text (only reasoning, the "prompted to use tools that aren't bound" dead-end), it re-invokes the model once with an ephemeral "provide your final answer" nudge (`tool_choice="none"` when tools are bound) so the run produces a real answer instead of silently ending. The dead-end message is discarded from graph state; a retry that is still answerless is returned unchanged with a warning (reasoning is never promoted to answer content). Opt in with `create_agent(..., middleware=[FinalAnswerMiddleware()])`. The `langgraph` extra now declares `langchain` explicitly (previously only transitive).
+
 ## 0.16.1
 - `core/agents`: a prior-turn reasoning message is folded into the following assistant message's `content` as `<reasoning>…</reasoning>` text during history extraction, so chain-of-thought round-trips to the model across all agent frameworks and ingress paths (AG-UI `AssistantMessage` has no reasoning field). The text `{chat_history}` summary and the langgraph/llama_index structured converters both surface it; a reasoning turn with no following assistant turn is dropped. Consumer note: turns that carry reasoning now replay their full chain-of-thought into history, which adds tokens — tune `max_history_messages` if context budget is tight.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.1"
+version = "0.16.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ crewai = core + [
 ]
 
 langgraph = core + [
+    "langchain>=1.0.0,<2.0.0",  # create_agent middleware (datarobot_genai.langgraph.middleware)
     "langchain-mcp-adapters>=0.1.12,<0.2.0",
     "langgraph>=1.0.0,<2.0.0",
     "langgraph-prebuilt>=1.0.0,<2.0.0",

--- a/src/datarobot_genai/langgraph/middleware.py
+++ b/src/datarobot_genai/langgraph/middleware.py
@@ -1,0 +1,143 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""``create_agent`` middleware for reasoning-model robustness.
+
+A reasoning model (e.g. ``gpt-oss``) whose prompt urges tool use can spend its
+whole turn planning a tool call that the bound tool set cannot satisfy, and
+return an ``AIMessage`` with **no tool calls and no answer text** — only
+reasoning. ``create_agent``'s loop exits on zero tool calls, so that answerless
+message becomes the node's final output and propagates (e.g. an inter-agent
+relay forwards empty content and the run produces no real answer).
+
+``FinalAnswerMiddleware`` detects that dead-end after the model call and
+re-invokes the model once with an ephemeral nudge to produce the final answer.
+It is cause-agnostic: a final ``AIMessage`` with neither text nor tool calls is
+never a useful outcome, so recovery cannot misfire on healthy turns.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware import ModelCallResult
+from langchain.agents.middleware import ModelRequest
+from langchain.agents.middleware import ModelResponse
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import BaseTool
+
+from datarobot_genai.core.agents.reasoning import flatten_to_text
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_NUDGE = (
+    "Provide your final answer to the user now, based on your analysis above. "
+    "Do not call any tools."
+)
+
+
+def _last_ai_message(response: ModelCallResult | ModelResponse[Any]) -> AIMessage | None:
+    """Return the last ``AIMessage`` from any ``ModelCallResult`` shape."""
+    if isinstance(response, AIMessage):
+        return response
+    result = getattr(response, "result", None)
+    if result is None:
+        # ExtendedModelResponse wraps the ModelResponse.
+        inner = getattr(response, "model_response", None)
+        result = getattr(inner, "result", None) if inner is not None else None
+    for message in reversed(result or []):
+        if isinstance(message, AIMessage):
+            return message
+    return None
+
+
+def _is_dead_end(response: ModelCallResult | ModelResponse[Any]) -> bool:
+    """Return True when the model produced neither tool calls nor answer text.
+
+    ``flatten_to_text`` keeps only text blocks, so both an empty ``content``
+    and a thinking-only content list (the shapes ``ChatLiteLLM`` produces for a
+    reasoning turn with no answer) read as empty.
+    """
+    message = _last_ai_message(response)
+    if message is None:
+        return False
+    return not message.tool_calls and not flatten_to_text(message.content).strip()
+
+
+class FinalAnswerMiddleware(AgentMiddleware):
+    """Recover a final answer when a reasoning model returns none.
+
+    On a dead-end model turn (no tool calls, no answer text), re-invoke the
+    model once with the conversation plus an ephemeral nudge message; when
+    tools are bound, the retry also sets ``tool_choice="none"`` so the model
+    cannot stall on another tool attempt. The dead-end message is discarded —
+    only the returned response is committed to graph state. If the retry is
+    also a dead-end it is returned as-is (with a warning logged); reasoning is
+    never promoted to answer content.
+
+    Usage::
+
+        agent = create_agent(llm, tools=tools, middleware=[FinalAnswerMiddleware()])
+    """
+
+    def __init__(self, *, nudge: str = _DEFAULT_NUDGE) -> None:
+        super().__init__()
+        self.tools: list[BaseTool] = []
+        self.nudge = nudge
+
+    def _finalize_request(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        return request.override(
+            messages=[*request.messages, HumanMessage(content=self.nudge)],
+            tool_choice="none" if request.tools else request.tool_choice,
+        )
+
+    def _log_recovery(self, recovered: ModelCallResult | ModelResponse[Any]) -> None:
+        if _is_dead_end(recovered):
+            logger.warning(
+                "Model returned no tool calls and no answer text even after a "
+                "finalize nudge; returning the answerless response unchanged."
+            )
+        else:
+            logger.info("Recovered a final answer from a dead-end model turn.")
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelCallResult:
+        """Run the model; on a dead-end, retry once with a finalize nudge."""
+        response: ModelCallResult = handler(request)
+        if _is_dead_end(response):
+            response = handler(self._finalize_request(request))
+            self._log_recovery(response)
+        return response
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelCallResult:
+        """Async variant of ``wrap_model_call``."""
+        response: ModelCallResult = await handler(request)
+        if _is_dead_end(response):
+            response = await handler(self._finalize_request(request))
+            self._log_recovery(response)
+        return response

--- a/tests/langgraph/test_middleware.py
+++ b/tests/langgraph/test_middleware.py
@@ -1,0 +1,189 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from langchain.agents.middleware import ExtendedModelResponse
+from langchain.agents.middleware import ModelRequest
+from langchain.agents.middleware import ModelResponse
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+
+from datarobot_genai.langgraph.middleware import FinalAnswerMiddleware
+from datarobot_genai.langgraph.middleware import _is_dead_end
+
+DEAD_END_EMPTY = AIMessage(
+    content="", additional_kwargs={"reasoning_content": "We must use the browse tool..."}
+)
+DEAD_END_THINKING = AIMessage(
+    content=[{"type": "thinking", "thinking": "Let's search for sources."}]
+)
+REAL_ANSWER = AIMessage(content="THE FINAL ANSWER")
+TOOL_CALL = AIMessage(
+    content="", tool_calls=[{"name": "word_counter", "args": {"text": "a b"}, "id": "tc1"}]
+)
+
+
+def result_of(response: Any) -> list[Any]:
+    """Narrow a ModelCallResult to the ModelResponse result list."""
+    assert isinstance(response, ModelResponse)
+    return response.result
+
+
+def make_request(*, tools: list[Any] | None = None, tool_choice: Any = None) -> ModelRequest[Any]:
+    return ModelRequest(
+        model=Mock(),
+        messages=[HumanMessage(content="think about ai")],
+        tools=tools or [],
+        tool_choice=tool_choice,
+    )
+
+
+def make_handler(script: list[AIMessage]) -> tuple[Any, list[ModelRequest[Any]]]:
+    """Scripted sync handler; records every request it receives."""
+    seen: list[ModelRequest[Any]] = []
+
+    def handler(request: ModelRequest[Any]) -> ModelResponse[Any]:
+        seen.append(request)
+        return ModelResponse(result=[script[min(len(seen) - 1, len(script) - 1)]])
+
+    return handler, seen
+
+
+def make_async_handler(script: list[AIMessage]) -> tuple[Any, list[ModelRequest[Any]]]:
+    seen: list[ModelRequest[Any]] = []
+
+    async def handler(request: ModelRequest[Any]) -> ModelResponse[Any]:
+        seen.append(request)
+        return ModelResponse(result=[script[min(len(seen) - 1, len(script) - 1)]])
+
+    return handler, seen
+
+
+@pytest.mark.parametrize(
+    "response, expected",
+    [
+        # Empty content with reasoning hoisted to additional_kwargs: dead end.
+        (ModelResponse(result=[DEAD_END_EMPTY]), True),
+        # Thinking-only content list (ChatLiteLLM injection shape): dead end.
+        (ModelResponse(result=[DEAD_END_THINKING]), True),
+        # Real answer text: not a dead end.
+        (ModelResponse(result=[REAL_ANSWER]), False),
+        # Tool-calling turn: not a dead end (the loop continues to tools).
+        (ModelResponse(result=[TOOL_CALL]), False),
+        # Bare AIMessage return shape is handled.
+        (DEAD_END_EMPTY, True),
+        (REAL_ANSWER, False),
+        # ExtendedModelResponse wrapping shape is handled.
+        (ExtendedModelResponse(model_response=ModelResponse(result=[DEAD_END_EMPTY])), True),
+        # No AIMessage at all: nothing to recover.
+        (ModelResponse(result=[]), False),
+    ],
+)
+def test_is_dead_end(response: Any, expected: bool) -> None:
+    assert _is_dead_end(response) is expected
+
+
+def test_dead_end_retries_once_with_nudge_and_returns_answer() -> None:
+    handler, seen = make_handler([DEAD_END_EMPTY, REAL_ANSWER])
+    request = make_request()
+
+    response = FinalAnswerMiddleware().wrap_model_call(request, handler)
+
+    assert len(seen) == 2
+    assert result_of(response) == [REAL_ANSWER]
+    retry = seen[1]
+    assert isinstance(retry.messages[-1], HumanMessage)
+    assert "final answer" in retry.messages[-1].content
+    # The original request is not mutated (override returns a new request).
+    assert len(request.messages) == 1
+
+
+def test_text_answer_does_not_retry() -> None:
+    handler, seen = make_handler([REAL_ANSWER])
+
+    response = FinalAnswerMiddleware().wrap_model_call(make_request(), handler)
+
+    assert len(seen) == 1
+    assert result_of(response) == [REAL_ANSWER]
+
+
+def test_tool_call_turn_does_not_retry() -> None:
+    handler, seen = make_handler([TOOL_CALL])
+
+    response = FinalAnswerMiddleware().wrap_model_call(make_request(), handler)
+
+    assert len(seen) == 1
+    assert result_of(response) == [TOOL_CALL]
+
+
+def test_retry_with_tools_bound_sets_tool_choice_none() -> None:
+    handler, seen = make_handler([DEAD_END_EMPTY, REAL_ANSWER])
+    request = make_request(tools=[Mock()], tool_choice="auto")
+
+    FinalAnswerMiddleware().wrap_model_call(request, handler)
+
+    assert seen[1].tool_choice == "none"
+
+
+def test_retry_without_tools_preserves_tool_choice() -> None:
+    handler, seen = make_handler([DEAD_END_EMPTY, REAL_ANSWER])
+    request = make_request(tools=[], tool_choice=None)
+
+    FinalAnswerMiddleware().wrap_model_call(request, handler)
+
+    assert seen[1].tool_choice is None
+
+
+def test_double_dead_end_returns_last_response_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    handler, seen = make_handler([DEAD_END_EMPTY, DEAD_END_THINKING])
+
+    with caplog.at_level(logging.WARNING, logger="datarobot_genai.langgraph.middleware"):
+        response = FinalAnswerMiddleware().wrap_model_call(make_request(), handler)
+
+    assert len(seen) == 2  # exactly one recovery attempt
+    assert result_of(response) == [DEAD_END_THINKING]
+    assert any("finalize nudge" in record.message for record in caplog.records)
+
+
+def test_custom_nudge_is_used() -> None:
+    handler, seen = make_handler([DEAD_END_EMPTY, REAL_ANSWER])
+
+    FinalAnswerMiddleware(nudge="Answer now.").wrap_model_call(make_request(), handler)
+
+    assert seen[1].messages[-1].content == "Answer now."
+
+
+async def test_async_dead_end_recovers() -> None:
+    handler, seen = make_async_handler([DEAD_END_EMPTY, REAL_ANSWER])
+
+    response = await FinalAnswerMiddleware().awrap_model_call(make_request(), handler)
+
+    assert len(seen) == 2
+    assert result_of(response) == [REAL_ANSWER]
+    assert "final answer" in seen[1].messages[-1].content
+
+
+async def test_async_text_answer_does_not_retry() -> None:
+    handler, seen = make_async_handler([REAL_ANSWER])
+
+    response = await FinalAnswerMiddleware().awrap_model_call(make_request(), handler)
+
+    assert len(seen) == 1
+    assert result_of(response) == [REAL_ANSWER]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1252,6 +1252,7 @@ langgraph = [
     { name = "datarobot-early-access" },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
+    { name = "langchain" },
     { name = "langchain-mcp-adapters" },
     { name = "langgraph" },
     { name = "langgraph-prebuilt" },
@@ -1413,6 +1414,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'auth'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drmcp'", specifier = ">=0.28.1,<1.0.0" },
     { name = "httpx", marker = "extra == 'drtools'", specifier = ">=0.28.1,<1.0.0" },
+    { name = "langchain", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-mcp-adapters", marker = "extra == 'langgraph'", specifier = ">=0.1.12,<0.2.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langgraph-prebuilt", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

A reasoning model (gpt-oss-20b deployed LLM in the agentic starter recipe) whose prompt urges tool use can spend its whole turn planning a tool call that the bound tool set cannot satisfy, returning an `AIMessage` with no tool calls and no answer text — only reasoning. `create_agent`'s loop exits on zero tool calls, so the answerless message becomes the node's final output: the user sees streamed reasoning and never a real response (follow-up to the BUZZOK-30869 symptom family; reproduced with the recipe out of the box). Fixing this by rewording prompts per recipe is fragile; this adds a framework-level safety net instead.

## CHANGES

- New `datarobot_genai/langgraph/middleware.py`: `FinalAnswerMiddleware` (`wrap_model_call`/`awrap_model_call`) — on a dead-end turn (no tool calls, no answer text) re-invokes the model once with an ephemeral "provide your final answer" nudge; `tool_choice="none"` when tools are bound
- Dead-end message is discarded from graph state; a still-answerless retry is returned unchanged with a warning (reasoning is never promoted to answer content)
- 17 unit tests (`tests/langgraph/test_middleware.py`): predicate shapes (empty content, thinking-only list, bare `AIMessage`, `ExtendedModelResponse`), retry/no-retry paths, `tool_choice` handling, custom nudge, sync + async
- `setup.py`: declare `langchain>=1.0,<2.0` in the `langgraph` extra (was only transitive via `nvidia-nat-langchain`)
- Version 0.16.2 + changelog entry

## TESTING

- Unit: 17/17 pass; ruff + mypy clean
- Integration (real `create_agent`, langchain 1.3.2, scripted model reproducing the dead-end): single-agent recovery and recipe-shaped planner→relay→writer graph verified — without the middleware the run ends answerless, with it the writer receives a real plan and the run produces the final article; async path verified
- Live confirmation against the gpt-oss-20b deployment pending (deployment currently stopped)

## NOTES

Opt-in: consumers add `middleware=[FinalAnswerMiddleware()]` to `create_agent(...)`. Follow-up PRs will wire this into the af-component-agent langgraph template and the recipe.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST) — N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in middleware with a single bounded retry; no default behavior change for existing agents until middleware is wired in.
> 
> **Overview**
> Adds **opt-in** LangGraph `create_agent` middleware so reasoning models that finish with only chain-of-thought (no tool calls, no user-visible answer) get one recovery LLM call instead of ending the run empty-handed.
> 
> **`FinalAnswerMiddleware`** (`datarobot_genai.langgraph.middleware`) wraps sync/async model calls: if the last `AIMessage` has neither `tool_calls` nor answer text (via `flatten_to_text`, including thinking-only content), it retries once with an ephemeral human nudge and **`tool_choice="none"`** when tools are bound. The dead-end turn is not kept in graph state; a still-empty retry is returned with a warning and reasoning is never surfaced as the answer.
> 
> Consumers enable it with `middleware=[FinalAnswerMiddleware()]`. The **`langgraph` extra** now declares **`langchain`** explicitly; version **0.16.2** and changelog document the feature. Unit tests cover dead-end detection, retry behavior, tool-choice handling, and async paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eb1b10fd42da0dfeae5106b2e60ce5eb16228aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->