### PR TITLE
Add per-request MCP tool category gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.3
+- `drmcp`: added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. `UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.
+
 ## 0.23.2
 - `drtools/files_api`: expose `overwrite` on `file_manage` copy/move (defaults to `rename`; use `replace` to overwrite existing files). Reject recursive `file_list` at `dr://` and return browse hints to reduce agent listing loops.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.2"
+version = "0.23.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.2"
+version = "0.23.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcpbase/fastmcp_transforms/transform.py
+++ b/src/datarobot_genai/drmcpbase/fastmcp_transforms/transform.py
@@ -24,7 +24,9 @@ from fastmcp.utilities.versions import VersionSpec
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import MCPRequestContext
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import MCPRequestMode
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import filter_tools_by_allowlist
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import filter_tools_by_category_gates
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import get_request_context
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import is_tool_category_disabled
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import is_tool_name_allowed
 
 logger = logging.getLogger(__name__)
@@ -36,6 +38,9 @@ class DataRobotMCPCatalogTransform(CodeMode):
 
     async def transform_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
         ctx = self._request_context()
+        # Category gates run first — precedence: gates → mode → allowlist.  A tool
+        # in a disabled category stays hidden even when allowlisted.
+        tools = filter_tools_by_category_gates(tools, ctx.disabled_categories)
         if ctx.mode is MCPRequestMode.CODE_EXECUTE:
             return await super().transform_tools(tools)
         if ctx.tool_allowlist is None:
@@ -51,10 +56,19 @@ class DataRobotMCPCatalogTransform(CodeMode):
     ) -> Tool | None:
         ctx = self._request_context()
         if ctx.mode is MCPRequestMode.CODE_EXECUTE:
-            return await super().get_tool(name, call_next, version=version)
-        if ctx.tool_allowlist is not None and not is_tool_name_allowed(name, ctx.tool_allowlist):
+            tool = await super().get_tool(name, call_next, version=version)
+        else:
+            if ctx.tool_allowlist is not None and not is_tool_name_allowed(
+                name, ctx.tool_allowlist
+            ):
+                return None
+            tool = await call_next(name, version=version)
+        # Category gates apply in every mode: a tool in a disabled category is not
+        # resolvable — and therefore not callable — for this request.  (CodeMode's
+        # synthetic discovery tools carry no category meta and are never gated.)
+        if tool is not None and is_tool_category_disabled(tool, ctx.disabled_categories):
             return None
-        return await call_next(name, version=version)
+        return tool
 
 
 def register_mcp_catalog_transform(mcp: Any) -> None:

--- a/src/datarobot_genai/drmcpbase/fastmcp_transforms/utils.py
+++ b/src/datarobot_genai/drmcpbase/fastmcp_transforms/utils.py
@@ -23,6 +23,7 @@ from typing import Any
 from fastmcp.server.dependencies import get_http_headers
 from fastmcp.tools import Tool
 
+from datarobot_genai.drmcpbase.dynamic_tools.enums import DataRobotMCPToolCategory
 from datarobot_genai.drmcputils.categories import parse_tool_allowlist_header
 
 MCP_MODE_HEADER = "x-datarobot-mcp-mode"
@@ -30,6 +31,27 @@ MCP_TOOLS_HEADER = "x-datarobot-mcp-tools"
 # Extension point for user-defined toolsets (global-mcp only, resolved from mongo).
 # Parsed here so the constant is co-located with the other header names.
 MCP_TOOLSETS_HEADER = "x-datarobot-mcp-toolsets"
+
+# Per-request category gates.  Optional booleans, default true; an explicit
+# ``false`` disables the whole category for that request only.  Gates take
+# precedence over the mode and the tools/toolsets allowlist: a tool in a
+# disabled category stays hidden even when allowlisted.
+MCP_ENABLE_PROXY_HEADER = "x-datarobot-mcp-enable-proxy"
+MCP_ENABLE_DYNAMIC_TOOLS_HEADER = "x-datarobot-mcp-enable-dynamic-tools"
+
+# Table-driven gate → category mapping so future gates (e.g. a generalized
+# ``x-datarobot-mcp-disable=<category,...>``) only need a new row.  Values are
+# ``DataRobotMCPToolCategory`` names exactly as the providers stamp them into
+# ``tool.meta["tool_category"]``.
+CATEGORY_GATE_HEADERS: Mapping[str, frozenset[str]] = {
+    MCP_ENABLE_PROXY_HEADER: frozenset({DataRobotMCPToolCategory.PROXIED_USER_MCP.name}),
+    MCP_ENABLE_DYNAMIC_TOOLS_HEADER: frozenset(
+        {DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT.name}
+    ),
+}
+
+_TRUE_HEADER_VALUES = frozenset({"true", "1", "yes", "on"})
+_FALSE_HEADER_VALUES = frozenset({"false", "0", "no", "off"})
 
 
 def get_fast_mcp_http_headers(**kwargs: Any) -> dict[str, str]:
@@ -50,6 +72,31 @@ def get_header_value(headers: Mapping[str, str], name: str) -> str | None:
 
 def get_header_case_insensitive(headers: Mapping[str, str], name: str) -> str | None:
     return get_header_value(headers, name)
+
+
+def parse_bool_header(raw: str | None, *, default: bool = True) -> bool:
+    """Parse an optional boolean header; unrecognized values fall back to *default*."""
+    if raw is None:
+        return default
+    token = raw.strip().casefold()
+    if token in _TRUE_HEADER_VALUES:
+        return True
+    if token in _FALSE_HEADER_VALUES:
+        return False
+    return default
+
+
+def parse_disabled_categories(headers: Mapping[str, str]) -> frozenset[str]:
+    """Resolve the category-gate headers to the set of disabled category names.
+
+    Every gate defaults to enabled; only an explicit ``false`` disables its
+    category for this request.
+    """
+    disabled: set[str] = set()
+    for header_name, category_names in CATEGORY_GATE_HEADERS.items():
+        if not parse_bool_header(get_header_value(headers, header_name)):
+            disabled.update(category_names)
+    return frozenset(disabled)
 
 
 class MCPRequestMode(Enum):
@@ -89,10 +136,32 @@ def is_tool_name_allowed(name: str, allowlist: frozenset[str]) -> bool:
     return name in allowlist
 
 
+def get_tool_category(tool: Tool) -> str | None:
+    """Category name stamped by the providers, or None for untagged (built-in) tools."""
+    category = (tool.meta or {}).get("tool_category")
+    return category if isinstance(category, str) else None
+
+
+def is_tool_category_disabled(tool: Tool, disabled_categories: frozenset[str]) -> bool:
+    if not disabled_categories:
+        return False
+    return get_tool_category(tool) in disabled_categories
+
+
+def filter_tools_by_category_gates(
+    tools: Sequence[Tool],
+    disabled_categories: frozenset[str],
+) -> Sequence[Tool]:
+    if not disabled_categories:
+        return tools
+    return [tool for tool in tools if not is_tool_category_disabled(tool, disabled_categories)]
+
+
 @dataclass(frozen=True, slots=True)
 class MCPRequestContext:
     mode: MCPRequestMode
     tool_allowlist: frozenset[str] | None
+    disabled_categories: frozenset[str] = frozenset()
 
     @classmethod
     def from_headers(cls, headers: Mapping[str, str]) -> "MCPRequestContext":
@@ -109,6 +178,7 @@ class MCPRequestContext:
         return cls(
             mode=MCPRequestMode.from_headers(headers),
             tool_allowlist=combined,
+            disabled_categories=parse_disabled_categories(headers),
         )
 
     @classmethod
@@ -129,3 +199,16 @@ def get_request_context() -> MCPRequestContext:
     ctx = MCPRequestContext.from_headers(get_fast_mcp_http_headers())
     _request_context_cache.set(ctx)
     return ctx
+
+
+def is_category_disabled_for_request(category_name: str) -> bool:
+    """Return True when a category gate disables *category_name* for the current request.
+
+    Safe to call from providers, including outside an HTTP request (startup
+    retrospection, in-process clients): any failure to read the request context
+    means "no gates", preserving the default-enabled behavior.
+    """
+    try:
+        return category_name in get_request_context().disabled_categories
+    except Exception:  # noqa: BLE001 — gates must never break the provider path
+        return False

