### PR TITLE
[MODEL-23712] Workload API | Artifact Replacement Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.19
+- `drtools/workload`: artifact replacement / rolling update.
+  - **Client** (`WorkloadApiClient`): added `get_workload_replacement`, `create_workload_replacement`, `delete_workload_replacement` against `GET/POST/DELETE /api/v2/workloads/{id}/replacement`.
+  - **Tools** (`replacement_tools`): `workload_replacement_get` — fetch current replacement status (candidate artifact, proton ids, config, timestamps); `workload_replacement_create` — start a rolling update by deploying a new artifact alongside the running version with optional warmup/retention config and runtime override; `workload_replacement_delete` — cancel an in-progress replacement and revert traffic to the original version.
+
 ## 0.16.18
 - `nat/datarobot_moderation_middleware`: streaming moderation now attaches prescore guard metrics to `TEXT_MESSAGE_START` chunks (matching DRUM/dome first-chunk semantics) and keeps postscore metrics on moderated `TEXT_MESSAGE_CONTENT` chunks.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.18"
+version = "0.16.19"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.18"
+version = "0.16.19"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -418,7 +418,8 @@ class WorkloadApiClient:
     ) -> dict[str, Any]:
         """POST /workloads/{id}/replacement — start a rolling replacement (202)."""
         with request_user_dr_client() as client:
-            return client.post(f"workloads/{workload_id}/replacement", json=payload).json()
+            resp = client.post(f"workloads/{workload_id}/replacement", json=payload)
+            return resp.json() if resp.content else {}
 
     def delete_workload_replacement(self, workload_id: str) -> dict[str, Any]:
         """DELETE /workloads/{id}/replacement — cancel an in-progress replacement (202)."""

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -403,3 +403,25 @@ class WorkloadApiClient:
         """DELETE /artifactRepositories/{id} — 204 No Content on success."""
         with request_user_dr_client() as client:
             client.delete(f"artifactRepositories/{repository_id}")
+
+    # ------------------------------------------------------------------ #
+    # Workload replacement (rolling update)                                #
+    # ------------------------------------------------------------------ #
+
+    def get_workload_replacement(self, workload_id: str) -> dict[str, Any]:
+        """GET /workloads/{id}/replacement — current replacement status."""
+        with request_user_dr_client() as client:
+            return client.get(f"workloads/{workload_id}/replacement").json()
+
+    def create_workload_replacement(
+        self, workload_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """POST /workloads/{id}/replacement — start a rolling replacement (202)."""
+        with request_user_dr_client() as client:
+            return client.post(f"workloads/{workload_id}/replacement", json=payload).json()
+
+    def delete_workload_replacement(self, workload_id: str) -> dict[str, Any]:
+        """DELETE /workloads/{id}/replacement — cancel an in-progress replacement (202)."""
+        with request_user_dr_client() as client:
+            resp = client.delete(f"workloads/{workload_id}/replacement")
+            return resp.json() if resp.content else {}

--- a/src/datarobot_genai/drtools/workload/replacement_tools.py
+++ b/src/datarobot_genai/drtools/workload/replacement_tools.py
@@ -118,6 +118,16 @@ async def workload_replacement_create(
         },
     }
     if runtime is not None:
