### PR TITLE
[BUZZOK-31232] Include the retrieved memory with the user message for llamaindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **Tools** (`replacement_tools`): `workload_replacement_get` — fetch current replacement status (candidate artifact, proton ids, config, timestamps); `workload_replacement_create` — start a rolling update by deploying a new artifact alongside the running version with optional warmup/retention config and runtime override; `workload_replacement_delete` — cancel an in-progress replacement and revert traffic to the original version.
 
 ## 0.16.18
+- `llamaindex`: ``LlamaIndexAgent.invoke`` now folds system messages (including memory injected by ``streaming_memory_agent``) into the latest user turn so retrieved memory reaches the workflow.
 - `nat/datarobot_moderation_middleware`: streaming moderation now attaches prescore guard metrics to `TEXT_MESSAGE_START` chunks (matching DRUM/dome first-chunk semantics) and keeps postscore metrics on moderated `TEXT_MESSAGE_CONTENT` chunks.
 
 ## 0.16.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.17.2
+- `llamaindex`: ``LlamaIndexAgent.invoke`` now prepends the ``streaming_memory_agent`` memory injection (system message immediately before the latest user turn) to the processed user prompt so retrieved memory reaches the workflow.
+
 ## 0.17.1
 - Added E2E test cases for moderations: OOTB and NeMo Guardrails
 
@@ -16,7 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **Tools** (`replacement_tools`): `workload_replacement_get` — fetch current replacement status (candidate artifact, proton ids, config, timestamps); `workload_replacement_create` — start a rolling update by deploying a new artifact alongside the running version with optional warmup/retention config and runtime override; `workload_replacement_delete` — cancel an in-progress replacement and revert traffic to the original version.
 
 ## 0.16.18
-- `llamaindex`: ``LlamaIndexAgent.invoke`` now folds the ``streaming_memory_agent`` memory injection (system message immediately before the latest user turn) into that user message so retrieved memory reaches the workflow.
 - `nat/datarobot_moderation_middleware`: streaming moderation now attaches prescore guard metrics to `TEXT_MESSAGE_START` chunks (matching DRUM/dome first-chunk semantics) and keeps postscore metrics on moderated `TEXT_MESSAGE_CONTENT` chunks.
 
 ## 0.16.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **Tools** (`replacement_tools`): `workload_replacement_get` — fetch current replacement status (candidate artifact, proton ids, config, timestamps); `workload_replacement_create` — start a rolling update by deploying a new artifact alongside the running version with optional warmup/retention config and runtime override; `workload_replacement_delete` — cancel an in-progress replacement and revert traffic to the original version.
 
 ## 0.16.18
-- `llamaindex`: ``LlamaIndexAgent.invoke`` now folds system messages (including memory injected by ``streaming_memory_agent``) into the latest user turn so retrieved memory reaches the workflow.
+- `llamaindex`: ``LlamaIndexAgent.invoke`` now folds the ``streaming_memory_agent`` memory injection (system message immediately before the latest user turn) into that user message so retrieved memory reaches the workflow.
 - `nat/datarobot_moderation_middleware`: streaming moderation now attaches prescore guard metrics to `TEXT_MESSAGE_START` chunks (matching DRUM/dome first-chunk semantics) and keeps postscore metrics on moderated `TEXT_MESSAGE_CONTENT` chunks.
 
 ## 0.16.17

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.1"
+version = "0.17.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.17.1"
+version = "0.17.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -221,6 +221,62 @@ class BaseAgent(Generic[TTool], abc.ABC):
         return MultiTurnSample(user_input=events)
 
 