--- a/src/datarobot_genai/drmcpbase/mcp_providers/user_mcp_provider.py
+++ b/src/datarobot_genai/drmcpbase/mcp_providers/user_mcp_provider.py
@@ -42,6 +42,7 @@ from datarobot_genai.drmcpbase.auth.exceptions import NoHeadersFoundInRequestCon
 from datarobot_genai.drmcpbase.datarobot_services.client import DataRobotClientWithAsyncAPI
 from datarobot_genai.drmcpbase.datarobot_services.client import TimeMeasurement
 from datarobot_genai.drmcpbase.dynamic_tools.enums import DataRobotMCPToolCategory
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import is_category_disabled_for_request
 from datarobot_genai.drmcpbase.feature_flags import check_mcp_tools_gallery_support
 
 logger = logging.getLogger(__name__)
@@ -208,6 +209,13 @@ class UserMCPProvider(Provider):
 
     async def _list_tools(self) -> Sequence[Tool]:
         tools: list[Tool] = []
+
+        if is_category_disabled_for_request(DataRobotMCPToolCategory.PROXIED_USER_MCP.name):
+            # Per-request gate (x-datarobot-mcp-enable-proxy: false): skip the whole
+            # user-MCP expansion — the entitlement check, the deployment listing and
+            # the per-deployment fan-out — not just the final listing.
+            logger.debug("Proxied user-MCP tools are disabled for this request; skipping fan-out.")
+            return tools
 
         if await check_mcp_tools_gallery_support(self.datarobot_api_client):
             results = await asyncio.gather(

--- a/tests/drmcpbase/unit/fastmcp_transforms/test_mcp_catalog_transform.py
+++ b/tests/drmcpbase/unit/fastmcp_transforms/test_mcp_catalog_transform.py
@@ -23,8 +23,11 @@ import pytest
 from fastmcp import FastMCP
 from fastmcp.experimental.transforms.code_mode import _ensure_async
 
+from datarobot_genai.drmcpbase.dynamic_tools.enums import DataRobotMCPToolCategory
 from datarobot_genai.drmcpbase.fastmcp_transforms import register_mcp_catalog_transform
 from datarobot_genai.drmcpbase.fastmcp_transforms.transform import DataRobotMCPCatalogTransform
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import MCP_ENABLE_DYNAMIC_TOOLS_HEADER
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import MCP_ENABLE_PROXY_HEADER
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import MCP_TOOLSETS_HEADER
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import MCPRequestContext
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import MCPRequestMode
@@ -33,7 +36,10 @@ from datarobot_genai.drmcpbase.fastmcp_transforms.utils import _resolve_toolsets
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import filter_tools_by_allowlist
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import get_header_case_insensitive
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import get_request_context
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import is_category_disabled_for_request
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import is_tool_name_allowed
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import parse_bool_header
+from datarobot_genai.drmcpbase.fastmcp_transforms.utils import parse_disabled_categories
 from datarobot_genai.drmcpbase.fastmcp_transforms.utils import parse_tool_allowlist_header
 
 
@@ -79,6 +85,119 @@ class TestParseToolAllowlistHeader:
 
     def test_none_when_only_commas(self) -> None:
         assert parse_tool_allowlist_header(",,,") is None
+
+
+class TestParseBoolHeader:
+    def test_default_true_when_absent(self) -> None:
+        # GIVEN no header value / WHEN parsed / THEN the default (true) applies
+        assert parse_bool_header(None) is True
+
+    def test_default_false_when_absent_and_default_false(self) -> None:
+        assert parse_bool_header(None, default=False) is False
+
+    @pytest.mark.parametrize("raw", ["false", "FALSE", "False", " false ", "0", "no", "off"])
+    def test_false_variants(self, raw: str) -> None:
+        assert parse_bool_header(raw) is False
+
+    @pytest.mark.parametrize("raw", ["true", "TRUE", " true ", "1", "yes", "on"])
+    def test_true_variants(self, raw: str) -> None:
+        assert parse_bool_header(raw, default=False) is True
+
+    @pytest.mark.parametrize("raw", ["", "  ", "banana", "flase"])
+    def test_unrecognized_values_fall_back_to_default(self, raw: str) -> None:
+        assert parse_bool_header(raw) is True
+        assert parse_bool_header(raw, default=False) is False
+
+
+class TestParseDisabledCategories:
+    def test_empty_when_no_gate_headers(self) -> None:
+        assert parse_disabled_categories({}) == frozenset()
+
+    def test_explicit_true_disables_nothing(self) -> None:
+        headers = {MCP_ENABLE_PROXY_HEADER: "true", MCP_ENABLE_DYNAMIC_TOOLS_HEADER: "true"}
+        assert parse_disabled_categories(headers) == frozenset()
+
+    def test_proxy_gate_false_disables_proxied_user_mcp(self) -> None:
+        headers = {MCP_ENABLE_PROXY_HEADER: "false"}
+        assert parse_disabled_categories(headers) == frozenset(
+            {DataRobotMCPToolCategory.PROXIED_USER_MCP.name}
+        )
+
+    def test_dynamic_tools_gate_false_disables_user_tool_deployment(self) -> None:
+        headers = {MCP_ENABLE_DYNAMIC_TOOLS_HEADER: "false"}
+        assert parse_disabled_categories(headers) == frozenset(
+            {DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT.name}
+        )
+
+    def test_both_gates_false_disables_both_categories(self) -> None:
+        headers = {
+            MCP_ENABLE_PROXY_HEADER: "false",
+            MCP_ENABLE_DYNAMIC_TOOLS_HEADER: "false",
+        }
+        assert parse_disabled_categories(headers) == frozenset(
+            {
+                DataRobotMCPToolCategory.PROXIED_USER_MCP.name,
+                DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT.name,
+            }
+        )
+
+    def test_mixed_case_header_key_is_recognized(self) -> None:
+        headers = {"X-DataRobot-MCP-Enable-Proxy": "false"}
+        assert parse_disabled_categories(headers) == frozenset(
+            {DataRobotMCPToolCategory.PROXIED_USER_MCP.name}
+        )
+
+
+class TestMCPRequestContextCategoryGates:
+    def test_default_context_has_no_disabled_categories(self) -> None:
+        ctx = MCPRequestContext.from_headers({})
+        assert ctx.disabled_categories == frozenset()
+
+    def test_gate_header_populates_disabled_categories(self) -> None:
+        ctx = MCPRequestContext.from_headers({MCP_ENABLE_PROXY_HEADER: "false"})
+        assert ctx.disabled_categories == frozenset(
+            {DataRobotMCPToolCategory.PROXIED_USER_MCP.name}
+        )
+
+    def test_gates_are_independent_of_mode_and_allowlist(self) -> None:
+        ctx = MCPRequestContext.from_headers(
+            {
+                MCP_ENABLE_DYNAMIC_TOOLS_HEADER: "false",
+                "x-datarobot-mcp-mode": "code_execute",
+                "x-datarobot-mcp-tools": "add",
+            }
+        )
+        assert ctx.mode == MCPRequestMode.CODE_EXECUTE
+        assert ctx.tool_allowlist == frozenset({"add"})
+        assert ctx.disabled_categories == frozenset(
+            {DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT.name}
+        )
+
+
+class TestIsCategoryDisabledForRequest:
+    def test_false_when_gate_absent(self, utils_module: str) -> None:
+        with patch(f"{utils_module}.get_fast_mcp_http_headers", return_value={}):
+            assert not is_category_disabled_for_request(
+                DataRobotMCPToolCategory.PROXIED_USER_MCP.name
+            )
+
+    def test_true_when_gate_header_false(self, utils_module: str) -> None:
+        with patch(
+            f"{utils_module}.get_fast_mcp_http_headers",
+            return_value={MCP_ENABLE_PROXY_HEADER: "false"},
+        ):
+            assert is_category_disabled_for_request(DataRobotMCPToolCategory.PROXIED_USER_MCP.name)
+
+    def test_false_when_request_context_unavailable(self, utils_module: str) -> None:
+        # GIVEN no HTTP request context (e.g. startup retrospection)
+        with patch(
+            f"{utils_module}.get_fast_mcp_http_headers",
+            side_effect=RuntimeError("no request"),
+        ):
+            # WHEN the gate is consulted / THEN it fails open to "not disabled"
+            assert not is_category_disabled_for_request(
+                DataRobotMCPToolCategory.PROXIED_USER_MCP.name
+            )
 
 
 class TestMCPRequestMode:
@@ -244,6 +363,139 @@ class TestDataRobotMCPCatalogTransform:
         )
         back_view = {t.name for t in await mcp.list_tools(run_middleware=False)}
         assert back_view == tools_view
