### PR TITLE
[BUZZOK-31532] Merge eval quality_score and answer_match_score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.5
+- Merge `quality_score` and `answer_match_score` in eval package into a single `score`.
+- Add `has_judge` and `benchmark` to outputs in eval package.
+
 ## 0.23.4
 - Upgrade github-actions to the latest releases with bug fixes, label validation and backport/cherry-picking capabilities
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.4"
+version = "0.23.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/eval/eval.py
+++ b/src/datarobot_genai/eval/eval.py
@@ -145,7 +145,13 @@ class EvalRunner:
         # 5. Normalize output
         try:
             normalized = normalize_output(
-                nemo_output_dir, dataset, self.endpoint, self.pipeline, run_id
+                nemo_output_dir,
+                dataset,
+                self.endpoint,
+                self.pipeline,
+                run_id,
+                benchmark=str(cfg["benchmark"]["name"]),
+                has_judge=bool(cfg.get("judge")),
             )
         except Exception as e:  # noqa: BLE001
             write_status(
@@ -169,7 +175,7 @@ class EvalRunner:
         print("Results: output/eval_results.json")
         print(f"  Total cases:        {normalized['total_cases']}")
         print(f"  Scored / inconcl.:  {s['scored_cases']} / {s['inconclusive_cases']}")
-        print(f"  Mean quality score: {s['mean_quality_score']}")
+        print(f"  Mean score:         {s['mean_score']}")
         print(f"  Pass rate:          {s['pass_rate']}")
         print(f"  Good case pass:     {s['good_case_pass_rate']}")
         print(f"  Bad case pass:      {s['bad_case_pass_rate']}")

--- a/src/datarobot_genai/eval/output.py
+++ b/src/datarobot_genai/eval/output.py
@@ -32,6 +32,8 @@ def normalize_output(
     endpoint: str,
     pipeline: str,
     run_id: str,
+    benchmark: str = "",
+    has_judge: bool = False,
 ) -> dict[str, Any]:
     dataset_by_id: dict[str, dict[str, Any]] = {}
     for c in dataset:
@@ -66,38 +68,43 @@ def normalize_output(
             original = dataset_by_id.get(case_id, {})
 
             scores: dict[str, Any] = pred.get("scores") or {}
-            quality_score: Any = scores.get("score")
+            score: Any = scores.get("score")
             grade: str = scores.get("judge_grade", "")
-            reason: str = scores.get("reason", "")
+            reason_raw: str = scores.get("reason", "")
             status: str = pred.get("status", "")
 
-            scored_ok = isinstance(quality_score, (int, float))
-            passed: bool | None = quality_score >= PASS_THRESHOLD if scored_ok else None
+            scored_ok = isinstance(score, (int, float))
+            passed: bool | None = score >= PASS_THRESHOLD if scored_ok else None
 
-            # A sample is "inconclusive" when the agent answered but the judge
-            # call failed (no numeric score). See BUGS.md #3.
-            # Judge-free benchmarks emit a human-readable ``reason`` (e.g.
-            # "canary present", "found EMAIL"); judge-based ones report the grade.
+            # ``reason`` is the human-readable explanation for the score,
+            # whatever its source: a judge grade for judge-based benchmarks, or a
+            # deterministic match explanation for judge-free ones. A sample is
+            # "inconclusive" when the agent answered but scoring produced no
+            # numeric score (e.g. a judge call failed). See BUGS.md #3.
             if scored_ok:
-                judge_reason = reason or f"judge grade: {grade}"
+                reason = reason_raw or (f"judge grade: {grade}" if grade else "")
             elif status == "scored":
-                detail = reason or grade or "returned no score"
-                judge_reason = f"inconclusive — {detail}"
+                detail = reason_raw or grade or "returned no score"
+                reason = f"inconclusive — {detail}"
             else:
-                judge_reason = f"inconclusive — agent {status}"
+                reason = f"inconclusive — agent {status}"
 
             cases.append(
                 {
                     "id": case_id,
+                    "benchmark": benchmark,
                     "input": original.get("input", meta.get("input", "")),
                     "expected_behavior": meta.get(
                         "expected_behavior", original.get("expected_behavior")
                     ),
                     "agent_response": pred.get("response") or "",
-                    "quality_score": quality_score,
-                    "judge_reason": judge_reason,
+                    "has_judge": has_judge,
+                    "score": score,
                     "passed": passed,
-                    "answer_match_score": None,
+                    "reason": reason,
+                    # Raw judge grade, preserved for traceability; null when no
+                    # judge ran or the judge returned no grade.
+                    "judge_grade": grade or None,
                     "notes": original.get("notes", meta.get("notes", "")),
                     "source": original.get("source", meta.get("source", "")),
                 }
@@ -110,13 +117,15 @@ def normalize_output(
             cases.append(
                 {
                     "id": c["id"],
+                    "benchmark": benchmark,
                     "input": c.get("input", ""),
                     "expected_behavior": c.get("expected_behavior"),
                     "agent_response": "",
-                    "quality_score": None,
-                    "judge_reason": "inconclusive — no prediction",
+                    "has_judge": has_judge,
+                    "score": None,
                     "passed": None,
-                    "answer_match_score": None,
+                    "reason": "inconclusive — no prediction",
+                    "judge_grade": None,
                     "notes": c.get("notes", ""),
                     "source": c.get("source", ""),
                 }
@@ -133,9 +142,9 @@ def normalize_output(
                         "value"
                     )
 
-    scored = [c for c in cases if isinstance(c["quality_score"], (int, float))]
+    scored = [c for c in cases if isinstance(c["score"], (int, float))]
     inconclusive = len(cases) - len(scored)
-    mean_score = sum(c["quality_score"] for c in scored) / len(scored) if scored else None
+    mean_score = sum(c["score"] for c in scored) / len(scored) if scored else None
     pass_rate = sum(1 for c in scored if c["passed"]) / len(scored) if scored else None
     good = [c for c in scored if c["expected_behavior"] == "good"]
     bad = [c for c in scored if c["expected_behavior"] == "bad"]
@@ -149,7 +158,7 @@ def normalize_output(
         "summary": {
             "scored_cases": len(scored),
             "inconclusive_cases": inconclusive,
-            "mean_quality_score": round(mean_score, 4) if mean_score is not None else None,
+            "mean_score": round(mean_score, 4) if mean_score is not None else None,
             "pass_rate": round(pass_rate, 4) if pass_rate is not None else None,
             "good_case_pass_rate": (
                 round(sum(1 for c in good if c["passed"]) / len(good), 4) if good else None

--- a/src/datarobot_genai/eval/schemas/output_schema.json
+++ b/src/datarobot_genai/eval/schemas/output_schema.json
@@ -14,10 +14,10 @@
       "properties": {
         "scored_cases":       { "type": "integer", "description": "Cases that received a numeric judge score" },
         "inconclusive_cases": { "type": "integer", "description": "Cases excluded from rates — agent errored or judge call failed (e.g. gateway content filter). See BUGS.md #3." },
-        "mean_quality_score": { "type": ["number", "null"], "description": "Average LLM judge score across scored cases (0-1)" },
+        "mean_score":         { "type": ["number", "null"], "description": "Average score across scored cases (0-1)" },
         "pass_rate":          { "type": ["number", "null"], "description": "Fraction of scored cases scoring >= 0.5" },
-        "good_case_pass_rate":{ "type": "number", "description": "Pass rate on expected_behavior=good cases only" },
-        "bad_case_pass_rate": { "type": "number", "description": "Pass rate on expected_behavior=bad cases only" }
+        "good_case_pass_rate":{ "type": ["number", "null"], "description": "Pass rate on expected_behavior=good cases only, or null if none" },
+        "bad_case_pass_rate": { "type": ["number", "null"], "description": "Pass rate on expected_behavior=bad cases only, or null if none" }
       }
     },
     "cases": {
@@ -26,13 +26,15 @@
         "type": "object",
         "properties": {
           "id":                 { "type": "string" },
+          "benchmark":          { "type": "string", "description": "Name of the benchmark that scored this case (e.g. answer_correctness)" },
           "input":              { "type": "string" },
           "expected_behavior":  { "type": "string", "enum": ["good", "bad"] },
           "agent_response":     { "type": "string", "description": "Raw response from the agent" },
-          "quality_score":      { "type": ["number", "null"], "description": "LLM judge score 0-1, or null if inconclusive" },
-          "judge_reason":       { "type": "string", "description": "Judge grade, or an 'inconclusive — ...' reason" },
+          "has_judge":          { "type": "boolean", "description": "Whether an LLM judge scored this case (true) or it was scored deterministically (false)" },
+          "score":              { "type": ["number", "null"], "description": "Score 0-1 (judge or deterministic), or null if inconclusive" },
           "passed":             { "type": ["boolean", "null"], "description": "score >= 0.5, or null if inconclusive" },
-          "answer_match_score": { "type": ["number", "null"], "description": "ROUGE-L score vs ideal_response, null if no ideal_response" },
+          "reason":             { "type": "string", "description": "Human-readable explanation for the score, or an 'inconclusive — ...' reason" },
+          "judge_grade":        { "type": ["string", "null"], "description": "Raw judge grade for traceability; null when no judge ran or the judge returned no grade" },
           "notes":              { "type": "string" },
           "source":             { "type": "string", "enum": ["collected", "synthetic"] }
         }

--- a/src/datarobot_genai/eval/summarize.py
+++ b/src/datarobot_genai/eval/summarize.py
@@ -41,7 +41,7 @@ class ResultsSummarizer:
 
         s: dict[str, Any] = data.get("summary", {})
         print("\nSummary")
-        print(f"  Mean quality score : {s.get('mean_quality_score')}")
+        print(f"  Mean score         : {s.get('mean_score')}")
         print(f"  Pass rate          : {s.get('pass_rate')}")
         print(f"  Good case pass     : {s.get('good_case_pass_rate')}")
         print(f"  Bad case pass      : {s.get('bad_case_pass_rate')}")
@@ -58,10 +58,10 @@ class ResultsSummarizer:
             print(f"  {'ID':<15} {'Expect':<8} {'Score':<7} {'Pass':<6} Reason")
             print(f"  {'-' * 15} {'-' * 8} {'-' * 7} {'-' * 6} {'-' * 45}")
             for c in cases:
-                score = c.get("quality_score")
+                score = c.get("score")
                 score_str = f"{score:.2f}" if isinstance(score, float) else str(score)
                 passed = "✓" if c.get("passed") else ("✗" if c.get("passed") is False else "?")
-                reason = (c.get("judge_reason") or "")[:50]
+                reason = (c.get("reason") or "")[:50]
                 print(
                     f"  {(c.get('id') or '?'):<15} {(c.get('expected_behavior') or '?'):<8} "
                     f"{score_str:<7} {passed:<6} {reason}"

--- a/tests/eval/test_cli.py
+++ b/tests/eval/test_cli.py
@@ -46,7 +46,7 @@ _RESULTS: dict[str, Any] = {
     "summary": {
         "scored_cases": 1,
         "inconclusive_cases": 0,
-        "mean_quality_score": 1.0,
+        "mean_score": 1.0,
         "pass_rate": 1.0,
         "good_case_pass_rate": 1.0,
         "bad_case_pass_rate": None,

--- a/tests/eval/test_eval.py
+++ b/tests/eval/test_eval.py
@@ -41,7 +41,7 @@ _NORMALIZED_RESULTS: dict[str, Any] = {
     "summary": {
         "scored_cases": 1,
         "inconclusive_cases": 0,
-        "mean_quality_score": 1.0,
+        "mean_score": 1.0,
         "pass_rate": 1.0,
         "good_case_pass_rate": 1.0,
         "bad_case_pass_rate": None,

--- a/tests/eval/test_output.py
+++ b/tests/eval/test_output.py
@@ -56,6 +56,29 @@ def _scored_row(
     }
 
 
+def _judge_free_row(
+    case_id: str,
+    expected_behavior: str,
+    score: float,
+    reason: str,
+    response: str = "agent response",
+) -> dict[str, Any]:
+    """Build a judge-free benchmark row: numeric ``score`` + ``reason``, no ``judge_grade``."""
+    category = "quality" if expected_behavior == "good" else "safety"
+    return {
+        "metadata": {
+            "id": case_id,
+            "expected_behavior": expected_behavior,
+            "input": "q",
+            "notes": "",
+            "source": "",
+        },
+        "response": response,
+        "scores": {"score": score, category: score, "reason": reason},
+        "status": "scored",
+    }
+
+
 def _inconclusive_row(case_id: str, expected_behavior: str = "bad") -> dict[str, Any]:
     return {
         "metadata": {
@@ -126,13 +149,89 @@ def test_normalize_output_scored_case(tmp_path: Path) -> None:
     _write_results(subdir, {"tasks": {}})
 
     dataset = [{"id": "good-001", "input": "q", "expected_behavior": "good"}]
-    result = normalize_output(str(tmp_path), dataset, "http://x", "p.yaml", "r1")
+    result = normalize_output(
+        str(tmp_path),
+        dataset,
+        "http://x",
+        "p.yaml",
+        "r1",
+        benchmark="answer_quality",
+        has_judge=True,
+    )
 
     case = result["cases"][0]
     assert case["id"] == "good-001"
-    assert case["quality_score"] == 1.0
+    assert case["score"] == 1.0
     assert case["passed"] is True
-    assert "judge grade" in case["judge_reason"]
+    assert "judge grade" in case["reason"]
+
+
+def test_normalize_output_judge_based_case_fields(tmp_path: Path) -> None:
+    subdir = tmp_path / "run"
+    _write_predictions(subdir, [_scored_row("good-001", "good", 1.0, "5")])
+    _write_results(subdir, {"tasks": {}})
+
+    dataset = [{"id": "good-001", "input": "q", "expected_behavior": "good"}]
+    result = normalize_output(
+        str(tmp_path),
+        dataset,
+        "http://x",
+        "p.yaml",
+        "r1",
+        benchmark="answer_quality",
+        has_judge=True,
+    )
+
+    case = result["cases"][0]
+    assert case["benchmark"] == "answer_quality"
+    assert case["has_judge"] is True
+    assert case["judge_grade"] == "5"
+    assert case["score"] == 1.0
+    assert "judge grade" in case["reason"]
+
+
+def test_normalize_output_judge_free_case_fields(tmp_path: Path) -> None:
+    subdir = tmp_path / "run"
+    _write_predictions(
+        subdir,
+        [
+            _judge_free_row("correct-001", "good", 1.0, "normalized match"),
+            _judge_free_row("wrong-001", "good", 0.0, "no normalized match"),
+        ],
+    )
+    _write_results(subdir, {"tasks": {}})
+
+    dataset = [
+        {"id": "correct-001", "input": "q", "expected_behavior": "good"},
+        {"id": "wrong-001", "input": "q", "expected_behavior": "good"},
+    ]
+    result = normalize_output(
+        str(tmp_path),
+        dataset,
+        "http://x",
+        "p.yaml",
+        "r1",
+        benchmark="answer_correctness",
+        has_judge=False,
+    )
+
+    by_id = {c["id"]: c for c in result["cases"]}
+    # The deterministic match lands in the unified ``score`` field; no judge ran,
+    # so has_judge is False and judge_grade is null. The match explanation is in
+    # ``reason``.
+    correct = by_id["correct-001"]
+    assert correct["benchmark"] == "answer_correctness"
+    assert correct["has_judge"] is False
+    assert correct["judge_grade"] is None
+    assert correct["score"] == 1.0
+    assert correct["passed"] is True
+    assert correct["reason"] == "normalized match"
+
+    wrong = by_id["wrong-001"]
+    assert wrong["has_judge"] is False
+    assert wrong["score"] == 0.0
+    assert wrong["passed"] is False
+    assert wrong["reason"] == "no normalized match"
 
 
 def test_normalize_output_score_below_threshold(tmp_path: Path) -> None:
@@ -169,7 +268,7 @@ def test_normalize_output_inconclusive_case(tmp_path: Path) -> None:
     assert result["summary"]["inconclusive_cases"] == 1
     assert result["summary"]["pass_rate"] is None
     case = result["cases"][0]
-    assert case["quality_score"] is None
+    assert case["score"] is None
     assert case["passed"] is None
 
 
@@ -252,9 +351,9 @@ def test_normalize_output_missing_prediction_surfaced_as_inconclusive(
     assert result["summary"]["scored_cases"] == 1
     assert result["summary"]["inconclusive_cases"] == 1
     missing = next(c for c in result["cases"] if c["id"] == "good-002")
-    assert missing["quality_score"] is None
+    assert missing["score"] is None
     assert missing["passed"] is None
-    assert "no prediction" in missing["judge_reason"]
+    assert "no prediction" in missing["reason"]
 
 
 def test_normalize_output_duplicate_dataset_id_warns(tmp_path: Path) -> None:
@@ -298,7 +397,7 @@ def test_normalize_output_duplicate_prediction_id_warns_and_skips(
     assert any("good-001" in str(w.message) for w in caught)
     # Only the first prediction should be kept.
     assert len(result["cases"]) == 1
-    assert result["cases"][0]["quality_score"] == 1.0
+    assert result["cases"][0]["score"] == 1.0
 
 
 def test_find_artifact_prefers_most_recently_modified(tmp_path: Path) -> None:

--- a/tests/eval/test_summarize.py
+++ b/tests/eval/test_summarize.py
@@ -40,7 +40,7 @@ def _minimal_results(
         "summary": {
             "scored_cases": scored,
             "inconclusive_cases": inconclusive,
-            "mean_quality_score": 1.0,
+            "mean_score": 1.0,
             "pass_rate": 1.0,
             "good_case_pass_rate": 1.0,
             "bad_case_pass_rate": 1.0,
@@ -49,13 +49,15 @@ def _minimal_results(
         "cases": [
             {
                 "id": "good-001",
+                "benchmark": "answer_quality",
                 "input": "question",
                 "expected_behavior": "good",
                 "agent_response": "answer",
-                "quality_score": 1.0,
-                "judge_reason": "judge grade: 5",
+                "has_judge": True,
+                "score": 1.0,
                 "passed": True,
-                "answer_match_score": None,
+                "reason": "judge grade: 5",
+                "judge_grade": "5",
                 "notes": "",
                 "source": "",
             }

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.4"
+version = "0.23.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

A bug report against the `eval` package flagged that `answer_match_score` was always `null` for judge-free benchmarks (e.g. `answer_correctness`), and that the deterministic match explanation was being written into `judge_reason`, mislabeling a judge-free result as if a judge produced it.

Digging in revealed the deeper issue: `quality_score` and `answer_match_score` were two fields for the *same* concept. This unifies the per-case output around a single score field and adds a judge field.
## CHANGES

**Unified per-case output schema:**
- `quality_score` → **`score`** — the single numeric score for every case (judge or deterministic).
- `judge_reason` → **`reason`** — the single human-readable explanation (judge grade *or* deterministic match reason).
- **Dropped `answer_match_score`** — it was a redundant copy of the score.
- **Added `has_judge`** (bool) — explicit provenance: LLM judge vs. deterministic scoring.
- **Added `benchmark`** (string) — the benchmark that scored the case (e.g. `answer_correctness`), so each case is self-describing.
- **Added `judge_grade`** (string|null) — the raw judge grade preserved for traceability; null when no judge ran.
- Summary: `mean_quality_score` → **`mean_score`**.

**Also in this change:**
- `output_schema.json` updated to match (renamed/added/dropped properties, corrected descriptions).
- Fixed a pre-existing schema bug: `good_case_pass_rate` / `bad_case_pass_rate` are `null` when there are no good/bad scored cases but were typed `number`-only.
- `summarize.py` and the CLI summary print updated for the renamed fields.
- Tests updated across `test_output.py`, `test_summarize.py`, `test_cli.py`, `test_eval.py`, plus new explicit judge-based and judge-free field-shape tests. Output validated against the schema end-to-end.


## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to `eval_results.json` and fixed output paths external CLIs may consume; scoring logic is refactored but covered by expanded tests.
> 
> **Overview**
> **Unifies eval `eval_results.json` so judge-based and judge-free benchmarks share one shape**, bumping the package to **0.23.1**.
> 
> Per-case fields rename **`quality_score` → `score`**, **`judge_reason` → `reason`**, and drop **`answer_match_score`**. New metadata includes **`benchmark`**, **`has_judge`**, and **`judge_grade`** (raw grade when a judge ran). Summary aggregates use **`mean_score`** instead of **`mean_quality_score`**. `normalize_output` now takes **`benchmark`** and **`has_judge`** from the pipeline config; `EvalRunner` passes benchmark name and whether a judge is configured.
> 
> **`output_schema.json`**, CLI completion/summarize output, and tests are updated to match. Deterministic scores (e.g. answer correctness) land in **`score`** with explanations in **`reason`**; judge runs still populate **`judge_grade`** for traceability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98be1f868dd8e16913cfae0026e71e76685d3f93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->