### PR TITLE
[DS-1875] fix: raise datastore previewQuery maxRows cap 999 -> 9999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.17.6
+- `drtools/predictive`: raised the `catalog_query_datastore` datastore-preview cap (`_PREVIEW_QUERY_MAX_ROWS`) from 999 to 9999, matching the `externalDataStores/<id>/previewQuery/` route's server-side `maxRows` limit (the `DataStorePreviewQueryValidator` allows up to 10000). Lets `offset`-based paging reach deeper before requiring SQL-level paging.
+
 ## 0.17.5
 - `e2e`: fixed NeMo-guardrails dragent tests crashing (SIGILL) on non-AVX-512 runners — excluded `annoy` (an sdist-only `-march=native` AVX-512 build) from the e2e resolution.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.17.5"
+version = "0.17.6"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -36,7 +36,9 @@ from datarobot_genai.drtools.pagination import merge_pagination_metadata
 logger = logging.getLogger(__name__)
 
 # Hard cap of the externalDataStores/<id>/previewQuery/ route's maxRows field.
-_PREVIEW_QUERY_MAX_ROWS = 999
+# The server-side validator (DataStorePreviewQueryValidator) allows up to 10_000;
+# we stay just under it.
+_PREVIEW_QUERY_MAX_ROWS = 9999
 
 
 def _serialize_datastore_params(params: Any) -> dict[str, Any]:
@@ -405,7 +407,7 @@ async def catalog_query_datastore(
 
     limit, message = clamp_limit(limit)
 
-    # previewQuery caps maxRows at 999; offset is emulated by over-fetching and
+    # previewQuery caps maxRows at 9999; offset is emulated by over-fetching and
     # slicing, so offset + limit must stay under that cap (push deeper paging
     # into the SQL itself).
     max_rows = offset + limit

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -663,7 +663,7 @@ async def test_catalog_query_datastore_positional_records_keyed_by_columns() -> 
 async def test_catalog_query_datastore_rejects_paging_past_preview_cap() -> None:
     with pytest.raises(ToolError):
         await data.catalog_query_datastore(
-            datastore_id="ds1", sql="SELECT 1", offset=950, limit=100
+            datastore_id="ds1", sql="SELECT 1", offset=9950, limit=100
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.17.5"
+version = "0.17.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

`catalog_query_datastore` rejected any `offset + limit` greater than **999**, a value derived from a stale assumption about the `externalDataStores/<id>/previewQuery/` route. Checking the authoritative backend validator (`DataStorePreviewQueryValidator` in `MLData/data_adapters/public_api/data_stores/validators.py`) shows the route's `maxRows` field is actually `gte=0, lte=10_000, default=1000` — so the tool was needlessly restricting how deep `offset`-based paging could reach. The `999` cap belongs to the *other* data-store endpoints (table `preview` / SQL `verify`), not `previewQuery`.

This raises the cap to **9999** (one under the true server-side limit of 10000) so deeper paging works before falling back to SQL-level `OFFSET/LIMIT`.

## CHANGES
- `drtools/predictive/data.py`: `_PREVIEW_QUERY_MAX_ROWS` 999 → 9999; updated the constant's doc comment and the inline paging comment to reflect the real 10000 server limit.
- `tests/drmcp/unit/predictive_tools/test_data.py`: bumped `test_catalog_query_datastore_rejects_paging_past_preview_cap` from `offset=950` to `offset=9950` so it still trips the (now higher) cap.
- `CHANGELOG.md` + `pyproject.toml` + `uv.lock`: version bump 0.17.5 → 0.17.6.

## TESTING
- `pytest tests/drmcp/unit/predictive_tools/test_data.py` → 46 passed.
- `ruff check` / `ruff format --check` → clean.

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST) — N/A, no new tool; constant + comment + test change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)