### PR TITLE
[MODEL-23715] Workload API | Acceptance Tests

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -33,6 +33,7 @@ tasks:
         OTEL_ENABLED=false \
         OTEL_SDK_DISABLED=true \
         ENABLE_PREDICTIVE_TOOLS=true \
+        ENABLE_WORKLOAD_TOOLS=true \
         MCP_SERVER_PORT={{.PORT}} uv run tests/drmcp/acceptance/ete_test_server.py &
       - |
         for i in {1..30}; do
@@ -109,7 +110,7 @@ tasks:
           echo "Stopping Jaeger"
           docker stop jaeger || true
       - echo "Running DR MCP Library acceptance tests"
-      - DR_MCP_SERVER_URL=http://localhost:{{.PORT}}/mcp DR_MCP_SERVER_HTTP_URL=http://localhost:{{.PORT}}/ uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/acceptance/{{end}} -s -vv
+      - ENABLE_WORKLOAD_TOOLS=true DR_MCP_SERVER_URL=http://localhost:{{.PORT}}/mcp DR_MCP_SERVER_HTTP_URL=http://localhost:{{.PORT}}/ uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/acceptance/{{end}} -s -vv
     silent: true
 
   drmcp-test-interactive:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.19.6
+- `drmcp`/`drtools/workload`: acceptance E2E tests for read-only workload tools (`workload_list`, `bundle_list`, `artifact_get`, `workload_get`, `workload_stats`) against a live MCP server with `ENABLE_WORKLOAD_TOOLS=true`.
+
 ## 0.19.5
 - `drmcp`/`drtools/workload`: integration tests for all 21 workload API MCP tools
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.5"
+version = "0.19.6"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.19.5"
+version = "0.19.6"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/mcp_utils_integration.py
+++ b/src/datarobot_genai/drmcp/test_utils/mcp_utils_integration.py
@@ -29,6 +29,7 @@ from datarobot_genai.drmcp.test_utils.stub_credentials import STUB_DATAROBOT_END
 # Default tool groups enabled for integration/acceptance MCP servers (model default is off).
 _TEST_SUITE_ENABLED_TOOLS_ENV: dict[str, str] = {
     "ENABLE_PREDICTIVE_TOOLS": "true",
+    "ENABLE_WORKLOAD_TOOLS": "true",
 }
 
 

--- a/tests/drmcp/acceptance/conftest.py
+++ b/tests/drmcp/acceptance/conftest.py
@@ -95,3 +95,25 @@ def classification_dataset_id(classification_project: dict[str, Any]) -> str:
 @pytest.fixture(scope="session")
 def nonexistent_dataset_name() -> str:
     return "nonexistent_dataset_name"
+
+
+@pytest.fixture(scope="session")
+def workload_id(dr_client: Any) -> str:
+    """Workload ID for acceptance tests (``TEST_WORKLOAD_ID`` env or first from API)."""
+    override = os.environ.get("TEST_WORKLOAD_ID")
+    if override:
+        return override
+    try:
+        result = dr_client.client.get_client().get("workloads/", params={"limit": 1}).json()
+        workloads = result.get("data") or []
+        if not workloads:
+            pytest.skip("No workloads available for acceptance tests")
+        return str(workloads[0]["id"])
+    except Exception as exc:
+        pytest.skip(f"Could not list workloads for acceptance tests: {exc}")
+
+
+@pytest.fixture(scope="session")
+def nonexistent_workload_id() -> str:
+    # Workload API validates MongoDB ObjectId shape (24 hex chars); bad format → 422.
+    return "000000000000000000000001"

