### PR TITLE
[MODEL-23790] Update Lifecycle Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.17.4
+- **Breaking** `drtools/workload`: submit-and-poll lifecycle workflow — `workload_start` and `workload_stop` return immediately after the request is accepted (202) with `accepted` and a `note` directing the agent to poll status; `workload_stop` no longer accepts `wait_stopped` or `timeout_seconds`. **`workload_wait_for_status` is replaced by `workload_get_status`** (`workload_id`, optional `target_status`): a lightweight single status fetch returning `status`, `target_reached`, and `raw`, raising on terminal `errored` without blocking. Removed `WorkloadApiClient.wait_for_workload_status` server-side polling.
+
 ## 0.17.3
 - `drtools/panels`: filter and transform Dataset panels with sandboxed code execution (`filter_panel`, `transform_panel`), saving results as derived child panels with lineage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.17.4
-- **Breaking** `drtools/workload`: submit-and-poll lifecycle workflow — `workload_start` and `workload_stop` return immediately after the request is accepted (202) with `accepted` and a `note` directing the agent to poll status; `workload_stop` no longer accepts `wait_stopped` or `timeout_seconds`. **`workload_wait_for_status` is replaced by `workload_get_status`** (`workload_id`, optional `target_status`): a lightweight single status fetch returning `status`, `target_reached`, and `raw`, raising on terminal `errored` without blocking. Removed `WorkloadApiClient.wait_for_workload_status` server-side polling.
+- `drtools/workload`: submit-and-poll lifecycle workflow — `workload_start` and `workload_stop` return immediately after the request is accepted (202) with `accepted` and a `note` directing the agent to poll status; `workload_stop` no longer accepts `wait_stopped` or `timeout_seconds`. **`workload_wait_for_status` is replaced by `workload_get_status`** (`workload_id`, optional `target_status`): a lightweight single status fetch returning `status`, `target_reached`, and `raw`, raising on terminal `errored` without blocking. Removed `WorkloadApiClient.wait_for_workload_status` server-side polling.
 
 ## 0.17.3
 - `drtools/panels`: filter and transform Dataset panels with sandboxed code execution (`filter_panel`, `transform_panel`), saving results as derived child panels with lineage.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -963,7 +963,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.3"
+version = "0.17.4"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.17.3"
+version = "0.17.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/constants.py
+++ b/src/datarobot_genai/drmcputils/constants.py
@@ -27,6 +27,8 @@ ARTIFACT_STATUSES: tuple[str, ...] = ("draft", "locked")
 
 ARTIFACT_TYPES: tuple[str, ...] = ("service", "nim")
 
+WORKLOAD_TERMINAL_FAILURE_STATUS = "errored"
+
 # Header names to check for authorization tokens (in order of preference)
 HEADER_TOKEN_CANDIDATE_NAMES = [
     "x-datarobot-authorization",

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import logging
-import time
 from typing import Any
 
 from datarobot_genai.drmcputils.clients.datarobot import request_user_dr_client
@@ -94,50 +92,6 @@ class WorkloadApiClient:
         """PATCH /workloads/{id} — partial update of name / description / importance."""
         with request_user_dr_client() as client:
             return client.patch(f"workloads/{workload_id}", json=payload).json()
-
-    # ------------------------------------------------------------------ #
-    # Workloads — polling                                                  #
-    # ------------------------------------------------------------------ #
-
-    async def wait_for_workload_status(
-        self,
-        workload_id: str,
-        target_status: str,
-        *,
-        timeout_seconds: int = 600,
-        poll_interval_seconds: int = 1,
-    ) -> dict[str, Any]:
-        """Poll until the workload reaches *target_status*, enters errored, or times out.
-
-        Uses :func:`asyncio.sleep` between polls so async callers do not block the event loop.
-
-        Raises
-        ------
-        RuntimeError
-            When the workload enters ``errored`` before reaching *target_status*.
-        TimeoutError
-            When *timeout_seconds* elapses before reaching *target_status*.
-        """
-        deadline = time.monotonic() + timeout_seconds
-        last_status: str | None = None
-        while True:
-            obj = self.get_workload(workload_id)
-            status = obj.get("status")
-            if status != last_status:
-                logger.info("Workload %s status: %s", workload_id, status)
-                last_status = status
-            if status == target_status:
-                return obj
-            if status == "errored":
-                raise RuntimeError(
-                    f"Workload {workload_id} errored while waiting for '{target_status}'"
-                )
-            if time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"Timeout waiting for workload {workload_id} to reach "
-                    f"'{target_status}'. Last status: {status}"
-                )
-            await asyncio.sleep(poll_interval_seconds)
 
     # ------------------------------------------------------------------ #
     # Workloads — settings                                                 #

