### PR TITLE
External dynamic tools: don't replay non-idempotent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.4
+- `drmcpbase`: external dynamic tools no longer replay non-idempotent requests on ambiguous failures. One retry policy (5 attempts) used to apply to every HTTP method — and retried *every* 5xx (`retry_all_server_errors` default), so a POST/PATCH whose first attempt reached the application could execute up to 5 times (duplicate side effects). POST/PATCH now retry only on provably-unprocessed failures: HTTP 429 or a connection that was never established. Idempotent methods (GET/PUT/DELETE) keep the full retry behavior.
+
 ## 0.23.3
 - `drmcp`: added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. `UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcpbase/dynamic_tools/external_tool.py
+++ b/src/datarobot_genai/drmcpbase/dynamic_tools/external_tool.py
@@ -40,6 +40,14 @@ logger = logging.getLogger(__name__)
 REQUEST_RETRY_SLEEP = 0.1
 REQUEST_MAX_RETRY = 5
 REQUEST_RETRYABLE_STATUS_CODES = {429, 570, 502, 503, 504}
+# Idempotent methods (RFC 9110, of the ones the config allows) are safe to
+# retry on any transient failure.  POST and PATCH are not: an ambiguous
+# failure (502/504 from a gateway, a mid-flight timeout) cannot prove the
+# first attempt didn't reach the application, so a retry can duplicate the
+# side effect.  They are retried only when the request provably never got
+# processed: a 429 rejection, or a connection that was never established.
+IDEMPOTENT_METHODS = frozenset({"GET", "PUT", "DELETE"})
+NON_IDEMPOTENT_RETRYABLE_STATUS_CODES = {429}
 
 # HTTP connection timeouts in seconds
 REQUEST_CONNECT_TIMEOUT = 30
@@ -84,6 +92,34 @@ class ExternalToolRegistrationConfig(BaseModel):
     )
 
 
+def _retry_options_for_method(method: str) -> ExponentialRetry:
+    """Retry policy scoped to what the HTTP method makes safe to replay."""
+    if method.upper() in IDEMPOTENT_METHODS:
+        return ExponentialRetry(
+            attempts=REQUEST_MAX_RETRY,
+            start_timeout=REQUEST_RETRY_SLEEP,
+            statuses=REQUEST_RETRYABLE_STATUS_CODES,
+            exceptions={
+                aiohttp.ClientError,
+                aiohttp.ServerTimeoutError,
+                asyncio.TimeoutError,
+            },
+        )
+    # POST/PATCH: only provably-unprocessed failures (see constants above).
+    # ClientConnectorError means the connection was never established, so the
+    # request was never sent; broader ClientError/timeout classes stay out
+    # because they include mid-flight failures after the server saw the request.
+    # retry_all_server_errors must be off — it retries every 5xx regardless of
+    # the `statuses` set.
+    return ExponentialRetry(
+        attempts=REQUEST_MAX_RETRY,
+        start_timeout=REQUEST_RETRY_SLEEP,
+        statuses=NON_IDEMPOTENT_RETRYABLE_STATUS_CODES,
+        exceptions={aiohttp.ClientConnectorError},
+        retry_all_server_errors=False,
+    )
+
+
 def _external_tool_callable_factory(
     spec: ExternalToolRegistrationConfig,
     allow_empty: bool = False,
@@ -125,16 +161,7 @@ def _external_tool_callable_factory(
         )
 
         # Configure retry strategy with exponential backoff
-        retry_options = ExponentialRetry(
-            attempts=REQUEST_MAX_RETRY,
-            start_timeout=REQUEST_RETRY_SLEEP,
-            statuses=REQUEST_RETRYABLE_STATUS_CODES,
-            exceptions={
-                aiohttp.ClientError,
-                aiohttp.ServerTimeoutError,
-                asyncio.TimeoutError,
-            },
-        )
+        retry_options = _retry_options_for_method(spec.method)
 
         # Execute request with retry logic
         async with aiohttp.ClientSession(timeout=client_timeout) as session:

--- a/tests/drmcp/unit/dynamic_tools/test_register.py
+++ b/tests/drmcp/unit/dynamic_tools/test_register.py
@@ -457,3 +457,100 @@ class TestExternalToolCallableErrorHandling:
             with pytest.raises(ToolError, match="stop sequence") as exc_info:
                 await callable_fn(input_model())
             assert "400" in str(exc_info.value)
+
+
+class TestExternalToolRetryPolicy:
+    """Retries are scoped to what the HTTP method makes safe to replay.
+
+    Regression: one retry policy (5 attempts on 429/502/503/504) applied to
+    every method, so a POST/PATCH whose first attempt did reach the
+    application was replayed up to 4 more times — duplicate side effects.
+    """
+
+    TOOL_URL = "https://api.example.com/test"
+
+    @staticmethod
+    def _tool_config(method: str) -> ExternalToolRegistrationConfig:
+        return ExternalToolRegistrationConfig(
+            name="test_tool",
+            method=method,  # type: ignore[arg-type]
+            base_url="https://api.example.com/",
+            endpoint="test",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "query_params": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    }
+                },
+            },
+        )
+
+    @staticmethod
+    def _callable_and_input(config: ExternalToolRegistrationConfig):
+        callable_fn = _external_tool_callable_factory(config, allow_empty=True)
+        input_model = inspect.signature(callable_fn).parameters["inputs"].annotation
+        return callable_fn, input_model
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    @pytest.mark.parametrize("status", [502, 503, 504])
+    @patch(
+        "datarobot_genai.drmcpbase.dynamic_tools.external_tool.get_http_headers", return_value={}
+    )
+    async def test_non_idempotent_methods_not_retried_on_ambiguous_failures(
+        self, mock_headers, method: str, status: int
+    ):
+        """GIVEN a POST/PATCH whose first attempt fails ambiguously (the request
+        may have been processed) WHEN the gateway-style status comes back THEN
+        the request is NOT replayed — the queued 200 would have made a retried
+        call succeed.
+        """
+        callable_fn, input_model = self._callable_and_input(self._tool_config(method))
+
+        with aioresponses() as mocked:
+            register = getattr(mocked, method.lower())
+            register(self.TOOL_URL, status=status, body="upstream error")
+            register(self.TOOL_URL, status=200, body="{}", content_type="application/json")
+
+            with pytest.raises(ToolError, match=f"HTTP {status}"):
+                await callable_fn(input_model())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    @patch(
+        "datarobot_genai.drmcpbase.dynamic_tools.external_tool.get_http_headers", return_value={}
+    )
+    async def test_non_idempotent_methods_retried_on_429(self, mock_headers, method: str):
+        """A 429 rejection provably never processed the request, so replaying
+        a POST/PATCH is safe — the retried call reaches the queued 200.
+        """
+        callable_fn, input_model = self._callable_and_input(self._tool_config(method))
+
+        with aioresponses() as mocked:
+            register = getattr(mocked, method.lower())
+            register(self.TOOL_URL, status=429, body="rate limited")
+            register(self.TOOL_URL, status=200, body="{}", content_type="application/json")
+
+            result = await callable_fn(input_model())
+            assert isinstance(result, ToolResult)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["GET", "PUT", "DELETE"])
+    @patch(
+        "datarobot_genai.drmcpbase.dynamic_tools.external_tool.get_http_headers", return_value={}
+    )
+    async def test_idempotent_methods_still_retried_on_transient_failures(
+        self, mock_headers, method: str
+    ):
+        """Idempotent methods keep the full retry behavior on 5xx."""
+        callable_fn, input_model = self._callable_and_input(self._tool_config(method))
+
+        with aioresponses() as mocked:
+            register = getattr(mocked, method.lower())
+            register(self.TOOL_URL, status=502, body="bad gateway")
+            register(self.TOOL_URL, status=200, body="{}", content_type="application/json")
+
+            result = await callable_fn(input_model())
+            assert isinstance(result, ToolResult)

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

One retry policy (5 attempts, exponential backoff) applied to every HTTP method — and aiohttp_retry's retry_all_server_errors default meant every 5xx was retried, not just the listed statuses. A POST/PATCH whose first attempt reached the application (ambiguous 502/504 from a gateway, 503, a mid-flight timeout) was replayed up to 4 more times, duplicating the side effect (created records, sent messages, etc.).

Retries are now scoped to what the method makes safe to replay:

- GET/PUT/DELETE (idempotent): unchanged full retry behavior.
- POST/PATCH: retried only on provably-unprocessed failures — HTTP 429, or a connection that was never established (ClientConnectorError, request never sent). Ambiguous failures fail fast with the upstream error.

Tests: parametrized behavioral proofs using queued mock responses (failure→200): POST/PATCH × 502/503/504 raise (no replay reaches the queued 200), POST/PATCH × 429 succeed (safe retry preserved), GET/PUT/DELETE × 502 succeed (idempotent retry preserved). 

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound HTTP behavior for POST/PATCH on deployment and other external dynamic MCP tools—fewer retries on transient 5xx, which fixes duplicate writes but may surface more one-shot failures to agents.
> 
> **Overview**
> **Release 0.23.4** documents the behavior change in `CHANGELOG.md` and bumps package version in `pyproject.toml` / `uv.lock`.
> 
> **`drmcpbase` external dynamic tools** no longer use one shared retry policy for every HTTP method. The factory now calls **`_retry_options_for_method`**, which keeps **GET/PUT/DELETE** on the existing policy (up to 5 attempts on 429/502/503/504/570 plus broad client/timeout errors). **POST/PATCH** only retry on **HTTP 429** or **`ClientConnectorError`** (connection never established), with **`retry_all_server_errors=False`** so gateway **502/503/504** are not replayed when the first attempt might already have been processed.
> 
> **Tests** in `test_register.py` add **`TestExternalToolRetryPolicy`**: POST/PATCH fail fast on ambiguous 5xx without consuming a queued success response; POST/PATCH still succeed after 429; idempotent methods still retry through 502.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba19d090ae9c72d1d5d13001f884e991488e38d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->