### PR TITLE
Add  subpackage for shared drtools and drmcpbase utilities e.g client…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,12 @@
 /src/datarobot_genai/drmcp/ @datarobot-oss/mcp
 /src/datarobot_genai/drtools/ @datarobot-oss/mcp
 /src/datarobot_genai/drmcpbase/ @datarobot-oss/mcp
+/src/datarobot_genai/drmcputils/ @datarobot-oss/mcp
 /tests/drmcp/ @datarobot-oss/mcp
 /tests/drmcpbase/ @datarobot-oss/mcp
+/tests/drmcputils/ @datarobot-oss/mcp
 /tests/drtools/ @datarobot-oss/mcp
 /e2e-tests/drmcp/ @datarobot-oss/mcp
 /.taskfiles/drmcp.yml @datarobot-oss/mcp
 /docs/drtools/ @datarobot-oss/mcp
+/README.md @datarobot-oss/mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.11', '3.12', '3.13' ]
-        module: [ 'core', 'crewai', 'langgraph', 'llamaindex', 'drmcpbase', 'drmcp', 'nat', 'dragent', 'eval']
+        module: [ 'core', 'crewai', 'langgraph', 'llamaindex', 'drmcpbase', 'drmcputils', 'drmcp', 'nat', 'dragent', 'eval']
     permissions:
       contents: read
       pull-requests: read

--- a/.taskfiles/tests.yml
+++ b/.taskfiles/tests.yml
@@ -25,6 +25,7 @@ tasks:
             - langgraph
             - llamaindex
             - drmcpbase
+            - drmcputils
             - drmcp
             - nat
             - dragent
@@ -34,8 +35,8 @@ tasks:
       - |
           echo "pytest path: tests/{{.MODULE}}"
           {{if eq .MODULE "nat"}}uv sync --extra nat --extra crewai --extra llamaindex --extra dragent{{end}}
-          {{if or (eq .MODULE "drmcpbase") (eq .MODULE "eval")}}
-          # drmcpbase and eval are intentionally minimal standalone extras,
+          {{if or (eq .MODULE "drmcpbase") (eq .MODULE "drmcputils") (eq .MODULE "eval")}}
+          # drmcpbase, drmcputils, and eval are intentionally minimal standalone extras,
           # so avoid loading root conftest rather than pulling in the full SDK just to run a package smoke test for now
           uv run pytest tests/{{.MODULE}} \
             --confcutdir=tests/{{.MODULE}} \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+## 0.16.4
+- Add `drmcputils` subpackage for shared drtools and drmcpbase utilities e.g clients and common code 
 
 ## 0.16.3
 - Migrate benchmark helper classes to genai[eval] package

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can also install:
 * `datarobot-genai[dragent]`&mdash;serve and orchestrate your agent with `DRAgent`.
 * `datarobot-genai[drtools]`&mdash;use the standard library of agentic tools DataRobot provides.
 * `datarobot-genai[drmcpbase]`&mdash;Base class to derive FastMCP servers.
