### PR TITLE
Upgrade workflows to latest releases, add cherrypick backporting and automated label validation

### DIFF
--- a/.github/workflows/workflow-backport.yaml
+++ b/.github/workflows/workflow-backport.yaml
@@ -1,0 +1,89 @@
+name: Backport
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backport
+# Cherry-picks a MERGED PR onto release branch(es), opening a PR per branch.
+# Trigger by adding a `backport <branch>` label, or via Actions → Run workflow
+# (enter a PR number + target branches). See BACKPORT.md for details & App setup.
+# ─────────────────────────────────────────────────────────────────────────────
+# REQUIRED LABELS  (run examples/workflow-ensure-labels.yaml once to create them)
+# - `backport <branch>`   — dev applies by hand to trigger; one per target branch.
+# - `backported <branch>` — added on success.
+# - `backport-failed`     — added when a cherry-pick conflicts.
+# - `do not merge`        — added to the backport PR when CI didn't auto-run.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Triggered by: a merged PR closed/labeled with a `backport <branch>` label, or manual dispatch.
+on:
+  pull_request_target:
+    types: [closed, labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Merged PR number to backport (e.g. 1234)'
+        required: true
+        type: string
+      target_branches:
+        description: 'Target branch(es), space-separated (e.g. "release/12.0 release/11.0")'
+        required: true
+        type: string
+
+jobs:
+  # Flow 1 (labels): compute the korthout label_pattern — on a `labeled` event,
+  # scoped to just that label's branch (regex-escaped) so already-backported
+  # branches aren't reprocessed; on merge, every `backport <branch>` label.
+  prepare:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport ')) ||
+        (github.event.action == 'closed' && contains(join(github.event.pull_request.labels.*.name, '|'), 'backport '))
+      )
+    runs-on: ubuntu-latest
+    outputs:
+      label_pattern: ${{ steps.pattern.outputs.label_pattern }}
+    steps:
+      - name: Compute label pattern
+        id: pattern
+        env:
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          if [ "$ACTION" = "labeled" ]; then
+            BRANCH=${LABEL_NAME#backport }
+            ESCAPED=$(printf '%s' "$BRANCH" | sed 's/[.$+(){}|]/\\&/g')
+            echo "label_pattern=^backport (${ESCAPED})\$" >> "$GITHUB_OUTPUT"
+          else
+            echo 'label_pattern=^backport ([^ ]+)$' >> "$GITHUB_OUTPUT"
+          fi
+
+  # Cherry-pick the PR to each labeled branch. APP_ID/APP_PRIVATE_KEY are optional:
+  # with them the backport PR runs CI automatically; without, it falls back to
+  # GITHUB_TOKEN (no auto-CI) — see BACKPORT.md for the one-time App setup.
+  backport:
+    needs: prepare
+    uses: datarobot-oss/github-actions/.github/workflows/backport.yaml@0.0.18
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      label_pattern: ${{ needs.prepare.outputs.label_pattern }}
+    secrets:
+      APP_ID: ${{ secrets.BACKPORT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+  # Flow 2 (manual): backport the merged PR number + branch(es) from the dispatch form.
+  backport-manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: datarobot-oss/github-actions/.github/workflows/backport.yaml@0.0.18
+    with:
+      pr_number: ${{ fromJSON(inputs.pr_number) }}
+      target_branches: ${{ inputs.target_branches }}
+    secrets:
+      APP_ID: ${{ secrets.BACKPORT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/workflow-ensure-labels.yaml
+++ b/.github/workflows/workflow-ensure-labels.yaml
@@ -1,0 +1,40 @@
+name: Ensure PR-automation labels
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ensure PR-automation labels
+# One-shot, idempotent label setup for the PR-automation & backport workflows.
+# Run from Actions → Run workflow. Optionally pass release branches to also make
+# backport label pairs, or enable cleanup of confusable review-label variants.
+# ─────────────────────────────────────────────────────────────────────────────
+# REQUIRED LABELS
+# - None — this workflow CREATES the labels the others require:
+#   `00 - Ready for Review`, `00 - Reviewed`, `backport-failed`, `do not merge`
+#   (+ `backport <branch>` / `backported <branch>` for any branches you pass).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Triggered by: manual dispatch only (run from the Actions tab).
+on:
+  workflow_dispatch:
+    inputs:
+      backport_branches:
+        description: 'Backport branches, comma/space-separated (e.g. "release/11.1, release/11.2"). Leave blank to skip.'
+        required: false
+        default: ''
+        type: string
+      delete_confusable:
+        description: 'Delete confusable review-label variants (migrates open PRs first)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  # Create/repair the automation labels (idempotent); optionally add per-branch
+  # backport labels and clean up confusable review-label variants.
+  ensure-labels:
+    uses: datarobot-oss/github-actions/.github/workflows/ensure-labels.yaml@0.0.18
+    with:
+      backport_branches: ${{ inputs.backport_branches }}
+      delete_confusable: ${{ inputs.delete_confusable }}
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/workflow-pr-automation.yaml
+++ b/.github/workflows/workflow-pr-automation.yaml
@@ -1,5 +1,17 @@
 name: PR Automation
 
+# ─────────────────────────────────────────────────────────────────────────────
+# PR Automation
+# Reviewer-facing helpers: marks approved PRs reviewed, pings Slack when a PR is
+# ready for review, links Jira tickets, and posts a 30-min digest of open PRs.
+# ─────────────────────────────────────────────────────────────────────────────
+# REQUIRED LABELS  (run examples/workflow-ensure-labels.yaml once to create them)
+# - `00 - Ready for Review` — dev applies by hand; triggers the Slack ping + digest.
+# - `00 - Reviewed`         — applied on approval; excludes the PR from the digest.
+# Missing labels hard-fail the job (a red X = a real setup problem, not hidden).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Triggered by: an approving review, PR label/open/edit events, a 30-min cron, or manual dispatch.
 on:
   pull_request_review:
     types: [submitted]
@@ -10,23 +22,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Triggered when a PR review is submitted with an "approved" state.
-  # Marks the PR as reviewed (e.g. applies a label or updates status) so the team
-  # knows it has passed code review and is ready for the next step.
+  # On an approving review: label the PR "00 - Reviewed".
   mark-reviewed:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.9
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-reviewed.yaml@0.0.18
     with:
       pr_number: ${{ github.event.pull_request.number }}
     permissions:
       pull-requests: write
 
-  # Triggered when the "ready for review" label is added to a PR.
-  # Sends a Slack notification with PR metadata (title, author, diff size, URL)
-  # so reviewers are alerted that the PR is ready for their attention.
+  # When a "ready for review" label is added: Slack the PR (title, author, diff, URL) to reviewers.
   notify-ready-for-review:
     if: github.event_name == 'pull_request' && contains(github.event.label.name, 'ready for review')
-    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.9
+    uses: datarobot-oss/github-actions/.github/workflows/mark-pr-to-review.yaml@0.0.18
     with:
       pr_number: ${{ github.event.pull_request.number }}
       pr_url: ${{ github.event.pull_request.html_url }}
@@ -40,12 +48,10 @@ jobs:
     permissions:
       pull-requests: write
 
-  # Triggered when a PR is opened or its title/description is edited.
-  # Parses the PR title or branch name for a Jira ticket ID and adds a link
-  # to the corresponding Jira issue in the PR description or as a comment.
+  # On PR open/edit: comment a link to any Jira ticket found in the title or branch name.
   add-jira-link:
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'edited')
-    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.9
+    uses: datarobot-oss/github-actions/.github/workflows/add-jira-link.yaml@0.0.18
     with:
       pr_title: ${{ github.event.pull_request.title }}
       pr_number: ${{ github.event.pull_request.number }}
@@ -53,15 +59,15 @@ jobs:
     permissions:
       pull-requests: write
 
-  # Triggered on a 30-minute cron schedule or manual workflow dispatch.
-  # Sends a Slack digest/reminder notification, useful for surfacing PRs
-  # that are still open and may need attention.
+  # On schedule/dispatch: Slack a digest of open PRs still awaiting review, and
+  # reconcile a missing "00 - Reviewed" label (needs pull-requests: write) if the
+  # event-driven mark-reviewed run was never dispatched.
   notify-slack-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.9
+    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.18
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     permissions:
       contents: read
-      pull-requests: read
-      checks: read
+      pull-requests: write
+      statuses: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.1
+- Upgrade github-actions to the latest releases with bug fixes, label validation and backport/cherry-picking capabilities
+
 ## 0.23.0
 - *Breaking change*: `dr_mem0_memory` agent memory TTL is now specified in days instead of seconds. Renamed `default_ttl_seconds` → `default_ttl_days` on `DRMem0MemoryClientConfig` and `AGENT_MEMORY_TTL_SECONDS` → `AGENT_MEMORY_TTL_DAYS` for the runtime parameter / env var.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.0"
+version = "0.23.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Upgrade github-actions workflows to latest releases

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Fix bugs in labels not always resolving
- Add support for cherry-picking to LTS branches
- Add automated label correction on the repos

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New `pull_request_target` backport automation can write branches and open PRs on release lines; misconfiguration or label mistakes could trigger unwanted cherry-picks, though scope is limited to GitHub Actions and repo labels.
> 
> **Overview**
> **Bumps** all `datarobot-oss/github-actions` reusable workflows in PR automation from **0.0.9 → 0.0.18**, with clearer in-file docs on required labels and behavior. The scheduled Slack digest job now has **`pull-requests: write`** and uses **`statuses: read`** instead of **`checks: read`**, so it can reconcile a missing **00 - Reviewed** label when the approval webhook did not run.
> 
> **Adds** a **Backport** workflow: after merge, **`backport <branch>`** labels (or manual dispatch with PR number + branches) cherry-pick onto release branches and open backport PRs, with a **prepare** job that scopes the label regex on late label adds. Optional **`BACKPORT_APP_*`** secrets enable CI on those PRs.
> 
> **Adds** **Ensure PR-automation labels**, a manual one-shot workflow to create standard review/backport labels, per-release **`backport` / `backported`** pairs, and optionally remove confusable review-label variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eff1e09d4ea24f75439fb598d74173a52140e7f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->