### PR TITLE
[BUZZOK-31207] Attach pre-score moderations to TEXT_MESSAGE_START chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.18
+- `nat/datarobot_moderation_middleware`: streaming moderation now attaches prescore guard metrics to `TEXT_MESSAGE_START` chunks (matching DRUM/dome first-chunk semantics) and keeps postscore metrics on moderated `TEXT_MESSAGE_CONTENT` chunks.
+
 ## 0.16.17
 - `crewai`: fixed a file-descriptor leak that crashed long-running `nat dragent serve` with `[Errno 24] Too many open files`. crewai's kickoff-outputs SQLite storage leaks connections (unclosed `with sqlite3.connect(...)`); the agent now runs crews with an in-process no-op task-output handler, so no database is opened.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.17"
+version = "0.16.18"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.17"
+version = "0.16.18"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -77,6 +77,7 @@ from ag_ui.core import UserMessage
 from datarobot_dome.api import EvaluationResult
 from datarobot_dome.api import ModerationPipeline
 from datarobot_dome.api import _from_dataframe
+from datarobot_dome.chat_helper import build_moderations_attribute_for_completion
 from datarobot_dome.constants import CHAT_COMPLETION_OBJECT
 from datarobot_dome.constants import DATAROBOT_MODERATIONS_ATTR
 from datarobot_dome.constants import DISABLE_MODERATION_RUNTIME_PARAM_NAME
