### PR TITLE
Use correct conventions for OTEL variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.19.3
+- Fixed OTEL traces endpoint resolution.
+
 ## 0.19.2
 - Updated dependency constraints to fix CVEs.
 

--- a/e2e-tests/dragent_tests/test_otel_tracing.py
+++ b/e2e-tests/dragent_tests/test_otel_tracing.py
@@ -35,6 +35,7 @@ from dragent_tests.helpers import workflow_file
 from dragent_tests.mock_otel_collector import MockOtelCollector
 
 OTLP_TRACES_PATH = "/otel/v1/traces"
+OTLP_PATH = "/otel"
 TEST_API_TOKEN = "test-token"
 TEST_USE_CASE_ID = "test-use-case-id"
 EXPECTED_ENTITY_ID = f"use-case-{TEST_USE_CASE_ID}"
@@ -53,7 +54,7 @@ def test_otel_spans_export_with_datarobot_headers(tmp_path: Path) -> None:
         env = {
             **os.environ,
             # Use the setup close to Codespaces
-            "OTEL_EXPORTER_OTLP_ENDPOINT": collector.endpoint + OTLP_TRACES_PATH,
+            "OTEL_EXPORTER_OTLP_ENDPOINT": collector.endpoint + OTLP_PATH,
             "OTEL_EXPORTER_OTLP_HEADERS": OTEL_EXPORTER_OTLP_HEADERS,
         }
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.2"
+version = "0.19.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.19.2"
+version = "0.19.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/datarobot_otel.py
+++ b/src/datarobot_genai/core/datarobot_otel.py
@@ -89,9 +89,13 @@ def resolve_datarobot_headers_from_env() -> dict[str, str] | None:
 def resolve_otel_traces_endpoint_from_env() -> str:
     # if OTEL_EXPORTER_OTLP_ENDPOINT is set: do not override it
     if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
-        # The convention for OTEL_EXPORTER_OTLP_ENDPOINT is to be base url,
-        # but we want the traces endpoint, so append /v1/traces
+        # The convention for OTEL_EXPORTER_OTLP_ENDPOINT is to be base url
+        # so we need to append /v1/traces
         otel_endpoint = os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"].rstrip("/")
+        # But in some cases for unknonw reasons we have OTEL_EXPORTER_OTLP_ENDPOINT
+        # with /v1/traces already
+        if otel_endpoint.endswith("/v1/traces"):
+            return otel_endpoint
         return f"{otel_endpoint}/v1/traces"
 
     # Derive from the DR API base URL: e.g. https://app.datarobot.com/api/v2

--- a/src/datarobot_genai/core/datarobot_otel.py
+++ b/src/datarobot_genai/core/datarobot_otel.py
@@ -37,6 +37,9 @@ import logging
 import os
 import urllib.parse
 
+from nat.data_models.common import get_secret_value
+from pydantic import SecretStr
+
 logger = logging.getLogger(__name__)
 
 # Idempotency state for ``bootstrap_otel_provider_for_datarobot``. Mutable
@@ -54,7 +57,7 @@ ENTITY_ID_PREFIX = "deployment-"
 
 
 def resolve_api_key_from_env() -> str:
-    return os.getenv("DATAROBOT_API_TOKEN", "")
+    return SecretStr(os.getenv("DATAROBOT_API_TOKEN", ""))
 
 
 def resolve_entity_id_from_env() -> str:
@@ -65,10 +68,29 @@ def resolve_entity_id_from_env() -> str:
     return f"{ENTITY_ID_PREFIX}{deployment_id}" if deployment_id else ""
 
 
-def resolve_otel_endpoint_from_env() -> str:
+def resolve_datarobot_headers_from_env() -> dict[str, str]:
+    # if OTEL_EXPORTER_OTLP_HEADERS are already set: do not override them
+    if os.getenv("OTEL_EXPORTER_OTLP_HEADERS"):
+        headers_list = os.environ["OTEL_EXPORTER_OTLP_HEADERS"].split(",")
+        headers: dict[str, str] = {}
+        for header in headers_list:
+            key, value = header.split("=", 1)
+            headers[key.strip()] = value.strip()
+        return headers
+    return {
+        "X-DataRobot-Api-Key": get_secret_value(resolve_api_key_from_env()),
+        "X-DataRobot-Entity-Id": resolve_entity_id_from_env(),
+    }
+
+
+def resolve_otel_traces_endpoint_from_env() -> str:
     # if OTEL_EXPORTER_OTLP_ENDPOINT is set: do not override it
     if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
-        return os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"]
+        # The convention for OTEL_EXPORTER_OTLP_ENDPOINT is to be base url,
+        # but we want the traces endpoint, so append /v1/traces
+        otel_endpoint = os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"].rstrip("/")
+        return f"{otel_endpoint}/v1/traces"
+
     # Derive from the DR API base URL: e.g. https://app.datarobot.com/api/v2
     # → https://app.datarobot.com/otel/v1/traces. The OTel collector ingress
     # lives at the same host, off /otel/v1/traces, not under /api/v2. We
@@ -128,10 +150,9 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
     if _BOOTSTRAP_STATE["installed"]:
         return False
 
