### PR TITLE
Updated CODEOWNERS to include common files like .gitignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /e2e-tests/uv.lock @datarobot-oss/buzok @datarobot-oss/mcp
 /README.md @datarobot-oss/buzok @datarobot-oss/mcp
 /.gitignore @datarobot-oss/buzok @datarobot-oss/mcp
+/.taskfiles/tests.yml @datarobot-oss/buzok @datarobot-oss/mcp
 /scripts/ @datarobot-oss/buzok @datarobot-oss/mcp
 
 # MCP team overrides for drmcp and drtools (last match wins)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@
 /setup.py @datarobot-oss/buzok @datarobot-oss/mcp
 /uv.lock @datarobot-oss/buzok @datarobot-oss/mcp
 /e2e-tests/uv.lock @datarobot-oss/buzok @datarobot-oss/mcp
+/README.md @datarobot-oss/buzok @datarobot-oss/mcp
+/.gitignore @datarobot-oss/buzok @datarobot-oss/mcp
+/scripts/ @datarobot-oss/buzok @datarobot-oss/mcp
 
 # MCP team overrides for drmcp and drtools (last match wins)
 /src/datarobot_genai/drmcp/ @datarobot-oss/mcp
@@ -21,4 +24,3 @@
 /e2e-tests/drmcp/ @datarobot-oss/mcp
 /.taskfiles/drmcp.yml @datarobot-oss/mcp
 /docs/drtools/ @datarobot-oss/mcp
-/README.md @datarobot-oss/mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.6
+- Updated CODEOWNERS to include common files like .gitignore
+
 ## 0.16.5
 - `drtools/workload`: Proton inspection and OTel log tools.
   - **New tools** (`proton_tools.py`): `proton_list` (paginated list of proton instances for a workload), `proton_get` (single proton by id), `proton_status_details` (per-replica pod status — CrashLoopBackOff, OOMKilled, container readiness; returns `{status: pending}` when no update received yet), `workload_logs` (OTel log lines with level, time-window, includes/excludes, span/trace-id filters).

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.5"
+version = "0.16.6"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.5"
+version = "0.16.6"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.5"
+version = "0.16.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Governance and version/changelog only; no application or library runtime behavior changes.
> 
> **Overview**
> **CODEOWNERS** now treats **`README.md`**, **`.gitignore`**, and **`scripts/`** like other repo-wide files: either **@datarobot-oss/buzok** or **@datarobot-oss/mcp** can approve. The MCP-only **`/README.md`** rule was removed so root README isn’t MCP-exclusive under “last match wins.”
> 
> Release metadata only: version **0.16.6** in **`pyproject.toml`** and lockfiles, plus a **CHANGELOG** note for the ownership update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf0ab33bb8fe84c3dbe156bd7ecabf6c06456b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->