@@ -555,6 +556,62 @@ def _datarobot_moderations_merged_prompt_and_response_eval(
     if response_eval.metrics:
         merged.update(_json_safe_moderation_metadata(response_eval.metrics))
     return cast(dict[str, Any], merged) if merged else None
+
+
+def _prescore_datarobot_moderations_from_df(
+    pipeline: Any,
+    prescore_df: pd.DataFrame,
+) -> dict[str, Any] | None:
+    """Serialize prescore guard metrics the same way dome attaches them to the first stream chunk."""
+    raw = build_moderations_attribute_for_completion(pipeline, prescore_df)
+    if not raw:
+        return None
+    return cast(dict[str, Any], _json_safe_moderation_metadata(raw))
+
+
+def _postscore_only_datarobot_moderations(
+    moderations: dict[str, Any] | None,
+    prescore_moderations: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Drop prescore keys so response-stage metrics stay on moderated text chunks only."""
+    if not moderations:
+        return None
+    if not prescore_moderations:
+        return moderations
+    stripped = {k: v for k, v in moderations.items() if k not in prescore_moderations}
+    return cast(dict[str, Any], stripped) if stripped else None
+
+
+def _is_text_message_start_response(response: DRAgentEventResponse) -> bool:
+    return bool(response.events and response.events[0].type == EventType.TEXT_MESSAGE_START)
+
+
+@dataclass
+class _StreamingPrescoreModerationState:
+    """Track prescore attachment across a moderated DRAgent stream (dome first-chunk semantics)."""
+
+    prescore_moderations: dict[str, Any] | None
+    prescore_attached: bool = False
+    saw_moderated_content: bool = False
+
+    def emit(self, response: DRAgentEventResponse) -> DRAgentEventResponse:
+        if (
+            not self.prescore_attached
+            and self.prescore_moderations
+            and _is_text_message_start_response(response)
+        ):
+            self.prescore_attached = True
+            return response.model_copy(update={"datarobot_moderations": self.prescore_moderations})
+        return response
+
+    def emit_moderated(self, response: DRAgentEventResponse) -> DRAgentEventResponse:
+        mods = response.datarobot_moderations
+        if self.prescore_moderations and mods:
+            if self.prescore_attached or self.saw_moderated_content:
+                mods = _postscore_only_datarobot_moderations(mods, self.prescore_moderations)
+                response = response.model_copy(update={"datarobot_moderations": mods})
+        self.saw_moderated_content = True
+        return response
 
 
 def _infer_parent_message_id_for_tool_calls(
@@ -1178,6 +1235,12 @@ async def _moderated_dragent_stream(
     pending_pass_through: list[DRAgentEventResponse] = []
     moderation_source_responses: list[DRAgentEventResponse] = []
     stopped_for_content_filter = False
+    prescore_state = _StreamingPrescoreModerationState(
+        prescore_moderations=_prescore_datarobot_moderations_from_df(
+            moderation._pipeline,
+            stream_state.prescore_df,
+        ),
+    )
 
     def buffer_passthrough(response: DRAgentEventResponse) -> None:
         if response.events and _defer_until_after_moderated_chunk(response.events[0]):
@@ -1209,7 +1272,7 @@ async def _moderated_dragent_stream(
                 first_text = response
                 break
             _track_dragent_response_events(open_text_message_ids, response)
-            yield response
+            yield prescore_state.emit(response)
         if first_text is None:
             return
 
@@ -1223,10 +1286,12 @@ async def _moderated_dragent_stream(
         ) as moderation_stream:
             async for moderated in moderation_stream:
                 source_response = moderation_source_responses.pop(0)
-                moderated_response = dome_chunk_to_dragent_event_response(
-                    moderated,
-                    source_ag_ui_events=source_response.events,
-                    stream_tool_index_map=stream_tool_index_map,
+                moderated_response = prescore_state.emit_moderated(
+                    dome_chunk_to_dragent_event_response(
+                        moderated,
+                        source_ag_ui_events=source_response.events,
+                        stream_tool_index_map=stream_tool_index_map,
+                    )
                 )
                 _track_dragent_response_events(open_text_message_ids, moderated_response)
                 yield moderated_response
@@ -1234,7 +1299,7 @@ async def _moderated_dragent_stream(
                     pending_deferred, pending_pass_through
                 ):
                     _track_dragent_response_events(open_text_message_ids, item)
-                    yield item
+                    yield prescore_state.emit(item)
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
                     for end_response in _synthetic_text_message_end_responses(
@@ -1249,7 +1314,7 @@ async def _moderated_dragent_stream(
                 pending_deferred, pending_pass_through
             ):
                 _track_dragent_response_events(open_text_message_ids, item)
-                yield item
+                yield prescore_state.emit(item)
             for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
                 yield end_response
     finally:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -85,6 +85,12 @@ from datarobot_genai.nat.datarobot_moderation_middleware import (
     _clear_moderation_invoke_state_if_set,
 )
 from datarobot_genai.nat.datarobot_moderation_middleware import _moderation_invoke_state_ctx
+from datarobot_genai.nat.datarobot_moderation_middleware import (
+    _postscore_only_datarobot_moderations,
+)
+from datarobot_genai.nat.datarobot_moderation_middleware import (
+    _prescore_datarobot_moderations_from_df,
+)
 from datarobot_genai.nat.datarobot_moderation_middleware import _set_moderation_invoke_state
 from datarobot_genai.nat.datarobot_moderation_middleware import _workflow_input_from_args
 from datarobot_genai.nat.datarobot_moderation_middleware import dome_chunk_to_dragent_event_response
@@ -346,6 +352,31 @@ async def _content_filter_on_last_stream_response_async(
                 object="chat.completion.chunk",
             )
             return
+        yield current
+        current = peek
+
+
+async def _stream_response_with_merged_moderation_metrics(
+    completion: Any,
+    **kwargs: Any,
+) -> Any:
+    """Echo streamed chunks with merged prescore + postscore moderation sidecars."""
+    prescore_mods = {"Prompts_token_count": 3, "blocked_promptText": False}
+    response_mods = {"Responses_token_count": 6, "blocked_completion": False}
+    merged = {**prescore_mods, **response_mods}
+    aiter = completion.__aiter__()
+    try:
+        current = await aiter.__anext__()
+    except StopAsyncIteration:
+        return
+    while True:
+        try:
+            peek = await aiter.__anext__()
+        except StopAsyncIteration:
+            setattr(current, DATAROBOT_MODERATIONS_ATTR, merged)
+            yield current
+            return
+        setattr(current, DATAROBOT_MODERATIONS_ATTR, merged)
         yield current
         current = peek
 
@@ -2035,6 +2066,102 @@ async def test_function_middleware_stream_yields_blocked_pre_invoke(
     stream_next.assert_not_called()
     assert len(chunks) == 1
     assert isinstance(chunks[0], DRAgentEventResponse)
+
+
+def test_postscore_only_datarobot_moderations_strips_prescore_keys() -> None:
+    prescore = {"Prompts_token_count": 3, "blocked_promptText": False}
+    merged = {**prescore, "Responses_token_count": 6, "blocked_completion": False}
+    assert _postscore_only_datarobot_moderations(merged, prescore) == {
+        "Responses_token_count": 6,
+        "blocked_completion": False,
+    }
+
+
+def test_prescore_datarobot_moderations_from_df_uses_pipeline_columns(
+    builder_mock: MagicMock,
+    moderation_config_mode: str,
+) -> None:
+    model_dir = INTEGRATION_MODERATION_MODEL_DIR
+    with patch.dict(
+        os.environ,
+        {
+            "DATAROBOT_API_TOKEN": "test-token",
+            "DATAROBOT_ENDPOINT": "https://example.test/api/v2",
+        },
+    ):
+        mw = _moderation_middleware_for_fixture_dir(
+            model_dir, builder_mock, config_mode=moderation_config_mode
+        )
+        pipeline = mw._get_moderation()._pipeline
+        prompt_col = pipeline.get_input_column(GuardStage.PROMPT)
+        prescore_df = pd.DataFrame(
+            {
+                prompt_col: ["Count moderation tokens for this prompt."],
+                f"blocked_{prompt_col}": [False],
+                f"replaced_{prompt_col}": [False],
+                "Prompts_token_count": [7],
+            }
+        )
+        mods = _prescore_datarobot_moderations_from_df(pipeline, prescore_df)
+    assert mods is not None
+    assert mods["Prompts_token_count"] == 7
+    assert "Responses_token_count" not in mods
+
+
+async def test_function_middleware_stream_attaches_prescore_to_text_message_start(
+    builder_mock: MagicMock,
+) -> None:
+    """Prescore metrics belong on TEXT_MESSAGE_START; content chunks keep postscore only."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    moderation.stream_response_async = _stream_response_with_merged_moderation_metrics
+    prescore_df = _prescore_df_ok("topic")
+    prescore_df["Prompts_token_count"] = [3]
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    mid = "msg-start"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid, role="assistant")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid, delta="hello")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("topic"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    start_chunks = [
+        c for c in chunks if c.events and c.events[0].type == EventType.TEXT_MESSAGE_START
+    ]
+    content_chunks = [
+        c for c in chunks if any(isinstance(ev, TextMessageContentEvent) for ev in c.events)
+    ]
+    assert len(start_chunks) == 1
+    assert start_chunks[0].datarobot_moderations is not None
+    assert start_chunks[0].datarobot_moderations["Prompts_token_count"] == 3
+    assert "Responses_token_count" not in start_chunks[0].datarobot_moderations
+    assert content_chunks
+    assert content_chunks[0].datarobot_moderations is not None
+    assert content_chunks[0].datarobot_moderations["Responses_token_count"] == 6
+    assert "Prompts_token_count" not in content_chunks[0].datarobot_moderations
 
 
 async def test_function_middleware_stream_echoes_single_text_chunk(builder_mock: MagicMock) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.17"
+version = "0.16.18"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
To match drum, dragent should attach the pre-score moderations to the TEXT_MESSAGE_START chunk.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Attach the pre-score moderations to the TEXT_MESSAGE_START chunk.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `datarobot_moderations` is shaped on AG-UI stream chunks; clients or observability that assumed merged prescore+postscore on every moderated delta may need to read start vs content events differently.
> 
> **Overview**
> **Aligns DRAgent streaming moderation metadata with DRUM/dome:** prescore guard metrics now land on the first **`TEXT_MESSAGE_START`** chunk, while moderated **`TEXT_MESSAGE_CONTENT`** chunks carry **postscore-only** `datarobot_moderations` (prescore keys stripped so clients are not double-fed).
> 
> The moderated stream path in `datarobot_moderation_middleware` builds prescore sidecars from the prescore dataframe via dome’s `build_moderations_attribute_for_completion`, tracks attachment with `_StreamingPrescoreModerationState`, and wraps passthrough plus moderated yields accordingly. Release **0.16.14** and changelog note the behavior; unit tests cover key stripping, prescore serialization, and the start-vs-content split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce28c46424fc59696284b52bcfbabb70ac32f9f3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->