+        if not runtime or not isinstance(runtime, dict):
+            raise ToolError(
+                "Argument validation error: 'runtime' must be a non-empty object.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+        if "containerGroups" not in runtime:
+            raise ToolError(
+                "Argument validation error: 'runtime' must contain 'containerGroups'.",
+                kind=ToolErrorKind.VALIDATION,
+            )
         payload["runtime"] = runtime
     try:
         return WorkloadApiClient().create_workload_replacement(wid, payload)

--- a/src/datarobot_genai/drtools/workload/replacement_tools.py
+++ b/src/datarobot_genai/drtools/workload/replacement_tools.py
@@ -1,0 +1,149 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+from typing import Any
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
+from datarobot_genai.drtools.core.utils import require_id
+
+_REPLACEMENT_STRATEGIES = ("rolling",)
+
+
+# ------------------------------------------------------------------ #
+# workload_replacement_get                                             #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "replacement", "datarobot", "get"},
+    description=(
+        "[Workload replacement—get] Retrieve the current rolling-update replacement "
+        "status for a workload. Returns candidate artifact id, candidate proton ids, "
+        "strategy, config, and timestamps.\n\n"
+        "Example: workload_replacement_get(workload_id='wkld-abc')"
+    ),
+)
+async def workload_replacement_get(
+    *,
+    workload_id: Annotated[str, "Id of the workload whose replacement to retrieve."],
+) -> dict[str, Any]:
+    wid = require_id(workload_id, "workload_id")
+    try:
+        return WorkloadApiClient().get_workload_replacement(wid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# workload_replacement_create                                          #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "replacement", "datarobot", "create"},
+    description=(
+        "[Workload replacement—create] Start a rolling replacement for a workload. "
+        "Deploys a new artifact alongside the running version; traffic switches once "
+        "the candidate is ready. Supports optional warmup/retention config and runtime "
+        "override.\n\n"
+        "Example: workload_replacement_create(workload_id='wkld-abc', "
+        "artifact_id='art-xyz')\n"
+        "Example: workload_replacement_create(workload_id='wkld-abc', "
+        "artifact_id='art-xyz', warmup_duration_minutes=5, keep_old_version_minutes=2)"
+    ),
+)
+async def workload_replacement_create(
+    *,
+    workload_id: Annotated[str, "Id of the workload to update."],
+    artifact_id: Annotated[str, "Id of the artifact to deploy as the replacement."],
+    strategy: Annotated[
+        str, "Replacement strategy. Currently only 'rolling' is supported."
+    ] = "rolling",
+    warmup_duration_minutes: Annotated[
+        int, "Minutes to keep the new version in warmup before switching traffic. Default 0."
+    ] = 0,
+    keep_old_version_minutes: Annotated[
+        int, "Minutes to retain the old version after traffic switch. Default 0."
+    ] = 0,
+    runtime: Annotated[
+        dict[str, Any] | None,
+        "Optional runtime override for the replacement. If omitted the current runtime is reused.",
+    ] = None,
+) -> dict[str, Any]:
+    wid = require_id(workload_id, "workload_id")
+    if not artifact_id or not artifact_id.strip():
+        raise ToolError(
+            "Argument validation error: 'artifact_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if strategy not in _REPLACEMENT_STRATEGIES:
+        raise ToolError(
+            f"Argument validation error: 'strategy' must be one of {_REPLACEMENT_STRATEGIES}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if warmup_duration_minutes < 0:
+        raise ToolError(
+            "Argument validation error: 'warmup_duration_minutes' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if keep_old_version_minutes < 0:
+        raise ToolError(
+            "Argument validation error: 'keep_old_version_minutes' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    payload: dict[str, Any] = {
+        "artifactId": artifact_id.strip(),
+        "strategy": strategy,
+        "config": {
+            "warmupDurationMinutes": warmup_duration_minutes,
+            "keepOldVersionMinutes": keep_old_version_minutes,
+        },
+    }
+    if runtime is not None:
+        payload["runtime"] = runtime
+    try:
+        return WorkloadApiClient().create_workload_replacement(wid, payload)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+
+# ------------------------------------------------------------------ #
+# workload_replacement_delete                                          #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"workload", "replacement", "datarobot", "delete"},
+    description=(
+        "[Workload replacement—delete] Cancel an in-progress rolling replacement. "
+        "Stops the candidate deployment and reverts traffic to the original version.\n\n"
+        "Example: workload_replacement_delete(workload_id='wkld-abc')"
+    ),
+)
+async def workload_replacement_delete(
+    *,
+    workload_id: Annotated[str, "Id of the workload whose replacement to cancel."],
+) -> dict[str, Any]:
+    wid = require_id(workload_id, "workload_id")
+    try:
+        return WorkloadApiClient().delete_workload_replacement(wid)
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -29,6 +29,7 @@ from datarobot_genai.drtools.workload import lifecycle_tools
 from datarobot_genai.drtools.workload import observability_tools
 from datarobot_genai.drtools.workload import proton_tools
 from datarobot_genai.drtools.workload import read_tools
+from datarobot_genai.drtools.workload import replacement_tools
 from datarobot_genai.drtools.workload import repository_tools
 
 # ------------------------------------------------------------------ #
@@ -1556,3 +1557,178 @@ async def test_artifact_delete_locked_error(patched_dr_client: MagicMock) -> Non
     with pytest.raises(ToolError) as exc_info:
         await artifact_tools.artifact_delete(artifact_id="art-locked")
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ================================================================== #
+# PR7 — workload replacement (rolling update)                         #
+# ================================================================== #
+
+# ------------------------------------------------------------------ #
+# workload_replacement_get                                             #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_get_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {
+            "candidateArtifactId": "art-new",
+            "strategy": "rolling",
+            "config": {"warmupDurationMinutes": 5, "keepOldVersionMinutes": 2},
+        }
+    )
+
+    result = await replacement_tools.workload_replacement_get(workload_id="wkld-abc")
+
+    patched_dr_client.get.assert_called_once_with("workloads/wkld-abc/replacement")
+    assert result["candidateArtifactId"] == "art-new"
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_get_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_get(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_get_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_get(workload_id="wkld-missing")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# workload_replacement_create                                          #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(
+        json=lambda: {"candidateArtifactId": "art-xyz", "strategy": "rolling"}
+    )
+
+    result = await replacement_tools.workload_replacement_create(
+        workload_id="wkld-abc", artifact_id="art-xyz"
+    )
+
+    patched_dr_client.post.assert_called_once_with(
+        "workloads/wkld-abc/replacement",
+        json={
+            "artifactId": "art-xyz",
+            "strategy": "rolling",
+            "config": {"warmupDurationMinutes": 0, "keepOldVersionMinutes": 0},
+        },
+    )
+    assert result["candidateArtifactId"] == "art-xyz"
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_with_config(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(json=lambda: {"candidateArtifactId": "art-xyz"})
+
+    await replacement_tools.workload_replacement_create(
+        workload_id="wkld-abc",
+        artifact_id="art-xyz",
+        warmup_duration_minutes=5,
+        keep_old_version_minutes=2,
+    )
+
+    patched_dr_client.post.assert_called_once_with(
+        "workloads/wkld-abc/replacement",
+        json={
+            "artifactId": "art-xyz",
+            "strategy": "rolling",
+            "config": {"warmupDurationMinutes": 5, "keepOldVersionMinutes": 2},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_with_runtime(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(json=lambda: {"candidateArtifactId": "art-xyz"})
+    runtime = {"containerGroups": [{"resourceBundles": [{"bundleId": "bundle-1"}]}]}
+
+    await replacement_tools.workload_replacement_create(
+        workload_id="wkld-abc", artifact_id="art-xyz", runtime=runtime
+    )
+
+    call_kwargs = patched_dr_client.post.call_args
+    assert call_kwargs[1]["json"]["runtime"] == runtime
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_empty_workload_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_create(workload_id="", artifact_id="art-xyz")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_empty_artifact_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_create(workload_id="wkld-abc", artifact_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_invalid_strategy_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_create(
+            workload_id="wkld-abc", artifact_id="art-xyz", strategy="bluegreen"
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_negative_warmup_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_create(
+            workload_id="wkld-abc", artifact_id="art-xyz", warmup_duration_minutes=-1
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.side_effect = ClientError("400", status_code=400, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_create(
+            workload_id="wkld-abc", artifact_id="art-xyz"
+        )
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# workload_replacement_delete                                          #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_delete_success(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.return_value = MagicMock(
+        content=b'{"status": "cancelled"}',
+        json=lambda: {"status": "cancelled"},
+    )
+
+    result = await replacement_tools.workload_replacement_delete(workload_id="wkld-abc")
+
+    patched_dr_client.delete.assert_called_once_with("workloads/wkld-abc/replacement")
+    assert result["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_delete_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_delete(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_delete_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.delete.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_delete(workload_id="wkld-missing")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -1660,6 +1660,25 @@ async def test_workload_replacement_create_with_runtime(patched_dr_client: Magic
 
 
 @pytest.mark.asyncio
+async def test_workload_replacement_create_empty_body(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.return_value = MagicMock(content=b"", json=lambda: {})
+
+    result = await replacement_tools.workload_replacement_create(
+        workload_id="wkld-abc", artifact_id="art-xyz"
+    )
+
+    patched_dr_client.post.assert_called_once_with(
+        "workloads/wkld-abc/replacement",
+        json={
+            "artifactId": "art-xyz",
+            "strategy": "rolling",
+            "config": {"warmupDurationMinutes": 0, "keepOldVersionMinutes": 0},
+        },
+    )
+    assert result == {}
+
+
+@pytest.mark.asyncio
 async def test_workload_replacement_create_empty_workload_id_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
         await replacement_tools.workload_replacement_create(workload_id="", artifact_id="art-xyz")
@@ -1687,6 +1706,24 @@ async def test_workload_replacement_create_negative_warmup_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
         await replacement_tools.workload_replacement_create(
             workload_id="wkld-abc", artifact_id="art-xyz", warmup_duration_minutes=-1
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_empty_runtime_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_create(
+            workload_id="wkld-abc", artifact_id="art-xyz", runtime={}
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_replacement_create_missing_container_groups_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await replacement_tools.workload_replacement_create(
+            workload_id="wkld-abc", artifact_id="art-xyz", runtime={"replicaCount": 2}
         )
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.16.18"
+version = "0.16.19"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Created workload api artifact replacement and rolling update tools
- Created unit tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Create/delete replacement tools can start or cancel live workload deployments; mistakes could affect production traffic, though behavior mirrors existing workload write tools and includes input validation.
> 
> **Overview**
> Adds **workload artifact replacement** (rolling update) for MCP agents and bumps the package to **0.16.19**.
> 
> `WorkloadApiClient` gains `get_workload_replacement`, `create_workload_replacement`, and `delete_workload_replacement` against `workloads/{id}/replacement`. New `replacement_tools` exposes `workload_replacement_get`, `workload_replacement_create` (artifact, optional warmup/retention, runtime override, `rolling` only), and `workload_replacement_delete`, with validation and `ClientError` → `ToolError` mapping consistent with other workload tools.
> 
> Unit tests cover success paths, payload shaping, and validation/upstream errors. The PR checklist still calls out integration/acceptance tests for new `drtools` tools if those are required for this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83098d15091757167f89d8b7ccd2dda2da774e16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->