### PR TITLE
[BUZZOK-31462] [BUZZOK-31468] Improvements for OTEL traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.21.2
+- Removed `fastapi` OpenTelemetry instrumentation from `dragent`
+- Attach `datarobot_agent` spans to NAT workflow trace context
+
 ## 0.21.1
 - Added `cryptography>=48.0.1` and `PyJWT>=2.13.0` to `override-dependencies` in pyproject.toml to address CVE-2026-54283 / CVE-2026-54282 (starlette) and related cryptography/JWT CVEs
 

--- a/e2e-tests/dragent_tests/conftest.py
+++ b/e2e-tests/dragent_tests/conftest.py
@@ -26,8 +26,8 @@ from datarobot_genai.core.utils.auth import AuthContextHeaderHandler
 from dotenv import load_dotenv
 
 from .helpers import BASE_URL
-from .helpers import MOCK_OTEL_COLLECTOR_PORT
-from .mock_otel_collector import MockOtelCollector
+from .otel_helpers import MOCK_OTEL_COLLECTOR_PORT
+from .otel_helpers import MockOtelCollector
 
 # Load .env from e2e-tests root
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
@@ -45,6 +45,20 @@ def otel_collector() -> Generator[MockOtelCollector]:  # type: ignore[type-arg]
     """
     with MockOtelCollector(port=MOCK_OTEL_COLLECTOR_PORT) as collector:
         yield collector
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel_collector(otel_collector: MockOtelCollector) -> Generator[None]:  # type: ignore[type-arg]
+    """Clear the session-scoped collector before each test.
+
+    The collector accumulates spans for the whole session, but the tracing
+    assertions verify that *this run's* spans form a single trace. Resetting
+    up front scopes the captured spans to the test under test. Safe because the
+    per-invocation ``datarobot_agent`` span is the trace root and ends last, so
+    by the time the previous test observed it, that run's spans had all flushed.
+    """
+    otel_collector.reset()
+    yield
 
 
 @pytest.fixture(scope="session")

--- a/e2e-tests/dragent_tests/helpers.py
+++ b/e2e-tests/dragent_tests/helpers.py
@@ -24,38 +24,10 @@ from ag_ui.core import Event
 from ag_ui.core import EventType
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
-from dragent_tests.mock_otel_collector import OTLP_TRACES_PATH
-from dragent_tests.mock_otel_collector import MockOtelCollector
-
 BASE_URL = "http://localhost:8080"
 
 GENERATE_STREAM_PATH = "/generate/stream"
 GENERATE_PATH = "/generate"
-
-# --- OpenTelemetry tracing -------------------------------------------------
-# The dragent server (started before pytest) is configured to export spans to
-# the in-process mock collector via OTEL_EXPORTER_OTLP_ENDPOINT /
-# OTEL_EXPORTER_OTLP_HEADERS. These constants MUST match the values the server
-# is launched with in ``e2e-tests/dragent/Taskfile.yaml``.
-MOCK_OTEL_COLLECTOR_PORT = int(os.environ.get("MOCK_OTEL_COLLECTOR_PORT", "4318"))
-# OTLP base endpoint the server exports to; ``/v1/traces`` is appended by the
-# DataRobot exporter (see resolve_otel_traces_endpoint_from_env).
-OTEL_EXPORTER_OTLP_ENDPOINT = f"http://localhost:{MOCK_OTEL_COLLECTOR_PORT}/otel"
-# Sentinel DataRobot auth headers; the mock collector does not validate them,
-# the tests only assert they reached the ingest unmodified.
-OTEL_API_KEY = "e2e-otel-token"
-OTEL_ENTITY_ID = "deployment-e2e-test"
-OTEL_EXPORTER_OTLP_HEADERS = (
-    f"X-DataRobot-Api-Key={OTEL_API_KEY},X-DataRobot-Entity-Id={OTEL_ENTITY_ID}"
-)
-
-# Span attributes that map to the deployment Tracing table columns, per
-# https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-tracing-code.html#map-spans-and-attributes-to-the-tracing-table
-# Mirrors the constants in
-# ``datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware``.
-GEN_AI_PROMPT = "gen_ai.prompt"  # Prompt column
-GEN_AI_COMPLETION = "gen_ai.completion"  # Completion column
-TOOL_NAME = "tool_name"  # Tools column
 
 AGENT = os.environ.get("AGENT", "base")
 AGENT_SUPPORTS_TOOL_CALLS = AGENT in ["langgraph", "nat", "llamaindex", "crewai"]
@@ -198,78 +170,3 @@ def collect_text(ag_ui_events: list[Event]) -> str:  # type: ignore[type-arg]
         if event.type in (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK):
             parts.append(event.delta)
     return "".join(parts)
-
-
-def _assert_datarobot_auth_headers(collector: MockOtelCollector) -> None:
-    """At least one trace export must carry the DataRobot ingest auth headers.
-
-    HTTP header names are case-insensitive, so compare on lowercased keys
-    rather than relying on the exporter's exact casing.
-    """
-
-    def lower(headers: dict[str, str]) -> dict[str, str]:
-        return {k.lower(): v for k, v in headers.items()}
-
-    authed = [
-        request
-        for request in collector.requests
-        if request.path == OTLP_TRACES_PATH
-        and lower(request.headers).get("x-datarobot-api-key") == OTEL_API_KEY
-        and lower(request.headers).get("x-datarobot-entity-id") == OTEL_ENTITY_ID
-    ]
-    assert authed, (
-        f"Expected ≥ 1 POST to {OTLP_TRACES_PATH} with DR auth headers "
-        f"(X-DataRobot-Api-Key={OTEL_API_KEY}, X-DataRobot-Entity-Id={OTEL_ENTITY_ID}); "
-        f"captured {len(collector.requests)} request(s) at paths "
-        f"{sorted({r.path for r in collector.requests})} with header keys "
-        f"{[sorted(r.headers.keys()) for r in collector.requests if r.path == OTLP_TRACES_PATH]}."
-    )
-
-
-def assert_tracing_conventions(
-    collector: MockOtelCollector,
-    prompt: str,
-    *,
-    expect_tool_name: bool = False,
-    timeout: float = 30.0,
-) -> None:
-    """Assert the agent exported DataRobot Tracing-table spans for *prompt*.
-
-    Finds this request's spans by ``gen_ai.prompt`` (the verbatim user message
-    recorded by the ``datarobot_otel_conventions`` middleware), then asserts the
-    convention attributes are present:
-
-    * ``gen_ai.prompt`` and ``gen_ai.completion`` on the per-invocation
-      ``datarobot_agent`` span, and
-    * the export carried the DataRobot ingest auth headers.
-
-    When *expect_tool_name* is set, also requires a ``tool_name`` span in the
-    same trace (frameworks that surface tool calls as AG-UI events).
-    """
-    agent_spans = collector.wait_for_spans(
-        lambda span: span.attributes.get(GEN_AI_PROMPT) == prompt
-        and GEN_AI_COMPLETION in span.attributes,
-        timeout=timeout,
-    )
-    if not agent_spans:
-        observed = sorted(
-            str(s.attributes[GEN_AI_PROMPT])
-            for s in collector.spans()
-            if GEN_AI_PROMPT in s.attributes
-        )
-        raise AssertionError(
-            f"No exported span carried {GEN_AI_PROMPT}=={prompt!r} together with "
-            f"{GEN_AI_COMPLETION}. Observed prompts: {observed}"
-        )
-
-    _assert_datarobot_auth_headers(collector)
-
-    if expect_tool_name:
-        trace_ids = {span.trace_id for span in agent_spans}
-        spans_in_trace = [s for s in collector.spans() if s.trace_id in trace_ids]
-        tool_spans = [s for s in spans_in_trace if s.attributes.get(TOOL_NAME)]
-        assert tool_spans, (
-            f"Expected a span carrying {TOOL_NAME!r} in the same trace as the "
-            f"agent span for the tool-calling request; "
-            f"got span names {sorted({s.name for s in spans_in_trace})}."
-        )

--- a/e2e-tests/dragent_tests/otel_helpers.py
+++ b/e2e-tests/dragent_tests/otel_helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""In-process mock OTLP/HTTP collector for e2e tests.
+"""In-process mock OTLP/HTTP collector and tracing assertions for e2e tests.
 
 The OTel SDK HTTP exporter and NAT's ``OTLPSpanAdapterExporter`` both POST
 spans via ``requests.Session()``; an in-process ``responses``/``respx`` patch
