### PR TITLE
[BUZZOK-31330] Omit temperature in llamaindex LLM when unconfigured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.18.4
-- `llama_index`: omit `temperature` when unconfigured so the model uses its own default (matching langgraph/crewai/nat). LlamaIndex's `LiteLLM` baked in `temperature=0.1`, breaking Anthropic extended thinking. Explicit values are still forwarded; also dropped the redundant E2E `temperature: 1` workaround.
+- `llama_index`: omit `temperature` when unconfigured so the model uses its own default (matching langgraph/crewai/nat). LlamaIndex's `LiteLLM` baked in `temperature=0.1`, breaking Anthropic extended thinking. Explicit values are still forwarded.
+- `e2e-tests`: set `temperature: 0` on the non-reasoning dragent configs for deterministic runs; reasoning overlays unset it (`temperature: ~`) because extended thinking is incompatible with any temperature modification.
 
 ## 0.18.3
 - `e2e-tests`: test cases to test different LLM scenarios with all tests: NIM, external, variety of LLMs in LLMGW.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.18.4
+- `llama_index`: omit `temperature` when unconfigured so the model uses its own default (matching langgraph/crewai/nat). LlamaIndex's `LiteLLM` baked in `temperature=0.1`, breaking Anthropic extended thinking. Explicit values are still forwarded; also dropped the redundant E2E `temperature: 1` workaround.
+
 ## 0.18.3
 - `e2e-tests`: test cases to test different LLM scenarios with all tests: NIM, external, variety of LLMs in LLMGW.
 

--- a/e2e-tests/dragent/base/workflow-reasoning-sonnet.yaml
+++ b/e2e-tests/dragent/base/workflow-reasoning-sonnet.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: enabled

--- a/e2e-tests/dragent/base/workflow.yaml
+++ b/e2e-tests/dragent/base/workflow.yaml
@@ -25,6 +25,7 @@ general:
 llms:
   datarobot_llm:
     _type: datarobot-llm-component
+    temperature: 0
 
 middleware:
   datarobot_guardrails:

--- a/e2e-tests/dragent/crewai/workflow-reasoning-gemini.yaml
+++ b/e2e-tests/dragent/crewai/workflow-reasoning-gemini.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking_config:
         thinking_budget: 1024

--- a/e2e-tests/dragent/crewai/workflow-reasoning-openai.yaml
+++ b/e2e-tests/dragent/crewai/workflow-reasoning-openai.yaml
@@ -17,5 +17,6 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       reasoning_effort: low

--- a/e2e-tests/dragent/crewai/workflow-reasoning-opus.yaml
+++ b/e2e-tests/dragent/crewai/workflow-reasoning-opus.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: adaptive

--- a/e2e-tests/dragent/crewai/workflow-reasoning-sonnet.yaml
+++ b/e2e-tests/dragent/crewai/workflow-reasoning-sonnet.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: enabled

--- a/e2e-tests/dragent/crewai/workflow.yaml
+++ b/e2e-tests/dragent/crewai/workflow.yaml
@@ -25,6 +25,7 @@ general:
 llms:
   datarobot_llm:
     _type: datarobot-llm-component
+    temperature: 0
 
 middleware:
   datarobot_guardrails:

--- a/e2e-tests/dragent/langgraph/workflow-reasoning-gemini.yaml
+++ b/e2e-tests/dragent/langgraph/workflow-reasoning-gemini.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking_config:
         thinking_budget: 1024

--- a/e2e-tests/dragent/langgraph/workflow-reasoning-openai.yaml
+++ b/e2e-tests/dragent/langgraph/workflow-reasoning-openai.yaml
@@ -17,5 +17,6 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       reasoning_effort: low

--- a/e2e-tests/dragent/langgraph/workflow-reasoning-opus.yaml
+++ b/e2e-tests/dragent/langgraph/workflow-reasoning-opus.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: adaptive

