### PR TITLE
[MODEL-24010] File API Tools Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.1
+- `drtools/files_api`: expose `overwrite` on `file_manage` copy/move (defaults to `rename`; use `replace` to overwrite existing files). Reject recursive `file_list` at `dr://` and return browse hints to reduce agent listing loops.
+
 ## 0.23.0
 - *Breaking change*: `dr_mem0_memory` agent memory TTL is now specified in days instead of seconds. Renamed `default_ttl_seconds` → `default_ttl_days` on `DRMem0MemoryClientConfig` and `AGENT_MEMORY_TTL_SECONDS` → `AGENT_MEMORY_TTL_DAYS` for the runtime parameter / env var.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.0"
+version = "0.23.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/files_api_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/files_api_stubs.py
@@ -295,9 +295,15 @@ class InMemoryFileSystemStore:
             )
 
     async def copy(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: int | None = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: int | None = None,
+        overwrite: str = "rename",
     ) -> None:
-        del maxdepth
+        del maxdepth, overwrite
         src = _strip_protocol(source)
         dst = _strip_protocol(dest)
         if src in self._files:
@@ -311,9 +317,15 @@ class InMemoryFileSystemStore:
                     self._files[f"{dst.rstrip('/')}/{rel}"] = data
 
     async def move(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: int | None = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: int | None = None,
+        overwrite: str = "rename",
     ) -> None:
-        await self.copy(source, dest, recursive=recursive, maxdepth=maxdepth)
+        await self.copy(source, dest, recursive=recursive, maxdepth=maxdepth, overwrite=overwrite)
         await self.delete(source, recursive=recursive)
 
     async def clone(self, path_or_id: str, *, files_to_omit: list[str] | None = None) -> str:

--- a/src/datarobot_genai/drmcputils/files/file_system_store.py
+++ b/src/datarobot_genai/drmcputils/files/file_system_store.py
@@ -218,13 +218,25 @@ class FileSystemStore(Protocol):
         ...
 
     async def copy(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: int | None = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: int | None = None,
+        overwrite: OverwriteStrategyName = "rename",
     ) -> None:
         """Copy ``source`` to ``dest`` within the filesystem."""
         ...
 
     async def move(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: int | None = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: int | None = None,
+        overwrite: OverwriteStrategyName = "rename",
     ) -> None:
         """Move/rename ``source`` to ``dest`` within the filesystem."""
         ...
@@ -389,14 +401,44 @@ class DataRobotFileSystemStore:
         await self._run(lambda fs: fs.rm(path, recursive=recursive, maxdepth=maxdepth))
 
     async def copy(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: int | None = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: int | None = None,
+        overwrite: OverwriteStrategyName = "rename",
     ) -> None:
-        await self._run(lambda fs: fs.copy(source, dest, recursive=recursive, maxdepth=maxdepth))
+        strategy = overwrite_strategy_from_name(overwrite)
+        await self._run(
+            lambda fs: fs.copy(
+                source,
+                dest,
+                recursive=recursive,
+                maxdepth=maxdepth,
+                overwrite_strategy=strategy,
+            )
+        )
 
     async def move(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: int | None = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: int | None = None,
+        overwrite: OverwriteStrategyName = "rename",
     ) -> None:
-        await self._run(lambda fs: fs.mv(source, dest, recursive=recursive, maxdepth=maxdepth))
+        strategy = overwrite_strategy_from_name(overwrite)
+        await self._run(
+            lambda fs: fs.mv(
+                source,
+                dest,
+                recursive=recursive,
+                maxdepth=maxdepth,
+                overwrite_strategy=strategy,
+            )
+        )
 
     async def clone(self, path_or_id: str, *, files_to_omit: list[str] | None = None) -> str:
         return await self._run(

--- a/src/datarobot_genai/drtools/files_api/common_utils.py
+++ b/src/datarobot_genai/drtools/files_api/common_utils.py
@@ -35,6 +35,26 @@ from datarobot_genai.drmcputils.files.file_system_store import FileSystemStore
 
 ROOT_PATH = DR_PROTOCOL
 
+# Shared agent-facing documentation for DataRobot's conflict-handling semantics.
+# Unlike POSIX filesystems, most write-like operations default to auto-renaming
+# ('name (2).ext') instead of replacing an existing file at the destination.
+OVERWRITE_STRATEGY_DOC = (
+    "Conflict handling (DataRobot differs from POSIX): when a destination file "
+    "already exists, 'rename' (default) auto-renames to 'name (2).ext' instead "
+    "of replacing it; use 'replace' to overwrite the existing file, 'skip' to "
+    "leave it unchanged, or 'error' to fail."
+)
+FILE_WRITE_MODE_DOC = (
+    "file_write uses mode (not overwrite): mode='overwrite' replaces content at "
+    "the exact path; mode='create' fails if the file already exists."
+)
+LIST_BROWSE_HINT = (
+    "To search a catalog tree without listing every subdirectory in a loop, "
+    "use pattern='dr://<catalog_id>/**/*.ext' or recursive=True with maxdepth "
+    "on a parent path. Paginate with offset/limit instead of re-listing the "
+    "same path."
+)
+
 
 class FilesApiLocalSettings(DataRobotAppFrameworkBaseSettings):
     """Settings governing local-disk access for the Files API tools.

--- a/src/datarobot_genai/drtools/files_api/imports_tools.py
+++ b/src/datarobot_genai/drtools/files_api/imports_tools.py
@@ -30,6 +30,7 @@ from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drmcputils.files.file_system_store import is_terminal_import_failure_status
 from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.files_api.common_utils import OVERWRITE_STRATEGY_DOC
 from datarobot_genai.drtools.files_api.common_utils import get_store as _get_store
 from datarobot_genai.drtools.files_api.common_utils import require_file_path as _require_file_path
 from datarobot_genai.drtools.files_api.common_utils import require_path as _require_path
@@ -56,7 +57,7 @@ _IMPORT_STATUS_NOTE = (
         "  - source='url': set url to a file or archive URL reachable by DataRobot.\n"
         "  - source='data_source': set data_source_id (and optional credential_id).\n"
         "  - unpack_archive: extract zip/tar archives when true (default).\n"
-        "  - overwrite: 'rename' (default), 'replace', 'skip', or 'error'.\n\n"
+        f"  - {OVERWRITE_STRATEGY_DOC}\n\n"
         "Example: file_import(path='dr://abc123/data/', source='url', "
         "url='https://example.com/report.zip')\n"
         "Example: file_import(path='dr://abc123/in/', source='data_source', "
@@ -91,7 +92,7 @@ async def file_import(
     ] = True,
     overwrite: Annotated[
         Literal["rename", "replace", "skip", "error"],
-        "Conflict strategy when a file already exists at the destination.",
+        f"{OVERWRITE_STRATEGY_DOC} Default 'rename'.",
     ] = "rename",
 ) -> dict[str, Any]:
     cleaned = _require_file_path(path)

--- a/src/datarobot_genai/drtools/files_api/mutations_tools.py
+++ b/src/datarobot_genai/drtools/files_api/mutations_tools.py
@@ -33,6 +33,8 @@ from datarobot_genai.drmcputils.constants import MAX_INLINE_SIZE
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.files_api.common_utils import FILE_WRITE_MODE_DOC
+from datarobot_genai.drtools.files_api.common_utils import OVERWRITE_STRATEGY_DOC
 from datarobot_genai.drtools.files_api.common_utils import decode_content
 from datarobot_genai.drtools.files_api.common_utils import get_store as _get_store
 from datarobot_genai.drtools.files_api.common_utils import require_file_path as _require_file_path
@@ -56,8 +58,8 @@ logger = logging.getLogger(__name__)
         "parent folders implicitly (DataRobot has no empty directories). The path "
         "must be under a catalog item; create one first with "
         "file_manage(action='create_dir') if needed.\n"
-        "  - encoding: 'utf-8' for text (default) or 'base64' for binary content.\n"
-        "  - mode: 'overwrite' (default) or 'create' (fails if the file exists).\n"
+        f"  - {FILE_WRITE_MODE_DOC}\n"
+        f"  - encoding: 'utf-8' for text (default) or 'base64' for binary content.\n"
         f"Content is capped at {MAX_INLINE_SIZE} bytes; use file_import for larger "
         "or remote files.\n\n"
         "Example: file_write(path='dr://abc123/notes.txt', content='hello')\n"
@@ -75,7 +77,7 @@ async def file_write(
     ] = "utf-8",
     mode: Annotated[
         Literal["overwrite", "create"],
-        "'overwrite' replaces existing content; 'create' fails if the file exists. Default 'overwrite'.",  # noqa: E501
+        f"{FILE_WRITE_MODE_DOC} Default 'overwrite'.",
     ] = "overwrite",
 ) -> dict[str, Any]:
     cleaned = _require_file_path(path)
@@ -110,7 +112,7 @@ async def file_write(
         "'/data/**/*.csv' (set recursive=True).\n"
         "  - path: destination. End with '/' to upload into a directory; give a full "
         "file path to upload a single file under that name.\n"
-        "  - overwrite: 'rename' (default), 'replace', 'skip', or 'error' on conflicts.\n\n"
+        f"  - {OVERWRITE_STRATEGY_DOC}\n\n"
         "Example: file_upload(local_path='/tmp/report.pdf', path='dr://abc123/docs/')\n"
         "Example (tree): file_upload(local_path='/tmp/data', path='dr://abc123/data/', "
         "recursive=True)\n"
@@ -139,7 +141,7 @@ async def file_upload(
     ] = None,
     overwrite: Annotated[
         Literal["rename", "replace", "skip", "error"],
-        "Conflict strategy when a destination file already exists. Default 'rename'.",
+        f"{OVERWRITE_STRATEGY_DOC} Default 'rename'.",
     ] = "rename",
 ) -> dict[str, Any]:
     cleaned_local = _require_path(local_path, "local_path")
@@ -190,10 +192,12 @@ async def file_upload(
         "  'copy'       — copy path to target_path. Set recursive=True for directories.\n"
         "  'move'       — move/rename path to target_path. Set recursive=True for directories.\n"
         "  'clone'      — clone a whole catalog item directory (path) to a new catalog "
-        "item; returns its id. Use files_to_omit to skip entries.\n\n"
+        "item; returns its id. Use files_to_omit to skip entries.\n"
+        f"  - copy/move: {OVERWRITE_STRATEGY_DOC}\n\n"
         "Example: file_manage(action='create_dir')\n"
         "Example: file_manage(action='delete', path='dr://abc123/old/', recursive=True)\n"
-        "Example: file_manage(action='copy', path='dr://abc123/a.txt', target_path='dr://abc123/b.txt')"
+        "Example: file_manage(action='copy', path='dr://abc123/a.txt', "
+        "target_path='dr://abc123/b.txt', overwrite='replace')"
     ),
 )
 async def file_manage(
@@ -222,6 +226,10 @@ async def file_manage(
         list[str] | None,
         "For 'clone', catalog-relative paths to exclude from the clone.",
     ] = None,
+    overwrite: Annotated[
+        Literal["rename", "replace", "skip", "error"],
+        f"For 'copy' and 'move' only. {OVERWRITE_STRATEGY_DOC} Default 'rename'.",
+    ] = "rename",
 ) -> dict[str, Any]:
     if maxdepth is not None and maxdepth < 1:
         raise ToolError(
@@ -258,8 +266,15 @@ async def file_manage(
     source = _require_file_path(path)
     target = _require_file_path(target_path, "target_path")
     if action == "copy":
-        await store.copy(source, target, recursive=recursive, maxdepth=maxdepth)
-        return {"copied": True, "source": source, "target": target}
+        await store.copy(
+            source, target, recursive=recursive, maxdepth=maxdepth, overwrite=overwrite
+        )
+        return {
+            "copied": True,
+            "source": source,
+            "target": target,
+            "overwrite": overwrite,
+        }
 
-    await store.move(source, target, recursive=recursive, maxdepth=maxdepth)
-    return {"moved": True, "source": source, "target": target}
+    await store.move(source, target, recursive=recursive, maxdepth=maxdepth, overwrite=overwrite)
+    return {"moved": True, "source": source, "target": target, "overwrite": overwrite}

--- a/src/datarobot_genai/drtools/files_api/read_tools.py
+++ b/src/datarobot_genai/drtools/files_api/read_tools.py
@@ -140,14 +140,6 @@ async def file_list(
 
     cleaned_path = _require_path(path)
 
-    if recursive and _is_root(cleaned_path):
-        raise ToolError(
-            "Argument validation error: recursive listing at 'dr://' is not supported. "
-            "List a specific catalog item (e.g. 'dr://<catalog_id>/') or use "
-            "pattern='dr://<catalog_id>/**/*'.",
-            kind=ToolErrorKind.VALIDATION,
-        )
-
     if as_tree:
         tree = await store.tree(cleaned_path, recursion_limit=maxdepth or 2)
         return {"path": cleaned_path, "tree": tree}
@@ -156,6 +148,13 @@ async def file_list(
         entries = await store.glob(pattern.strip(), maxdepth=maxdepth)
         listed = pattern.strip()
     elif recursive:
+        if _is_root(cleaned_path):
+            raise ToolError(
+                "Argument validation error: recursive listing at 'dr://' is not supported. "
+                "List a specific catalog item (e.g. 'dr://<catalog_id>/') or use "
+                "pattern='dr://<catalog_id>/**/*'.",
+                kind=ToolErrorKind.VALIDATION,
+            )
         entries = await store.find(cleaned_path, maxdepth=maxdepth)
         listed = cleaned_path
     else:

--- a/src/datarobot_genai/drtools/files_api/read_tools.py
+++ b/src/datarobot_genai/drtools/files_api/read_tools.py
@@ -36,14 +36,36 @@ from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drmcputils.files.file_system_store import DEFAULT_SIGN_EXPIRATION_SECONDS
 from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.files_api.common_utils import LIST_BROWSE_HINT
 from datarobot_genai.drtools.files_api.common_utils import ROOT_PATH
 from datarobot_genai.drtools.files_api.common_utils import get_store as _get_store
+from datarobot_genai.drtools.files_api.common_utils import is_root as _is_root
 from datarobot_genai.drtools.files_api.common_utils import require_file_path as _require_file_path
 from datarobot_genai.drtools.files_api.common_utils import require_path as _require_path
 from datarobot_genai.drtools.pagination import clamp_limit
 from datarobot_genai.drtools.pagination import merge_pagination_metadata
 
 logger = logging.getLogger(__name__)
+
+
+def _list_browse_hint(
+    *,
+    recursive: bool,
+    pattern: str | None,
+    total_count: int,
+    offset: int,
+    limit: int,
+) -> str | None:
+    """Return guidance to help agents avoid repetitive directory-by-directory listing."""
+    hints: list[str] = []
+    if not recursive and pattern is None:
+        hints.append(LIST_BROWSE_HINT)
+    if total_count > offset + limit:
+        hints.append(
+            f"Paginated: showing {offset + 1}–{offset + limit} of {total_count}; "
+            "advance offset for the next page instead of re-listing the same path."
+        )
+    return " ".join(hints) if hints else None
 
 
 # ------------------------------------------------------------------ #
@@ -58,8 +80,9 @@ logger = logging.getLogger(__name__)
         "dr://<catalog_id>/path. Call with path='dr://' to list catalog items "
         "(top-level directories); call with a catalog path to list its contents.\n"
         "  - pattern: glob match (e.g. dr://<catalog_id>/**/*.csv). Overrides recursive.\n"
-        "  - recursive: list everything beneath path (no globbing).\n"
+        "  - recursive: list everything beneath path (no globbing). Not supported at dr://.\n"
         "  - as_tree: return a compact indented tree string instead of entries.\n"
+        f"  - {LIST_BROWSE_HINT}\n"
         "Returns entries with name, type ('file'|'directory'), size, format, created_at.\n\n"
         "Example: file_list(path='dr://')\n"
         "Example: file_list(path='dr://abc123/', recursive=True)\n"
@@ -78,7 +101,8 @@ async def file_list(
     ] = None,
     recursive: Annotated[
         bool,
-        "List everything beneath path (posix find semantics, no globbing). Default False.",
+        "List everything beneath path (posix find semantics, no globbing). "
+        "Not supported at dr:// — list a specific catalog path instead. Default False.",
     ] = False,
     as_tree: Annotated[
         bool,
@@ -111,6 +135,14 @@ async def file_list(
 
     cleaned_path = _require_path(path)
 
+    if recursive and _is_root(cleaned_path):
+        raise ToolError(
+            "Argument validation error: recursive listing at 'dr://' is not supported. "
+            "List a specific catalog item (e.g. 'dr://<catalog_id>/') or use "
+            "pattern='dr://<catalog_id>/**/*'.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
     if as_tree:
         tree = await store.tree(cleaned_path, recursion_limit=maxdepth or 2)
         return {"path": cleaned_path, "tree": tree}
@@ -133,6 +165,15 @@ async def file_list(
         "count": len(page),
         "total_count": len(entries),
     }
+    hint = _list_browse_hint(
+        recursive=recursive,
+        pattern=pattern,
+        total_count=len(entries),
+        offset=offset,
+        limit=clamped_limit,
+    )
+    if hint:
+        results["hint"] = hint
     return merge_pagination_metadata(results, {}, note, offset=offset, limit=clamped_limit)
 
 

--- a/tests/drmcp/unit/files_api_tools/test_file_system_store.py
+++ b/tests/drmcp/unit/files_api_tools/test_file_system_store.py
@@ -97,12 +97,33 @@ class FakeFS:
         self.recorded = ("rm", path, recursive, maxdepth)
         return self._resolve("rm", None)
 
-    def copy(self, path1: str, path2: str, recursive: bool = False, maxdepth: Any = None) -> Any:
-        self.recorded = ("copy", path1, path2, recursive, maxdepth)
+    def copy(
+        self,
+        path1: str,
+        path2: str,
+        recursive: bool = False,
+        maxdepth: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        self.recorded = (
+            "copy",
+            path1,
+            path2,
+            recursive,
+            maxdepth,
+            kwargs.get("overwrite_strategy"),
+        )
         return self._resolve("copy", None)
 
-    def mv(self, path1: str, path2: str, recursive: bool = False, maxdepth: Any = None) -> Any:
-        self.recorded = ("mv", path1, path2, recursive, maxdepth)
+    def mv(
+        self,
+        path1: str,
+        path2: str,
+        recursive: bool = False,
+        maxdepth: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        self.recorded = ("mv", path1, path2, recursive, maxdepth, kwargs.get("overwrite_strategy"))
         return self._resolve("mv", None)
 
     def clone_catalog_item_dir(self, path_or_id: str, files_to_omit: Any = None) -> Any:
@@ -285,10 +306,24 @@ async def test_delete_copy_move_delegate() -> None:
     store, fs = _store_and_fs()
     await store.delete("dr://abc/x", recursive=True, maxdepth=2)
     assert fs.recorded == ("rm", "dr://abc/x", True, 2)
-    await store.copy("dr://abc/a", "dr://abc/b", recursive=True)
-    assert fs.recorded == ("copy", "dr://abc/a", "dr://abc/b", True, None)
-    await store.move("dr://abc/a", "dr://abc/b")
-    assert fs.recorded == ("mv", "dr://abc/a", "dr://abc/b", False, None)
+    await store.copy("dr://abc/a", "dr://abc/b", recursive=True, overwrite="replace")
+    assert fs.recorded == (
+        "copy",
+        "dr://abc/a",
+        "dr://abc/b",
+        True,
+        None,
+        FilesOverwriteStrategy.REPLACE,
+    )
+    await store.move("dr://abc/a", "dr://abc/b", overwrite="skip")
+    assert fs.recorded == (
+        "mv",
+        "dr://abc/a",
+        "dr://abc/b",
+        False,
+        None,
+        FilesOverwriteStrategy.SKIP,
+    )
 
 
 async def test_clone_returns_new_catalog_id() -> None:

--- a/tests/drmcp/unit/files_api_tools/test_mutations.py
+++ b/tests/drmcp/unit/files_api_tools/test_mutations.py
@@ -62,14 +62,30 @@ class FakeStore:
         self._record("delete", path, recursive=recursive, maxdepth=maxdepth)
 
     async def copy(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: Any = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: Any = None,
+        overwrite: str = "rename",
     ) -> None:
-        self._record("copy", source, dest, recursive=recursive, maxdepth=maxdepth)
+        self._record(
+            "copy", source, dest, recursive=recursive, maxdepth=maxdepth, overwrite=overwrite
+        )
 
     async def move(
-        self, source: str, dest: str, *, recursive: bool = False, maxdepth: Any = None
+        self,
+        source: str,
+        dest: str,
+        *,
+        recursive: bool = False,
+        maxdepth: Any = None,
+        overwrite: str = "rename",
     ) -> None:
-        self._record("move", source, dest, recursive=recursive, maxdepth=maxdepth)
+        self._record(
+            "move", source, dest, recursive=recursive, maxdepth=maxdepth, overwrite=overwrite
+        )
 
     async def clone(self, path_or_id: str, *, files_to_omit: Any = None) -> str:
         self._record("clone", path_or_id, files_to_omit=files_to_omit)
@@ -270,17 +286,41 @@ async def test_file_manage_copy(monkeypatch: pytest.MonkeyPatch) -> None:
     result = await mut_mod.file_manage(
         action="copy", path="dr://abc/a.txt", target_path="dr://abc/b.txt"
     )
-    assert result == {"copied": True, "source": "dr://abc/a.txt", "target": "dr://abc/b.txt"}
+    assert result == {
+        "copied": True,
+        "source": "dr://abc/a.txt",
+        "target": "dr://abc/b.txt",
+        "overwrite": "rename",
+    }
     assert store.calls[0][0] == "copy"
+    assert store.calls[0][2]["overwrite"] == "rename"
+
+
+async def test_file_manage_copy_with_replace(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _use_store(monkeypatch, FakeStore())
+    result = await mut_mod.file_manage(
+        action="copy",
+        path="dr://abc/a.txt",
+        target_path="dr://abc/b.txt",
+        overwrite="replace",
+    )
+    assert result["overwrite"] == "replace"
+    assert store.calls[0][2]["overwrite"] == "replace"
 
 
 async def test_file_manage_move(monkeypatch: pytest.MonkeyPatch) -> None:
     store = _use_store(monkeypatch, FakeStore())
     result = await mut_mod.file_manage(
-        action="move", path="dr://abc/a.txt", target_path="dr://abc/b.txt"
+        action="move", path="dr://abc/a.txt", target_path="dr://abc/b.txt", overwrite="replace"
     )
-    assert result == {"moved": True, "source": "dr://abc/a.txt", "target": "dr://abc/b.txt"}
+    assert result == {
+        "moved": True,
+        "source": "dr://abc/a.txt",
+        "target": "dr://abc/b.txt",
+        "overwrite": "replace",
+    }
     assert store.calls[0][0] == "move"
+    assert store.calls[0][2]["overwrite"] == "replace"
 
 
 async def test_file_manage_clone(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/drmcp/unit/files_api_tools/test_tools.py
+++ b/tests/drmcp/unit/files_api_tools/test_tools.py
@@ -144,6 +144,20 @@ async def test_file_list_validation_errors(
         await tools_mod.file_list(path="dr://abc/", **kwargs)
 
 
+async def test_file_list_recursive_at_root_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_store(monkeypatch, FakeStore(ls=[]))
+    with pytest.raises(ToolError, match="recursive listing at 'dr://'"):
+        await tools_mod.file_list(path="dr://", recursive=True)
+
+
+async def test_file_list_includes_browse_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    entries = [_entry(f"abc/{i}.txt") for i in range(3)]
+    _use_store(monkeypatch, FakeStore(ls=entries))
+    result = await tools_mod.file_list(path="dr://abc/", limit=2)
+    assert "hint" in result
+    assert "pattern=" in result["hint"]
+
+
 # ------------------------------------------------------------------ #
 # file_info                                                            #
 # ------------------------------------------------------------------ #

--- a/tests/drmcp/unit/files_api_tools/test_tools.py
+++ b/tests/drmcp/unit/files_api_tools/test_tools.py
@@ -150,6 +150,20 @@ async def test_file_list_recursive_at_root_rejected(monkeypatch: pytest.MonkeyPa
         await tools_mod.file_list(path="dr://", recursive=True)
 
 
+async def test_file_list_root_as_tree_ignores_recursive(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _use_store(monkeypatch, FakeStore(tree="abc/\n  a.txt"))
+    result = await tools_mod.file_list(path="dr://", as_tree=True, recursive=True)
+    assert result["tree"] == "abc/\n  a.txt"
+    assert store.calls[0][0] == "tree"
+
+
+async def test_file_list_root_pattern_ignores_recursive(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _use_store(monkeypatch, FakeStore(glob=[_entry("abc/a.csv")]))
+    result = await tools_mod.file_list(path="dr://", pattern="dr://abc/**/*.csv", recursive=True)
+    assert result["path"] == "dr://abc/**/*.csv"
+    assert store.calls[0][0] == "glob"
+
+
 async def test_file_list_includes_browse_hint(monkeypatch: pytest.MonkeyPatch) -> None:
     entries = [_entry(f"abc/{i}.txt") for i in range(3)]
     _use_store(monkeypatch, FakeStore(ls=entries))

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

Fixes issues in the file api tools related to 
- infinite loop in the top-level directories
- overwrite strategies

## TESTING
<img width="713" height="564" alt="Screenshot 2026-07-07 at 2 04 10 PM" src="https://github.com/user-attachments/assets/3ac53729-09a8-48c9-8877-4c4585746b36" />

<img width="838" height="826" alt="Screenshot 2026-07-07 at 2 08 15 PM" src="https://github.com/user-attachments/assets/8ae27078-44f5-4c3b-9b43-0e3f274078de" />

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defaults stay `rename`; changes are additive tool parameters, validation, and documentation with unit test coverage—no auth or breaking API shifts.
> 
> **Overview**
> **Release 0.23.1** tightens the Files API MCP tools for agent ergonomics and conflict handling on structural operations.
> 
> `file_manage` **copy** and **move** now accept an **`overwrite`** argument (`rename` default, or `replace` / `skip` / `error`), passed through `FileSystemStore` / `DataRobotFileSystemStore` as `FilesOverwriteStrategy`. Responses echo the chosen strategy. Import, upload, and write tool docs now share centralized explanations of DataRobot’s non-POSIX conflict semantics vs `file_write`’s `mode`.
> 
> `file_list` **rejects** `recursive=True` at `dr://` with a validation error, and may return a **`hint`** field (glob/recursive browse guidance and pagination nudges) so agents avoid repetitive directory listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce87a6b1ece7dadf28bfb01d7d7cf616ca46fbc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->