+* `datarobot-genai[drmcputils]`&mdash;shared MCP utilities consumed by `drmcpbase` and `drtools`.
 * `datarobot-genai[drmcp]`&mdash;host a custom MCP server in DataRobot (includes `drmcpbase`, `drtools`, and template-server dependencies).
 * `datarobot-genai[memory]`&mdash;use the Mem0-backed memory client and NAT memory provider.
 * `datarobot-genai[eval]`&mdash;agent evaluation utilities built on the NeMo Evaluator launcher.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1086,7 +1086,6 @@ requires-dist = [
     { name = "aiohttp-retry", marker = "extra == 'drmcp'", specifier = ">=2.8.3,<3.0.0" },
     { name = "aiohttp-retry", marker = "extra == 'drmcpbase'", specifier = ">=2.8.3,<3.0.0" },
     { name = "anthropic", marker = "extra == 'crewai'", specifier = "~=0.71.0,<1.0.0" },
-    { name = "anthropic", marker = "extra == 'eval'", specifier = ">=0.40.0" },
     { name = "anyio", marker = "extra == 'dragent'", specifier = "==4.11.0" },
     { name = "anyio", marker = "extra == 'nat'", specifier = "==4.11.0" },
     { name = "async-lru", marker = "extra == 'drmcp'", specifier = ">=2.3.0" },
@@ -1148,6 +1147,7 @@ requires-dist = [
     { name = "langgraph-prebuilt", marker = "extra == 'langgraph'", specifier = ">=1.0.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'crewai'", specifier = ">=1.83.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'dragent'", specifier = ">=1.83.0,<2.0.0" },
+    { name = "litellm", marker = "extra == 'eval'", specifier = ">=1.83.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'langgraph'", specifier = ">=1.83.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'llamaindex'", specifier = ">=1.83.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'nat'", specifier = ">=1.83.0,<2.0.0" },
@@ -1276,7 +1276,7 @@ requires-dist = [
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]
-provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "eval", "drmcpbase", "drmcp", "drtools", "dragent", "memory"]
+provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "eval", "drmcpbase", "drmcputils", "drmcp", "drtools", "dragent", "memory"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.3"
+version = "0.16.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -193,16 +193,21 @@ omit = [
 
 # Custom import restrictions (enforced by scripts/check_imports.py)
 [subpackages.import-restrictions]
-drtools_allowed_subpackages = ["drtools"]
+drtools_allowed_subpackages = ["drtools", "drmcputils"]
 drtools_forbidden = [
     "fastmcp",
     "datarobot_genai.drmcpbase",
 ]
-drmcp_allowed_subpackages = ["drtools", "drmcp", "drmcpbase"]
-drmcpbase_allowed_subpackages = ["drmcpbase"]
+drmcp_allowed_subpackages = ["drtools", "drmcp", "drmcpbase", "drmcputils"]
+drmcpbase_allowed_subpackages = ["drmcpbase", "drmcputils"]
 drmcpbase_forbidden = [
     "datarobot_genai.drtools",
     "datarobot_genai.drmcp",
+    "datarobot_genai.core",
+]
+drmcputils_allowed_subpackages = ["drmcputils"]
+drmcputils_forbidden = [
+    "fastmcp",
     "datarobot_genai.core",
 ]
 

--- a/scripts/check_imports.py
+++ b/scripts/check_imports.py
@@ -17,9 +17,10 @@
 Custom import checker.
 
 Enforces the following rules:
-1. drtools cannot import from: core, drmcp, drmcpbase, fastmcp
-2. drmcp can only import from drtools, drmcp, and drmcpbase subpackages
-3. drmcpbase can only import from drmcpbase (must not import drtools, drmcp, or core)
+1. drmcputils can only import from drmcputils (must not import core, fastmcp, or any other subpackage)
+2. drtools can only import from drtools and drmcputils (must not import core, drmcp, drmcpbase, or fastmcp)
+3. drmcpbase can only import from drmcpbase and drmcputils (must not import drtools, drmcp, or core)
+4. drmcp can only import from drtools, drmcp, drmcpbase, and drmcputils subpackages
 """
 
 import ast
@@ -50,6 +51,8 @@ def load_config(base_dir: Path) -> dict[str, Any]:
                     "drmcp_allowed_subpackages": config["drmcp_allowed_subpackages"],
                     "drmcpbase_allowed_subpackages": config["drmcpbase_allowed_subpackages"],
                     "drmcpbase_forbidden": config["drmcpbase_forbidden"],
+                    "drmcputils_allowed_subpackages": config["drmcputils_allowed_subpackages"],
+                    "drmcputils_forbidden": config["drmcputils_forbidden"],
                 }
         except Exception as e:
             print(f"Warning: Failed to load pyproject.toml: {e}")
@@ -68,6 +71,7 @@ class ImportChecker(ast.NodeVisitor):
         self.is_drtools = "drtools" in parts
         self.is_drmcp = "drmcp" in parts and "drmcpbase" not in parts
         self.is_drmcpbase = "drmcpbase" in parts
+        self.is_drmcputils = "drmcputils" in parts
         self.config = config
 
     def visit_Import(self, node: ast.Import) -> None:
@@ -159,6 +163,17 @@ class ImportChecker(ast.NodeVisitor):
                 "drmcpbase",
             )
 
+        elif self.is_drmcputils:
+            self._check_forbidden(
+                lineno, module_name, self.config["drmcputils_forbidden"], "drmcputils"
+            )
+            self._check_allowed_local(
+                lineno,
+                module_name,
+                self.config["drmcputils_allowed_subpackages"],
+                "drmcputils",
+            )
+
 
 def check_file(filepath: Path, config: dict[str, Any]) -> List[Tuple[int, str]]:
     """Check a single Python file for import violations."""
@@ -183,7 +198,7 @@ def main():
 
     all_errors = []
 
-    for subpackage in ("drtools", "drmcp", "drmcpbase"):
+    for subpackage in ("drtools", "drmcp", "drmcpbase", "drmcputils"):
         package_dir = src_dir / subpackage
         if package_dir.exists():
             for py_file in package_dir.rglob("*.py"):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 """Setup script defining optional dependencies (extras) for the package.
 
 This script defines all extras and automatically merges 'core' dependencies
-into all other extras except standalone extras (`auth`, `drtools`, `drmcpbase`, `drmcp`, `eval`)
+into all other extras except standalone extras (`auth`, `drtools`, `drmcpbase`, `drmcp`, `drmcputils`, `eval`)
 at build time.
 """
 
@@ -108,9 +108,12 @@ auth = [
   "okta-client-python>=0.2.0,<1.0.0",
 ]
 
-# drtools: no subpackages dependencies other than auth.
+# drmcputils is a leaf subpackage: no imports from other datarobot_genai subpackages.
+drmcputils = []
+
+# drtools: no subpackages dependencies other than auth and drmcputils.
 # polars for internal tabular data; pandas only at predict API boundary (datarobot-predict).
-drtools = auth + [
+drtools = auth + drmcputils + [
     "beautifulsoup4>=4.12.0,<5.0.0",
     "httpx>=0.28.1,<1.0.0",
     "tavily-python>=0.7.20,<1.0.0",
@@ -134,7 +137,7 @@ eval_deps = [
 ]
 
 # drmcpbase is standalone set of dependencies for MCP Servers only (no core).
-drmcpbase = [
+drmcpbase = drmcputils + [
     "starlette>=1.0.1",  # CVE-2026-48710 fixed in 1.0.1
     "fastmcp>=3.4.1,<4.0.0",
     "aiohttp>=3.13.3,<4.0.0",
@@ -172,6 +175,7 @@ extras_require = {
     "auth": auth,
     "eval": eval_deps,
     "drmcpbase": drmcpbase,
+    "drmcputils": drmcputils,
     "drmcp": drmcp,
     "drtools": drtools,
     "dragent": dragent,

--- a/src/datarobot_genai/drmcputils/__init__.py
+++ b/src/datarobot_genai/drmcputils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/drmcputils/__init__.py
+++ b/tests/drmcputils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/drmcputils/test_package.py
+++ b/tests/drmcputils/test_package.py
@@ -1,0 +1,17 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_drmcputils_dummy() -> None:
+    pass

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1546,7 +1546,7 @@ requires-dist = [
     { name = "tavily-python", marker = "extra == 'drmcp'", specifier = ">=0.7.20,<1.0.0" },
     { name = "tavily-python", marker = "extra == 'drtools'", specifier = ">=0.7.20,<1.0.0" },
 ]
-provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "eval", "drmcpbase", "drmcp", "drtools", "dragent", "memory"]
+provides-extras = ["core", "crewai", "langgraph", "llamaindex", "nat", "auth", "eval", "drmcpbase", "drmcputils", "drmcp", "drtools", "dragent", "memory"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Add  `drmcputils` subpackage for shared `drtools` and `drmcpbase` utilities e.g clients and common code

# RATIONALE

<img width="1537" height="806" alt="image" src="https://github.com/user-attachments/assets/a40bbdee-8681-43bd-93fd-f688cd901cb2" />

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffold-only change (empty package, dependency and lint wiring); no runtime behavior or shared implementation moved yet.
> 
> **Overview**
> Introduces **`drmcputils`** as a new leaf subpackage (0.16.4) meant to hold shared MCP utilities for **`drtools`** and **`drmcpbase`**. This PR is mostly **scaffolding**: an empty package, a dummy smoke test, and **`datarobot-genai[drmcputils]`** as a standalone extra with no extra deps.
> 
> **Packaging & layering:** `drtools` and `drmcpbase` now depend on the `drmcputils` extra; import rules in `pyproject.toml` / `check_imports.py` treat `drmcputils` as self-contained only (no `core`, `fastmcp`, or sibling subpackages), while `drtools`, `drmcpbase`, and `drmcp` may import it.
> 
> **CI & docs:** `drmcputils` is in the per-module test matrix (minimal pytest with `--confcutdir`), MCP team **CODEOWNERS** coverage, and **README** documents the new extra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a697b6be9c0f8a9de9128eadd45c1ec9aaa6b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->