--- a/e2e-tests/dragent/langgraph/workflow-reasoning-sonnet.yaml
+++ b/e2e-tests/dragent/langgraph/workflow-reasoning-sonnet.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: enabled

--- a/e2e-tests/dragent/langgraph/workflow.yaml
+++ b/e2e-tests/dragent/langgraph/workflow.yaml
@@ -25,6 +25,7 @@ general:
 llms:
   datarobot_llm:
     _type: datarobot-llm-component
+    temperature: 0
 
 middleware:
   datarobot_guardrails:

--- a/e2e-tests/dragent/llamaindex/workflow-reasoning-gemini.yaml
+++ b/e2e-tests/dragent/llamaindex/workflow-reasoning-gemini.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking_config:
         thinking_budget: 1024

--- a/e2e-tests/dragent/llamaindex/workflow-reasoning-openai.yaml
+++ b/e2e-tests/dragent/llamaindex/workflow-reasoning-openai.yaml
@@ -17,5 +17,6 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       reasoning_effort: low

--- a/e2e-tests/dragent/llamaindex/workflow-reasoning-opus.yaml
+++ b/e2e-tests/dragent/llamaindex/workflow-reasoning-opus.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: adaptive

--- a/e2e-tests/dragent/llamaindex/workflow-reasoning-sonnet.yaml
+++ b/e2e-tests/dragent/llamaindex/workflow-reasoning-sonnet.yaml
@@ -17,7 +17,6 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
-    temperature: 1
     extra_body:
       thinking:
         type: enabled

--- a/e2e-tests/dragent/llamaindex/workflow-reasoning-sonnet.yaml
+++ b/e2e-tests/dragent/llamaindex/workflow-reasoning-sonnet.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: enabled

--- a/e2e-tests/dragent/llamaindex/workflow.yaml
+++ b/e2e-tests/dragent/llamaindex/workflow.yaml
@@ -25,6 +25,7 @@ general:
 llms:
   datarobot_llm:
     _type: datarobot-llm-component
+    temperature: 0
 
 middleware:
   datarobot_guardrails:

--- a/e2e-tests/dragent/nat/workflow-reasoning-gemini.yaml
+++ b/e2e-tests/dragent/nat/workflow-reasoning-gemini.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking_config:
         thinking_budget: 1024

--- a/e2e-tests/dragent/nat/workflow-reasoning-openai.yaml
+++ b/e2e-tests/dragent/nat/workflow-reasoning-openai.yaml
@@ -17,5 +17,6 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       reasoning_effort: low

--- a/e2e-tests/dragent/nat/workflow-reasoning-opus.yaml
+++ b/e2e-tests/dragent/nat/workflow-reasoning-opus.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: adaptive

--- a/e2e-tests/dragent/nat/workflow-reasoning-sonnet.yaml
+++ b/e2e-tests/dragent/nat/workflow-reasoning-sonnet.yaml
@@ -17,6 +17,7 @@ base: workflow.yaml
 
 llms:
   datarobot_llm:
+    temperature: ~  # unset inherited base temperature: thinking is incompatible with temperature
     extra_body:
       thinking:
         type: enabled

--- a/e2e-tests/dragent/nat/workflow.yaml
+++ b/e2e-tests/dragent/nat/workflow.yaml
@@ -38,6 +38,7 @@ functions:
 llms:
   datarobot_llm:
     _type: datarobot-llm-component
+    temperature: 0
 
 function_groups:
   mcp_tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.18.3"
