### PR TITLE
[MODEL-23814] File API | File Import Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.18.7
+- `drtools/files_api`: async import tools for large or remote files — `file_import` (background ingest from a URL or data source, returns a `status_id`) and `file_get_status` (single non-blocking status fetch with optional `target_status` / `target_reached`, raises on terminal failure). Backed by new store methods on `DataRobotFileSystemStore` (`import_from_url`, `import_from_data_source`, `get_status`).
+
 ## 0.18.6
 - `drtools/files_api`: write and structural tools for the DataRobot Files API filesystem — `file_write` (inline UTF-8/base64 content, `overwrite`/`create` modes, capped at `MAX_INLINE_SIZE`) and `file_manage` (consolidated `create_dir` | `delete` | `copy` | `move` | `clone` lifecycle actions). Backed by new store methods on `DataRobotFileSystemStore` (`write`, `create_dir`, `delete`, `copy`, `move`, `clone`); shared path/content helpers live in `common_utils.py`.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.18.6"
+version = "0.18.7"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.18.6"
+version = "0.18.7"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/files/file_system_store.py
+++ b/src/datarobot_genai/drmcputils/files/file_system_store.py
@@ -72,11 +72,15 @@ OverwriteStrategyName = Literal["rename", "replace", "skip", "error"]
 
 
 def normalize_status_location(status_id: str) -> str:
-    """Return a relative API route for ``status/<id>/`` from a bare id or route."""
-    cleaned = status_id.strip().strip("/")
-    if cleaned.startswith("status/"):
-        return f"{cleaned}/"
-    return f"status/{cleaned}/"
+    """Return a relative API route for ``status/<id>/`` from a bare id, route, or URL."""
+    cleaned = status_id.strip()
+    if not cleaned:
+        raise ToolError(
+            "Argument validation error: 'status_id' cannot be empty.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    bare_id = extract_status_id(cleaned)
+    return f"status/{bare_id}/"
 
 
 def extract_status_id(async_location: str) -> str:
@@ -432,7 +436,13 @@ class DataRobotFileSystemStore:
             client = dr.client.get_client()
             response = client.get(location, allow_redirects=False)
             if response.status_code == 307:
-                response = client.get(response.headers["Location"], allow_redirects=False)
+                redirect = response.headers.get("Location")
+                if not redirect:
+                    raise ToolError(
+                        "Status redirect (307) missing Location header.",
+                        kind=ToolErrorKind.UPSTREAM,
+                    )
+                response = client.get(redirect, allow_redirects=False)
             if response.status_code == 303:
                 return {
                     "status": FILE_IMPORT_COMPLETED_STATUS,

--- a/src/datarobot_genai/drmcputils/files/file_system_store.py
+++ b/src/datarobot_genai/drmcputils/files/file_system_store.py
@@ -31,9 +31,6 @@ Design mirrors :mod:`datarobot_genai.drmcputils.files.store`:
   inside the thread.
 - DataRobot/fsspec errors are normalised to :class:`ToolError` so tool code
   never leaks SDK or OS exception types.
-
-Only read operations live here for now; write, structural, and async-import
-operations are layered on in later changes.
 """
 
 from __future__ import annotations
@@ -45,11 +42,15 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
+from typing import Literal
 from typing import NoReturn
 from typing import Protocol
 from typing import TypeVar
 from typing import runtime_checkable
+from urllib.parse import urlparse
 
+import datarobot as dr
+from datarobot.enums import FilesOverwriteStrategy
 from datarobot.errors import ClientError
 
 from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
@@ -64,6 +65,40 @@ T = TypeVar("T")
 DR_PROTOCOL = "dr://"
 DEFAULT_LIST_LIMIT = 100
 DEFAULT_SIGN_EXPIRATION_SECONDS = 100
+FILE_IMPORT_COMPLETED_STATUS = "completed"
+FILE_IMPORT_TERMINAL_FAILURE_PREFIXES = ("error", "abort")
+
+OverwriteStrategyName = Literal["rename", "replace", "skip", "error"]
+
+
+def normalize_status_location(status_id: str) -> str:
+    """Return a relative API route for ``status/<id>/`` from a bare id or route."""
+    cleaned = status_id.strip().strip("/")
+    if cleaned.startswith("status/"):
+        return f"{cleaned}/"
+    return f"status/{cleaned}/"
+
+
+def extract_status_id(async_location: str) -> str:
+    """Extract the bare status id from an async Location header or route."""
+    location = async_location.strip().rstrip("/")
+    if location.startswith("http://") or location.startswith("https://"):
+        path = urlparse(location).path.rstrip("/")
+        location = path.split("/api/v2/", 1)[-1] if "/api/v2/" in path else path.lstrip("/")
+    if location.startswith("status/"):
+        return location.split("/", 1)[1].split("/", 1)[0]
+    return location.split("/")[-1]
+
+
+def overwrite_strategy_from_name(name: OverwriteStrategyName) -> FilesOverwriteStrategy:
+    return FilesOverwriteStrategy(name)
+
+
+def is_terminal_import_failure_status(status: str | None) -> bool:
+    if not status:
+        return False
+    lowered = status.lower()
+    return lowered[:5] in FILE_IMPORT_TERMINAL_FAILURE_PREFIXES
 
 
 @dataclass(frozen=True, slots=True)
@@ -176,6 +211,33 @@ class FileSystemStore(Protocol):
 
     async def clone(self, path_or_id: str, *, files_to_omit: list[str] | None = None) -> str:
         """Clone a catalog item directory and return the new catalog item id."""
+        ...
+
+    async def import_from_url(
+        self,
+        path: str,
+        url: str,
+        *,
+        unpack_archive: bool = True,
+        overwrite: OverwriteStrategyName = "rename",
+    ) -> str:
+        """Start a URL import and return the async status id."""
+        ...
+
+    async def import_from_data_source(
+        self,
+        path: str,
+        data_source_id: str,
+        *,
+        credential_id: str | None = None,
+        unpack_archive: bool = True,
+        overwrite: OverwriteStrategyName = "rename",
+    ) -> str:
+        """Start a data-source import and return the async status id."""
+        ...
+
+    async def get_status(self, status_id: str) -> dict[str, Any]:
+        """Fetch the current async status payload for a single import job."""
         ...
 
 
@@ -300,3 +362,86 @@ class DataRobotFileSystemStore:
         return await self._run(
             lambda fs: fs.clone_catalog_item_dir(path_or_id, files_to_omit=files_to_omit)
         )
+
+    async def import_from_url(
+        self,
+        path: str,
+        url: str,
+        *,
+        unpack_archive: bool = True,
+        overwrite: OverwriteStrategyName = "rename",
+    ) -> str:
+        strategy = overwrite_strategy_from_name(overwrite)
+
+        def _call(fs: Any) -> str:
+            catalog_id, internal_path = fs._split_path(path)
+            prefix = f"{internal_path.rstrip('/')}/" if internal_path else None
+            entity = fs._get_files_wrapper_for_folder_id(catalog_id).upload_from_url(
+                url=url,
+                use_archive_contents=unpack_archive,
+                overwrite=strategy,
+                wait_for_completion=False,
+                prefix=prefix,
+            )
+            location = entity._async_status_location
+            if not location:
+                raise ToolError(
+                    "Import did not return an async status location.",
+                    kind=ToolErrorKind.UPSTREAM,
+                )
+            return extract_status_id(location)
+
+        return await self._run(_call)
+
+    async def import_from_data_source(
+        self,
+        path: str,
+        data_source_id: str,
+        *,
+        credential_id: str | None = None,
+        unpack_archive: bool = True,
+        overwrite: OverwriteStrategyName = "rename",
+    ) -> str:
+        strategy = overwrite_strategy_from_name(overwrite)
+
+        def _call(fs: Any) -> str:
+            catalog_id, internal_path = fs._split_path(path)
+            prefix = f"{internal_path.rstrip('/')}/" if internal_path else None
+            entity = fs._get_files_wrapper_for_folder_id(catalog_id).upload_from_data_source(
+                data_source_id=data_source_id,
+                credential_id=credential_id,
+                prefix=prefix,
+                use_archive_contents=unpack_archive,
+                overwrite=strategy,
+                wait_for_completion=False,
+            )
+            location = entity._async_status_location
+            if not location:
+                raise ToolError(
+                    "Import did not return an async status location.",
+                    kind=ToolErrorKind.UPSTREAM,
+                )
+            return extract_status_id(location)
+
+        return await self._run(_call)
+
+    async def get_status(self, status_id: str) -> dict[str, Any]:
+        location = normalize_status_location(status_id)
+
+        def _fetch() -> dict[str, Any]:
+            client = dr.client.get_client()
+            response = client.get(location, allow_redirects=False)
+            if response.status_code == 307:
+                response = client.get(response.headers["Location"], allow_redirects=False)
+            if response.status_code == 303:
+                return {
+                    "status": FILE_IMPORT_COMPLETED_STATUS,
+                    "redirect_location": response.headers.get("Location"),
+                }
+            return response.json()
+
+        with request_user_dr_sdk(headers_auth_only=self._headers_auth_only):
+            try:
+                return await asyncio.to_thread(_fetch)
+            except ClientError as exc:
+                raise_tool_error_for_client_error(exc)

--- a/src/datarobot_genai/drtools/files_api/imports.py
+++ b/src/datarobot_genai/drtools/files_api/imports.py
@@ -1,0 +1,179 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async import tools for the DataRobot Files API filesystem.
+
+Large or remote payloads are ingested via background jobs. ``file_import`` starts
+the job and returns a ``status_id``; ``file_get_status`` performs a single
+non-blocking status fetch so callers can poll until completion.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+from typing import Any
+from typing import Literal
+
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drmcputils.files.file_system_store import is_terminal_import_failure_status
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.files_api.common_utils import get_store as _get_store
+from datarobot_genai.drtools.files_api.common_utils import require_file_path as _require_file_path
+from datarobot_genai.drtools.files_api.common_utils import require_path as _require_path
+
+logger = logging.getLogger(__name__)
+
+_IMPORT_STATUS_NOTE = (
+    "Import started. Poll file_get_status(status_id=..., target_status='completed') "
+    "every few seconds until target_reached is true."
+)
+
+
+# ------------------------------------------------------------------ #
+# file_import                                                          #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"file", "datarobot", "import", "upload", "url", "data_source"},
+    description=(
+        "[Files—import] Start a background import into a catalog directory. "
+        "Use for large or remote files instead of file_write. Returns immediately "
+        "with a status_id; poll file_get_status until completion.\n"
+        "  - source='url': set url to a file or archive URL reachable by DataRobot.\n"
+        "  - source='data_source': set data_source_id (and optional credential_id).\n"
+        "  - unpack_archive: extract zip/tar archives when true (default).\n"
+        "  - overwrite: 'rename' (default), 'replace', 'skip', or 'error'.\n\n"
+        "Example: file_import(path='dr://abc123/data/', source='url', "
+        "url='https://example.com/report.zip')\n"
+        "Example: file_import(path='dr://abc123/in/', source='data_source', "
+        "data_source_id='ds-123')"
+    ),
+)
+async def file_import(
+    *,
+    path: Annotated[
+        str,
+        "Destination directory under a catalog item (dr://<catalog_id>/folder/).",
+    ],
+    source: Annotated[
+        Literal["url", "data_source"],
+        "Import source type: 'url' or 'data_source'.",
+    ],
+    url: Annotated[
+        str | None,
+        "Remote file or archive URL. Required when source='url'.",
+    ] = None,
+    data_source_id: Annotated[
+        str | None,
+        "DataRobot data source id. Required when source='data_source'.",
+    ] = None,
+    credential_id: Annotated[
+        str | None,
+        "Optional credential id for data_source imports.",
+    ] = None,
+    unpack_archive: Annotated[
+        bool,
+        "Extract archive contents when true; upload as-is when false. Default true.",
+    ] = True,
+    overwrite: Annotated[
+        Literal["rename", "replace", "skip", "error"],
+        "Conflict strategy when a file already exists at the destination.",
+    ] = "rename",
+) -> dict[str, Any]:
+    cleaned = _require_file_path(path)
+    store = _get_store()
+
+    if source == "url":
+        remote_url = _require_path(url, "url")
+        status_id = await store.import_from_url(
+            cleaned,
+            remote_url,
+            unpack_archive=unpack_archive,
+            overwrite=overwrite,
+        )
+    else:
+        ds_id = _require_path(data_source_id, "data_source_id")
+        status_id = await store.import_from_data_source(
+            cleaned,
+            ds_id,
+            credential_id=credential_id,
+            unpack_archive=unpack_archive,
+            overwrite=overwrite,
+        )
+
+    return {
+        "path": cleaned,
+        "source": source,
+        "status_id": status_id,
+        "note": _IMPORT_STATUS_NOTE,
+    }
+
+
+# ------------------------------------------------------------------ #
+# file_get_status                                                      #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"file", "datarobot", "import", "status"},
+    description=(
+        "[Files—import status] Fetch the current status of a background import "
+        "started by file_import. Performs ONE non-blocking fetch — it does not "
+        "wait or poll. Pass target_status='completed' to get target_reached. "
+        "Raises if the import enters a terminal failure state.\n\n"
+        "Example: file_get_status(status_id='abc123')\n"
+        "Example: file_get_status(status_id='abc123', target_status='completed')"
+    ),
+)
+async def file_get_status(
+    *,
+    status_id: Annotated[str, "Status id returned by file_import."],
+    target_status: Annotated[
+        str | None,
+        "Optional status to compare against, e.g. 'completed'. Does not block.",
+    ] = None,
+) -> dict[str, Any]:
+    sid = _require_path(status_id, "status_id")
+    if target_status is not None:
+        target = target_status.strip()
+        if not target:
+            raise ToolError(
+                "Argument validation error: 'target_status' cannot be empty.",
+                kind=ToolErrorKind.VALIDATION,
+            )
+    else:
+        target = None
+
+    raw = await _get_store().get_status(sid)
+    status = raw.get("status")
+    if is_terminal_import_failure_status(str(status) if status is not None else None):
+        raise ToolError(
+            f"Import {sid!r} entered terminal status {status!r}.",
+            kind=ToolErrorKind.UPSTREAM,
+        )
+
+    if target is None:
+        return {"status_id": sid, "status": status, "raw": raw}
+
+    normalized_status = str(status).lower() if status is not None else ""
+    normalized_target = target.lower()
+    return {
+        "status_id": sid,
+        "status": status,
+        "target_reached": normalized_status == normalized_target,
+        "raw": raw,
+    }

--- a/tests/drmcp/unit/files_api_tools/test_file_system_store.py
+++ b/tests/drmcp/unit/files_api_tools/test_file_system_store.py
@@ -324,8 +324,55 @@ async def test_get_status_fetches_json_payload() -> None:
 def test_status_helpers() -> None:
     assert normalize_status_location("job123") == "status/job123/"
     assert normalize_status_location("status/job123/") == "status/job123/"
+    assert normalize_status_location("https://host/api/v2/status/job123/") == "status/job123/"
     assert extract_status_id("status/job123/") == "job123"
     assert extract_status_id("https://host/api/v2/status/job123/") == "job123"
     assert is_terminal_import_failure_status("ERROR")
     assert is_terminal_import_failure_status("aborted")
     assert not is_terminal_import_failure_status("completed")
+
+
+async def test_get_status_accepts_full_async_url() -> None:
+    store = _store_with()
+    requested: list[str] = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"status": "INPROGRESS"}
+
+    fake_client = type(
+        "C",
+        (),
+        {
+            "get": lambda _s, loc, allow_redirects=False: requested.append(loc) or FakeResponse(),
+        },
+    )()
+    with patch(
+        "datarobot_genai.drmcputils.files.file_system_store.dr.client.get_client",
+        return_value=fake_client,
+    ):
+        await store.get_status("https://host/api/v2/status/job123/")
+    assert requested == ["status/job123/"]
+
+
+async def test_get_status_307_without_location_raises_tool_error() -> None:
+    store = _store_with()
+
+    class RedirectResponse:
+        status_code = 307
+        headers: dict[str, str] = {}
+
+    fake_client = type(
+        "C",
+        (),
+        {"get": lambda _s, _loc, allow_redirects=False: RedirectResponse()},
+    )()
+    with patch(
+        "datarobot_genai.drmcputils.files.file_system_store.dr.client.get_client",
+        return_value=fake_client,
+    ):
+        with pytest.raises(ToolError, match="307") as exc:
+            await store.get_status("job123")
+    assert exc.value.kind == ToolErrorKind.UPSTREAM

--- a/tests/drmcp/unit/files_api_tools/test_file_system_store.py
+++ b/tests/drmcp/unit/files_api_tools/test_file_system_store.py
@@ -27,6 +27,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from datarobot.enums import FilesOverwriteStrategy
 from datarobot.errors import ClientError
 
 from datarobot_genai.drmcputils.exceptions import ToolError
@@ -34,6 +35,9 @@ from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drmcputils.files.file_system_store import DataRobotFileSystemStore
 from datarobot_genai.drmcputils.files.file_system_store import FileEntry
 from datarobot_genai.drmcputils.files.file_system_store import FileSystemStore
+from datarobot_genai.drmcputils.files.file_system_store import extract_status_id
+from datarobot_genai.drmcputils.files.file_system_store import is_terminal_import_failure_status
+from datarobot_genai.drmcputils.files.file_system_store import normalize_status_location
 
 
 class FakeFS:
@@ -94,6 +98,34 @@ class FakeFS:
         self.recorded = ("clone", path_or_id, files_to_omit)
         return self._resolve("clone_catalog_item_dir", "")
 
+    def _split_path(self, path: str) -> tuple[str, str]:
+        stripped = path.removeprefix("dr://").strip("/")
+        catalog_id, _, rest = stripped.partition("/")
+        return catalog_id, rest
+
+    def _get_files_wrapper_for_folder_id(self, catalog_id: str) -> FakeFilesWrapper:
+        self.recorded = ("files_wrapper", catalog_id)
+        return self._files_wrapper
+
+
+class FakeFilesEntity:
+    def __init__(self, async_location: str) -> None:
+        self._async_status_location = async_location
+
+
+class FakeFilesWrapper:
+    def __init__(self, *, async_location: str = "status/job123/") -> None:
+        self._async_location = async_location
+        self.last_call: tuple[str, dict[str, Any]] | None = None
+
+    def upload_from_url(self, **kwargs: Any) -> FakeFilesEntity:
+        self.last_call = ("upload_from_url", kwargs)
+        return FakeFilesEntity(self._async_location)
+
+    def upload_from_data_source(self, **kwargs: Any) -> FakeFilesEntity:
+        self.last_call = ("upload_from_data_source", kwargs)
+        return FakeFilesEntity(self._async_location)
+
 
 @contextmanager
 def _noop_sdk(**_: Any) -> Iterator[None]:
@@ -103,6 +135,9 @@ def _noop_sdk(**_: Any) -> Iterator[None]:
 def _store_and_fs(**behavior: Any) -> tuple[DataRobotFileSystemStore, FakeFS]:
     """Patch the SDK + fsspec backend; return the store and the shared fake fs."""
     fs = FakeFS(**behavior)
+    fs._files_wrapper = FakeFilesWrapper(
+        async_location=behavior.get("async_location", "status/job123/")
+    )
     patch(
         "datarobot_genai.drmcputils.files.file_system_store.request_user_dr_sdk",
         _noop_sdk,
@@ -230,3 +265,67 @@ async def test_clone_returns_new_catalog_id() -> None:
     store, fs = _store_and_fs(clone_catalog_item_dir="clone1")
     assert await store.clone("dr://abc/", files_to_omit=["s.txt"]) == "clone1"
     assert fs.recorded == ("clone", "dr://abc/", ["s.txt"])
+
+
+async def test_import_from_url_returns_status_id() -> None:
+    store, fs = _store_and_fs()
+    status_id = await store.import_from_url(
+        "dr://abc123/data/",
+        "https://example.com/file.zip",
+        unpack_archive=False,
+        overwrite="replace",
+    )
+    assert status_id == "job123"
+    assert fs.recorded == ("files_wrapper", "abc123")
+    assert fs._files_wrapper.last_call == (
+        "upload_from_url",
+        {
+            "url": "https://example.com/file.zip",
+            "use_archive_contents": False,
+            "overwrite": FilesOverwriteStrategy.REPLACE,
+            "wait_for_completion": False,
+            "prefix": "data/",
+        },
+    )
+
+
+async def test_import_from_data_source_returns_status_id() -> None:
+    store, fs = _store_and_fs(async_location="https://host/api/v2/status/ds-job/")
+    status_id = await store.import_from_data_source(
+        "dr://abc123/in/",
+        "ds-456",
+        credential_id="cred-1",
+    )
+    assert status_id == "ds-job"
+    assert fs._files_wrapper.last_call[0] == "upload_from_data_source"
+    assert fs._files_wrapper.last_call[1]["data_source_id"] == "ds-456"
+    assert fs._files_wrapper.last_call[1]["credential_id"] == "cred-1"
+    assert fs._files_wrapper.last_call[1]["wait_for_completion"] is False
+
+
+async def test_get_status_fetches_json_payload() -> None:
+    store = _store_with()
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"status": "INPROGRESS"}
+
+    fake_client = type("C", (), {"get": lambda _s, _loc, allow_redirects=False: FakeResponse()})()
+    with patch(
+        "datarobot_genai.drmcputils.files.file_system_store.dr.client.get_client",
+        return_value=fake_client,
+    ):
+        payload = await store.get_status("job123")
+    assert payload == {"status": "INPROGRESS"}
+
+
+def test_status_helpers() -> None:
+    assert normalize_status_location("job123") == "status/job123/"
+    assert normalize_status_location("status/job123/") == "status/job123/"
+    assert extract_status_id("status/job123/") == "job123"
+    assert extract_status_id("https://host/api/v2/status/job123/") == "job123"
+    assert is_terminal_import_failure_status("ERROR")
+    assert is_terminal_import_failure_status("aborted")
+    assert not is_terminal_import_failure_status("completed")

--- a/tests/drmcp/unit/files_api_tools/test_imports.py
+++ b/tests/drmcp/unit/files_api_tools/test_imports.py
@@ -1,0 +1,118 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for async Files API import tools (file_import, file_get_status)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drtools.files_api import imports as imports_mod
+
+
+class FakeStore:
+    """Records import/status calls and returns scripted payloads."""
+
+    def __init__(self, **scripted: Any) -> None:
+        self._scripted = scripted
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _record(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        self.calls.append((name, args, kwargs))
+        return self._scripted.get(name)
+
+    async def import_from_url(self, path: str, url: str, **kwargs: Any) -> str:
+        return self._record("import_from_url", path, url, **kwargs) or "job-url"
+
+    async def import_from_data_source(self, path: str, data_source_id: str, **kwargs: Any) -> str:
+        return self._record("import_from_data_source", path, data_source_id, **kwargs) or "job-ds"
+
+    async def get_status(self, status_id: str) -> dict[str, Any]:
+        return self._record("get_status", status_id) or {"status": "INPROGRESS"}
+
+
+def _use_store(monkeypatch: pytest.MonkeyPatch, store: FakeStore) -> FakeStore:
+    monkeypatch.setattr(imports_mod, "_get_store", lambda: store)
+    return store
+
+
+async def test_file_import_from_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _use_store(monkeypatch, FakeStore())
+    result = await imports_mod.file_import(
+        path="dr://abc123/data/",
+        source="url",
+        url="https://example.com/file.zip",
+        unpack_archive=False,
+        overwrite="replace",
+    )
+    assert result["status_id"] == "job-url"
+    assert result["source"] == "url"
+    assert "file_get_status" in result["note"]
+    name, args, kwargs = store.calls[0]
+    assert name == "import_from_url"
+    assert args == ("dr://abc123/data/", "https://example.com/file.zip")
+    assert kwargs == {"unpack_archive": False, "overwrite": "replace"}
+
+
+async def test_file_import_from_data_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _use_store(monkeypatch, FakeStore())
+    result = await imports_mod.file_import(
+        path="dr://abc123/in/",
+        source="data_source",
+        data_source_id="ds-1",
+        credential_id="cred-1",
+    )
+    assert result["status_id"] == "job-ds"
+    name, args, kwargs = store.calls[0]
+    assert name == "import_from_data_source"
+    assert args == ("dr://abc123/in/", "ds-1")
+    assert kwargs["credential_id"] == "cred-1"
+
+
+async def test_file_import_requires_url_for_url_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_store(monkeypatch, FakeStore())
+    with pytest.raises(ToolError, match="url"):
+        await imports_mod.file_import(path="dr://abc123/data/", source="url")
+
+
+async def test_file_import_requires_data_source_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_store(monkeypatch, FakeStore())
+    with pytest.raises(ToolError, match="data_source_id"):
+        await imports_mod.file_import(path="dr://abc123/data/", source="data_source")
+
+
+async def test_file_get_status_without_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _use_store(monkeypatch, FakeStore(get_status={"status": "INPROGRESS", "message": "x"}))
+    result = await imports_mod.file_get_status(status_id="job123")
+    assert result == {
+        "status_id": "job123",
+        "status": "INPROGRESS",
+        "raw": {"status": "INPROGRESS", "message": "x"},
+    }
+    assert store.calls[0][0] == "get_status"
+
+
+async def test_file_get_status_target_reached(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_store(monkeypatch, FakeStore(get_status={"status": "completed"}))
+    result = await imports_mod.file_get_status(status_id="job123", target_status="completed")
+    assert result["target_reached"] is True
+
+
+async def test_file_get_status_raises_on_terminal_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_store(monkeypatch, FakeStore(get_status={"status": "ERROR"}))
+    with pytest.raises(ToolError, match="terminal status"):
+        await imports_mod.file_get_status(status_id="job123")

--- a/uv.lock
+++ b/uv.lock
@@ -1104,7 +1104,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.18.6"
+version = "0.18.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Created file import tools
- Created unit tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New tools trigger remote imports and data-source credentials against the Files API; behavior is submit-and-poll only, but misconfiguration or overwrite choices can affect catalog content.
> 
> **Overview**
> Adds **async background import** for the Files API so agents can ingest large or remote payloads without blocking on `file_write`.
> 
> **`file_import`** kicks off URL or data-source uploads into a `dr://` catalog path and returns a **`status_id`** immediately (`wait_for_completion=False`). **`file_get_status`** does a single poll (optional **`target_reached`** vs `target_status`) and raises on terminal error/abort statuses.
> 
> **`DataRobotFileSystemStore`** gains `import_from_url`, `import_from_data_source`, and `get_status` (including status-route normalization, redirect handling for completed jobs, and overwrite strategy mapping). Shared helpers cover status id extraction and failure detection.
> 
> Release **0.18.7** with changelog; unit tests cover the store and import tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0504146f722e22546d5a4fdbb0d97622e59d2b54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->