+
+
+class TestCategoryGatesInTransform:
+    """Category gates (Track 0) — precedence: gates → mode → allowlist."""
+
+    PROXIED = DataRobotMCPToolCategory.PROXIED_USER_MCP.name
+    DYNAMIC = DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT.name
+
+    @staticmethod
+    def make_server() -> FastMCP:
+        mcp = FastMCP("category gates test")
+
+        @mcp.tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers (built-in, untagged)."""
+            return a + b
+
+        @mcp.tool(meta={"tool_category": DataRobotMCPToolCategory.PROXIED_USER_MCP.name})
+        def proxied_tool() -> str:
+            """Return a canned value (stands in for a proxied user-MCP tool)."""
+            return "proxied"
+
+        @mcp.tool(meta={"tool_category": DataRobotMCPToolCategory.USER_TOOL_DEPLOYMENT.name})
+        def dynamic_tool() -> str:
+            """Return a canned value (stands in for a dynamic deployment tool)."""
+            return "dynamic"
+
+        mcp.add_transform(
+            DataRobotMCPCatalogTransform(sandbox_provider=_UnsafeTestSandboxProvider())
+        )
+        return mcp
+
+    @pytest.fixture
+    def mock_context(self, transform_module: str) -> Iterator[Mock]:
+        with patch(f"{transform_module}.get_request_context") as m:
+            m.return_value = MCPRequestContext(mode=MCPRequestMode.TOOLS, tool_allowlist=None)
+            yield m
+
+    @pytest.mark.asyncio
+    async def test_gates_default_on_all_tools_visible(self, mock_context: Mock) -> None:
+        # GIVEN no gate headers (defaults: enabled)
+        mcp = self.make_server()
+
+        names = {t.name for t in await mcp.list_tools(run_middleware=False)}
+
+        assert {"add", "proxied_tool", "dynamic_tool"} <= names
+
+    @pytest.mark.asyncio
+    async def test_proxy_gate_hides_proxied_tools_only(self, mock_context: Mock) -> None:
+        mock_context.return_value = MCPRequestContext(
+            mode=MCPRequestMode.TOOLS,
+            tool_allowlist=None,
+            disabled_categories=frozenset({self.PROXIED}),
+        )
+        mcp = self.make_server()
+
+        names = {t.name for t in await mcp.list_tools(run_middleware=False)}
+
+        assert "proxied_tool" not in names
+        assert {"add", "dynamic_tool"} <= names
+
+    @pytest.mark.asyncio
+    async def test_dynamic_gate_hides_deployment_tools_only(self, mock_context: Mock) -> None:
+        mock_context.return_value = MCPRequestContext(
+            mode=MCPRequestMode.TOOLS,
+            tool_allowlist=None,
+            disabled_categories=frozenset({self.DYNAMIC}),
+        )
+        mcp = self.make_server()
+
+        names = {t.name for t in await mcp.list_tools(run_middleware=False)}
+
+        assert "dynamic_tool" not in names
+        assert {"add", "proxied_tool"} <= names
+
+    @pytest.mark.asyncio
+    async def test_gate_takes_precedence_over_allowlist(self, mock_context: Mock) -> None:
+        # GIVEN the proxied tool is explicitly allowlisted but its category is gated off
+        mock_context.return_value = MCPRequestContext(
+            mode=MCPRequestMode.TOOLS,
+            tool_allowlist=frozenset({"proxied_tool", "add"}),
+            disabled_categories=frozenset({self.PROXIED}),
+        )
+        mcp = self.make_server()
+
+        # WHEN listing / THEN the gated tool stays hidden despite the allowlist
+        names = {t.name for t in await mcp.list_tools(run_middleware=False)}
+        assert names == {"add"}
+
+    @pytest.mark.asyncio
+    async def test_gated_tool_is_not_resolvable(self, mock_context: Mock) -> None:
+        mock_context.return_value = MCPRequestContext(
+            mode=MCPRequestMode.TOOLS,
+            tool_allowlist=None,
+            disabled_categories=frozenset({self.PROXIED}),
+        )
+        mcp = self.make_server()
+
+        assert await mcp.get_tool("proxied_tool") is None
+        assert await mcp.get_tool("add") is not None
+
+    @pytest.mark.asyncio
+    async def test_gate_applies_in_code_execute_mode_get_tool(self, mock_context: Mock) -> None:
+        # GIVEN code_execute mode with the proxy category gated off
+        mock_context.return_value = MCPRequestContext(
+            mode=MCPRequestMode.CODE_EXECUTE,
+            tool_allowlist=None,
+            disabled_categories=frozenset({self.PROXIED}),
+        )
+        mcp = self.make_server()
+
+        # THEN the gated tool cannot be resolved even in code mode,
+        # while the synthetic discovery tools stay available (no category meta)
+        assert await mcp.get_tool("proxied_tool") is None
+        assert await mcp.get_tool("execute") is not None
+
+    @pytest.mark.asyncio
+    async def test_gate_off_then_on_between_requests(self, mock_context: Mock) -> None:
+        mcp = self.make_server()
+
+        mock_context.return_value = MCPRequestContext(
+            mode=MCPRequestMode.TOOLS,
+            tool_allowlist=None,
+            disabled_categories=frozenset({self.PROXIED}),
+        )
+        gated = {t.name for t in await mcp.list_tools(run_middleware=False)}
+        assert "proxied_tool" not in gated
+
+        mock_context.return_value = MCPRequestContext(
+            mode=MCPRequestMode.TOOLS, tool_allowlist=None
+        )
+        ungated = {t.name for t in await mcp.list_tools(run_middleware=False)}
+        assert "proxied_tool" in ungated
 
 
 class _NamedTool:

--- a/tests/drmcpbase/unit/mcp_providers/test_user_mcp_provider.py
+++ b/tests/drmcpbase/unit/mcp_providers/test_user_mcp_provider.py
@@ -189,6 +189,36 @@ class TestUserMCPProvider:
         assert mock_asyncio_gather.call_args.kwargs == {"return_exceptions": True}
 
     @pytest.mark.asyncio
+    async def test_private_method_list_tools_short_circuits_when_proxy_gate_disabled(
+        self,
+        module_under_test: str,
+        mock_asyncio_gather: AsyncMock,
+        mock_get_user_mcp_proxy_providers_for_user: AsyncMock,
+        mock_is_datarobot_api_client_initialized: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: Mock,
+        mock_mcp_proxy_provider: Mock,
+    ) -> None:
+        # GIVEN a request with x-datarobot-mcp-enable-proxy: false
+        mock_is_datarobot_api_client_initialized.return_value = True
+        mcp_provider = UserMCPProvider(Mock())
+        mcp_provider.datarobot_api_client = Mock()
+
+        with patch(
+            f"{module_under_test}.is_category_disabled_for_request", return_value=True
+        ) as mock_gate:
+            # WHEN tools are listed
+            output = await mcp_provider._list_tools()
+
+        # THEN the whole fan-out is skipped — no entitlement check, no deployment
+        # listing, no per-deployment expansion — not just an empty listing
+        mock_gate.assert_called_once_with(DataRobotMCPToolCategory.PROXIED_USER_MCP.name)
+        mock_is_mcp_tools_gallery_support_enabled.assert_not_called()
+        mock_get_user_mcp_proxy_providers_for_user.assert_not_called()
+        mock_mcp_proxy_provider.list_tools.assert_not_called()
+        mock_asyncio_gather.assert_not_called()
+        assert output == []
+
+    @pytest.mark.asyncio
     async def test_private_method_list_tools_return_empty_if_dr_api_client_uninitialized(
         self,
         mock_asyncio_gather: AsyncMock,

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.2"
+version = "0.23.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). 
Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. 
`UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools are listed and callable per request on the MCP catalog path; defaults stay enabled and provider gate checks fail open, but mis-set headers could hide deployment or proxy tools clients expect.
> 
> **Overview**
> Adds **per-request HTTP gates** so callers can turn off whole MCP tool categories without changing server config. **`x-datarobot-mcp-enable-proxy: false`** hides **`PROXIED_USER_MCP`** tools; **`x-datarobot-mcp-enable-dynamic-tools: false`** hides **`USER_TOOL_DEPLOYMENT`** tools. Omitted headers or any value other than explicit false keep both categories **enabled**.
> 
> **`MCPRequestContext`** now carries **`disabled_categories`** parsed from those headers (with shared boolean parsing). **`DataRobotMCPCatalogTransform`** applies category filtering **before** code-execute mode and tool allowlists on **`tools/list`**, and blocks **`get_tool`** / calls for gated tools in every mode (CodeMode synthetic tools stay ungated). **`UserMCPProvider._list_tools`** skips the full proxied user-MCP fan-out when the proxy gate is off.
> 
> Bumps package version to **0.23.3** and documents the behavior in **CHANGELOG**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f95d9f1272279d3cd71bf871950ff6345e8fa13e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->