@@ -29,6 +29,7 @@ the collector's startup.
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 from collections.abc import Callable
@@ -43,6 +44,31 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTrace
 # OTLP/HTTP traces ingest path. The DataRobot collector ingress lives off
 # ``/otel/v1/traces`` (see ``resolve_otel_traces_endpoint_from_env``).
 OTLP_TRACES_PATH = "/otel/v1/traces"
+
+# --- OpenTelemetry tracing config ------------------------------------------
+# The dragent server (started before pytest) is configured to export spans to
+# the in-process mock collector via OTEL_EXPORTER_OTLP_ENDPOINT /
+# OTEL_EXPORTER_OTLP_HEADERS. These constants MUST match the values the server
+# is launched with in ``e2e-tests/dragent/Taskfile.yaml``.
+MOCK_OTEL_COLLECTOR_PORT = int(os.environ.get("MOCK_OTEL_COLLECTOR_PORT", "4318"))
+# OTLP base endpoint the server exports to; ``/v1/traces`` is appended by the
+# DataRobot exporter (see resolve_otel_traces_endpoint_from_env).
+OTEL_EXPORTER_OTLP_ENDPOINT = f"http://localhost:{MOCK_OTEL_COLLECTOR_PORT}/otel"
+# Sentinel DataRobot auth headers; the mock collector does not validate them,
+# the tests only assert they reached the ingest unmodified.
+OTEL_API_KEY = "e2e-otel-token"
+OTEL_ENTITY_ID = "deployment-e2e-test"
+OTEL_EXPORTER_OTLP_HEADERS = (
+    f"X-DataRobot-Api-Key={OTEL_API_KEY},X-DataRobot-Entity-Id={OTEL_ENTITY_ID}"
+)
+
+# Span attributes that map to the deployment Tracing table columns, per
+# https://docs.datarobot.com/en/docs/agentic-ai/agentic-develop/agentic-tracing-code.html#map-spans-and-attributes-to-the-tracing-table
+# Mirrors the constants in
+# ``datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware``.
+GEN_AI_PROMPT = "gen_ai.prompt"  # Prompt column
+GEN_AI_COMPLETION = "gen_ai.completion"  # Completion column
+TOOL_NAME = "tool_name"  # Tools column
 
 
 @dataclass(frozen=True)
