### PR TITLE
[MODEL-23816] File API | Acceptance Tests

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -34,6 +34,7 @@ tasks:
         OTEL_SDK_DISABLED=true \
         ENABLE_PREDICTIVE_TOOLS=true \
         ENABLE_WORKLOAD_TOOLS=true \
+        ENABLE_FILES_API_TOOLS=true \
         MCP_SERVER_PORT={{.PORT}} uv run tests/drmcp/acceptance/ete_test_server.py &
       - |
         for i in {1..30}; do
@@ -110,7 +111,7 @@ tasks:
           echo "Stopping Jaeger"
           docker stop jaeger || true
       - echo "Running DR MCP Library acceptance tests"
-      - ENABLE_WORKLOAD_TOOLS=true DR_MCP_SERVER_URL=http://localhost:{{.PORT}}/mcp DR_MCP_SERVER_HTTP_URL=http://localhost:{{.PORT}}/ uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/acceptance/{{end}} -s -vv
+      - DR_MCP_SERVER_URL=http://localhost:{{.PORT}}/mcp DR_MCP_SERVER_HTTP_URL=http://localhost:{{.PORT}}/ uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/acceptance/{{end}} -s -vv
     silent: true
 
   drmcp-test-interactive:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.19.9
+- `drmcp`/`drtools/files_api`: acceptance E2E tests for read-only Files API tools (`file_list`, `file_info`, `file_read`, `file_sign`) against a live MCP server with `ENABLE_FILES_API_TOOLS=true`.
+
 ## 0.19.8
 - `drmcp`/`drtools/files_api`: integration tests for all 9 Files API MCP tools
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.8"
+version = "0.19.9"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.19.8"
+version = "0.19.9"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/tests/drmcp/acceptance/conftest.py
+++ b/tests/drmcp/acceptance/conftest.py
@@ -120,45 +120,34 @@ def nonexistent_workload_id() -> str:
     return "000000000000000000000001"
 
 
-def _discover_files_catalog_and_file_path() -> tuple[str, str]:
-    """Return (catalog_id, dr:// path) for the first file found under any catalog."""
+_FILES_API_TEST_FILENAME = "acceptance-test.txt"
+_FILES_API_TEST_CONTENT = b"mcp files api acceptance test\n"
+
+
+@pytest.fixture(scope="session")
+def files_api_test_file(dr_client: Any) -> dict[str, str]:
+    """Create a small catalog file for Files API acceptance tests."""
+    del dr_client  # ensure DataRobot client is configured for the session
     fs = DataRobotFileSystem()
-    catalogs = fs.ls("dr://", detail=True)
-
-    for cat_info in catalogs:
-        cat_name = str(cat_info.get("name", "")).rstrip("/")
-        catalog_id = cat_name.split("/")[0]
-        if not catalog_id:
-            continue
-        found = fs.find(f"dr://{catalog_id}/", withdirs=False, detail=True)
-        for rel_path, info in found.items():
-            if info.get("type") != "file":
-                continue
-            if rel_path.startswith("dr://"):
-                return catalog_id, rel_path
-            return catalog_id, f"dr://{rel_path}"
-
-    pytest.skip("No files found under any Files API catalog for acceptance tests")
+    try:
+        catalog_id = fs.create_catalog_item_dir()
+        file_path = f"dr://{catalog_id}/{_FILES_API_TEST_FILENAME}"
+        fs.pipe_file(file_path, value=_FILES_API_TEST_CONTENT, mode="create")
+    except Exception as exc:
+        pytest.skip(f"Could not provision Files API test file: {exc}")
+    return {"catalog_id": catalog_id, "file_path": file_path}
 
 
 @pytest.fixture(scope="session")