-    api_key = resolve_api_key_from_env()
-    entity_id = resolve_entity_id_from_env()
-    endpoint = resolve_otel_endpoint_from_env()
-    if not api_key or not entity_id or not endpoint:
+    headers = resolve_datarobot_headers_from_env()
+    endpoint = resolve_otel_traces_endpoint_from_env()
+    if not headers or not endpoint:
         logger.info(
             "Skipping OTel TracerProvider bootstrap: DataRobot deployment env "
             "(MLOPS_DEPLOYMENT_ID / DATAROBOT_API_TOKEN / "
@@ -163,10 +184,7 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
 
         exporter = OTLPSpanExporter(
             endpoint=endpoint,
-            headers={
-                "X-DataRobot-Api-Key": api_key,
-                "X-DataRobot-Entity-Id": entity_id,
-            },
+            headers=headers,
         )
         processor = BatchSpanProcessor(exporter)
 
@@ -201,7 +219,7 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
         "DataRobot OTel span processor %s → %s (entity_id=%s)",
         action,
         endpoint,
-        entity_id,
+        headers["X-DataRobot-Entity-Id"],
     )
     return True
 

--- a/src/datarobot_genai/core/datarobot_otel.py
+++ b/src/datarobot_genai/core/datarobot_otel.py
@@ -37,8 +37,6 @@ import logging
 import os
 import urllib.parse
 
-from pydantic import SecretStr
-
 logger = logging.getLogger(__name__)
 
 # Idempotency state for ``bootstrap_otel_provider_for_datarobot``. Mutable
@@ -55,7 +53,7 @@ _BOOTSTRAP_STATE: dict[str, bool] = {"installed": False}
 ENTITY_ID_PREFIX = "deployment-"
 
 
-def resolve_api_key_from_env() -> SecretStr:
+def resolve_api_key_from_env() -> str:
     return os.getenv("DATAROBOT_API_TOKEN", "")
 
 
@@ -92,10 +90,6 @@ def resolve_otel_traces_endpoint_from_env() -> str:
         # The convention for OTEL_EXPORTER_OTLP_ENDPOINT is to be base url
         # so we need to append /v1/traces
         otel_endpoint = os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"].rstrip("/")
-        # But in some cases for unknonw reasons we have OTEL_EXPORTER_OTLP_ENDPOINT
-        # with /v1/traces already
-        if otel_endpoint.endswith("/v1/traces"):
-            return otel_endpoint
         return f"{otel_endpoint}/v1/traces"
 
     # Derive from the DR API base URL: e.g. https://app.datarobot.com/api/v2

--- a/src/datarobot_genai/core/datarobot_otel.py
+++ b/src/datarobot_genai/core/datarobot_otel.py
@@ -37,7 +37,6 @@ import logging
 import os
 import urllib.parse
 
-from nat.data_models.common import get_secret_value
 from pydantic import SecretStr
 
 logger = logging.getLogger(__name__)
@@ -56,8 +55,8 @@ _BOOTSTRAP_STATE: dict[str, bool] = {"installed": False}
 ENTITY_ID_PREFIX = "deployment-"
 
 
-def resolve_api_key_from_env() -> str:
-    return SecretStr(os.getenv("DATAROBOT_API_TOKEN", ""))
+def resolve_api_key_from_env() -> SecretStr:
+    return os.getenv("DATAROBOT_API_TOKEN", "")
 
 
 def resolve_entity_id_from_env() -> str:
@@ -68,7 +67,7 @@ def resolve_entity_id_from_env() -> str:
     return f"{ENTITY_ID_PREFIX}{deployment_id}" if deployment_id else ""
 
 
-def resolve_datarobot_headers_from_env() -> dict[str, str]:
+def resolve_datarobot_headers_from_env() -> dict[str, str] | None:
     # if OTEL_EXPORTER_OTLP_HEADERS are already set: do not override them
     if os.getenv("OTEL_EXPORTER_OTLP_HEADERS"):
         headers_list = os.environ["OTEL_EXPORTER_OTLP_HEADERS"].split(",")
@@ -77,10 +76,14 @@ def resolve_datarobot_headers_from_env() -> dict[str, str]:
             key, value = header.split("=", 1)
             headers[key.strip()] = value.strip()
         return headers
-    return {
-        "X-DataRobot-Api-Key": get_secret_value(resolve_api_key_from_env()),
-        "X-DataRobot-Entity-Id": resolve_entity_id_from_env(),
-    }
+    api_key = resolve_api_key_from_env()
+    entity_id = resolve_entity_id_from_env()
+    if api_key and entity_id:
+        return {
+            "X-DataRobot-Api-Key": api_key,
+            "X-DataRobot-Entity-Id": entity_id,
+        }
+    return None
 
 
 def resolve_otel_traces_endpoint_from_env() -> str:

--- a/src/datarobot_genai/core/telemetry_agent.py
+++ b/src/datarobot_genai/core/telemetry_agent.py
@@ -125,12 +125,16 @@ def instrument(
     # spans through a separate channel that does not touch the OTel SDK
     # global provider — so without this bootstrap, the framework
     # instrumentors patched below would emit spans through a no-op tracer
-    # and nothing reaches DataRobot. Silently no-ops when DR deployment env
-    # is incomplete (local dev) or when another component already installed
-    # a provider.
-    from datarobot_genai.core.datarobot_otel import bootstrap_otel_provider_for_datarobot
+    # and nothing reaches DataRobot.
+    #
+    # TODO (BUZZOK-31396): Call bootstrap from the deployment/notebook entrypoint instead of
+    # here so notebook hosts that already install their own TracerProvider
+    # (via setup_otel_env_variables) are not double-bootstrapped. See
+    # https://github.com/datarobot/datarobot-user-models/blob/master/public_dropin_environments/python311_genai_agents/run_agent.py#L188
+    if os.getenv("MLOPS_DEPLOYMENT_ID"):
+        from datarobot_genai.core.datarobot_otel import bootstrap_otel_provider_for_datarobot
 
-    bootstrap_otel_provider_for_datarobot()
+        bootstrap_otel_provider_for_datarobot()
 
     _instrument_threading()
     _instrument_http_clients()

--- a/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
@@ -175,7 +175,7 @@ async def datarobot_otelcollector_telemetry_exporter(
     }
 
     # Never log the secret. Sorted keys only.
-    logger.debug(
+    logger.info(
         "Configuring datarobot_otelcollector exporter endpoint=%s entity_id=%s header_keys=%s",
         config.endpoint,
         headers.get("X-DataRobot-Entity-Id", ""),

--- a/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
@@ -23,13 +23,8 @@ This exporter mirrors the conventions documented in DataRobot's
 ``datarobot-external-agent-monitoring`` skill (see
 ``datarobot-oss/datarobot-agent-skills``), adapted to NAT's plugin model:
 
-* Headers are passed directly to the exporter — never via
-  ``OTEL_EXPORTER_OTLP_*`` env vars, which some frameworks misinterpret.
-* ``datarobot_entity_id`` uses the ``deployment-<id>`` shape. When omitted it
-  is auto-derived from ``MLOPS_DEPLOYMENT_ID`` (the bare deployment ID
-  exposed inside a DataRobot deployment) with the ``deployment-`` prefix
-  auto-prepended.
-* ``datarobot_api_key`` defaults to ``DATAROBOT_API_TOKEN``.
+* Headers are passed directly to the exporter, not relying on ``OTEL_EXPORTER_OTLP_*`` env vars,
+  which some frameworks misinterpret.
 * ``endpoint`` defaults to ``<DR base host>/otel/v1/traces`` derived from
   ``DATAROBOT_PUBLIC_API_ENDPOINT`` / ``DATAROBOT_ENDPOINT`` (the OTel
   collector ingress lives at the same host as the DR API, off
@@ -50,13 +45,10 @@ pin them in ``workflow.yaml`` to point at a non-default collector.
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import AsyncGenerator
 
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_telemetry_exporter
-from nat.data_models.common import SerializableSecretStr
-from nat.data_models.common import get_secret_value
 from nat.data_models.intermediate_step import IntermediateStep
 from nat.data_models.telemetry_exporter import TelemetryExporterBaseConfig
 from nat.observability.mixin.batch_config_mixin import BatchConfigMixin
@@ -64,12 +56,9 @@ from nat.observability.mixin.collector_config_mixin import CollectorConfigMixin
 from nat.plugins.opentelemetry import OTLPSpanAdapterExporter
 from nat.plugins.opentelemetry.otel_span_exporter import get_opentelemetry_sdk_version
 from pydantic import Field
-from pydantic import field_validator
 
-from datarobot_genai.core.datarobot_otel import ENTITY_ID_PREFIX
-from datarobot_genai.core.datarobot_otel import resolve_api_key_from_env
-from datarobot_genai.core.datarobot_otel import resolve_entity_id_from_env
-from datarobot_genai.core.datarobot_otel import resolve_otel_endpoint_from_env
+from datarobot_genai.core.datarobot_otel import resolve_datarobot_headers_from_env
+from datarobot_genai.core.datarobot_otel import resolve_otel_traces_endpoint_from_env
 from datarobot_genai.core.telemetry_nat_context import pop_nat_span_context
 from datarobot_genai.core.telemetry_nat_context import push_nat_span_context
 from datarobot_genai.core.telemetry_nat_context import reset_nat_span_context
@@ -139,30 +128,12 @@ class DataRobotOtelCollectorTelemetryExporter(  # type: ignore[call-arg]
     """
 
     endpoint: str = Field(
-        default_factory=resolve_otel_endpoint_from_env,
+        default_factory=resolve_otel_traces_endpoint_from_env,
         description=(
             "OTLP/HTTP endpoint for the DataRobot OTel collector. If "
             "omitted, derived from DATAROBOT_PUBLIC_API_ENDPOINT / "
             "DATAROBOT_ENDPOINT by stripping any path (e.g. /api/v2) and "
             "appending /otel/v1/traces."
-        ),
-    )
-    datarobot_api_key: SerializableSecretStr = Field(
-        default_factory=lambda: SerializableSecretStr(resolve_api_key_from_env()),
-        description=(
-            "DataRobot API key sent as the X-DataRobot-Api-Key header. If "
-            "omitted, derived from the DATAROBOT_API_TOKEN env var."
-        ),
-    )
-    datarobot_entity_id: str = Field(
-        default_factory=resolve_entity_id_from_env,
-        description=(
-            "DataRobot entity identifier sent as the X-DataRobot-Entity-Id "
-            "header. Must use the prefixed form 'deployment-<id>' (e.g. "
-            "'deployment-abc123') for shell deployments created by the "
-            "datarobot-external-agent-monitoring skill. If omitted, derived "
-            "from MLOPS_DEPLOYMENT_ID with the 'deployment-' prefix "
-            "auto-prepended."
         ),
     )
     extra_headers: dict[str, str] = Field(
@@ -177,24 +148,6 @@ class DataRobotOtelCollectorTelemetryExporter(  # type: ignore[call-arg]
         description="The resource attributes to add to the span.",
     )
 
-    @field_validator("datarobot_entity_id")
-    @classmethod
-    def _validate_entity_id_prefix(cls, value: str) -> str:
-        # Empty is permitted because the auto-derive path may legitimately
-        # return an empty string when MLOPS_DEPLOYMENT_ID is not set (e.g.
-        # local dev). Any non-empty value must still match the
-        # 'deployment-<id>' shape documented in the DR
-        # external-agent-monitoring skill.
-        if value and not value.startswith(ENTITY_ID_PREFIX):
-            raise ValueError(
-                "datarobot_entity_id must be of the form 'deployment-<id>' "
-                f"(got {value!r}). Inside a DataRobot deployment, omit the "
-                "field — it is auto-derived from MLOPS_DEPLOYMENT_ID. For "
-                "local dev, run create_shell_deployment.py from the "
-                "datarobot-external-agent-monitoring skill."
-            )
-        return value
-
 
 @register_telemetry_exporter(config_type=DataRobotOtelCollectorTelemetryExporter)
 async def datarobot_otelcollector_telemetry_exporter(
@@ -202,18 +155,7 @@ async def datarobot_otelcollector_telemetry_exporter(
     builder: Builder,
 ) -> AsyncGenerator[DataRobotOTLPSpanAdapterExporter]:
     """Yield an OTLP span exporter pointed at the DataRobot OTel collector."""
-    # if OTEL_EXPORTER_OTLP_HEADERS are already set: do not override them
-    if os.getenv("OTEL_EXPORTER_OTLP_HEADERS"):
-        headers_list = os.environ["OTEL_EXPORTER_OTLP_HEADERS"].split(",")
-        headers: dict[str, str] = {}
-        for header in headers_list:
-            key, value = header.split("=", 1)
-            headers[key.strip()] = value.strip()
-    else:
-        headers = {
-            "X-DataRobot-Api-Key": get_secret_value(config.datarobot_api_key),
-            "X-DataRobot-Entity-Id": config.datarobot_entity_id,
-        }
+    headers = resolve_datarobot_headers_from_env()
     # Caller-supplied headers win on collision; lets you e.g. add request-
     # specific X-DataRobot-* metadata without forking the exporter.
     headers.update(config.extra_headers)
@@ -236,7 +178,7 @@ async def datarobot_otelcollector_telemetry_exporter(
     logger.debug(
         "Configuring datarobot_otelcollector exporter endpoint=%s entity_id=%s header_keys=%s",
         config.endpoint,
-        config.datarobot_entity_id,
+        headers.get("X-DataRobot-Entity-Id", ""),
         sorted(headers.keys()),
     )
 

--- a/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
@@ -155,7 +155,7 @@ async def datarobot_otelcollector_telemetry_exporter(
     builder: Builder,
 ) -> AsyncGenerator[DataRobotOTLPSpanAdapterExporter]:
     """Yield an OTLP span exporter pointed at the DataRobot OTel collector."""
-    headers = resolve_datarobot_headers_from_env()
+    headers = resolve_datarobot_headers_from_env() or {}
     # Caller-supplied headers win on collision; lets you e.g. add request-
     # specific X-DataRobot-* metadata without forking the exporter.
     headers.update(config.extra_headers)

--- a/tests/core/test_datarobot_otel.py
+++ b/tests/core/test_datarobot_otel.py
@@ -32,6 +32,7 @@ _ENV_VARS = (
     "DATAROBOT_PUBLIC_API_ENDPOINT",
     "OTEL_SERVICE_NAME",
     "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
 )
 
 
@@ -66,39 +67,89 @@ class TestEnvResolvers:
     def test_endpoint_strips_api_path(self, clean_env):
         clean_env.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
         assert (
-            datarobot_otel.resolve_otel_endpoint_from_env() == "https://example.test/otel/v1/traces"
+            datarobot_otel.resolve_otel_traces_endpoint_from_env()
+            == "https://example.test/otel/v1/traces"
         )
 
     def test_public_endpoint_priority(self, clean_env):
         clean_env.setenv("DATAROBOT_PUBLIC_API_ENDPOINT", "https://public.test/api/v2")
         clean_env.setenv("DATAROBOT_ENDPOINT", "https://internal.test/api/v2")
         assert (
-            datarobot_otel.resolve_otel_endpoint_from_env() == "https://public.test/otel/v1/traces"
+            datarobot_otel.resolve_otel_traces_endpoint_from_env()
+            == "https://public.test/otel/v1/traces"
         )
 
     def test_endpoint_empty_when_unset(self, clean_env):
-        assert datarobot_otel.resolve_otel_endpoint_from_env() == ""
+        assert datarobot_otel.resolve_otel_traces_endpoint_from_env() == ""
 
     def test_endpoint_empty_for_malformed_url(self, clean_env):
         clean_env.setenv("DATAROBOT_ENDPOINT", "not-a-url")
-        assert datarobot_otel.resolve_otel_endpoint_from_env() == ""
+        assert datarobot_otel.resolve_otel_traces_endpoint_from_env() == ""
 
-    def test_explicit_otlp_endpoint_returned_verbatim(self, clean_env):
-        # OTEL_EXPORTER_OTLP_ENDPOINT is the standard OTel override. When set
-        # it is returned as-is, with no host extraction or /otel/v1/traces
-        # rewriting.
-        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test:4318/v1/traces")
+    def test_explicit_otlp_base_url_appends_traces_path(self, clean_env):
+        # OTEL_EXPORTER_OTLP_ENDPOINT is the standard OTel base URL; we append
+        # /v1/traces rather than returning it verbatim.
+        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test:4318")
         assert (
-            datarobot_otel.resolve_otel_endpoint_from_env()
+            datarobot_otel.resolve_otel_traces_endpoint_from_env()
+            == "https://collector.test:4318/v1/traces"
+        )
+
+    def test_explicit_otlp_base_url_strips_trailing_slash(self, clean_env):
+        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test:4318/")
+        assert (
+            datarobot_otel.resolve_otel_traces_endpoint_from_env()
             == "https://collector.test:4318/v1/traces"
         )
 
     def test_explicit_otlp_endpoint_wins_over_datarobot_endpoint(self, clean_env):
         # The standard OTel override takes precedence over the DR-derived
         # endpoint so an operator can point spans at any collector.
-        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test/v1/traces")
+        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test")
         clean_env.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
-        assert datarobot_otel.resolve_otel_endpoint_from_env() == "https://collector.test/v1/traces"
+        assert (
+            datarobot_otel.resolve_otel_traces_endpoint_from_env()
+            == "https://collector.test/v1/traces"
+        )
+
+
+class TestHeaderResolvers:
+    def test_headers_from_datarobot_env(self, clean_env):
+        clean_env.setenv("DATAROBOT_API_TOKEN", "tok")
+        clean_env.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
+        assert datarobot_otel.resolve_datarobot_headers_from_env() == {
+            "X-DataRobot-Api-Key": "tok",
+            "X-DataRobot-Entity-Id": "deployment-abc123",
+        }
+
+    def test_headers_empty_when_env_unset(self, clean_env):
+        assert datarobot_otel.resolve_datarobot_headers_from_env() == {
+            "X-DataRobot-Api-Key": "",
+            "X-DataRobot-Entity-Id": "",
+        }
+
+    def test_headers_parsed_from_otlp_env(self, clean_env):
+        clean_env.setenv(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "X-DataRobot-Api-Key=env-key,X-DataRobot-Entity-Id=deployment-env",
+        )
+        assert datarobot_otel.resolve_datarobot_headers_from_env() == {
+            "X-DataRobot-Api-Key": "env-key",
+            "X-DataRobot-Entity-Id": "deployment-env",
+        }
+
+    def test_headers_value_with_equals_preserved(self, clean_env):
+        # A header value can legitimately contain '=' (e.g. base64 padding or
+        # a token with '='). Splitting on the first '=' only must keep the
+        # full value intact rather than truncating at the first '='.
+        clean_env.setenv(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "Authorization=Basic dXNlcjpwYXNz==,X-Token=a=b=c",
+        )
+        assert datarobot_otel.resolve_datarobot_headers_from_env() == {
+            "Authorization": "Basic dXNlcjpwYXNz==",
+            "X-Token": "a=b=c",
+        }
 
 
 class TestBootstrapOtelProvider:

--- a/tests/core/test_datarobot_otel.py
+++ b/tests/core/test_datarobot_otel.py
@@ -122,11 +122,18 @@ class TestHeaderResolvers:
             "X-DataRobot-Entity-Id": "deployment-abc123",
         }
 
-    def test_headers_empty_when_env_unset(self, clean_env):
-        assert datarobot_otel.resolve_datarobot_headers_from_env() == {
-            "X-DataRobot-Api-Key": "",
-            "X-DataRobot-Entity-Id": "",
-        }
+    def test_headers_none_when_env_unset(self, clean_env):
+        # Both DATAROBOT_API_TOKEN and MLOPS_DEPLOYMENT_ID must be set; otherwise
+        # the resolver returns None so callers can skip auth header injection.
+        assert datarobot_otel.resolve_datarobot_headers_from_env() is None
+
+    def test_headers_none_when_api_key_only(self, clean_env):
+        clean_env.setenv("DATAROBOT_API_TOKEN", "tok")
+        assert datarobot_otel.resolve_datarobot_headers_from_env() is None
+
+    def test_headers_none_when_entity_id_only(self, clean_env):
+        clean_env.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
+        assert datarobot_otel.resolve_datarobot_headers_from_env() is None
 
     def test_headers_parsed_from_otlp_env(self, clean_env):
         clean_env.setenv(
@@ -167,6 +174,11 @@ class TestBootstrapOtelProvider:
 
     def test_skips_when_api_key_only(self, clean_env):
         clean_env.setenv("DATAROBOT_API_TOKEN", "tok")
+        assert datarobot_otel.bootstrap_otel_provider_for_datarobot() is False
+        assert isinstance(trace.get_tracer_provider(), ProxyTracerProvider)
+
+    def test_skips_when_entity_id_only(self, clean_env):
+        clean_env.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
         assert datarobot_otel.bootstrap_otel_provider_for_datarobot() is False
         assert isinstance(trace.get_tracer_provider(), ProxyTracerProvider)
 

--- a/tests/core/test_telemetry_agent.py
+++ b/tests/core/test_telemetry_agent.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
+
 from datarobot_genai.core.telemetry_agent import instrument
 
 
@@ -34,3 +36,17 @@ def test_instrument_with_frameworks() -> None:
 def test_instrument_nat() -> None:
     instrument("nat")
     instrument("nat")
+
+
+def test_instrument_skips_bootstrap_without_deployment_id(monkeypatch) -> None:
+    monkeypatch.delenv("MLOPS_DEPLOYMENT_ID", raising=False)
+    with patch("datarobot_genai.core.datarobot_otel.bootstrap_otel_provider_for_datarobot") as mock:
+        instrument()
+    mock.assert_not_called()
+
+
+def test_instrument_bootstraps_when_deployment_id_set(monkeypatch) -> None:
+    monkeypatch.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
+    with patch("datarobot_genai.core.datarobot_otel.bootstrap_otel_provider_for_datarobot") as mock:
+        instrument()
+    mock.assert_called_once()

--- a/tests/dragent/plugins/test_datarobot_otelcollector.py
+++ b/tests/dragent/plugins/test_datarobot_otelcollector.py
@@ -20,7 +20,6 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
 
 from datarobot_genai.dragent.plugins.datarobot_otelcollector import (
     DataRobotOtelCollectorTelemetryExporter,
@@ -38,6 +37,7 @@ _ENV_VARS = (
     "MLOPS_DEPLOYMENT_ID",
     "DATAROBOT_ENDPOINT",
     "DATAROBOT_PUBLIC_API_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
     "OTEL_EXPORTER_OTLP_HEADERS",
 )
 
@@ -56,114 +56,79 @@ def clean_env(monkeypatch):
 def _make_config(**overrides) -> DataRobotOtelCollectorTelemetryExporter:
     base = {
         "endpoint": ENDPOINT,
-        "datarobot_api_key": API_KEY,
-        "datarobot_entity_id": ENTITY_ID,
         "project": "test-agent",
     }
     base.update(overrides)
     return DataRobotOtelCollectorTelemetryExporter(**base)
 
 
+def _set_datarobot_env(clean_env, *, api_key=API_KEY, entity_id=ENTITY_ID):
+    clean_env.setenv("DATAROBOT_API_TOKEN", api_key)
+    clean_env.setenv("MLOPS_DEPLOYMENT_ID", entity_id.removeprefix("deployment-"))
+
+
 class TestConfigValidation:
     def test_explicit_values_valid(self, clean_env):
         cfg = _make_config()
         assert cfg.endpoint == ENDPOINT
-        assert cfg.datarobot_api_key.get_secret_value() == API_KEY
-        assert cfg.datarobot_entity_id == ENTITY_ID
         assert cfg.extra_headers == {}
-
-    def test_explicit_invalid_entity_id_rejected(self, clean_env):
-        # Bare ID without the 'deployment-' prefix should still fail
-        # validation when explicitly provided — relaxation only allows
-        # empty (for the env-not-set / local-dev path).
-        with pytest.raises(ValidationError) as excinfo:
-            _make_config(datarobot_entity_id="abc123")
-        assert "deployment-<id>" in str(excinfo.value)
-
-    def test_entity_id_with_prefix_valid(self, clean_env):
-        cfg = _make_config(datarobot_entity_id="deployment-xyz")
-        assert cfg.datarobot_entity_id == "deployment-xyz"
-
-    def test_api_key_not_logged_in_repr(self, clean_env):
-        cfg = _make_config(datarobot_api_key="super-secret-token")
-        rendered = repr(cfg)
-        assert "super-secret-token" not in rendered
-        # Pydantic's SecretStr renders as '**********' or similar.
-        assert "**" in rendered or "Secret" in rendered
 
 
 class TestEnvDerivation:
-    def test_all_three_fields_derived_from_env(self, clean_env):
-        clean_env.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
-        clean_env.setenv("DATAROBOT_API_TOKEN", "tok-derived")
+    def test_endpoint_derived_from_env(self, clean_env):
         clean_env.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
         cfg = DataRobotOtelCollectorTelemetryExporter(project="test-agent")
-        assert cfg.datarobot_entity_id == "deployment-abc123"
-        assert cfg.datarobot_api_key.get_secret_value() == "tok-derived"
         assert cfg.endpoint == "https://example.test/otel/v1/traces"
 
-    def test_entity_id_auto_prefixed(self, clean_env):
-        clean_env.setenv("MLOPS_DEPLOYMENT_ID", "6a1716687ee09515373a0ee5")
-        cfg = DataRobotOtelCollectorTelemetryExporter(
-            datarobot_api_key=API_KEY,
-            endpoint=ENDPOINT,
-            project="test-agent",
-        )
-        assert cfg.datarobot_entity_id == "deployment-6a1716687ee09515373a0ee5"
-
-    def test_explicit_entity_id_wins_over_env(self, clean_env):
-        clean_env.setenv("MLOPS_DEPLOYMENT_ID", "from-env")
-        cfg = _make_config(datarobot_entity_id="deployment-explicit")
-        assert cfg.datarobot_entity_id == "deployment-explicit"
-
     def test_public_endpoint_takes_priority_over_endpoint(self, clean_env):
-        # resolve_datarobot_endpoint puts DATAROBOT_PUBLIC_API_ENDPOINT
+        # resolve_otel_traces_endpoint_from_env puts DATAROBOT_PUBLIC_API_ENDPOINT
         # ahead of DATAROBOT_ENDPOINT — same precedence here.
         clean_env.setenv("DATAROBOT_PUBLIC_API_ENDPOINT", "https://public.test/api/v2")
         clean_env.setenv("DATAROBOT_ENDPOINT", "https://internal.test/api/v2")
-        cfg = DataRobotOtelCollectorTelemetryExporter(
-            datarobot_api_key=API_KEY,
-            datarobot_entity_id=ENTITY_ID,
-            project="test-agent",
-        )
+        cfg = DataRobotOtelCollectorTelemetryExporter(project="test-agent")
         assert cfg.endpoint == "https://public.test/otel/v1/traces"
 
     def test_endpoint_strips_api_path_segment(self, clean_env):
         # DATAROBOT_ENDPOINT typically includes the /api/v2 suffix; the OTel
         # collector lives at /otel/v1/traces off the host, not under /api.
         clean_env.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
-        cfg = DataRobotOtelCollectorTelemetryExporter(
-            datarobot_api_key=API_KEY,
-            datarobot_entity_id=ENTITY_ID,
-            project="test-agent",
-        )
+        cfg = DataRobotOtelCollectorTelemetryExporter(project="test-agent")
         assert cfg.endpoint == "https://example.test/otel/v1/traces"
 
     def test_endpoint_empty_when_env_unset(self, clean_env):
         # No silent fallback to app.datarobot.com — empty is the explicit
         # "not configured" signal so an unconfigured env never targets
         # the public DR endpoint by accident.
-        cfg = DataRobotOtelCollectorTelemetryExporter(
-            datarobot_api_key=API_KEY,
-            datarobot_entity_id=ENTITY_ID,
-            project="test-agent",
-        )
+        cfg = DataRobotOtelCollectorTelemetryExporter(project="test-agent")
         assert cfg.endpoint == ""
 
-    def test_entity_id_empty_when_env_unset(self, clean_env):
-        cfg = DataRobotOtelCollectorTelemetryExporter(
-            datarobot_api_key=API_KEY,
-            endpoint=ENDPOINT,
-            project="test-agent",
-        )
-        assert cfg.datarobot_entity_id == ""
+    def test_explicit_otlp_base_url_appends_traces_path(self, clean_env):
+        # OTEL_EXPORTER_OTLP_ENDPOINT is the standard OTel base URL; we append
+        # /v1/traces rather than returning it verbatim.
+        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test:4318")
+        cfg = DataRobotOtelCollectorTelemetryExporter(project="test-agent")
+        assert cfg.endpoint == "https://collector.test:4318/v1/traces"
+
+    def test_explicit_otlp_base_url_strips_trailing_slash(self, clean_env):
+        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test:4318/")
+        cfg = DataRobotOtelCollectorTelemetryExporter(project="test-agent")
+        assert cfg.endpoint == "https://collector.test:4318/v1/traces"
+
+    def test_explicit_otlp_endpoint_wins_over_datarobot_endpoint(self, clean_env):
+        # The standard OTel override takes precedence over the DR-derived
+        # endpoint so an operator can point spans at any collector.
+        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test")
+        clean_env.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
+        cfg = DataRobotOtelCollectorTelemetryExporter(project="test-agent")
+        assert cfg.endpoint == "https://collector.test/v1/traces"
 
 
 class TestExporterFactory:
     # The @register_telemetry_exporter decorator wraps the function in
     # asynccontextmanager, so each call below uses ``async with``.
 
-    async def test_emits_both_datarobot_headers(self):
+    async def test_emits_both_datarobot_headers(self, clean_env):
+        _set_datarobot_env(clean_env)
         cfg = _make_config()
         with patch(
             "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"
@@ -177,7 +142,8 @@ class TestExporterFactory:
         assert kwargs["headers"]["X-DataRobot-Api-Key"] == API_KEY
         assert kwargs["headers"]["X-DataRobot-Entity-Id"] == ENTITY_ID
 
-    async def test_extra_headers_override_defaults(self):
+    async def test_extra_headers_override_defaults(self, clean_env):
+        _set_datarobot_env(clean_env)
         cfg = _make_config(
             extra_headers={
                 "X-DataRobot-Entity-Id": "deployment-override",
@@ -196,9 +162,10 @@ class TestExporterFactory:
         # API key still present because extra_headers didn't override it.
         assert kwargs["headers"]["X-DataRobot-Api-Key"] == API_KEY
 
-    async def test_secret_value_extracted_for_header(self):
+    async def test_secret_value_extracted_for_header(self, clean_env):
         # The header dict should contain the resolved secret string, not a
         # SecretStr wrapper — OTLP exporter expects str values.
+        _set_datarobot_env(clean_env)
         cfg = _make_config()
         with patch(
             "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"
@@ -249,7 +216,7 @@ class TestExporterFactory:
 
 class TestOtlpHeadersEnvOverride:
     """When OTEL_EXPORTER_OTLP_HEADERS is set, the standard OTel header env var
-    wins over the DataRobot auth headers derived from config.
+    wins over the DataRobot auth headers derived from env.
     """
 
     async def test_headers_parsed_from_env(self, clean_env):
@@ -265,13 +232,14 @@ class TestOtlpHeadersEnvOverride:
                 pass
 
         headers = mock_exporter.call_args.kwargs["headers"]
-        # Env-provided headers replace the config-derived DR auth headers.
+        # Env-provided headers replace the DR auth headers derived from env.
         assert headers["X-DataRobot-Api-Key"] == "env-key"
         assert headers["X-DataRobot-Entity-Id"] == "deployment-env"
 
-    async def test_env_headers_take_precedence_over_config(self, clean_env):
-        # Config still supplies API key + entity id, but the env header var
+    async def test_env_headers_take_precedence_over_datarobot_env(self, clean_env):
+        # DR env still supplies API key + entity id, but the OTel header var
         # must override them entirely.
+        _set_datarobot_env(clean_env)
         clean_env.setenv("OTEL_EXPORTER_OTLP_HEADERS", "X-DataRobot-Api-Key=env-key")
         cfg = _make_config()
         with patch(
@@ -282,7 +250,7 @@ class TestOtlpHeadersEnvOverride:
 
         headers = mock_exporter.call_args.kwargs["headers"]
         assert headers["X-DataRobot-Api-Key"] == "env-key"
-        # The config-derived value did not leak through.
+        # The env-derived value did not leak through.
         assert headers["X-DataRobot-Api-Key"] != API_KEY
 
     async def test_extra_headers_still_merged_over_env_headers(self, clean_env):
@@ -318,9 +286,10 @@ class TestOtlpHeadersEnvOverride:
         assert headers["Authorization"] == "Basic dXNlcjpwYXNz=="
         assert headers["X-Token"] == "a=b=c"
 
-    async def test_config_headers_used_when_env_unset(self, clean_env):
-        # Sanity check the default path: with no env var, the DR auth headers
-        # are derived from config as before.
+    async def test_datarobot_env_headers_used_when_otlp_headers_unset(self, clean_env):
+        # Sanity check the default path: with no OTEL_EXPORTER_OTLP_HEADERS,
+        # the DR auth headers are derived from env as before.
+        _set_datarobot_env(clean_env)
         cfg = _make_config()
         with patch(
             "datarobot_genai.dragent.plugins.datarobot_otelcollector.DataRobotOTLPSpanAdapterExporter"

--- a/tests/dragent/plugins/test_datarobot_otelcollector.py
+++ b/tests/dragent/plugins/test_datarobot_otelcollector.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 
 import pytest
 
+from datarobot_genai.core.datarobot_otel import resolve_datarobot_headers_from_env
 from datarobot_genai.dragent.plugins.datarobot_otelcollector import (
     DataRobotOtelCollectorTelemetryExporter,
 )
@@ -123,6 +124,19 @@ class TestEnvDerivation:
         assert cfg.endpoint == "https://collector.test/v1/traces"
 
 
+class TestHeaderResolvers:
+    def test_headers_none_when_datarobot_env_incomplete(self, clean_env):
+        assert resolve_datarobot_headers_from_env() is None
+
+    def test_headers_none_when_api_key_only(self, clean_env):
+        clean_env.setenv("DATAROBOT_API_TOKEN", API_KEY)
+        assert resolve_datarobot_headers_from_env() is None
+
+    def test_headers_none_when_entity_id_only(self, clean_env):
+        clean_env.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
+        assert resolve_datarobot_headers_from_env() is None
+
+
 class TestExporterFactory:
     # The @register_telemetry_exporter decorator wraps the function in
     # asynccontextmanager, so each call below uses ``async with``.
@@ -177,7 +191,10 @@ class TestExporterFactory:
         assert isinstance(api_key_header, str)
         assert api_key_header == API_KEY
 
-    async def test_project_becomes_service_name(self):
+    async def test_project_becomes_service_name(self, clean_env):
+        # Resource attributes are independent of auth headers, but the exporter
+        # factory still needs resolvable headers — supply DR env here.
+        _set_datarobot_env(clean_env)
         # The inherited ``project`` field should populate the OTel
         # ``service.name`` resource attribute, matching NAT's built-in
         # otelcollector exporter.
@@ -194,7 +211,8 @@ class TestExporterFactory:
         assert attrs["telemetry.sdk.name"] == "opentelemetry"
         assert "telemetry.sdk.version" in attrs
 
-    async def test_resource_attributes_override_defaults(self):
+    async def test_resource_attributes_override_defaults(self, clean_env):
+        _set_datarobot_env(clean_env)
         # Explicit resource_attributes win over the defaults derived from
         # ``project`` / SDK metadata.
         cfg = _make_config(

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.2"
+version = "0.19.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

In my previous PR I assumed that `OTEL_EXPORTER_OTLP_ENDPOINT` should be the traces endpoint. It is not: its the base endpoint for the whole OTEL API, and we need to add `/v1/traces` to make it work.

This also unifies reading `OTEL_EXPORTER_OTLP_HEADERS` from env if set.

And after this unification tracing stopped working in Codespaces again: because we are setting up the right exporter in `run_agent.py`, so we should not reconfigure it in tracking_agent... I made a ticket to simplify that, but for now I had to disable internal bootstrap.

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OTLP endpoints and auth headers are derived (including removal of workflow overrides), which can break misconfigured deployments that relied on the old full-URL or yaml fields, though behavior now matches standard OTel conventions.
> 
> **Overview**
> Aligns DataRobot OTel export with **standard OpenTelemetry env semantics**: `OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a **base URL** and **`/v1/traces` is appended** (trailing slashes stripped), instead of using the value as the full traces URL.
> 
> **Centralizes** auth and endpoint resolution in `datarobot_otel.py` via `resolve_datarobot_headers_from_env()` and `resolve_otel_traces_endpoint_from_env()`. When `OTEL_EXPORTER_OTLP_HEADERS` is set, it is parsed (including values containing `=`) and **takes precedence** over `DATAROBOT_API_TOKEN` / `MLOPS_DEPLOYMENT_ID`; otherwise headers are built from those env vars. The NAT **`datarobot_otelcollector`** exporter and **`bootstrap_otel_provider_for_datarobot`** both use these helpers.
> 
> **Removes** workflow/config fields `datarobot_api_key` and `datarobot_entity_id` (and entity-id validation); tracing auth is **env-driven** with `extra_headers` still able to override. E2e OTel test sets the OTLP base to `/otel` (not `/otel/v1/traces`). Unit tests expanded for the new behavior; `datarobot-genai` bumped to **0.19.2** in e2e lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894008b53438c0f1be6bc9cf9e3e4b3cc631a1c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->