+def _message_content_as_str(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    return "".join(getattr(part, "text", "") for part in content if part is not None)
+
+
+def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgentInput:
+    """Fold AG-UI system messages into the latest user turn.
+
+    ``streaming_memory_agent`` injects retrieved memories as a system message
+    immediately before the last user message. Agents that only read the last
+    user turn (for example ``LlamaIndexAgent``) must merge those system
+    messages here so retrieved memory reaches the model.
+    """
+    messages = list(run_agent_input.messages)
+    if not messages:
+        return run_agent_input
+
+    last_user_idx: int | None = None
+    for idx in range(len(messages) - 1, -1, -1):
+        message = messages[idx]
+        if getattr(message, "role", None) == "user" and _message_content_as_str(
+            getattr(message, "content", None)
+        ):
+            last_user_idx = idx
+            break
+
+    if last_user_idx is None:
+        return run_agent_input
+
+    system_texts = [
+        text
+        for message in messages[:last_user_idx]
+        if getattr(message, "role", None) == "system"
+        for text in [_message_content_as_str(getattr(message, "content", None))]
+        if text
+    ]
+    if not system_texts:
+        return run_agent_input
+
+    user_message = messages[last_user_idx]
+    user_content = _message_content_as_str(getattr(user_message, "content", None))
+    merged_content = "\n\n".join(system_texts) + "\n\n" + user_content
+
+    updated_messages = [
+        message
+        for message in messages
+        if message is not user_message and getattr(message, "role", None) != "system"
+    ]
+    updated_messages.append(user_message.model_copy(update={"content": merged_content}))
+
+    return run_agent_input.model_copy(update={"messages": updated_messages})
+
+
 def extract_user_prompt_content(run_agent_input: RunAgentInput) -> Any:
     """Extract the last user message content from input."""
     user_messages = [msg for msg in run_agent_input.messages if msg.role == "user"]

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -293,11 +293,16 @@ def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgen
     user_message = messages[last_user_idx]
     user_content = _message_content_as_str(getattr(user_message, "content", None))
     merged_content = memory_text + "\n\n" + user_content
+    merged_user_message = user_message.model_copy(update={"content": merged_content})
 
-    updated_messages = [
-        message for message in messages if message not in (memory_message, user_message)
-    ]
-    updated_messages.append(user_message.model_copy(update={"content": merged_content}))
+    updated_messages: list[Any] = []
+    for message in messages:
+        if message is memory_message:
+            continue
+        if message is user_message:
+            updated_messages.append(merged_user_message)
+        else:
+            updated_messages.append(message)
 
     return run_agent_input.model_copy(update={"messages": updated_messages})
 

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -229,13 +229,17 @@ def _message_content_as_str(content: Any) -> str:
     return "".join(getattr(part, "text", "") for part in content if part is not None)
 
 
-def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgentInput:
-    """Fold AG-UI system messages into the latest user turn.
+STREAMING_MEMORY_CONTEXT_PREFIX = "Relevant context from memory:\n"
 
-    ``streaming_memory_agent`` injects retrieved memories as a system message
+
+def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgentInput:
+    """Fold a ``streaming_memory_agent`` memory injection into the latest user turn.
+
+    ``streaming_memory_agent`` inserts retrieved memories as a system message
     immediately before the last user message. Agents that only read the last
-    user turn (for example ``LlamaIndexAgent``) must merge those system
-    messages here so retrieved memory reaches the model.
+    user turn (for example ``LlamaIndexAgent``) must merge that message here
+    so retrieved memory reaches the model. Other system messages are left
+    unchanged.
     """
     messages = list(run_agent_input.messages)
     if not messages:
@@ -250,27 +254,23 @@ def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgen
             last_user_idx = idx
             break
 
-    if last_user_idx is None:
+    if last_user_idx is None or last_user_idx == 0:
         return run_agent_input
 
-    system_texts = [
-        text
-        for message in messages[:last_user_idx]
-        if getattr(message, "role", None) == "system"
-        for text in [_message_content_as_str(getattr(message, "content", None))]
-        if text
-    ]
-    if not system_texts:
+    memory_message = messages[last_user_idx - 1]
+    if getattr(memory_message, "role", None) != "system":
+        return run_agent_input
+
+    memory_text = _message_content_as_str(getattr(memory_message, "content", None))
+    if not memory_text.startswith(STREAMING_MEMORY_CONTEXT_PREFIX):
         return run_agent_input
 
     user_message = messages[last_user_idx]
     user_content = _message_content_as_str(getattr(user_message, "content", None))
-    merged_content = "\n\n".join(system_texts) + "\n\n" + user_content
+    merged_content = memory_text + "\n\n" + user_content
 
     updated_messages = [
-        message
-        for message in messages
-        if message is not user_message and getattr(message, "role", None) != "system"
+        message for message in messages if message not in (memory_message, user_message)
     ]
     updated_messages.append(user_message.model_copy(update={"content": merged_content}))
 

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -268,45 +268,6 @@ def prepend_streaming_memory_to_prompt(prompt: str, run_agent_input: RunAgentInp
     return streaming_context + "\n\n" + prompt
 
 
-def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgentInput:
-    """Fold a ``streaming_memory_agent`` memory injection into the latest user turn.
-
-    ``streaming_memory_agent`` inserts retrieved memories as a system message
-    immediately before the last user message. Agents that only read the last
-    user turn (for example ``LlamaIndexAgent``) must merge that message here
-    so retrieved memory reaches the model. Other system messages are left
-    unchanged.
-    """
-    messages = list(run_agent_input.messages)
-    if not messages:
-        return run_agent_input
-
-    last_user_idx = _last_user_message_index(messages)
-    if last_user_idx is None or last_user_idx == 0:
-        return run_agent_input
-
-    memory_text = extract_streaming_memory_context(run_agent_input)
-    if memory_text is None:
-        return run_agent_input
-
-    memory_message = messages[last_user_idx - 1]
-    user_message = messages[last_user_idx]
-    user_content = _message_content_as_str(getattr(user_message, "content", None))
-    merged_content = memory_text + "\n\n" + user_content
-    merged_user_message = user_message.model_copy(update={"content": merged_content})
-
-    updated_messages: list[Any] = []
-    for message in messages:
-        if message is memory_message:
-            continue
-        if message is user_message:
-            updated_messages.append(merged_user_message)
-        else:
-            updated_messages.append(message)
-
-    return run_agent_input.model_copy(update={"messages": updated_messages})
-
-
 def extract_user_prompt_content(run_agent_input: RunAgentInput) -> Any:
     """Extract the last user message content from input."""
     user_messages = [msg for msg in run_agent_input.messages if msg.role == "user"]

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -232,6 +232,42 @@ def _message_content_as_str(content: Any) -> str:
 STREAMING_MEMORY_CONTEXT_PREFIX = "Relevant context from memory:\n"
 
 
+def _last_user_message_index(messages: list[Any]) -> int | None:
+    for idx in range(len(messages) - 1, -1, -1):
+        message = messages[idx]
+        if getattr(message, "role", None) == "user" and _message_content_as_str(
+            getattr(message, "content", None)
+        ):
+            return idx
+    return None
+
+
+def extract_streaming_memory_context(run_agent_input: RunAgentInput) -> str | None:
+    """Return ``streaming_memory_agent`` context to prepend to a user prompt, or None."""
+    messages = list(run_agent_input.messages)
+    last_user_idx = _last_user_message_index(messages)
+    if last_user_idx is None or last_user_idx == 0:
+        return None
+
+    memory_message = messages[last_user_idx - 1]
+    if getattr(memory_message, "role", None) != "system":
+        return None
+
+    memory_text = _message_content_as_str(getattr(memory_message, "content", None))
+    if not memory_text.startswith(STREAMING_MEMORY_CONTEXT_PREFIX):
+        return None
+
+    return memory_text
+
+
+def prepend_streaming_memory_to_prompt(prompt: str, run_agent_input: RunAgentInput) -> str:
+    """Prepend ``streaming_memory_agent`` context to a processed user prompt."""
+    streaming_context = extract_streaming_memory_context(run_agent_input)
+    if not streaming_context:
+        return prompt
+    return streaming_context + "\n\n" + prompt
+
+
 def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgentInput:
     """Fold a ``streaming_memory_agent`` memory injection into the latest user turn.
 
@@ -245,26 +281,15 @@ def apply_system_context_to_run_input(run_agent_input: RunAgentInput) -> RunAgen
     if not messages:
         return run_agent_input
 
-    last_user_idx: int | None = None
-    for idx in range(len(messages) - 1, -1, -1):
-        message = messages[idx]
-        if getattr(message, "role", None) == "user" and _message_content_as_str(
-            getattr(message, "content", None)
-        ):
-            last_user_idx = idx
-            break
-
+    last_user_idx = _last_user_message_index(messages)
     if last_user_idx is None or last_user_idx == 0:
         return run_agent_input
 
+    memory_text = extract_streaming_memory_context(run_agent_input)
+    if memory_text is None:
+        return run_agent_input
+
     memory_message = messages[last_user_idx - 1]
-    if getattr(memory_message, "role", None) != "system":
-        return run_agent_input
-
-    memory_text = _message_content_as_str(getattr(memory_message, "content", None))
-    if not memory_text.startswith(STREAMING_MEMORY_CONTEXT_PREFIX):
-        return run_agent_input
-
     user_message = messages[last_user_idx]
     user_content = _message_content_as_str(getattr(user_message, "content", None))
     merged_content = memory_text + "\n\n" + user_content

--- a/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
+++ b/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
@@ -67,6 +67,7 @@ from nat.cli.register_workflow import register_per_user_function
 from nat.memory.models import MemoryItem
 from nat.plugins.langchain.agent.auto_memory_wrapper.register import AutoMemoryAgentConfig
 
+from datarobot_genai.core.agents.base import STREAMING_MEMORY_CONTEXT_PREFIX
 from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
 from datarobot_genai.dragent.frontends.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
@@ -123,7 +124,7 @@ def _last_user_text(messages: list[Any]) -> str:
 
 def _with_memory_context(messages: list[Any], memory_text: str) -> list[Any]:
     """Return a new list with a system message inserted before the last user message."""
-    payload = f"Relevant context from memory:\n{memory_text}"
+    payload = f"{STREAMING_MEMORY_CONTEXT_PREFIX}{memory_text}"
     sys_msg = AgUiSystemMessage(id=str(uuid.uuid4()), content=payload)
     out = list(messages)
     for i in range(len(out) - 1, -1, -1):

--- a/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
+++ b/src/datarobot_genai/dragent/plugins/streaming_memory_agent.py
@@ -56,6 +56,7 @@ from collections.abc import AsyncGenerator
 from typing import Annotated
 from typing import Any
 
+from ag_ui.core import Message
 from ag_ui.core import RunAgentInput
 from ag_ui.core import SystemMessage as AgUiSystemMessage
 from ag_ui.core import UserMessage as AgUiUserMessage
@@ -112,7 +113,7 @@ def _user_id_from_context() -> str:
     return "default_user"
 
 
-def _last_user_text(messages: list[Any]) -> str:
+def _last_user_text(messages: list[Message]) -> str:
     for msg in reversed(messages):
         if isinstance(msg, AgUiUserMessage) and msg.content:
             content = msg.content
@@ -122,7 +123,7 @@ def _last_user_text(messages: list[Any]) -> str:
     return ""
 
 
-def _with_memory_context(messages: list[Any], memory_text: str) -> list[Any]:
+def _with_memory_context(messages: list[Message], memory_text: str) -> list[Message]:
     """Return a new list with a system message inserted before the last user message."""
     payload = f"{STREAMING_MEMORY_CONTEXT_PREFIX}{memory_text}"
     sys_msg = AgUiSystemMessage(id=str(uuid.uuid4()), content=payload)

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -48,6 +48,7 @@ from llama_index.llms.litellm import LiteLLM
 from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
+from datarobot_genai.core.agents.base import apply_system_context_to_run_input
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 from datarobot_genai.llama_index.history import ag_ui_history_to_chat_messages
@@ -160,6 +161,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the LlamaIndex workflow with the provided completion parameters."""
+        run_agent_input = apply_system_context_to_run_input(run_agent_input)
         user_prompt_content = extract_user_prompt_content(run_agent_input)
         input_message = str(user_prompt_content)
 

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -48,9 +48,9 @@ from llama_index.llms.litellm import LiteLLM
 from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
-from datarobot_genai.core.agents.base import apply_system_context_to_run_input
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
+from datarobot_genai.core.agents.base import prepend_streaming_memory_to_prompt
 from datarobot_genai.llama_index.history import ag_ui_history_to_chat_messages
 
 if TYPE_CHECKING:
@@ -161,7 +161,6 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
 
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the LlamaIndex workflow with the provided completion parameters."""
-        run_agent_input = apply_system_context_to_run_input(run_agent_input)
         user_prompt_content = extract_user_prompt_content(run_agent_input)
         input_message = str(user_prompt_content)
 
@@ -179,6 +178,8 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
             structured_chat_history = (
                 ag_ui_history_to_chat_messages(self.history_messages(run_agent_input)) or None
             )
+
+        input_message = prepend_streaming_memory_to_prompt(input_message, run_agent_input)
 
         logger.info(f"Running agent with user prompt: {input_message}")
 

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -28,7 +28,6 @@ from ragas.messages import AIMessage
 from ragas.messages import HumanMessage
 
 from datarobot_genai.core.agents.base import BaseAgent
-from datarobot_genai.core.agents.base import apply_system_context_to_run_input
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_streaming_memory_context
 from datarobot_genai.core.agents.base import extract_user_prompt_content
@@ -214,90 +213,6 @@ def test_extract_user_prompt_content_the_last_user_message_is_a_json_string(
     user_prompt = extract_user_prompt_content(run_agent_input)
     # THEN the user prompt is the last user message
     assert user_prompt == {"foo": "bar"}
-
-
-def test_apply_system_context_merges_memory_into_user_turn(run_agent_input: RunAgentInput) -> None:
-    run_agent_input.messages = [
-        UserMessage(id="u1", role="user", content="First turn"),
-        SystemMessage(
-            id="s1",
-            role="system",
-            content="Relevant context from memory:\nUser likes concise answers.",
-        ),
-        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
-    ]
-
-    prepared = apply_system_context_to_run_input(run_agent_input)
-
-    assert len(prepared.messages) == 2
-    assert prepared.messages[-1].role == "user"
-    assert "Relevant context from memory:" in prepared.messages[-1].content
-    assert prepared.messages[-1].content.endswith('{"topic": "AI"}')
-    assert all(message.role != "system" for message in prepared.messages)
-
-
-def test_apply_system_context_leaves_other_system_messages_untouched(
-    run_agent_input: RunAgentInput,
-) -> None:
-    run_agent_input.messages = [
-        SystemMessage(id="s0", role="system", content="You are a helpful assistant."),
-        UserMessage(id="u1", role="user", content="First turn"),
-        SystemMessage(
-            id="s1",
-            role="system",
-            content="Relevant context from memory:\nUser likes concise answers.",
-        ),
-        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
-    ]
-
-    prepared = apply_system_context_to_run_input(run_agent_input)
-
-    assert len(prepared.messages) == 3
-    assert prepared.messages[0].role == "system"
-    assert prepared.messages[0].content == "You are a helpful assistant."
-    assert prepared.messages[1].role == "user"
-    assert prepared.messages[1].content == "First turn"
-    assert "Relevant context from memory:" in prepared.messages[-1].content
-    assert prepared.messages[-1].content.endswith('{"topic": "AI"}')
-
-
-def test_apply_system_context_preserves_order_with_trailing_empty_user(
-    run_agent_input: RunAgentInput,
-) -> None:
-    run_agent_input.messages = [
-        UserMessage(id="u1", role="user", content="First turn"),
-        SystemMessage(
-            id="s1",
-            role="system",
-            content="Relevant context from memory:\nUser likes concise answers.",
-        ),
-        UserMessage(id="u2", role="user", content="What about AI?"),
-        UserMessage(id="u3", role="user", content=""),
-    ]
-
-    prepared = apply_system_context_to_run_input(run_agent_input)
-
-    assert len(prepared.messages) == 3
-    assert prepared.messages[0].content == "First turn"
-    assert "Relevant context from memory:" in prepared.messages[1].content
-    assert prepared.messages[1].content.endswith("What about AI?")
-    assert prepared.messages[-1].role == "user"
-    assert prepared.messages[-1].content == ""
-    assert extract_user_prompt_content(prepared) == ""
-
-
-def test_apply_system_context_ignores_non_memory_system_message_before_last_user(
-    run_agent_input: RunAgentInput,
-) -> None:
-    run_agent_input.messages = [
-        UserMessage(id="u1", role="user", content="First turn"),
-        SystemMessage(id="s1", role="system", content="Some other system instruction."),
-        UserMessage(id="u2", role="user", content="Second turn"),
-    ]
-
-    prepared = apply_system_context_to_run_input(run_agent_input)
-
-    assert prepared.messages == run_agent_input.messages
 
 
 def test_extract_streaming_memory_context_returns_injected_memory(

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -234,6 +234,45 @@ def test_apply_system_context_merges_memory_into_user_turn(run_agent_input: RunA
     assert all(message.role != "system" for message in prepared.messages)
 
 
+def test_apply_system_context_leaves_other_system_messages_untouched(
+    run_agent_input: RunAgentInput,
+) -> None:
+    run_agent_input.messages = [
+        SystemMessage(id="s0", role="system", content="You are a helpful assistant."),
+        UserMessage(id="u1", role="user", content="First turn"),
+        SystemMessage(
+            id="s1",
+            role="system",
+            content="Relevant context from memory:\nUser likes concise answers.",
+        ),
+        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
+    ]
+
+    prepared = apply_system_context_to_run_input(run_agent_input)
+
+    assert len(prepared.messages) == 3
+    assert prepared.messages[0].role == "system"
+    assert prepared.messages[0].content == "You are a helpful assistant."
+    assert prepared.messages[1].role == "user"
+    assert prepared.messages[1].content == "First turn"
+    assert "Relevant context from memory:" in prepared.messages[-1].content
+    assert prepared.messages[-1].content.endswith('{"topic": "AI"}')
+
+
+def test_apply_system_context_ignores_non_memory_system_message_before_last_user(
+    run_agent_input: RunAgentInput,
+) -> None:
+    run_agent_input.messages = [
+        UserMessage(id="u1", role="user", content="First turn"),
+        SystemMessage(id="s1", role="system", content="Some other system instruction."),
+        UserMessage(id="u2", role="user", content="Second turn"),
+    ]
+
+    prepared = apply_system_context_to_run_input(run_agent_input)
+
+    assert prepared.messages == run_agent_input.messages
+
+
 def test_extract_history_messages_excludes_final_user_turn_only_when_last_message_is_user() -> None:
     # GIVEN a RunAgentInput with multiple messages ending with user
     run_agent_input = _make_run_agent_input_from_dicts(

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -30,8 +30,10 @@ from ragas.messages import HumanMessage
 from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import apply_system_context_to_run_input
 from datarobot_genai.core.agents.base import default_usage_metrics
+from datarobot_genai.core.agents.base import extract_streaming_memory_context
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 from datarobot_genai.core.agents.base import make_system_prompt
+from datarobot_genai.core.agents.base import prepend_streaming_memory_to_prompt
 from datarobot_genai.core.agents.history import extract_history_messages
 
 
@@ -271,6 +273,43 @@ def test_apply_system_context_ignores_non_memory_system_message_before_last_user
     prepared = apply_system_context_to_run_input(run_agent_input)
 
     assert prepared.messages == run_agent_input.messages
+
+
+def test_extract_streaming_memory_context_returns_injected_memory(
+    run_agent_input: RunAgentInput,
+) -> None:
+    run_agent_input.messages = [
+        UserMessage(id="u1", role="user", content="First turn"),
+        SystemMessage(
+            id="s1",
+            role="system",
+            content="Relevant context from memory:\nUser likes concise answers.",
+        ),
+        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
+    ]
+
+    assert extract_streaming_memory_context(run_agent_input) == (
+        "Relevant context from memory:\nUser likes concise answers."
+    )
+
+
+def test_prepend_streaming_memory_to_prompt_preserves_processed_prompt(
+    run_agent_input: RunAgentInput,
+) -> None:
+    run_agent_input.messages = [
+        UserMessage(id="u1", role="user", content="First turn"),
+        SystemMessage(
+            id="s1",
+            role="system",
+            content="Relevant context from memory:\nUser likes concise answers.",
+        ),
+        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
+    ]
+
+    merged = prepend_streaming_memory_to_prompt("Memory:\nUse concise answers.", run_agent_input)
+
+    assert merged.startswith("Relevant context from memory:")
+    assert merged.endswith("Memory:\nUse concise answers.")
 
 
 def test_extract_history_messages_excludes_final_user_turn_only_when_last_message_is_user() -> None:

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -261,6 +261,31 @@ def test_apply_system_context_leaves_other_system_messages_untouched(
     assert prepared.messages[-1].content.endswith('{"topic": "AI"}')
 
 
+def test_apply_system_context_preserves_order_with_trailing_empty_user(
+    run_agent_input: RunAgentInput,
+) -> None:
+    run_agent_input.messages = [
+        UserMessage(id="u1", role="user", content="First turn"),
+        SystemMessage(
+            id="s1",
+            role="system",
+            content="Relevant context from memory:\nUser likes concise answers.",
+        ),
+        UserMessage(id="u2", role="user", content="What about AI?"),
+        UserMessage(id="u3", role="user", content=""),
+    ]
+
+    prepared = apply_system_context_to_run_input(run_agent_input)
+
+    assert len(prepared.messages) == 3
+    assert prepared.messages[0].content == "First turn"
+    assert "Relevant context from memory:" in prepared.messages[1].content
+    assert prepared.messages[1].content.endswith("What about AI?")
+    assert prepared.messages[-1].role == "user"
+    assert prepared.messages[-1].content == ""
+    assert extract_user_prompt_content(prepared) == ""
+
+
 def test_apply_system_context_ignores_non_memory_system_message_before_last_user(
     run_agent_input: RunAgentInput,
 ) -> None:

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -28,6 +28,7 @@ from ragas.messages import AIMessage
 from ragas.messages import HumanMessage
 
 from datarobot_genai.core.agents.base import BaseAgent
+from datarobot_genai.core.agents.base import apply_system_context_to_run_input
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 from datarobot_genai.core.agents.base import make_system_prompt
@@ -211,6 +212,26 @@ def test_extract_user_prompt_content_the_last_user_message_is_a_json_string(
     user_prompt = extract_user_prompt_content(run_agent_input)
     # THEN the user prompt is the last user message
     assert user_prompt == {"foo": "bar"}
+
+
+def test_apply_system_context_merges_memory_into_user_turn(run_agent_input: RunAgentInput) -> None:
+    run_agent_input.messages = [
+        UserMessage(id="u1", role="user", content="First turn"),
+        SystemMessage(
+            id="s1",
+            role="system",
+            content="Relevant context from memory:\nUser likes concise answers.",
+        ),
+        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
+    ]
+
+    prepared = apply_system_context_to_run_input(run_agent_input)
+
+    assert len(prepared.messages) == 2
+    assert prepared.messages[-1].role == "user"
+    assert "Relevant context from memory:" in prepared.messages[-1].content
+    assert prepared.messages[-1].content.endswith('{"topic": "AI"}')
+    assert all(message.role != "system" for message in prepared.messages)
 
 
 def test_extract_history_messages_excludes_final_user_turn_only_when_last_message_is_user() -> None:

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -902,6 +902,32 @@ async def test_invoke_replaces_chat_history_placeholder() -> None:
     assert "{chat_history}" not in text
 
 
+async def test_invoke_merges_streaming_memory_system_message_into_user_turn(
+    run_agent_input: RunAgentInput,
+) -> None:
+    # GIVEN a llamaindex agent receiving memory injected as a system message
+    workflow = CapturingWorkflow(events=[], state="S")
+    agent = MyLlamaAgent(workflow, structured_history=False)
+    run_agent_input.messages = [
+        UserMessage(id="u1", role="user", content="First turn"),
+        AgSystemMessage(
+            id="s1",
+            role="system",
+            content="Relevant context from memory:\nUser likes concise answers.",
+        ),
+        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
+    ]
+
+    # WHEN invoking the agent
+    events = [event async for event in agent.invoke(run_agent_input)]
+
+    # THEN retrieved memory is folded into the user prompt passed to the workflow
+    assert isinstance(events[-1][0], RunFinishedEvent)
+    assert workflow.captured_user_msgs
+    assert "Relevant context from memory:" in workflow.captured_user_msgs[0]
+    assert workflow.captured_user_msgs[0].endswith('{"topic": "AI"}')
+
+
 async def test_invoke_passes_structured_chat_history_when_enabled(events: list[Any]) -> None:
     # GIVEN structured_history=True and a prior tool-call turn
     wf = ChatHistoryCapturingWorkflow(events=events, state="S")

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -915,7 +915,7 @@ async def test_invoke_merges_streaming_memory_system_message_into_user_turn(
             role="system",
             content="Relevant context from memory:\nUser likes concise answers.",
         ),
-        UserMessage(id="u2", role="user", content='{"topic": "AI"}'),
+        UserMessage(id="u2", role="user", content="What about AI?"),
     ]
 
     # WHEN invoking the agent
@@ -925,7 +925,7 @@ async def test_invoke_merges_streaming_memory_system_message_into_user_turn(
     assert isinstance(events[-1][0], RunFinishedEvent)
     assert workflow.captured_user_msgs
     assert "Relevant context from memory:" in workflow.captured_user_msgs[0]
-    assert workflow.captured_user_msgs[0].endswith('{"topic": "AI"}')
+    assert workflow.captured_user_msgs[0].endswith("What about AI?")
 
 
 async def test_invoke_passes_structured_chat_history_when_enabled(events: list[Any]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.1"
+version = "0.17.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
LlamaIndex agents don't currently use the retrieved memory because they only use the last user message and the memory is injected as a system message directly preceding the last user message.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Extract the retrieved memory and include it with the last user message for LlamaIndex agent.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow input-shaping change for LlamaIndex + streaming memory with unit tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> **LlamaIndex agents now receive retrieved memory** when wrapped by `streaming_memory_agent`. That plugin injects memory as a system message right before the latest user turn, but `LlamaIndexAgent` only forwards the last user message to the workflow—so memory was dropped.
> 
> A shared helper `apply_system_context_to_run_input` in `core/agents/base` detects that injection (via `STREAMING_MEMORY_CONTEXT_PREFIX`), prepends it to the final user content, and removes the transient system message. Other system prompts (e.g. assistant instructions) are unchanged. `LlamaIndexAgent.invoke` runs this step before `extract_user_prompt_content`. `streaming_memory_agent` now uses the same prefix constant for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b167fd0dffe6f09742975e76a2a88123fc3433. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->