### PR TITLE
Fix dynamic-prompt lineage crash and refresh name-churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.3
+- `drmcp`: fixed dynamic-prompt registration stamping the category under `resource_category` instead of `prompt_category`, which crashed every lineage sync over a dynamically registered prompt with a `KeyError`.
+- `drmcp`: fixed the prompt-template refresh comparing the stored version-id string against the whole version object — the comparison was always unequal, so every refresh re-registered unchanged prompts under new deduplicated names.
+
 ## 0.23.2
 - `drtools/files_api`: expose `overwrite` on `file_manage` copy/move (defaults to `rename`; use `replace` to overwrite existing files). Reject recursive `file_list` at `dr://` and return browse hints to reduce agent listing loops.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.2"
+version = "0.23.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
+++ b/src/datarobot_genai/drmcp/core/dynamic_prompts/controllers.py
@@ -135,7 +135,7 @@ async def refresh_registered_prompt_template(headers_auth_only: bool = False) ->
 
         mcp_prompt_template_version, mcp_prompt = mcp_prompt_templates_mappings[prompt_template.id]
 
-        if mcp_prompt_template_version != latest_version:
+        if mcp_prompt_template_version != latest_version.id:
             # Current version saved in MCP is not the latest one => update it
             await register_prompt_from_datarobot_prompt_management(
                 prompt_template=prompt_template, prompt_template_version=latest_version

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -531,7 +531,7 @@ async def register_prompt(
     prompt_name_no_duplicate = await get_prompt_name_no_duplicate(mcp, prompt_name)
 
     meta = meta or {}
-    meta["resource_category"] = prompt_category.name
+    meta["prompt_category"] = prompt_category.name
     prompt = Prompt.from_function(
         fn=wrapped_fn,
         name=prompt_name_no_duplicate,

--- a/tests/drmcp/unit/dynamic_prompts/test_controllers.py
+++ b/tests/drmcp/unit/dynamic_prompts/test_controllers.py
@@ -391,6 +391,54 @@ class TestPromptTemplatesRefresh:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures(
+        "mock_lineage_manager_init",
+        "mock_sync_mcp_prompts",
+    )
+    async def test_refresh_skips_prompt_template_with_unchanged_version(
+        self, mcp_server: DataRobotMCP, mock_module_under_test: str
+    ) -> None:
+        """
+        GIVEN a registered prompt template whose stored version is already the latest
+        WHEN the refresh runs
+        THEN the prompt is not re-registered and the mapping is unchanged
+        (regression: the stored version-id string was compared against the whole
+        version object, so every refresh re-registered the prompt under a new
+        deduplicated name).
+        """
+        prompt_template = dr.genai.PromptTemplate(
+            id="pt1", name="pt1 name", description="pt1 description"
+        )
+        latest_version = dr.genai.PromptTemplateVersion(
+            id="ptv1.2",
+            prompt_template_id=prompt_template.id,
+            version=2,
+            prompt_text="Text 1",
+            variables=[],
+        )
+        await mcp_server.set_prompt_mapping("pt1", "ptv1.2", "pt1 name")
+
+        with (
+            patch(
+                f"{mock_module_under_test}.get_datarobot_prompt_templates",
+                Mock(return_value=[prompt_template]),
+            ),
+            patch(
+                f"{mock_module_under_test}.get_datarobot_prompt_template_versions",
+                Mock(return_value={prompt_template.id: [latest_version]}),
+            ),
+            patch(
+                f"{mock_module_under_test}.register_prompt_from_datarobot_prompt_management",
+                new_callable=AsyncMock,
+            ) as mock_register,
+        ):
+            await refresh_registered_prompt_template()
+
+        mock_register.assert_not_called()
+        internal_mappings = await mcp_server.get_prompt_mapping()
+        assert internal_mappings == {"pt1": ("ptv1.2", "pt1 name")}
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures(
         "mock_get_datarobot_prompt_templates",
         "mock_get_datarobot_prompt_template_versions",
     )

--- a/tests/drmcp/unit/test_register_prompt.py
+++ b/tests/drmcp/unit/test_register_prompt.py
@@ -20,6 +20,8 @@ import pytest
 from fastmcp.prompts import Prompt
 
 from datarobot_genai.drmcp.core.enums import DataRobotMCPPromptCategory
+from datarobot_genai.drmcp.core.lineage.entities import MCPPromptMetadata
+from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 from datarobot_genai.drmcp.core.mcp_instance import (
     check_prompt_registration_status_after_it_finishes,
 )
@@ -135,9 +137,7 @@ class TestRegisterPrompt:
             title=None,
             description=None,
             tags=None,
-            meta={
-                "resource_category": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION.name
-            },
+            meta={"prompt_category": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION.name},
         )
         mock_datarobot_mcp_server.add_prompt.assert_called_once_with(
             mock_prompt_from_function.return_value
@@ -180,9 +180,7 @@ class TestRegisterPrompt:
             title=None,
             description=None,
             tags=None,
-            meta={
-                "resource_category": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION.name
-            },
+            meta={"prompt_category": DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION.name},
         )
 
     @pytest.mark.asyncio
@@ -211,3 +209,28 @@ class TestRegisterPrompt:
         mock_get_prompt_name_no_duplicate.assert_called_once_with(
             mock_datarobot_mcp_server, "my_prompt"
         )
+
+    @pytest.mark.asyncio
+    async def test_register_prompt_meta_is_readable_by_lineage(self) -> None:
+        """
+        GIVEN a prompt registered via register_prompt on a live server
+        WHEN lineage builds MCPPromptMetadata from the registered FastMCP prompt
+        THEN the category is read from meta without error
+        (regression: register_prompt stamped the category under 'resource_category'
+        while lineage reads 'prompt_category', so every lineage sync over a
+        dynamically registered prompt crashed with KeyError).
+        """
+        test_mcp = DataRobotMCP()
+
+        async def greet() -> str:
+            return "hi"
+
+        with patch("datarobot_genai.drmcp.core.mcp_instance.mcp", test_mcp):
+            await register_prompt(fn=greet, name="greet")
+            prompts = await test_mcp.get_prompts()
+
+        registered = next(p for p in prompts.values() if p.name == "greet")
+        metadata = MCPPromptMetadata.from_fastmcp_item(registered)
+
+        assert metadata.name == "greet"
+        assert metadata.type == DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION.name

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.2"
+version = "0.23.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Two small correctness fixes in the dynamic-prompts path:

- Lineage sync crashed on dynamically registered prompts. register_prompt stamped the prompt category under meta["resource_category"], while MCPPromptMetadata.from_fastmcp_item reads meta["prompt_category"]. Any lineage sync after registering a prompt from Prompt Management raised KeyError: 'prompt_category'. The category is now stamped under the key lineage reads (matching the dr_mcp_prompt decorator path, which was already correct).
- Prompt-template refresh re-registered unchanged prompts. refresh_registered_prompt_template compared the stored version-id string against the whole PromptTemplateVersion object, so the "is this still the latest version" check was always false. Every refresh re-registered every prompt, and the duplicate-name guard renamed them (my_prompt → my_prompt (abcd) → …). The comparison now uses latest_version.id.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bug fixes in dynamic prompt registration and refresh with regression tests; no API or auth changes.
> 
> **Overview**
> **drmcp** dynamic prompts get two correctness fixes in **0.23.3**.
> 
> `register_prompt` now writes the category to **`meta["prompt_category"]`** (aligned with `dr_mcp_prompt` and `MCPPromptMetadata.from_fastmcp_item`), instead of **`resource_category`**, which caused **`KeyError: 'prompt_category'`** on lineage sync after Prompt Management registration.
> 
> `refresh_registered_prompt_template` compares the stored version id to **`latest_version.id`** instead of the full **`PromptTemplateVersion`** object, so unchanged templates are skipped and refresh no longer re-registers every prompt under deduplicated names.
> 
> Tests cover unchanged-version refresh skip and lineage-readable prompt meta; changelog and version bump included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e42dfe78cdfd2c35f82353e0c7e9093282b3e8d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->