### PR TITLE
[MODEL-23716] Workload API | Integration Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.19.2
+- `drmcp`/`drtools/workload`: integration tests for all 21 workload API MCP tools
+
 ## 0.19.1
 - `crewai`: an empty `agent_role` streaming chunk (CrewAI's `[] Working on task:` task boundary) no longer opens an AG-UI step that is never closed → fixes the `RUN_FINISHED while steps are still active` verifier error.
 - `e2e-tests` (crewai): lower `max_iter` to 5 in the dragent crewai workflow config (was 20) so a runaway ReAct loop is forced to a final answer instead of stalling the stream past the 60s httpx read timeout (the pytest global timeout is 300s).

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.19.1"
+version = "0.19.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -196,6 +196,10 @@ def _apply_dr_client_stubs() -> None:
         mock_rest.get = stub_dr.stub_rest_get
     if stub_dr.stub_rest_post:
         mock_rest.post = stub_dr.stub_rest_post
+    if stub_dr.stub_rest_patch:
+        mock_rest.patch = stub_dr.stub_rest_patch
+    if stub_dr.stub_rest_delete:
+        mock_rest.delete = stub_dr.stub_rest_delete
     stub_dr.client = MagicMock()
     stub_dr.client.get_client = lambda: mock_rest
 

--- a/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
+++ b/src/datarobot_genai/drmcp/test_utils/integration_mcp_server.py
@@ -146,6 +146,21 @@ def _stub_request_user_dr_sdk(*, headers_auth_only: bool = True) -> Generator[An
     yield dr
 
 
+def _make_stub_request_user_dr_client(
+    mock_rest: MagicMock,
+) -> Any:
+    """Return a stub for request_user_dr_client that skips client_configuration."""
+
+    @contextmanager
+    def _stub_request_user_dr_client(
+        *, headers_auth_only: bool = True
+    ) -> Generator[MagicMock, None, None]:
+        del headers_auth_only
+        yield mock_rest
+
+    return _stub_request_user_dr_client
+
+
 def _patch_datarobot_token_for_stdio() -> None:
     """Patch get_datarobot_access_token for stdio (no headers)."""
     tools_datarobot_client.get_datarobot_access_token = _get_datarobot_access_token_stdio_fallback
@@ -206,6 +221,7 @@ def _apply_dr_client_stubs() -> None:
     _apply_dr_sdk_stubs(stub_dr, mock_rest)
 
     tools_datarobot_client.request_user_dr_sdk = _stub_request_user_dr_sdk
+    tools_datarobot_client.request_user_dr_client = _make_stub_request_user_dr_client(mock_rest)
     thread_safe_client = tools_datarobot_client.ThreadSafeDataRobotClient
     thread_safe_client.request_user_client = _stub_thread_safe_request_user_client  # type: ignore[method-assign]
     tools_datarobot_client.get_datarobot_access_token = _get_datarobot_access_token_stdio_fallback

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -18,6 +18,12 @@ from unittest.mock import MagicMock
 
 import polars as pl
 
+from datarobot_genai.drmcp.test_utils.stubs.stub_rest_response import StubRestResponse
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import workload_stub_delete
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import workload_stub_get
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import workload_stub_patch
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import workload_stub_post
+
 # Project id used by test_create_dr_client(); use for integration tests with stubs.
 STUB_PROJECT_ID = "test_project_123"
 
@@ -334,16 +340,6 @@ class StubDataStore:
         self.params = {"type": "jdbc", "driver": "postgresql"}
 
 
-class StubRestResponse:
-    """Stub HTTP response for client.get()/client.post() REST calls."""
-
-    def __init__(self, data: dict[str, Any]):
-        self._data = data
-
-    def json(self) -> dict[str, Any]:
-        return self._data
-
-
 class StubDRClient:
     """Stub DataRobot client for tests (canned responses; use with dr_client_stubs)."""
 
@@ -358,6 +354,8 @@ class StubDRClient:
         self.BatchPredictionJob = StubBatchPredictionJobAPI()
         self.stub_rest_get: Any = None
         self.stub_rest_post: Any = None
+        self.stub_rest_patch: Any = None
+        self.stub_rest_delete: Any = None
 
 
 def test_create_dr_client() -> StubDRClient:
@@ -461,8 +459,8 @@ def test_create_dr_client() -> StubDRClient:
         return StubUseCase(use_case_id, name=name)
 
     # --- REST method stubs for dr_module.client.get_client() ---
-    def stub_get(url: str, params: dict | None = None, **kwargs: Any) -> StubRestResponse:
-        """Stub for rest_client.get() REST calls."""
+    def _stub_get_non_workload(url: str, params: dict | None) -> StubRestResponse:
+        response = StubRestResponse({"data": [], "next": None})
         if "predictionResults" in url:
             limit = (params or {}).get("limit", 100)
             rows = [
@@ -473,9 +471,9 @@ def test_create_dr_client() -> StubDRClient:
                 }
                 for i in range(min(limit, 5))
             ]
-            return StubRestResponse({"data": rows, "next": None})
-        if "externalDataStores" in url:
-            return StubRestResponse(
+            response = StubRestResponse({"data": rows, "next": None})
+        elif "externalDataStores" in url:
+            response = StubRestResponse(
                 {
                     "data": [
                         {
@@ -488,9 +486,11 @@ def test_create_dr_client() -> StubDRClient:
                     "next": None,
                 }
             )
-        if "externalDataDrivers" in url and "tables" in url:
-            return StubRestResponse({"data": [{"name": "public.users"}, {"name": "public.orders"}]})
-        if url.rstrip("/") == "deployments":
+        elif "externalDataDrivers" in url and "tables" in url:
+            response = StubRestResponse(
+                {"data": [{"name": "public.users"}, {"name": "public.orders"}]}
+            )
+        elif url.rstrip("/") == "deployments":
             all_deployments: list[dict[str, Any]] = [
                 {
                     "id": STUB_VDB_DEPLOYMENT_ID,
@@ -515,8 +515,8 @@ def test_create_dr_client() -> StubDRClient:
                     if isinstance(d.get("model"), dict)
                     and d["model"].get("targetType") == model_target_type
                 ]
-            return StubRestResponse({"data": all_deployments, "next": None})
-        if "useCases" in url:
+            response = StubRestResponse({"data": all_deployments, "next": None})
+        elif "useCases" in url:
             data: list[dict] = [
                 {"id": STUB_USE_CASE_ID, "name": "Stub Use Case"},
                 {"id": "stub_use_case_id_2", "name": "Another Use Case"},
@@ -524,11 +524,22 @@ def test_create_dr_client() -> StubDRClient:
             search = (params or {}).get("search")
             if search:
                 data = [uc for uc in data if search.lower() in uc["name"].lower()]
-            return StubRestResponse({"data": data, "next": None})
-        return StubRestResponse({"data": [], "next": None})
+            response = StubRestResponse({"data": data, "next": None})
+        return response
+
+    def stub_get(url: str, params: dict | None = None, **kwargs: Any) -> StubRestResponse:
+        """Stub for rest_client.get() REST calls."""
+        workload_response = workload_stub_get(url, params, **kwargs)
+        if workload_response is not None:
+            return workload_response
+        return _stub_get_non_workload(url, params)
 
     def stub_post(url: str, json: dict | None = None, **kwargs: Any) -> StubRestResponse:
         """Stub for rest_client.post() REST calls."""
+        workload_response = workload_stub_post(url, json, **kwargs)
+        if workload_response is not None:
+            return workload_response
+
         if "deployments" in url and "predictions" in url:
             # vdb_query calls POST deployments/{id}/predictions/
             return StubRestResponse(
@@ -556,6 +567,20 @@ def test_create_dr_client() -> StubDRClient:
             )
         return StubRestResponse({"data": []})
 
+    def stub_patch(url: str, json: dict | None = None, **kwargs: Any) -> StubRestResponse:
+        """Stub for rest_client.patch() REST calls."""
+        workload_response = workload_stub_patch(url, json, **kwargs)
+        if workload_response is not None:
+            return workload_response
+        return StubRestResponse({})
+
+    def stub_delete(url: str, **kwargs: Any) -> StubRestResponse:
+        """Stub for rest_client.delete() REST calls."""
+        workload_response = workload_stub_delete(url, **kwargs)
+        if workload_response is not None:
+            return workload_response
+        return StubRestResponse({})
+
     # Configure the stub methods
     client.Project.get = get_project
     client.Model.get = get_model
@@ -569,6 +594,8 @@ def test_create_dr_client() -> StubDRClient:
     # onto mock_rest after replacing client.client.
     client.stub_rest_get = stub_get
     client.stub_rest_post = stub_post
+    client.stub_rest_patch = stub_patch
+    client.stub_rest_delete = stub_delete
     return client
 
 

--- a/src/datarobot_genai/drmcp/test_utils/stubs/stub_rest_response.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/stub_rest_response.py
@@ -1,0 +1,51 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+
+class StubRestResponse:
+    """Stub HTTP response for client.get()/client.post()/patch()/delete() REST calls."""
+
+    def __init__(
+        self,
+        data: dict[str, Any] | None = None,
+        *,
+        text: str | None = None,
+        content: bytes | None = None,
+        status_code: int = 200,
+    ):
+        self._data = data or {}
+        self._text = text
+        self._content = content
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+    @property
+    def text(self) -> str:
+        if self._text is not None:
+            return self._text
+        return ""
+
+    @property
+    def content(self) -> bytes:
+        if self._content is not None:
+            return self._content
+        if self._data:
+            import json
+
+            return json.dumps(self._data).encode()
+        return b""

--- a/src/datarobot_genai/drmcp/test_utils/stubs/workload_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/workload_stubs.py
@@ -1,0 +1,256 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""REST stubs for DataRobot Workload API tools (integration tests)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from datarobot_genai.drmcp.test_utils.stubs.stub_rest_response import StubRestResponse
+
+STUB_WORKLOAD_ID = "stub_workload_id"
+STUB_ARTIFACT_ID = "stub_artifact_id"
+STUB_PROTON_ID = "stub_proton_id"
+STUB_BUILD_ID = "stub_build_id"
+STUB_REPOSITORY_ID = "stub_repository_id"
+STUB_BUNDLE_ID = "cpu.small"
+
+_WORKLOAD: dict[str, Any] = {
+    "id": STUB_WORKLOAD_ID,
+    "name": "Stub Workload Alpha",
+    "status": "running",
+    "artifactId": STUB_ARTIFACT_ID,
+    "importance": "low",
+}
+
+_ARTIFACT: dict[str, Any] = {
+    "id": STUB_ARTIFACT_ID,
+    "name": "Stub Service Artifact",
+    "status": "draft",
+    "type": "service",
+}
+
+_REPOSITORY: dict[str, Any] = {
+    "id": STUB_REPOSITORY_ID,
+    "name": "Stub Artifact Repository",
+    "type": "service",
+}
+
+_BUILD: dict[str, Any] = {"id": STUB_BUILD_ID, "status": "success"}
+
+_PROTON: dict[str, Any] = {"id": STUB_PROTON_ID, "status": "running", "replicaCount": 1}
+
+_LOG: dict[str, Any] = {
+    "body": "Server started on port 8080",
+    "level": "info",
+    "timestamp": "2026-01-01T00:00:00Z",
+}
+
+
+def _params_dict(params: dict[str, Any] | list[tuple[str, Any]] | None) -> dict[str, Any]:
+    if params is None:
+        return {}
+    if isinstance(params, dict):
+        return params
+    out: dict[str, Any] = {}
+    for key, value in params:
+        if key in out:
+            existing = out[key]
+            out[key] = [existing, value] if not isinstance(existing, list) else [*existing, value]
+        else:
+            out[key] = value
+    return out
+
+
+def _paginate(items: list[dict[str, Any]], params: dict[str, Any]) -> dict[str, Any]:
+    offset = int(params.get("offset", 0))
+    limit = int(params.get("limit", 100))
+    page = items[offset : offset + limit]
+    return {
+        "data": page,
+        "count": len(page),
+        "totalCount": len(items),
+        "next": None,
+        "previous": None,
+    }
+
+
+def _workload_get_response(url: str, p: dict[str, Any]) -> StubRestResponse | None:
+    response: StubRestResponse | None = None
+    if url.rstrip("/") == "workloads":
+        items = [_WORKLOAD]
+        search = p.get("search")
+        if search:
+            needle = str(search).lower()
+            items = [w for w in items if needle in w["name"].lower()]
+        response = StubRestResponse(_paginate(items, p))
+    elif url.startswith("workloads/") and url.count("/") == 1:
+        response = StubRestResponse(_WORKLOAD)
+    elif "/settings" in url:
+        response = StubRestResponse(
+            {"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1}]}}
+        )
+    elif "/stats" in url:
+        response = StubRestResponse(
+            {
+                "requestCount": 120,
+                "errorRate": 0.01,
+                "responseTimeQuantileMs": 45,
+                "slowRequestsCount": 2,
+            }
+        )
+    elif "/history" in url:
+        response = StubRestResponse(
+            _paginate([{"artifactId": STUB_ARTIFACT_ID, "deployedAt": "2026-01-01T00:00:00Z"}], p)
+        )
+    elif "/events" in url:
+        response = StubRestResponse(_paginate([{"type": "status_change", "status": "running"}], p))
+    elif "/related" in url:
+        response = StubRestResponse({"artifacts": [{"id": STUB_ARTIFACT_ID}]})
+    elif url.endswith("/protons") or url.endswith("/protons/"):
+        response = StubRestResponse(_paginate([_PROTON], p))
+    elif "/protons/" in url and url.endswith("/statusDetails"):
+        response = StubRestResponse(
+            {"replicas": [{"name": "pod-0", "phase": "Running", "ready": True, "restartCount": 0}]}
+        )
+    elif "/protons/" in url:
+        response = StubRestResponse(_PROTON)
+    elif "/replacement" in url:
+        response = StubRestResponse(
+            {"candidateArtifactId": STUB_ARTIFACT_ID, "strategy": "rolling"}
+        )
+    elif url.rstrip("/") == "mlops/compute/bundles":
+        response = StubRestResponse(
+            {
+                "data": [
+                    {
+                        "id": STUB_BUNDLE_ID,
+                        "cpuCount": 1,
+                        "memoryBytes": 134217728,
+                        "gpuType": None,
+                    }
+                ]
+            }
+        )
+    return response
+
+
+def _artifact_get_response(url: str, p: dict[str, Any]) -> StubRestResponse | None:
+    response: StubRestResponse | None = None
+    if url.rstrip("/") == "artifacts":
+        response = StubRestResponse(_paginate([_ARTIFACT], p))
+    elif url.startswith("artifacts/") and url.count("/") == 1:
+        response = StubRestResponse(_ARTIFACT)
+    elif url.endswith("/builds") or url.endswith("/builds/"):
+        response = StubRestResponse(_paginate([_BUILD], p))
+    elif "/builds/" in url and url.endswith("/logs"):
+        response = StubRestResponse(text="Step 1/3: FROM python:3.11\nBuild complete.\n")
+    elif "/builds/" in url:
+        response = StubRestResponse(_BUILD)
+    return response
+
+
+def _repository_get_response(url: str, p: dict[str, Any]) -> StubRestResponse | None:
+    response: StubRestResponse | None = None
+    if url.rstrip("/") == "artifactRepositories":
+        response = StubRestResponse(_paginate([_REPOSITORY], p))
+    elif url.startswith("artifactRepositories/"):
+        response = StubRestResponse(_REPOSITORY)
+    return response
+
+
+def workload_stub_get(
+    url: str, params: dict[str, Any] | list[tuple[str, Any]] | None = None, **kwargs: Any
+) -> StubRestResponse | None:
+    del kwargs
+    p = _params_dict(params)
+    for handler in (_workload_get_response, _artifact_get_response, _repository_get_response):
+        response = handler(url, p)
+        if response is not None:
+            return response
+    if url.startswith("otel/workload/") and "/logs/" in url:
+        return StubRestResponse(_paginate([_LOG], p))
+    return None
+
+
+def workload_stub_post(
+    url: str, json: dict[str, Any] | None = None, **kwargs: Any
+) -> StubRestResponse | None:
+    del kwargs
+    payload = json or {}
+    response: StubRestResponse | None = None
+    if url.rstrip("/") == "workloads":
+        response = StubRestResponse(
+            {
+                "id": STUB_WORKLOAD_ID,
+                "name": payload.get("name", "new-workload"),
+                "status": "initializing",
+                "artifactId": payload.get("artifactId"),
+            }
+        )
+    elif url.endswith("/start") or url.endswith("/stop"):
+        response = StubRestResponse({"accepted": True})
+    elif url.endswith("/replacement"):
+        response = StubRestResponse(
+            {
+                "candidateArtifactId": payload.get("artifactId", STUB_ARTIFACT_ID),
+                "strategy": payload.get("strategy", "rolling"),
+            }
+        )
+    elif url.rstrip("/") == "artifacts":
+        response = StubRestResponse(
+            {
+                "id": "stub_artifact_new",
+                "name": payload.get("name", "new-artifact"),
+                "status": "draft",
+            }
+        )
+    elif url.endswith("/clone"):
+        response = StubRestResponse(
+            {
+                "id": "stub_artifact_clone",
+                "name": payload.get("name", "cloned-artifact"),
+                "status": "draft",
+            }
+        )
+    elif url.endswith("/builds"):
+        response = StubRestResponse({"buildIds": [STUB_BUILD_ID]})
+    return response
+
+
+def workload_stub_patch(
+    url: str, json: dict[str, Any] | None = None, **kwargs: Any
+) -> StubRestResponse | None:
+    del kwargs
+    payload = json or {}
+    response: StubRestResponse | None = None
+    if url.startswith("workloads/") and url.count("/") == 1:
+        response = StubRestResponse({"id": url.split("/", 1)[1], **payload})
+    elif "/settings" in url:
+        runtime = payload.get("runtime", payload)
+        response = StubRestResponse({"id": "repl-1", "status": "in_progress", "runtime": runtime})
+    elif url.startswith("artifacts/"):
+        aid = url.split("/", 1)[1]
+        response = StubRestResponse({"id": aid, **payload})
+    return response
+
+
+def workload_stub_delete(url: str, **kwargs: Any) -> StubRestResponse | None:
+    del kwargs
+    if url.startswith("workloads/"):
+        return StubRestResponse({})
+    if url.startswith("artifactRepositories/"):
+        return StubRestResponse({})
+    return None

--- a/tests/drmcp/integration/test_workload_tools.py
+++ b/tests/drmcp/integration/test_workload_tools.py
@@ -1,0 +1,496 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for DataRobot Workload API MCP tools."""
+
+import json
+
+import pytest
+from mcp.types import TextContent
+
+from datarobot_genai.drmcp.test_utils.mcp_utils_integration import integration_test_mcp_session
+from datarobot_genai.drmcp.test_utils.mcp_utils_integration import (
+    integration_test_server_params_with_env,
+)
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import STUB_ARTIFACT_ID
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import STUB_BUILD_ID
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import STUB_BUNDLE_ID
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import STUB_PROTON_ID
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import STUB_REPOSITORY_ID
+from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import STUB_WORKLOAD_ID
+
+_EXPECTED_TOOLS = frozenset(
+    {
+        "workload_list",
+        "workload_get",
+        "workload_create_payload",
+        "workload_create",
+        "workload_update",
+        "workload_action",
+        "bundle_list",
+        "artifact_get",
+        "artifact_create",
+        "artifact_update",
+        "artifact_action",
+        "artifact_repository_get",
+        "artifact_repository_delete",
+        "artifact_build_get",
+        "artifact_build_action",
+        "workload_settings",
+        "workload_replacement",
+        "workload_stats",
+        "workload_logs",
+        "workload_activity",
+        "proton_get",
+    }
+)
+
+
+def _workload_server_params():
+    """Return server params with workload tools enabled."""
+    return integration_test_server_params_with_env({"ENABLE_WORKLOAD_TOOLS": "true"})
+
+
+def _parse_result(result: object) -> dict:
+    assert not getattr(result, "isError", True)
+    content = getattr(result, "content", [])
+    assert len(content) > 0
+    assert isinstance(content[0], TextContent)
+    return json.loads(content[0].text)
+
+
+@pytest.mark.asyncio
+class TestMCPWorkloadToolsRegistration:
+    """Verify workload tools are registered in the MCP server."""
+
+    async def test_tools_registered(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            result = await session.list_tools()
+            tool_names = {t.name for t in result.tools}
+            missing = _EXPECTED_TOOLS - tool_names
+            assert not missing, f"workload tools not registered: {missing}"
+
+
+@pytest.mark.asyncio
+class TestMCPWorkloadDiscoveryIntegration:
+    """Integration tests for workload_list, workload_get, and bundle_list."""
+
+    async def test_workload_list_returns_workloads(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(await session.call_tool("workload_list", {}))
+            assert "workloads" in data
+            assert data["count"] >= 1
+            workload_ids = [w["id"] for w in data["workloads"]]
+            assert STUB_WORKLOAD_ID in workload_ids
+
+    async def test_workload_list_with_search(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("workload_list", {"search": "Alpha", "limit": 10})
+            )
+            assert data["count"] >= 1
+            for workload in data["workloads"]:
+                assert "alpha" in workload["name"].lower()
+
+    async def test_workload_get_success(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("workload_get", {"workload_id": STUB_WORKLOAD_ID})
+            )
+            assert data["id"] == STUB_WORKLOAD_ID
+            assert data["status"] == "running"
+
+    async def test_workload_get_target_status(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_get",
+                    {"workload_id": STUB_WORKLOAD_ID, "target_status": "running"},
+                )
+            )
+            assert data["target_reached"] is True
+            assert data["status"] == "running"
+
+    async def test_workload_get_missing_id(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            result = await session.call_tool("workload_get", {})
+            assert result.isError
+
+    async def test_bundle_list_returns_bundles(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(await session.call_tool("bundle_list", {}))
+            assert "data" in data
+            bundle_ids = [b["id"] for b in data["data"]]
+            assert STUB_BUNDLE_ID in bundle_ids
+
+
+@pytest.mark.asyncio
+class TestMCPWorkloadCreateIntegration:
+    """Integration tests for workload_create_payload and workload_create."""
+
+    async def test_workload_create_payload_existing_artifact(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_create_payload",
+                    {"name": "integration-wl", "artifact_id": STUB_ARTIFACT_ID},
+                )
+            )
+            assert "payload" in data
+            assert data["payload"]["artifactId"] == STUB_ARTIFACT_ID
+
+    async def test_workload_create_payload_inline_artifact(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_create_payload",
+                    {
+                        "name": "echo-wl",
+                        "artifact_name": "echo",
+                        "image_uri": "hashicorp/http-echo:0.2.3",
+                        "port": 8080,
+                        "cpu": 1,
+                        "memory_bytes": 134217728,
+                    },
+                )
+            )
+            container = data["payload"]["artifact"]["spec"]["containerGroups"][0]["containers"][0]
+            assert container["imageUri"] == "hashicorp/http-echo:0.2.3"
+
+    async def test_workload_create_success(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            payload_data = _parse_result(
+                await session.call_tool(
+                    "workload_create_payload",
+                    {"name": "new-wl", "artifact_id": STUB_ARTIFACT_ID},
+                )
+            )
+            data = _parse_result(
+                await session.call_tool("workload_create", {"payload": payload_data["payload"]})
+            )
+            assert data["id"] == STUB_WORKLOAD_ID
+            assert data["status"] == "initializing"
+
+
+@pytest.mark.asyncio
+class TestMCPWorkloadLifecycleIntegration:
+    """Integration tests for workload_update and workload_action."""
+
+    async def test_workload_update_name(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_update",
+                    {"workload_id": STUB_WORKLOAD_ID, "name": "renamed-workload"},
+                )
+            )
+            assert data["name"] == "renamed-workload"
+
+    async def test_workload_action_start(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_action",
+                    {"workload_id": STUB_WORKLOAD_ID, "action": "start"},
+                )
+            )
+            assert data["workload_id"] == STUB_WORKLOAD_ID
+            assert "note" in data
+            assert "workload_get(" in data["note"]
+
+    async def test_workload_action_delete(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_action",
+                    {"workload_id": STUB_WORKLOAD_ID, "action": "delete"},
+                )
+            )
+            assert data == {"deleted": True, "workload_id": STUB_WORKLOAD_ID}
+
+
+@pytest.mark.asyncio
+class TestMCPArtifactToolsIntegration:
+    """Integration tests for artifact_get, artifact_create, artifact_update, artifact_action."""
+
+    async def test_artifact_get_list(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(await session.call_tool("artifact_get", {}))
+            assert "artifacts" in data
+            artifact_ids = [a["id"] for a in data["artifacts"]]
+            assert STUB_ARTIFACT_ID in artifact_ids
+
+    async def test_artifact_get_single(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("artifact_get", {"artifact_id": STUB_ARTIFACT_ID})
+            )
+            assert data["id"] == STUB_ARTIFACT_ID
+            assert data["status"] == "draft"
+
+    async def test_artifact_create_success(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_create",
+                    {
+                        "payload": {
+                            "name": "integration-artifact",
+                            "spec": {
+                                "type": "service",
+                                "containerGroups": [
+                                    {
+                                        "containers": [
+                                            {
+                                                "name": "main",
+                                                "imageUri": "nginx:latest",
+                                                "primary": True,
+                                                "port": 8080,
+                                            }
+                                        ]
+                                    }
+                                ],
+                            },
+                        }
+                    },
+                )
+            )
+            assert data["status"] == "draft"
+            assert "id" in data
+
+    async def test_artifact_update_name(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_update",
+                    {"artifact_id": STUB_ARTIFACT_ID, "name": "updated-artifact"},
+                )
+            )
+            assert data["name"] == "updated-artifact"
+
+    async def test_artifact_action_lock(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_action",
+                    {"artifact_id": STUB_ARTIFACT_ID, "action": "lock"},
+                )
+            )
+            assert data["status"] == "locked"
+
+    async def test_artifact_action_clone(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_action",
+                    {
+                        "artifact_id": STUB_ARTIFACT_ID,
+                        "action": "clone",
+                        "name": "artifact-clone",
+                    },
+                )
+            )
+            assert data["name"] == "artifact-clone"
+            assert data["status"] == "draft"
+
+
+@pytest.mark.asyncio
+class TestMCPArtifactRepositoryToolsIntegration:
+    """Integration tests for artifact_repository_get and artifact_repository_delete."""
+
+    async def test_artifact_repository_get_list(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(await session.call_tool("artifact_repository_get", {}))
+            assert "repositories" in data
+            repo_ids = [r["id"] for r in data["repositories"]]
+            assert STUB_REPOSITORY_ID in repo_ids
+
+    async def test_artifact_repository_get_single(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_repository_get", {"repository_id": STUB_REPOSITORY_ID}
+                )
+            )
+            assert data["id"] == STUB_REPOSITORY_ID
+
+    async def test_artifact_repository_delete(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_repository_delete", {"repository_id": STUB_REPOSITORY_ID}
+                )
+            )
+            assert data == {"deleted": True, "repository_id": STUB_REPOSITORY_ID}
+
+
+@pytest.mark.asyncio
+class TestMCPArtifactBuildToolsIntegration:
+    """Integration tests for artifact_build_get and artifact_build_action."""
+
+    async def test_artifact_build_get_list(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("artifact_build_get", {"artifact_id": STUB_ARTIFACT_ID})
+            )
+            assert "builds" in data
+            build_ids = [b["id"] for b in data["builds"]]
+            assert STUB_BUILD_ID in build_ids
+
+    async def test_artifact_build_get_with_logs(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_build_get",
+                    {
+                        "artifact_id": STUB_ARTIFACT_ID,
+                        "build_id": STUB_BUILD_ID,
+                        "include_logs": True,
+                    },
+                )
+            )
+            assert data["id"] == STUB_BUILD_ID
+            assert "logs" in data
+            assert "FROM python" in data["logs"]
+
+    async def test_artifact_build_action_trigger(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "artifact_build_action",
+                    {"artifact_id": STUB_ARTIFACT_ID, "action": "trigger"},
+                )
+            )
+            assert STUB_BUILD_ID in data["buildIds"]
+
+
+@pytest.mark.asyncio
+class TestMCPWorkloadRuntimeToolsIntegration:
+    """Integration tests for workload_settings and workload_replacement."""
+
+    async def test_workload_settings_read(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("workload_settings", {"workload_id": STUB_WORKLOAD_ID})
+            )
+            assert "runtime" in data
+            assert data["runtime"]["containerGroups"][0]["replicaCount"] == 1
+
+    async def test_workload_settings_update(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            runtime = {"containerGroups": [{"name": "default", "replicaCount": 2}]}
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_settings",
+                    {"workload_id": STUB_WORKLOAD_ID, "runtime": runtime},
+                )
+            )
+            assert data["status"] == "in_progress"
+
+    async def test_workload_replacement_read(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("workload_replacement", {"workload_id": STUB_WORKLOAD_ID})
+            )
+            assert "candidateArtifactId" in data
+
+    async def test_workload_replacement_create(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_replacement",
+                    {
+                        "workload_id": STUB_WORKLOAD_ID,
+                        "artifact_id": STUB_ARTIFACT_ID,
+                    },
+                )
+            )
+            assert data["candidateArtifactId"] == STUB_ARTIFACT_ID
+
+
+@pytest.mark.asyncio
+class TestMCPWorkloadObservabilityToolsIntegration:
+    """Integration tests for stats, logs, activity, and proton_get."""
+
+    async def test_workload_stats(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("workload_stats", {"workload_id": STUB_WORKLOAD_ID})
+            )
+            assert data["requestCount"] == 120
+            assert "errorRate" in data
+
+    async def test_workload_logs(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("workload_logs", {"workload_id": STUB_WORKLOAD_ID})
+            )
+            assert "logs" in data
+            assert data["count"] >= 1
+
+    async def test_workload_activity_history(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_activity",
+                    {"workload_id": STUB_WORKLOAD_ID, "kind": "history"},
+                )
+            )
+            assert "history" in data
+            assert data["history"][0]["artifactId"] == STUB_ARTIFACT_ID
+
+    async def test_workload_activity_events(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_activity",
+                    {"workload_id": STUB_WORKLOAD_ID, "kind": "events"},
+                )
+            )
+            assert "events" in data
+
+    async def test_workload_activity_related(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "workload_activity",
+                    {"workload_id": STUB_WORKLOAD_ID, "kind": "related"},
+                )
+            )
+            assert "artifacts" in data
+
+    async def test_proton_get_list(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool("proton_get", {"workload_id": STUB_WORKLOAD_ID})
+            )
+            assert "protons" in data
+            proton_ids = [p["id"] for p in data["protons"]]
+            assert STUB_PROTON_ID in proton_ids
+
+    async def test_proton_get_with_status_details(self) -> None:
+        async with integration_test_mcp_session(server_params=_workload_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "proton_get",
+                    {
+                        "workload_id": STUB_WORKLOAD_ID,
+                        "proton_id": STUB_PROTON_ID,
+                        "include_status_details": True,
+                    },
+                )
+            )
+            assert data["id"] == STUB_PROTON_ID
+            assert "status_details" in data
+            assert data["status_details"]["replicas"][0]["phase"] == "Running"

--- a/uv.lock
+++ b/uv.lock
@@ -1104,7 +1104,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

Created integration tests for workload API MCP tools
- REST stubs for all Workload API endpoints used by the tools
- Extended `StubRestResponse` with text/content support and added `stub_patch`/`stub_delete`
- Covers all tools

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and stub infrastructure; no production workload tool behavior changes beyond version/changelog.
> 
> **Overview**
> Adds **end-to-end MCP integration coverage** for all **21 workload API tools** when `ENABLE_WORKLOAD_TOOLS=true`, exercising registration plus happy-path calls across discovery, create/lifecycle, artifacts, repositories, builds, settings/replacement, and observability.
> 
> **Test harness changes:** introduces **`workload_stubs`** REST fakes for workloads, artifacts, builds, repositories, protons, OTel logs, and bundles; extracts **`StubRestResponse`** with optional `text`/`content`; routes workload URLs ahead of existing predictive stubs in **`stub_get`/`stub_post`** and adds **`stub_patch`/`stub_delete`** wired through **`integration_mcp_server`**.
> 
> **Release:** bumps package version to **0.19.2** and documents the change in **CHANGELOG**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd31583d0d5dfef6606b49edca139757c5636e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->