### PR TITLE
[APP-6278] Fall back to OTEL_ENTITY_ID in bootstrap_otel_provider_for_datarobot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.16.20
+- `core/datarobot_otel`: `resolve_entity_id_from_env()` now falls back to `OTEL_ENTITY_ID` when `MLOPS_DEPLOYMENT_ID` is absent, so `bootstrap_otel_provider_for_datarobot()` exports agent framework spans in local dev and deployments that only have `OTEL_ENTITY_ID` set via Pulumi.
+
 ## 0.16.19
 - `drtools/workload`: artifact replacement / rolling update.
   - **Client** (`WorkloadApiClient`): added `get_workload_replacement`, `create_workload_replacement`, `delete_workload_replacement` against `GET/POST/DELETE /api/v2/workloads/{id}/replacement`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.16.19"
+version = "0.16.20"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/datarobot_otel.py
+++ b/src/datarobot_genai/core/datarobot_otel.py
@@ -62,7 +62,11 @@ def resolve_entity_id_from_env() -> str:
     # auto-prepend the 'deployment-' prefix required by the OTel ingest path.
     # Mirrors the MLOPS_DEPLOYMENT_ID-driven pattern used by the A2A frontend.
     deployment_id = os.getenv("MLOPS_DEPLOYMENT_ID", "")
-    return f"{ENTITY_ID_PREFIX}{deployment_id}" if deployment_id else ""
+    if deployment_id:
+        return f"{ENTITY_ID_PREFIX}{deployment_id}"
+    # Fall back to OTEL_ENTITY_ID (set by Pulumi infra / af-component-agent)
+    # so local dev and non-DRUM deployments can still export spans.
+    return os.getenv("OTEL_ENTITY_ID", "")
 
 
 def resolve_otel_endpoint_from_env() -> str:

--- a/src/datarobot_genai/core/datarobot_otel.py
+++ b/src/datarobot_genai/core/datarobot_otel.py
@@ -62,11 +62,7 @@ def resolve_entity_id_from_env() -> str:
     # auto-prepend the 'deployment-' prefix required by the OTel ingest path.
     # Mirrors the MLOPS_DEPLOYMENT_ID-driven pattern used by the A2A frontend.
     deployment_id = os.getenv("MLOPS_DEPLOYMENT_ID", "")
-    if deployment_id:
-        return f"{ENTITY_ID_PREFIX}{deployment_id}"
-    # Fall back to OTEL_ENTITY_ID (set by Pulumi infra / af-component-agent)
-    # so local dev and non-DRUM deployments can still export spans.
-    return os.getenv("OTEL_ENTITY_ID", "")
+    return f"{ENTITY_ID_PREFIX}{deployment_id}" if deployment_id else ""
 
 
 def resolve_otel_endpoint_from_env() -> str:
@@ -130,7 +126,7 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
         return False
 
     api_key = resolve_api_key_from_env()
-    entity_id = resolve_entity_id_from_env()
+    entity_id = resolve_entity_id_from_env() or os.getenv("OTEL_ENTITY_ID", "")
     endpoint = resolve_otel_endpoint_from_env()
     if not api_key or not entity_id or not endpoint:
         logger.info(


### PR DESCRIPTION
## CHANGES

resolve_entity_id_from_env() now checks OTEL_ENTITY_ID when MLOPS_DEPLOYMENT_ID is absent, so agent framework instrumentors can export spans in local dev and af-component-agent deployments that only have OTEL_ENTITY_ID set via Pulumi.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive env resolution change in telemetry bootstrap with no change to behavior when MLOPS_DEPLOYMENT_ID is present.
> 
> **Overview**
> **`resolve_entity_id_from_env()`** still builds `deployment-<id>` from **`MLOPS_DEPLOYMENT_ID`** when that variable is set; when it is missing, it now returns **`OTEL_ENTITY_ID`** instead of an empty string.
> 
> That lets **`bootstrap_otel_provider_for_datarobot()`** satisfy the entity-id check and set **`X-DataRobot-Entity-Id`** for framework auto-instrumentor spans in local dev and **af-component-agent** / Pulumi setups that only expose **`OTEL_ENTITY_ID`**, without changing the DRUM deployment path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955f47933e2f9c3be4f7ca004eba4177e05103fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->