### PR TITLE
Run e2e custom metric server via uv

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -191,7 +191,7 @@ jobs:
         uses: JarvusInnovations/background-action@v1
         with:
           working-directory: e2e-tests
-          run: uvicorn custom_metric_app.app:app --port ${{ env.CUSTOM_METRIC_PORT }} &
+          run: uv run uvicorn custom_metric_app.app:app --port ${{ env.CUSTOM_METRIC_PORT }} &
           wait-on: http-get://localhost:${{ env.CUSTOM_METRIC_PORT }}/health
           wait-for: 10s
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Addd to `e2e-tests` for moderations:
 - ootb custom_metric guard
 - Custom model guard
 - All NeMo Evaluator guards
+- `e2e-tests`: run the custom metric server through `uv run uvicorn` so CI and local ootb-custom runs use the e2e virtualenv without requiring activation.
 
 ## 0.18.2
 - `drtools/files_api`: new read-only DataRobot Files API tool surface for browsing the hierarchical `dr://<catalog_id>/path` filesystem — `file_list` (ls/recursive/glob/tree with pagination), `file_info` (single file/directory metadata), `file_read` (inline UTF-8/base64 content with byte-range reads, capped at `MAX_INLINE_SIZE`), and `file_sign` (temporary signed download URLs for large files). Gated behind the new `enable_files_api_tools` config flag (`ENABLE_FILES_API_TOOLS`), disabled by default, and registered as the `files_api` tool type. Moved the `datarobot-early-access[fs]` dependency into `drmcputils` and dropped the now-redundant `datarobot` pins from `drtools`/`drmcpbase`.

--- a/e2e-tests/scripts/run_local.py
+++ b/e2e-tests/scripts/run_local.py
@@ -156,9 +156,10 @@ def _stop_server(proc: subprocess.Popen[bytes]) -> None:
 
 
 def _start_guards_server() -> subprocess.Popen[bytes]:
-    print(f">>> uvicorn custom_metric_app.app:app --port {CUSTOM_METRIC_PORT}", file=sys.stderr)
+    cmd = ["uv", "run", "uvicorn", "custom_metric_app.app:app", "--port", CUSTOM_METRIC_PORT]
+    print(f">>> {' '.join(shlex.quote(p) for p in cmd)}", file=sys.stderr)
     return subprocess.Popen(
-        ["uvicorn", "custom_metric_app.app:app", "--port", CUSTOM_METRIC_PORT],
+        cmd,
         cwd=str(E2E_ROOT),
         start_new_session=True,
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# RATIONALE

The ootb-custom e2e jobs install dependencies with `uv sync` and run tests with `uv run pytest`, but the custom metric background step invoked bare `uvicorn`. Because the e2e virtualenv is not activated in the workflow or local runner, `uvicorn` may not be available on `PATH` even though it is installed in the uv-managed environment.

## CHANGES

- Run the CI custom metric server with `uv run uvicorn`.
- Run the local e2e custom metric server with the same `uv run uvicorn` command and print the exact command being launched.
- Add a changelog entry for the e2e custom metric server fix.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

## TESTING

- `uv run python -m py_compile scripts/run_local.py`
- `uv run ruff check scripts/run_local.py`
- `uv run python - <<'PY' ...` monkeypatch assertion confirming `_start_guards_server()` launches `["uv", "run", "uvicorn", ...]`
- `git fetch origin otkach/BUZZOK-31133_additional_moderation_tests && git diff --name-only origin/otkach/BUZZOK-31133_additional_moderation_tests...HEAD` confirms `CHANGELOG.md` is present in the PR diff
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a37b95de-321f-43c6-9d4d-8ea7783e5800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a37b95de-321f-43c6-9d4d-8ea7783e5800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

