### PR TITLE
[MODEL-23711] Worload API | Artifacts Build and Repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.14
+- `drtools/workload`: PR6 — artifact builds and repositories.
+  - **Client** (`WorkloadApiClient`): added `list_artifact_builds`, `trigger_artifact_build`,
+    `get_artifact_build`, `get_artifact_build_logs` (text/plain response), `delete_artifact_build`
+    targeting `GET/POST /artifacts/{id}/builds` and `GET/DELETE /artifacts/{id}/builds/{build_id}`;
+    added `list_artifact_repositories`, `get_artifact_repository`, `delete_artifact_repository`
+    targeting `GET /artifactRepositories` and `GET/DELETE /artifactRepositories/{id}`.
+  - **Tools** (`drtools/workload/build_tools.py`): `artifact_build_list`, `artifact_build_trigger`,
+    `artifact_build_get`, `artifact_build_logs`, `artifact_build_delete`.
+  - **Tools** (`drtools/workload/repository_tools.py`): `artifact_repository_list` (filterable by
+    search/type), `artifact_repository_get`, `artifact_repository_delete`.
+  - **Tests**: 23 new unit tests; total workload-tool suite reaches 98 passing tests.
+
 ## 0.16.13
 - `dragent/frontends`: `POST /chat/completions` now reports the agent's configured LLM model (via `core/config.default_response_model`) instead of NAT's `"unknown-model"`, on the non-streaming body and streaming content chunks. The request's `model` is ignored (the agent runs its `workflow.yaml`/env-configured LLM) and need not be sent; moderation's `MODERATION_MODEL_NAME` is preserved. Known gap: NAT's terminal `finish_reason="stop"` streaming chunk still reports `"unknown-model"`.
 
 ## 0.16.12
 - A2A per-user workflow keys use gateway identity headers instead of caller-supplied `context_id`; invalid auth context is rejected.
--
+
 ## 0.16.11
 - Fix datarobot_genai.eval.benchmarks pipeline YAML reference retrievals
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.12"
+version = "0.16.14"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.13"
+version = "0.16.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/constants.py
+++ b/src/datarobot_genai/drmcputils/constants.py
@@ -23,6 +23,8 @@ LOG_LEVELS = ("debug", "info", "warn", "error")
 
 IMPORTANCE_VALUES = ("low", "moderate", "high", "critical")
 