@@ -215,3 +241,103 @@ class MockOtelCollector:
                 return
 
         return _Handler
+
+
+def _assert_datarobot_auth_headers(collector: MockOtelCollector) -> None:
+    """At least one trace export must carry the DataRobot ingest auth headers.
+
+    HTTP header names are case-insensitive, so compare on lowercased keys
+    rather than relying on the exporter's exact casing.
+    """
+
+    def lower(headers: dict[str, str]) -> dict[str, str]:
+        return {k.lower(): v for k, v in headers.items()}
+
+    authed = [
+        request
+        for request in collector.requests
+        if request.path == OTLP_TRACES_PATH
+        and lower(request.headers).get("x-datarobot-api-key") == OTEL_API_KEY
+        and lower(request.headers).get("x-datarobot-entity-id") == OTEL_ENTITY_ID
+    ]
+    assert authed, (
+        f"Expected ≥ 1 POST to {OTLP_TRACES_PATH} with DR auth headers "
+        f"(X-DataRobot-Api-Key={OTEL_API_KEY}, X-DataRobot-Entity-Id={OTEL_ENTITY_ID}); "
+        f"captured {len(collector.requests)} request(s) at paths "
+        f"{sorted({r.path for r in collector.requests})} with header keys "
+        f"{[sorted(r.headers.keys()) for r in collector.requests if r.path == OTLP_TRACES_PATH]}."
+    )
+
+
+def _assert_single_trace_id(collector: MockOtelCollector) -> None:
+    """Every span exported for the current run must share one ``trace_id``.
+
+    A single agent invocation must produce a single, connected trace: the
+    per-invocation ``datarobot_agent`` root span and all of its children (LLM
+    calls, tool calls, framework spans) must share one ``trace_id``. A break in
+    OTel context propagation would surface here as spans split across multiple
+    traces.
+
+    This relies on the ``_reset_otel_collector`` autouse fixture clearing the
+    session-scoped collector before each test, so the captured spans belong to
+    the run under test only.
+    """
+    all_spans = collector.spans()
+    trace_ids = {span.trace_id for span in all_spans}
+    assert len(trace_ids) == 1, (
+        f"Expected all {len(all_spans)} exported span(s) to share one trace_id, "
+        f"but found {len(trace_ids)} distinct trace_id(s). Span name -> trace_id: "
+        f"{sorted((s.name, s.trace_id.hex()) for s in all_spans)}"
+    )
+
+
+def assert_tracing_conventions(
+    collector: MockOtelCollector,
+    prompt: str,
+    *,
+    expect_tool_name: bool = False,
+    timeout: float = 30.0,
+) -> None:
+    """Assert the agent exported DataRobot Tracing-table spans for *prompt*.
+
+    Finds this request's spans by ``gen_ai.prompt`` (the verbatim user message
+    recorded by the ``datarobot_otel_conventions`` middleware), then asserts the
+    convention attributes are present:
+
+    * ``gen_ai.prompt`` and ``gen_ai.completion`` on the per-invocation
+      ``datarobot_agent`` span,
+    * every exported span for the run shares a single ``trace_id``, and
+    * the export carried the DataRobot ingest auth headers.
+
+    When *expect_tool_name* is set, also requires a ``tool_name`` span in the
+    same trace (frameworks that surface tool calls as AG-UI events).
+    """
+    agent_spans = collector.wait_for_spans(
+        lambda span: span.attributes.get(GEN_AI_PROMPT) == prompt
+        and GEN_AI_COMPLETION in span.attributes,
+        timeout=timeout,
+    )
+    if not agent_spans:
+        observed = sorted(
+            str(s.attributes[GEN_AI_PROMPT])
+            for s in collector.spans()
+            if GEN_AI_PROMPT in s.attributes
+        )
+        raise AssertionError(
+            f"No exported span carried {GEN_AI_PROMPT}=={prompt!r} together with "
+            f"{GEN_AI_COMPLETION}. Observed prompts: {observed}"
+        )
+
+    _assert_single_trace_id(collector)
+
+    _assert_datarobot_auth_headers(collector)
+
+    if expect_tool_name:
+        trace_ids = {span.trace_id for span in agent_spans}
+        spans_in_trace = [s for s in collector.spans() if s.trace_id in trace_ids]
+        tool_spans = [s for s in spans_in_trace if s.attributes.get(TOOL_NAME)]
+        assert tool_spans, (
+            f"Expected a span carrying {TOOL_NAME!r} in the same trace as the "
+            f"agent span for the tool-calling request; "
+            f"got span names {sorted({s.name for s in spans_in_trace})}."
+        )

