### PR TITLE
[BUZZOK-31184] Skip CrewAI MCP adapter when local server is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.20.1
+- `crewai` MCP: unreachable local (loopback) MCP server → skip the adapter and log one clean warning, instead of a ~30s stall + background-thread traceback before continuing without tools.
+
 ## 0.20.0
 - Added `dragent` middleware `datarobot_otel_conventions` which sets up attributes in agent spans according to DataRobot Open Telemetry conventions
 - Instrumented `fastapi` in `dragent`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.20.0"
+version = "0.20.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/mcp/config.py
+++ b/src/datarobot_genai/core/mcp/config.py
@@ -15,11 +15,9 @@
 import json
 import logging
 import re
-import socket
 from typing import Any
 from typing import Literal
 from typing import cast
-from urllib.parse import urlparse
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from pydantic import field_validator
@@ -81,20 +79,14 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
 
         return candidate
 
-    @field_validator("mcp_server_port", mode="before")
+    @field_validator("mcp_server_port", mode="after")
     @classmethod
-    def validate_mcp_server_port(cls, value: Any) -> int | None:
-        if value is None or value == "":
-            return None
-        try:
-            port = int(value)
-        except (TypeError, ValueError):
-            logger.warning("mcp_server_port must be an integer; ignoring")
-            return None
-        if not 1 <= port <= 65535:
+    def validate_mcp_server_port(cls, value: int | None) -> int | None:
+        # Pydantic already coerces/rejects the type; only the range is ours.
+        if value is not None and not 1 <= value <= 65535:
             logger.warning("mcp_server_port must be between 1 and 65535; ignoring")
             return None
-        return port
+        return value
 
     def _authorization_bearer_header(self) -> dict[str, str]:
         """Return Authorization header with Bearer token or empty dict."""
