### PR TITLE
[BUZZOK-31265] fix: exclude annoy to stop E2E NeMo-guardrails SIGILL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.17.5
+- `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.
+
 ## 0.17.4
 - `drtools/workload`: submit-and-poll lifecycle workflow — `workload_start` and `workload_stop` return immediately after the request is accepted (202) with `accepted` and a `note` directing the agent to poll status; `workload_stop` no longer accepts `wait_stopped` or `timeout_seconds`. **`workload_wait_for_status` is replaced by `workload_get_status`** (`workload_id`, optional `target_status`): a lightweight single status fetch returning `status`, `target_reached`, and `raw`, raising on terminal `errored` without blocking. Removed `WorkloadApiClient.wait_for_workload_status` server-side polling.
 

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -66,6 +66,7 @@ override-dependencies = [
     "opentelemetry-instrumentation>=0.60b1,<0.61",
 ]
 exclude-dependencies = [
+    "annoy",                    # nemoguardrails ANN index; sdist -march=native build SIGILLs on non-AVX-512 runners (BUZZOK-31265)
     "llama-index-llms-azure-openai",
     "llama-index-llms-bedrock",
     "llama-index-llms-nvidia",

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -20,6 +20,7 @@ overrides = [
     { name = "opentelemetry-sdk", specifier = ">=1.39.0,<2.0.0" },
 ]
 excludes = [
+    "annoy",
     "build",
     "diskcache",
     "flask",
@@ -279,12 +280,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
-
-[[package]]
-name = "annoy"
-version = "1.17.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/38/e321b0e05d8cc068a594279fb7c097efb1df66231c295d482d7ad51b6473/annoy-1.17.3.tar.gz", hash = "sha256:9cbfebefe0a5f843eba29c6be4c84d601f4f41ad4ded0486f1b88c3b07739c15", size = 647460, upload-time = "2023-06-14T16:37:34.152Z" }
 
 [[package]]
 name = "anthropic"
@@ -4082,7 +4077,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
-    { name = "annoy" },
     { name = "fastapi" },
     { name = "fastembed" },
     { name = "httpx" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.17.4"
+version = "0.17.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.4"
+version = "0.17.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

The dragent `nemo-guardrails--crewai` E2E job crashes with SIGILL (exit 132), so every CrewAI test fails. Root cause (confirmed via gdb on the runner): `annoy` — nemoguardrails' embeddings ANN index — is sdist-only and compiles with `-march=native`, baking AVX-512 into the `.so`. On the heterogeneous CI fleet that cached binary is restored onto a non-AVX-512 runner (AMD EPYC) and executes an illegal AVX-512 instruction (`vmovups …%zmm0`) in `annoy.add_item`.

# CHANGES

- **Exclude `annoy`** from the e2e resolution (`exclude-dependencies`) + re-lock. `moderations` doesn't use annoy (confirmed with @Anatolii / @Reza), so this is safe. Without annoy the embeddings index can't build, but the guard catches that and no-ops — **no NeMo config change needed**.
- Bump `0.17.4 → 0.17.5` + CHANGELOG.

# TESTING

The nemo matrix is **dispatch-only** (not part of pr-tests), so the PR's auto-checks don't exercise this fix. Validated via a manual `moderations.yaml` dispatch: `nemo-guardrails--crewai` no longer SIGILLs and **passes (15 passed / 0 failed)** — see run 27688313000.

# SCOPE / NOTES

Scoped to **the crash only**. Out of scope (separate follow-ups):
- The guard's LLM call still doesn't *succeed* — it no-ops on a pre-existing gateway 404 (and, beneath it, an asyncio event-loop bug in `datarobot_dome`). Tracked in **BUZZOK-31306**.
- `langgraph`/`llamaindex`/`nat` nemo jobs fail on **unrelated pre-existing bugs** (BUZZOK-31264; BUZZOK-31266).

# Checklist
- [ ] Reviewed guideline
- [x] Updated Changelog
- [ ] New tools (N/A)