--- a/e2e-tests/dragent_tests/otel_helpers.py
+++ b/e2e-tests/dragent_tests/otel_helpers.py
@@ -33,6 +33,7 @@ import os
 import threading
 import time
 from collections.abc import Callable
+from collections.abc import Sequence
 from dataclasses import dataclass
 from dataclasses import field
 from http.server import BaseHTTPRequestHandler
@@ -269,25 +270,114 @@ def _assert_datarobot_auth_headers(collector: MockOtelCollector) -> None:
     )
 
 
-def _assert_single_trace_id(collector: MockOtelCollector) -> None:
+def _describe_span(span: ExportedSpan) -> str:
+    """One-line, debuggable description of a span (name, ids, attributes).
+
+    Attributes are the key signal for tracking down an orphaned span (e.g. the
+    ``http.*`` / ``url.*`` attributes pin down which outbound call escaped the
+    agent trace), so they are always included.
+    """
+    if span.attributes:
+        attrs = ", ".join(f"{k}={v!r}" for k, v in sorted(span.attributes.items()))
+    else:
+        attrs = "<none>"
+    return (
+        f"name={span.name!r} span_id={span.span_id.hex()} "
+        f"trace_id={span.trace_id.hex()} attrs={{{attrs}}}"
+    )
+
+
+# OTel semantic-convention attribute keys that carry a span's request URL. The
+# requests/httpx instrumentors use ``http.url`` (legacy) or ``url.full`` (stable
+# semconv); check both so the URL-ignore filter is convention-agnostic.
+_SPAN_URL_ATTRIBUTE_KEYS = ("http.url", "url.full")
+
+
+def _span_url(span: ExportedSpan) -> str | None:
+    for key in _SPAN_URL_ATTRIBUTE_KEYS:
+        value = span.attributes.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _span_url_is_ignored(span: ExportedSpan, ignore_span_urls: Sequence[str]) -> bool:
+    if not ignore_span_urls:
+        return False
+    url = _span_url(span)
+    if url is None:
+        return False
+    return any(fragment in url for fragment in ignore_span_urls)
+
+
+def _assert_single_trace_id(
+    collector: MockOtelCollector,
+    *,
+    agent_trace_ids: set[bytes],
+    ignore_span_urls: Sequence[str] = (),
+) -> None:
     """Every span exported for the current run must share one ``trace_id``.
 
     A single agent invocation must produce a single, connected trace: the
-    per-invocation ``datarobot_agent`` root span and all of its children (LLM
-    calls, tool calls, framework spans) must share one ``trace_id``. A break in
-    OTel context propagation would surface here as spans split across multiple
-    traces.
+    per-invocation ``datarobot_agent`` root span, its framework children
+    (workflow, guards, tool-call spans), *and* every outbound HTTP call made
+    while serving the request must share one ``trace_id``. A break in OTel
+    context propagation surfaces here as spans split across multiple traces —
+    commonly bootstrap/setup HTTP client spans (token validation, guard/MCP
+    setup) that were started without the agent span as their parent.
 
-    This relies on the ``_reset_otel_collector`` autouse fixture clearing the
+    *agent_trace_ids* is the trace_id set of the matched ``datarobot_agent``
+    span(s); it identifies the expected trace so orphans can be contrasted
+    against it in the failure output.
+
+    *ignore_span_urls* holds URL fragments (substring match against a span's
+    ``http.url`` / ``url.full``) for HTTP spans that legitimately root their own
+    trace because they fire at *import* time — before any workflow trace exists
+    (e.g. LiteLLM's model-cost-map fetch, the DataRobot client version check).
+    Such spans are dropped before the single-trace check.
+
+    Relies on the ``_reset_otel_collector`` autouse fixture clearing the
     session-scoped collector before each test, so the captured spans belong to
     the run under test only.
     """
-    all_spans = collector.spans()
+    all_spans = [
+        span
+        for span in collector.spans()
+        if not _span_url_is_ignored(span, ignore_span_urls)
+    ]
     trace_ids = {span.trace_id for span in all_spans}
