### PR TITLE
[BUZZOK-30092] crewai: preserve MCP server's raw inputSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.21.2
+- `crewai`: preserve the MCP server's raw `inputSchema` instead of mcpadapt's lossy pydantic round-trip (which dropped property `type`s / added null keys that azure rejects), matching langgraph/llamaindex.
+
 ## 0.21.1
 - Added `cryptography>=48.0.1` and `PyJWT>=2.13.0` to `override-dependencies` in pyproject.toml to address CVE-2026-54283 / CVE-2026-54282 (starlette) and related cryptography/JWT CVEs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/mcp.py
+++ b/src/datarobot_genai/crewai/mcp.py
@@ -13,32 +13,37 @@
 # limitations under the License.
 
 """
-MCP integration for CrewAI using MCPServerAdapter.
+MCP integration for CrewAI.
 
-This module provides MCP server connection management for CrewAI agents.
+Loads MCP tools via mcpadapt, keeping each tool's server ``inputSchema`` as the LLM-facing
+function-call parameters so the schema stays provider-portable (see ``_RawSchemaCrewAIAdapter``).
 """
 
 import logging
 import socket
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Any
 from urllib.parse import urlparse
 
 from crewai.tools import BaseTool
-from crewai_tools import MCPServerAdapter
+from mcpadapt.core import MCPAdapt
+from mcpadapt.crewai_adapter import CrewAIAdapter
 from pydantic import BaseModel
 
 from datarobot_genai.core.mcp import MCPConfig
 
 logger = logging.getLogger(__name__)
 
+_EMPTY_OBJECT_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}
+
 
 def _local_server_reachable(url: str, timeout: float = 1.0) -> bool:
     """TCP-probe a local MCP server's host:port.
 
-    CrewAI connects via crewai_tools/mcpadapt on a background thread, so an
-    unstarted local server otherwise blocks ~30s and leaks a thread traceback.
-    A quick probe lets us skip the adapter and degrade cleanly instead.
+    CrewAI connects via mcpadapt on a background thread, so an unstarted local server
+    otherwise blocks ~30s and leaks a thread traceback. A quick probe lets us skip the
+    adapter and degrade cleanly instead.
     """
     parsed = urlparse(url)
     host = parsed.hostname or "localhost"
@@ -50,24 +55,37 @@ def _local_server_reachable(url: str, timeout: float = 1.0) -> bool:
         return False
 
 
-class _EmptyArgsSchema(BaseModel):
-    """Fallback schema for MCP tools that declare no input parameters."""
+class _RawSchemaCrewAIAdapter(CrewAIAdapter):
+    """Adapt MCP tools but hand the LLM the server's ``inputSchema`` as the tool parameters.
+
+    The stock adapter derives the function-call ``parameters`` from a pydantic model -- a
+    lossy round-trip that drops property ``type``s and adds null/empty keys that azure rejects
+    (bedrock tolerates them). Keep the model for arg validation, but return the server's schema
+    (as ``super().adapt`` leaves it -- ``$ref``s resolved) for the ``parameters``. Note the
+    text-prompt ``description`` still carries the lossy schema; the native tool-call path uses
+    ``parameters``.
+    """
+
+    @staticmethod
+    def _keep_raw_schema(tool: BaseTool, mcp_tool: Any) -> BaseTool:
+        raw = getattr(mcp_tool, "inputSchema", None) or _EMPTY_OBJECT_SCHEMA
+        base: type[BaseModel] = tool.args_schema or BaseModel
+
+        class _RawArgsSchema(base):  # type: ignore[valid-type,misc]
+            @classmethod
+            def model_json_schema(cls, *args: Any, **kwargs: Any) -> dict[str, Any]:
+                return raw
+
+        tool.args_schema = _RawArgsSchema
+        return tool
+
+    def adapt(self, func: Any, mcp_tool: Any) -> BaseTool:
+        return self._keep_raw_schema(super().adapt(func, mcp_tool), mcp_tool)
 
 
-def _sanitize_tool_schemas(tools: list[BaseTool]) -> list[BaseTool]:
-    # Azure OpenAI rejects tools whose parameters field is None; replace with
-    # an empty-object schema for any MCP tool that has no input schema.
-    for tool in tools:
-        if tool.args_schema is None:
-            tool.args_schema = _EmptyArgsSchema
-    return tools
-
-
-# here it is async to conform with other MCP adapters
 @asynccontextmanager
 async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTool], None]:
     """Context manager for MCP tools that handles connection lifecycle."""
