### PR TITLE
[BUZZOK-31231] Use akickoff instead of kickoff_async for CrewAI agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.17.6
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
-- `crewai`: when streaming kickoff completes without TEXT stream chunks, emit the final kickoff result as a text message so AG-UI clients still receive the response.
+- `crewai`: when streaming kickoff completes without TEXT stream chunks, emit the final kickoff result using the text message lifecycle so AG-UI clients still receive the response.
 - `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior.
+- `dragent`: defer ``RUN_FINISHED`` in moderated streams and close dangling ``TEXT_MESSAGE_*`` segments before it so AG-UI event ordering stays valid.
 
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
 - `crewai`: when streaming kickoff completes without TEXT stream chunks, emit the final kickoff result using the text message lifecycle so AG-UI clients still receive the response.
 - `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior.
-- `dragent`: defer ``RUN_FINISHED`` in moderated streams and close dangling ``TEXT_MESSAGE_*`` segments before it so AG-UI event ordering stays valid.
+- `dragent`: defer ``RUN_FINISHED`` in moderated streams, emit buffered ``TEXT_MESSAGE_START`` before moderated ``TEXT_MESSAGE_CONTENT``, and close dangling text segments before ``RUN_FINISHED`` so AG-UI event ordering stays valid.
 
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.17.6
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
 - `crewai`: when streaming kickoff completes without TEXT stream chunks, emit the final kickoff result as a text message so AG-UI clients still receive the response.
+- `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior.
 
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `crewai`: when streaming kickoff completes without TEXT stream chunks, emit the final kickoff result using the text message lifecycle so AG-UI clients still receive the response.
 - `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior, including inline hallucinations after ``Action Input``.
 - `crewai`: after streaming ReAct scaffolding, emit ``crew_output.result.raw`` when it is not already present in streamed text so tool results reach AG-UI clients.
+- `llamaindex`: when streaming deltas stop early but ``AgentOutput`` carries the full response, emit the missing suffix so clients receive the complete answer (for example tool-returned object IDs).
 - `dragent`: defer ``RUN_FINISHED`` in moderated streams, emit buffered ``TEXT_MESSAGE_START`` before moderated ``TEXT_MESSAGE_CONTENT``, and close dangling text segments before ``RUN_FINISHED`` so AG-UI event ordering stays valid.
 
 ## 0.17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.17.6
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
 - `crewai`: when streaming kickoff completes without TEXT stream chunks, emit the final kickoff result using the text message lifecycle so AG-UI clients still receive the response.
-- `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior.
+- `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior, including inline hallucinations after ``Action Input``.
+- `crewai`: after streaming ReAct scaffolding, emit ``crew_output.result.raw`` when it is not already present in streamed text so tool results reach AG-UI clients.
 - `dragent`: defer ``RUN_FINISHED`` in moderated streams, emit buffered ``TEXT_MESSAGE_START`` before moderated ``TEXT_MESSAGE_CONTENT``, and close dangling text segments before ``RUN_FINISHED`` so AG-UI event ordering stays valid.
 
 ## 0.17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `crewai`: after streaming ReAct scaffolding, emit ``crew_output.result.raw`` when it is not already present in streamed text so tool results reach AG-UI clients.
 - `llamaindex`: when streaming deltas stop early but ``AgentOutput`` carries the full response, emit the missing suffix so clients receive the complete answer (for example tool-returned object IDs).
 - `dragent`: defer ``RUN_FINISHED`` in moderated streams, emit buffered ``TEXT_MESSAGE_START`` before moderated ``TEXT_MESSAGE_CONTENT``, and close dangling text segments before ``RUN_FINISHED`` so AG-UI event ordering stays valid.
+- `dragent`: close dangling ``TOOL_CALL`` segments before ``RUN_FINISHED`` when upstream ends without ``TOOL_CALL_END`` (for example stream-converter ``mark_args_done`` after workflow ``RUN_FINISHED``).
 - `dragent`: moderated streaming treats responses with batched ``TEXT_MESSAGE_START`` + ``TEXT_MESSAGE_CONTENT`` (NAT ``stream_converter`` shape) as text deltas instead of skipping them when only the start event is first, and preserves the source content ``message_id`` when rebuilding moderated chunks.
 
 ## 0.17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.17.6
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
+- `crewai`: when streaming kickoff completes without TEXT stream chunks, emit the final kickoff result as a text message so AG-UI clients still receive the response.
 
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `dragent`: defer ``RUN_FINISHED`` in moderated streams, emit buffered ``TEXT_MESSAGE_START`` before moderated ``TEXT_MESSAGE_CONTENT``, and close dangling text segments before ``RUN_FINISHED`` so AG-UI event ordering stays valid.
 - `dragent`: close dangling ``TOOL_CALL`` segments before ``RUN_FINISHED`` when upstream ends without ``TOOL_CALL_END`` (for example stream-converter ``mark_args_done`` after workflow ``RUN_FINISHED``), flushing deferred ``TOOL_CALL_RESULT`` pairs from the stream-converter registry when present.
 - `dragent`: moderated streaming treats responses with batched ``TEXT_MESSAGE_START`` + ``TEXT_MESSAGE_CONTENT`` (NAT ``stream_converter`` shape) as text deltas instead of skipping them when only the start event is first, and preserves the source content ``message_id`` when rebuilding moderated chunks.
+- `dragent`: moderated streaming re-emits ``TOOL_CALL_END`` / ``TOOL_CALL_RESULT`` events that share a source batch with moderated text deltas so ``events_to_messages`` can rebuild tool history.
 
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `crewai`: after streaming ReAct scaffolding, emit ``crew_output.result.raw`` when it is not already present in streamed text so tool results reach AG-UI clients.
 - `llamaindex`: when streaming deltas stop early but ``AgentOutput`` carries the full response, emit the missing suffix so clients receive the complete answer (for example tool-returned object IDs).
 - `dragent`: defer ``RUN_FINISHED`` in moderated streams, emit buffered ``TEXT_MESSAGE_START`` before moderated ``TEXT_MESSAGE_CONTENT``, and close dangling text segments before ``RUN_FINISHED`` so AG-UI event ordering stays valid.
-- `dragent`: close dangling ``TOOL_CALL`` segments before ``RUN_FINISHED`` when upstream ends without ``TOOL_CALL_END`` (for example stream-converter ``mark_args_done`` after workflow ``RUN_FINISHED``).
+- `dragent`: close dangling ``TOOL_CALL`` segments before ``RUN_FINISHED`` when upstream ends without ``TOOL_CALL_END`` (for example stream-converter ``mark_args_done`` after workflow ``RUN_FINISHED``), flushing deferred ``TOOL_CALL_RESULT`` pairs from the stream-converter registry when present.
 - `dragent`: moderated streaming treats responses with batched ``TEXT_MESSAGE_START`` + ``TEXT_MESSAGE_CONTENT`` (NAT ``stream_converter`` shape) as text deltas instead of skipping them when only the start event is first, and preserves the source content ``message_id`` when rebuilding moderated chunks.
 
 ## 0.17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `crewai`: after streaming ReAct scaffolding, emit ``crew_output.result.raw`` when it is not already present in streamed text so tool results reach AG-UI clients.
 - `llamaindex`: when streaming deltas stop early but ``AgentOutput`` carries the full response, emit the missing suffix so clients receive the complete answer (for example tool-returned object IDs).
 - `dragent`: defer ``RUN_FINISHED`` in moderated streams, emit buffered ``TEXT_MESSAGE_START`` before moderated ``TEXT_MESSAGE_CONTENT``, and close dangling text segments before ``RUN_FINISHED`` so AG-UI event ordering stays valid.
