### PR TITLE
[MODEL-23710] Workload API | Artifact Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.14
+- `drtools/workload`: artifact core management.
+  - **Client** (`WorkloadApiClient`): added `list_artifacts`, `get_artifact`, `create_artifact`,
+    `put_artifact`, `patch_artifact`, `delete_artifact`, and `clone_artifact` methods targeting
+    `GET/POST /artifacts/`, `GET/PUT/PATCH/DELETE /artifacts/{id}`, and
+    `POST /artifacts/{id}/clone`.
+  - **Tools** (`drtools/workload/artifact_tools.py`): `artifact_list` (paginated, filterable by
+    status/type/repository/search), `artifact_get`, `artifact_create`, `artifact_update` (PATCH
+    helper for name/description/spec), `artifact_lock` (PATCH shortcut to set status→locked),
+    `artifact_clone`, and `artifact_delete`.
+
 ## 0.16.13
 - `dragent/frontends`: `POST /chat/completions` now reports the agent's configured LLM model (via `core/config.default_response_model`) instead of NAT's `"unknown-model"`, on the non-streaming body and streaming content chunks. The request's `model` is ignored (the agent runs its `workflow.yaml`/env-configured LLM) and need not be sent; moderation's `MODERATION_MODEL_NAME` is preserved. Known gap: NAT's terminal `finish_reason="stop"` streaming chunk still reports `"unknown-model"`.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.12"
+version = "0.16.14"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.13"
+version = "0.16.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/constants.py
+++ b/src/datarobot_genai/drmcputils/constants.py
@@ -23,6 +23,10 @@ LOG_LEVELS = ("debug", "info", "warn", "error")
 
 IMPORTANCE_VALUES = ("low", "moderate", "high", "critical")
 
