### PR TITLE
[BUZZOK-31306] Bump datarobot-moderations floor to 11.2.35 for NeMo guard fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.21.2
+- Bumped `datarobot-moderations` floor to `>=11.2.35` (lock resolves 11.2.40) so the NeMo `llmGateway` "stay on topic" guard no longer silently fails open — it had been no-opping on an asyncio event-loop error, leaving guardrails unenforced.
+
 ## 0.21.1
 - Added `cryptography>=48.0.1` and `PyJWT>=2.13.0` to `override-dependencies` in pyproject.toml to address CVE-2026-54283 / CVE-2026-54282 (starlette) and related cryptography/JWT CVEs
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -967,7 +967,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1130,12 +1130,12 @@ requires-dist = [
     { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drtools'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.35,<12.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1385,7 +1385,7 @@ example-quickstart = [{ name = "datarobot-genai", extras = ["langgraph"], editab
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.33"
+version = "11.2.40"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1404,7 +1404,7 @@ dependencies = [
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/26/763042a9b2ae2f6bcf10aee14a019d3a52d36becb9bb6091f8f40492d660/datarobot_moderations-11.2.33-py3-none-any.whl", hash = "sha256:1b835a8e53306b41407ff30dbd90631cbe0084cdbe5bb0bdb2b79999dc1adcf8", size = 149461, upload-time = "2026-06-03T13:33:56.177Z" },
+    { url = "https://files.pythonhosted.org/packages/57/62/28d817458c4eec64845b335c3fa3af6caf7782013f2061001d1f167bb15f/datarobot_moderations-11.2.40-py3-none-any.whl", hash = "sha256:dc3bf52e99a6cc7b26ede735a74da7fe070abbad58b5110f50a9adb57288e64e", size = 167842, upload-time = "2026-06-30T18:50:11.284Z" },
 ]
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ core = [
     "opentelemetry-instrumentation-httpx>=0.43b0,<1.0.0",
     "opentelemetry-instrumentation-openai>=0.40.5,<1.0.0",
     "opentelemetry-instrumentation-threading>=0.43b0,<1.0.0",
-    "datarobot-moderations[all]>=11.2.33,<12.0.0",
+    "datarobot-moderations[all]>=11.2.35,<12.0.0",  # 11.2.35 fixes NeMo llmGateway guard silently failing open
     # Keep this version in sync with all consumers of agent messages e.g. the fastapi_server of the
     # agent application template
     "ag-ui-protocol==0.1.15",

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.21.1"
+version = "0.21.2"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1445,12 +1445,12 @@ requires-dist = [
     { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = "==3.14.0.2026.3.18.162920" },
     { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drtools'", specifier = "==3.14.0.2026.3.18.162920" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.33,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.33,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.35,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'nat'", specifier = ">=11.2.35,<12.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1631,7 +1631,7 @@ dev = [
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.33"
+version = "11.2.40"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1651,7 +1651,7 @@ dependencies = [
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/26/763042a9b2ae2f6bcf10aee14a019d3a52d36becb9bb6091f8f40492d660/datarobot_moderations-11.2.33-py3-none-any.whl", hash = "sha256:1b835a8e53306b41407ff30dbd90631cbe0084cdbe5bb0bdb2b79999dc1adcf8", size = 149461, upload-time = "2026-06-03T13:33:56.177Z" },
+    { url = "https://files.pythonhosted.org/packages/57/62/28d817458c4eec64845b335c3fa3af6caf7782013f2061001d1f167bb15f/datarobot_moderations-11.2.40-py3-none-any.whl", hash = "sha256:dc3bf52e99a6cc7b26ede735a74da7fe070abbad58b5110f50a9adb57288e64e", size = 167842, upload-time = "2026-06-30T18:50:11.284Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

The NeMo `llmGateway` "stay on topic" guard on dragent was silently failing open. With NeMo moderation enabled, the guard raised an asyncio event-loop error inside `datarobot_dome` and no-oped, so guardrails were never actually enforced — the "NeMo enabled" E2E jobs passed only because the guard did nothing. The fix landed in `datarobot-moderations` 11.2.35, but every consumer was still pinned below it (11.2.33).

## CHANGES

- Bump `datarobot-moderations[all]` floor `>=11.2.33` → `>=11.2.35` in `setup.py` `core` (applies to all agent extras: crewai/langgraph/llamaindex/nat/dragent).
- Re-lock root + `e2e-tests` `uv.lock`; both resolve **11.2.40**, which also carries the streamed block-message hang fix (moderations #669) relevant to the streaming agents.
- Bump `datarobot-genai` `0.21.1` → `0.21.2` + changelog entry.

E2E install is `uv sync` (non-frozen), so this floor makes the `nemo-guardrails` E2E actually exercise the fixed guard.

## Checklist
- [x] Updated Changelog
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] New tools in `src/datarobot_genai/drtools/` require integration/acceptance tests — N/A (dependency bump only)

## NOTES

Follow-up planned for this PR, gated on a green `nemo-guardrails` E2E `workflow_dispatch` run on this branch: promote the nemo case out of `workflow_dispatch`-only so a fail-open regression is actually caught, and refresh the now-stale "expected RED / pending PR #648" comment in `e2e-tests/cases/moderations.yaml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump in the moderation/guardrails path; low code churn but higher impact if resolution or upstream behavior regresses, since agents rely on this for enforcement.
> 
> **Overview**
> Releases **datarobot-genai 0.21.2** as a dependency-only fix so NeMo **llmGateway** “stay on topic” guardrails actually run instead of failing open.
> 
> The `core` extra (and thus crewai/langgraph/llamaindex/nat/dragent) now requires **`datarobot-moderations[all]>=11.2.35`** (was `>=11.2.33`) in `setup.py`, with root and `e2e-tests` locks resolving **11.2.40**. **CHANGELOG** documents that 11.2.35 fixes the asyncio event-loop error that caused the guard to no-op while moderation appeared enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73896202e33821962c0412570a9df3a070d14491. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->