-    # If no MCP server configured, return empty tools list
     if not mcp_config.server_config:
         logger.info("No MCP server configured, using empty tools list")
         yield []
@@ -75,8 +93,8 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
 
     url = mcp_config.server_config["url"]
 
-    # A local MCP server that isn't running would otherwise block ~30s and dump
-    # a background-thread traceback; skip the adapter and degrade cleanly.
+    # A local MCP server that isn't running would otherwise block ~30s and dump a
+    # background-thread traceback; skip the adapter and degrade cleanly.
     if mcp_config.is_local_server and not _local_server_reachable(url):
         logger.warning(
             "Local MCP server at %s is not reachable. Continuing without MCP tools.",
@@ -88,8 +106,8 @@ async def mcp_tools_context(mcp_config: MCPConfig) -> AsyncGenerator[list[BaseTo
     logger.info("Connecting to MCP server: %s", url)
 
     try:
-        adapter = MCPServerAdapter(mcp_config.server_config)
-        tools = _sanitize_tool_schemas(adapter.__enter__())
+        adapter = MCPAdapt(mcp_config.server_config, _RawSchemaCrewAIAdapter())
+        tools = adapter.__enter__()
     except Exception as exc:
         logger.warning(
             "Failed to connect to MCP server at %s: %s. Continuing without MCP tools.",

--- a/tests/crewai/test_mcp.py
+++ b/tests/crewai/test_mcp.py
@@ -14,6 +14,7 @@
 
 import os
 import socket
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -21,9 +22,9 @@ import pytest
 from pydantic import BaseModel
 
 from datarobot_genai.core.mcp import MCPConfig
-from datarobot_genai.crewai.mcp import _EmptyArgsSchema
+from datarobot_genai.crewai.mcp import _EMPTY_OBJECT_SCHEMA
 from datarobot_genai.crewai.mcp import _local_server_reachable
-from datarobot_genai.crewai.mcp import _sanitize_tool_schemas
+from datarobot_genai.crewai.mcp import _RawSchemaCrewAIAdapter
 from datarobot_genai.crewai.mcp import mcp_tools_context
 
 
@@ -34,8 +35,8 @@ def mock_tools():
 
 @pytest.fixture
 def mock_adapter(mock_tools):
-    """Fixture for mocking MCPServerAdapter."""
-    with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:
+    """Fixture for mocking mcpadapt's MCPAdapt."""
+    with patch("datarobot_genai.crewai.mcp.MCPAdapt") as mock:
         mock_adapter_instance = MagicMock()
         mock_adapter_instance.__enter__.return_value = mock_tools
         mock_adapter_instance.__exit__.return_value = None
@@ -49,39 +50,36 @@ def clear_environment_variables():
         yield
 
 
-class TestSanitizeToolSchemas:
-    def test_none_args_schema_replaced_with_empty_schema(self):
+class TestRawSchemaAdapter:
+    """The adapter keeps the MCP server's raw inputSchema as the tool schema, instead of
+    mcpadapt's lossy pydantic round-trip (which drops property types -> azure rejects).
+    """
+
+    def test_preserves_raw_input_schema(self):
+        raw = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "max_results": {"type": "integer", "default": 3},
+            },
+            "required": ["query"],
+        }
+
+        class _Base(BaseModel):
+            query: str
+            max_results: int = 3
+
+        tool = MagicMock()
+        tool.args_schema = _Base
+        out = _RawSchemaCrewAIAdapter._keep_raw_schema(tool, SimpleNamespace(inputSchema=raw))
+        # the LLM-facing schema is the raw one (every property typed), not the lossy model's
+        assert out.args_schema.model_json_schema() == raw
+
+    def test_missing_input_schema_falls_back_to_empty_object(self):
         tool = MagicMock()
         tool.args_schema = None
-        result = _sanitize_tool_schemas([tool])
-        assert result[0].args_schema is _EmptyArgsSchema
-
-    def test_existing_args_schema_untouched(self):
-        class MySchema(BaseModel):
-            value: int
-
-        tool = MagicMock()
-        tool.args_schema = MySchema
-        result = _sanitize_tool_schemas([tool])
-        assert result[0].args_schema is MySchema
-
-    def test_mixed_tools_sanitized_correctly(self):
-        class MySchema(BaseModel):
-            value: int
-
-        tool_with_schema = MagicMock()
-        tool_with_schema.args_schema = MySchema
-        tool_without_schema = MagicMock()
-        tool_without_schema.args_schema = None
-        result = _sanitize_tool_schemas([tool_with_schema, tool_without_schema])
-        assert result[0].args_schema is MySchema
-        assert result[1].args_schema is _EmptyArgsSchema
-
-    def test_empty_args_schema_produces_valid_openai_parameters(self):
-        # Azure OpenAI requires parameters to be type "object"; verify the
-        # fallback schema serializes correctly.
-        schema = _EmptyArgsSchema.model_json_schema()
-        assert schema.get("type") == "object"
+        out = _RawSchemaCrewAIAdapter._keep_raw_schema(tool, SimpleNamespace(inputSchema=None))
+        assert out.args_schema.model_json_schema() == _EMPTY_OBJECT_SCHEMA
 
 
 class TestMCPToolsContext:
@@ -101,7 +99,7 @@ class TestMCPToolsContext:
         async with mcp_tools_context(mcp_config) as tools:
             assert tools == mock_tools
             mock_adapter.assert_called_once()
-            # Check that the server config was passed correctly
+            # Check that the server config was passed correctly (first positional arg)
             call_args = mock_adapter.call_args[0][0]
             assert call_args["url"] == test_url
             assert call_args["transport"] == "streamable-http"
@@ -123,7 +121,6 @@ class TestMCPToolsContext:
         async with mcp_tools_context(mcp_config) as tools:
             assert tools == mock_tools
             mock_adapter.assert_called_once()
-            # Check that the server config was passed correctly
             call_args = mock_adapter.call_args[0][0]
             expected_url = f"{api_base}/deployments/{deployment_id}/directAccess/mcp"
             assert call_args["url"] == expected_url
@@ -152,81 +149,39 @@ class TestMCPToolsContext:
         async with mcp_tools_context(mcp_config) as tools:
             assert tools == mock_tools
             mock_adapter.assert_called_once()
-            # Check that forwarded headers are included in the server config
             call_args = mock_adapter.call_args[0][0]
             assert call_args["headers"]["x-datarobot-api-key"] == "scoped-token-123"
             assert call_args["headers"]["Authorization"] == f"Bearer {api_key}"
 
     @pytest.mark.usefixtures("mock_adapter")
     async def test_mcp_tools_context_propagates_exceptions(self):
-        """Test context manager propagates exceptions."""
+        """Exceptions raised inside the context body propagate (not swallowed)."""
         test_url = "https://mcp-server.example.com/mcp"
         mcp_config = MCPConfig(external_mcp_url=test_url)
         with pytest.raises(RuntimeError):
             async with mcp_tools_context(mcp_config):
                 raise RuntimeError("Connection failed")
 
-    async def test_mcp_tools_context_sanitizes_none_args_schema(self, mock_adapter):
-        """Tools with None args_schema get a valid empty schema so
-        Azure OpenAI doesn't reject them.
-        """
-        null_schema_tool = MagicMock()
-        null_schema_tool.args_schema = None
-        with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:
-            instance = MagicMock()
-            instance.__enter__.return_value = [null_schema_tool]
-            instance.__exit__.return_value = None
-            mock.return_value = instance
-            test_url = "https://mcp-server.example.com/mcp"
-            mcp_config = MCPConfig(external_mcp_url=test_url)
-            async with mcp_tools_context(mcp_config) as tools:
-                assert len(tools) == 1
-                assert tools[0].args_schema is _EmptyArgsSchema
-
-    async def test_mcp_tools_context_preserves_existing_args_schema(self, mock_adapter):
-        """Tools that already have a valid args_schema are left untouched."""
-
-        class MySchema(BaseModel):
-            query: str
-
-        tool_with_schema = MagicMock()
-        tool_with_schema.args_schema = MySchema
-        with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock:
-            instance = MagicMock()
-            instance.__enter__.return_value = [tool_with_schema]
-            instance.__exit__.return_value = None
-            mock.return_value = instance
-            test_url = "https://mcp-server.example.com/mcp"
-            mcp_config = MCPConfig(external_mcp_url=test_url)
-            async with mcp_tools_context(mcp_config) as tools:
-                assert tools[0].args_schema is MySchema
-
     async def test_mcp_tools_context_connection_error_yields_empty(self):
         """Test graceful fallback when MCP server connection fails."""
         test_url = "https://mcp-server.example.com/mcp"
         mcp_config = MCPConfig(external_mcp_url=test_url)
-        with patch(
-            "datarobot_genai.crewai.mcp.MCPServerAdapter", side_effect=ConnectionError("refused")
-        ):
+        with patch("datarobot_genai.crewai.mcp.MCPAdapt", side_effect=ConnectionError("refused")):
             async with mcp_tools_context(mcp_config) as tools:
                 assert tools == []
 
     async def test_unreachable_local_server_skips_adapter(self):
-        """A local MCP server that isn't running short-circuits before the adapter
-        is built, avoiding the ~30s blocking connect and background-thread traceback.
+        """A local MCP server that isn't running short-circuits before the adapter is
+        built, avoiding the ~30s blocking connect and background-thread traceback.
         """
-        # Hold a bound-but-not-listening socket: connections are refused, and
-        # keeping it open reserves the port so the OS can't reuse it mid-test.
+        # Bound-but-not-listening socket: connections are refused, and holding it open
+        # reserves the port so the OS can't reuse it mid-test.
         bound = socket.socket()
         bound.bind(("127.0.0.1", 0))
         closed_port = bound.getsockname()[1]
         try:
             mcp_config = MCPConfig(mcp_server_port=closed_port)
-            with patch("datarobot_genai.crewai.mcp.MCPServerAdapter") as mock_adapter:
-                instance = MagicMock()
-                instance.__enter__.return_value = []
-                instance.__exit__.return_value = None
-                mock_adapter.return_value = instance
+            with patch("datarobot_genai.crewai.mcp.MCPAdapt") as mock_adapter:
                 async with mcp_tools_context(mcp_config) as tools:
                     assert tools == []
                 mock_adapter.assert_not_called()
@@ -246,8 +201,8 @@ class TestLocalServerReachable:
             listener.close()
 
     def test_unreachable_when_closed(self):
-        # Hold a bound-but-not-listening socket: connections are refused, and
-        # keeping it open reserves the port so the OS can't reuse it mid-test.
+        # Bound-but-not-listening socket: connection refused; holding it open reserves
+        # the port so the OS can't reuse it mid-test.
         bound = socket.socket()
         bound.bind(("127.0.0.1", 0))
         port = bound.getsockname()[1]

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

CrewAI's stock MCP adapter round-trips each tool's `inputSchema` through a pydantic model to derive the LLM-facing function-call `parameters`. That round-trip is lossy: it drops property `type`s and adds null/empty keys that Azure OpenAI rejects (bedrock tolerates them), so MCP tools fail on azure-backed models. This keeps the MCP server's original `inputSchema` as the tool parameters so they stay provider-portable, matching the langgraph/llamaindex agents.

Split out of #503 (CrewAI AG-UI tool-call events) — the two are independent (different files, no shared symbols); this is the MCP half.

## CHANGES

- Replace `crewai_tools.MCPServerAdapter` with `mcpadapt.MCPAdapt` + a `_RawSchemaCrewAIAdapter`.
- Adapter keeps the pydantic model for arg validation, but returns the server's raw (`$ref`-resolved) `inputSchema` as the LLM-facing `parameters`.
- Empty-object schema fallback for tools with no input schema (replaces `_EmptyArgsSchema`/`_sanitize_tool_schemas`).
- `mcpadapt` stays transitive via `crewai-tools[mcp]` — no dependency change.
- Rewrite `test_mcp.py` to assert raw-schema preservation and the empty-object fallback.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog

## NOTES
- Version bumps to `0.21.2`, same as #503; whichever merges second should rebase and bump to `0.21.3`.
- The adapter subclasses `mcpadapt`'s internal `CrewAIAdapter` (relies on mcpadapt/pydantic internals); `crewai-tools<0.77.0` currently constrains `mcpadapt` to 0.1.x, so no explicit cap is declared.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tool JSON schemas are sent to LLMs and subclasses mcpadapt’s CrewAIAdapter (internal API); impact is limited to CrewAI MCP integration with regression tests, but Azure tool-calling behavior is business-critical.
> 
> **Overview**
> **CrewAI MCP** now wires tools through `mcpadapt.MCPAdapt` with a custom `_RawSchemaCrewAIAdapter` instead of `crewai_tools.MCPServerAdapter`, so LLM-facing tool **parameters** come from the MCP server’s original `inputSchema` rather than a pydantic-derived schema that stripped property `type`s and added keys Azure rejects.
> 
> The adapter still uses the pydantic model from the stock path for **argument validation**, but overrides `model_json_schema()` to return the server schema (or a fixed empty-object schema when `inputSchema` is missing). The old `_sanitize_tool_schemas` / `_EmptyArgsSchema` post-pass is removed in favor of that fallback inside the adapter.
> 
> Release **0.21.2** is recorded in `CHANGELOG.md`, `pyproject.toml`, and `uv.lock`. Tests mock `MCPAdapt` and assert raw-schema preservation and the empty-object fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca7cd347ded6f41db46dc4b9f614edce0719ba2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->