@@ -138,25 +130,6 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
         mcp_server_port), as opposed to a DataRobot deployment or external URL.
         """
         return self._config_kind() == "local"
-
-    def server_reachable(self, timeout: float = 1.0) -> bool:
-        """TCP-probe the resolved MCP server's host:port.
-
-        A reliable up/down signal for a local server (process listening or not).
-        For remote hosts a load balancer may answer even when the MCP endpoint is
-        down, so callers should gate this with `is_local_server`.
-        """
-        config = self.server_config
-        if not config:
-            return False
-        parsed = urlparse(config["url"])
-        host = parsed.hostname or "localhost"
-        port = parsed.port or (443 if parsed.scheme == "https" else 80)
-        try:
-            with socket.create_connection((host, port), timeout=timeout):
-                return True
-        except OSError:
-            return False
 
     def _authorization_context_header(self) -> dict[str, str]:
         """Return X-DataRobot-Authorization-Context header or empty dict."""

--- a/src/datarobot_genai/core/mcp/config.py
+++ b/src/datarobot_genai/core/mcp/config.py
@@ -15,8 +15,10 @@
 import json
 import logging
 import re
+import socket
 from typing import Any
 from typing import Literal
+from urllib.parse import urlparse
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from pydantic import field_validator
@@ -100,6 +102,34 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
         if self._server_config is None:
             self._server_config = self._build_server_config()
         return self._server_config
+
+    @property
+    def is_local_server(self) -> bool:
+        """True when the MCP server is a local process we start (resolved via
+        mcp_server_port), as opposed to a DataRobot deployment or external URL.
+        """
+        return bool(
+            self.mcp_server_port and not self.mcp_deployment_id and not self.external_mcp_url
+        )
+
+    def server_reachable(self, timeout: float = 1.0) -> bool:
+        """TCP-probe the resolved MCP server's host:port.
+
+        A reliable up/down signal for a local server (process listening or not).
+        For remote hosts a load balancer may answer even when the MCP endpoint is
+        down, so callers should gate this with `is_local_server`.
+        """
+        config = self.server_config
+        if not config:
+            return False
+        parsed = urlparse(config["url"])
+        host = parsed.hostname or "localhost"
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        try:
+            with socket.create_connection((host, port), timeout=timeout):
+                return True
+        except OSError:
+            return False
 
     def _authorization_context_header(self) -> dict[str, str]:
         """Return X-DataRobot-Authorization-Context header or empty dict."""

--- a/src/datarobot_genai/core/mcp/config.py
+++ b/src/datarobot_genai/core/mcp/config.py
@@ -18,6 +18,7 @@ import re
 import socket
 from typing import Any
 from typing import Literal
+from typing import cast
 from urllib.parse import urlparse
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
@@ -80,6 +81,21 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
 
         return candidate
 
+    @field_validator("mcp_server_port", mode="before")
+    @classmethod
+    def validate_mcp_server_port(cls, value: Any) -> int | None:
+        if value is None or value == "":
+            return None
+        try:
+            port = int(value)
+        except (TypeError, ValueError):
+            logger.warning("mcp_server_port must be an integer; ignoring")
+            return None
+        if not 1 <= port <= 65535:
+            logger.warning("mcp_server_port must be between 1 and 65535; ignoring")
+            return None
+        return port
+
     def _authorization_bearer_header(self) -> dict[str, str]:
         """Return Authorization header with Bearer token or empty dict."""
         if not self.datarobot_api_token:
@@ -103,14 +119,25 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
             self._server_config = self._build_server_config()
         return self._server_config
 
+    def _config_kind(self) -> Literal["deployment", "external", "local"] | None:
+        """Single source of truth for which MCP server config is active.
+
+        Precedence: deployment > external > local.
+        """
+        if self.mcp_deployment_id:
+            return "deployment"
+        if self.external_mcp_url:
+            return "external"
+        if self.mcp_server_port:
+            return "local"
+        return None
+
     @property
     def is_local_server(self) -> bool:
         """True when the MCP server is a local process we start (resolved via
         mcp_server_port), as opposed to a DataRobot deployment or external URL.
         """
-        return bool(
-            self.mcp_server_port and not self.mcp_deployment_id and not self.external_mcp_url
-        )
+        return self._config_kind() == "local"
 
     def server_reachable(self, timeout: float = 1.0) -> bool:
         """TCP-probe the resolved MCP server's host:port.
@@ -162,7 +189,9 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
             Server configuration dict with url, transport, and optional headers,
             or None if not configured.
         """
-        if self.mcp_deployment_id:
+        kind = self._config_kind()
+
+        if kind == "deployment":
             # DataRobot deployment ID - requires authentication
             if self.datarobot_endpoint is None:
                 raise ValueError(
@@ -188,7 +217,7 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
                 "headers": headers,
             }
 
-        if self.external_mcp_url:
+        if kind == "external":
             # External MCP URL - no authentication needed
             headers = {}
 
@@ -200,13 +229,13 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
             logger.info(f"Using external MCP URL: {self.external_mcp_url}")
 
             return {
-                "url": self.external_mcp_url.rstrip("/"),
+                # cast: kind == "external" guarantees external_mcp_url is set
+                "url": cast(str, self.external_mcp_url).rstrip("/"),
                 "transport": self.external_mcp_transport,
                 "headers": headers,
             }
 
-        # No MCP configuration found, setup localhost if running locally
-        if self.mcp_server_port:
+        if kind == "local":
             url = f"http://localhost:{self.mcp_server_port}"
             headers = self._build_authenticated_headers()
             logger.info(f"Using localhost MCP server: {url}")

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -19,10 +19,8 @@ This module provides MCP server connection management for CrewAI agents.
 """
 
 import logging
-import socket
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
 from crewai_tools import MCPServerAdapter
@@ -31,27 +29,6 @@ from pydantic import BaseModel
 from datarobot_genai.core.mcp import MCPConfig
 
 logger = logging.getLogger(__name__)