+version = "0.18.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -36,6 +36,16 @@ def _create_datarobot_litellm(config: dict[str, Any]) -> Any:
         """
 
         @property
+        def _model_kwargs(self) -> dict[str, Any]:
+            kwargs = super()._model_kwargs
+            # LlamaIndex's LiteLLM defaults temperature to 0.1 and always sends it;
+            # omit it when unconfigured so the model uses its own default (else a
+            # baked-in value trips guards like Anthropic thinking's temperature==1).
+            if "temperature" not in config:
+                kwargs.pop("temperature", None)
+            return kwargs
+
+        @property
         def metadata(self) -> LLMMetadata:
             """Returns the metadata for the LLM.
 

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -84,6 +84,17 @@ def test_get_datarobot_gateway_llm_merges_parameters() -> None:
     assert llm.temperature == 0.25
 
 
+def test_get_datarobot_gateway_llm_omits_temperature_when_unconfigured() -> None:
+    """An unconfigured temperature is not sent, so the model uses its own default."""
+    llm = llama_index_llm.get_datarobot_gateway_llm()
+    assert "temperature" not in llm._model_kwargs
+
+
+def test_get_datarobot_gateway_llm_keeps_explicit_temperature_on_the_wire() -> None:
+    llm = llama_index_llm.get_datarobot_gateway_llm(parameters={"temperature": 0.25})
+    assert llm._model_kwargs["temperature"] == 0.25
+
+
 def test_get_datarobot_deployment_llm_appends_chat_completions_to_api_base() -> None:
     llm = llama_index_llm.get_datarobot_deployment_llm("dep-abc-123")
     assert isinstance(llm, LiteLLM)

--- a/uv.lock
+++ b/uv.lock
@@ -1104,7 +1104,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.18.3"
+version = "0.18.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

All four dragent frameworks share the same gateway LLM config, yet only `primary-test--llamaindex` failed the reasoning E2E with `temperature may only be set to 1 when thinking is enabled` (BUZZOK-31330). Root cause is purely client-side: LlamaIndex's `LiteLLM` declares `temperature` with a baked-in default of `0.1` and always emits it on the wire, while the langgraph/crewai/nat adapters default `temperature` to `None` and drop it when unset. With extended thinking enabled (the reasoning overlay sets `extra_body.thinking`, applied to every call), Anthropic/Bedrock rejects any `temperature != 1`, so every llamaindex completion 500s and all tests time out. The other frameworks send no temperature and pass.

This makes the llamaindex adapter behave like the others — omit `temperature` when it is not configured so the model uses its own default — which fixes any consumer that enables thinking without explicitly setting a temperature, not just the E2E.

## CHANGES

- `llama_index`: override `DataRobotLiteLLM._model_kwargs` to drop `temperature` when it was not configured; an explicitly configured `temperature` (incl. `0`) is still forwarded.
- `e2e-tests`: remove the now-redundant `temperature: 1` workaround from `llamaindex/workflow-reasoning-sonnet.yaml` so it matches the other overlays.
- `tests/llamaindex`: add coverage for omit-when-unconfigured and keep-when-explicit.
- Bump version to 0.18.4 and update CHANGELOG.

## NOTES

- The router path (`RouterDataRobotLiteLLM`) needs no change — it overrides `_chat`/`_stream`/`_achat`/`_astream` and never calls `_get_all_kwargs`, so it never injected the default temperature.

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to LlamaIndex LLM request kwargs with unit tests; behavior only differs when temperature is unset, reducing provider rejection risk for thinking-enabled calls.
> 
> **Overview**
> Fixes LlamaIndex gateway calls failing under **Anthropic extended thinking** when `temperature` is not set in workflow config. **`DataRobotLiteLLM`** now overrides **`_model_kwargs`** to drop **`temperature`** unless it was explicitly configured, instead of always sending LlamaIndex’s baked-in **`0.1`**.
> 
> This aligns LlamaIndex with the langgraph/crewai/nat adapters (omit unset **`temperature`** so the provider default applies). Explicit **`temperature`** values, including **`0`**, are still forwarded.
> 
> The llamaindex sonnet reasoning E2E overlay no longer needs **`temperature: 1`**. Version **0.18.4** with tests covering omit-vs-explicit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22500484137ab561c31e193f5f18ef95854919da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->