### PR TITLE
[BUZZOK-31231] CrewAI kickoff_async -> akickoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.17.7
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
+- `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior.
 
 ## 0.17.7
 - `drtools/workload`: consolidated the workload/artifact tool surface from 39 tools to 21 for agent ergonomics, following MCP tool-design guidance. No functionality was lost; every tool still issues a single non-blocking REST call (no client-side polling or waiting).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.17.7
+- `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
+
+## 0.17.7
 - `drtools/workload`: consolidated the workload/artifact tool surface from 39 tools to 21 for agent ergonomics, following MCP tool-design guidance. No functionality was lost; every tool still issues a single non-blocking REST call (no client-side polling or waiting).
 
 ## 0.17.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.17.7
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
-- `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior.
+- `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior, including inline hallucinations after ``Action Input``.
 
 ## 0.17.7
 - `drtools/workload`: consolidated the workload/artifact tool surface from 39 tools to 21 for agent ergonomics, following MCP tool-design guidance. No functionality was lost; every tool still issues a single non-blocking REST call (no client-side polling or waiting).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.17.7
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
 - `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior, including inline hallucinations after ``Action Input``.
+- `crewai`: emit ``LLMStreamChunkEvent`` from router ``acall`` so ``Crew.akickoff`` streaming receives text chunks.
 
 ## 0.17.7
 - `drtools/workload`: consolidated the workload/artifact tool surface from 39 tools to 21 for agent ergonomics, following MCP tool-design guidance. No functionality was lost; every tool still issues a single non-blocking REST call (no client-side polling or waiting).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.17.7
+## 0.17.8
 - `crewai`: `CrewAIAgent.invoke` now calls `crew.akickoff` instead of the deprecated `kickoff_async`.
 - `crewai`: apply client-side stop-word truncation in ``LitellmStopWordLLM.acall`` so native async kickoff preserves ReAct tool-loop behavior, including inline hallucinations after ``Action Input``.
 - `crewai`: emit ``LLMStreamChunkEvent`` from router ``acall`` so ``Crew.akickoff`` streaming receives text chunks.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.7"
+version = "0.17.8"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.17.7"
+version = "0.17.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -415,7 +415,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
 
                 if history_summary and not existing_history_text.strip():
                     kickoff_inputs["chat_history"] = f"\n\nPrior conversation:\n{history_summary}"
-            crew_output = await crew.kickoff_async(inputs=kickoff_inputs)
+            crew_output = await crew.akickoff(inputs=kickoff_inputs)
             current_agent_role = ""
             message_id = str(uuid.uuid4())
 

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -50,6 +50,13 @@ class LitellmStopWordLLM(LLM):
             return self._apply_stop_words(result)
         return result
 
+    async def acall(self, *args: Any, **kwargs: Any) -> Any:
+        """Async variant of :meth:`call` used by ``Crew.akickoff``."""
+        result = await super().acall(*args, **kwargs)
+        if isinstance(result, str):
+            return self._apply_stop_words(result)
+        return result
+
 
 def _crewai_model_factory(config: dict) -> LLM:
     config["stream_options"] = config.get("stream_options", {"include_usage": True})

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -50,23 +50,38 @@ class LitellmStopWordLLM(LLM):
 
     @staticmethod
     def _truncate_react_hallucination_after_action_input(content: str) -> str:
-        """Drop inline fake observations that omit the ``Observation:`` label."""
+        """Truncate hallucinated text appended after ``Action Input:``.
+
+        Models sometimes emit fake tool results or a second ReAct step inline,
+        without an ``Observation:`` label. Keep only the action-input value:
+        text on the same line as ``Action Input:``, stopping before any inline
+        ``Thought:`` or ``Final Answer:`` label.
+        """
         marker = "Action Input:"
-        marker_idx = content.find(marker)
-        if marker_idx == -1:
+        marker_start = content.find(marker)
+        if marker_start == -1:
             return content
-        after_marker = content[marker_idx + len(marker) :]
-        cut_at = len(content)
-        line_break = after_marker.find("\n")
-        if line_break != -1:
-            cut_at = min(cut_at, marker_idx + len(marker) + line_break)
-        for stop in ("Thought:", "Final Answer:"):
-            stop_idx = after_marker.find(stop)
-            if stop_idx > 0:
-                cut_at = min(cut_at, marker_idx + len(marker) + stop_idx)
-        if cut_at == len(content):
+
+        value_start = marker_start + len(marker)
+        value_text = content[value_start:]
+
+        # Earliest index in ``content`` where hallucinated suffix may begin.
+        truncation_points = [len(content)]
+
+        newline_in_value = value_text.find("\n")
+        if newline_in_value != -1:
+            truncation_points.append(value_start + newline_in_value)
+
+        for react_label in ("Thought:", "Final Answer:"):
+            label_offset = value_text.find(react_label)
+            # Ignore labels glued directly to the marker (offset 0).
+            if label_offset > 0:
+                truncation_points.append(value_start + label_offset)
+
+        cut_end = min(truncation_points)
+        if cut_end == len(content):
             return content
-        return content[:cut_at].rstrip()
+        return content[:cut_end].rstrip()
 
     def call(self, *args: Any, **kwargs: Any) -> Any:
         """Enforce client-side stop-word truncation when API ignores stop parameter."""

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -243,6 +243,7 @@ def get_router_llm(
             available_tools: list[dict] | None = None,
             **kwargs: Any,
         ) -> str:
+            call_id = str(uuid.uuid4())
             accumulated = []
             tool_calls_seen: list[Any] = []
             response = await self._llm_router.acompletion(
@@ -255,6 +256,10 @@ def get_router_llm(
                 delta = chunk.choices[0].delta
                 if delta.content:
                     accumulated.append(delta.content)
+                    crewai_event_bus.emit(
+                        self,
+                        event=LLMStreamChunkEvent(chunk=delta.content, call_id=call_id),
+                    )
                     if callbacks:
                         for cb in callbacks:
                             if hasattr(cb, "on_llm_new_token"):

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -43,6 +43,31 @@ class LitellmStopWordLLM(LLM):
         super().__init__(*args, **kwargs)
         self.is_litellm = True
 
+    def _apply_stop_words(self, content: str) -> str:
+        """Apply configured stop words, then truncate inline ReAct hallucinations."""
+        truncated = super()._apply_stop_words(content)
+        return self._truncate_react_hallucination_after_action_input(truncated)
+
+    @staticmethod
+    def _truncate_react_hallucination_after_action_input(content: str) -> str:
+        """Drop inline fake observations that omit the ``Observation:`` label."""
+        marker = "Action Input:"
+        marker_idx = content.find(marker)
+        if marker_idx == -1:
+            return content
+        after_marker = content[marker_idx + len(marker) :]
+        cut_at = len(content)
+        line_break = after_marker.find("\n")
+        if line_break != -1:
+            cut_at = min(cut_at, marker_idx + len(marker) + line_break)
+        for stop in ("Thought:", "Final Answer:"):
+            stop_idx = after_marker.find(stop)
+            if stop_idx > 0:
+                cut_at = min(cut_at, marker_idx + len(marker) + stop_idx)
+        if cut_at == len(content):
+            return content
+        return content[:cut_at].rstrip()
+
     def call(self, *args: Any, **kwargs: Any) -> Any:
         """Enforce client-side stop-word truncation when API ignores stop parameter."""
         result = super().call(*args, **kwargs)

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -67,7 +67,7 @@ class CrewForTest:
         self.output = output
         self.verbose = True
 
-    async def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[name-defined]
+    async def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[name-defined]
         return self.output or CrewOutput(raw="final-output")
 
 
@@ -220,9 +220,9 @@ async def test_invoke_does_not_include_chat_history_by_default(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     out = CrewOutput(raw="agent result")
     agent = AgentForTest(
@@ -241,9 +241,9 @@ async def test_invoke_overwrites_blank_chat_history_placeholder(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     class AgentWithPlaceholder(AgentForTest):
         def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
@@ -272,9 +272,9 @@ async def test_invoke_does_not_overwrite_non_empty_chat_history_override(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     class AgentWithOverride(AgentForTest):
         def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:
@@ -297,9 +297,9 @@ async def test_invoke_includes_tool_calls_in_history(
     captured_inputs: dict[str, Any] = {}
 
     class CapturingCrew(CrewForTest):
-        def kickoff_async(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
+        def akickoff(self, *, inputs: dict[str, Any]) -> CrewOutput | CrewStreamingOutput:  # type: ignore[override]
             captured_inputs.update(inputs)
-            return super().kickoff_async(inputs=inputs)
+            return super().akickoff(inputs=inputs)
 
     class AgentWithPlaceholder(AgentForTest):
         def make_kickoff_inputs(self, user_prompt_content: str) -> dict[str, Any]:

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -279,6 +279,26 @@ async def test_litellm_stop_word_llm_acall_applies_stop_words(
     assert "Final Answer:" not in result
 
 
+def test_litellm_stop_word_llm_truncates_inline_react_after_action_input(
+    stop_word_llm: LitellmStopWordLLM,
+) -> None:
+    """Models may hallucinate a second ``Thought`` without an ``Observation:`` label."""
+    hallucinated = (
+        "Thought: you should always think about what to do\n"
+        "Action: generate_objectid\n"
+        'Action Input: {"type":"deployment"}\n'
+        "dff6ff5bc0f04cf69bf4c020cff634c0Thought: you should always think about what to do\n"
+        "Action: generate_objectid\n"
+    )
+    with patch.object(LLM, "call", return_value=hallucinated):
+        result = stop_word_llm.call("test message")
+    assert result == (
+        "Thought: you should always think about what to do\n"
+        "Action: generate_objectid\n"
+        'Action Input: {"type":"deployment"}'
+    )
+
+
 def test_litellm_stop_word_llm_call_no_stop_words_returns_unchanged() -> None:
     """Without stop words configured, responses pass through unchanged."""
     llm = LitellmStopWordLLM(model="openai/gpt-4o")

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -261,6 +261,24 @@ def test_litellm_stop_word_llm_call_applies_stop_words(
     assert "Final Answer:" not in result
 
 
+async def test_litellm_stop_word_llm_acall_applies_stop_words(
+    stop_word_llm: LitellmStopWordLLM,
+) -> None:
+    """Async kickoff uses ``acall``; stop words must truncate there too."""
+    hallucinated = (
+        "Thought: I need to search.\n"
+        "Action: search\n"
+        "Action Input: query\n"
+        "Observation: fake result\n"
+        "Final Answer: hallucinated"
+    )
+    with patch.object(LLM, "acall", return_value=hallucinated):
+        result = await stop_word_llm.acall("test message")
+    assert result == "Thought: I need to search.\nAction: search\nAction Input: query"
+    assert "Observation:" not in result
+    assert "Final Answer:" not in result
+
+
 def test_litellm_stop_word_llm_call_no_stop_words_returns_unchanged() -> None:
     """Without stop words configured, responses pass through unchanged."""
     llm = LitellmStopWordLLM(model="openai/gpt-4o")

--- a/tests/crewai/test_router_llm.py
+++ b/tests/crewai/test_router_llm.py
@@ -153,3 +153,43 @@ async def test_router_llm_acall_streams_and_accumulates() -> None:
 
     result = await llm.acall(messages=[{"role": "user", "content": "hi"}])
     assert result == "Async result"
+
+
+@pytest.mark.asyncio
+async def test_router_llm_acall_emits_llm_stream_chunk_events() -> None:
+    """Verify acall() emits LLMStreamChunkEvent for Crew.akickoff streaming."""
+    from crewai.events import crewai_event_bus
+    from crewai.events.types.llm_events import LLMStreamChunkEvent
+
+    from datarobot_genai.crewai.llm import get_router_llm
+
+    chunks = [_make_chunk("Hello"), _make_chunk(" world")]
+
+    async def fake_acompletion(*args: Any, **kwargs: Any) -> Any:
+        async def gen() -> Any:
+            for c in chunks:
+                yield c
+
+        return gen()
+
+    mock_router = MagicMock()
+    mock_router.acompletion = fake_acompletion
+
+    with patch("litellm.Router", return_value=mock_router):
+        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        llm = get_router_llm(primary, [fb])
+
+    emitted: list[LLMStreamChunkEvent] = []
+
+    def capture(_: object, event: object) -> None:
+        if isinstance(event, LLMStreamChunkEvent):
+            emitted.append(event)
+
+    with crewai_event_bus.scoped_handlers():
+        crewai_event_bus.register_handler(LLMStreamChunkEvent, capture)
+        await llm.acall(messages=[{"role": "user", "content": "hi"}])
+
+    assert len(emitted) == 2
+    assert emitted[0].chunk == "Hello"
+    assert emitted[1].chunk == " world"

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.7"
+version = "0.17.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Crew.kickoff_async runs in a thread whereas Crew.akickoff uses native async/await. The former causes a cascade of
```
AttributeError: '_UnixSelectorEventLoop' object has no attribute '_ssock'
[agent]  Exception ignored in: <function BaseEventLoop.__del__ at 0x1035491c0>
[agent]  Traceback (most recent call last):
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 705, in __del__
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/unix_events.py", line 68, in close
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/selector_events.py", line 104, in close
[agent]    File "/Users/james.clemens/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/asyncio/selector_events.py", line 111, in _close_self_pipe
[agent]  AttributeError: '_UnixSelectorEventLoop' object has no attribute '_ssock'
```
after the `word_counter` tool was introduced in `af-component-agent==11.10.23` and then subsequent agent calls fail.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Use `akickoff` instead of `kickoff_async`. Apply stop works in the CrewAI LLM `acall`. Emit `LLMStreamChunkEvent` in the CrewAI LLM router. Truncate hallucinated tool response so the tool is actually called.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted CrewAI integration and LLM response post-processing with unit test coverage; no auth, data, or API contract changes beyond following CrewAI’s renamed async kickoff entrypoint.
> 
> **Overview**
> **CrewAI** `CrewAIAgent.invoke` now awaits **`crew.akickoff`** instead of the deprecated **`kickoff_async`**, matching current CrewAI APIs.
> 
> **`LitellmStopWordLLM`** applies the same client-side stop-word and ReAct cleanup on the async path: **`acall`** delegates to the parent then runs **`_apply_stop_words`**, which also **truncates inline hallucinations** after `Action Input:` (e.g. fake `Thought:` without an `Observation:` label). Sync **`call`** behavior is extended via the shared **`_apply_stop_words`** hook.
> 
> Tests and changelog updated; e2e lock bumps the editable **`datarobot-genai`** version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f06eb989e5f26c89495a92e902eab6a880c6e9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->