### PR TITLE
Batch of small verified bug fixes acroos different tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.4
+- `drtools/jira`: `jira_transition_issue` now POSTs to `issue/{key}/transitions` — it POSTed to `issue/{key}`, which the Jira API rejects, so issue transitions never happened.
+- `drtools/perplexity`: `perplexity_search` accepts a list of sub-queries again — the parameter was annotated `Annotated[str, list[str], ...]`, which makes `list[str]` inert metadata, so multi-query lists were rejected at schema validation despite being fully supported downstream.
+- `drtools/predictive`: dataset-insights text-column detection no longer mutates the categorical list while iterating (the column right after each detected text column was skipped) and no longer raises on object columns holding non-strings.
+- `drtools/dr_docs`: search results return a ~300-char word-boundary snippet as `description` instead of the full page body (tens of KB per result); a failed docs-index build now backs off for 5 minutes instead of re-running the sitemap + full content fetch on every search just to return "no results".
+- `drmcp`: `dr_mcp_prompt` no longer uses a shared mutable `PromptInitArguments()` default — each decoration gets a fresh instance, so one prompt's category/meta can't leak into another's registration.
+
 ## 0.23.3
 - `drmcp`: added per-request MCP tool category gates via `x-datarobot-mcp-enable-proxy` and `x-datarobot-mcp-enable-dynamic-tools` (default enabled; explicit `false` disabled `PROXIED_USER_MCP` or `USER_TOOL_DEPLOYMENT` for that request). Category gates took precedence over mode and tool allowlists — gated tools were hidden from listing and could not be resolved or called. `UserMCPProvider` short-circuited the proxied user-MCP fan-out when the proxy gate was disabled.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/mcp_instance.py
