### PR TITLE
Added x-datarobot-external-access-token header support for okta 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.19.4
+- Added x-datarobot-external-access-token header support for okta integration
+
 ## 0.19.3
 - Fixed OTEL traces endpoint resolution.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.3"
+version = "0.19.4"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.19.3"
+version = "0.19.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/constants.py
+++ b/src/datarobot_genai/drmcputils/constants.py
@@ -35,6 +35,7 @@ REPLACEMENT_STRATEGIES: tuple[str, ...] = ("rolling",)
 HEADER_TOKEN_CANDIDATE_NAMES = [
     "x-datarobot-authorization",
     "x-datarobot-api-key",
+    "x-datarobot-external-access-token",
     "x-datarobot-api-token",
     "authorization",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.3"
+version = "0.19.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION


<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive entry in the header preference list with no new auth logic; scope is limited to token extraction order for MCP/tool requests.
> 
> **Overview**
> **Release 0.19.4** adds **`x-datarobot-external-access-token`** to the ordered `HEADER_TOKEN_CANDIDATE_NAMES` list in `drmcputils/constants.py`, so MCP and drtools HTTP auth resolution (`_extract_token_from_headers`) can treat the gateway-forwarded Okta external access token as a credential source alongside existing `x-datarobot-*` and `Authorization` headers.
> 
> Version bumps and lockfile updates align the package at **0.19.4**; **CHANGELOG** documents the Okta integration support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9bfa725cc7bb6ad7197bf0b982c798a3232d67. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->