-
-_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
-
-
-def _local_mcp_server_reachable(url: str, timeout: float = 1.0) -> bool:
-    """Probe a loopback MCP URL for a listening server.
-
-    Returns False only when the URL targets loopback and the connection is
-    refused (the "local MCP server not started" case) — letting the caller skip
-    the blocking MCPServerAdapter setup, which otherwise stalls ~30s and leaks a
-    background-thread traceback. Remote URLs are not probed and return True.
-    """
-    parsed = urlparse(url)
-    if parsed.hostname not in _LOOPBACK_HOSTS:
-        return True
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    try:
-        with socket.create_connection((parsed.hostname, port), timeout=timeout):
-            return True
-    except OSError:
-        return False
 
 
 class _EmptyArgsSchema(BaseModel):
@@ -81,7 +58,7 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
 
     # A local MCP server that isn't running would otherwise block ~30s and dump
     # a background-thread traceback; skip the adapter and degrade cleanly.
-    if not _local_mcp_server_reachable(url):
+    if mcp_config.is_local_server and not mcp_config.server_reachable():
         logger.warning(
             "Local MCP server at %s is not reachable. Continuing without MCP tools.",
             url,

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -19,8 +19,10 @@ This module provides MCP server connection management for CrewAI agents.
 """
 
 import logging
+import socket
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
 from crewai_tools import MCPServerAdapter
@@ -29,6 +31,27 @@ from pydantic import BaseModel
 from datarobot_genai.core.mcp import MCPConfig
 
 logger = logging.getLogger(__name__)
+
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _local_mcp_server_reachable(url: str, timeout: float = 1.0) -> bool:
+    """Probe a loopback MCP URL for a listening server.
+
+    Returns False only when the URL targets loopback and the connection is
+    refused (the "local MCP server not started" case) — letting the caller skip
+    the blocking MCPServerAdapter setup, which otherwise stalls ~30s and leaks a
+    background-thread traceback. Remote URLs are not probed and return True.
+    """
+    parsed = urlparse(url)
+    if parsed.hostname not in _LOOPBACK_HOSTS:
+        return True
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((parsed.hostname, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 
 class _EmptyArgsSchema(BaseModel):
@@ -55,6 +78,17 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
         return
 
     url = mcp_config.server_config["url"]
+
+    # A local MCP server that isn't running would otherwise block ~30s and dump
+    # a background-thread traceback; skip the adapter and degrade cleanly.
+    if not _local_mcp_server_reachable(url):
+        logger.warning(
+            "Local MCP server at %s is not reachable. Continuing without MCP tools.",
+            url,
+        )
+        yield []
+        return
+
     logger.info("Connecting to MCP server: %s", url)
 
     try:

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -19,8 +19,10 @@ This module provides MCP server connection management for CrewAI agents.
 """
 
 import logging
+import socket
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
 from crewai_tools import MCPServerAdapter
@@ -29,6 +31,23 @@ from pydantic import BaseModel
 from datarobot_genai.core.mcp import MCPConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _local_server_reachable(url: str, timeout: float = 1.0) -> bool:
+    """TCP-probe a local MCP server's host:port.
+
+    CrewAI connects via crewai_tools/mcpadapt on a background thread, so an
+    unstarted local server otherwise blocks ~30s and leaks a thread traceback.
+    A quick probe lets us skip the adapter and degrade cleanly instead.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
 
 
 class _EmptyArgsSchema(BaseModel):
@@ -58,7 +77,7 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
 
     # A local MCP server that isn't running would otherwise block ~30s and dump
     # a background-thread traceback; skip the adapter and degrade cleanly.
-    if mcp_config.is_local_server and not mcp_config.server_reachable():
+    if mcp_config.is_local_server and not _local_server_reachable(url):
         logger.warning(
             "Local MCP server at %s is not reachable. Continuing without MCP tools.",
             url,

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -58,10 +58,36 @@ class TestMCPConfig:
         with patch.dict(os.environ, {}, clear=True):
             assert MCPConfig().is_local_server is False
 
+    def test_is_local_server_false_when_deployment_takes_priority(self):
+        # mcp_server_port set but a deployment also configured -> deployment wins.
+        with patch.dict(os.environ, {}, clear=True):
+            config = MCPConfig(
+                mcp_server_port=9000,
+                mcp_deployment_id="a" * 24,
+                datarobot_endpoint="https://app.datarobot.com",
+                datarobot_api_token="tok",
+            )
+        assert config.is_local_server is False
+        assert "directAccess/mcp" in config.server_config["url"]
+
+    def test_is_local_server_false_when_external_takes_priority(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = MCPConfig(mcp_server_port=9000, external_mcp_url="https://mcp.example.com/mcp")
+        assert config.is_local_server is False
+        assert config.server_config["url"] == "https://mcp.example.com/mcp"
+
+    def test_invalid_mcp_server_port_ignored(self):
+        # Out-of-range port is dropped (warn + None), never crashing server_reachable.
+        with patch.dict(os.environ, {}, clear=True):
+            config = MCPConfig(mcp_server_port=99999)
+        assert config.mcp_server_port is None
+        assert config.is_local_server is False
+        assert config.server_reachable() is False
+
     def test_server_reachable_true_when_listening(self):
         listener = socket.socket()
         listener.bind(("127.0.0.1", 0))
-        listener.listen(1)
+        listener.listen(128)
         port = listener.getsockname()[1]
         try:
             with patch.dict(os.environ, {}, clear=True):
@@ -70,13 +96,16 @@ class TestMCPConfig:
             listener.close()
 
     def test_server_reachable_false_when_closed(self):
-        # Reserve then release a port so nothing is listening on it.
-        probe = socket.socket()
-        probe.bind(("127.0.0.1", 0))
-        closed_port = probe.getsockname()[1]
-        probe.close()
-        with patch.dict(os.environ, {}, clear=True):
-            assert MCPConfig(mcp_server_port=closed_port).server_reachable() is False
+        # Hold a bound-but-not-listening socket: connections are refused, and
+        # keeping it open reserves the port so the OS can't reuse it mid-test.
+        bound = socket.socket()
+        bound.bind(("127.0.0.1", 0))
+        port = bound.getsockname()[1]
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                assert MCPConfig(mcp_server_port=port).server_reachable() is False
+        finally:
+            bound.close()
 
     def test_mcp_config_with_external_url(self):
         """Test MCP config with external URL."""

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-import socket
 from http import HTTPStatus
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -77,35 +76,12 @@ class TestMCPConfig:
         assert config.server_config["url"] == "https://mcp.example.com/mcp"
 
     def test_invalid_mcp_server_port_ignored(self):
-        # Out-of-range port is dropped (warn + None), never crashing server_reachable.
+        # Out-of-range port is dropped (warn + None) rather than producing a config.
         with patch.dict(os.environ, {}, clear=True):
             config = MCPConfig(mcp_server_port=99999)
         assert config.mcp_server_port is None
         assert config.is_local_server is False
-        assert config.server_reachable() is False
-
-    def test_server_reachable_true_when_listening(self):
-        listener = socket.socket()
-        listener.bind(("127.0.0.1", 0))
-        listener.listen(128)
-        port = listener.getsockname()[1]
-        try:
-            with patch.dict(os.environ, {}, clear=True):
-                assert MCPConfig(mcp_server_port=port).server_reachable() is True
-        finally:
-            listener.close()
-
-    def test_server_reachable_false_when_closed(self):
-        # Hold a bound-but-not-listening socket: connections are refused, and
-        # keeping it open reserves the port so the OS can't reuse it mid-test.
-        bound = socket.socket()
-        bound.bind(("127.0.0.1", 0))
-        port = bound.getsockname()[1]
-        try:
-            with patch.dict(os.environ, {}, clear=True):
-                assert MCPConfig(mcp_server_port=port).server_reachable() is False
-        finally:
-            bound.close()
+        assert config.server_config is None
 
     def test_mcp_config_with_external_url(self):
         """Test MCP config with external URL."""

--- a/tests/core/mcp/test_common.py
+++ b/tests/core/mcp/test_common.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import socket
 from http import HTTPStatus
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -43,6 +44,39 @@ class TestMCPConfig:
         assert config.mcp_deployment_id is None
         assert config.datarobot_api_token is None
         assert config.server_config is None
+
+    def test_is_local_server_true_for_mcp_server_port(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert MCPConfig(mcp_server_port=9000).is_local_server is True
+
+    def test_is_local_server_false_for_external_url(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = MCPConfig(external_mcp_url="https://mcp.example.com/mcp")
+        assert config.is_local_server is False
+
+    def test_is_local_server_false_when_unconfigured(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert MCPConfig().is_local_server is False
+
+    def test_server_reachable_true_when_listening(self):
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                assert MCPConfig(mcp_server_port=port).server_reachable() is True
+        finally:
+            listener.close()
+
+    def test_server_reachable_false_when_closed(self):
+        # Reserve then release a port so nothing is listening on it.
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        closed_port = probe.getsockname()[1]
+        probe.close()
+        with patch.dict(os.environ, {}, clear=True):
+            assert MCPConfig(mcp_server_port=closed_port).server_reachable() is False
 
     def test_mcp_config_with_external_url(self):
         """Test MCP config with external URL."""

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -214,18 +214,20 @@ class TestMCPToolsContext:
         """A local MCP server that isn't running short-circuits before the adapter
         is built, avoiding the ~30s blocking connect and background-thread traceback.
         """
-        # Reserve then release a loopback port so nothing is listening on it.
-        probe = socket.socket()
-        probe.bind(("127.0.0.1", 0))
-        closed_port = probe.getsockname()[1]
-        probe.close()
-
-        mcp_config = MCPConfig(mcp_server_port=closed_port)
-        with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock_adapter:
-            instance = MagicMock()
-            instance.__enter__.return_value = []
-            instance.__exit__.return_value = None
-            mock_adapter.return_value = instance
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools == []
-            mock_adapter.assert_not_called()
+        # Hold a bound-but-not-listening socket: connections are refused, and
+        # keeping it open reserves the port so the OS can't reuse it mid-test.
+        bound = socket.socket()
+        bound.bind(("127.0.0.1", 0))
+        closed_port = bound.getsockname()[1]
+        try:
+            mcp_config = MCPConfig(mcp_server_port=closed_port)
+            with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock_adapter:
+                instance = MagicMock()
+                instance.__enter__.return_value = []
+                instance.__exit__.return_value = None
+                mock_adapter.return_value = instance
+                async with mcp_tools_context(mcp_config) as tools:
+                    assert tools == []
+                mock_adapter.assert_not_called()
+        finally:
+            bound.close()

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import socket
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -208,3 +209,23 @@ class TestMCPToolsContext:
         ):
             async with mcp_tools_context(mcp_config) as tools:
                 assert tools == []
+
+    async def test_unreachable_local_server_skips_adapter(self):
+        """A local MCP server that isn't running short-circuits before the adapter
+        is built, avoiding the ~30s blocking connect and background-thread traceback.
+        """
+        # Reserve then release a loopback port so nothing is listening on it.
+        probe = socket.socket()
+        probe.bind(("127.0.0.1", 0))
+        closed_port = probe.getsockname()[1]
+        probe.close()
+
+        mcp_config = MCPConfig(mcp_server_port=closed_port)
+        with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock_adapter:
+            instance = MagicMock()
+            instance.__enter__.return_value = []
+            instance.__exit__.return_value = None
+            mock_adapter.return_value = instance
+            async with mcp_tools_context(mcp_config) as tools:
+                assert tools == []
+            mock_adapter.assert_not_called()

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 
 from datarobot_genai.core.mcp import MCPConfig
 from datarobot_genai.crewai.mcp import _EmptyArgsSchema
+from datarobot_genai.crewai.mcp import _local_server_reachable
 from datarobot_genai.crewai.mcp import _sanitize_tool_schemas
 from datarobot_genai.crewai.mcp import mcp_tools_context
 
@@ -229,5 +230,28 @@ class TestMCPToolsContext:
                 async with mcp_tools_context(mcp_config) as tools:
                     assert tools == []
                 mock_adapter.assert_not_called()
+        finally:
+            bound.close()
+
+
+class TestLocalServerReachable:
+    def test_reachable_when_listening(self):
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(128)
+        port = listener.getsockname()[1]
+        try:
+            assert _local_server_reachable(f"http://localhost:{port}/mcp") is True
+        finally:
+            listener.close()
+
+    def test_unreachable_when_closed(self):
+        # Hold a bound-but-not-listening socket: connections are refused, and
+        # keeping it open reserves the port so the OS can't reuse it mid-test.
+        bound = socket.socket()
+        bound.bind(("127.0.0.1", 0))
+        port = bound.getsockname()[1]
+        try:
+            assert _local_server_reachable(f"http://localhost:{port}/mcp") is False
         finally:
             bound.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

When no local MCP server is listening, `nat dragent run` (CrewAI) stalls ~30s and prints a full background-thread `ExceptionGroup` traceback before continuing without tools — alarming output for an expected condition (the local MCP server simply wasn't started).

CrewAI connects via `crewai_tools` → `mcpadapt`, which runs the connection on a daemon thread. A refused connection still blocks the main thread on a never-set ready event for the full 30s `connect_timeout`, and the daemon thread's `httpx.ConnectError` escapes as an unhandled exception that the caller's `try/except` cannot suppress.

## CHANGES

- Add `_local_mcp_server_reachable()` TCP pre-flight probe in `crewai/mcp.py`, scoped to loopback hosts (`localhost`/`127.0.0.1`/`::1`).
- When a loopback MCP URL is unreachable, log one clean warning and yield no tools — skipping `MCPServerAdapter` (and its blocking daemon thread) entirely.
- Remote/deployment URLs are not probed → behavior unchanged.
- Add unit test `test_unreachable_local_server_skips_adapter`; bump to `0.19.10` + changelog.

## NOTES

- Loopback scoping is intentional: a TCP probe reliably detects a local server (process up ⇔ port open), but for a remote/deployment URL the load balancer answers on :443 even when the MCP endpoint is down, so probing wouldn't help. Remote-unreachable keeps the prior ~30s/traceback behavior.
- Verified live with `nat dragent run` against an unreachable MCP URL: before = 30s stall + `Exception in thread Thread-3` traceback; after = single clean warning, ~0s.

## RELATED

- The original `[Errno 24] Too many open files` failure reported in BUZZOK-31184 was the CrewAI sqlite fd-leak fixed in BUZZOK-31177; this PR addresses the remaining MCP-connect noise.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, opt-in fast-fail for loopback-only MCP URLs; remote behavior and existing connection-error handling are preserved.
> 
> **Overview**
> CrewAI MCP setup now **TCP-probes loopback URLs** (`localhost`, `127.0.0.1`, `::1`) before `MCPServerAdapter` runs. If nothing is listening, `mcp_tools_context` logs a single warning and yields **no tools** instead of blocking ~30s and surfacing a background-thread traceback from `mcpadapt`.
> 
> **Remote/deployment MCP URLs are unchanged** — they skip the probe and still use the existing connect + exception fallback. Release **0.19.10** with changelog; new test `test_unreachable_local_server_skips_adapter` asserts the adapter is never constructed when the local port is closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb5129970a9cfa24697c5b55fb63430ada79b47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->