+++ b/src/datarobot_genai/drmcp/core/mcp_instance.py
@@ -560,17 +560,21 @@ async def register_prompt(
 
 def dr_mcp_prompt(
     prompt_category: DataRobotMCPPromptCategory = DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE,
-    prompt_init_args: PromptInitArguments = PromptInitArguments(),
+    prompt_init_args: PromptInitArguments | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     def prompt_decorator(func: Callable[P, T]) -> Callable[P, T]:
         @wraps(func)
         def _inner_decorator(*args: P.args, **kwargs: P.kwargs) -> T:
             return func(*args, **kwargs)
 
-        prompt_init_args.set_prompt_category(prompt_category)
-        registered = mcp.prompt(**prompt_init_args.to_dict())(_inner_decorator)
-        if prompt_init_args.enabled is False:
-            mcp.disable(names={prompt_init_args.name or func.__name__}, components={"prompt"})
+        # A fresh instance per decoration when not supplied: a shared default
+        # instance would be mutated by every decoration (set_prompt_category),
+        # leaking one prompt's category/meta into another's registration.
+        init_args = prompt_init_args if prompt_init_args is not None else PromptInitArguments()
+        init_args.set_prompt_category(prompt_category)
+        registered = mcp.prompt(**init_args.to_dict())(_inner_decorator)
+        if init_args.enabled is False:
+            mcp.disable(names={init_args.name or func.__name__}, components={"prompt"})
         return registered
 
     return prompt_decorator

--- a/src/datarobot_genai/drtools/core/clients/dr_docs.py
+++ b/src/datarobot_genai/drtools/core/clients/dr_docs.py
@@ -63,6 +63,16 @@ AGENTIC_AI_PATH = "/en/docs/agentic-ai/"
 # Cache TTL in seconds (1 day)
 CACHE_TTL_SECONDS = 86400
 
+# Cooldown before retrying a failed index build.  Without it a failed build
+# leaves the index permanently "stale", so every search re-runs the whole
+# sitemap + content fetch (serialized behind the build lock) just to return
+# nothing again.
+FAILED_BUILD_RETRY_SECONDS = 300
+
+# Search results return a snippet of the page body, not the full text — a full
+# page is tens of KB and result sets are up to MAX_RESULTS pages.
+DESCRIPTION_SNIPPET_MAX_CHARS = 300
+
 # Maximum number of results to return
 MAX_RESULTS = 10
 MAX_RESULTS_DEFAULT = 3
@@ -125,11 +135,16 @@ class DocPage:
         self.tf = _compute_tf(self._title_tokens * 3 + self._text_tokens)
 
     def as_dict(self) -> dict[str, str]:
-        """Return a dictionary representation of the page."""
+        """Return a dictionary representation of the page (body as a snippet)."""
+        description = self.text
+        if len(description) > DESCRIPTION_SNIPPET_MAX_CHARS:
+            # Cut at a word boundary so the snippet doesn't end mid-word.
+            cut = description.rfind(" ", 0, DESCRIPTION_SNIPPET_MAX_CHARS)
+            description = description[: cut if cut > 0 else DESCRIPTION_SNIPPET_MAX_CHARS] + "…"
         return {
             "url": self.url,
             "title": self.title,
-            "description": self.text,
+            "description": description,
         }
 
 
@@ -140,13 +155,20 @@ class _DocsIndex:
         self.pages: list[DocPage] = []
         self._df: dict[str, int] = {}  # document frequency
         self._built_at: float = 0.0  # timestamp of when the last index was built
+        self._last_build_failed_at: float = 0.0
 
     @property
     def is_stale(self) -> bool:
         """Check if the index needs refreshing."""
         if not self.pages:
-            return True
+            # After a failed build, wait out the cooldown instead of re-running
+            # the full sitemap + content fetch on every search.
+            return (time.time() - self._last_build_failed_at) > FAILED_BUILD_RETRY_SECONDS
         return (time.time() - self._built_at) > CACHE_TTL_SECONDS
+
+    def mark_build_failed(self) -> None:
+        """Record a failed build so `is_stale` backs off before retrying."""
+        self._last_build_failed_at = time.time()
 
     def build(self, pages: list[DocPage]) -> None:
         """
@@ -313,12 +335,17 @@ async def _ensure_index() -> _DocsIndex:
             return _index
 
         logger.info("Building DataRobot agentic-ai docs index...")
-        async with aiohttp.ClientSession() as session:
-            pages = await _create_datarobot_agentic_docs_pages(session)
-            if pages:
-                _index.build(pages)
-            else:
-                logger.warning("No pages found for docs index")
+        try:
+            async with aiohttp.ClientSession() as session:
+                pages = await _create_datarobot_agentic_docs_pages(session)
+        except Exception:
+            _index.mark_build_failed()
+            raise
+        if pages:
+            _index.build(pages)
+        else:
+            _index.mark_build_failed()
+            logger.warning("No pages found for docs index")
 
     return _index
 

--- a/src/datarobot_genai/drtools/core/clients/jira.py
+++ b/src/datarobot_genai/drtools/core/clients/jira.py
@@ -323,7 +323,7 @@ class JiraClient:
         ------
             httpx.HTTPStatusError: If the API request fails
         """
-        url = await self._get_full_url(f"issue/{issue_key}")
+        url = await self._get_full_url(f"issue/{issue_key}/transitions")
         payload = {"transition": {"id": transition_id}}
 
         response = await self._client.post(url, json=payload)

--- a/src/datarobot_genai/drtools/perplexity/tools.py
+++ b/src/datarobot_genai/drtools/perplexity/tools.py
@@ -59,8 +59,7 @@ _PPLX_STRUCTURED = "https://docs.perplexity.ai/guides/structured-outputs"
 async def perplexity_search(
     *,
     query: Annotated[
-        str,
-        list[str],
+        str | list[str],
         f"The search query string OR "
         f"a list of up to {MAX_QUERIES} sub-queries for multi-query research.",
     ],

--- a/src/datarobot_genai/drtools/predictive/training.py
+++ b/src/datarobot_genai/drtools/predictive/training.py
@@ -163,12 +163,13 @@ def _build_dataset_insights(df: pd.DataFrame) -> dict[str, Any]:
     categorical_cols = df.select_dtypes(include=["object", "category"]).columns.tolist()
     datetime_cols = df.select_dtypes(include=["datetime64"]).columns.tolist()
 
-    # Identify potential text columns (categorical with high cardinality)
-    text_cols = []
-    for col in categorical_cols:
-        if df[col].str.len().mean() > 20:  # Text detection
-            text_cols.append(col)
-            categorical_cols.remove(col)  # Remove from categorical columns
+    # Identify potential text columns (categorical with high cardinality).
+    # astype(str) tolerates mixed-dtype object columns (.str.len() raises on
+    # non-strings); an empty column means mean() is NaN, which compares False.
+    text_cols = [
+        col for col in categorical_cols if df[col].dropna().astype(str).str.len().mean() > 20
+    ]
+    categorical_cols = [col for col in categorical_cols if col not in text_cols]
 
     # Calculate missing data
     missing_data = {}

--- a/tests/drmcp/unit/perplexity_tools/test_tools.py
+++ b/tests/drmcp/unit/perplexity_tools/test_tools.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import patch
 
 import pytest
+from fastmcp.tools import Tool
 
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drtools.core.clients.perplexity import PerplexityError
@@ -344,3 +345,18 @@ class TestPerplexityThink:
             with pytest.raises(Exception) as exc_info:
                 await perplexity_sonar(prompt="test prompt")
             assert "unexpected error" in str(exc_info.value).lower()
+
+
+class TestPerplexitySearchSchema:
+    def test_query_schema_accepts_string_or_list(self) -> None:
+        """GIVEN the tool schema generated from the signature
+        THEN 'query' accepts a string OR a list of strings
+        (regression: Annotated[str, list[str], ...] made list[str] inert
+        metadata, so multi-query lists were rejected at schema validation).
+        """
+        tool = Tool.from_function(perplexity_search)
+
+        query_schema = tool.parameters["properties"]["query"]
+        types = {branch.get("type") for branch in query_schema.get("anyOf", [])}
+        assert "string" in types
+        assert "array" in types

--- a/tests/drmcp/unit/predictive_tools/test_training.py
+++ b/tests/drmcp/unit/predictive_tools/test_training.py
@@ -344,3 +344,34 @@ async def test_catalog_suggest_ml_problems_dataset_not_found() -> None:
             match=r"Dataset 'nonexistent_dataset_id' not found",
         ):
             await training.catalog_suggest_ml_problems(dataset_id="nonexistent_dataset_id")
+
+
+class TestBuildDatasetInsights:
+    def test_consecutive_text_columns_both_detected(self) -> None:
+        """GIVEN two adjacent text-like columns
+        WHEN insights are built
+        THEN both are classified as text and removed from categorical
+        (regression: the categorical list was mutated while iterating, so the
+        column right after each detected text column was skipped).
+        """
+        long_text = "this is a reasonably long sentence used for text detection"
+        df = pd.DataFrame(
+            {
+                "text_a": [long_text] * 3,
+                "text_b": [long_text] * 3,
+                "category": ["a", "b", "c"],
+            }
+        )
+
+        insights = training._build_dataset_insights(df)
+
+        assert insights["text_columns"] == ["text_a", "text_b"]
+        assert insights["categorical_columns"] == ["category"]
+
+    def test_mixed_dtype_object_column_does_not_raise(self) -> None:
+        """An object column holding non-strings used to raise from .str.len()."""
+        df = pd.DataFrame({"mixed": [1, "two", None], "num": [1.0, 2.0, 3.0]})
+
+        insights = training._build_dataset_insights(df)
+
+        assert "mixed" in insights["categorical_columns"]

--- a/tests/drmcp/unit/test_mcp_instance.py
+++ b/tests/drmcp/unit/test_mcp_instance.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from collections.abc import Iterator
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -19,6 +20,7 @@ from unittest.mock import patch
 import pytest
 from fastmcp.exceptions import NotFoundError
 
+from datarobot_genai.drmcp.core.enums import DataRobotMCPPromptCategory
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 from datarobot_genai.drmcp.core.mcp_instance import PromptInitArguments
 from datarobot_genai.drmcp.core.mcp_instance import ResourceInitArguments
@@ -26,6 +28,7 @@ from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_integration_tool
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_prompt
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_resource
 from datarobot_genai.drmcp.core.mcp_instance import dr_mcp_tool
+from datarobot_genai.drmcp.core.mcp_instance import mcp
 from datarobot_genai.drmcp.core.mcp_instance import update_mcp_tool_init_args_with_tool_category
 from datarobot_genai.drmcpbase.dynamic_tools.enums import DataRobotMCPToolCategory
 
@@ -402,3 +405,32 @@ class TestMCPResourceDecorator:
         # The handler must be registered unwrapped: a sync pass-through wrapper
         # would hide an async handler's coroutine-ness from FastMCP.
         assert registered_func is mock_mcp_resource_callable
+
+
+class TestDrMcpPromptInitArgsIsolation:
+    def test_default_prompt_init_args_is_none(self) -> None:
+        """Regression: the signature default was a single PromptInitArguments
+        instance created at import time — shared and mutated
+        (set_prompt_category) by every decoration that used the default.
+        """
+        default = inspect.signature(dr_mcp_prompt).parameters["prompt_init_args"].default
+        assert default is None
+
+    def test_each_decoration_gets_isolated_meta(self) -> None:
+        """Two default-arg decorations must not share init-args state."""
+        with patch.object(mcp, "prompt") as mock_prompt:
+            mock_prompt.return_value = lambda func: func
+
+            @dr_mcp_prompt(DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE)
+            def prompt_one() -> str:
+                return "one"
+
+            @dr_mcp_prompt(DataRobotMCPPromptCategory.USER_PROMPT_TEMPLATE_VERSION)
+            def prompt_two() -> str:
+                return "two"
+
+        first_meta = mock_prompt.call_args_list[0].kwargs["meta"]
+        second_meta = mock_prompt.call_args_list[1].kwargs["meta"]
+        assert first_meta["prompt_category"] == "USER_PROMPT_TEMPLATE"
+        assert second_meta["prompt_category"] == "USER_PROMPT_TEMPLATE_VERSION"
+        assert first_meta is not second_meta

--- a/tests/drmcp/unit/tool_clients/test_dr_docs_client.py
+++ b/tests/drmcp/unit/tool_clients/test_dr_docs_client.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from unittest.mock import AsyncMock
 from unittest.mock import patch
 
+from datarobot_genai.drtools.core.clients.dr_docs import DESCRIPTION_SNIPPET_MAX_CHARS
+from datarobot_genai.drtools.core.clients.dr_docs import FAILED_BUILD_RETRY_SECONDS
 from datarobot_genai.drtools.core.clients.dr_docs import DocPage
 from datarobot_genai.drtools.core.clients.dr_docs import _compute_tf
 from datarobot_genai.drtools.core.clients.dr_docs import _DocsIndex
@@ -623,3 +626,58 @@ class TestFetchPageContent:
             # Should use URL-derived title
             assert "Modeling" in result["title"]
             assert "Autopilot" in result["title"]
+
+
+class TestDocPageSnippet:
+    def test_long_body_is_truncated_at_word_boundary(self) -> None:
+        """Search results return a snippet, not the full page body
+        (regression: as_dict dumped the entire page text — tens of KB per
+        result — as 'description').
+        """
+        page = DocPage(url="https://docs.datarobot.com/x", title="T", text="word " * 200)
+
+        description = page.as_dict()["description"]
+
+        assert description.endswith("\u2026")
+        assert len(description) <= DESCRIPTION_SNIPPET_MAX_CHARS + 1
+        # The cut lands on a word boundary — no partial token before the ellipsis.
+        assert set(description[:-1].split()) == {"word"}
+
+    def test_short_body_unchanged(self) -> None:
+        page = DocPage(url="https://docs.datarobot.com/x", title="T", text="short text")
+
+        assert page.as_dict()["description"] == "short text"
+
+
+class TestFailedBuildBackoff:
+    def test_is_stale_backs_off_after_failed_build(self) -> None:
+        """GIVEN an empty index whose last build failed
+        THEN it is not stale during the cooldown and stale again afterwards
+        (regression: a failed build left the index permanently stale, so every
+        search re-ran the sitemap + full content fetch just to return nothing).
+        """
+        index = _DocsIndex()
+        assert index.is_stale  # a first build is always allowed
+
+        index.mark_build_failed()
+        assert not index.is_stale
+
+        index._last_build_failed_at = time.time() - (FAILED_BUILD_RETRY_SECONDS + 1)
+        assert index.is_stale
+
+    async def test_ensure_index_marks_failure_on_empty_build(self) -> None:
+        import datarobot_genai.drtools.core.clients.dr_docs as dr_docs_module
+
+        fresh_index = _DocsIndex()
+        with (
+            patch.object(dr_docs_module, "_index", fresh_index),
+            patch.object(
+                dr_docs_module,
+                "_create_datarobot_agentic_docs_pages",
+                new=AsyncMock(return_value=[]),
+            ) as mock_create,
+        ):
+            await dr_docs_module._ensure_index()
+            await dr_docs_module._ensure_index()
+
+        assert mock_create.await_count == 1

--- a/tests/drmcp/unit/tool_clients/test_jira_client.py
+++ b/tests/drmcp/unit/tool_clients/test_jira_client.py
@@ -245,6 +245,36 @@ class TestJiraClient:
                 mock_get_cloud_id.assert_awaited_once()
                 assert mock_get_cloud_id.call_args.kwargs["auth"] == auth
 
+    @pytest.mark.asyncio
+    async def test_transition_issue_posts_to_transitions_endpoint(
+        self, mock_access_token: str, mock_cloud_id: str
+    ) -> None:
+        """GIVEN an issue key and a transition id
+        WHEN transition_jira_issue is called
+        THEN the payload is POSTed to issue/{key}/transitions
+        (regression: it POSTed to issue/{key}, which the Jira API rejects —
+        the transition never happened).
+        """
+        with patch(
+            "datarobot_genai.drtools.core.clients.jira.get_atlassian_cloud_id",
+            new_callable=AsyncMock,
+            return_value=mock_cloud_id,
+        ):
+            async with JiraClient(mock_access_token) as client:
+                captured: dict = {}
+
+                async def mock_post(url: str, json: dict | None = None) -> httpx.Response:
+                    captured["url"] = url
+                    captured["json"] = json
+                    return make_response(204, None, mock_cloud_id)
+
+                client._client.post = mock_post
+
+                await client.transition_jira_issue("PROJ-123", "31")
+
+        assert captured["url"].endswith("/rest/api/3/issue/PROJ-123/transitions")
+        assert captured["json"] == {"transition": {"id": "31"}}
+
 
 class TestIssueModel:
     def _base_fields(self, **overrides: object) -> dict[str, object]:

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.3"
+version = "0.23.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- jira.py: transition_jira_issue POSTed to issue/{key} — an endpoint Jira rejects — so transitions silently never happened. Now posts to issue/{key}/transitions.

- perplexity/tools.py: query: Annotated[str, list[str], …] made list[str] inert metadata, so the multi-query mode the body fully supports was unreachable through the schema. Now str | list[str]; the regression test generates the real tool schema and asserts both branches.

- training.py: text-column detection removed items from categorical_cols while iterating it, skipping the column right after every detected text column; .str.len() also raised on mixed-dtype object columns. Rewritten as two comprehensions with astype(str).

- dr_docs.py: search results dumped the full page body (tens of KB × up to 10 results) as description; now a ~300-char word-boundary snippet.

- same file: a failed index build left _built_at at 0, so every search re-ran the sitemap + ~30 page fetches serialized behind the lock and still returned "no results". Failed builds now record a timestamp and back off for 5 minutes (exception path included).

- mcp_instance.py: dr_mcp_prompt's default was one shared PromptInitArguments() instance mutated by every decoration; now None → fresh instance per decoration.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes touch external Jira API behavior, MCP prompt registration metadata, and docs index build paths; impact is limited to correcting broken behavior rather than new features.
> 
> **Overview**
> Release **0.23.4** bundles several regression fixes across Jira, Perplexity, predictive profiling, docs search, and MCP prompt registration, with matching unit tests.
> 
> **Jira** — `transition_jira_issue` now POSTs to `issue/{key}/transitions` instead of `issue/{key}`, so workflow transitions actually apply.
> 
> **Perplexity** — `perplexity_search` exposes `query` as `str | list[str]` so multi-query lists pass MCP schema validation again (replacing a broken `Annotated[str, list[str], …]` pattern).
> 
> **Predictive** — Dataset insight text-column detection no longer mutates the categorical list during iteration (which skipped the next column) and uses `astype(str)` so mixed object columns do not raise.
> 
> **DR docs** — Search `description` is a ~300-character word-boundary snippet; failed index builds record a timestamp and **5-minute** backoff so every search does not re-fetch the sitemap.
> 
> **drmcp** — `dr_mcp_prompt` defaults `prompt_init_args` to `None` and allocates a fresh `PromptInitArguments()` per decoration so prompt category/meta cannot leak between prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7e1d9b7e08370a57b120ddc92106c09045e886. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->