### PR TITLE
Stop clobbering the global SDK Use Case; drop raw Authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.23.4
 - `drmcputils`: request-scoped DataRobot clients now save and restore the SDK's global default Use Case instead of permanently nulling the process-global `datarobot.context.Context` singleton, which clobbered a default set concurrently by the embedding application.
-- *Breaking change*: `drmcputils` no longer accepts the raw `Authorization` header as a DataRobot API token. On OAuth-protected MCP servers that header carries the MCP access token (e.g. an Okta JWT), not a DataRobot key — forwarding it to the DataRobot API was token confusion across audiences. It was originally a local-dev convenience; use `x-datarobot-api-token` (or `x-datarobot-authorization: Bearer <token>`) instead.
+- `drmcputils` no longer accepts the raw `Authorization` header as a DataRobot API token. On OAuth-protected MCP servers that header carries the MCP access token (e.g. an Okta JWT), not a DataRobot key — forwarding it to the DataRobot API was token confusion across audiences. It was originally a local-dev convenience; use `x-datarobot-api-token` (or `x-datarobot-authorization: Bearer <token>`) instead.
 
 ## 0.23.3
 - `drmcp`: added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. `UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.4
+- `drmcputils`: request-scoped DataRobot clients now save and restore the SDK's global default Use Case instead of permanently nulling the process-global `datarobot.context.Context` singleton, which clobbered a default set concurrently by the embedding application.
+- *Breaking change*: `drmcputils` no longer accepts the raw `Authorization` header as a DataRobot API token. On OAuth-protected MCP servers that header carries the MCP access token (e.g. an Okta JWT), not a DataRobot key — forwarding it to the DataRobot API was token confusion across audiences. It was originally a local-dev convenience; use `x-datarobot-api-token` (or `x-datarobot-authorization: Bearer <token>`) instead.
+
 ## 0.23.3
 - `drmcp`: added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. `UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.23.4
-- `drmcputils`: request-scoped DataRobot clients now save and restore the SDK's global default Use Case instead of permanently nulling the process-global `datarobot.context.Context` singleton, which clobbered a default set concurrently by the embedding application.
+- `drmcputils`: request-scoped DataRobot clients now save and restore the SDK's global default Use Case instead of permanently nulling the process-global `datarobot.context.Context` singleton, which clobbered a default set concurrently by the embedding application. The suspension is reference-counted, so overlapping request-scoped blocks restore the default exactly once (last one out) instead of racing each other.
 - `drmcputils` no longer accepts the raw `Authorization` header as a DataRobot API token. On OAuth-protected MCP servers that header carries the MCP access token (e.g. an Okta JWT), not a DataRobot key — forwarding it to the DataRobot API was token confusion across audiences. It was originally a local-dev convenience; use `x-datarobot-api-token` (or `x-datarobot-authorization: Bearer <token>`) instead.
 
 ## 0.23.3