+ARTIFACT_TYPES: tuple[str, ...] = ("service", "nim")
+
 # Header names to check for authorization tokens (in order of preference)
 HEADER_TOKEN_CANDIDATE_NAMES = [
     "x-datarobot-authorization",

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -279,3 +279,70 @@ class WorkloadApiClient:
             params.append(("traceId", trace_id))
         with request_user_dr_client() as client:
             return client.get(f"otel/workload/{workload_id}/logs/", params=params).json()
+
+    # ------------------------------------------------------------------ #
+    # Artifact builds                                                      #
+    # ------------------------------------------------------------------ #
+
+    def list_artifact_builds(
+        self,
+        artifact_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """GET /artifacts/{id}/builds."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        with request_user_dr_client() as client:
+            return client.get(f"artifacts/{artifact_id}/builds", params=params).json()
+
+    def trigger_artifact_build(self, artifact_id: str) -> dict[str, Any]:
+        """POST /artifacts/{id}/builds — start image build(s) for a draft service artifact."""
+        with request_user_dr_client() as client:
+            return client.post(f"artifacts/{artifact_id}/builds").json()
+
+    def get_artifact_build(self, artifact_id: str, build_id: str) -> dict[str, Any]:
+        """GET /artifacts/{id}/builds/{build_id}."""
+        with request_user_dr_client() as client:
+            return client.get(f"artifacts/{artifact_id}/builds/{build_id}").json()
+
+    def get_artifact_build_logs(self, artifact_id: str, build_id: str) -> str:
+        """GET /artifacts/{id}/builds/{build_id}/logs — returns raw log text."""
+        with request_user_dr_client() as client:
+            return client.get(f"artifacts/{artifact_id}/builds/{build_id}/logs").text
+
+    def delete_artifact_build(self, artifact_id: str, build_id: str) -> None:
+        """DELETE /artifacts/{id}/builds/{build_id} — cancel or delete a build (204)."""
+        with request_user_dr_client() as client:
+            client.delete(f"artifacts/{artifact_id}/builds/{build_id}")
+
+    # ------------------------------------------------------------------ #
+    # Artifact repositories                                                #
+    # ------------------------------------------------------------------ #
+
+    def list_artifact_repositories(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        search: str | None = None,
+        artifact_type: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /artifactRepositories."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if search:
+            params["search"] = search
+        if artifact_type:
+            params["type"] = artifact_type
+        with request_user_dr_client() as client:
+            return client.get("artifactRepositories", params=params).json()
+
+    def get_artifact_repository(self, repository_id: str) -> dict[str, Any]:
+        """GET /artifactRepositories/{id}."""
+        with request_user_dr_client() as client:
+            return client.get(f"artifactRepositories/{repository_id}").json()
+
+    def delete_artifact_repository(self, repository_id: str) -> None:
+        """DELETE /artifactRepositories/{id} — 204 No Content on success."""
+        with request_user_dr_client() as client:
+            client.delete(f"artifactRepositories/{repository_id}")

--- a/src/datarobot_genai/drtools/workload/build_tools.py
+++ b/src/datarobot_genai/drtools/workload/build_tools.py
@@ -1,0 +1,171 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+from typing import Any
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
+from datarobot_genai.drtools.core.utils import require_id
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+
+# ------------------------------------------------------------------ #
+# artifact_build_list                                                  #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "build", "workload", "datarobot", "list"},
+    description=(
+        "[Artifact build—list] List image builds for an artifact. Returns build "
+        "status, timestamps, and build id. Supports pagination.\n\n"
+        "Example: artifact_build_list(artifact_id='art-abc')"
+    ),
+)
+async def artifact_build_list(
+    *,
+    artifact_id: Annotated[str, "Id of the artifact whose builds to list."],
+    limit: Annotated[int, "Max builds to return (1–100). Default 100."] = 100,
+    offset: Annotated[int, "Builds to skip for pagination. Default 0."] = 0,
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    clamped_limit, note = clamp_limit(limit)
+    try:
+        result = WorkloadApiClient().list_artifact_builds(aid, limit=clamped_limit, offset=offset)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"builds": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_trigger                                               #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "build", "workload", "datarobot", "trigger"},
+    description=(
+        "[Artifact build—trigger] Start an image build for a draft service artifact "
+        "(codeRef). Locked artifacts are rejected. Returns the triggered build record.\n\n"
+        "Example: artifact_build_trigger(artifact_id='art-abc')"
+    ),
+)
+async def artifact_build_trigger(
+    *,
+    artifact_id: Annotated[str, "Id of the draft artifact to build."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    try:
+        return WorkloadApiClient().trigger_artifact_build(aid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_get                                                   #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "build", "workload", "datarobot", "get"},
+    description=(
+        "[Artifact build—get] Retrieve a specific build by id. Returns status, "
+        "timestamps, and build metadata.\n\n"
+        "Example: artifact_build_get(artifact_id='art-abc', build_id='bld-xyz')"
+    ),
+)
+async def artifact_build_get(
+    *,
+    artifact_id: Annotated[str, "Id of the artifact."],
+    build_id: Annotated[str, "Id of the build to retrieve."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    bid = require_id(build_id, "build_id")
+    try:
+        return WorkloadApiClient().get_artifact_build(aid, bid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_logs                                                  #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "build", "workload", "datarobot", "logs"},
+    description=(
+        "[Artifact build—logs] Retrieve the raw build log output for a specific "
+        "image build. Useful for debugging build failures.\n\n"
+        "Example: artifact_build_logs(artifact_id='art-abc', build_id='bld-xyz')"
+    ),
+)
+async def artifact_build_logs(
+    *,
+    artifact_id: Annotated[str, "Id of the artifact."],
+    build_id: Annotated[str, "Id of the build whose logs to retrieve."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    bid = require_id(build_id, "build_id")
+    try:
+        logs = WorkloadApiClient().get_artifact_build_logs(aid, bid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+    return {"artifact_id": aid, "build_id": bid, "logs": logs}
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_delete                                                #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "build", "workload", "datarobot", "delete"},
+    description=(
+        "[Artifact build—delete] Cancel or delete an image build for a draft artifact. "
+        "Locked artifacts cannot have their builds deleted.\n\n"
+        "Example: artifact_build_delete(artifact_id='art-abc', build_id='bld-xyz')"
+    ),
+)
+async def artifact_build_delete(
+    *,
+    artifact_id: Annotated[str, "Id of the draft artifact."],
+    build_id: Annotated[str, "Id of the build to cancel or delete."],
+) -> dict[str, Any]:
+    aid = require_id(artifact_id, "artifact_id")
+    bid = require_id(build_id, "build_id")
+    try:
+        WorkloadApiClient().delete_artifact_build(aid, bid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+    return {"deleted": True, "artifact_id": aid, "build_id": bid}

--- a/src/datarobot_genai/drtools/workload/repository_tools.py
+++ b/src/datarobot_genai/drtools/workload/repository_tools.py
@@ -1,0 +1,131 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+from typing import Any
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.constants import ARTIFACT_TYPES
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
+from datarobot_genai.drtools.core.utils import require_id
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+
+# ------------------------------------------------------------------ #
+# artifact_repository_list                                             #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "repository", "workload", "datarobot", "list"},
+    description=(
+        "[Artifact repository—list] Discover artifact repositories. Returns id, name, "
+        "type, and timestamps. Supports pagination and optional search/type filters.\n\n"
+        "Example: artifact_repository_list()\n"
+        "Example: artifact_repository_list(search='my-registry', artifact_type='service')"
+    ),
+)
+async def artifact_repository_list(
+    *,
+    search: Annotated[
+        str | None, "Case-insensitive filter on name, description, and partial id."
+    ] = None,
+    artifact_type: Annotated[str | None, "Filter by type: 'service' or 'nim'."] = None,
+    limit: Annotated[int, "Max repositories to return (1–100). Default 100."] = 100,
+    offset: Annotated[int, "Repositories to skip for pagination. Default 0."] = 0,
+) -> dict[str, Any]:
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if artifact_type and artifact_type.lower() not in ARTIFACT_TYPES:
+        raise ToolError(
+            f"Argument validation error: 'artifact_type' must be one of {ARTIFACT_TYPES}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    clamped_limit, note = clamp_limit(limit)
+    try:
+        result = WorkloadApiClient().list_artifact_repositories(
+            limit=clamped_limit,
+            offset=offset,
+            search=search,
+            artifact_type=artifact_type.lower() if artifact_type else None,
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"repositories": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+# ------------------------------------------------------------------ #
+# artifact_repository_get                                              #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "repository", "workload", "datarobot", "get"},
+    description=(
+        "[Artifact repository—get] Retrieve a single artifact repository by id. "
+        "Returns full metadata including name, type, spec, and timestamps.\n\n"
+        "Example: artifact_repository_get(repository_id='repo-abc123')"
+    ),
+)
+async def artifact_repository_get(
+    *,
+    repository_id: Annotated[str, "Id of the artifact repository to retrieve."],
+) -> dict[str, Any]:
+    rid = require_id(repository_id, "repository_id")
+    try:
+        return WorkloadApiClient().get_artifact_repository(rid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# artifact_repository_delete                                           #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"artifact", "repository", "workload", "datarobot", "delete"},
+    description=(
+        "[Artifact repository—delete] Permanently delete an artifact repository. "
+        "Artifacts within the repository are cascade-deleted unless they are locked "
+        "or currently in use by a workload — those will cause a 409 conflict.\n\n"
+        "Example: artifact_repository_delete(repository_id='repo-abc123')"
+    ),
+)
+async def artifact_repository_delete(
+    *,
+    repository_id: Annotated[str, "Id of the artifact repository to delete."],
+) -> dict[str, Any]:
+    rid = require_id(repository_id, "repository_id")
+    try:
+        WorkloadApiClient().delete_artifact_repository(rid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+    return {"deleted": True, "repository_id": rid}

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -23,10 +23,12 @@ from datarobot.errors import ClientError
 
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.workload import build_tools
 from datarobot_genai.drtools.workload import lifecycle_tools
 from datarobot_genai.drtools.workload import observability_tools
 from datarobot_genai.drtools.workload import proton_tools
 from datarobot_genai.drtools.workload import read_tools
+from datarobot_genai.drtools.workload import repository_tools
 
 # ------------------------------------------------------------------ #
 # Shared fixtures                                                       #
@@ -1012,4 +1014,274 @@ async def test_workload_logs_client_error(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
     with pytest.raises(ToolError) as exc_info:
         await proton_tools.workload_logs(workload_id="wkld-abc")
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ================================================================== #
+# PR6 — artifact builds + repositories                                 #
+# ================================================================== #
+
+# ------------------------------------------------------------------ #
+# artifact_build_list                                                  #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_list_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "data": [
+                {"id": "bld-1", "status": "success"},
+                {"id": "bld-2", "status": "running"},
+            ],
+            "count": 2,
+            "totalCount": 2,
+        }
+    )
+
+    result = await build_tools.artifact_build_list(artifact_id="art-abc")
+
+    patched_dr_client.get.assert_called_once_with(
+        "artifacts/art-abc/builds", params={"limit": 100, "offset": 0}
+    )
+    assert result["count"] == 2
+    assert result["builds"][0]["id"] == "bld-1"
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_list_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_list(artifact_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_list_negative_offset_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_list(artifact_id="art-abc", offset=-1)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_list_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_list(artifact_id="art-missing")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_trigger                                               #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_trigger_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(json=lambda: {"buildIds": ["bld-new"]})
+
+    result = await build_tools.artifact_build_trigger(artifact_id="art-abc")
+
+    patched_dr_client.post.assert_called_once_with("artifacts/art-abc/builds")
+    assert result["buildIds"] == ["bld-new"]
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_trigger_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_trigger(artifact_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_trigger_locked_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.side_effect = ClientError("422", status_code=422, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_trigger(artifact_id="art-locked")
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_get                                                   #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_get_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "bld-xyz", "status": "success"}
+    )
+
+    result = await build_tools.artifact_build_get(artifact_id="art-abc", build_id="bld-xyz")
+
+    patched_dr_client.get.assert_called_once_with("artifacts/art-abc/builds/bld-xyz")
+    assert result["id"] == "bld-xyz"
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_get_empty_build_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_get(artifact_id="art-abc", build_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_logs                                                  #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_logs_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(text="Step 1/3: FROM python:3.11\n")
+
+    result = await build_tools.artifact_build_logs(artifact_id="art-abc", build_id="bld-xyz")
+
+    patched_dr_client.get.assert_called_once_with("artifacts/art-abc/builds/bld-xyz/logs")
+    assert result == {
+        "artifact_id": "art-abc",
+        "build_id": "bld-xyz",
+        "logs": "Step 1/3: FROM python:3.11\n",
+    }
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_logs_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_logs(artifact_id="art-abc", build_id="bld-xyz")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# artifact_build_delete                                                #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_delete_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.return_value = MagicMock()
+
+    result = await build_tools.artifact_build_delete(artifact_id="art-abc", build_id="bld-xyz")
+
+    patched_dr_client.delete.assert_called_once_with("artifacts/art-abc/builds/bld-xyz")
+    assert result == {"deleted": True, "artifact_id": "art-abc", "build_id": "bld-xyz"}
+
+
+@pytest.mark.asyncio
+async def test_artifact_build_delete_empty_ids_raise() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await build_tools.artifact_build_delete(artifact_id="", build_id="bld-xyz")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# artifact_repository_list                                             #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_list_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "data": [{"id": "repo-1", "name": "my-registry"}],
+            "count": 1,
+            "totalCount": 1,
+        }
+    )
+
+    result = await repository_tools.artifact_repository_list()
+
+    patched_dr_client.get.assert_called_once_with(
+        "artifactRepositories", params={"limit": 100, "offset": 0}
+    )
+    assert result["count"] == 1
+    assert result["repositories"][0]["id"] == "repo-1"
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_list_with_filters(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"data": [], "count": 0, "totalCount": 0}
+    )
+
+    await repository_tools.artifact_repository_list(search="ecr", artifact_type="nim")
+
+    patched_dr_client.get.assert_called_once_with(
+        "artifactRepositories",
+        params={"limit": 100, "offset": 0, "search": "ecr", "type": "nim"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_list_invalid_type_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await repository_tools.artifact_repository_list(artifact_type="docker")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_list_negative_offset_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await repository_tools.artifact_repository_list(offset=-1)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+# ------------------------------------------------------------------ #
+# artifact_repository_get                                              #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_get_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "repo-abc", "name": "my-registry"}
+    )
+
+    result = await repository_tools.artifact_repository_get(repository_id="repo-abc")
+
+    patched_dr_client.get.assert_called_once_with("artifactRepositories/repo-abc")
+    assert result["id"] == "repo-abc"
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_get_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await repository_tools.artifact_repository_get(repository_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_get_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await repository_tools.artifact_repository_get(repository_id="repo-missing")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# artifact_repository_delete                                           #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_delete_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.return_value = MagicMock()
+
+    result = await repository_tools.artifact_repository_delete(repository_id="repo-abc")
+
+    patched_dr_client.delete.assert_called_once_with("artifactRepositories/repo-abc")
+    assert result == {"deleted": True, "repository_id": "repo-abc"}
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_delete_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await repository_tools.artifact_repository_delete(repository_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_artifact_repository_delete_conflict(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.side_effect = ClientError("409 Conflict", status_code=409, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await repository_tools.artifact_repository_delete(repository_id="repo-in-use")
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.13"
+version = "0.16.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Created workload api artifact build and repository tools
- Created unit tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

## TESTING

<img width="477" height="416" alt="Screenshot 2026-06-12 at 3 28 33 PM" src="https://github.com/user-attachments/assets/67cd3257-1f4b-4478-bf99-508773a6b2cf" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes trigger, cancel/delete build, and delete repository operations to agents via MCP; repository delete can cascade or 409 on locked/in-use artifacts, though behavior mirrors the upstream API with existing auth scoping.
> 
> **Overview**
> **Release 0.16.16** extends the Workload API surface for **artifact image builds** and **artifact repositories**, building on the artifact CRUD added in 0.16.15.
> 
> `WorkloadApiClient` gains REST wrappers for `GET/POST /artifacts/{id}/builds`, per-build `GET`/`DELETE`, plain-text build logs, and `GET/DELETE /artifactRepositories` (list supports search and type filters).
> 
> New MCP-oriented tools in `build_tools.py` (`artifact_build_list`, `artifact_build_trigger`, `artifact_build_get`, `artifact_build_logs`, `artifact_build_delete`) and `repository_tools.py` (`artifact_repository_list`, `artifact_repository_get`, `artifact_repository_delete`) follow the same validation, pagination, and `ClientError` → `ToolError` patterns as other workload tools. They register with the existing `drtools.workload` package when workload tools are enabled.
> 
> Unit coverage was added in `tests/drmcp/unit/workload_tools/test_tools.py`; a couple of minor artifact test tweaks (formatting, one removed whitespace-name case, clone 404 test rename) are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 850867b8aba6ad349c29818d777198dbd0f3a506. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->