### PR TITLE
Fix dynamic-tool schema defaults and guard circular refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.4
+- `drmcpbase`: dynamic-tool schema conversion now preserves declared falsy defaults (`0`, `false`, `""`, `[]`) instead of collapsing them to `None`, and a circular `$defs` reference now raises a clean `SchemaValidationError` at registration instead of crashing with an unbounded `RecursionError`.
+
 ## 0.23.3
 - `drmcp`: added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. `UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcpbase/dynamic_tools/schema.py
+++ b/src/datarobot_genai/drmcpbase/dynamic_tools/schema.py
@@ -38,6 +38,11 @@ class PropertyConfig:
     default_description: str
 
 
+# Nested create_schema_model recursion cap: converts a circular ``$ref`` chain
+# (e.g. #/$defs/Node referencing itself) into a clean SchemaValidationError
+# instead of an unbounded RecursionError at tool-registration time.
+MAX_SCHEMA_NESTING_DEPTH = 20
+
 # Type mapping from JSON Schema to Python types
 _JSON_TYPE_MAPPING: dict[str, type[Any]] = {
     "string": str,
@@ -195,17 +200,21 @@ def _is_optional_field(field_spec: dict[str, Any]) -> bool:
 class FieldTypeResolver:
     """Resolves Python types for JSON schema fields."""
 
-    def __init__(self, model_name: str, allow_nested: bool, resolver: SchemaResolver):
+    def __init__(
+        self, model_name: str, allow_nested: bool, resolver: SchemaResolver, depth: int = 0
+    ):
         """Initialize field type resolver.
 
         Args:
             model_name: Name of the parent model
             allow_nested: Whether nested objects/arrays are allowed
             resolver: Schema resolver for handling references
+            depth: Current nesting depth, threaded through nested model creation
         """
         self.model_name = model_name
         self.allow_nested = allow_nested
         self.resolver = resolver
+        self.depth = depth
 
     def _validate_nested_allowed(self, field_name: str, structure_type: str) -> None:
         """Validate that nested structures are allowed.
@@ -242,6 +251,7 @@ class FieldTypeResolver:
             schema=field_spec,
             allow_nested=self.allow_nested,
             definitions=self.resolver.definitions,
+            _depth=self.depth + 1,
         )
 
     def _resolve_array_type(self, field_name: str, field_spec: dict[str, Any]) -> type[Any]:
@@ -271,6 +281,7 @@ class FieldTypeResolver:
                 schema=items_spec,
                 allow_nested=self.allow_nested,
                 definitions=self.resolver.definitions,
+                _depth=self.depth + 1,
             )
             return list[item_model]  # type: ignore[valid-type]
 
@@ -330,6 +341,7 @@ def create_schema_model(
     schema: dict[str, Any],
     allow_nested: bool,
     definitions: dict[str, Any] | None = None,
+    _depth: int = 0,
 ) -> type[BaseModel]:
     """Create a Pydantic model from a JSON schema, supporting nested objects.
 
@@ -339,11 +351,24 @@ def create_schema_model(
         allow_nested: Whether to allow nested objects and arrays in
                 the schema. If False, raises error on complex types.
         definitions: Dictionary of reusable schema definitions ($defs)
+        _depth: Internal recursion depth, guarded by MAX_SCHEMA_NESTING_DEPTH
 
     Returns
     -------
         A Pydantic BaseModel class
+
+    Raises
+    ------
+        SchemaValidationError: If the schema nests deeper than
+            MAX_SCHEMA_NESTING_DEPTH (e.g. a circular ``$ref``)
     """
+    if _depth > MAX_SCHEMA_NESTING_DEPTH:
+        raise SchemaValidationError(
+            f"Schema for model '{name}' nests deeper than the maximum of "
+            f"{MAX_SCHEMA_NESTING_DEPTH} levels. The schema likely contains a "
+            f"circular '$ref' (a definition that references itself)."
+        )
+
     if not schema or not schema.get("properties"):
         return create_model(name)
 
@@ -351,7 +376,7 @@ def create_schema_model(
     definitions = definitions or schema.get("$defs", {})
 
     resolver = SchemaResolver(definitions)
-    field_resolver = FieldTypeResolver(name, allow_nested, resolver)
+    field_resolver = FieldTypeResolver(name, allow_nested, resolver, depth=_depth)
 
     properties = schema.get("properties", {})
     required_fields = set(schema.get("required", []))
@@ -368,10 +393,15 @@ def create_schema_model(
         # Resolve the field type from the resolved spec
         field_type = field_resolver.resolve(field_name, resolved_spec)
 
-        # Get default value and description
-        default = (
-            ... if is_required else (resolved_spec.get("default") or field_spec.get("default"))
-        )
+        # Get default value and description.  Look the default up by key presence
+        # so declared falsy defaults (0, False, "", []) survive instead of being
+        # collapsed to None by an ``or`` chain.
+        if is_required:
+            default = ...
+        elif "default" in resolved_spec:
+            default = resolved_spec["default"]
+        else:
+            default = field_spec.get("default")
         description = resolved_spec.get("description") or field_spec.get("description")
 
         # Wrap in Optional if field has anyOf/oneOf with null

--- a/tests/drmcp/unit/dynamic_tools/test_schema.py
+++ b/tests/drmcp/unit/dynamic_tools/test_schema.py
@@ -961,6 +961,89 @@ class TestCreateSchemaModel:
         instance = model()
         assert instance is not None
 
+    @pytest.mark.parametrize(
+        ("field_type", "declared_default"),
+        [
+            ("integer", 0),
+            ("number", 0.0),
+            ("boolean", False),
+            ("string", ""),
+            ("array", []),
+        ],
+    )
+    def test_create_model_preserves_falsy_defaults(self, field_type, declared_default):
+        """GIVEN a field declaring a falsy default (0, False, "", [])
+        WHEN the model is created
+        THEN the declared default survives instead of collapsing to None
+        (regression: the default lookup used an ``or`` chain).
+        """
+        schema = {
+            "type": "object",
+            "properties": {"field": {"type": field_type, "default": declared_default}},
+        }
+
+        model = create_schema_model(name="FalsyDefaultModel", schema=schema, allow_nested=False)
+
+        instance = model()
+        assert instance.field == declared_default
+        assert instance.field is not None
+
+    def test_create_model_field_without_default_stays_none(self):
+        """A non-required field with no declared default still defaults to None."""
+        schema = {
+            "type": "object",
+            "properties": {"field": {"type": "integer"}},
+        }
+
+        model = create_schema_model(name="NoDefaultModel", schema=schema, allow_nested=False)
+
+        assert model().field is None
+
+    def test_create_model_rejects_circular_ref(self):
+        """GIVEN a self-referential $defs definition
+        WHEN the model is created
+        THEN a clean SchemaValidationError is raised
+        (regression: the recursion was unguarded and crashed with RecursionError).
+        """
+        schema = {
+            "type": "object",
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {"child": {"$ref": "#/$defs/Node"}},
+                }
+            },
+        }
+
+        with pytest.raises(SchemaValidationError, match="circular"):
+            create_schema_model(name="CircularModel", schema=schema, allow_nested=True)
+
+    def test_create_model_rejects_mutually_circular_refs(self):
+        """A → B → A reference cycles are also caught."""
+        schema = {
+            "type": "object",
+            "properties": {"root": {"$ref": "#/$defs/A"}},
+            "$defs": {
+                "A": {"type": "object", "properties": {"b": {"$ref": "#/$defs/B"}}},
+                "B": {"type": "object", "properties": {"a": {"$ref": "#/$defs/A"}}},
+            },
+        }
+
+        with pytest.raises(SchemaValidationError, match="circular"):
+            create_schema_model(name="MutualCycleModel", schema=schema, allow_nested=True)
+
+    def test_create_model_allows_deep_but_finite_nesting(self):
+        """Legitimate nesting below the cap still works."""
+        # Build 5 levels of nested objects
+        leaf: dict = {"type": "object", "properties": {"value": {"type": "string"}}}
+        schema = leaf
+        for _ in range(5):
+            schema = {"type": "object", "properties": {"child": schema}}
+
+        model = create_schema_model(name="DeepModel", schema=schema, allow_nested=True)
+        assert issubclass(model, BaseModel)
+
 
 class TestSchemaValidationError:
     """Tests for SchemaValidationError exception."""

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Two correctness fixes in the JSON-schema → Pydantic conversion used for dynamic external tools:

- Declared falsy defaults were dropped. The default lookup used an or chain, so default: 0, default: false, default: "" and default: [] all collapsed to None — external tools received None where the schema promised a concrete falsy value. The lookup is now key-presence-based; fields with no declared default keep the previous None behavior.
- Circular $defs references crashed registration. A definition referencing itself (directly or via another definition) recursed through create_schema_model with no guard until RecursionError. Recursion depth is now tracked and capped (MAX_SCHEMA_NESTING_DEPTH = 20), turning a cycle into a clean SchemaValidationError that names the likely cause, while legitimate deep nesting below the cap is unaffected.
Tests: parametrized falsy-default preservation, no-default fallback, direct and mutual $ref cycles, and deep-but-finite nesting. 

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized correctness fixes in schema-to-Pydantic conversion with new unit tests; no auth, API, or runtime behavior changes outside dynamic tool registration.
> 
> **Overview**
> Fixes two bugs in **JSON Schema → Pydantic** conversion for dynamic external MCP tools (`drmcpbase/dynamic_tools/schema.py`).
> 
> **Falsy defaults** — Optional field defaults no longer use an `or` chain, so declared values like `0`, `false`, `""`, and `[]` stay on the generated model instead of becoming `None`.
> 
> **Circular `$defs`** — Nested model building tracks depth (`MAX_SCHEMA_NESTING_DEPTH = 20`). Self-referential or A↔B `$ref` cycles raise **`SchemaValidationError`** at registration instead of an unbounded **`RecursionError`**.
> 
> Release **0.23.4** (changelog + lockfile). Unit tests cover falsy defaults, missing defaults, direct/mutual cycles, and deep finite nesting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2decc1f3ac887a9640f25c69e4ab27b72890eb7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->