--- a/docs/src/drtools/auth.md
+++ b/docs/src/drtools/auth.md
@@ -25,7 +25,7 @@ Credentials are defined in `datarobot_genai.drtools.core.credentials.ToolsAuthCr
 
 | Secret | Header examples |
 |---|---|
-| DataRobot API token | `Authorization: Bearer <token>`, `x-datarobot-api-token` |
+| DataRobot API token | `x-datarobot-api-token: <token>`, `x-datarobot-authorization: Bearer <token>` |
 | Tavily | `x-tavily-api-key` |
 | Perplexity | `x-perplexity-api-key` |
 | OAuth fallback | `x-datarobot-<provider>-access-token` |
@@ -66,7 +66,7 @@ from langchain_mcp_adapters.sessions import StreamableHttpConnection
 connection = StreamableHttpConnection(
     url="https://my-mcp.example.com/mcp",
     headers={
-        "Authorization": "Bearer <datarobot-api-token>",
+        "x-datarobot-api-token": "<datarobot-api-token>",
         "x-datarobot-authorization-context": "<jwt-auth-context>",
     },
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/clients/datarobot.py
+++ b/src/datarobot_genai/drmcputils/clients/datarobot.py
@@ -67,6 +67,25 @@ def get_datarobot_access_token(*, headers_auth_only: bool = True) -> str:
 
 
 @contextmanager
+def _suspend_default_use_case() -> Iterator[None]:
+    """Temporarily clear the SDK's default Use Case for the block's duration.
+
+    ``DRContext`` is a process-global singleton (not request state), so the
+    previous behavior — permanently nulling ``use_case`` — clobbered a default
+    Use Case set concurrently by the embedding application. Read the stored
+    value directly: both the ``use_case`` property and ``get_use_case()`` are
+    ``@_init_context``-decorated and would trigger client init / a UseCase
+    lookup over the network.
+    """
+    previous_use_case = DRContext._use_case
+    DRContext.use_case = None
+    try:
+        yield
+    finally:
+        DRContext.use_case = previous_use_case
+
+
+@contextmanager
 def request_user_dr_client(*, headers_auth_only: bool = True) -> Iterator[RESTClientObject]:
     """Yield a request-user-scoped ``RESTClientObject`` for the block's duration.
 
@@ -83,8 +102,8 @@ def request_user_dr_client(*, headers_auth_only: bool = True) -> Iterator[RESTCl
     endpoint = get_credentials().datarobot.datarobot_endpoint
     with client_configuration(token=token, endpoint=endpoint):
         # Avoid use-case context from trafaret affecting tool calls.
-        DRContext.use_case = None
-        yield cast(RESTClientObject, dr.client.get_client())
+        with _suspend_default_use_case():
+            yield cast(RESTClientObject, dr.client.get_client())
 
 
 @contextmanager
@@ -102,8 +121,8 @@ def request_user_dr_sdk(*, headers_auth_only: bool = True) -> Iterator[Any]:
     token = get_datarobot_access_token(headers_auth_only=headers_auth_only)
     endpoint = get_credentials().datarobot.datarobot_endpoint
     with client_configuration(token=token, endpoint=endpoint):
-        DRContext.use_case = None
-        yield dr
+        with _suspend_default_use_case():
+            yield dr
 
 
 class ThreadSafeDataRobotClient:
@@ -118,5 +137,5 @@ class ThreadSafeDataRobotClient:
         token = get_datarobot_access_token(headers_auth_only=headers_auth_only)
         with client_configuration(token=token, endpoint=self.endpoint):
             # Avoid use-case context from trafaret affecting tool calls.
-            DRContext.use_case = None
-            yield cast(RESTClientObject, dr.client.get_client())
+            with _suspend_default_use_case():
+                yield cast(RESTClientObject, dr.client.get_client())

--- a/src/datarobot_genai/drmcputils/clients/datarobot.py
+++ b/src/datarobot_genai/drmcputils/clients/datarobot.py
@@ -22,6 +22,7 @@ get their own client, so we never mutate the process-global ``dr.Client()``.
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -66,23 +67,43 @@ def get_datarobot_access_token(*, headers_auth_only: bool = True) -> str:
     return get_credentials().datarobot.datarobot_api_token
 
 
-@contextmanager
-def _suspend_default_use_case() -> Iterator[None]:
-    """Temporarily clear the SDK's default Use Case for the block's duration.
+class _UseCaseSuspension:
+    """Reference-counted suspension of the SDK's global default Use Case.
 
-    ``DRContext`` is a process-global singleton (not request state), so the
-    previous behavior — permanently nulling ``use_case`` — clobbered a default
-    Use Case set concurrently by the embedding application. Read the stored
-    value directly: both the ``use_case`` property and ``get_use_case()`` are
-    ``@_init_context``-decorated and would trigger client init / a UseCase
-    lookup over the network.
+    ``DRContext`` is a process-global singleton (not request state), so
+    permanently nulling ``use_case`` would clobber a default Use Case set
+    concurrently by the embedding application. The first entrant saves the
+    default and clears it; the last one out restores it — so overlapping
+    request-scoped blocks don't restore ``None`` over each other.
+
+    Reads the stored ``_use_case`` directly: both the ``use_case`` property
+    and ``get_use_case()`` are ``@_init_context``-decorated and would trigger
+    client init / a UseCase lookup over the network.
     """
-    previous_use_case = DRContext._use_case
-    DRContext.use_case = None
-    try:
-        yield
-    finally:
-        DRContext.use_case = previous_use_case
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._depth = 0
+        self._saved: Any = None
+
+    @contextmanager
+    def suspend(self) -> Iterator[None]:
+        with self._lock:
+            if self._depth == 0:
+                self._saved = DRContext._use_case
+                DRContext.use_case = None
+            self._depth += 1
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._depth -= 1
+                if self._depth == 0:
+                    DRContext.use_case = self._saved
+                    self._saved = None
+
+
+_suspend_default_use_case = _UseCaseSuspension().suspend
 
 
 @contextmanager

--- a/src/datarobot_genai/drmcputils/constants.py
+++ b/src/datarobot_genai/drmcputils/constants.py
@@ -31,11 +31,14 @@ WORKLOAD_TERMINAL_FAILURE_STATUS = "errored"
 
 REPLACEMENT_STRATEGIES: tuple[str, ...] = ("rolling",)
 
-# Header names to check for authorization tokens (in order of preference)
+# Header names to check for DataRobot API tokens (in order of preference).
+# Deliberately excludes the raw ``authorization`` header: on OAuth-protected
+# MCP servers it carries the MCP access token (e.g. an Okta JWT), not a
+# DataRobot API key — forwarding it to the DataRobot API would be token
+# confusion across audiences. Use ``x-datarobot-api-token`` in local dev.
 HEADER_TOKEN_CANDIDATE_NAMES = [
     "x-datarobot-authorization",
     "x-datarobot-api-key",
     "x-datarobot-external-access-token",
     "x-datarobot-api-token",
-    "authorization",
 ]

--- a/tests/drmcp/unit/test_core_clients.py
+++ b/tests/drmcp/unit/test_core_clients.py
@@ -139,21 +139,27 @@ class TestPrefixMountPath:
 class TestExtractTokenFromHeaders:
     """Test cases for _extract_token_from_headers function."""
 
-    def test_extract_bearer_token_from_authorization_header(self):
-        """Test extracting Bearer token from authorization header."""
-        headers = {"authorization": "Bearer test-token-123"}
+    def test_raw_authorization_header_is_ignored(self):
+        """The raw authorization header is never used as a DataRobot API token.
+
+        On OAuth-protected MCP servers it carries the MCP access token (e.g. an
+        Okta JWT), not a DataRobot API key — forwarding it would be token
+        confusion across audiences. It was originally a local-dev convenience;
+        local dev should use x-datarobot-api-token instead.
+        """
+        headers = {"authorization": "Bearer okta-mcp-access-token"}
         result = _extract_token_from_headers(headers)
-        assert result == "test-token-123"
+        assert result is None
 
     def test_extract_bearer_token_case_insensitive(self):
         """Test that Bearer prefix is case-insensitive."""
-        headers = {"authorization": "BEARER test-token-123"}
+        headers = {"x-datarobot-authorization": "BEARER test-token-123"}
         result = _extract_token_from_headers(headers)
         assert result == "test-token-123"
 
-    def test_extract_plain_token_from_authorization_header(self):
-        """Test extracting plain token (without Bearer prefix) from authorization header."""
-        headers = {"authorization": "plain-token-123"}
+    def test_extract_plain_token_without_bearer_prefix(self):
+        """Test extracting plain token (without Bearer prefix)."""
+        headers = {"x-datarobot-authorization": "plain-token-123"}
         result = _extract_token_from_headers(headers)
         assert result == "plain-token-123"
 
@@ -169,10 +175,10 @@ class TestExtractTokenFromHeaders:
         result = _extract_token_from_headers(headers)
         assert result == "api-key-789"
 
-    def test_prefers_api_key_over_authorization(self):
-        """Test current candidate order where API key headers are checked before authorization."""
+    def test_prefers_api_key_over_api_token(self):
+        """Test current candidate order where x-datarobot-api-key is checked first."""
         headers = {
-            "authorization": "Bearer auth-token",
+            "authorization": "Bearer auth-token",  # never a candidate
             "x-datarobot-api-token": "Bearer api-token",
             "x-datarobot-api-key": "Bearer api-key",
         }
@@ -199,31 +205,31 @@ class TestExtractTokenFromHeaders:
 
     def test_handles_empty_token_after_stripping(self):
         """Test that function returns None when token is empty after stripping."""
-        headers = {"authorization": "Bearer   "}
+        headers = {"x-datarobot-authorization": "Bearer   "}
         result = _extract_token_from_headers(headers)
         assert result is None
 
     def test_handles_non_string_header_value(self):
         """Test that function skips non-string header values."""
-        headers = {"authorization": 12345}
+        headers = {"x-datarobot-authorization": 12345}
         result = _extract_token_from_headers(headers)
         assert result is None
 
     def test_handles_none_header_value(self):
         """Test that function handles None header values."""
-        headers = {"authorization": None}
+        headers = {"x-datarobot-authorization": None}
         result = _extract_token_from_headers(headers)
         assert result is None
 
     def test_strips_whitespace_from_token(self):
         """Test that function strips whitespace from extracted token."""
-        headers = {"authorization": "Bearer   token-with-spaces   "}
+        headers = {"x-datarobot-authorization": "Bearer   token-with-spaces   "}
         result = _extract_token_from_headers(headers)
         assert result == "token-with-spaces"
 
     def test_handles_bearer_with_multiple_spaces(self):
         """Test that function handles Bearer prefix with multiple spaces."""
-        headers = {"authorization": "Bearer  token-123"}
+        headers = {"x-datarobot-authorization": "Bearer  token-123"}
         result = _extract_token_from_headers(headers)
         assert result == "token-123"
 
@@ -233,8 +239,10 @@ class TestExtractTokenFromHeaders:
         result = _extract_token_from_headers(headers)
         assert result == "user-api-key"
 
-    def test_prefers_x_datarobot_authorization_over_authorization(self):
-        """Test gateway scenario: x-datarobot-authorization is preferred."""
+    def test_gateway_scenario_uses_x_datarobot_authorization(self):
+        """Gateway scenario: x-datarobot-authorization is used, the raw
+        authorization header (the service JWT) never is.
+        """
         headers = {
             "x-datarobot-authorization": "Bearer user-api-key",
             "authorization": "Bearer s2s-jwt-token",
@@ -317,7 +325,7 @@ class TestExtractTokenFromHeadersWithFallback:
 
     def test_prefers_standard_header_over_auth_context(self):
         """Test that standard headers are preferred over auth context metadata."""
-        headers = {"authorization": "Bearer standard-token"}
+        headers = {"x-datarobot-authorization": "Bearer standard-token"}
 
         with patch(
             "datarobot_genai.drmcputils.auth._extract_token_from_auth_context"

--- a/tests/drmcp/unit/test_resolve_auth.py
+++ b/tests/drmcp/unit/test_resolve_auth.py
@@ -67,7 +67,7 @@ class TestResolveDatarobotToken:
             token="config-token",
             strategy=AuthResolutionStrategy.HTTP,
         )
-        set_request_headers({"authorization": "Bearer header-token"})
+        set_request_headers({"x-datarobot-api-token": "header-token"})
 
         assert resolve_datarobot_token() == "header-token"
 
@@ -86,7 +86,7 @@ class TestResolveDatarobotToken:
             token="config-token",
             strategy=AuthResolutionStrategy.CONFIG,
         )
-        set_request_headers({"authorization": "Bearer header-token"})
+        set_request_headers({"x-datarobot-api-token": "header-token"})
 
         assert resolve_datarobot_token() == "config-token"
 
@@ -103,6 +103,40 @@ class TestResolveDatarobotToken:
         mock_get_headers.side_effect = RuntimeError("no context")
 
         assert resolve_datarobot_token() is None
+
+    def test_raw_authorization_header_never_used(
+        self, credentials_holder: dict[str, MagicMock]
+    ) -> None:
+        """GIVEN only a raw Authorization header (on OAuth-protected servers it
+        carries the MCP access token, e.g. an Okta JWT — not a DataRobot key)
+        WHEN the DataRobot token is resolved
+        THEN it is never forwarded as a DR API key
+        (regression: 'authorization' used to be the last token candidate).
+        """
+        credentials_holder["creds"] = _mock_tools_credentials(
+            strategy=AuthResolutionStrategy.HTTP,
+        )
+        set_request_headers({"authorization": "Bearer okta-mcp-access-token"})
+
+        assert resolve_datarobot_token() is None
+
+    def test_datarobot_headers_used_alongside_raw_authorization(
+        self, credentials_holder: dict[str, MagicMock]
+    ) -> None:
+        """The DataRobot-specific headers keep working when a raw Authorization
+        header is also present.
+        """
+        credentials_holder["creds"] = _mock_tools_credentials(
+            strategy=AuthResolutionStrategy.HTTP,
+        )
+        set_request_headers(
+            {
+                "authorization": "Bearer okta-mcp-access-token",
+                "x-datarobot-api-token": "dr-api-token",
+            }
+        )
+
+        assert resolve_datarobot_token() == "dr-api-token"
 
 
 class TestResolveSecret:

--- a/tests/drtools/unit/core/test_datarobot_sdk.py
+++ b/tests/drtools/unit/core/test_datarobot_sdk.py
@@ -32,10 +32,10 @@ _MODULE = "datarobot_genai.drmcputils.clients.datarobot"
 class TestRequestUserDrSdk:
     @patch(f"{_MODULE}.client_configuration")
     @patch(f"{_MODULE}.get_credentials")
-    def test_uses_token_from_authorization_header(
+    def test_uses_token_from_x_datarobot_authorization_header(
         self, mock_get_creds, mock_client_configuration
     ) -> None:
-        set_request_headers({"authorization": "Bearer header-token"})
+        set_request_headers({"x-datarobot-authorization": "Bearer header-token"})
         mock_creds = MagicMock()
         mock_creds.datarobot.datarobot_endpoint = "https://test.datarobot.com/api/v2"
         mock_get_creds.return_value = mock_creds
@@ -79,19 +79,46 @@ class TestRequestUserDrSdk:
     @patch(f"{_MODULE}.client_configuration")
     @patch(f"{_MODULE}.get_credentials")
     @patch(f"{_MODULE}.DRContext")
-    def test_resets_dr_context_use_case(
+    def test_suspends_and_restores_dr_context_use_case(
         self, mock_dr_context, mock_get_creds, mock_client_configuration
     ) -> None:
+        """GIVEN the application set a default Use Case on the global SDK context
+        WHEN a request-scoped SDK client is used
+        THEN the default is cleared only inside the block and restored on exit
+        (regression: it was nulled permanently — DRContext is a process-global
+        singleton, so concurrent users had their default clobbered).
+        """
         with patch(f"{_MODULE}.resolve_datarobot_token", return_value="tok"):
             mock_creds = MagicMock()
             mock_creds.datarobot.datarobot_endpoint = "https://test.datarobot.com/api/v2"
             mock_get_creds.return_value = mock_creds
             mock_dr_context.use_case = "some-use-case"
+            mock_dr_context._use_case = "some-use-case"
 
             with request_user_dr_sdk():
-                pass
+                assert mock_dr_context.use_case is None
 
-            assert mock_dr_context.use_case is None
+            assert mock_dr_context.use_case == "some-use-case"
+
+    @patch(f"{_MODULE}.client_configuration")
+    @patch(f"{_MODULE}.get_credentials")
+    @patch(f"{_MODULE}.DRContext")
+    def test_restores_dr_context_use_case_on_error(
+        self, mock_dr_context, mock_get_creds, mock_client_configuration
+    ) -> None:
+        """The saved default Use Case is restored even when the block raises."""
+        with patch(f"{_MODULE}.resolve_datarobot_token", return_value="tok"):
+            mock_creds = MagicMock()
+            mock_creds.datarobot.datarobot_endpoint = "https://test.datarobot.com/api/v2"
+            mock_get_creds.return_value = mock_creds
+            mock_dr_context.use_case = "some-use-case"
+            mock_dr_context._use_case = "some-use-case"
+
+            with pytest.raises(RuntimeError, match="boom"):
+                with request_user_dr_sdk():
+                    raise RuntimeError("boom")
+
+            assert mock_dr_context.use_case == "some-use-case"
 
     @patch(f"{_MODULE}.client_configuration")
     @patch(f"{_MODULE}.get_credentials")

--- a/tests/drtools/unit/core/test_datarobot_sdk.py
+++ b/tests/drtools/unit/core/test_datarobot_sdk.py
@@ -23,6 +23,7 @@ from datarobot.auth.session import AuthCtx
 from datarobot.auth.users import User
 
 from datarobot_genai.drmcputils.auth import set_request_headers
+from datarobot_genai.drmcputils.clients.datarobot import _suspend_default_use_case
 from datarobot_genai.drmcputils.clients.datarobot import request_user_dr_sdk
 from datarobot_genai.drmcputils.exceptions import ToolError
 
@@ -119,6 +120,30 @@ class TestRequestUserDrSdk:
                     raise RuntimeError("boom")
 
             assert mock_dr_context.use_case == "some-use-case"
+
+    @patch(f"{_MODULE}.DRContext")
+    def test_overlapping_suspends_restore_once(self, mock_dr_context) -> None:
+        """GIVEN two request-scoped blocks that overlap (interleaved, not nested)
+        WHEN the first block exits while the second is still active
+        THEN the default stays cleared until the last block exits, and only the
+        original default is restored
+        (regression: the later entrant saved ``None`` and restored ``None`` over
+        the earlier block's restore).
+        """
+        mock_dr_context.use_case = "some-use-case"
+        mock_dr_context._use_case = "some-use-case"
+
+        block_a = _suspend_default_use_case()
+        block_a.__enter__()
+        mock_dr_context._use_case = None  # mirror what the property setter stored
+        block_b = _suspend_default_use_case()
+        block_b.__enter__()
+
+        block_a.__exit__(None, None, None)
+        assert mock_dr_context.use_case is None  # block B is still active
+
+        block_b.__exit__(None, None, None)
+        assert mock_dr_context.use_case == "some-use-case"
 
     @patch(f"{_MODULE}.client_configuration")
     @patch(f"{_MODULE}.get_credentials")

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- Request-scoped clients permanently nulled the SDK's default Use Case. datarobot.context.Context is a process-global singleton, so DRContext.use_case = None inside the request-scoped client helpers wiped a default Use Case set concurrently by the embedding application. The helpers now suspend it for the block and restore it on exit (also on error), reading the stored value directly to avoid the @_init_context-decorated accessors that would trigger client init or a network Use Case lookup.
- Breaking: the raw Authorization header is no longer accepted as a DataRobot API token. It was originally a local-dev convenience, but on OAuth-protected MCP servers that header carries the MCP access token (e.g. an Okta JWT) — forwarding it to the DataRobot API was token confusion across audiences. Use x-datarobot-api-token (or x-datarobot-authorization: Bearer <token>) instead; the not-found error message and auth docs now say so.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking header-based auth can break local or gateway setups that relied on `Authorization` for DataRobot keys, and the global SDK Use Case restore path touches shared process state used by concurrent tool requests.
> 
> **Overview**
> **`drmcputils` request-scoped DataRobot clients** now **suspend and restore** the process-global SDK default Use Case via `_suspend_default_use_case()` instead of leaving `DRContext.use_case` permanently `None`, including on errors inside `request_user_dr_client`, `request_user_dr_sdk`, and `ThreadSafeDataRobotClient`.
> 
> **Breaking auth change:** the raw **`Authorization` header is no longer treated as a DataRobot API token** (`authorization` removed from `HEADER_TOKEN_CANDIDATE_NAMES`). Callers must use **`x-datarobot-api-token`** or **`x-datarobot-authorization: Bearer <token>`**; auth docs and tests were updated accordingly. Release **0.23.4** and changelog entries document both fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453489583246083195d636f4708c49dc2c7ba739. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->