--- a/src/datarobot_genai/drtools/workload/lifecycle_tools.py
+++ b/src/datarobot_genai/drtools/workload/lifecycle_tools.py
@@ -393,7 +393,15 @@ async def workload_get_status(
         )
 
     wid = workload_id.strip()
-    target = target_status.strip() if target_status else None
+    if target_status is not None:
+        target = target_status.strip()
+        if not target:
+            raise ToolError(
+                "Argument validation error: 'target_status' cannot be empty.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+    else:
+        target = None
     try:
         obj = WorkloadApiClient().get_workload(wid)
     except ClientError as exc:

--- a/src/datarobot_genai/drtools/workload/lifecycle_tools.py
+++ b/src/datarobot_genai/drtools/workload/lifecycle_tools.py
@@ -24,6 +24,32 @@ from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
 
+_WORKLOAD_TERMINAL_FAILURE_STATUS = "errored"
+
+
+def _submit_response_with_note(
+    *,
+    workload_id: str,
+    raw: dict[str, Any],
+    action: str,
+    target_status: str,
+) -> dict[str, Any]:
+    """Wrap a 202 start/stop response with a poll-instruction note.
+
+    Mirrors the predict batch submit pattern: the tool only requests the
+    operation and returns immediately; the caller must poll workload_get_status.
+    """
+    return {
+        "workload_id": workload_id,
+        "accepted": raw,
+        "note": (
+            f"This tool only requests the workload {action}; it does NOT wait for "
+            f"completion. Poll workload_get_status(workload_id={workload_id!r}, "
+            f"target_status={target_status!r}) every few seconds until target_reached "
+            "is true. It raises if the workload enters 'errored'."
+        ),
+    }
+
 
 @tool_metadata(
     tags={"workload", "datarobot", "payload", "helper"},
@@ -211,9 +237,10 @@ async def workload_create(
 @tool_metadata(
     tags={"workload", "datarobot", "start"},
     description=(
-        "[Workload—start] Start a stopped workload. Returns immediately after the "
-        "request is accepted (202). Use workload_wait_for_status with "
-        "target_status='running' to block until live.\n\n"
+        "[Workload—start] Request a stopped workload to start. Returns immediately "
+        "after the request is accepted (202); does NOT wait for completion. "
+        "Required follow-up: poll workload_get_status with target_status='running' "
+        "until target_reached is true.\n\n"
         "Example: workload_start(workload_id='wkld-abc')"
     ),
 )
@@ -226,57 +253,44 @@ async def workload_start(
             "Argument validation error: 'workload_id' cannot be empty.",
             kind=ToolErrorKind.VALIDATION,
         )
+    wid = workload_id.strip()
     try:
-        return WorkloadApiClient().start_workload(workload_id.strip())
+        raw = WorkloadApiClient().start_workload(wid)
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
+    return _submit_response_with_note(
+        workload_id=wid, raw=raw, action="start", target_status="running"
+    )
 
 
 @tool_metadata(
     tags={"workload", "datarobot", "stop"},
     description=(
-        "[Workload—stop] Stop a running workload. By default waits until the "
-        "workload reaches 'stopped' status (up to timeout_seconds). Set "
-        "wait_stopped=False to return immediately after the stop request.\n\n"
+        "[Workload—stop] Request a running workload to stop. Returns immediately "
+        "after the request is accepted (202); does NOT wait for completion. "
+        "Required follow-up: poll workload_get_status with target_status='stopped' "
+        "until target_reached is true.\n\n"
         "Example: workload_stop(workload_id='wkld-abc')"
     ),
 )
 async def workload_stop(
     *,
     workload_id: Annotated[str, "Id of the workload to stop."],
-    wait_stopped: Annotated[bool, "Poll until status is 'stopped'. Default true."] = True,
-    timeout_seconds: Annotated[
-        int, "Max seconds to wait when wait_stopped is true. Default 120."
-    ] = 120,
 ) -> dict[str, Any]:
     if not workload_id or not workload_id.strip():
         raise ToolError(
             "Argument validation error: 'workload_id' cannot be empty.",
             kind=ToolErrorKind.VALIDATION,
         )
-    if timeout_seconds < 1:
-        raise ToolError(
-            "Argument validation error: 'timeout_seconds' must be >= 1.",
-            kind=ToolErrorKind.VALIDATION,
-        )
 
-    client = WorkloadApiClient()
+    wid = workload_id.strip()
     try:
-        result = client.stop_workload(workload_id.strip())
+        raw = WorkloadApiClient().stop_workload(wid)
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
-
-    if wait_stopped:
-        try:
-            result = await client.wait_for_workload_status(
-                workload_id.strip(), "stopped", timeout_seconds=timeout_seconds
-            )
-        except (RuntimeError, TimeoutError) as exc:
-            raise ToolError(str(exc), kind=ToolErrorKind.UPSTREAM) from exc
-        except ClientError as exc:
-            raise_tool_error_for_client_error(exc)
-
-    return result
+    return _submit_response_with_note(
+        workload_id=wid, raw=raw, action="stop", target_status="stopped"
+    )
 
 
 @tool_metadata(
@@ -352,45 +366,48 @@ async def workload_update(
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "wait"},
+    tags={"workload", "datarobot", "status"},
     description=(
-        "[Workload—wait for status] Poll a workload until it reaches a target "
-        "status, raises if it enters 'errored', or times out. "
-        "Common targets: 'running' (after start), 'stopped' (after stop).\n\n"
-        "Example: workload_wait_for_status(workload_id='wkld-abc', target_status='running')"
+        "[Workload—get status] Lightweight single status check for a workload. "
+        "REQUIRED polling step after workload_start or workload_stop. Returns the "
+        "current status and, when target_status is supplied, a target_reached flag. "
+        "Poll every few seconds until target_reached is true. Raises if the workload "
+        "enters 'errored'. Does not block or wait. Common targets: 'running' (after "
+        "start), 'stopped' (after stop).\n\n"
+        "Example: workload_get_status(workload_id='wkld-abc', target_status='running')"
     ),
 )
-async def workload_wait_for_status(
+async def workload_get_status(
     *,
-    workload_id: Annotated[str, "Id of the workload to poll."],
-    target_status: Annotated[str, "Status to wait for, e.g. 'running', 'stopped', 'initializing'."],
-    timeout_seconds: Annotated[
-        int, "Max seconds to wait before raising a timeout error. Default 600."
-    ] = 600,
+    workload_id: Annotated[str, "Id of the workload to check."],
+    target_status: Annotated[
+        str | None,
+        "Optional status to compare against, e.g. 'running', 'stopped'. When set, "
+        "the response includes target_reached.",
+    ] = None,
 ) -> dict[str, Any]:
     if not workload_id or not workload_id.strip():
         raise ToolError(
             "Argument validation error: 'workload_id' cannot be empty.",
             kind=ToolErrorKind.VALIDATION,
         )
-    if not target_status or not target_status.strip():
-        raise ToolError(
-            "Argument validation error: 'target_status' cannot be empty.",
-            kind=ToolErrorKind.VALIDATION,
-        )
-    if timeout_seconds < 1:
-        raise ToolError(
-            "Argument validation error: 'timeout_seconds' must be >= 1.",
-            kind=ToolErrorKind.VALIDATION,
-        )
 
+    wid = workload_id.strip()
+    target = target_status.strip() if target_status else None
     try:
-        return await WorkloadApiClient().wait_for_workload_status(
-            workload_id.strip(),
-            target_status.strip(),
-            timeout_seconds=timeout_seconds,
-        )
-    except (RuntimeError, TimeoutError) as exc:
-        raise ToolError(str(exc), kind=ToolErrorKind.UPSTREAM) from exc
+        obj = WorkloadApiClient().get_workload(wid)
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
+
+    status = obj.get("status")
+    if status == _WORKLOAD_TERMINAL_FAILURE_STATUS:
+        raise ToolError(
+            f"Workload {wid} entered terminal status {status!r}.",
+            kind=ToolErrorKind.UPSTREAM,
+        )
+    return {
+        "workload_id": wid,
+        "status": status,
+        "target_reached": target is None or status == target,
+        "raw": obj,
+    }

--- a/src/datarobot_genai/drtools/workload/lifecycle_tools.py
+++ b/src/datarobot_genai/drtools/workload/lifecycle_tools.py
@@ -19,12 +19,11 @@ from datarobot.errors import ClientError
 
 from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
 from datarobot_genai.drmcputils.constants import IMPORTANCE_VALUES
+from datarobot_genai.drmcputils.constants import WORKLOAD_TERMINAL_FAILURE_STATUS
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.core.clients.datarobot_workload import WorkloadApiClient
-
-_WORKLOAD_TERMINAL_FAILURE_STATUS = "errored"
 
 
 def _submit_response_with_note(
@@ -408,7 +407,7 @@ async def workload_get_status(
         raise_tool_error_for_client_error(exc)
 
     status = obj.get("status")
-    if status == _WORKLOAD_TERMINAL_FAILURE_STATUS:
+    if status == WORKLOAD_TERMINAL_FAILURE_STATUS:
         raise ToolError(
             f"Workload {wid} entered terminal status {status!r}.",
             kind=ToolErrorKind.UPSTREAM,

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -376,7 +376,9 @@ async def test_workload_start_success(patched_dr_client: MagicMock) -> None:
     result = await lifecycle_tools.workload_start(workload_id="wkld-abc")
 
     patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/start")
-    assert result == {"accepted": True}
+    assert result["workload_id"] == "wkld-abc"
+    assert result["accepted"] == {"accepted": True}
+    assert "workload_get_status" in result["note"]
 
 
 @pytest.mark.asyncio
@@ -392,64 +394,32 @@ async def test_workload_start_empty_id_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_workload_stop_no_wait(patched_dr_client: MagicMock) -> None:
+async def test_workload_stop_success(patched_dr_client: MagicMock) -> None:
     patched_dr_client.post.return_value = MagicMock(
         content=b'{"accepted":true}', json=lambda: {"accepted": True}
     )
 
-    result = await lifecycle_tools.workload_stop(workload_id="wkld-abc", wait_stopped=False)
+    result = await lifecycle_tools.workload_stop(workload_id="wkld-abc")
 
     patched_dr_client.post.assert_called_once_with("workloads/wkld-abc/stop")
-    assert result == {"accepted": True}
+    assert result["workload_id"] == "wkld-abc"
+    assert result["accepted"] == {"accepted": True}
+    assert "workload_get_status" in result["note"]
 
 
 @pytest.mark.asyncio
-async def test_workload_stop_with_wait(patched_dr_client: MagicMock) -> None:
-    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
-    patched_dr_client.get.return_value = MagicMock(
-        json=lambda: {"id": "wkld-abc", "status": "stopped"}
-    )
-
-    result = await lifecycle_tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
-
-    assert result["status"] == "stopped"
+async def test_workload_stop_empty_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await lifecycle_tools.workload_stop(workload_id="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
-async def test_workload_stop_timeout_raises(patched_dr_client: MagicMock) -> None:
-    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
-    patched_dr_client.get.return_value = MagicMock(
-        json=lambda: {"id": "wkld-abc", "status": "running"}
-    )
+async def test_workload_stop_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.post.side_effect = ClientError("404 Not Found", status_code=404, json={})
 
     with pytest.raises(ToolError) as exc_info:
-        await lifecycle_tools.workload_stop(
-            workload_id="wkld-abc", wait_stopped=True, timeout_seconds=1
-        )
-    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
-
-
-@pytest.mark.asyncio
-async def test_workload_stop_errored_raises(patched_dr_client: MagicMock) -> None:
-    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
-    patched_dr_client.get.return_value = MagicMock(
-        json=lambda: {"id": "wkld-abc", "status": "errored"}
-    )
-
-    with pytest.raises(ToolError) as exc_info:
-        await lifecycle_tools.workload_stop(
-            workload_id="wkld-abc", wait_stopped=True, timeout_seconds=30
-        )
-    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
-
-
-@pytest.mark.asyncio
-async def test_workload_stop_wait_client_error(patched_dr_client: MagicMock) -> None:
-    patched_dr_client.post.return_value = MagicMock(content=b"{}", json=lambda: {})
-    patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
-
-    with pytest.raises(ToolError) as exc_info:
-        await lifecycle_tools.workload_stop(workload_id="wkld-abc", wait_stopped=True)
+        await lifecycle_tools.workload_stop(workload_id="wkld-abc")
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
 
 
@@ -520,50 +490,76 @@ async def test_workload_update_invalid_importance_raises() -> None:
 
 
 # ------------------------------------------------------------------ #
-# workload_wait_for_status                                             #
+# workload_get_status                                                  #
 # ------------------------------------------------------------------ #
 
 
 @pytest.mark.asyncio
-async def test_workload_wait_for_status_immediate(patched_dr_client: MagicMock) -> None:
+async def test_workload_get_status_target_reached(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.return_value = MagicMock(
         json=lambda: {"id": "wkld-abc", "status": "running"}
     )
 
-    result = await lifecycle_tools.workload_wait_for_status(
+    result = await lifecycle_tools.workload_get_status(
         workload_id="wkld-abc", target_status="running"
     )
 
+    patched_dr_client.get.assert_called_once_with("workloads/wkld-abc")
     assert result["status"] == "running"
+    assert result["target_reached"] is True
 
 
 @pytest.mark.asyncio
-async def test_workload_wait_for_status_errored_raises(patched_dr_client: MagicMock) -> None:
+async def test_workload_get_status_target_not_reached(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "initializing"}
+    )
+
+    result = await lifecycle_tools.workload_get_status(
+        workload_id="wkld-abc", target_status="running"
+    )
+
+    assert result["status"] == "initializing"
+    assert result["target_reached"] is False
+
+
+@pytest.mark.asyncio
+async def test_workload_get_status_no_target(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.return_value = MagicMock(
+        json=lambda: {"id": "wkld-abc", "status": "running"}
+    )
+
+    result = await lifecycle_tools.workload_get_status(workload_id="wkld-abc")
+
+    assert result["status"] == "running"
+    assert result["target_reached"] is True
+
+
+@pytest.mark.asyncio
+async def test_workload_get_status_errored_raises(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.return_value = MagicMock(
         json=lambda: {"id": "wkld-abc", "status": "errored"}
     )
 
     with pytest.raises(ToolError) as exc_info:
-        await lifecycle_tools.workload_wait_for_status(
-            workload_id="wkld-abc", target_status="running"
-        )
+        await lifecycle_tools.workload_get_status(workload_id="wkld-abc", target_status="running")
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
 @pytest.mark.asyncio
-async def test_workload_wait_for_status_empty_target_raises() -> None:
+async def test_workload_get_status_empty_id_raises() -> None:
     with pytest.raises(ToolError) as exc_info:
-        await lifecycle_tools.workload_wait_for_status(workload_id="wkld-abc", target_status="")
+        await lifecycle_tools.workload_get_status(workload_id="")
     assert exc_info.value.kind is ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio
-async def test_workload_wait_for_status_zero_timeout_raises() -> None:
+async def test_workload_get_status_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
+
     with pytest.raises(ToolError) as exc_info:
-        await lifecycle_tools.workload_wait_for_status(
-            workload_id="wkld-abc", target_status="running", timeout_seconds=0
-        )
-    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+        await lifecycle_tools.workload_get_status(workload_id="wkld-abc")
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
 
 
 # ================================================================== #

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -554,6 +554,20 @@ async def test_workload_get_status_empty_id_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_workload_get_status_empty_target_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await lifecycle_tools.workload_get_status(workload_id="wkld-abc", target_status="")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_workload_get_status_whitespace_target_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await lifecycle_tools.workload_get_status(workload_id="wkld-abc", target_status="   ")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
 async def test_workload_get_status_not_found(patched_dr_client: MagicMock) -> None:
     patched_dr_client.get.side_effect = ClientError("404 Not Found", status_code=404, json={})
 

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.3"
+version = "0.17.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

Update lifecycle tools that were waiting on a job to finish, to a non-blocking response.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking MCP tool API and workflow contract for agents that relied on blocking start/stop or `workload_wait_for_status`; incorrect or missing polling can leave workloads in transitional states without automatic timeout handling.
> 
> **Overview**
> **Breaking** workload lifecycle tools now follow a submit-and-poll pattern (aligned with predictive batch jobs in 0.15.45), shifting completion responsibility from the library to the calling agent.
> 
> `workload_start` and `workload_stop` return right after the API accepts the operation (202), wrapping the raw response in `accepted` plus a `note` that tells the agent to poll `workload_get_status`. **`workload_stop` no longer supports `wait_stopped` or `timeout_seconds`**—it never blocks until stopped.
> 
> **`workload_wait_for_status` is removed** and replaced by **`workload_get_status`**: one `GET` per call returning `status`, `target_reached` (when `target_status` is set), and `raw`; it raises on `errored` but does not sleep or enforce timeouts. Server-side polling is gone from **`WorkloadApiClient`** (`wait_for_workload_status` deleted).
> 
> Version bumps to **0.17.4** with changelog; unit tests updated for the new shapes and polling tool behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f832de88eb1d4622405708b9bea00ae8afd8f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->