--- a/tests/drmcp/acceptance/test_workload_tools.py
+++ b/tests/drmcp/acceptance/test_workload_tools.py
@@ -1,0 +1,273 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Acceptance tests for DataRobot Workload API MCP tools."""
+
+import inspect
+import os
+from typing import Any
+
+import pytest
+
+from datarobot_genai.drmcp import ETETestExpectations
+from datarobot_genai.drmcp import ToolBaseE2E
+from datarobot_genai.drmcp import ToolCallTestExpectations
+from datarobot_genai.drmcp import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
+
+
+@pytest.fixture(scope="session")
+def expectations_for_workload_list_success() -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="workload_list",
+                parameters={},
+                result={"count": 0, "offset": 0, "limit": 100},
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "workload",
+            "workloads",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_bundle_list_success() -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="bundle_list",
+                parameters={},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "bundle",
+            "cpu",
+            "resource",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_artifact_get_list_success() -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="artifact_get",
+                parameters={},
+                result={"count": 0, "offset": 0, "limit": 100},
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "artifact",
+            "artifacts",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_workload_get_success(workload_id: str) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="workload_get",
+                parameters={"workload_id": workload_id},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "workload",
+            "status",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_workload_get_not_found(
+    nonexistent_workload_id: str,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="workload_get",
+                parameters={"workload_id": nonexistent_workload_id},
+                result="[not_found] DataRobot API error (404):",
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "not found",
+            "does not exist",
+            "unable",
+            nonexistent_workload_id,
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_workload_stats_success(workload_id: str) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="workload_stats",
+                parameters={"workload_id": workload_id},
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "workload",
+            "request",
+            "stats",
+        ],
+    )
+
+
+@pytest.mark.skipif(
+    not os.getenv("ENABLE_WORKLOAD_TOOLS"),
+    reason="Workload tools are not enabled on the MCP server",
+)
+@pytest.mark.asyncio
+class TestWorkloadToolsE2E(ToolBaseE2E):
+    """End-to-end acceptance tests for Workload API MCP tools."""
+
+    async def test_workload_list_success(
+        self,
+        llm_client: Any,
+        expectations_for_workload_list_success: ETETestExpectations,
+    ) -> None:
+        """LLM lists workloads via workload_list."""
+        prompt = (
+            "List all DataRobot workloads I have access to. "
+            "Use the workload_list tool and summarize what you find."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_workload_list_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_workload_list_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_bundle_list_success(
+        self,
+        llm_client: Any,
+        expectations_for_bundle_list_success: ETETestExpectations,
+    ) -> None:
+        """LLM lists compute bundles via bundle_list."""
+        prompt = (
+            "Show me the available compute resource bundles for DataRobot workloads. "
+            "Use the bundle_list tool."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_bundle_list_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_bundle_list_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_artifact_get_list_success(
+        self,
+        llm_client: Any,
+        expectations_for_artifact_get_list_success: ETETestExpectations,
+    ) -> None:
+        """LLM lists artifacts via artifact_get."""
+        prompt = (
+            "List all artifacts in DataRobot using the artifact_get tool "
+            "(omit artifact_id to list). Summarize the results."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_artifact_get_list_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_artifact_get_list_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_workload_get_success(
+        self,
+        llm_client: Any,
+        workload_id: str,
+        expectations_for_workload_get_success: ETETestExpectations,
+    ) -> None:
+        """LLM fetches a single workload via workload_get."""
+        prompt = (
+            f"Get the details for DataRobot workload '{workload_id}' using workload_get. "
+            "Tell me its name and status."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_workload_get_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_workload_get_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_workload_get_not_found(
+        self,
+        llm_client: Any,
+        nonexistent_workload_id: str,
+        expectations_for_workload_get_not_found: ETETestExpectations,
+    ) -> None:
+        """LLM handles a missing workload id from workload_get."""
+        prompt = (
+            f"Fetch workload '{nonexistent_workload_id}' with workload_get and explain "
+            "what happened if it cannot be found."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_workload_get_not_found"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_workload_get_not_found,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_workload_stats_success(
+        self,
+        llm_client: Any,
+        workload_id: str,
+        expectations_for_workload_stats_success: ETETestExpectations,
+    ) -> None:
+        """LLM reads workload performance stats via workload_stats."""
+        prompt = (
+            f"Get performance statistics for workload '{workload_id}' using workload_stats. "
+            "Summarize request volume or error rate if present."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_workload_stats_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_workload_stats_success,
+                llm_client,
+                session,
+                test_name,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.5"
+version = "0.19.6"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Created acceptance tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests, changelog, version bumps, and test-only env flags; no runtime MCP or workload tool implementation is modified.
> 
> **Overview**
> Adds **acceptance E2E coverage** for read-only Workload API MCP tools (`workload_list`, `bundle_list`, `artifact_get`, `workload_get`, `workload_stats`) using the existing `ToolBaseE2E` + LLM Gateway pattern against a live MCP server.
> 
> **Test harness:** `tests/drmcp/acceptance/test_workload_tools.py` drives natural-language prompts, asserts expected tool calls/results, and skips when `ENABLE_WORKLOAD_TOOLS` is unset. `conftest.py` gains session fixtures for a real `workload_id` (`TEST_WORKLOAD_ID` or first from `workloads/`) and a valid-but-missing ObjectId for 404 cases.
> 
> **CI / local runs:** `ENABLE_WORKLOAD_TOOLS=true` is wired into the acceptance dev server (`.taskfiles/drmcp.yml`), the acceptance pytest invocation, and integration subprocess defaults (`mcp_utils_integration.py`), matching how predictive tools are enabled for suites.
> 
> Release notes bump **0.19.6** (`pyproject.toml`, lockfiles, `CHANGELOG.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c626f30b4c5df32b4015ae969ed2eb68b52c1d09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->