+ARTIFACT_STATUSES: tuple[str, ...] = ("draft", "locked")
+
+ARTIFACT_TYPES: tuple[str, ...] = ("service", "nim")
+
 # Header names to check for authorization tokens (in order of preference)
 HEADER_TOKEN_CANDIDATE_NAMES = [
     "x-datarobot-authorization",

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -279,3 +279,60 @@ class WorkloadApiClient:
             params.append(("traceId", trace_id))
         with request_user_dr_client() as client:
             return client.get(f"otel/workload/{workload_id}/logs/", params=params).json()
+
+    # ------------------------------------------------------------------ #
+    # Artifacts                                                            #
+    # ------------------------------------------------------------------ #
+
+    def list_artifacts(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        status: str | None = None,
+        artifact_type: str | None = None,
+        repository_id: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /artifacts/ with optional filters and pagination."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if search:
+            params["search"] = search
+        if status:
+            params["status"] = status
+        if artifact_type:
+            params["type"] = artifact_type
+        if repository_id:
+            params["repositoryId"] = repository_id
+        with request_user_dr_client() as client:
+            return client.get("artifacts/", params=params).json()
+
+    def get_artifact(self, artifact_id: str) -> dict[str, Any]:
+        """GET /artifacts/{id}."""
+        with request_user_dr_client() as client:
+            return client.get(f"artifacts/{artifact_id}").json()
+
+    def create_artifact(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST /artifacts/ — returns the created ArtifactFormatted (201)."""
+        with request_user_dr_client() as client:
+            return client.post("artifacts/", json=payload).json()
+
+    def put_artifact(self, artifact_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """PUT /artifacts/{id} — full replacement with InputArtifact payload."""
+        with request_user_dr_client() as client:
+            return client.put(f"artifacts/{artifact_id}", json=payload).json()
+
+    def patch_artifact(self, artifact_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """PATCH /artifacts/{id} — partial update via UpdateArtifactRequest."""
+        with request_user_dr_client() as client:
+            return client.patch(f"artifacts/{artifact_id}", json=payload).json()
+
+    def delete_artifact(self, artifact_id: str) -> None:
+        """DELETE /artifacts/{id} — 204 No Content on success."""
+        with request_user_dr_client() as client:
+            client.delete(f"artifacts/{artifact_id}")
+
+    def clone_artifact(self, artifact_id: str, name: str) -> dict[str, Any]:
+        """POST /artifacts/{id}/clone — duplicate with a new name."""
+        with request_user_dr_client() as client:
+            return client.post(f"artifacts/{artifact_id}/clone", json={"name": name}).json()

--- a/src/datarobot_genai/drtools/workload/artifact_tools.py
+++ b/src/datarobot_genai/drtools/workload/artifact_tools.py
@@ -189,18 +189,24 @@ async def artifact_update(
     ] = None,
 ) -> dict[str, Any]:
     aid = require_id(artifact_id, "artifact_id")
-    if not any([name, description, spec]):
-        raise ToolError(
-            "Argument validation error: at least one of name, description, or spec must be set.",
-            kind=ToolErrorKind.VALIDATION,
-        )
     patch: dict[str, Any] = {}
     if name is not None:
-        patch["name"] = name.strip()
+        stripped_name = name.strip()
+        if not stripped_name:
+            raise ToolError(
+                "Argument validation error: 'name' cannot be empty.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+        patch["name"] = stripped_name
     if description is not None:
         patch["description"] = description.strip()
     if spec is not None:
         patch["spec"] = spec
+    if not patch:
+        raise ToolError(
+            "Argument validation error: at least one of name, description, or spec must be set.",
+            kind=ToolErrorKind.VALIDATION,
+        )
     try:
         return WorkloadApiClient().patch_artifact(aid, patch)
     except ClientError as exc:

--- a/src/datarobot_genai/drtools/workload/artifact_tools.py
+++ b/src/datarobot_genai/drtools/workload/artifact_tools.py
@@ -18,6 +18,8 @@ from typing import Any
 from datarobot.errors import ClientError
 
 from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.constants import ARTIFACT_STATUSES
+from datarobot_genai.drmcputils.constants import ARTIFACT_TYPES
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drtools.core import tool_metadata
@@ -25,10 +27,6 @@ from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiC
 from datarobot_genai.drtools.core.utils import require_id
 from datarobot_genai.drtools.pagination import clamp_limit
 from datarobot_genai.drtools.pagination import merge_pagination_metadata
-
-_ARTIFACT_STATUSES = ("draft", "locked")
-_ARTIFACT_TYPES = ("service", "nim")
-
 
 # ------------------------------------------------------------------ #
 # artifact_list                                                        #
@@ -62,14 +60,14 @@ async def artifact_list(
             "Argument validation error: 'offset' must be >= 0.",
             kind=ToolErrorKind.VALIDATION,
         )
-    if status and status.lower() not in _ARTIFACT_STATUSES:
+    if status and status.lower() not in ARTIFACT_STATUSES:
         raise ToolError(
-            f"Argument validation error: 'status' must be one of {_ARTIFACT_STATUSES}.",
+            f"Argument validation error: 'status' must be one of {ARTIFACT_STATUSES}.",
             kind=ToolErrorKind.VALIDATION,
         )
-    if artifact_type and artifact_type.lower() not in _ARTIFACT_TYPES:
+    if artifact_type and artifact_type.lower() not in ARTIFACT_TYPES:
         raise ToolError(
-            f"Argument validation error: 'artifact_type' must be one of {_ARTIFACT_TYPES}.",
+            f"Argument validation error: 'artifact_type' must be one of {ARTIFACT_TYPES}.",
             kind=ToolErrorKind.VALIDATION,
         )
     clamped_limit, note = clamp_limit(limit)

--- a/src/datarobot_genai/drtools/workload/artifact_tools.py
+++ b/src/datarobot_genai/drtools/workload/artifact_tools.py
@@ -1,0 +1,289 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+from typing import Any
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
+from datarobot_genai.drtools.core.utils import require_id
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+
+_ARTIFACT_STATUSES = ("draft", "locked")
+_ARTIFACT_TYPES = ("service", "nim")
+
+
+# ------------------------------------------------------------------ #
+# artifact_list                                                        #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "workload", "datarobot", "list"},
+    description=(
+        "[Artifact—list] Discover artifacts: returns id, name, status (draft/locked), "
+        "type, spec, and timestamps. Supports pagination and optional filters for "
+        "status, type, repository, and search text. "
+        "Not for a single known artifact id (artifact_get).\n\n"
+        "Example: artifact_list()\n"
+        "Example: artifact_list(search='my-service', status='draft')"
+    ),
+)
+async def artifact_list(
+    *,
+    search: Annotated[
+        str | None, "Case-insensitive filter on name, description, and partial id."
+    ] = None,
+    status: Annotated[str | None, "Filter by status: 'draft' or 'locked'."] = None,
+    artifact_type: Annotated[str | None, "Filter by type: 'service' or 'nim'."] = None,
+    repository_id: Annotated[str | None, "Filter by artifact repository id."] = None,
+    limit: Annotated[int, "Max artifacts to return (1–100). Default 100."] = 100,
+    offset: Annotated[int, "Artifacts to skip for pagination. Default 0."] = 0,
+) -> dict[str, Any]:
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if status and status.lower() not in _ARTIFACT_STATUSES:
+        raise ToolError(
+            f"Argument validation error: 'status' must be one of {_ARTIFACT_STATUSES}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if artifact_type and artifact_type.lower() not in _ARTIFACT_TYPES:
+        raise ToolError(
+            f"Argument validation error: 'artifact_type' must be one of {_ARTIFACT_TYPES}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    clamped_limit, note = clamp_limit(limit)
+    try:
+        result = WorkloadApiClient().list_artifacts(
+            limit=clamped_limit,
+            offset=offset,
+            search=search,
+            status=status.lower() if status else None,
+            artifact_type=artifact_type.lower() if artifact_type else None,
+            repository_id=repository_id,
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"artifacts": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+# ------------------------------------------------------------------ #
+# artifact_get                                                         #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "workload", "datarobot", "get"},
+    description=(
+        "[Artifact—get] Retrieve a single artifact by id: full spec, status, "
+        "type, version, repository, and timestamps.\n\n"
+        "Example: artifact_get(artifact_id='art-abc123')"
+    ),
+)
+async def artifact_get(
+    *,
+    artifact_id: Annotated[str, "Id of the artifact to retrieve."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    try:
+        return WorkloadApiClient().get_artifact(aid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_create                                                      #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "workload", "datarobot", "create"},
+    description=(
+        "[Artifact—create] Create a new draft artifact from an InputArtifact payload. "
+        "The payload must contain 'name' and 'spec'. 'spec' must have 'type' "
+        "('service' or 'nim') and 'containerGroups'. Artifacts are always created "
+        "as drafts.\n\n"
+        "Example: artifact_create(payload={'name': 'my-svc', 'spec': {'type': 'service', "
+        "'containerGroups': [{'containers': [{'name': 'main', 'imageUri': 'nginx:latest', "
+        "'primary': true, 'port': 8080}]}]}})"
+    ),
+)
+async def artifact_create(
+    *,
+    payload: Annotated[
+        dict[str, Any],
+        "InputArtifact payload. Must contain 'name' and 'spec' with 'type' and 'containerGroups'.",
+    ],
+) -> dict[str, Any]:
+    if not payload or not isinstance(payload, dict):
+        raise ToolError(
+            "Argument validation error: 'payload' must be a non-empty object.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if not (payload.get("name") or "").strip():
+        raise ToolError(
+            "Argument validation error: payload must contain a non-empty 'name'.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if not payload.get("spec"):
+        raise ToolError(
+            "Argument validation error: payload must contain a 'spec' object.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    try:
+        return WorkloadApiClient().create_artifact(payload)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_update                                                      #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "workload", "datarobot", "update"},
+    description=(
+        "[Artifact—update] Partially update a draft artifact: name, description, "
+        "or spec. Only the supplied fields are changed. At least one field is required. "
+        "Locked artifacts cannot be updated.\n\n"
+        "Example: artifact_update(artifact_id='art-abc', name='new-name')"
+    ),
+)
+async def artifact_update(
+    *,
+    artifact_id: Annotated[str, "Id of the artifact to update."],
+    name: Annotated[str | None, "New artifact name."] = None,
+    description: Annotated[str | None, "New artifact description."] = None,
+    spec: Annotated[
+        dict[str, Any] | None,
+        "New artifact spec (replaces current spec). Must include 'type' and 'containerGroups'.",
+    ] = None,
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    if not any([name, description, spec]):
+        raise ToolError(
+            "Argument validation error: at least one of name, description, or spec must be set.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    patch: dict[str, Any] = {}
+    if name is not None:
+        patch["name"] = name.strip()
+    if description is not None:
+        patch["description"] = description.strip()
+    if spec is not None:
+        patch["spec"] = spec
+    try:
+        return WorkloadApiClient().patch_artifact(aid, patch)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_lock                                                        #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "workload", "datarobot", "lock"},
+    description=(
+        "[Artifact—lock] Lock a draft artifact so it can be versioned and used "
+        "in production deployments. Once locked, an artifact cannot be updated "
+        "or deleted. Use workload_promote to lock the artifact currently running "
+        "on a workload instead.\n\n"
+        "Example: artifact_lock(artifact_id='art-abc')"
+    ),
+)
+async def artifact_lock(
+    *,
+    artifact_id: Annotated[str, "Id of the draft artifact to lock."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    try:
+        return WorkloadApiClient().patch_artifact(aid, {"status": "locked"})
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_clone                                                       #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "workload", "datarobot", "clone"},
+    description=(
+        "[Artifact—clone] Duplicate an existing artifact under a new name. "
+        "The clone is created as a draft regardless of the original's status, "
+        "allowing further modification before use.\n\n"
+        "Example: artifact_clone(artifact_id='art-abc', name='my-service-v2')"
+    ),
+)
+async def artifact_clone(
+    *,
+    artifact_id: Annotated[str, "Id of the artifact to clone."],
+    name: Annotated[str, "Name for the cloned artifact."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    if not name or not name.strip():
+        raise ToolError(
+            "Argument validation error: 'name' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    try:
+        return WorkloadApiClient().clone_artifact(aid, name.strip())
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_delete                                                      #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "workload", "datarobot", "delete"},
+    description=(
+        "[Artifact—delete] Permanently delete a draft artifact. Locked artifacts "
+        "and artifacts currently in use by a workload cannot be deleted.\n\n"
+        "Example: artifact_delete(artifact_id='art-abc')"
+    ),
+)
+async def artifact_delete(
+    *,
+    artifact_id: Annotated[str, "Id of the artifact to delete."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    try:
+        WorkloadApiClient().delete_artifact(aid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+    return {"deleted": True, "artifact_id": aid}

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -1205,6 +1205,14 @@ async def test_artifact_update_no_fields_raises() -> None:
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
+@pytest.mark.asyncio
+async def test_artifact_update_whitespace_name_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_update(artifact_id="art-abc", name="   ")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "name" in str(exc_info.value).lower()
+
+
 # ------------------------------------------------------------------ #
 # artifact_lock                                                        #
 # ------------------------------------------------------------------ #

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -23,6 +23,7 @@ from datarobot.errors import ClientError
 
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.workload import artifact_tools
 from datarobot_genai.drtools.workload import lifecycle_tools
 from datarobot_genai.drtools.workload import observability_tools
 from datarobot_genai.drtools.workload import proton_tools
@@ -1012,4 +1013,281 @@ async def test_workload_logs_client_error(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
     with pytest.raises(ToolError) as exc_info:
         await proton_tools.workload_logs(workload_id="wkld-abc")
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ================================================================== #
+# PR5 — artifacts core                                                 #
+# ================================================================== #
+
+# ------------------------------------------------------------------ #
+# artifact_list                                                        #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "data": [
+                {"id": "art-1", "name": "my-service", "status": "draft"},
+                {"id": "art-2", "name": "my-nim", "status": "locked"},
+            ],
+            "count": 2,
+            "totalCount": 2,
+        }
+    )
+
+    result = await artifact_tools.artifact_list()
+
+    patched_dr_client.get.assert_called_once_with(
+        "artifacts/",
+        params={"limit": 100, "offset": 0},
+    )
+    assert result["count"] == 2
+    assert result["artifacts"][0]["id"] == "art-1"
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_with_filters(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"data": [], "count": 0, "totalCount": 0}
+    )
+
+    await artifact_tools.artifact_list(
+        search="my-svc", status="draft", artifact_type="service", repository_id="repo-1"
+    )
+
+    patched_dr_client.get.assert_called_once_with(
+        "artifacts/",
+        params={
+            "limit": 100,
+            "offset": 0,
+            "search": "my-svc",
+            "status": "draft",
+            "type": "service",
+            "repositoryId": "repo-1",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_invalid_status_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_list(status="pending")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_invalid_type_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_list(artifact_type="docker")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_list_negative_offset_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_list(offset=-1)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# artifact_get                                                         #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_get_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "art-abc", "name": "my-service", "status": "draft"}
+    )
+
+    result = await artifact_tools.artifact_get(artifact_id="art-abc")
+
+    patched_dr_client.get.assert_called_once_with("artifacts/art-abc")
+    assert result["id"] == "art-abc"
+
+
+@pytest.mark.asyncio
+async def test_artifact_get_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_get(artifact_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_get_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_get(artifact_id="art-missing")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# artifact_create                                                      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_create_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(
+        json=lambda: {"id": "art-new", "name": "my-svc", "status": "draft"}
+    )
+    payload = {
+        "name": "my-svc",
+        "spec": {
+            "type": "service",
+            "containerGroups": [{"containers": [{"name": "main", "imageUri": "nginx:latest"}]}],
+        },
+    }
+
+    result = await artifact_tools.artifact_create(payload=payload)
+
+    patched_dr_client.post.assert_called_once_with("artifacts/", json=payload)
+    assert result["id"] == "art-new"
+
+
+@pytest.mark.asyncio
+async def test_artifact_create_missing_name_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_create(payload={"spec": {"type": "service"}})
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_create_missing_spec_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_create(payload={"name": "my-svc"})
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_create_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.side_effect = ClientError("422", status_code=422, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_create(payload={"name": "x", "spec": {"type": "service"}})
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# artifact_update                                                      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_update_name(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.patch.return_value = MagicMock(
+        json=lambda: {"id": "art-abc", "name": "new-name"}
+    )
+
+    result = await artifact_tools.artifact_update(artifact_id="art-abc", name="new-name")
+
+    patched_dr_client.patch.assert_called_once_with("artifacts/art-abc", json={"name": "new-name"})
+    assert result["name"] == "new-name"
+
+
+@pytest.mark.asyncio
+async def test_artifact_update_multiple_fields(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.patch.return_value = MagicMock(json=lambda: {"id": "art-abc"})
+
+    await artifact_tools.artifact_update(artifact_id="art-abc", name="x", description="desc")
+
+    patched_dr_client.patch.assert_called_once_with(
+        "artifacts/art-abc", json={"name": "x", "description": "desc"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_artifact_update_no_fields_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_update(artifact_id="art-abc")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# artifact_lock                                                        #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_lock_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.patch.return_value = MagicMock(
+        json=lambda: {"id": "art-abc", "status": "locked"}
+    )
+
+    result = await artifact_tools.artifact_lock(artifact_id="art-abc")
+
+    patched_dr_client.patch.assert_called_once_with("artifacts/art-abc", json={"status": "locked"})
+    assert result["status"] == "locked"
+
+
+@pytest.mark.asyncio
+async def test_artifact_lock_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_lock(artifact_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# artifact_clone                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_clone_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(
+        json=lambda: {"id": "art-new", "name": "my-service-v2", "status": "draft"}
+    )
+
+    result = await artifact_tools.artifact_clone(artifact_id="art-abc", name="my-service-v2")
+
+    patched_dr_client.post.assert_called_once_with(
+        "artifacts/art-abc/clone", json={"name": "my-service-v2"}
+    )
+    assert result["name"] == "my-service-v2"
+
+
+@pytest.mark.asyncio
+async def test_artifact_clone_empty_name_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_clone(artifact_id="art-abc", name="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_clone_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_clone(artifact_id="art-missing", name="clone")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# artifact_delete                                                      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_delete_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.return_value = MagicMock()
+
+    result = await artifact_tools.artifact_delete(artifact_id="art-abc")
+
+    patched_dr_client.delete.assert_called_once_with("artifacts/art-abc")
+    assert result == {"deleted": True, "artifact_id": "art-abc"}
+
+
+@pytest.mark.asyncio
+async def test_artifact_delete_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_delete(artifact_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_delete_locked_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.side_effect = ClientError("409 Conflict", status_code=409, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await artifact_tools.artifact_delete(artifact_id="art-locked")
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.13"
+version = "0.16.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

Created workload api artifact tools
Created unit tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

## TESTING

<img width="453" height="381" alt="Screenshot 2026-06-12 at 11 33 54 AM" src="https://github.com/user-attachments/assets/c789e84a-d473-4550-9efe-a813e46b8415" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New write paths (create, update, lock, clone, delete) call production Workload APIs under the request user’s credentials; mistakes can mutate or remove draft artifacts, though behavior matches existing workload tool patterns and is covered by unit tests only (no integration/acceptance tests in this PR).
> 
> **Overview**
> Adds **Workload API artifact management** for MCP agents: `WorkloadApiClient` now covers list/get/create/put/patch/delete/clone on `/artifacts/`, and a new `artifact_tools` module exposes **`artifact_list`**, **`artifact_get`**, **`artifact_create`**, **`artifact_update`**, **`artifact_lock`**, **`artifact_clone`**, and **`artifact_delete`** with validation, pagination, and `ToolError` mapping consistent with other workload tools.
> 
> Unit tests for these tools are in `tests/drmcp/unit/workload_tools/test_tools.py`. Release is **0.16.14** (changelog, `pyproject.toml`, lockfiles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772bde04660bcd3eab7d4fa1969d9eb95d37ece5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->