### PR TITLE
[BUZZOK-31515] Agent memory TTL in days instead of seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.0
+- *Breaking change*: `dr_mem0_memory` agent memory TTL is now specified in days instead of seconds. Renamed `default_ttl_seconds` → `default_ttl_days` on `DRMem0MemoryClientConfig` and `AGENT_MEMORY_TTL_SECONDS` → `AGENT_MEMORY_TTL_DAYS` for the runtime parameter / env var.
+
 ## 0.22.1
 - `crewai`: stream AG-UI `ToolCall*` and per-agent `Step*` events so crews render like the langgraph/llamaindex agents — per-agent steps, per-turn message bubbles, and tool calls (errors surfaced as the result), with injected tools reliably reaching the model.
 - `crewai`: preserve the MCP server's raw `inputSchema` instead of mcpadapt's lossy pydantic round-trip (which dropped property `type`s / added null keys that azure rejects), matching langgraph/llamaindex.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -974,6 +974,8 @@ crewai = [
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "litellm" },
+    { name = "mcpadapt", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "mcpadapt", version = "0.1.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "nvidia-nat-crewai" },
     { name = "openai" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
@@ -1154,6 +1156,7 @@ requires-dist = [
     { name = "llama-index-llms-litellm", marker = "extra == 'llamaindex'", specifier = ">=0.4.1,<0.7.0" },
     { name = "llama-index-llms-openai", marker = "extra == 'llamaindex'", specifier = ">=0.6.0,<0.7.0" },
     { name = "llama-index-tools-mcp", marker = "extra == 'llamaindex'", specifier = ">=0.1.0,<0.5.0" },
+    { name = "mcpadapt", marker = "extra == 'crewai'", specifier = ">=0.1.9" },
     { name = "mem0ai", marker = "extra == 'dragent'", specifier = ">=1.0.4,<2.0.0" },
     { name = "mem0ai", marker = "extra == 'nat'", specifier = ">=1.0.4,<2.0.0" },
     { name = "nemo-evaluator-launcher", marker = "extra == 'eval'" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.22.1"
+version = "0.23.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_mem0_memory.py
@@ -70,7 +70,7 @@ class Config(DataRobotAppFrameworkBaseSettings):
 
     mem0_api_key: str | None = None
     agent_memory_space_id: str | None = None
-    agent_memory_ttl_seconds: int | None = None
+    agent_memory_ttl_days: int | None = None
 
 
 def _get_default_memory_backend_config() -> Config:
@@ -88,20 +88,19 @@ def _get_default_agent_memory_space_id() -> str | None:
     return _get_default_memory_backend_config().agent_memory_space_id
 
 
-def _get_default_ttl_seconds() -> int | None:
-    return Config().agent_memory_ttl_seconds
+def _get_default_ttl_days() -> int | None:
+    return Config().agent_memory_ttl_days
 
 
-def _ttl_to_expiration_date(ttl_seconds: int) -> str:
-    """Translate a TTL in seconds into Mem0's ``expiration_date`` format.
+def _ttl_to_expiration_date(ttl_days: int) -> str:
+    """Translate a TTL in days into Mem0's ``expiration_date`` format.
 
     Mem0's REST ``add`` endpoint expects ``expiration_date`` as a
     ``YYYY-MM-DD`` calendar date (not a timestamp); the platform's
-    expiration sweep deletes memories on or after that date. Sub-day TTLs
-    are rounded up to "today" by the calendar floor — callers needing
-    finer granularity should pass ``expiration_date`` explicitly.
+    expiration sweep deletes memories on or after that date. Callers
+    needing finer granularity should pass ``expiration_date`` explicitly.
     """
-    return (datetime.now(UTC) + timedelta(seconds=ttl_seconds)).strftime("%Y-%m-%d")
+    return (datetime.now(UTC) + timedelta(days=ttl_days)).strftime("%Y-%m-%d")
 
 
 class _UserManagerShim:
@@ -180,18 +179,18 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
             "Defaults to the ``DATAROBOT_API_TOKEN`` env var."
         ),
     )
-    default_ttl_seconds: int | None = Field(
-        default_factory=_get_default_ttl_seconds,
+    default_ttl_days: int | None = Field(
+        default_factory=_get_default_ttl_days,
         ge=0,
         description=(
-            "Default TTL in seconds for stored memories. When set to a "
+            "Default TTL in days for stored memories. When set to a "
             "positive value, the editor passes "
-            "``expiration_date = today + default_ttl_seconds`` (UTC, "
+            "``expiration_date = today + default_ttl_days`` (UTC, "
             "``YYYY-MM-DD``) through to Mem0's ``add`` API so memories "
             "auto-expire. Callers may override per-call by passing "
             "``expiration_date`` in ``add_params``. ``None`` or ``0`` "
             "leaves the field unset (no expiration). Defaults from the "
-            "``AGENT_MEMORY_TTL_SECONDS`` env var."
+            "``AGENT_MEMORY_TTL_DAYS`` env var."
         ),
     )
 
@@ -220,14 +219,14 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
     def __init__(
         self,
         client: Any,
-        ttl_seconds: int | None = None,
+        ttl_days: int | None = None,
         *,
         store_name: str = "mem0",
         store_id: str | None = None,
     ) -> None:
         self._client = client
         self._mem0 = client._memory
-        self._ttl_seconds = ttl_seconds
+        self._ttl_days = ttl_days
         self._store_name = store_name
         self._store_id = store_id
 
@@ -273,8 +272,8 @@ class DRMem0Editor(MemoryEditor):  # type: ignore[misc]
         # the caller hasn't supplied one. Per-call overrides (e.g. via
         # ``add_params: {expiration_date: ...}`` in workflow.yaml) win so
         # special-case memories can opt out of or extend the default.
-        if "expiration_date" not in add_kwargs and self._ttl_seconds:
-            add_kwargs["expiration_date"] = _ttl_to_expiration_date(self._ttl_seconds)
+        if "expiration_date" not in add_kwargs and self._ttl_days:
+            add_kwargs["expiration_date"] = _ttl_to_expiration_date(self._ttl_days)
 
         coroutines = []
         for item in items:
@@ -467,7 +466,7 @@ async def dr_mem0_memory_client(
 
     editor: MemoryEditor = DRMem0Editor(
         _create_mem0_client(config, api_key),
-        ttl_seconds=config.default_ttl_seconds,
+        ttl_days=config.default_ttl_days,
         store_name=store_name,
         store_id=store_id,
     )

--- a/tests/dragent/plugins/test_datarobot_mem0_memory.py
+++ b/tests/dragent/plugins/test_datarobot_mem0_memory.py
@@ -178,9 +178,9 @@ async def test_add_items_item_user_id_beats_configured_user_id() -> None:
 
 
 async def test_add_items_injects_expiration_date_from_default_ttl() -> None:
-    # GIVEN an editor configured with a positive TTL (e.g. AGENT_MEMORY_TTL_SECONDS = 1 day).
+    # GIVEN an editor configured with a positive TTL (e.g. AGENT_MEMORY_TTL_DAYS = 1).
     mem0 = FakeMem0Api()
-    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_seconds=86_400)
+    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_days=1)
     item = MemoryItem(
         conversation=[{"role": "user", "content": "remember Python"}],
         user_id="session-user-123",
@@ -197,8 +197,8 @@ async def test_add_items_injects_expiration_date_from_default_ttl() -> None:
     # THEN the Mem0 call carries ``expiration_date = today + ttl`` as YYYY-MM-DD,
     # so the platform's expiration sweep will delete the memory after that date.
     valid_dates = {
-        (before + timedelta(seconds=86_400)).strftime("%Y-%m-%d"),
-        (after + timedelta(seconds=86_400)).strftime("%Y-%m-%d"),
+        (before + timedelta(days=1)).strftime("%Y-%m-%d"),
+        (after + timedelta(days=1)).strftime("%Y-%m-%d"),
     }
     assert mem0.add_calls[0]["kwargs"]["expiration_date"] in valid_dates
 
@@ -222,7 +222,7 @@ async def test_add_items_omits_expiration_date_when_no_default_ttl() -> None:
 async def test_add_items_treats_ttl_zero_as_no_expiration() -> None:
     # GIVEN an editor explicitly configured with ttl=0 (the "no expiration" opt-out).
     mem0 = FakeMem0Api()
-    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_seconds=0)
+    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_days=0)
     item = MemoryItem(
         conversation=[{"role": "user", "content": "remember Python"}],
         user_id="session-user-123",
@@ -238,7 +238,7 @@ async def test_add_items_treats_ttl_zero_as_no_expiration() -> None:
 async def test_add_items_caller_supplied_expiration_date_beats_default_ttl() -> None:
     # GIVEN an editor with a configured TTL and a per-call expiration_date override.
     mem0 = FakeMem0Api()
-    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_seconds=86_400)
+    editor = DRMem0Editor(FakeMem0Client(mem0), ttl_days=1)
     item = MemoryItem(
         conversation=[{"role": "user", "content": "remember Python"}],
         user_id="session-user-123",
@@ -254,7 +254,7 @@ async def test_add_items_caller_supplied_expiration_date_beats_default_ttl() -> 
 
 
 def test_ttl_to_expiration_date_returns_calendar_date() -> None:
-    # GIVEN a TTL in seconds.
+    # GIVEN a TTL in days.
     # WHEN converted to mem0's expiration_date format.
     from datetime import datetime
     from datetime import timedelta
@@ -262,7 +262,7 @@ def test_ttl_to_expiration_date_returns_calendar_date() -> None:
     from datarobot_genai.dragent.plugins.datarobot_mem0_memory import _ttl_to_expiration_date
 
     before = datetime.now(UTC)
-    result = _ttl_to_expiration_date(7 * 86_400)
+    result = _ttl_to_expiration_date(7)
     after = datetime.now(UTC)
 
     # THEN the result is a YYYY-MM-DD string within +7 days of "now".
@@ -430,21 +430,21 @@ async def test_remove_items_with_falsy_memory_id_still_deletes(memory_id: Any) -
 async def test_registered_memory_client_forwards_default_ttl_to_editor(
     monkeypatch: Any,
 ) -> None:
-    # GIVEN a config with a configured default_ttl_seconds and a stubbed mem0
+    # GIVEN a config with a configured default_ttl_days and a stubbed mem0
     # client (the real one needs network access to validate the API key).
     monkeypatch.setattr(
         datarobot_mem0_memory, "_create_mem0_client", lambda *_a, **_k: FakeMem0Client()
     )
     monkeypatch.setattr(datarobot_mem0_memory, "patch_with_retry", lambda ed, **_: ed)
 
-    config = DRMem0MemoryClientConfig(api_key="secret-key", default_ttl_seconds=12_345)
+    config = DRMem0MemoryClientConfig(api_key="secret-key", default_ttl_days=7)
 
     # WHEN NAT builds the memory client.
     async with datarobot_mem0_memory.dr_mem0_memory_client(config, object()) as editor:
         # THEN the editor stores the TTL so subsequent add_items calls inject
         # expiration_date — without this hop the config value would be inert.
         assert isinstance(editor, DRMem0Editor)
-        assert editor._ttl_seconds == 12_345
+        assert editor._ttl_days == 7
 
 
 async def test_registered_memory_client_uses_config_api_key_and_retry(monkeypatch: Any) -> None:
@@ -530,43 +530,43 @@ def test_memory_client_config_explicit_agent_memory_space_id_beats_env(
 
 
 def test_memory_client_config_uses_settings_default_ttl(monkeypatch: Any) -> None:
-    # GIVEN AGENT_MEMORY_TTL_SECONDS is set in the env (e.g. by infra/agent.py's
+    # GIVEN AGENT_MEMORY_TTL_DAYS is set in the env (e.g. by infra/agent.py's
     # runtime parameter), exposing the recipe's configured retention to the
     # NAT memory editor.
-    monkeypatch.setenv("AGENT_MEMORY_TTL_SECONDS", "604800")
+    monkeypatch.setenv("AGENT_MEMORY_TTL_DAYS", "7")
 
-    # WHEN the NAT memory config is created without an explicit default_ttl_seconds.
+    # WHEN the NAT memory config is created without an explicit default_ttl_days.
     config = DRMem0MemoryClientConfig(api_key="any")
 
-    # THEN the field defaults from the AGENT_MEMORY_TTL_SECONDS env var, so the
+    # THEN the field defaults from the AGENT_MEMORY_TTL_DAYS env var, so the
     # recipe's runtime parameter automatically reaches mem0 via expiration_date.
-    assert config.default_ttl_seconds == 604800
+    assert config.default_ttl_days == 7
 
 
 def test_memory_client_config_explicit_default_ttl_beats_env(monkeypatch: Any) -> None:
-    # GIVEN AGENT_MEMORY_TTL_SECONDS set in env but the workflow passing an
+    # GIVEN AGENT_MEMORY_TTL_DAYS set in env but the workflow passing an
     # explicit override (e.g. a per-deployment retention different from the
     # global default).
-    monkeypatch.setenv("AGENT_MEMORY_TTL_SECONDS", "100")
+    monkeypatch.setenv("AGENT_MEMORY_TTL_DAYS", "100")
 
     # WHEN the config is constructed with an explicit value.
-    config = DRMem0MemoryClientConfig(api_key="any", default_ttl_seconds=42)
+    config = DRMem0MemoryClientConfig(api_key="any", default_ttl_days=42)
 
     # THEN the explicit value wins (env is only the default).
-    assert config.default_ttl_seconds == 42
+    assert config.default_ttl_days == 42
 
 
 def test_memory_client_config_default_ttl_is_none_without_env(monkeypatch: Any) -> None:
-    # GIVEN no AGENT_MEMORY_TTL_SECONDS env var (e.g. a deployment that
+    # GIVEN no AGENT_MEMORY_TTL_DAYS env var (e.g. a deployment that
     # opted out of TTL or never set the recipe's runtime parameter).
-    monkeypatch.delenv("AGENT_MEMORY_TTL_SECONDS", raising=False)
+    monkeypatch.delenv("AGENT_MEMORY_TTL_DAYS", raising=False)
 
     # WHEN the config is constructed without an explicit override.
     config = DRMem0MemoryClientConfig(api_key="any")
 
-    # THEN default_ttl_seconds is None — memories never expire, matching the
+    # THEN default_ttl_days is None — memories never expire, matching the
     # pre-TTL behavior so existing deployments don't silently change semantics.
-    assert config.default_ttl_seconds is None
+    assert config.default_ttl_days is None
 
 
 async def test_registered_memory_client_yields_unconfigured_editor_without_api_key(

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.22.1"
+version = "0.23.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Both Mem0 and the DR memory service effectively have a granularity of 1 day for the expiration date.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Switch from seconds to days for the agent memory TTL.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API/env rename for TTL affects deployments and recipes that still set seconds or `AGENT_MEMORY_TTL_SECONDS`; misconfiguration could shorten or lengthen retention until values are updated.
> 
> **Overview**
> **0.23.0** switches agent memory retention for `dr_mem0_memory` from **seconds to days**, matching Mem0/DataRobot memory expiration, which is calendar-date (`YYYY-MM-DD`) granularity.
> 
> **Breaking renames:** `DRMem0MemoryClientConfig.default_ttl_seconds` → `default_ttl_days`, runtime/env `AGENT_MEMORY_TTL_SECONDS` → `AGENT_MEMORY_TTL_DAYS`, and `DRMem0Editor` / settings use `ttl_days` / `agent_memory_ttl_days`. `_ttl_to_expiration_date` now adds `timedelta(days=…)` instead of seconds; docs no longer describe sub-day TTL rounding. Per-call `expiration_date` overrides and `None`/`0` meaning “no expiration” are unchanged.
> 
> Tests and changelog document the migration (e.g. `1` day instead of `86_400` seconds). Lockfiles bump `datarobot-genai` to **0.23.0**; e2e lock also pins `mcpadapt` for the crewai extra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614e4561a8e5625fc55fd8e83c01aa061c5643c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->