-    assert len(trace_ids) == 1, (
+    if len(trace_ids) == 1:
+        return
+
+    # The agent invocation's trace is the reference; anything outside it is an
+    # orphan. Fall back to the most populated trace if the agent span's trace is
+    # ambiguous (0 or >1 distinct ids).
+    if len(agent_trace_ids) == 1:
+        main_trace = next(iter(agent_trace_ids))
+    else:
+        main_trace = max(trace_ids, key=lambda tid: sum(s.trace_id == tid for s in all_spans))
+
+    spans_by_trace: dict[bytes, list[ExportedSpan]] = {}
+    for span in all_spans:
+        spans_by_trace.setdefault(span.trace_id, []).append(span)
+
+    orphans = [span for span in all_spans if span.trace_id != main_trace]
+
+    main_names = sorted(span.name for span in spans_by_trace.get(main_trace, []))
+    orphan_traces = sorted(
+        (tid.hex(), sorted(s.name for s in spans))
+        for tid, spans in spans_by_trace.items()
+        if tid != main_trace
+    )
+    orphan_details = "\n".join(f"    - {_describe_span(span)}" for span in orphans)
+
+    raise AssertionError(
         f"Expected all {len(all_spans)} exported span(s) to share one trace_id, "
-        f"but found {len(trace_ids)} distinct trace_id(s). Span name -> trace_id: "
-        f"{sorted((s.name, s.trace_id.hex()) for s in all_spans)}"
+        f"but found {len(trace_ids)} distinct trace_id(s).\n"
+        f"  Agent trace {main_trace.hex()} ({len(main_names)} span(s)): {main_names}\n"
+        f"  Orphan trace(s) ({len(orphans)} span(s) across {len(orphan_traces)} trace(s)): "
+        f"{orphan_traces}\n"
+        f"  Orphaned span details:\n{orphan_details}"
     )
 
 
@@ -296,6 +386,7 @@ def assert_tracing_conventions(
     prompt: str,
     *,
     expect_tool_name: bool = False,
+    ignore_span_urls: Sequence[str] = (),
     timeout: float = 30.0,
 ) -> None:
     """Assert the agent exported DataRobot Tracing-table spans for *prompt*.
@@ -306,11 +397,15 @@ def assert_tracing_conventions(
 
     * ``gen_ai.prompt`` and ``gen_ai.completion`` on the per-invocation
       ``datarobot_agent`` span,
-    * every exported span for the run shares a single ``trace_id``, and
+    * every exported span for the run (including outbound HTTP calls) shares a
+      single ``trace_id``, and
     * the export carried the DataRobot ingest auth headers.
 
     When *expect_tool_name* is set, also requires a ``tool_name`` span in the
     same trace (frameworks that surface tool calls as AG-UI events).
+
+    *ignore_span_urls* excludes import-time HTTP client spans (matched by URL
+    fragment) from the single-trace check — see ``_assert_single_trace_id``.
     """
     agent_spans = collector.wait_for_spans(
         lambda span: span.attributes.get(GEN_AI_PROMPT) == prompt
@@ -328,7 +423,11 @@ def assert_tracing_conventions(
             f"{GEN_AI_COMPLETION}. Observed prompts: {observed}"
         )
 
-    _assert_single_trace_id(collector)
+    _assert_single_trace_id(
+        collector,
+        agent_trace_ids={span.trace_id for span in agent_spans},
+        ignore_span_urls=ignore_span_urls,
+    )
 
     _assert_datarobot_auth_headers(collector)
 

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -22,11 +22,11 @@ from datarobot_genai.core.agents.verify import validate_sequence
 from dragent_tests.helpers import AGENT
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS_STREAMING
-from dragent_tests.helpers import assert_tracing_conventions
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import stream_sse_responses
-from dragent_tests.mock_otel_collector import MockOtelCollector
+from dragent_tests.otel_helpers import MockOtelCollector
+from dragent_tests.otel_helpers import assert_tracing_conventions
 
 if not os.environ.get("MCP_DEPLOYMENT_ID"):
     pytest.skip("MCP deployment ID is not set, skipping MCP tool call tests", allow_module_level=True)

--- a/e2e-tests/dragent_tests/test_run_agent_inline.py
+++ b/e2e-tests/dragent_tests/test_run_agent_inline.py
@@ -29,14 +29,14 @@ from pathlib import Path
 from openai.types.chat import ChatCompletion
 
 from dragent_tests.helpers import E2E_ROOT
-from dragent_tests.helpers import OTEL_EXPORTER_OTLP_ENDPOINT
-from dragent_tests.helpers import OTEL_EXPORTER_OTLP_HEADERS
 from dragent_tests.helpers import agent_dir
-from dragent_tests.helpers import assert_tracing_conventions
 from dragent_tests.helpers import build_chat_completion
 from dragent_tests.helpers import spawn_runner
 from dragent_tests.helpers import workflow_file
-from dragent_tests.mock_otel_collector import MockOtelCollector
+from dragent_tests.otel_helpers import OTEL_EXPORTER_OTLP_ENDPOINT
+from dragent_tests.otel_helpers import OTEL_EXPORTER_OTLP_HEADERS
+from dragent_tests.otel_helpers import MockOtelCollector
+from dragent_tests.otel_helpers import assert_tracing_conventions
 
 RUNNER_SCRIPT = E2E_ROOT / "dragent" / "run_agent.py"
 

--- a/e2e-tests/dragent_tests/test_run_agent_inline.py
+++ b/e2e-tests/dragent_tests/test_run_agent_inline.py
@@ -40,6 +40,18 @@ from dragent_tests.otel_helpers import assert_tracing_conventions
 
 RUNNER_SCRIPT = E2E_ROOT / "dragent" / "run_agent.py"
 
+# HTTP client spans that fire at *import* time -- before any workflow trace
+# exists -- so they legitimately root their own trace. Unlike the server-based
+# tests (where these fire during startup, before the collector is reset), the
+# inline runner bootstraps the whole runtime inside the test window and captures
+# them. Matched by URL fragment and excluded from the single-trace assertion.
+#   * LiteLLM fetches its model-cost map from GitHub on import.
+#   * The DataRobot python client (used by moderation) checks the API version.
+IMPORT_TIME_HTTP_SPAN_URLS = (
+    "model_prices_and_context_window",
+    "/api/v2/version",
+)
+
 
 def test_run_agent_inline(tmp_path: Path, otel_collector: MockOtelCollector) -> None:
     """Inline run produces a valid ``ChatCompletion`` and exports Tracing spans.
@@ -84,8 +96,12 @@ def test_run_agent_inline(tmp_path: Path, otel_collector: MockOtelCollector) -> 
         f"Expected non-empty assistant message content.\n{result.stderr}\n{result_text}"
     )
 
-    # THEN: the inline run exported convention spans with the DR auth headers
-    assert_tracing_conventions(otel_collector, prompt)
+    # THEN: the inline run exported convention spans with the DR auth headers.
+    # Import-time HTTP client spans (LiteLLM cost map, DR version check) root
+    # their own trace and are ignored for the single-trace assertion.
+    assert_tracing_conventions(
+        otel_collector, prompt, ignore_span_urls=IMPORT_TIME_HTTP_SPAN_URLS
+    )
 
 
 def test_inline_runner_script_is_packaged_with_tests() -> None:

--- a/e2e-tests/dragent_tests/test_run_agent_inline.py
+++ b/e2e-tests/dragent_tests/test_run_agent_inline.py
@@ -40,16 +40,19 @@ from dragent_tests.otel_helpers import assert_tracing_conventions
 
 RUNNER_SCRIPT = E2E_ROOT / "dragent" / "run_agent.py"
 
-# HTTP client spans that fire at *import* time -- before any workflow trace
-# exists -- so they legitimately root their own trace. Unlike the server-based
-# tests (where these fire during startup, before the collector is reset), the
-# inline runner bootstraps the whole runtime inside the test window and captures
-# them. Matched by URL fragment and excluded from the single-trace assertion.
+# HTTP client spans that fire during import / workflow-load -- before any
+# workflow trace exists -- so they legitimately root their own trace. Unlike the
+# server-based tests (where these fire during startup, before the collector is
+# reset), the inline runner bootstraps the whole runtime inside the test window
+# and captures them. Matched by URL fragment and excluded from the single-trace
+# assertion.
 #   * LiteLLM fetches its model-cost map from GitHub on import.
 #   * The DataRobot python client (used by moderation) checks the API version.
-IMPORT_TIME_HTTP_SPAN_URLS = (
+#   * NAT probes the MCP deployment while loading tools (directAccess/mcp).
+SETUP_HTTP_SPAN_URLS = (
     "model_prices_and_context_window",
     "/api/v2/version",
+    "/directAccess/mcp",
 )
 
 
@@ -97,10 +100,10 @@ def test_run_agent_inline(tmp_path: Path, otel_collector: MockOtelCollector) -> 
     )
 
     # THEN: the inline run exported convention spans with the DR auth headers.
-    # Import-time HTTP client spans (LiteLLM cost map, DR version check) root
-    # their own trace and are ignored for the single-trace assertion.
+    # Setup-time HTTP client spans (LiteLLM cost map, DR version check, MCP
+    # discovery) root their own trace and are ignored for the single-trace check.
     assert_tracing_conventions(
-        otel_collector, prompt, ignore_span_urls=IMPORT_TIME_HTTP_SPAN_URLS
+        otel_collector, prompt, ignore_span_urls=SETUP_HTTP_SPAN_URLS
     )
 
 

--- a/e2e-tests/dragent_tests/test_run_agent_inline.py
+++ b/e2e-tests/dragent_tests/test_run_agent_inline.py
@@ -49,6 +49,10 @@ RUNNER_SCRIPT = E2E_ROOT / "dragent" / "run_agent.py"
 #   * LiteLLM fetches its model-cost map from GitHub on import.
 #   * The DataRobot python client (used by moderation) checks the API version.
 #   * NAT probes the MCP deployment while loading tools (directAccess/mcp).
+#
+# TODO (BUZZOK-31396): remove this special case once the OTel TracerProvider is
+# bootstrapped from the deployment/notebook entrypoint before these setup calls
+# run, so they are captured under the workflow trace instead of rooting their own.
 SETUP_HTTP_SPAN_URLS = (
     "model_prices_and_context_window",
     "/api/v2/version",

--- a/e2e-tests/dragent_tests/test_single_response.py
+++ b/e2e-tests/dragent_tests/test_single_response.py
@@ -21,10 +21,10 @@ from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
 from dragent_tests.helpers import AGENT
 from dragent_tests.helpers import GENERATE_PATH
-from dragent_tests.helpers import assert_tracing_conventions
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
-from dragent_tests.mock_otel_collector import MockOtelCollector
+from dragent_tests.otel_helpers import MockOtelCollector
+from dragent_tests.otel_helpers import assert_tracing_conventions
 
 if AGENT == "nat":
     pytest.skip(

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 import httpx
 from datarobot_genai.core.agents.verify import validate_sequence
 
-from dragent_tests.helpers import assert_tracing_conventions
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import stream_sse_responses
-from dragent_tests.mock_otel_collector import MockOtelCollector
+from dragent_tests.otel_helpers import MockOtelCollector
+from dragent_tests.otel_helpers import assert_tracing_conventions
 
 
 def test_generate_streaming(

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -25,12 +25,12 @@ from dragent_tests.helpers import AGENT
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS
 from dragent_tests.helpers import AGENT_SUPPORTS_TOOL_CALLS_STREAMING
 from dragent_tests.helpers import LLM
-from dragent_tests.helpers import assert_tracing_conventions
 from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import stream_sse_responses
-from dragent_tests.mock_otel_collector import MockOtelCollector
+from dragent_tests.otel_helpers import MockOtelCollector
+from dragent_tests.otel_helpers import assert_tracing_conventions
 
 if not AGENT_SUPPORTS_TOOL_CALLS:
     pytest.skip(f"{AGENT} agent does not support tool calls, skipping tool call tests", allow_module_level=True)

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -379,15 +379,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asgiref"
-version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -967,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1013,7 +1004,6 @@ dragent = [
     { name = "nvidia-nat-opentelemetry" },
     { name = "openai" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
-    { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-openai" },
     { name = "opentelemetry-instrumentation-requests" },
@@ -1203,7 +1193,6 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'llamaindex'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'nat'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-crewai", marker = "extra == 'crewai'", specifier = ">=0.40.5,<1.0.0" },
-    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'dragent'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'core'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'crewai'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'dragent'", specifier = ">=0.43b0,<1.0.0" },
@@ -4699,22 +4688,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation-asgi"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/db/851fa88db7441da82d50bd80f2de5ee55213782e25dc858e04d0c9961d60/opentelemetry_instrumentation_asgi-0.60b1.tar.gz", hash = "sha256:16bfbe595cd24cda309a957456d0fc2523f41bc7b076d1f2d7e98a1ad9876d6f", size = 26107, upload-time = "2025-12-11T13:36:47.015Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/76/1fb94367cef64420d2171157a6b9509582873bd09a6afe08a78a8d1f59d9/opentelemetry_instrumentation_asgi-0.60b1-py3-none-any.whl", hash = "sha256:d48def2dbed10294c99cfcf41ebbd0c414d390a11773a41f472d20000fcddc25", size = 16933, upload-time = "2025-12-11T13:35:40.462Z" },
-]
-
-[[package]]
 name = "opentelemetry-instrumentation-crewai"
 version = "0.48.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4727,22 +4700,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/17/8c/bb088239d4f57c46828fcff580263a100de3ec1e7b270d288609d077f262/opentelemetry_instrumentation_crewai-0.48.1.tar.gz", hash = "sha256:e7e53cbbdee480859e90bfc202f80b06845529bf8ddc95a1b9d94337ce403428", size = 4671, upload-time = "2025-11-17T15:26:35.806Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/5d/a47e9d93bf158c5d4385a3b5c75d36ab107b8b9b121a93414e70b0240e9f/opentelemetry_instrumentation_crewai-0.48.1-py3-none-any.whl", hash = "sha256:1961e18c3c7f9c1847cff20a77cb74bd03750fb3efae8470d8feb06799ca35cc", size = 6233, upload-time = "2025-11-17T15:26:02.944Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-fastapi"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-asgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ nat = core + [
 
 dragent = nat + [
     "starlette>=1.0.1",
-    "opentelemetry-instrumentation-fastapi>=0.43b0,<1.0.0",
 ]
 
 # Eventually NAT will be merged into dragent

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -54,28 +54,6 @@ _INVALID_AUTH_CONTEXT_MSG = (
 )
 
 
-def _instrument_fastapi_app(app: FastAPI) -> None:
-    """Attach OTel ASGI instrumentation so incoming requests open a server span.
-
-    NAT does not open an OpenTelemetry parent span for the request, so without
-    this there is no trace context for downstream spans (e.g. the middleware's
-    ``datarobot_agent`` span) to nest under. Instrumentation uses the globally
-    installed SDK ``TracerProvider``; when none is bootstrapped (e.g. running
-    outside a DataRobot deployment) the spans are no-ops. The import is guarded
-    so a missing instrumentation package never breaks app startup.
-    """
-    try:
-        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-    except ImportError:
-        logger.debug("opentelemetry-instrumentation-fastapi not installed; skipping")
-        return
-
-    try:
-        FastAPIInstrumentor.instrument_app(app)
-    except Exception:
-        logger.exception("Failed to instrument FastAPI app for OpenTelemetry")
-
-
 def _resolve_identity_from_headers(headers: dict[str, str] | None) -> str | None:
     """Extract gateway-validated user identity from A2A-forwarded headers.
 
@@ -277,8 +255,6 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
                 logger.info("A2A worker resources cleaned up")
 
         app.router.lifespan_context = lifespan
-
-        _instrument_fastapi_app(app)
 
         setup_logging()
         return app

--- a/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
@@ -31,6 +31,7 @@ from nat.middleware.middleware import CallNextStream
 from nat.middleware.middleware import FunctionMiddlewareContext
 from opentelemetry import trace
 
+from datarobot_genai.core.telemetry.nat_context import use_nat_workflow_trace_context
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 
 logger = logging.getLogger(__name__)
@@ -146,7 +147,10 @@ class DataRobotOtelConventionsMiddleware(
         context: FunctionMiddlewareContext,  # noqa: ARG002
         **kwargs: Any,
     ) -> Any:
-        with tracer.start_as_current_span(AGENT_SPAN_NAME) as span:
+        with (
+            use_nat_workflow_trace_context(),
+            tracer.start_as_current_span(AGENT_SPAN_NAME) as span,
+        ):
             prompt = self._prompt_from_args(args)
             if prompt is not None:
                 span.set_attribute(GEN_AI_PROMPT, prompt)
@@ -165,7 +169,10 @@ class DataRobotOtelConventionsMiddleware(
         context: FunctionMiddlewareContext,  # noqa: ARG002
         **kwargs: Any,
     ) -> AsyncIterator[Any]:
-        with tracer.start_as_current_span(AGENT_SPAN_NAME) as span:
+        with (
+            use_nat_workflow_trace_context(),
+            tracer.start_as_current_span(AGENT_SPAN_NAME) as span,
+        ):
             prompt = self._prompt_from_args(args)
             if prompt is not None:
                 span.set_attribute(GEN_AI_PROMPT, prompt)

--- a/uv.lock
+++ b/uv.lock
@@ -394,15 +394,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asgiref"
-version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1130,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1202,7 +1193,6 @@ dragent = [
     { name = "nvidia-nat-opentelemetry" },
     { name = "openai" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
-    { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-openai" },
     { name = "opentelemetry-instrumentation-requests" },
@@ -1518,7 +1508,6 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'llamaindex'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'nat'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-crewai", marker = "extra == 'crewai'", specifier = ">=0.40.5,<1.0.0" },
-    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'dragent'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'core'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'crewai'", specifier = ">=0.43b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'dragent'", specifier = ">=0.43b0,<1.0.0" },
@@ -5005,22 +4994,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation-asgi"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/db/851fa88db7441da82d50bd80f2de5ee55213782e25dc858e04d0c9961d60/opentelemetry_instrumentation_asgi-0.60b1.tar.gz", hash = "sha256:16bfbe595cd24cda309a957456d0fc2523f41bc7b076d1f2d7e98a1ad9876d6f", size = 26107, upload-time = "2025-12-11T13:36:47.015Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/76/1fb94367cef64420d2171157a6b9509582873bd09a6afe08a78a8d1f59d9/opentelemetry_instrumentation_asgi-0.60b1-py3-none-any.whl", hash = "sha256:d48def2dbed10294c99cfcf41ebbd0c414d390a11773a41f472d20000fcddc25", size = 16933, upload-time = "2025-12-11T13:35:40.462Z" },
-]
-
-[[package]]
 name = "opentelemetry-instrumentation-crewai"
 version = "0.48.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5033,22 +5006,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/17/8c/bb088239d4f57c46828fcff580263a100de3ec1e7b270d288609d077f262/opentelemetry_instrumentation_crewai-0.48.1.tar.gz", hash = "sha256:e7e53cbbdee480859e90bfc202f80b06845529bf8ddc95a1b9d94337ce403428", size = 4671, upload-time = "2025-11-17T15:26:35.806Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/5d/a47e9d93bf158c5d4385a3b5c75d36ab107b8b9b121a93414e70b0240e9f/opentelemetry_instrumentation_crewai-0.48.1-py3-none-any.whl", hash = "sha256:1961e18c3c7f9c1847cff20a77cb74bd03750fb3efae8470d8feb06799ca35cc", size = 6233, upload-time = "2025-11-17T15:26:02.944Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-fastapi"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-asgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

1. Remove `fastapi` instrumentation: it creates a lot of noise. We instrument agent actions ourselved, we don't need a generic API instrumentation.
2. Explicitly call `use_nat_workflow_trace_context` for `datarobot_agent` traces.

This also reworks testing traces in E2E: consolidated related code in `otel_helpers.py`, and checked that all exported spans has the same trace id.

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how traces are linked in production observability; mis-parenting could fragment or mis-attribute spans in the Tracing table, though scope is limited to telemetry wiring.
> 
> **Overview**
> **Tracing** no longer instruments the FastAPI ASGI app with OpenTelemetry. The `_instrument_fastapi_app` helper and its call during `build_app()` are removed, so incoming HTTP requests no longer get a server span as the default parent.
> 
> **`datarobot_otel_conventions` middleware** now wraps each invoke/stream path in `use_nat_workflow_trace_context()` before creating the `datarobot_agent` span. SDK spans (including `gen_ai.*` attributes and tool-call children) are parented to the active NAT workflow trace—via the per-run NAT span stack or `workflow_trace_id`—instead of relying on FastAPI request instrumentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7ba510b16e0704317401aa155a5613e1378d8b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->