### PR TITLE
Resolve proxied user-MCP tools without full deployment fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.4
+- `drmcpbase`: `UserMCPProvider` now resolves a single proxied tool directly from its `user-mcp-<last4>_` namespace instead of fanning out to every user MCP deployment (entitlement check, deployment listing and a per-deployment MCP handshake) on every `tools/call` — including calls for tools it does not own.
+
 ## 0.23.3
 - `drmcp`: added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. `UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcpbase/mcp_providers/user_mcp_provider.py
+++ b/src/datarobot_genai/drmcpbase/mcp_providers/user_mcp_provider.py
@@ -30,6 +30,7 @@ from fastmcp.server.providers.proxy import ProxyClient
 from fastmcp.server.providers.proxy import ProxyProvider
 from fastmcp.server.transforms import Namespace
 from fastmcp.tools.base import Tool
+from fastmcp.utilities.versions import VersionSpec
 from httpx import AsyncClient
 from mcp.shared._httpx_utils import create_mcp_http_client
 
@@ -62,6 +63,8 @@ def _mark_as_proxied_user_mcp(tool: Tool) -> Tool:
 
 
 CACHE_TTL_IN_SECOND = 10 * TimeMeasurement.MINUTE.to_numeric_value_in_second()
+# Root of every proxied tool's namespace prefix ("user-mcp-<last4>_<tool>").
+USER_MCP_NAMESPACE_ROOT = "user-mcp-"
 MCP_K8S_POD_TCP_CONNECT_TIMEOUT_IN_SECOND = 60 * TimeMeasurement.SECOND.to_numeric_value_in_second()
 MCP_READ_TIMEOUT_IN_SECOND = 30 * TimeMeasurement.SECOND.to_numeric_value_in_second()
 MCP_WRITE_TIMEOUT_IN_SECOND = 30 * TimeMeasurement.SECOND.to_numeric_value_in_second()
@@ -142,9 +145,13 @@ class UserMCPProxyProviderCache:
         self._cache: LRUCache = LRUCache(maxsize=max_cache_size)
 
     @staticmethod
-    def get_namespace_transform(user_mcp_deployment_id: str) -> Namespace:
+    def get_namespace_prefix(user_mcp_deployment_id: str) -> str:
         last_four_digit = user_mcp_deployment_id[-4:] or user_mcp_deployment_id
-        return Namespace(f"user-mcp-{last_four_digit}")
+        return f"{USER_MCP_NAMESPACE_ROOT}{last_four_digit}"
+
+    @staticmethod
+    def get_namespace_transform(user_mcp_deployment_id: str) -> Namespace:
+        return Namespace(UserMCPProxyProviderCache.get_namespace_prefix(user_mcp_deployment_id))
 
     @cachedmethod(lambda self: self._cache)
     def get(self, user_mcp_deployment_id: str) -> ProxyProvider:
@@ -228,3 +235,43 @@ class UserMCPProvider(Provider):
                 else:
                     tools.extend(_mark_as_proxied_user_mcp(tool) for tool in r)
         return tools
+
+    async def _get_tool(self, name: str, version: VersionSpec | None = None) -> Tool | None:
+        """Resolve a single proxied tool without fanning out to every deployment.
+
+        The base ``Provider`` implementation resolves ``get_tool`` through
+        ``_list_tools()``, which for this provider means an entitlement check, a
+        deployment listing and an MCP handshake with *every* user MCP deployment
+        on *every* ``tools/call`` — including calls for tools this provider does
+        not even own. Proxied tool names always carry their deployment namespace
+        (``user-mcp-<last4>_<tool>``), so resolve the owning deployment from the
+        name and query only its proxy.
+        """
+        if not name.startswith(USER_MCP_NAMESPACE_ROOT):
+            # Not a proxied user-MCP tool: skip all remote work.
+            return None
+
+        if is_category_disabled_for_request(DataRobotMCPToolCategory.PROXIED_USER_MCP.name):
+            logger.debug("Proxied user-MCP tools are disabled for this request; skipping lookup.")
+            return None
+
+        if not await check_mcp_tools_gallery_support(self.datarobot_api_client):
+            return None
+
+        for user_mcp_deployment_id in await self.get_user_mcp_deployment_ids():
+            namespace_prefix = UserMCPProxyProviderCache.get_namespace_prefix(
+                user_mcp_deployment_id
+            )
+            if not name.startswith(f"{namespace_prefix}_"):
+                continue
+            # More than one deployment can share the same last-4 suffix, so keep
+            # scanning candidates until one of them owns the tool.
+            proxy_provider = self.get_or_create_mcp_proxy_provider(user_mcp_deployment_id)
+            try:
+                tool = await proxy_provider.get_tool(name, version)
+            except Exception as ex:
+                logger.warning("Failed to get tool %r from user MCP proxy: %s", name, ex)
+                continue
+            if tool is not None:
+                return _mark_as_proxied_user_mcp(tool)
+        return None

--- a/tests/drmcpbase/unit/mcp_providers/test_user_mcp_provider.py
+++ b/tests/drmcpbase/unit/mcp_providers/test_user_mcp_provider.py
@@ -378,6 +378,141 @@ class TestUserMCPProvider:
             f"{mock_datarobot_endpoint}/deployments/{user_mcp_deployment_id}/directAccess/mcp"
         )
 
+    @pytest.fixture
+    def real_namespace_prefix(self, mock_user_mcp_proxy_provider_cache_cls: Mock) -> None:
+        """Restore the real prefix derivation on the autouse-patched cache class."""
+        mock_user_mcp_proxy_provider_cache_cls.get_namespace_prefix.side_effect = (
+            UserMCPProxyProviderCache.get_namespace_prefix
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_tool_skips_all_remote_work_for_non_proxied_names(
+        self,
+        mock_get_user_mcp_deployment_ids: AsyncMock,
+        mock_get_or_create_mcp_proxy_provider: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: AsyncMock,
+    ) -> None:
+        # GIVEN a tools/call for a tool that is not a proxied user-MCP tool
+        mcp_provider = UserMCPProvider(Mock())
+        mcp_provider.datarobot_api_client = Mock()
+
+        # WHEN the provider chain asks this provider to resolve it
+        output = await mcp_provider._get_tool("datarobot_docs_search")
+
+        # THEN no remote work happens at all — no entitlement check, no
+        # deployment listing, no proxy handshake (regression: the default
+        # _get_tool fanned out to every user MCP deployment for ANY tool name)
+        assert output is None
+        mock_is_mcp_tools_gallery_support_enabled.assert_not_called()
+        mock_get_user_mcp_deployment_ids.assert_not_called()
+        mock_get_or_create_mcp_proxy_provider.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_tool_short_circuits_when_proxy_gate_disabled(
+        self,
+        module_under_test: str,
+        mock_get_user_mcp_deployment_ids: AsyncMock,
+        mock_is_mcp_tools_gallery_support_enabled: AsyncMock,
+    ) -> None:
+        # GIVEN a request with x-datarobot-mcp-enable-proxy: false
+        mcp_provider = UserMCPProvider(Mock())
+        mcp_provider.datarobot_api_client = Mock()
+
+        with patch(
+            f"{module_under_test}.is_category_disabled_for_request", return_value=True
+        ) as mock_gate:
+            # WHEN a proxied tool is resolved
+            output = await mcp_provider._get_tool("user-mcp-ab12_search")
+
+        # THEN the lookup is skipped before any remote work
+        mock_gate.assert_called_once_with(DataRobotMCPToolCategory.PROXIED_USER_MCP.name)
+        assert output is None
+        mock_is_mcp_tools_gallery_support_enabled.assert_not_called()
+        mock_get_user_mcp_deployment_ids.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_tool_returns_none_when_gallery_support_disabled(
+        self,
+        mock_get_user_mcp_deployment_ids: AsyncMock,
+        mock_is_mcp_tools_gallery_support_enabled: AsyncMock,
+    ) -> None:
+        # GIVEN the tools-gallery entitlement is off for this user
+        mock_is_mcp_tools_gallery_support_enabled.return_value = False
+        mcp_provider = UserMCPProvider(Mock())
+        mcp_provider.datarobot_api_client = Mock()
+
+        # WHEN a proxied tool is resolved / THEN no deployment listing happens
+        assert await mcp_provider._get_tool("user-mcp-ab12_search") is None
+        mock_get_user_mcp_deployment_ids.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("real_namespace_prefix")
+    async def test_get_tool_resolves_only_the_owning_deployment(
+        self,
+        mock_get_user_mcp_deployment_ids: AsyncMock,
+        mock_get_or_create_mcp_proxy_provider: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: AsyncMock,
+    ) -> None:
+        # GIVEN two user MCP deployments and a call for a tool namespaced to the second
+        mock_is_mcp_tools_gallery_support_enabled.return_value = True
+        mock_get_user_mcp_deployment_ids.return_value = ["deployment-ab12", "deployment-cd34"]
+
+        def remote_search(q: str) -> str:
+            """Search."""
+            return q
+
+        proxied_tool = Tool.from_function(fn=remote_search, name="user-mcp-cd34_search")
+        owning_proxy = Mock()
+        owning_proxy.get_tool = AsyncMock(return_value=proxied_tool)
+        mock_get_or_create_mcp_proxy_provider.return_value = owning_proxy
+
+        mcp_provider = UserMCPProvider(Mock())
+        mcp_provider.datarobot_api_client = Mock()
+
+        # WHEN the tool is resolved
+        output = await mcp_provider._get_tool("user-mcp-cd34_search")
+
+        # THEN only the owning deployment's proxy is queried (no full fan-out)
+        mock_get_or_create_mcp_proxy_provider.assert_called_once_with("deployment-cd34")
+        owning_proxy.get_tool.assert_awaited_once_with("user-mcp-cd34_search", None)
+        # AND the tool is stamped like the listing path stamps it
+        assert output is not None
+        assert output.meta is not None
+        assert output.meta["tool_category"] == DataRobotMCPToolCategory.PROXIED_USER_MCP.name
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("real_namespace_prefix")
+    async def test_get_tool_scans_next_candidate_on_last4_collision(
+        self,
+        mock_get_user_mcp_deployment_ids: AsyncMock,
+        mock_get_or_create_mcp_proxy_provider: Mock,
+        mock_is_mcp_tools_gallery_support_enabled: AsyncMock,
+    ) -> None:
+        # GIVEN two deployments sharing the same last-4 suffix; the first does
+        # not own the tool (and its proxy even errors)
+        mock_is_mcp_tools_gallery_support_enabled.return_value = True
+        mock_get_user_mcp_deployment_ids.return_value = ["one-ab12", "two-ab12"]
+
+        def remote_search(q: str) -> str:
+            """Search."""
+            return q
+
+        proxied_tool = Tool.from_function(fn=remote_search, name="user-mcp-ab12_search")
+        broken_proxy = Mock()
+        broken_proxy.get_tool = AsyncMock(side_effect=RuntimeError("handshake failed"))
+        owning_proxy = Mock()
+        owning_proxy.get_tool = AsyncMock(return_value=proxied_tool)
+        mock_get_or_create_mcp_proxy_provider.side_effect = [broken_proxy, owning_proxy]
+
+        mcp_provider = UserMCPProvider(Mock())
+        mcp_provider.datarobot_api_client = Mock()
+
+        # WHEN the tool is resolved / THEN the collision candidate is skipped
+        # and the owning deployment still resolves the tool
+        output = await mcp_provider._get_tool("user-mcp-ab12_search")
+        assert output is not None
+        assert output.name == "user-mcp-ab12_search"
+
 
 class TestUserMCPProxyProviderCache:
     @pytest.fixture
@@ -444,6 +579,24 @@ class TestUserMCPProxyProviderCache:
     ) -> None:
         output = UserMCPProxyProviderCache.get_namespace_transform(user_mcp_deployment_id)
         assert output._prefix == f"user-mcp-{namespace_transform_value}"
+
+    @pytest.mark.parametrize(
+        "user_mcp_deployment_id, expected_suffix",
+        [
+            ("dsafdafd", "dafd"),
+            ("fd", "fd"),
+        ],
+    )
+    def test_get_namespace_prefix_matches_transform(
+        self,
+        user_mcp_deployment_id: str,
+        expected_suffix: str,
+    ) -> None:
+        """_get_tool's prefix matching must stay in lockstep with the transform."""
+        prefix = UserMCPProxyProviderCache.get_namespace_prefix(user_mcp_deployment_id)
+        assert prefix == f"user-mcp-{expected_suffix}"
+        transform = UserMCPProxyProviderCache.get_namespace_transform(user_mcp_deployment_id)
+        assert transform._prefix == prefix
 
 
 class TestMCPProxyClientSetup:

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

UserMCPProvider inherited FastMCP's default _get_tool, which resolves a name via _list_tools() — so every tools/call triggered the entitlement check, the MCP-deployment listing, and a streamable-HTTP handshake with every user MCP deployment, including calls for built-in or dynamic tools this provider doesn't even own.

_get_tool is now overridden to resolve directly:

- Names without the user-mcp- namespace return immediately — no remote work for any non-proxied tool call.
- The per-request proxy gate and the tools-gallery entitlement short-circuit before the deployment listing.
- The owning deployment is derived from the user-mcp-<last4>_ namespace (new get_namespace_prefix helper shared with the Namespace transform), and only that deployment's proxy is queried. Deployments sharing a last-4 suffix are scanned as collision candidates; a failing candidate logs a warning and the scan continues.
- Resolved tools get the same PROXIED_USER_MCP meta stamp as the listing path, keeping category gates effective.

Tests: no-remote-work for non-proxied names, gate and entitlement short-circuits, single-deployment resolution with meta stamping, last-4 collision scan, and a lockstep test between get_namespace_prefix and the Namespace transform.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot path for every MCP tool resolution/call in multi-provider chains; behavior should match listing for owned proxied tools but depends on namespace prefix matching and deployment-id collision scanning.
> 
> **Overview**
> **`UserMCPProvider`** overrides **`_get_tool`** so **`tools/call`** no longer inherits FastMCP’s default path through **`_list_tools()`**, which previously ran entitlement checks, deployment listing, and an MCP handshake against **every** user MCP deployment on **every** call—including built-in tools this provider does not own.
> 
> Non-**`user-mcp-`** names return immediately with no remote work. Proxied names still honor the per-request proxy gate and tools-gallery entitlement, then match **`user-mcp-<last4>_`** via a shared **`get_namespace_prefix`** (aligned with the existing **`Namespace`** transform) and query only candidate deployments’ proxies, continuing on last-4 collisions or proxy errors. Resolved tools get the same **`PROXIED_USER_MCP`** meta stamp as listing.
> 
> Release **0.23.4** with unit tests for short-circuits, single-deployment resolution, and collision handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d77468066f4c77af509d6525f85329ac0251da9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->