+- `dragent`: moderated streaming treats responses with batched ``TEXT_MESSAGE_START`` + ``TEXT_MESSAGE_CONTENT`` (NAT ``stream_converter`` shape) as text deltas instead of skipping them when only the start event is first, and preserves the source content ``message_id`` when rebuilding moderated chunks.
 
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.17.6
+- `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
+
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.
 

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -139,9 +139,14 @@ def collect_ag_ui_events(responses: list[DRAgentEventResponse]) -> list[Event]: 
 
 
 def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
-    """Join text deltas from text message events."""
+    """Join text deltas from assistant text and reasoning message events."""
     parts = []
     for event in ag_ui_events:
-        if event.type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):
+        if event.type in (
+            EventType.TEXT_MESSAGE_CONTENT,
+            EventType.TEXT_MESSAGE_CHUNK,
+            EventType.REASONING_MESSAGE_CONTENT,
+            EventType.REASONING_MESSAGE_CHUNK,
+        ):
             parts.append(event.delta)
     return "".join(parts)

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -139,7 +139,7 @@ def collect_ag_ui_events(responses: list[DRAgentEventResponse]) -> list[Event]: 
 
 
 def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
-    """Join text deltas from assistant text and reasoning message events."""
+    """Join text deltas from assistant text, reasoning, and tool-result events."""
     parts = []
     for event in ag_ui_events:
         if event.type in (
@@ -149,4 +149,6 @@ def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
             EventType.REASONING_MESSAGE_CHUNK,
         ):
             parts.append(event.delta)
+        elif event.type == EventType.TOOL_CALL_RESULT:
+            parts.append(event.content)
     return "".join(parts)

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.4"
+version = "0.17.5"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.5"
+version = "0.17.6"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.17.5"
+version = "0.17.6"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -415,7 +415,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
                 if history_summary and not existing_history_text.strip():
                     kickoff_inputs["chat_history"] = f"\n\nPrior conversation:\n{history_summary}"
-            crew_output = await crew.kickoff_async(inputs=kickoff_inputs)
+            crew_output = await crew.akickoff(inputs=kickoff_inputs)
             current_agent_role = ""
             message_id = str(uuid.uuid4())
 

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -422,6 +422,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
             if isinstance(crew_output, CrewStreamingOutput):
                 reasoning_started = False
                 text_started = False
+                streamed_text = ""
                 async for chunk in crew_output:
                     # Show task transitions
                     logger.debug(f"CrewAI chunk: {chunk.model_dump_json()}")
@@ -540,6 +541,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                                     zero_metrics,
                                 )
                             text_started = True
+                            streamed_text += chunk.content
                             yield (
                                 TextMessageContentEvent(
                                     type=EventType.TEXT_MESSAGE_CONTENT,
@@ -556,18 +558,19 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                     ragas_event_listener.messages
                 )
                 usage_metrics = self._extract_usage_metrics(crew_output.result)
+                final_text = str(crew_output.result.raw).strip()
                 if text_started:
                     yield (
                         TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),
                         None,
                         usage_metrics,
                     )
-                else:
-                    # ``akickoff`` may complete without emitting TEXT stream chunks even
-                    # when the crew produced a final answer; fall back to the kickoff
-                    # result so AG-UI clients still receive the response text.
-                    response_text = crew_output.get_full_text() or str(crew_output.result.raw)
-                    if response_text:
+                    if (
+                        final_text
+                        and final_text not in streamed_text
+                        and ("Action:" in streamed_text or "Action Input:" in streamed_text)
+                    ):
+                        message_id = str(uuid.uuid4())
                         yield (
                             TextMessageStartEvent(
                                 type=EventType.TEXT_MESSAGE_START,
@@ -580,7 +583,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                             TextMessageContentEvent(
                                 type=EventType.TEXT_MESSAGE_CONTENT,
                                 message_id=message_id,
-                                delta=response_text,
+                                delta=final_text,
                             ),
                             None,
                             usage_metrics,
@@ -593,6 +596,35 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                             None,
                             usage_metrics,
                         )
+                elif final_text:
+                    # ``akickoff`` may complete without emitting TEXT stream chunks even
+                    # when the crew produced a final answer; fall back to the kickoff
+                    # result so AG-UI clients still receive the response text.
+                    yield (
+                        TextMessageStartEvent(
+                            type=EventType.TEXT_MESSAGE_START,
+                            message_id=message_id,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
+                    yield (
+                        TextMessageContentEvent(
+                            type=EventType.TEXT_MESSAGE_CONTENT,
+                            message_id=message_id,
+                            delta=final_text,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
+                    yield (
+                        TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=message_id,
+                        ),
+                        None,
+                        usage_metrics,
+                    )
                 if reasoning_started:
                     yield (
                         ReasoningMessageEndEvent(

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -562,6 +562,21 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                         None,
                         usage_metrics,
                     )
+                else:
+                    # ``akickoff`` may complete without emitting TEXT stream chunks even
+                    # when the crew produced a final answer; fall back to the kickoff
+                    # result so AG-UI clients still receive the response text.
+                    response_text = crew_output.get_full_text() or str(crew_output.result.raw)
+                    if response_text:
+                        yield (
+                            TextMessageChunkEvent(
+                                type=EventType.TEXT_MESSAGE_CHUNK,
+                                message_id=message_id,
+                                delta=response_text,
+                            ),
+                            None,
+                            usage_metrics,
+                        )
                 if reasoning_started:
                     yield (
                         ReasoningMessageEndEvent(

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -569,10 +569,26 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
                     response_text = crew_output.get_full_text() or str(crew_output.result.raw)
                     if response_text:
                         yield (
-                            TextMessageChunkEvent(
-                                type=EventType.TEXT_MESSAGE_CHUNK,
+                            TextMessageStartEvent(
+                                type=EventType.TEXT_MESSAGE_START,
+                                message_id=message_id,
+                            ),
+                            None,
+                            usage_metrics,
+                        )
+                        yield (
+                            TextMessageContentEvent(
+                                type=EventType.TEXT_MESSAGE_CONTENT,
                                 message_id=message_id,
                                 delta=response_text,
+                            ),
+                            None,
+                            usage_metrics,
+                        )
+                        yield (
+                            TextMessageEndEvent(
+                                type=EventType.TEXT_MESSAGE_END,
+                                message_id=message_id,
                             ),
                             None,
                             usage_metrics,

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -50,6 +50,13 @@ class LitellmStopWordLLM(LLM):
             return self._apply_stop_words(result)
         return result
 
+    async def acall(self, *args: Any, **kwargs: Any) -> Any:
+        """Async variant of :meth:`call` used by ``Crew.akickoff``."""
+        result = await super().acall(*args, **kwargs)
+        if isinstance(result, str):
+            return self._apply_stop_words(result)
+        return result
+
 
 def _crewai_model_factory(config: dict) -> LLM:
     config["stream_options"] = config.get("stream_options", {"include_usage": True})

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -43,6 +43,31 @@ class LitellmStopWordLLM(LLM):
         super().__init__(*args, **kwargs)
         self.is_litellm = True
 
+    def _apply_stop_words(self, content: str) -> str:
+        """Apply configured stop words, then truncate inline ReAct hallucinations."""
+        truncated = super()._apply_stop_words(content)
+        return self._truncate_react_hallucination_after_action_input(truncated)
+
+    @staticmethod
+    def _truncate_react_hallucination_after_action_input(content: str) -> str:
+        """Drop inline fake observations that omit the ``Observation:`` label."""
+        marker = "Action Input:"
+        marker_idx = content.find(marker)
+        if marker_idx == -1:
+            return content
+        after_marker = content[marker_idx + len(marker) :]
+        cut_at = len(content)
+        line_break = after_marker.find("\n")
+        if line_break != -1:
+            cut_at = min(cut_at, marker_idx + len(marker) + line_break)
+        for stop in ("Thought:", "Final Answer:"):
+            stop_idx = after_marker.find(stop)
+            if stop_idx > 0:
+                cut_at = min(cut_at, marker_idx + len(marker) + stop_idx)
+        if cut_at == len(content):
+            return content
+        return content[:cut_at].rstrip()
+
     def call(self, *args: Any, **kwargs: Any) -> Any:
         """Enforce client-side stop-word truncation when API ignores stop parameter."""
         result = super().call(*args, **kwargs)

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -207,6 +207,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         message_id = str(uuid.uuid4())
         text_started = False
         any_text_emitted = False
+        streamed_text = ""
         # Id of the most recently closed assistant text bubble. A following tool call
         # names it as its parent_message_id so the call attaches to the message that
         # introduced it (AG-UI grouping) instead of an orphan id; reset on a tool
@@ -229,6 +230,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                         usage_metrics,
                     )
                     text_started = False
+                    streamed_text = ""
                 if current_agent_name is not None:
                     yield (
                         StepFinishedEvent(
@@ -292,6 +294,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                     )
                     text_started = True
                     any_text_emitted = True
+                streamed_text += delta
                 yield (
                     TextMessageContentEvent(
                         type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=delta
@@ -321,11 +324,28 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                         )
                         text_started = True
                         any_text_emitted = True
+                        streamed_text = content_str
                         yield (
                             TextMessageContentEvent(
                                 type=EventType.TEXT_MESSAGE_CONTENT,
                                 message_id=message_id,
                                 delta=content_str,
+                            ),
+                            None,
+                            usage_metrics,
+                        )
+                    elif content_str.startswith(streamed_text) and len(content_str) > len(
+                        streamed_text
+                    ):
+                        # Streaming deltas may stop early; AgentOutput carries the full answer.
+                        missing = content_str[len(streamed_text) :]
+                        any_text_emitted = True
+                        streamed_text = content_str
+                        yield (
+                            TextMessageContentEvent(
+                                type=EventType.TEXT_MESSAGE_CONTENT,
+                                message_id=message_id,
+                                delta=missing,
                             ),
                             None,
                             usage_metrics,
@@ -385,6 +405,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
                         usage_metrics,
                     )
                     text_started = False
+                    streamed_text = ""
                     # Capture the closed bubble's id (before minting a fresh one) so the
                     # tool call below can name it as its parent_message_id.
                     last_text_message_id = message_id
@@ -443,32 +464,50 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         except (AttributeError, TypeError):
             state = None
 
-        # Use subclass-defined response extraction as final fallback when no text was streamed
+        # Use subclass-defined response extraction as final fallback when no text was streamed,
+        # or to append any suffix missing from partial stream deltas.
         fallback_text = self.extract_response_text(state, events)
-        if not any_text_emitted and fallback_text:
-            yield (
-                TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id),
-                None,
-                usage_metrics,
-            )
-            yield (
-                TextMessageContentEvent(
-                    type=EventType.TEXT_MESSAGE_CONTENT,
-                    message_id=message_id,
-                    delta=fallback_text,
-                ),
-                None,
-                usage_metrics,
-            )
-            yield (
-                TextMessageEndEvent(
-                    type=EventType.TEXT_MESSAGE_END,
-                    message_id=message_id,
-                ),
-                None,
-                usage_metrics,
-            )
-            message_id = str(uuid.uuid4())
+        if fallback_text:
+            if not any_text_emitted:
+                yield (
+                    TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id),
+                    None,
+                    usage_metrics,
+                )
+                yield (
+                    TextMessageContentEvent(
+                        type=EventType.TEXT_MESSAGE_CONTENT,
+                        message_id=message_id,
+                        delta=fallback_text,
+                    ),
+                    None,
+                    usage_metrics,
+                )
+                yield (
+                    TextMessageEndEvent(
+                        type=EventType.TEXT_MESSAGE_END,
+                        message_id=message_id,
+                    ),
+                    None,
+                    usage_metrics,
+                )
+                message_id = str(uuid.uuid4())
+            elif (
+                text_started
+                and fallback_text.startswith(streamed_text)
+                and len(fallback_text) > len(streamed_text)
+            ):
+                missing = fallback_text[len(streamed_text) :]
+                yield (
+                    TextMessageContentEvent(
+                        type=EventType.TEXT_MESSAGE_CONTENT,
+                        message_id=message_id,
+                        delta=missing,
+                    ),
+                    None,
+                    usage_metrics,
+                )
+                streamed_text = fallback_text
 
         # Close the final agent's step. Each STEP_STARTED needs a matching
         # STEP_FINISHED; without this, the UI shows the last step as still running.

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1117,6 +1117,16 @@ def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
             open_message_ids.add(event.message_id)
 
 
+def _track_open_tool_call(open_tool_call_ids: set[str], event: Event) -> None:
+    """Track tool calls that started but did not end."""
+    if isinstance(event, ToolCallEndEvent):
+        if event.tool_call_id:
+            open_tool_call_ids.discard(event.tool_call_id)
+    elif isinstance(event, ToolCallStartEvent):
+        if event.tool_call_id:
+            open_tool_call_ids.add(event.tool_call_id)
+
+
 def _synthetic_text_message_end_events(
     open_message_ids: set[str],
 ) -> list[TextMessageEndEvent]:
@@ -1137,11 +1147,34 @@ def _synthetic_text_message_end_responses(
     ]
 
 
+def _synthetic_tool_call_end_events(open_tool_call_ids: set[str]) -> list[ToolCallEndEvent]:
+    """Close dangling tool calls when upstream ends the stream without ``TOOL_CALL_END``."""
+    end_events = [
+        ToolCallEndEvent(tool_call_id=tool_call_id) for tool_call_id in open_tool_call_ids
+    ]
+    open_tool_call_ids.clear()
+    return end_events
+
+
+def _synthetic_tool_call_end_responses(
+    open_tool_call_ids: set[str],
+) -> list[DRAgentEventResponse]:
+    """Wrap synthetic ``TOOL_CALL_END`` events as ``DRAgentEventResponse`` batches."""
+    zero = default_usage_metrics()
+    return [
+        DRAgentEventResponse(events=[end_event], usage_metrics=zero)
+        for end_event in _synthetic_tool_call_end_events(open_tool_call_ids)
+    ]
+
+
 def _track_dragent_response_events(
-    open_message_ids: set[str], response: DRAgentEventResponse
+    open_message_ids: set[str],
+    open_tool_call_ids: set[str],
+    response: DRAgentEventResponse,
 ) -> None:
     for event in response.events:
         _track_open_text_message(open_message_ids, event)
+        _track_open_tool_call(open_tool_call_ids, event)
 
 
 def _response_has_assistant_text_deltas(response: DRAgentEventResponse) -> bool:
@@ -1230,6 +1263,16 @@ def _pending_end_message_ids(pending_deferred: list[DRAgentEventResponse]) -> se
     }
 
 
+def _pending_tool_end_ids(pending_deferred: list[DRAgentEventResponse]) -> set[str]:
+    return {
+        item.events[0].tool_call_id
+        for item in pending_deferred
+        if item.events
+        and item.events[0].type == EventType.TOOL_CALL_END
+        and item.events[0].tool_call_id
+    }
+
+
 def _prepend_synthetic_text_message_ends_for_dangling_segments(
     pending_deferred: list[DRAgentEventResponse],
     open_text_message_ids: set[str],
@@ -1248,12 +1291,27 @@ def _prepend_synthetic_text_message_ends_for_dangling_segments(
     open_text_message_ids.difference_update(ids_to_close)
 
 
-def _drain_pending_with_dangling_text_closed(
+def _prepend_synthetic_tool_call_ends_for_dangling_calls(
+    pending_deferred: list[DRAgentEventResponse],
+    open_tool_call_ids: set[str],
+) -> None:
+    """Close dangling tool calls before ``RUN_FINISHED`` reaches the client."""
+    still_open = open_tool_call_ids - _pending_tool_end_ids(pending_deferred)
+    if not still_open:
+        return
+    ids_to_close = set(still_open)
+    pending_deferred[:0] = _synthetic_tool_call_end_responses(ids_to_close)
+    open_tool_call_ids.difference_update(ids_to_close)
+
+
+def _drain_pending_with_dangling_lifecycle_closed(
     pending_deferred: list[DRAgentEventResponse],
     pending_pass_through: list[DRAgentEventResponse],
     open_text_message_ids: set[str],
+    open_tool_call_ids: set[str],
 ) -> list[DRAgentEventResponse]:
-    """Drain pending events after closing any dangling text segments."""
+    """Drain pending events after closing dangling text segments and tool calls."""
+    _prepend_synthetic_tool_call_ends_for_dangling_calls(pending_deferred, open_tool_call_ids)
     _prepend_synthetic_text_message_ends_for_dangling_segments(
         pending_deferred, open_text_message_ids
     )
@@ -1326,6 +1384,7 @@ async def _moderated_dragent_stream(
     """
     stream_tool_index_map: dict[int, str] = {}
     open_text_message_ids: set[str] = set()
+    open_tool_call_ids: set[str] = set()
     emitted_text_message_starts: set[str] = set()
     pending_deferred: list[DRAgentEventResponse] = []
     pending_pass_through: list[DRAgentEventResponse] = []
@@ -1370,10 +1429,26 @@ async def _moderated_dragent_stream(
             if response.events and _response_has_assistant_text_deltas(response):
                 first_text = response
                 break
-            _track_dragent_response_events(open_text_message_ids, response)
-            _record_emitted_text_message_starts(emitted_text_message_starts, response)
-            yield prescore_state.emit(response)
+            if response.events and response.events[0].type == EventType.RUN_FINISHED:
+                pending_run_finished.append(response)
+            else:
+                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, response)
+                _record_emitted_text_message_starts(emitted_text_message_starts, response)
+                yield prescore_state.emit(response)
         if first_text is None:
+            for item in _drain_pending_with_dangling_lifecycle_closed(
+                pending_deferred,
+                pending_pass_through,
+                open_text_message_ids,
+                open_tool_call_ids,
+            ):
+                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
+                _record_emitted_text_message_starts(emitted_text_message_starts, item)
+                yield prescore_state.emit(item)
+            for item in pending_run_finished:
+                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
+                _record_emitted_text_message_starts(emitted_text_message_starts, item)
+                yield prescore_state.emit(item)
             return
 
         async with contextlib.aclosing(
@@ -1433,16 +1508,20 @@ async def _moderated_dragent_stream(
                                 }
                             }
                         )
-                _track_dragent_response_events(open_text_message_ids, moderated_response)
+                _track_dragent_response_events(
+                    open_text_message_ids, open_tool_call_ids, moderated_response
+                )
                 yield moderated_response
                 for item in _drain_pending_after_moderated_chunk(
                     pending_deferred, pending_pass_through
                 ):
-                    _track_dragent_response_events(open_text_message_ids, item)
+                    _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
                     _record_emitted_text_message_starts(emitted_text_message_starts, item)
                     yield prescore_state.emit(item)
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
+                    for end_response in _synthetic_tool_call_end_responses(open_tool_call_ids):
+                        yield end_response
                     for end_response in _synthetic_text_message_end_responses(
                         open_text_message_ids
                     ):
@@ -1451,14 +1530,17 @@ async def _moderated_dragent_stream(
                     break
 
         if not stopped_for_content_filter:
-            for item in _drain_pending_with_dangling_text_closed(
-                pending_deferred, pending_pass_through, open_text_message_ids
+            for item in _drain_pending_with_dangling_lifecycle_closed(
+                pending_deferred,
+                pending_pass_through,
+                open_text_message_ids,
+                open_tool_call_ids,
             ):
-                _track_dragent_response_events(open_text_message_ids, item)
+                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
                 _record_emitted_text_message_starts(emitted_text_message_starts, item)
                 yield prescore_state.emit(item)
             for item in pending_run_finished:
-                _track_dragent_response_events(open_text_message_ids, item)
+                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
                 _record_emitted_text_message_starts(emitted_text_message_starts, item)
                 yield prescore_state.emit(item)
     finally:

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1103,6 +1103,20 @@ def _prompt_sent_after_prescore_replacement(
     return original_prompt, False
 
 
+# Moderated streaming lifecycle helpers (_moderated_dragent_stream and below).
+#
+# Three concerns that must stay coordinated:
+#
+# 1. Ordering — defer TEXT_MESSAGE_START/END and RUN_FINISHED until moderated text
+#    deltas drain; close dangling text segments before RUN_FINISHED so AG-UI and
+#    storage see valid segment boundaries.
+# 2. Registry flush — stream_converter / step adaptor defer TOOL_CALL_END + RESULT
+#    via mark_args_done; flush those pairs before synthetic closes so history rebuilds.
+# 3. Passthrough re-emit — dome_chunk_to_dragent_event_response rebuilds moderated
+#    text and drops co-located TOOL_CALL_END / TOOL_CALL_RESULT; re-emit them from
+#    the source batch after each moderated chunk.
+
+
 def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
     """Track assistant text segments that received content but did not end."""
     if isinstance(event, TextMessageEndEvent):

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1103,13 +1103,6 @@ def _prompt_sent_after_prescore_replacement(
     return original_prompt, False
 
 
-def skip_event_type(event: Event) -> bool:
-    return event.type not in {
-        EventType.TEXT_MESSAGE_CONTENT,
-        EventType.TEXT_MESSAGE_CHUNK,
-    }
-
-
 def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
     """Track assistant text segments that received content but did not end."""
     if isinstance(event, TextMessageEndEvent):
@@ -1138,17 +1131,6 @@ def _synthetic_text_message_end_events(
     return end_events
 
 
-def _synthetic_text_message_end_responses(
-    open_message_ids: set[str],
-) -> list[DRAgentEventResponse]:
-    """Wrap synthetic ``TEXT_MESSAGE_END`` events as ``DRAgentEventResponse`` batches."""
-    zero = default_usage_metrics()
-    return [
-        DRAgentEventResponse(events=[end_event], usage_metrics=zero)
-        for end_event in _synthetic_text_message_end_events(open_message_ids)
-    ]
-
-
 def _synthetic_tool_call_end_events(open_tool_call_ids: set[str]) -> list[ToolCallEndEvent]:
     """Close dangling tool calls when upstream ends the stream without ``TOOL_CALL_END``."""
     end_events = [
@@ -1158,15 +1140,26 @@ def _synthetic_tool_call_end_events(open_tool_call_ids: set[str]) -> list[ToolCa
     return end_events
 
 
+def _zero_metric_event_responses(events: list[Event]) -> list[DRAgentEventResponse]:
+    """Wrap each AG-UI event as its own ``DRAgentEventResponse`` batch."""
+    if not events:
+        return []
+    zero = default_usage_metrics()
+    return [DRAgentEventResponse(events=[event], usage_metrics=zero) for event in events]
+
+
+def _synthetic_text_message_end_responses(
+    open_message_ids: set[str],
+) -> list[DRAgentEventResponse]:
+    """Wrap synthetic ``TEXT_MESSAGE_END`` events as ``DRAgentEventResponse`` batches."""
+    return _zero_metric_event_responses(_synthetic_text_message_end_events(open_message_ids))
+
+
 def _synthetic_tool_call_end_responses(
     open_tool_call_ids: set[str],
 ) -> list[DRAgentEventResponse]:
     """Wrap synthetic ``TOOL_CALL_END`` events as ``DRAgentEventResponse`` batches."""
-    zero = default_usage_metrics()
-    return [
-        DRAgentEventResponse(events=[end_event], usage_metrics=zero)
-        for end_event in _synthetic_tool_call_end_events(open_tool_call_ids)
-    ]
+    return _zero_metric_event_responses(_synthetic_tool_call_end_events(open_tool_call_ids))
 
 
 def _track_dragent_response_events(
@@ -1197,12 +1190,13 @@ def _tool_lifecycle_passthrough_responses(
     chunk and drops co-located ``TOOL_CALL_END`` / ``TOOL_CALL_RESULT`` events that
     ``mark_args_done`` or the step adaptor attached to the same batch.
     """
-    zero = default_usage_metrics()
-    return [
-        DRAgentEventResponse(events=[event], usage_metrics=zero)
-        for event in response.events
-        if isinstance(event, (ToolCallEndEvent, ToolCallResultEvent))
-    ]
+    return _zero_metric_event_responses(
+        [
+            event
+            for event in response.events
+            if isinstance(event, (ToolCallEndEvent, ToolCallResultEvent))
+        ]
+    )
 
 
 def _merge_moderations_into_multi_event_response(
@@ -1282,17 +1276,7 @@ def _pending_end_message_ids(pending_deferred: list[DRAgentEventResponse]) -> se
     }
 
 
-def _pending_tool_end_ids(pending_deferred: list[DRAgentEventResponse]) -> set[str]:
-    return {
-        item.events[0].tool_call_id
-        for item in pending_deferred
-        if item.events
-        and item.events[0].type == EventType.TOOL_CALL_END
-        and item.events[0].tool_call_id
-    }
-
-
-def _pending_tool_end_ids_in_responses(responses: list[DRAgentEventResponse]) -> set[str]:
+def _tool_call_end_ids_in_responses(responses: list[DRAgentEventResponse]) -> set[str]:
     """Collect ``tool_call_id`` values from ``TOOL_CALL_END`` events in *responses*."""
     end_ids: set[str] = set()
     for item in responses:
@@ -1315,49 +1299,48 @@ def _flushed_deferred_tool_call_responses(
     return flushed
 
 
-def _prepend_flushed_deferred_tool_call_responses(
+def _prepare_pending_lifecycle_closure(
     pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
+    open_text_message_ids: set[str],
     open_tool_call_ids: set[str],
 ) -> None:
-    """Flush step-adaptor deferred ``TOOL_CALL_END``/``RESULT`` pairs before synthetic ends."""
+    """Track buffered events, flush deferred tool results, prepend synthetic closes."""
+    for batch in (pending_pass_through, pending_deferred):
+        for item in batch:
+            _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
+
     flushed = _flushed_deferred_tool_call_responses(open_tool_call_ids)
     if flushed:
         pending_deferred[:0] = list(reversed(flushed))
+        for item in flushed:
+            _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
+
+    pending_tool_ends = _tool_call_end_ids_in_responses(pending_deferred + pending_pass_through)
+    still_open_tools = open_tool_call_ids - pending_tool_ends
+    if still_open_tools:
+        ids_to_close = set(still_open_tools)
+        pending_deferred[:0] = _synthetic_tool_call_end_responses(ids_to_close)
+        open_tool_call_ids.difference_update(ids_to_close)
+
+    still_open_text = open_text_message_ids - _pending_end_message_ids(pending_deferred)
+    if still_open_text:
+        ids_to_close = set(still_open_text)
+        pending_deferred[:0] = _synthetic_text_message_end_responses(ids_to_close)
+        open_text_message_ids.difference_update(ids_to_close)
 
 
-def _prepend_synthetic_text_message_ends_for_dangling_segments(
-    pending_deferred: list[DRAgentEventResponse],
+def _lifecycle_closure_responses(
     open_text_message_ids: set[str],
-) -> None:
-    """Close dangling text segments before ``RUN_FINISHED`` reaches the client.
-
-    ``TEXT_MESSAGE_CHUNK`` responses (and other deltas without a matching upstream END) leave
-    message ids in ``open_text_message_ids``. Synthetic ends are prepended to the deferred
-    queue so they drain before pass-through lifecycle events such as ``RUN_FINISHED``.
-    """
-    still_open = open_text_message_ids - _pending_end_message_ids(pending_deferred)
-    if not still_open:
-        return
-    ids_to_close = set(still_open)
-    pending_deferred[:0] = _synthetic_text_message_end_responses(ids_to_close)
-    open_text_message_ids.difference_update(ids_to_close)
-
-
-def _prepend_synthetic_tool_call_ends_for_dangling_calls(
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
     open_tool_call_ids: set[str],
-) -> None:
-    """Close dangling tool calls before ``RUN_FINISHED`` reaches the client."""
-    pending_ends = _pending_tool_end_ids(pending_deferred) | _pending_tool_end_ids_in_responses(
-        pending_pass_through
-    )
-    still_open = open_tool_call_ids - pending_ends
-    if not still_open:
-        return
-    ids_to_close = set(still_open)
-    pending_deferred[:0] = _synthetic_tool_call_end_responses(ids_to_close)
-    open_tool_call_ids.difference_update(ids_to_close)
+) -> list[DRAgentEventResponse]:
+    """Flush deferred tool results and synthesize dangling text/tool closes."""
+    responses = _flushed_deferred_tool_call_responses(open_tool_call_ids)
+    if open_tool_call_ids:
+        responses.extend(_synthetic_tool_call_end_responses(set(open_tool_call_ids)))
+    if open_text_message_ids:
+        responses.extend(_synthetic_text_message_end_responses(set(open_text_message_ids)))
+    return responses
 
 
 def _drain_pending_with_dangling_lifecycle_closed(
@@ -1367,18 +1350,8 @@ def _drain_pending_with_dangling_lifecycle_closed(
     open_tool_call_ids: set[str],
 ) -> list[DRAgentEventResponse]:
     """Drain pending events after closing dangling text segments and tool calls."""
-    for item in pending_pass_through:
-        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-    for item in pending_deferred:
-        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-    _prepend_flushed_deferred_tool_call_responses(pending_deferred, open_tool_call_ids)
-    for item in pending_deferred:
-        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-    _prepend_synthetic_tool_call_ends_for_dangling_calls(
-        pending_deferred, pending_pass_through, open_tool_call_ids
-    )
-    _prepend_synthetic_text_message_ends_for_dangling_segments(
-        pending_deferred, open_text_message_ids
+    _prepare_pending_lifecycle_closure(
+        pending_deferred, pending_pass_through, open_text_message_ids, open_tool_call_ids
     )
     return _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through)
 
@@ -1427,6 +1400,53 @@ def _take_pending_text_message_start_for_message(
     return None
 
 
+def _with_text_message_start_if_needed(
+    moderated_response: DRAgentEventResponse,
+    source_response: DRAgentEventResponse,
+    *,
+    emitted_text_message_starts: set[str],
+    pending_deferred: list[DRAgentEventResponse],
+    prescore_state: _StreamingPrescoreModerationState,
+) -> DRAgentEventResponse:
+    """Prepend ``TEXT_MESSAGE_START`` (and prescore mods) before the first moderated delta."""
+    message_id = _text_message_id_from_response(source_response)
+    first_delta = _first_text_delta_event(source_response)
+    if not (
+        message_id and message_id not in emitted_text_message_starts and first_delta is not None
+    ):
+        return moderated_response
+
+    extra_start_events: list[Any] = list(_leading_text_message_starts(source_response))
+    if not extra_start_events:
+        pending_start = _take_pending_text_message_start_for_message(pending_deferred, message_id)
+        if pending_start is not None:
+            extra_start_events.extend(
+                ev
+                for ev in pending_start.events
+                if isinstance(ev, TextMessageStartEvent) and ev.message_id == message_id
+            )
+        else:
+            extra_start_events.append(
+                TextMessageStartEvent(message_id=message_id, role="assistant")
+            )
+    emitted_text_message_starts.add(message_id)
+    moderated_response = moderated_response.model_copy(
+        update={"events": extra_start_events + moderated_response.events}
+    )
+    if not prescore_state.prescore_attached and prescore_state.prescore_moderations:
+        prescore_state.prescore_attached = True
+        existing_mods = moderated_response.datarobot_moderations or {}
+        moderated_response = moderated_response.model_copy(
+            update={
+                "datarobot_moderations": {
+                    **prescore_state.prescore_moderations,
+                    **existing_mods,
+                }
+            }
+        )
+    return moderated_response
+
+
 async def _aclose_async_iterator(iterator: AsyncGenerator[Any]) -> None:
     """Close an async generator, ignoring errors from double-close or partial consumption."""
     try:
@@ -1463,6 +1483,11 @@ async def _moderated_dragent_stream(
         ),
     )
 
+    def emit_buffered(response: DRAgentEventResponse) -> DRAgentEventResponse:
+        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, response)
+        _record_emitted_text_message_starts(emitted_text_message_starts, response)
+        return prescore_state.emit(response)
+
     def buffer_passthrough(response: DRAgentEventResponse) -> None:
         if response.events and response.events[0].type == EventType.RUN_FINISHED:
             pending_run_finished.append(response)
@@ -1497,9 +1522,7 @@ async def _moderated_dragent_stream(
             if response.events and response.events[0].type == EventType.RUN_FINISHED:
                 pending_run_finished.append(response)
             else:
-                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, response)
-                _record_emitted_text_message_starts(emitted_text_message_starts, response)
-                yield prescore_state.emit(response)
+                yield emit_buffered(response)
         if first_text is None:
             for item in _drain_pending_with_dangling_lifecycle_closed(
                 pending_deferred,
@@ -1507,13 +1530,9 @@ async def _moderated_dragent_stream(
                 open_text_message_ids,
                 open_tool_call_ids,
             ):
-                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-                _record_emitted_text_message_starts(emitted_text_message_starts, item)
-                yield prescore_state.emit(item)
+                yield emit_buffered(item)
             for item in pending_run_finished:
-                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-                _record_emitted_text_message_starts(emitted_text_message_starts, item)
-                yield prescore_state.emit(item)
+                yield emit_buffered(item)
             return
 
         async with contextlib.aclosing(
@@ -1526,53 +1545,19 @@ async def _moderated_dragent_stream(
         ) as moderation_stream:
             async for moderated in moderation_stream:
                 source_response = moderation_source_responses.pop(0)
-                moderated_response = prescore_state.emit_moderated(
-                    dome_chunk_to_dragent_event_response(
-                        moderated,
-                        source_ag_ui_events=source_response.events,
-                        stream_tool_index_map=stream_tool_index_map,
-                    )
+                moderated_response = _with_text_message_start_if_needed(
+                    prescore_state.emit_moderated(
+                        dome_chunk_to_dragent_event_response(
+                            moderated,
+                            source_ag_ui_events=source_response.events,
+                            stream_tool_index_map=stream_tool_index_map,
+                        )
+                    ),
+                    source_response,
+                    emitted_text_message_starts=emitted_text_message_starts,
+                    pending_deferred=pending_deferred,
+                    prescore_state=prescore_state,
                 )
-                message_id = _text_message_id_from_response(source_response)
-                first_delta = _first_text_delta_event(source_response)
-                if (
-                    message_id
-                    and message_id not in emitted_text_message_starts
-                    and first_delta is not None
-                ):
-                    extra_start_events: list[Any] = list(
-                        _leading_text_message_starts(source_response)
-                    )
-                    if not extra_start_events:
-                        pending_start = _take_pending_text_message_start_for_message(
-                            pending_deferred, message_id
-                        )
-                        if pending_start is not None:
-                            extra_start_events.extend(
-                                ev
-                                for ev in pending_start.events
-                                if isinstance(ev, TextMessageStartEvent)
-                                and ev.message_id == message_id
-                            )
-                        else:
-                            extra_start_events.append(
-                                TextMessageStartEvent(message_id=message_id, role="assistant")
-                            )
-                    emitted_text_message_starts.add(message_id)
-                    moderated_response = moderated_response.model_copy(
-                        update={"events": extra_start_events + moderated_response.events}
-                    )
-                    if not prescore_state.prescore_attached and prescore_state.prescore_moderations:
-                        prescore_state.prescore_attached = True
-                        existing_mods = moderated_response.datarobot_moderations or {}
-                        moderated_response = moderated_response.model_copy(
-                            update={
-                                "datarobot_moderations": {
-                                    **prescore_state.prescore_moderations,
-                                    **existing_mods,
-                                }
-                            }
-                        )
                 _track_dragent_response_events(
                     open_text_message_ids, open_tool_call_ids, moderated_response
                 )
@@ -1581,22 +1566,16 @@ async def _moderated_dragent_stream(
                 for item in _drain_pending_after_moderated_chunk(
                     pending_deferred, pending_pass_through
                 ):
-                    _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-                    _record_emitted_text_message_starts(emitted_text_message_starts, item)
-                    yield prescore_state.emit(item)
+                    yield emit_buffered(item)
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
-                    for flushed in _flushed_deferred_tool_call_responses(open_tool_call_ids):
-                        _track_dragent_response_events(
-                            open_text_message_ids, open_tool_call_ids, flushed
-                        )
-                        yield flushed
-                    for end_response in _synthetic_tool_call_end_responses(open_tool_call_ids):
-                        yield end_response
-                    for end_response in _synthetic_text_message_end_responses(
-                        open_text_message_ids
+                    for closure in _lifecycle_closure_responses(
+                        open_text_message_ids, open_tool_call_ids
                     ):
-                        yield end_response
+                        _track_dragent_response_events(
+                            open_text_message_ids, open_tool_call_ids, closure
+                        )
+                        yield closure
                     stopped_for_content_filter = True
                     break
 
@@ -1607,13 +1586,9 @@ async def _moderated_dragent_stream(
                 open_text_message_ids,
                 open_tool_call_ids,
             ):
-                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-                _record_emitted_text_message_starts(emitted_text_message_starts, item)
-                yield prescore_state.emit(item)
+                yield emit_buffered(item)
             for item in pending_run_finished:
-                _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-                _record_emitted_text_message_starts(emitted_text_message_starts, item)
-                yield prescore_state.emit(item)
+                yield emit_buffered(item)
     finally:
         await _aclose_async_iterator(upstream)
 

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1248,19 +1248,36 @@ def _drain_pending_with_dangling_text_closed(
     return _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through)
 
 
-def _take_pending_text_message_starts(
+def _text_message_id_from_response(response: DRAgentEventResponse) -> str | None:
+    if not response.events:
+        return None
+    ev0 = response.events[0]
+    if isinstance(ev0, (TextMessageContentEvent, TextMessageChunkEvent)):
+        return ev0.message_id
+    return None
+
+
+def _record_emitted_text_message_starts(
+    emitted_message_ids: set[str], response: DRAgentEventResponse
+) -> None:
+    for event in response.events:
+        if isinstance(event, TextMessageStartEvent) and event.message_id:
+            emitted_message_ids.add(event.message_id)
+
+
+def _take_pending_text_message_start_for_message(
     pending_deferred: list[DRAgentEventResponse],
-) -> list[DRAgentEventResponse]:
-    """Remove and return buffered ``TEXT_MESSAGE_START`` events in upstream order."""
-    starts: list[DRAgentEventResponse] = []
-    remaining: list[DRAgentEventResponse] = []
-    for item in pending_deferred:
-        if item.events and item.events[0].type == EventType.TEXT_MESSAGE_START:
-            starts.append(item)
-        else:
-            remaining.append(item)
-    pending_deferred[:] = remaining
-    return starts
+    message_id: str,
+) -> DRAgentEventResponse | None:
+    """Remove and return a buffered ``TEXT_MESSAGE_START`` for *message_id* only."""
+    for index, item in enumerate(pending_deferred):
+        if (
+            item.events
+            and item.events[0].type == EventType.TEXT_MESSAGE_START
+            and item.events[0].message_id == message_id
+        ):
+            return pending_deferred.pop(index)
+    return None
 
 
 async def _aclose_async_iterator(iterator: AsyncGenerator[Any]) -> None:
@@ -1285,6 +1302,7 @@ async def _moderated_dragent_stream(
     """
     stream_tool_index_map: dict[int, str] = {}
     open_text_message_ids: set[str] = set()
+    emitted_text_message_starts: set[str] = set()
     pending_deferred: list[DRAgentEventResponse] = []
     pending_pass_through: list[DRAgentEventResponse] = []
     moderation_source_responses: list[DRAgentEventResponse] = []
@@ -1326,6 +1344,7 @@ async def _moderated_dragent_stream(
                 first_text = response
                 break
             _track_dragent_response_events(open_text_message_ids, response)
+            _record_emitted_text_message_starts(emitted_text_message_starts, response)
             yield prescore_state.emit(response)
         if first_text is None:
             return
@@ -1347,15 +1366,45 @@ async def _moderated_dragent_stream(
                         stream_tool_index_map=stream_tool_index_map,
                     )
                 )
-                for start_response in _take_pending_text_message_starts(pending_deferred):
-                    _track_dragent_response_events(open_text_message_ids, start_response)
-                    yield prescore_state.emit(start_response)
+                message_id = _text_message_id_from_response(source_response)
+                if (
+                    message_id
+                    and message_id not in emitted_text_message_starts
+                    and source_response.events
+                    and isinstance(source_response.events[0], TextMessageContentEvent)
+                ):
+                    extra_start_events: list[Any] = []
+                    pending_start = _take_pending_text_message_start_for_message(
+                        pending_deferred, message_id
+                    )
+                    if pending_start is not None:
+                        extra_start_events.extend(pending_start.events)
+                    else:
+                        extra_start_events.append(
+                            TextMessageStartEvent(message_id=message_id, role="assistant")
+                        )
+                    emitted_text_message_starts.add(message_id)
+                    moderated_response = moderated_response.model_copy(
+                        update={"events": extra_start_events + moderated_response.events}
+                    )
+                    if not prescore_state.prescore_attached and prescore_state.prescore_moderations:
+                        prescore_state.prescore_attached = True
+                        existing_mods = moderated_response.datarobot_moderations or {}
+                        moderated_response = moderated_response.model_copy(
+                            update={
+                                "datarobot_moderations": {
+                                    **prescore_state.prescore_moderations,
+                                    **existing_mods,
+                                }
+                            }
+                        )
                 _track_dragent_response_events(open_text_message_ids, moderated_response)
                 yield moderated_response
-                for item in _drain_pending_with_dangling_text_closed(
-                    pending_deferred, pending_pass_through, open_text_message_ids
+                for item in _drain_pending_after_moderated_chunk(
+                    pending_deferred, pending_pass_through
                 ):
                     _track_dragent_response_events(open_text_message_ids, item)
+                    _record_emitted_text_message_starts(emitted_text_message_starts, item)
                     yield prescore_state.emit(item)
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
@@ -1371,6 +1420,7 @@ async def _moderated_dragent_stream(
                 pending_deferred, pending_pass_through, open_text_message_ids
             ):
                 _track_dragent_response_events(open_text_message_ids, item)
+                _record_emitted_text_message_starts(emitted_text_message_starts, item)
                 yield prescore_state.emit(item)
     finally:
         await _aclose_async_iterator(upstream)

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -124,6 +124,7 @@ from datarobot_genai.dragent.frontends.converters import (
 )
 from datarobot_genai.dragent.frontends.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.dragent.frontends.tool_call_registry import mark_args_done
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
 from datarobot_genai.dragent.workflow_paths import discover_workflow_yaml
 from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
@@ -1273,6 +1274,39 @@ def _pending_tool_end_ids(pending_deferred: list[DRAgentEventResponse]) -> set[s
     }
 
 
+def _pending_tool_end_ids_in_responses(responses: list[DRAgentEventResponse]) -> set[str]:
+    """Collect ``tool_call_id`` values from ``TOOL_CALL_END`` events in *responses*."""
+    end_ids: set[str] = set()
+    for item in responses:
+        for event in item.events:
+            if isinstance(event, ToolCallEndEvent) and event.tool_call_id:
+                end_ids.add(event.tool_call_id)
+    return end_ids
+
+
+def _flushed_deferred_tool_call_responses(
+    open_tool_call_ids: set[str],
+) -> list[DRAgentEventResponse]:
+    """Return deferred ``TOOL_CALL_END``/``RESULT`` pairs from the stream-converter registry."""
+    zero = default_usage_metrics()
+    flushed: list[DRAgentEventResponse] = []
+    for tool_call_id in list(open_tool_call_ids):
+        deferred_events = mark_args_done(tool_call_id)
+        if deferred_events:
+            flushed.append(DRAgentEventResponse(events=deferred_events, usage_metrics=zero))
+    return flushed
+
+
+def _prepend_flushed_deferred_tool_call_responses(
+    pending_deferred: list[DRAgentEventResponse],
+    open_tool_call_ids: set[str],
+) -> None:
+    """Flush step-adaptor deferred ``TOOL_CALL_END``/``RESULT`` pairs before synthetic ends."""
+    flushed = _flushed_deferred_tool_call_responses(open_tool_call_ids)
+    if flushed:
+        pending_deferred[:0] = list(reversed(flushed))
+
+
 def _prepend_synthetic_text_message_ends_for_dangling_segments(
     pending_deferred: list[DRAgentEventResponse],
     open_text_message_ids: set[str],
@@ -1293,10 +1327,14 @@ def _prepend_synthetic_text_message_ends_for_dangling_segments(
 
 def _prepend_synthetic_tool_call_ends_for_dangling_calls(
     pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
     open_tool_call_ids: set[str],
 ) -> None:
     """Close dangling tool calls before ``RUN_FINISHED`` reaches the client."""
-    still_open = open_tool_call_ids - _pending_tool_end_ids(pending_deferred)
+    pending_ends = _pending_tool_end_ids(pending_deferred) | _pending_tool_end_ids_in_responses(
+        pending_pass_through
+    )
+    still_open = open_tool_call_ids - pending_ends
     if not still_open:
         return
     ids_to_close = set(still_open)
@@ -1311,7 +1349,16 @@ def _drain_pending_with_dangling_lifecycle_closed(
     open_tool_call_ids: set[str],
 ) -> list[DRAgentEventResponse]:
     """Drain pending events after closing dangling text segments and tool calls."""
-    _prepend_synthetic_tool_call_ends_for_dangling_calls(pending_deferred, open_tool_call_ids)
+    for item in pending_pass_through:
+        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
+    for item in pending_deferred:
+        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
+    _prepend_flushed_deferred_tool_call_responses(pending_deferred, open_tool_call_ids)
+    for item in pending_deferred:
+        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
+    _prepend_synthetic_tool_call_ends_for_dangling_calls(
+        pending_deferred, pending_pass_through, open_tool_call_ids
+    )
     _prepend_synthetic_text_message_ends_for_dangling_segments(
         pending_deferred, open_text_message_ids
     )
@@ -1520,6 +1567,11 @@ async def _moderated_dragent_stream(
                     yield prescore_state.emit(item)
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
+                    for flushed in _flushed_deferred_tool_call_responses(open_tool_call_ids):
+                        _track_dragent_response_events(
+                            open_text_message_ids, open_tool_call_ids, flushed
+                        )
+                        yield flushed
                     for end_response in _synthetic_tool_call_end_responses(open_tool_call_ids):
                         yield end_response
                     for end_response in _synthetic_text_message_end_responses(

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1112,7 +1112,7 @@ def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
     """Track assistant text segments that received content but did not end."""
     if isinstance(event, TextMessageEndEvent):
         open_message_ids.discard(event.message_id)
-    elif isinstance(event, TextMessageContentEvent):
+    elif isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
         if event.message_id:
             open_message_ids.add(event.message_id)
 
@@ -1173,11 +1173,12 @@ def _defer_until_after_moderated_chunk(event: Event) -> bool:
     If TEXT_MESSAGE_START for the next segment is yielded before moderated content for the
     previous segment, storage switches active_message and can drop or mis-attribute the
     last deltas (truncation in DB). TEXT_MESSAGE_END must stay after moderated text for AG-UI.
+
+    ``RUN_FINISHED`` is buffered separately and only emitted after dangling text segments close.
     """
     return event.type in (
         EventType.TEXT_MESSAGE_END,
         EventType.TEXT_MESSAGE_START,
-        EventType.RUN_FINISHED,
     )
 
 
@@ -1328,6 +1329,7 @@ async def _moderated_dragent_stream(
     emitted_text_message_starts: set[str] = set()
     pending_deferred: list[DRAgentEventResponse] = []
     pending_pass_through: list[DRAgentEventResponse] = []
+    pending_run_finished: list[DRAgentEventResponse] = []
     moderation_source_responses: list[DRAgentEventResponse] = []
     stopped_for_content_filter = False
     prescore_state = _StreamingPrescoreModerationState(
@@ -1338,7 +1340,9 @@ async def _moderated_dragent_stream(
     )
 
     def buffer_passthrough(response: DRAgentEventResponse) -> None:
-        if response.events and _defer_until_after_moderated_chunk(response.events[0]):
+        if response.events and response.events[0].type == EventType.RUN_FINISHED:
+            pending_run_finished.append(response)
+        elif response.events and _defer_until_after_moderated_chunk(response.events[0]):
             pending_deferred.append(response)
         else:
             pending_pass_through.append(response)
@@ -1450,6 +1454,10 @@ async def _moderated_dragent_stream(
             for item in _drain_pending_with_dangling_text_closed(
                 pending_deferred, pending_pass_through, open_text_message_ids
             ):
+                _track_dragent_response_events(open_text_message_ids, item)
+                _record_emitted_text_message_starts(emitted_text_message_starts, item)
+                yield prescore_state.emit(item)
+            for item in pending_run_finished:
                 _track_dragent_response_events(open_text_message_ids, item)
                 _record_emitted_text_message_starts(emitted_text_message_starts, item)
                 yield prescore_state.emit(item)

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -71,6 +71,7 @@ from ag_ui.core import TextMessageStartEvent
 from ag_ui.core import ToolCallArgsEvent
 from ag_ui.core import ToolCallChunkEvent
 from ag_ui.core import ToolCallEndEvent
+from ag_ui.core import ToolCallResultEvent
 from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import ToolMessage
 from ag_ui.core import UserMessage
@@ -1187,6 +1188,23 @@ def _response_has_assistant_text_deltas(response: DRAgentEventResponse) -> bool:
     )
 
 
+def _tool_lifecycle_passthrough_responses(
+    response: DRAgentEventResponse,
+) -> list[DRAgentEventResponse]:
+    """Re-emit tool end/result events from a moderated source batch.
+
+    ``dome_chunk_to_dragent_event_response`` rebuilds text from the moderated OpenAI
+    chunk and drops co-located ``TOOL_CALL_END`` / ``TOOL_CALL_RESULT`` events that
+    ``mark_args_done`` or the step adaptor attached to the same batch.
+    """
+    zero = default_usage_metrics()
+    return [
+        DRAgentEventResponse(events=[event], usage_metrics=zero)
+        for event in response.events
+        if isinstance(event, (ToolCallEndEvent, ToolCallResultEvent))
+    ]
+
+
 def _merge_moderations_into_multi_event_response(
     incoming: DRAgentEventResponse,
     moderated_completion_response: DRAgentEventResponse,
@@ -1559,6 +1577,7 @@ async def _moderated_dragent_stream(
                     open_text_message_ids, open_tool_call_ids, moderated_response
                 )
                 yield moderated_response
+                pending_pass_through.extend(_tool_lifecycle_passthrough_responses(source_response))
                 for item in _drain_pending_after_moderated_chunk(
                     pending_deferred, pending_pass_through
                 ):

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1098,10 +1098,8 @@ def skip_event_type(event: Event) -> bool:
 
 
 def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
-    """Track assistant text segments that started or received content but did not end."""
-    if isinstance(event, TextMessageStartEvent):
-        open_message_ids.add(event.message_id)
-    elif isinstance(event, TextMessageEndEvent):
+    """Track assistant text segments that received content but did not end."""
+    if isinstance(event, TextMessageEndEvent):
         open_message_ids.discard(event.message_id)
     elif isinstance(event, TextMessageContentEvent):
         if event.message_id:
@@ -1250,6 +1248,21 @@ def _drain_pending_with_dangling_text_closed(
     return _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through)
 
 
+def _take_pending_text_message_starts(
+    pending_deferred: list[DRAgentEventResponse],
+) -> list[DRAgentEventResponse]:
+    """Remove and return buffered ``TEXT_MESSAGE_START`` events in upstream order."""
+    starts: list[DRAgentEventResponse] = []
+    remaining: list[DRAgentEventResponse] = []
+    for item in pending_deferred:
+        if item.events and item.events[0].type == EventType.TEXT_MESSAGE_START:
+            starts.append(item)
+        else:
+            remaining.append(item)
+    pending_deferred[:] = remaining
+    return starts
+
+
 async def _aclose_async_iterator(iterator: AsyncGenerator[Any]) -> None:
     """Close an async generator, ignoring errors from double-close or partial consumption."""
     try:
@@ -1334,6 +1347,9 @@ async def _moderated_dragent_stream(
                         stream_tool_index_map=stream_tool_index_map,
                     )
                 )
+                for start_response in _take_pending_text_message_starts(pending_deferred):
+                    _track_dragent_response_events(open_text_message_ids, start_response)
+                    yield prescore_state.emit(start_response)
                 _track_dragent_response_events(open_text_message_ids, moderated_response)
                 yield moderated_response
                 for item in _drain_pending_with_dangling_text_closed(

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -405,6 +405,15 @@ def _openai_chat_completion_chunk_to_nat_chat_response_chunk(
     )
 
 
+def _first_text_delta_in_events(
+    events: list[Any],
+) -> TextMessageContentEvent | TextMessageChunkEvent | None:
+    for event in events:
+        if isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
+            return event
+    return None
+
+
 def _streaming_text_events_from_openai_chunk(
     completion: ChatCompletionChunk,
     source_ag_ui_events: list[Any] | None,
@@ -413,16 +422,18 @@ def _streaming_text_events_from_openai_chunk(
     delta_content = completion.choices[0].delta.content
     text = "" if delta_content is None else delta_content
     if source_ag_ui_events:
-        ev0 = source_ag_ui_events[0]
-        if isinstance(ev0, TextMessageContentEvent):
+        delta_event = _first_text_delta_in_events(source_ag_ui_events)
+        if isinstance(delta_event, TextMessageContentEvent):
             if text:
-                return [TextMessageContentEvent(message_id=ev0.message_id, delta=text)]
-            return [TextMessageChunkEvent(message_id=ev0.message_id, role="assistant", delta="")]
-        if isinstance(ev0, TextMessageChunkEvent):
+                return [TextMessageContentEvent(message_id=delta_event.message_id, delta=text)]
+            return [
+                TextMessageChunkEvent(message_id=delta_event.message_id, role="assistant", delta="")
+            ]
+        if isinstance(delta_event, TextMessageChunkEvent):
             return [
                 TextMessageChunkEvent(
-                    message_id=ev0.message_id,
-                    role=ev0.role,
+                    message_id=delta_event.message_id,
+                    role=delta_event.role,
                     delta=text or "",
                 )
             ]
@@ -583,7 +594,7 @@ def _postscore_only_datarobot_moderations(
 
 
 def _is_text_message_start_response(response: DRAgentEventResponse) -> bool:
-    return bool(response.events and response.events[0].type == EventType.TEXT_MESSAGE_START)
+    return any(isinstance(ev, TextMessageStartEvent) for ev in response.events)
 
 
 @dataclass
@@ -1248,13 +1259,26 @@ def _drain_pending_with_dangling_text_closed(
     return _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through)
 
 
+def _first_text_delta_event(
+    response: DRAgentEventResponse,
+) -> TextMessageContentEvent | TextMessageChunkEvent | None:
+    return _first_text_delta_in_events(response.events)
+
+
+def _leading_text_message_starts(response: DRAgentEventResponse) -> list[TextMessageStartEvent]:
+    """Return ``TEXT_MESSAGE_START`` events that precede the first text delta in *response*."""
+    starts: list[TextMessageStartEvent] = []
+    for event in response.events:
+        if isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
+            break
+        if isinstance(event, TextMessageStartEvent):
+            starts.append(event)
+    return starts
+
+
 def _text_message_id_from_response(response: DRAgentEventResponse) -> str | None:
-    if not response.events:
-        return None
-    ev0 = response.events[0]
-    if isinstance(ev0, (TextMessageContentEvent, TextMessageChunkEvent)):
-        return ev0.message_id
-    return None
+    delta_event = _first_text_delta_event(response)
+    return delta_event.message_id if delta_event is not None else None
 
 
 def _record_emitted_text_message_starts(
@@ -1271,10 +1295,9 @@ def _take_pending_text_message_start_for_message(
 ) -> DRAgentEventResponse | None:
     """Remove and return a buffered ``TEXT_MESSAGE_START`` for *message_id* only."""
     for index, item in enumerate(pending_deferred):
-        if (
-            item.events
-            and item.events[0].type == EventType.TEXT_MESSAGE_START
-            and item.events[0].message_id == message_id
+        if any(
+            isinstance(event, TextMessageStartEvent) and event.message_id == message_id
+            for event in item.events
         ):
             return pending_deferred.pop(index)
     return None
@@ -1322,7 +1345,7 @@ async def _moderated_dragent_stream(
 
     async def next_text_response() -> DRAgentEventResponse | None:
         async for response in upstream:
-            if not response.events or skip_event_type(response.events[0]):
+            if not response.events or not _response_has_assistant_text_deltas(response):
                 buffer_passthrough(response)
                 continue
             return response
@@ -1340,7 +1363,7 @@ async def _moderated_dragent_stream(
     first_text: DRAgentEventResponse | None = None
     try:
         async for response in upstream:
-            if response.events and not skip_event_type(response.events[0]):
+            if response.events and _response_has_assistant_text_deltas(response):
                 first_text = response
                 break
             _track_dragent_response_events(open_text_message_ids, response)
@@ -1367,22 +1390,30 @@ async def _moderated_dragent_stream(
                     )
                 )
                 message_id = _text_message_id_from_response(source_response)
+                first_delta = _first_text_delta_event(source_response)
                 if (
                     message_id
                     and message_id not in emitted_text_message_starts
-                    and source_response.events
-                    and isinstance(source_response.events[0], TextMessageContentEvent)
+                    and first_delta is not None
                 ):
-                    extra_start_events: list[Any] = []
-                    pending_start = _take_pending_text_message_start_for_message(
-                        pending_deferred, message_id
+                    extra_start_events: list[Any] = list(
+                        _leading_text_message_starts(source_response)
                     )
-                    if pending_start is not None:
-                        extra_start_events.extend(pending_start.events)
-                    else:
-                        extra_start_events.append(
-                            TextMessageStartEvent(message_id=message_id, role="assistant")
+                    if not extra_start_events:
+                        pending_start = _take_pending_text_message_start_for_message(
+                            pending_deferred, message_id
                         )
+                        if pending_start is not None:
+                            extra_start_events.extend(
+                                ev
+                                for ev in pending_start.events
+                                if isinstance(ev, TextMessageStartEvent)
+                                and ev.message_id == message_id
+                            )
+                        else:
+                            extra_start_events.append(
+                                TextMessageStartEvent(message_id=message_id, role="assistant")
+                            )
                     emitted_text_message_starts.add(message_id)
                     moderated_response = moderated_response.model_copy(
                         update={"events": extra_start_events + moderated_response.events}

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -48,6 +48,7 @@ import uuid
 from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from dataclasses import field
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
@@ -1117,6 +1118,93 @@ def _prompt_sent_after_prescore_replacement(
 #    the source batch after each moderated chunk.
 
 
+@dataclass
+class _StreamLifecycleState:
+    """Mutable buffers and open-segment trackers for moderated DRAgent streaming."""
+
+    open_text_message_ids: set[str] = field(default_factory=set)
+    open_tool_call_ids: set[str] = field(default_factory=set)
+    emitted_text_message_starts: set[str] = field(default_factory=set)
+    pending_deferred: list[DRAgentEventResponse] = field(default_factory=list)
+    pending_pass_through: list[DRAgentEventResponse] = field(default_factory=list)
+    pending_run_finished: list[DRAgentEventResponse] = field(default_factory=list)
+
+    def track_response(self, response: DRAgentEventResponse) -> None:
+        for event in response.events:
+            _track_open_text_message(self.open_text_message_ids, event)
+            _track_open_tool_call(self.open_tool_call_ids, event)
+        for event in response.events:
+            if isinstance(event, TextMessageStartEvent) and event.message_id:
+                self.emitted_text_message_starts.add(event.message_id)
+
+    def buffer_passthrough(self, response: DRAgentEventResponse) -> None:
+        if response.events and response.events[0].type == EventType.RUN_FINISHED:
+            self.pending_run_finished.append(response)
+        elif response.events and _defer_until_after_moderated_chunk(response.events[0]):
+            self.pending_deferred.append(response)
+        else:
+            self.pending_pass_through.append(response)
+
+    def drain_pending_after_moderated_chunk(self) -> list[DRAgentEventResponse]:
+        ordered = _pending_after_moderated_chunk(self.pending_deferred, self.pending_pass_through)
+        self.pending_deferred.clear()
+        self.pending_pass_through.clear()
+        return ordered
+
+    def prepare_pending_lifecycle_closure(self) -> None:
+        """Track buffered events, flush deferred tool results, prepend synthetic closes."""
+        for batch in (self.pending_pass_through, self.pending_deferred):
+            for item in batch:
+                self.track_response(item)
+
+        flushed = _flushed_deferred_tool_call_responses(self.open_tool_call_ids)
+        if flushed:
+            self.pending_deferred[:0] = list(reversed(flushed))
+            for item in flushed:
+                self.track_response(item)
+
+        pending_tool_ends = _tool_call_end_ids_in_responses(
+            self.pending_deferred + self.pending_pass_through
+        )
+        still_open_tools = self.open_tool_call_ids - pending_tool_ends
+        if still_open_tools:
+            ids_to_close = set(still_open_tools)
+            self.pending_deferred[:0] = _synthetic_tool_call_end_responses(ids_to_close)
+            self.open_tool_call_ids.difference_update(ids_to_close)
+
+        still_open_text = self.open_text_message_ids - _pending_end_message_ids(
+            self.pending_deferred
+        )
+        if still_open_text:
+            ids_to_close = set(still_open_text)
+            self.pending_deferred[:0] = _synthetic_text_message_end_responses(ids_to_close)
+            self.open_text_message_ids.difference_update(ids_to_close)
+
+    def lifecycle_closure_responses(self) -> list[DRAgentEventResponse]:
+        """Flush deferred tool results and synthesize dangling text/tool closes."""
+        responses = _flushed_deferred_tool_call_responses(self.open_tool_call_ids)
+        if self.open_tool_call_ids:
+            responses.extend(_synthetic_tool_call_end_responses(set(self.open_tool_call_ids)))
+        if self.open_text_message_ids:
+            responses.extend(_synthetic_text_message_end_responses(set(self.open_text_message_ids)))
+        return responses
+
+    def drain_pending_with_dangling_lifecycle_closed(self) -> list[DRAgentEventResponse]:
+        """Drain pending events after closing dangling text segments and tool calls."""
+        self.prepare_pending_lifecycle_closure()
+        return self.drain_pending_after_moderated_chunk()
+
+    def take_pending_text_message_start(self, message_id: str) -> DRAgentEventResponse | None:
+        """Remove and return a buffered ``TEXT_MESSAGE_START`` for *message_id* only."""
+        for index, item in enumerate(self.pending_deferred):
+            if any(
+                isinstance(event, TextMessageStartEvent) and event.message_id == message_id
+                for event in item.events
+            ):
+                return self.pending_deferred.pop(index)
+        return None
+
+
 def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
     """Track assistant text segments that received content but did not end."""
     if isinstance(event, TextMessageEndEvent):
@@ -1174,16 +1262,6 @@ def _synthetic_tool_call_end_responses(
 ) -> list[DRAgentEventResponse]:
     """Wrap synthetic ``TOOL_CALL_END`` events as ``DRAgentEventResponse`` batches."""
     return _zero_metric_event_responses(_synthetic_tool_call_end_events(open_tool_call_ids))
-
-
-def _track_dragent_response_events(
-    open_message_ids: set[str],
-    open_tool_call_ids: set[str],
-    response: DRAgentEventResponse,
-) -> None:
-    for event in response.events:
-        _track_open_text_message(open_message_ids, event)
-        _track_open_tool_call(open_tool_call_ids, event)
 
 
 def _response_has_assistant_text_deltas(response: DRAgentEventResponse) -> bool:
@@ -1270,16 +1348,6 @@ def _pending_after_moderated_chunk(
     return deferred_ends + list(pending_pass_through) + deferred_starts + deferred_other
 
 
-def _drain_pending_after_moderated_chunk(
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
-) -> list[DRAgentEventResponse]:
-    ordered = _pending_after_moderated_chunk(pending_deferred, pending_pass_through)
-    pending_deferred.clear()
-    pending_pass_through.clear()
-    return ordered
-
-
 def _pending_end_message_ids(pending_deferred: list[DRAgentEventResponse]) -> set[str]:
     return {
         item.events[0].message_id
@@ -1313,63 +1381,6 @@ def _flushed_deferred_tool_call_responses(
     return flushed
 
 
-def _prepare_pending_lifecycle_closure(
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
-    open_text_message_ids: set[str],
-    open_tool_call_ids: set[str],
-) -> None:
-    """Track buffered events, flush deferred tool results, prepend synthetic closes."""
-    for batch in (pending_pass_through, pending_deferred):
-        for item in batch:
-            _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-
-    flushed = _flushed_deferred_tool_call_responses(open_tool_call_ids)
-    if flushed:
-        pending_deferred[:0] = list(reversed(flushed))
-        for item in flushed:
-            _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, item)
-
-    pending_tool_ends = _tool_call_end_ids_in_responses(pending_deferred + pending_pass_through)
-    still_open_tools = open_tool_call_ids - pending_tool_ends
-    if still_open_tools:
-        ids_to_close = set(still_open_tools)
-        pending_deferred[:0] = _synthetic_tool_call_end_responses(ids_to_close)
-        open_tool_call_ids.difference_update(ids_to_close)
-
-    still_open_text = open_text_message_ids - _pending_end_message_ids(pending_deferred)
-    if still_open_text:
-        ids_to_close = set(still_open_text)
-        pending_deferred[:0] = _synthetic_text_message_end_responses(ids_to_close)
-        open_text_message_ids.difference_update(ids_to_close)
-
-
-def _lifecycle_closure_responses(
-    open_text_message_ids: set[str],
-    open_tool_call_ids: set[str],
-) -> list[DRAgentEventResponse]:
-    """Flush deferred tool results and synthesize dangling text/tool closes."""
-    responses = _flushed_deferred_tool_call_responses(open_tool_call_ids)
-    if open_tool_call_ids:
-        responses.extend(_synthetic_tool_call_end_responses(set(open_tool_call_ids)))
-    if open_text_message_ids:
-        responses.extend(_synthetic_text_message_end_responses(set(open_text_message_ids)))
-    return responses
-
-
-def _drain_pending_with_dangling_lifecycle_closed(
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
-    open_text_message_ids: set[str],
-    open_tool_call_ids: set[str],
-) -> list[DRAgentEventResponse]:
-    """Drain pending events after closing dangling text segments and tool calls."""
-    _prepare_pending_lifecycle_closure(
-        pending_deferred, pending_pass_through, open_text_message_ids, open_tool_call_ids
-    )
-    return _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through)
-
-
 def _first_text_delta_event(
     response: DRAgentEventResponse,
 ) -> TextMessageContentEvent | TextMessageChunkEvent | None:
@@ -1392,47 +1403,26 @@ def _text_message_id_from_response(response: DRAgentEventResponse) -> str | None
     return delta_event.message_id if delta_event is not None else None
 
 
-def _record_emitted_text_message_starts(
-    emitted_message_ids: set[str], response: DRAgentEventResponse
-) -> None:
-    for event in response.events:
-        if isinstance(event, TextMessageStartEvent) and event.message_id:
-            emitted_message_ids.add(event.message_id)
-
-
-def _take_pending_text_message_start_for_message(
-    pending_deferred: list[DRAgentEventResponse],
-    message_id: str,
-) -> DRAgentEventResponse | None:
-    """Remove and return a buffered ``TEXT_MESSAGE_START`` for *message_id* only."""
-    for index, item in enumerate(pending_deferred):
-        if any(
-            isinstance(event, TextMessageStartEvent) and event.message_id == message_id
-            for event in item.events
-        ):
-            return pending_deferred.pop(index)
-    return None
-
-
 def _with_text_message_start_if_needed(
     moderated_response: DRAgentEventResponse,
     source_response: DRAgentEventResponse,
     *,
-    emitted_text_message_starts: set[str],
-    pending_deferred: list[DRAgentEventResponse],
+    lifecycle: _StreamLifecycleState,
     prescore_state: _StreamingPrescoreModerationState,
 ) -> DRAgentEventResponse:
     """Prepend ``TEXT_MESSAGE_START`` (and prescore mods) before the first moderated delta."""
     message_id = _text_message_id_from_response(source_response)
     first_delta = _first_text_delta_event(source_response)
     if not (
-        message_id and message_id not in emitted_text_message_starts and first_delta is not None
+        message_id
+        and message_id not in lifecycle.emitted_text_message_starts
+        and first_delta is not None
     ):
         return moderated_response
 
     extra_start_events: list[Any] = list(_leading_text_message_starts(source_response))
     if not extra_start_events:
-        pending_start = _take_pending_text_message_start_for_message(pending_deferred, message_id)
+        pending_start = lifecycle.take_pending_text_message_start(message_id)
         if pending_start is not None:
             extra_start_events.extend(
                 ev
@@ -1443,7 +1433,7 @@ def _with_text_message_start_if_needed(
             extra_start_events.append(
                 TextMessageStartEvent(message_id=message_id, role="assistant")
             )
-    emitted_text_message_starts.add(message_id)
+    lifecycle.emitted_text_message_starts.add(message_id)
     moderated_response = moderated_response.model_copy(
         update={"events": extra_start_events + moderated_response.events}
     )
@@ -1482,12 +1472,7 @@ async def _moderated_dragent_stream(
     during peek-ahead are buffered and emitted after each moderated chunk.
     """
     stream_tool_index_map: dict[int, str] = {}
-    open_text_message_ids: set[str] = set()
-    open_tool_call_ids: set[str] = set()
-    emitted_text_message_starts: set[str] = set()
-    pending_deferred: list[DRAgentEventResponse] = []
-    pending_pass_through: list[DRAgentEventResponse] = []
-    pending_run_finished: list[DRAgentEventResponse] = []
+    lifecycle = _StreamLifecycleState()
     moderation_source_responses: list[DRAgentEventResponse] = []
     stopped_for_content_filter = False
     prescore_state = _StreamingPrescoreModerationState(
@@ -1498,22 +1483,13 @@ async def _moderated_dragent_stream(
     )
 
     def emit_buffered(response: DRAgentEventResponse) -> DRAgentEventResponse:
-        _track_dragent_response_events(open_text_message_ids, open_tool_call_ids, response)
-        _record_emitted_text_message_starts(emitted_text_message_starts, response)
+        lifecycle.track_response(response)
         return prescore_state.emit(response)
-
-    def buffer_passthrough(response: DRAgentEventResponse) -> None:
-        if response.events and response.events[0].type == EventType.RUN_FINISHED:
-            pending_run_finished.append(response)
-        elif response.events and _defer_until_after_moderated_chunk(response.events[0]):
-            pending_deferred.append(response)
-        else:
-            pending_pass_through.append(response)
 
     async def next_text_response() -> DRAgentEventResponse | None:
         async for response in upstream:
             if not response.events or not _response_has_assistant_text_deltas(response):
-                buffer_passthrough(response)
+                lifecycle.buffer_passthrough(response)
                 continue
             return response
         return None
@@ -1534,18 +1510,13 @@ async def _moderated_dragent_stream(
                 first_text = response
                 break
             if response.events and response.events[0].type == EventType.RUN_FINISHED:
-                pending_run_finished.append(response)
+                lifecycle.pending_run_finished.append(response)
             else:
                 yield emit_buffered(response)
         if first_text is None:
-            for item in _drain_pending_with_dangling_lifecycle_closed(
-                pending_deferred,
-                pending_pass_through,
-                open_text_message_ids,
-                open_tool_call_ids,
-            ):
+            for item in lifecycle.drain_pending_with_dangling_lifecycle_closed():
                 yield emit_buffered(item)
-            for item in pending_run_finished:
+            for item in lifecycle.pending_run_finished:
                 yield emit_buffered(item)
             return
 
@@ -1568,40 +1539,28 @@ async def _moderated_dragent_stream(
                         )
                     ),
                     source_response,
-                    emitted_text_message_starts=emitted_text_message_starts,
-                    pending_deferred=pending_deferred,
+                    lifecycle=lifecycle,
                     prescore_state=prescore_state,
                 )
-                _track_dragent_response_events(
-                    open_text_message_ids, open_tool_call_ids, moderated_response
-                )
+                lifecycle.track_response(moderated_response)
                 yield moderated_response
-                pending_pass_through.extend(_tool_lifecycle_passthrough_responses(source_response))
-                for item in _drain_pending_after_moderated_chunk(
-                    pending_deferred, pending_pass_through
-                ):
+                lifecycle.pending_pass_through.extend(
+                    _tool_lifecycle_passthrough_responses(source_response)
+                )
+                for item in lifecycle.drain_pending_after_moderated_chunk():
                     yield emit_buffered(item)
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
-                    for closure in _lifecycle_closure_responses(
-                        open_text_message_ids, open_tool_call_ids
-                    ):
-                        _track_dragent_response_events(
-                            open_text_message_ids, open_tool_call_ids, closure
-                        )
+                    for closure in lifecycle.lifecycle_closure_responses():
+                        lifecycle.track_response(closure)
                         yield closure
                     stopped_for_content_filter = True
                     break
 
         if not stopped_for_content_filter:
-            for item in _drain_pending_with_dangling_lifecycle_closed(
-                pending_deferred,
-                pending_pass_through,
-                open_text_message_ids,
-                open_tool_call_ids,
-            ):
+            for item in lifecycle.drain_pending_with_dangling_lifecycle_closed():
                 yield emit_buffered(item)
-            for item in pending_run_finished:
+            for item in lifecycle.pending_run_finished:
                 yield emit_buffered(item)
     finally:
         await _aclose_async_iterator(upstream)

--- a/src/datarobot_genai/nat/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/nat/datarobot_moderation_middleware.py
@@ -1103,7 +1103,7 @@ def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
         open_message_ids.add(event.message_id)
     elif isinstance(event, TextMessageEndEvent):
         open_message_ids.discard(event.message_id)
-    elif isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
+    elif isinstance(event, TextMessageContentEvent):
         if event.message_id:
             open_message_ids.add(event.message_id)
 
@@ -1168,6 +1168,7 @@ def _defer_until_after_moderated_chunk(event: Event) -> bool:
     return event.type in (
         EventType.TEXT_MESSAGE_END,
         EventType.TEXT_MESSAGE_START,
+        EventType.RUN_FINISHED,
     )
 
 
@@ -1207,6 +1208,46 @@ def _drain_pending_after_moderated_chunk(
     pending_deferred.clear()
     pending_pass_through.clear()
     return ordered
+
+
+def _pending_end_message_ids(pending_deferred: list[DRAgentEventResponse]) -> set[str]:
+    return {
+        item.events[0].message_id
+        for item in pending_deferred
+        if item.events
+        and item.events[0].type == EventType.TEXT_MESSAGE_END
+        and item.events[0].message_id
+    }
+
+
+def _prepend_synthetic_text_message_ends_for_dangling_segments(
+    pending_deferred: list[DRAgentEventResponse],
+    open_text_message_ids: set[str],
+) -> None:
+    """Close dangling text segments before ``RUN_FINISHED`` reaches the client.
+
+    ``TEXT_MESSAGE_CHUNK`` responses (and other deltas without a matching upstream END) leave
+    message ids in ``open_text_message_ids``. Synthetic ends are prepended to the deferred
+    queue so they drain before pass-through lifecycle events such as ``RUN_FINISHED``.
+    """
+    still_open = open_text_message_ids - _pending_end_message_ids(pending_deferred)
+    if not still_open:
+        return
+    ids_to_close = set(still_open)
+    pending_deferred[:0] = _synthetic_text_message_end_responses(ids_to_close)
+    open_text_message_ids.difference_update(ids_to_close)
+
+
+def _drain_pending_with_dangling_text_closed(
+    pending_deferred: list[DRAgentEventResponse],
+    pending_pass_through: list[DRAgentEventResponse],
+    open_text_message_ids: set[str],
+) -> list[DRAgentEventResponse]:
+    """Drain pending events after closing any dangling text segments."""
+    _prepend_synthetic_text_message_ends_for_dangling_segments(
+        pending_deferred, open_text_message_ids
+    )
+    return _drain_pending_after_moderated_chunk(pending_deferred, pending_pass_through)
 
 
 async def _aclose_async_iterator(iterator: AsyncGenerator[Any]) -> None:
@@ -1295,8 +1336,8 @@ async def _moderated_dragent_stream(
                 )
                 _track_dragent_response_events(open_text_message_ids, moderated_response)
                 yield moderated_response
-                for item in _drain_pending_after_moderated_chunk(
-                    pending_deferred, pending_pass_through
+                for item in _drain_pending_with_dangling_text_closed(
+                    pending_deferred, pending_pass_through, open_text_message_ids
                 ):
                     _track_dragent_response_events(open_text_message_ids, item)
                     yield prescore_state.emit(item)
@@ -1310,13 +1351,11 @@ async def _moderated_dragent_stream(
                     break
 
         if not stopped_for_content_filter:
-            for item in _drain_pending_after_moderated_chunk(
-                pending_deferred, pending_pass_through
+            for item in _drain_pending_with_dangling_text_closed(
+                pending_deferred, pending_pass_through, open_text_message_ids
             ):
                 _track_dragent_response_events(open_text_message_ids, item)
                 yield prescore_state.emit(item)
-            for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
-                yield end_response
     finally:
         await _aclose_async_iterator(upstream)
 

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -661,6 +661,25 @@ async def test_invoke_streaming_falls_back_to_result_when_no_text_chunks(
     assert contents[0].delta == "final from result"
 
 
+async def test_invoke_streaming_emits_crew_result_after_react_stream(
+    mock_ragas_event_listener, run_agent_input
+) -> None:
+    # GIVEN streamed ReAct scaffolding and a clean kickoff result
+    chunks = [
+        _text_chunk("Thought: plan\nAction: tool\nAction Input: x\n", "Planner"),
+    ]
+    result = CrewOutput(raw="69cbb73789723b6936c6c9e1")
+    streaming = _FakeStreamingOutput(chunks, result)
+    agent = AgentForTest(api_base="https://x/", api_key="k", verbose=False)
+    agent._crew_for_test = CrewForTest(streaming)
+
+    events = [e async for (e, _, _) in agent.invoke(run_agent_input)]
+
+    validate_sequence(events)
+    contents = [e for e in events if isinstance(e, TextMessageContentEvent)]
+    assert any(c.delta == "69cbb73789723b6936c6c9e1" for c in contents)
+
+
 async def test_invoke_streaming_single_agent_role_uses_single_message(
     mock_ragas_event_listener, run_agent_input
 ) -> None:

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -638,6 +638,25 @@ async def test_invoke_streaming_skips_empty_text_chunks(
     assert all(c.delta for c in contents)
 
 
+async def test_invoke_streaming_falls_back_to_result_when_no_text_chunks(
+    mock_ragas_event_listener, run_agent_input
+) -> None:
+    # GIVEN a streaming crew that completes without TEXT stream chunks
+    result = CrewOutput(raw="final from result")
+    streaming = _FakeStreamingOutput([], result)
+    agent = AgentForTest(api_base="https://x/", api_key="k", verbose=False)
+    agent._crew_for_test = CrewForTest(streaming)
+
+    # WHEN we collect the AG-UI event stream
+    events = [e async for (e, _, _) in agent.invoke(run_agent_input)]
+
+    # THEN the sequence is valid and the final kickoff result is emitted once
+    validate_sequence(events)
+    chunks = [e for e in events if isinstance(e, TextMessageChunkEvent)]
+    assert len(chunks) == 1
+    assert chunks[0].delta == "final from result"
+
+
 async def test_invoke_streaming_single_agent_role_uses_single_message(
     mock_ragas_event_listener, run_agent_input
 ) -> None:

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -67,7 +67,7 @@ class CrewForTest:
         self.output = output
         self.verbose = True
 
-    async def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[name-defined]
+    async def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[name-defined]
         return self.output or CrewOutput(raw="final-output")
 
 
@@ -220,9 +220,9 @@ async def test_invoke_does_not_include_chat_history_by_default(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     out = CrewOutput(raw="agent result")
     agent = AgentForTest(
@@ -241,9 +241,9 @@ async def test_invoke_overwrites_blank_chat_history_placeholder(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     class AgentWithPlaceholder(AgentForTest):
         def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
@@ -272,9 +272,9 @@ async def test_invoke_does_not_overwrite_non_empty_chat_history_override(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     class AgentWithOverride(AgentForTest):
         def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
@@ -297,9 +297,9 @@ async def test_invoke_includes_tool_calls_in_history(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     class AgentWithPlaceholder(AgentForTest):
         def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -652,9 +652,13 @@ async def test_invoke_streaming_falls_back_to_result_when_no_text_chunks(
 
     # THEN the sequence is valid and the final kickoff result is emitted once
     validate_sequence(events)
-    chunks = [e for e in events if isinstance(e, TextMessageChunkEvent)]
-    assert len(chunks) == 1
-    assert chunks[0].delta == "final from result"
+    starts = [e for e in events if isinstance(e, TextMessageStartEvent)]
+    ends = [e for e in events if isinstance(e, TextMessageEndEvent)]
+    contents = [e for e in events if isinstance(e, TextMessageContentEvent)]
+    assert len(starts) == 1
+    assert len(ends) == 1
+    assert len(contents) == 1
+    assert contents[0].delta == "final from result"
 
 
 async def test_invoke_streaming_single_agent_role_uses_single_message(

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -279,6 +279,26 @@ async def test_litellm_stop_word_llm_acall_applies_stop_words(
     assert "Final Answer:" not in result
 
 
+def test_litellm_stop_word_llm_truncates_inline_react_after_action_input(
+    stop_word_llm: LitellmStopWordLLM,
+) -> None:
+    """Models may hallucinate a second ``Thought`` without an ``Observation:`` label."""
+    hallucinated = (
+        "Thought: you should always think about what to do\n"
+        "Action: generate_objectid\n"
+        'Action Input: {"type":"deployment"}\n'
+        "dff6ff5bc0f04cf69bf4c020cff634c0Thought: you should always think about what to do\n"
+        "Action: generate_objectid\n"
+    )
+    with patch.object(LLM, "call", return_value=hallucinated):
+        result = stop_word_llm.call("test message")
+    assert result == (
+        "Thought: you should always think about what to do\n"
+        "Action: generate_objectid\n"
+        'Action Input: {"type":"deployment"}'
+    )
+
+
 def test_litellm_stop_word_llm_call_no_stop_words_returns_unchanged() -> None:
     """Without stop words configured, responses pass through unchanged."""
     llm = LitellmStopWordLLM(model="openai/gpt-4o")

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -261,6 +261,24 @@ def test_litellm_stop_word_llm_call_applies_stop_words(
     assert "Final Answer:" not in result
 
 
+async def test_litellm_stop_word_llm_acall_applies_stop_words(
+    stop_word_llm: LitellmStopWordLLM,
+) -> None:
+    """Async kickoff uses ``acall``; stop words must truncate there too."""
+    hallucinated = (
+        "Thought: I need to search.\n"
+        "Action: search\n"
+        "Action Input: query\n"
+        "Observation: fake result\n"
+        "Final Answer: hallucinated"
+    )
+    with patch.object(LLM, "acall", return_value=hallucinated):
+        result = await stop_word_llm.acall("test message")
+    assert result == "Thought: I need to search.\nAction: search\nAction Input: query"
+    assert "Observation:" not in result
+    assert "Final Answer:" not in result
+
+
 def test_litellm_stop_word_llm_call_no_stop_words_returns_unchanged() -> None:
     """Without stop words configured, responses pass through unchanged."""
     llm = LitellmStopWordLLM(model="openai/gpt-4o")

--- a/tests/llamaindex/test_agent.py
+++ b/tests/llamaindex/test_agent.py
@@ -737,6 +737,36 @@ async def test_invoke_tool_result_message_id_is_distinct_from_text_bubbles(
     assert text_starts[0].message_id != text_starts[1].message_id
 
 
+async def test_invoke_emits_partial_stream_then_agent_output_suffix(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """Partial AgentStream deltas plus a full AgentOutput must emit the complete text."""
+    full_id = "69cbb73789723b6936c6c9e1"
+    partial_id = full_id[:12]
+    workflow = Workflow(
+        events=[
+            AgentWorkflowStartEvent(),
+            AgentInput(
+                input=[ChatMessage(content="generate id", role=MessageRole.USER)],
+                current_agent_name="A",
+            ),
+            AgentStream(delta=partial_id, response="", current_agent_name="A"),
+            AgentOutput(
+                response=ChatMessage(content=full_id, role=MessageRole.ASSISTANT),
+                current_agent_name="A",
+            ),
+        ],
+        state="S",
+    )
+    agent = MyLlamaAgent(workflow)
+
+    ag_events = [e async for e, _, _ in agent.invoke(run_agent_input)]
+
+    validate_sequence(ag_events)
+    contents = [e for e in ag_events if isinstance(e, TextMessageContentEvent)]
+    assert "".join(e.delta for e in contents) == full_id
+
+
 async def test_invoke_agent_stream_multiple_agents(
     run_agent_input: RunAgentInput,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2380,6 +2380,64 @@ async def test_function_middleware_stream_preserves_message_id_per_text_chunk(
     assert content_events[1].delta == "b"
 
 
+async def test_function_middleware_stream_moderates_start_and_content_batch(
+    builder_mock: MagicMock,
+) -> None:
+    """``convert_chunks_to_agui_events`` batches START+CONTENT; moderation must not drop text."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hello")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    mid = "msg-stream"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                TextMessageStartEvent(message_id=mid, role="assistant"),
+                TextMessageContentEvent(message_id=mid, delta="hello"),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid)],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    content_events = [e for e in flat if isinstance(e, TextMessageContentEvent)]
+    assert "".join(e.delta for e in content_events) == "hello"
+    start_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TEXT_MESSAGE_START)
+    content_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TEXT_MESSAGE_CONTENT)
+    assert start_idx < content_idx
+
+
 async def test_function_middleware_stream_defers_text_message_end_before_run_finished(
     builder_mock: MagicMock,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2494,6 +2494,63 @@ async def test_function_middleware_stream_chunk_only_upstream_passes_ag_ui_valid
     assert all(end_idx < finished_idx for end_idx in end_indices)
 
 
+async def test_function_middleware_stream_emits_deferred_start_before_content(
+    builder_mock: MagicMock,
+) -> None:
+    """Buffered ``TEXT_MESSAGE_START`` must precede the moderated ``CONTENT`` for that segment."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hello")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    mid = "msg-1"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid, role="assistant")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid, delta="hello")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid)],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    start_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TEXT_MESSAGE_START)
+    content_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TEXT_MESSAGE_CONTENT)
+    assert start_idx < content_idx
+
+
 async def test_function_middleware_stream_preserves_step_order_at_agent_transition(
     builder_mock: MagicMock,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2554,14 +2554,16 @@ async def test_function_middleware_stream_chunk_only_upstream_passes_ag_ui_valid
     assert all(end_idx < finished_idx for end_idx in end_indices)
 
 
+@pytest.mark.parametrize("text_delta", ["hello", None], ids=["with_text", "tool_only"])
 async def test_function_middleware_stream_closes_dangling_tool_calls_before_run_finished(
     builder_mock: MagicMock,
+    text_delta: str | None,
 ) -> None:
-    """``TOOL_CALL_START`` without ``TOOL_CALL_END`` must finish before ``RUN_FINISHED``."""
+    """``TOOL_CALL_START`` without upstream ``TOOL_CALL_END`` must close before ``RUN_FINISHED``."""
     pipeline = _pipeline_mock()
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
-    prescore_df = _prescore_df_ok("hello")
+    prescore_df = _prescore_df_ok(text_delta or "hello")
     _set_evaluate_prompt_async_return(moderation, prescore_df)
     tc_id = "tooluse_test"
     mid = "msg-1"
@@ -2579,10 +2581,11 @@ async def test_function_middleware_stream_closes_dangling_tool_calls_before_run_
             ],
             usage_metrics=zero,
         )
-        yield DRAgentEventResponse(
-            events=[TextMessageContentEvent(message_id=mid, delta="hello")],
-            usage_metrics=zero,
-        )
+        if text_delta is not None:
+            yield DRAgentEventResponse(
+                events=[TextMessageContentEvent(message_id=mid, delta=text_delta)],
+                usage_metrics=zero,
+            )
         yield DRAgentEventResponse(
             events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
             usage_metrics=zero,
@@ -2612,62 +2615,16 @@ async def test_function_middleware_stream_closes_dangling_tool_calls_before_run_
     assert all(end_idx < finished_idx for end_idx in tool_end_indices)
 
 
-async def test_function_middleware_stream_no_text_closes_tool_calls_before_run_finished(
+@pytest.mark.parametrize(
+    "co_located_tool_lifecycle",
+    [False, True],
+    ids=["deferred_registry", "co_located_batch"],
+)
+async def test_function_middleware_stream_preserves_tool_result_for_history(
     builder_mock: MagicMock,
+    co_located_tool_lifecycle: bool,
 ) -> None:
-    """Tool-only upstream must still close dangling tool calls before ``RUN_FINISHED``."""
-    pipeline = _pipeline_mock()
-    pipeline.get_prescore_guards.return_value = [MagicMock()]
-    moderation = _moderation_mock(pipeline)
-    prescore_df = _prescore_df_ok("hello")
-    _set_evaluate_prompt_async_return(moderation, prescore_df)
-    tc_id = "tooluse_only"
-    zero = default_usage_metrics()
-
-    async def upstream():
-        yield DRAgentEventResponse(
-            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
-            usage_metrics=zero,
-        )
-        yield DRAgentEventResponse(
-            events=[
-                ToolCallStartEvent(tool_call_id=tc_id, tool_call_name="generate_objectid"),
-                ToolCallArgsEvent(tool_call_id=tc_id, delta='{"type":"deployment"}'),
-            ],
-            usage_metrics=zero,
-        )
-        yield DRAgentEventResponse(
-            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
-            usage_metrics=zero,
-        )
-
-    stream_next = MagicMock(return_value=upstream())
-
-    with patch(
-        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
-        return_value=moderation,
-    ):
-        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
-        chunks = [
-            item
-            async for item in mw.function_middleware_stream(
-                _make_run_input("hello"),
-                call_next=stream_next,
-                context=_fn_context(),
-            )
-        ]
-
-    flat = [ev for resp in chunks for ev in resp.events]
-    validate_sequence(flat)
-    finished_idx = next(i for i, e in enumerate(flat) if e.type == EventType.RUN_FINISHED)
-    tool_end_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TOOL_CALL_END)
-    assert tool_end_idx < finished_idx
-
-
-async def test_function_middleware_stream_flushes_deferred_tool_result_for_history(
-    builder_mock: MagicMock,
-) -> None:
-    """Deferred ``TOOL_CALL_RESULT`` must flush before synthetic ``TOOL_CALL_END`` only."""
+    """``TOOL_CALL_RESULT`` must survive moderation for ``events_to_messages`` history folding."""
     from datarobot_genai.core.agents.events import events_to_messages
     from datarobot_genai.dragent.frontends.tool_call_registry import defer_tool_end
     from datarobot_genai.dragent.frontends.tool_call_registry import reset as reset_tool_registry
@@ -2676,84 +2633,29 @@ async def test_function_middleware_stream_flushes_deferred_tool_result_for_histo
     pipeline = _pipeline_mock()
     pipeline.get_prescore_guards.return_value = [MagicMock()]
     moderation = _moderation_mock(pipeline)
-    prescore_df = _prescore_df_ok("69cbb73789723b6936c6c9e1")
-    _set_evaluate_prompt_async_return(moderation, prescore_df)
-    tc_id = "tooluse_deferred"
-    object_id = "69cbb73789723b6936c6c9e1"
-    mid = "msg-1"
-    zero = default_usage_metrics()
-    defer_tool_end(
-        tc_id,
-        [
-            ToolCallEndEvent(tool_call_id=tc_id),
-            ToolCallResultEvent(
-                message_id=tc_id,
-                tool_call_id=tc_id,
-                content=object_id,
-                role="tool",
-            ),
-        ],
-    )
-
-    async def upstream():
-        yield DRAgentEventResponse(
-            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
-            usage_metrics=zero,
-        )
-        yield DRAgentEventResponse(
-            events=[
-                ToolCallStartEvent(tool_call_id=tc_id, tool_call_name="generate_objectid"),
-                ToolCallArgsEvent(tool_call_id=tc_id, delta='{"type":"deployment"}'),
-            ],
-            usage_metrics=zero,
-        )
-        yield DRAgentEventResponse(
-            events=[TextMessageContentEvent(message_id=mid, delta=object_id)],
-            usage_metrics=zero,
-        )
-        yield DRAgentEventResponse(
-            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
-            usage_metrics=zero,
-        )
-
-    stream_next = MagicMock(return_value=upstream())
-
-    with patch(
-        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
-        return_value=moderation,
-    ):
-        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
-        chunks = [
-            item
-            async for item in mw.function_middleware_stream(
-                _make_run_input("generate id"),
-                call_next=stream_next,
-                context=_fn_context(),
-            )
-        ]
-
-    flat = [ev for resp in chunks for ev in resp.events]
-    validate_sequence(flat)
-    tool_result = next((m for m in events_to_messages(flat) if m.role == "tool"), None)
-    assert tool_result is not None
-    assert object_id in tool_result.content
-
-
-async def test_function_middleware_stream_passthrough_tool_result_from_moderated_batch(
-    builder_mock: MagicMock,
-) -> None:
-    """Tool end/result co-located with a moderated text batch must still reach the client."""
-    from datarobot_genai.core.agents.events import events_to_messages
-
-    pipeline = _pipeline_mock()
-    pipeline.get_prescore_guards.return_value = [MagicMock()]
-    moderation = _moderation_mock(pipeline)
     object_id = "69cbb73789723b6936c6c9e1"
     prescore_df = _prescore_df_ok(object_id)
     _set_evaluate_prompt_async_return(moderation, prescore_df)
-    tc_id = "tooluse_batch"
-    mid = "msg-batch"
+    tc_id = "tooluse_history"
+    mid = "msg-1"
     zero = default_usage_metrics()
+    tool_lifecycle = [
+        ToolCallEndEvent(tool_call_id=tc_id),
+        ToolCallResultEvent(
+            message_id=tc_id,
+            tool_call_id=tc_id,
+            content=object_id,
+            role="tool",
+        ),
+    ]
+    if co_located_tool_lifecycle:
+        text_events: list[Any] = [
+            TextMessageContentEvent(message_id=mid, delta=object_id),
+            *tool_lifecycle,
+        ]
+    else:
+        defer_tool_end(tc_id, tool_lifecycle)
+        text_events = [TextMessageContentEvent(message_id=mid, delta=object_id)]
 
     async def upstream():
         yield DRAgentEventResponse(
@@ -2767,19 +2669,7 @@ async def test_function_middleware_stream_passthrough_tool_result_from_moderated
             ],
             usage_metrics=zero,
         )
-        yield DRAgentEventResponse(
-            events=[
-                TextMessageContentEvent(message_id=mid, delta=object_id),
-                ToolCallEndEvent(tool_call_id=tc_id),
-                ToolCallResultEvent(
-                    message_id=tc_id,
-                    tool_call_id=tc_id,
-                    content=object_id,
-                    role="tool",
-                ),
-            ],
-            usage_metrics=zero,
-        )
+        yield DRAgentEventResponse(events=text_events, usage_metrics=zero)
         yield DRAgentEventResponse(
             events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
             usage_metrics=zero,

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2439,6 +2439,61 @@ async def test_function_middleware_stream_defers_text_message_end_before_run_fin
     assert end_idx < finished_idx
 
 
+async def test_function_middleware_stream_chunk_only_upstream_passes_ag_ui_validation(
+    builder_mock: MagicMock,
+) -> None:
+    """``TEXT_MESSAGE_CHUNK`` without START/END must still finish before ``RUN_FINISHED``."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hello")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    mid = "msg-chunk"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                TextMessageChunkEvent(
+                    type=EventType.TEXT_MESSAGE_CHUNK,
+                    message_id=mid,
+                    delta="hello",
+                )
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    finished_idx = next(i for i, e in enumerate(flat) if e.type == EventType.RUN_FINISHED)
+    end_indices = [i for i, e in enumerate(flat) if e.type == EventType.TEXT_MESSAGE_END]
+    assert all(end_idx < finished_idx for end_idx in end_indices)
+
+
 async def test_function_middleware_stream_preserves_step_order_at_agent_transition(
     builder_mock: MagicMock,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2552,6 +2552,116 @@ async def test_function_middleware_stream_chunk_only_upstream_passes_ag_ui_valid
     assert all(end_idx < finished_idx for end_idx in end_indices)
 
 
+async def test_function_middleware_stream_closes_dangling_tool_calls_before_run_finished(
+    builder_mock: MagicMock,
+) -> None:
+    """``TOOL_CALL_START`` without ``TOOL_CALL_END`` must finish before ``RUN_FINISHED``."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hello")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    tc_id = "tooluse_test"
+    mid = "msg-1"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                ToolCallStartEvent(tool_call_id=tc_id, tool_call_name="generate_objectid"),
+                ToolCallArgsEvent(tool_call_id=tc_id, delta='{"type":"deployment"}'),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid, delta="hello")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    finished_idx = next(i for i, e in enumerate(flat) if e.type == EventType.RUN_FINISHED)
+    tool_end_indices = [i for i, e in enumerate(flat) if e.type == EventType.TOOL_CALL_END]
+    assert tool_end_indices
+    assert all(end_idx < finished_idx for end_idx in tool_end_indices)
+
+
+async def test_function_middleware_stream_no_text_closes_tool_calls_before_run_finished(
+    builder_mock: MagicMock,
+) -> None:
+    """Tool-only upstream must still close dangling tool calls before ``RUN_FINISHED``."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hello")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    tc_id = "tooluse_only"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                ToolCallStartEvent(tool_call_id=tc_id, tool_call_name="generate_objectid"),
+                ToolCallArgsEvent(tool_call_id=tc_id, delta='{"type":"deployment"}'),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    finished_idx = next(i for i, e in enumerate(flat) if e.type == EventType.RUN_FINISHED)
+    tool_end_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TOOL_CALL_END)
+    assert tool_end_idx < finished_idx
+
+
 async def test_function_middleware_stream_emits_deferred_start_before_content(
     builder_mock: MagicMock,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2739,6 +2739,75 @@ async def test_function_middleware_stream_flushes_deferred_tool_result_for_histo
     assert object_id in tool_result.content
 
 
+async def test_function_middleware_stream_passthrough_tool_result_from_moderated_batch(
+    builder_mock: MagicMock,
+) -> None:
+    """Tool end/result co-located with a moderated text batch must still reach the client."""
+    from datarobot_genai.core.agents.events import events_to_messages
+
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    object_id = "69cbb73789723b6936c6c9e1"
+    prescore_df = _prescore_df_ok(object_id)
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    tc_id = "tooluse_batch"
+    mid = "msg-batch"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                ToolCallStartEvent(tool_call_id=tc_id, tool_call_name="generate_objectid"),
+                ToolCallArgsEvent(tool_call_id=tc_id, delta='{"type":"deployment"}'),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                TextMessageContentEvent(message_id=mid, delta=object_id),
+                ToolCallEndEvent(tool_call_id=tc_id),
+                ToolCallResultEvent(
+                    message_id=tc_id,
+                    tool_call_id=tc_id,
+                    content=object_id,
+                    role="tool",
+                ),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("generate id"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    tool_result = next((m for m in events_to_messages(flat) if m.role == "tool"), None)
+    assert tool_result is not None
+    assert object_id in tool_result.content
+
+
 async def test_function_middleware_stream_emits_deferred_start_before_content(
     builder_mock: MagicMock,
 ) -> None:

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -46,6 +46,8 @@ from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import TextMessageStartEvent
 from ag_ui.core import ToolCall
 from ag_ui.core import ToolCallArgsEvent
+from ag_ui.core import ToolCallEndEvent
+from ag_ui.core import ToolCallResultEvent
 from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import ToolMessage
 from ag_ui.core import UserMessage
@@ -2660,6 +2662,81 @@ async def test_function_middleware_stream_no_text_closes_tool_calls_before_run_f
     finished_idx = next(i for i, e in enumerate(flat) if e.type == EventType.RUN_FINISHED)
     tool_end_idx = next(i for i, e in enumerate(flat) if e.type == EventType.TOOL_CALL_END)
     assert tool_end_idx < finished_idx
+
+
+async def test_function_middleware_stream_flushes_deferred_tool_result_for_history(
+    builder_mock: MagicMock,
+) -> None:
+    """Deferred ``TOOL_CALL_RESULT`` must flush before synthetic ``TOOL_CALL_END`` only."""
+    from datarobot_genai.core.agents.events import events_to_messages
+    from datarobot_genai.dragent.frontends.tool_call_registry import defer_tool_end
+    from datarobot_genai.dragent.frontends.tool_call_registry import reset as reset_tool_registry
+
+    reset_tool_registry()
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("69cbb73789723b6936c6c9e1")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    tc_id = "tooluse_deferred"
+    object_id = "69cbb73789723b6936c6c9e1"
+    mid = "msg-1"
+    zero = default_usage_metrics()
+    defer_tool_end(
+        tc_id,
+        [
+            ToolCallEndEvent(tool_call_id=tc_id),
+            ToolCallResultEvent(
+                message_id=tc_id,
+                tool_call_id=tc_id,
+                content=object_id,
+                role="tool",
+            ),
+        ],
+    )
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[
+                ToolCallStartEvent(tool_call_id=tc_id, tool_call_name="generate_objectid"),
+                ToolCallArgsEvent(tool_call_id=tc_id, delta='{"type":"deployment"}'),
+            ],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid, delta=object_id)],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("generate id"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    tool_result = next((m for m in events_to_messages(flat) if m.role == "tool"), None)
+    assert tool_result is not None
+    assert object_id in tool_result.content
 
 
 async def test_function_middleware_stream_emits_deferred_start_before_content(

--- a/tests/nat/test_datarobot_moderation_middleware.py
+++ b/tests/nat/test_datarobot_moderation_middleware.py
@@ -2551,6 +2551,104 @@ async def test_function_middleware_stream_emits_deferred_start_before_content(
     assert start_idx < content_idx
 
 
+async def test_function_middleware_stream_keeps_deferred_start_for_later_segment(
+    builder_mock: MagicMock,
+) -> None:
+    """Do not emit a deferred START for segment B while moderating segment A text."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    prescore_df = _prescore_df_ok("hello")
+    _set_evaluate_prompt_async_return(moderation, prescore_df)
+    planner_mid = "msg-planner"
+    writer_mid = "msg-writer"
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepStartedEvent(step_name="Content Planner")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=planner_mid, role="assistant")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=planner_mid, delta="plan-1")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=planner_mid, delta=" plan-2")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=planner_mid)],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepFinishedEvent(step_name="Content Planner")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepStartedEvent(step_name="Content Writer")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=writer_mid, role="assistant")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=writer_mid, delta="hello")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=writer_mid)],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[StepFinishedEvent(step_name="Content Writer")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t1", run_id="r1")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.nat.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    validate_sequence(flat)
+    writer_start_idx = next(
+        i
+        for i, e in enumerate(flat)
+        if e.type == EventType.TEXT_MESSAGE_START and e.message_id == writer_mid
+    )
+    writer_content_idx = next(
+        i
+        for i, e in enumerate(flat)
+        if e.type == EventType.TEXT_MESSAGE_CONTENT and e.message_id == writer_mid
+    )
+    assert writer_start_idx < writer_content_idx
+
+
 async def test_function_middleware_stream_preserves_step_order_at_agent_transition(
     builder_mock: MagicMock,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.5"
+version = "0.17.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
`Crew.kickoff_async` runs in a thread whereas `Crew.akickoff` uses native `async/await`. The former causes a cascade of 
```
AttributeError: '_UnixSelectorEventLoop' object has no attribute '_ssock'
[agent]  Exception ignored in: <function BaseEventLoop.__del__ at 0x1035491c0>
[agent]  Traceback (most recent call last):
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 705, in __del__
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/unix_events.py", line 68, in close
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/selector_events.py", line 104, in close
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/selector_events.py", line 111, in _close_self_pipe
[agent]  AttributeError: '_UnixSelectorEventLoop' object has no attribute '_ssock'
```
after the `word_counter` tool was introduced in `af-component-agent==11.10.23` and then subsequent agent calls fail.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Use `akickoff` instead of `kickoff_async`.

Then iterated a bunch of changes to fix e2e test failures/flakes. Better handling of event sequence and tool calls. Apply stop words when using `acall` with CrewAI and try to cut off hallucinated tool results so the tool actually gets called.

Tested the latest dev build with a recent version of the recipe to confirm it fixes the issue.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single API swap on the async crew entrypoint with matching test mocks; no auth, data, or new feature surface.
> 
> **Overview**
> Switches the CrewAI agent invoke path from **`Crew.kickoff_async`** to **`Crew.akickoff`** so crew runs stay on the host asyncio loop instead of a threaded kickoff path.
> 
> Test doubles (`CrewForTest` and capturing crews) are updated to expose **`akickoff`** with the same inputs contract. Kickoff input and chat-history behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb432131d11fe7b6f4a118ddded44a189724c5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->