### PR TITLE
[BUZZOK-31219] Fix minor bug in displaying summaries when None present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.12
+- Fix `ResultsSummarizer.print_summary` crash when a case has `expected_behavior: null` or `id: null`
+
 ## 0.16.11
 - Fix datarobot_genai.eval.benchmarks pipeline YAML reference retrievals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.11"
+version = "0.16.12"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/eval/summarize.py
+++ b/src/datarobot_genai/eval/summarize.py
@@ -63,7 +63,7 @@ class ResultsSummarizer:
                 passed = "✓" if c.get("passed") else ("✗" if c.get("passed") is False else "?")
                 reason = (c.get("judge_reason") or "")[:50]
                 print(
-                    f"  {c['id']:<15} {c.get('expected_behavior', '?'):<8} "
+                    f"  {(c.get('id') or '?'):<15} {(c.get('expected_behavior') or '?'):<8} "
                     f"{score_str:<7} {passed:<6} {reason}"
                 )
 

--- a/tests/eval/test_summarize.py
+++ b/tests/eval/test_summarize.py
@@ -138,3 +138,28 @@ def test_print_summary_no_nemo_section_when_empty(
     ResultsSummarizer(tmp_path).print_summary()
     out = capsys.readouterr().out
     assert "NeMo Aggregate" not in out
+
+
+def test_print_summary_null_expected_behavior_renders_as_question_mark(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Cases with expected_behavior: null must not raise a format TypeError."""
+    data = _minimal_results()
+    data["cases"][0]["expected_behavior"] = None
+    _write_results(tmp_path / "eval_results.json", data)
+    ResultsSummarizer(tmp_path).print_summary()
+    out = capsys.readouterr().out
+    assert "good-001" in out
+    assert "?" in out
+
+
+def test_print_summary_null_id_renders_as_question_mark(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Cases with id: null must not raise a format TypeError."""
+    data = _minimal_results()
+    data["cases"][0]["id"] = None
+    _write_results(tmp_path / "eval_results.json", data)
+    ResultsSummarizer(tmp_path).print_summary()
+    out = capsys.readouterr().out
+    assert "?" in out

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.11"
+version = "0.16.12"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Fix minor bug in displaying summaries when None present for evaluation results in terminal

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 812de4088f2b547855bf457d7f198f93e2016b17. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->