-def files_catalog_id() -> str:
-    """Catalog id for Files API tests (``TEST_FILES_CATALOG_ID`` or auto-discovered)."""
-    override = os.environ.get("TEST_FILES_CATALOG_ID")
-    if override:
-        return override
-    catalog_id, _ = _discover_files_catalog_and_file_path()
-    return catalog_id
+def files_catalog_id(files_api_test_file: dict[str, str]) -> str:
+    """Catalog id for Files API acceptance tests."""
+    return files_api_test_file["catalog_id"]
 
 
 @pytest.fixture(scope="session")
-def files_file_path() -> str:
+def files_file_path(files_api_test_file: dict[str, str]) -> str:
     """``dr://`` path to a file for Files API acceptance tests."""
-    override = os.environ.get("TEST_FILES_FILE_PATH")
-    if override:
-        return override
-    _, file_path = _discover_files_catalog_and_file_path()
-    return file_path
+    return files_api_test_file["file_path"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/drmcp/acceptance/conftest.py
+++ b/tests/drmcp/acceptance/conftest.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from datarobot.fs import DataRobotFileSystem
 
 from datarobot_genai.drmcp.test_utils.clients.dr_gateway import DRLLMGatewayMCPClient
 from datarobot_genai.drmcp.test_utils.mcp_utils_ete import get_dr_llm_gateway_client_config
@@ -121,12 +122,8 @@ def nonexistent_workload_id() -> str:
 
 def _discover_files_catalog_and_file_path() -> tuple[str, str]:
     """Return (catalog_id, dr:// path) for the first file found under any catalog."""
-    from datarobot.fs import DataRobotFileSystem
-
     fs = DataRobotFileSystem()
     catalogs = fs.ls("dr://", detail=True)
-    if not catalogs:
-        pytest.skip("No Files API catalog items available for acceptance tests")
 
     for cat_info in catalogs:
         cat_name = str(cat_info.get("name", "")).rstrip("/")

--- a/tests/drmcp/acceptance/conftest.py
+++ b/tests/drmcp/acceptance/conftest.py
@@ -117,3 +117,54 @@ def workload_id(dr_client: Any) -> str:
 def nonexistent_workload_id() -> str:
     # Workload API validates MongoDB ObjectId shape (24 hex chars); bad format → 422.
     return "000000000000000000000001"
+
+
+def _discover_files_catalog_and_file_path() -> tuple[str, str]:
+    """Return (catalog_id, dr:// path) for the first file found under any catalog."""
+    from datarobot.fs import DataRobotFileSystem
+
+    fs = DataRobotFileSystem()
+    catalogs = fs.ls("dr://", detail=True)
+    if not catalogs:
+        pytest.skip("No Files API catalog items available for acceptance tests")
+
+    for cat_info in catalogs:
+        cat_name = str(cat_info.get("name", "")).rstrip("/")
+        catalog_id = cat_name.split("/")[0]
+        if not catalog_id:
+            continue
+        found = fs.find(f"dr://{catalog_id}/", withdirs=False, detail=True)
+        for rel_path, info in found.items():
+            if info.get("type") != "file":
+                continue
+            if rel_path.startswith("dr://"):
+                return catalog_id, rel_path
+            return catalog_id, f"dr://{rel_path}"
+
+    pytest.skip("No files found under any Files API catalog for acceptance tests")
+
+
+@pytest.fixture(scope="session")
+def files_catalog_id() -> str:
+    """Catalog id for Files API tests (``TEST_FILES_CATALOG_ID`` or auto-discovered)."""
+    override = os.environ.get("TEST_FILES_CATALOG_ID")
+    if override:
+        return override
+    catalog_id, _ = _discover_files_catalog_and_file_path()
+    return catalog_id
+
+
+@pytest.fixture(scope="session")
+def files_file_path() -> str:
+    """``dr://`` path to a file for Files API acceptance tests."""
+    override = os.environ.get("TEST_FILES_FILE_PATH")
+    if override:
+        return override
+    _, file_path = _discover_files_catalog_and_file_path()
+    return file_path
+
+
+@pytest.fixture(scope="session")
+def nonexistent_files_path() -> str:
+    """Filesystem path that should not exist (valid catalog id shape, missing file)."""
+    return "dr://000000000000000000000001/nonexistent.txt"

--- a/tests/drmcp/acceptance/test_files_api_tools.py
+++ b/tests/drmcp/acceptance/test_files_api_tools.py
@@ -1,0 +1,233 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Acceptance tests for DataRobot Files API MCP tools."""
+
+import inspect
+import os
+from typing import Any
+
+import pytest
+
+from datarobot_genai.drmcp import ETETestExpectations
+from datarobot_genai.drmcp import ToolBaseE2E
+from datarobot_genai.drmcp import ToolCallTestExpectations
+from datarobot_genai.drmcp import ete_test_mcp_session
+
+
+@pytest.fixture(scope="session")
+def expectations_for_file_list_success() -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="file_list",
+                parameters={"path": "dr://"},
+                result={"path": "dr://"},
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "catalog",
+            "file",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_file_info_success(files_file_path: str) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="file_info",
+                parameters={"path": files_file_path},
+                result={"type": "file"},
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "file",
+            "size",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_file_read_success(files_file_path: str) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="file_read",
+                parameters={"path": files_file_path},
+                result={"encoding": "", "content": ""},
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "file",
+            "content",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_file_sign_success(files_file_path: str) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="file_sign",
+                parameters={"path": files_file_path},
+                result={"url": "", "expiration": 0},
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "url",
+            "download",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_file_info_not_found(
+    nonexistent_files_path: str,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="file_info",
+                parameters={"path": nonexistent_files_path},
+                result="[not_found]",
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "not found",
+            "does not exist",
+            "unable",
+            nonexistent_files_path,
+        ],
+    )
+
+
+@pytest.mark.skipif(
+    not os.getenv("ENABLE_FILES_API_TOOLS"),
+    reason="Files API tools are not enabled on the MCP server",
+)
+@pytest.mark.asyncio
+class TestFilesApiToolsE2E(ToolBaseE2E):
+    """End-to-end acceptance tests for Files API MCP tools."""
+
+    async def test_file_list_success(
+        self,
+        llm_client: Any,
+        expectations_for_file_list_success: ETETestExpectations,
+    ) -> None:
+        """LLM lists catalog items at the filesystem root via file_list."""
+        prompt = (
+            "List the top-level catalog items in the DataRobot filesystem. "
+            "Use file_list with path='dr://' and summarize what you find."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_file_list_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_file_list_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_file_info_success(
+        self,
+        llm_client: Any,
+        files_file_path: str,
+        expectations_for_file_info_success: ETETestExpectations,
+    ) -> None:
+        """LLM fetches file metadata via file_info."""
+        prompt = (
+            f"Get metadata for the DataRobot filesystem file at '{files_file_path}' "
+            "using file_info. Tell me its type and size."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_file_info_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_file_info_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_file_read_success(
+        self,
+        llm_client: Any,
+        files_file_path: str,
+        expectations_for_file_read_success: ETETestExpectations,
+    ) -> None:
+        """LLM reads a file inline via file_read."""
+        prompt = (
+            f"Read the contents of '{files_file_path}' using file_read and summarize "
+            "what the file contains."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_file_read_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_file_read_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_file_sign_success(
+        self,
+        llm_client: Any,
+        files_file_path: str,
+        expectations_for_file_sign_success: ETETestExpectations,
+    ) -> None:
+        """LLM creates a signed download URL via file_sign."""
+        prompt = (
+            f"Create a temporary signed download URL for '{files_file_path}' using "
+            "file_sign with expiration=300. Share the URL in your response."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_file_sign_success"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_file_sign_success,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_file_info_not_found(
+        self,
+        llm_client: Any,
+        nonexistent_files_path: str,
+        expectations_for_file_info_not_found: ETETestExpectations,
+    ) -> None:
+        """LLM handles a missing filesystem path from file_info."""
+        prompt = (
+            f"Fetch metadata for '{nonexistent_files_path}' with file_info and explain "
+            "what happened if the path cannot be found."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_file_info_not_found"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_file_info_not_found,
+                llm_client,
+                session,
+                test_name,
+            )

--- a/tests/drmcp/acceptance/test_files_api_tools.py
+++ b/tests/drmcp/acceptance/test_files_api_tools.py
@@ -131,7 +131,8 @@ class TestFilesApiToolsE2E(ToolBaseE2E):
         """LLM lists catalog items at the filesystem root via file_list."""
         prompt = (
             "List the top-level catalog items in the DataRobot filesystem. "
-            "Use file_list with path='dr://' and summarize what you find."
+            "Use file_list with path='dr://' and provide a detailed summary in complete "
+            "sentences of what catalog items and files you find."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
@@ -152,8 +153,9 @@ class TestFilesApiToolsE2E(ToolBaseE2E):
     ) -> None:
         """LLM fetches file metadata via file_info."""
         prompt = (
-            f"Get metadata for the DataRobot filesystem file at '{files_file_path}' "
-            "using file_info. Tell me its type and size."
+            f"Use file_info to inspect the DataRobot filesystem file at '{files_file_path}'. "
+            "Provide a detailed summary in complete sentences describing the file type, "
+            "size in bytes, format, and created_at timestamp from the tool result."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
@@ -174,8 +176,9 @@ class TestFilesApiToolsE2E(ToolBaseE2E):
     ) -> None:
         """LLM reads a file inline via file_read."""
         prompt = (
-            f"Read the contents of '{files_file_path}' using file_read and summarize "
-            "what the file contains."
+            f"Read the contents of '{files_file_path}' using file_read. "
+            "Provide a detailed summary in complete sentences of the file encoding, "
+            "how many bytes were read, and what the content says."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
@@ -197,7 +200,8 @@ class TestFilesApiToolsE2E(ToolBaseE2E):
         """LLM creates a signed download URL via file_sign."""
         prompt = (
             f"Create a temporary signed download URL for '{files_file_path}' using "
-            "file_sign with expiration=300. Share the URL in your response."
+            "file_sign with expiration=300. Provide a detailed summary in complete sentences "
+            "that includes the signed URL and how long it remains valid."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
@@ -218,8 +222,9 @@ class TestFilesApiToolsE2E(ToolBaseE2E):
     ) -> None:
         """LLM handles a missing filesystem path from file_info."""
         prompt = (
-            f"Fetch metadata for '{nonexistent_files_path}' with file_info and explain "
-            "what happened if the path cannot be found."
+            f"Fetch metadata for '{nonexistent_files_path}' with file_info. "
+            "If the path cannot be found, explain in detail in complete sentences "
+            "what error occurred and why the lookup failed."
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.19.8"
+version = "0.19.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Created file API acceptance tests

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests, Taskfile env for the test server, and version/changelog; no production Files API or MCP tool implementation logic is modified.
> 
> **Overview**
> Adds **acceptance E2E coverage** for read-only Files API MCP tools (`file_list`, `file_info`, `file_read`, `file_sign`) using the existing `ToolBaseE2E` + LLM prompt pattern, gated when `ENABLE_FILES_API_TOOLS` is unset on the server.
> 
> **Test harness:** `conftest.py` gains session fixtures that auto-discover a catalog id and file path via `DataRobotFileSystem` (overridable with `TEST_FILES_CATALOG_ID` / `TEST_FILES_FILE_PATH`), plus a stable missing-path fixture for not-found behavior.
> 
> **CI / local tasks:** the background acceptance MCP server now starts with `ENABLE_FILES_API_TOOLS=true`; the acceptance pytest invocation no longer passes `ENABLE_WORKLOAD_TOOLS=true` on the command line (workload tools remain enabled at server startup). Version bumped to **0.19.9** with changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7149f518ca6cc447b9f2809ab4834657243f3fd5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->