### PR TITLE
[MODEL-24055][MODEL-24056] fix files_api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.11
+- `drtools/files_api` (MODEL-24055): `file_manage(action='delete')` no longer reports `{"deleted": true}` when a non-recursive delete targets a non-empty directory — it now raises a validation `ToolError` telling the caller to pass `recursive=True`. Deleting a nonexistent path remains a silent no-op.
+- `drtools/files_api` (MODEL-24056): `file_manage(action='clone')`'s `files_to_omit` now tolerates a JSON-encoded string (some MCP clients serialize array arguments this way) and treats an empty list the same as omitting the argument (the platform rejects an empty list outright).
+
 ## 0.23.10
 - `drmcp`: made log secret-redaction targeted — removed the catch-all that redacted any 20+-char alphanumeric string (ObjectIds, request/trace ids and class names became `[REDACTED]`); now redacts JWTs, `Bearer`/`Basic` authorization values and secret-shaped key assignments (`token=…`, `api_key: …`, `DATAROBOT_API_TOKEN=…`), and broadened OpenAI-key matching to `sk-proj-…` style keys of any length.
 - `drmcputils`: added `log_redaction` (`SECRET_PATTERNS`, `redact_secrets`) as the shared home for the log-redaction patterns so global-mcp and the user-MCP formatter apply the same rules; `drmcp.core.logging.SecretRedactingFormatter` now delegates to it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.23.11
-- `drtools/files_api` (MODEL-24055): `file_manage(action='delete')` no longer reports `{"deleted": true}` when a non-recursive delete targets a non-empty directory — it now raises a validation `ToolError` telling the caller to pass `recursive=True`. Deleting a nonexistent path remains a silent no-op.
-- `drtools/files_api` (MODEL-24056): `file_manage(action='clone')`'s `files_to_omit` now tolerates a JSON-encoded string (some MCP clients serialize array arguments this way) and treats an empty list the same as omitting the argument (the platform rejects an empty list outright).
+- `drtools/files_api` (MODEL-24055): fixed `file_manage(action='delete')` reporting `{"deleted": true}` when a non-recursive delete targeted a non-empty directory — it now raises a validation `ToolError` telling the caller to pass `recursive=True`. Deleting a nonexistent path remains a silent no-op.
+- `drtools/files_api` (MODEL-24056): made `file_manage(action='clone')`'s `files_to_omit` tolerate a JSON-encoded string (some MCP clients serialize array arguments this way) and treat an empty list the same as omitting the argument (the platform rejects an empty list outright).
 
 ## 0.23.10
 - `drmcp`: made log secret-redaction targeted — removed the catch-all that redacted any 20+-char alphanumeric string (ObjectIds, request/trace ids and class names became `[REDACTED]`); now redacts JWTs, `Bearer`/`Basic` authorization values and secret-shaped key assignments (`token=…`, `api_key: …`, `DATAROBOT_API_TOKEN=…`), and broadened OpenAI-key matching to `sk-proj-…` style keys of any length.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.10"
+version = "0.23.11"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/files/file_system_store.py
+++ b/src/datarobot_genai/drmcputils/files/file_system_store.py
@@ -71,6 +71,15 @@ FILE_IMPORT_TERMINAL_FAILURE_PREFIXES = ("error", "abort")
 OverwriteStrategyName = Literal["rename", "replace", "skip", "error"]
 
 
+class DirectoryNotEmptyError(Exception):
+    """Raised by :meth:`FileSystemStore.delete` for a non-recursive delete of a non-empty directory.
+
+    Distinct from the silent no-op for an already-missing path: that case has nothing to
+    signal, while this one represents a real guard rejecting the request, which callers
+    should surface rather than report as a successful deletion.
+    """
+
+
 def normalize_status_location(status_id: str) -> str:
     """Return a relative API route for ``status/<id>/`` from a bare id, route, or URL."""
     cleaned = status_id.strip()
@@ -214,7 +223,11 @@ class FileSystemStore(Protocol):
     async def delete(
         self, path: str, *, recursive: bool = False, maxdepth: int | None = None
     ) -> None:
-        """Delete file(s) or director(ies) at ``path`` (silent if absent)."""
+        """Delete file(s) or director(ies) at ``path`` (silent if absent).
+
+        Raises :class:`DirectoryNotEmptyError` if ``recursive`` is ``False`` and ``path`` is
+        an existing, non-empty directory (nothing is deleted in that case).
+        """
         ...
 
     async def copy(
@@ -398,7 +411,23 @@ class DataRobotFileSystemStore:
     async def delete(
         self, path: str, *, recursive: bool = False, maxdepth: int | None = None
     ) -> None:
-        await self._run(lambda fs: fs.rm(path, recursive=recursive, maxdepth=maxdepth))
+        def _call(fs: Any) -> None:
+            if not recursive:
+                try:
+                    info = fs.info(path)
+                except FileNotFoundError:
+                    info = None
+                if (
+                    info is not None
+                    and info.get("type") == "directory"
+                    and fs.ls(path, detail=False)
+                ):
+                    raise DirectoryNotEmptyError(
+                        f"{path!r} is a non-empty directory; pass recursive=True to delete it."
+                    )
+            fs.rm(path, recursive=recursive, maxdepth=maxdepth)
+
+        await self._run(_call)
 
     async def copy(
         self,

--- a/src/datarobot_genai/drtools/files_api/mutations_tools.py
+++ b/src/datarobot_genai/drtools/files_api/mutations_tools.py
@@ -24,14 +24,19 @@ remote files (by URL or data source), use the import tools instead.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Annotated
 from typing import Any
 from typing import Literal
 
+from pydantic import BeforeValidator
+from pydantic import Field
+
 from datarobot_genai.drmcputils.constants import MAX_INLINE_SIZE
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drmcputils.files.file_system_store import DirectoryNotEmptyError
 from datarobot_genai.drtools.core import tool_metadata
 from datarobot_genai.drtools.files_api.common_utils import FILE_WRITE_MODE_DOC
 from datarobot_genai.drtools.files_api.common_utils import OVERWRITE_STRATEGY_DOC
@@ -44,6 +49,22 @@ from datarobot_genai.drtools.files_api.common_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_json_encoded_list(value: Any) -> Any:
+    """Decode a JSON-encoded array string back into a list.
+
+    Some MCP clients/bridges serialize array arguments to a JSON string
+    (e.g. ``'["a.txt"]'``) instead of sending a native array, even though the
+    advertised schema declares an array type. Malformed strings are passed
+    through unchanged so the normal list-type validation error still fires.
+    """
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
 
 
 # ------------------------------------------------------------------ #
@@ -197,7 +218,8 @@ async def file_upload(
         "  'create_dir' — create a new empty catalog item directory; returns its "
         "dr://<catalog_id>/ path. (path/target_path ignored.)\n"
         "  'delete'     — delete file(s)/director(ies) at path. Set recursive=True to "
-        "remove a non-empty directory. Silent if the path does not exist.\n"
+        "remove a non-empty directory (otherwise fails with a validation error). Silent if "
+        "the path does not exist.\n"
         "  'copy'       — copy path to target_path. Set recursive=True for directories.\n"
         "  'move'       — move/rename path to target_path. Set recursive=True for directories.\n"
         "  'clone'      — clone a whole catalog item directory (path) to a new catalog "
@@ -237,7 +259,8 @@ async def file_manage(
     ] = None,
     files_to_omit: Annotated[
         list[str] | None,
-        "For 'clone', catalog-relative paths to exclude from the clone.",
+        BeforeValidator(_coerce_json_encoded_list),
+        Field(description="For 'clone', catalog-relative paths to exclude from the clone."),
     ] = None,
     overwrite: Annotated[
         Literal["rename", "replace", "skip", "error"],
@@ -262,12 +285,20 @@ async def file_manage(
 
     if action == "delete":
         cleaned = _require_file_path(path)
-        await store.delete(cleaned, recursive=recursive, maxdepth=maxdepth)
+        try:
+            await store.delete(cleaned, recursive=recursive, maxdepth=maxdepth)
+        except DirectoryNotEmptyError as exc:
+            raise ToolError(
+                f"{cleaned!r} is a non-empty directory; set recursive=True to delete it.",
+                kind=ToolErrorKind.VALIDATION,
+            ) from exc
         return {"deleted": True, "path": cleaned}
 
     if action == "clone":
         cleaned = _require_file_path(path)
-        catalog_id = await store.clone(cleaned, files_to_omit=files_to_omit)
+        # An empty list is rejected by the platform (it requires a non-empty list or
+        # None); normalize so an empty omit list behaves like omitting the argument.
+        catalog_id = await store.clone(cleaned, files_to_omit=files_to_omit or None)
         return {
             "cloned": True,
             "source": cleaned,

--- a/tests/drmcp/integration/test_files_api_tools.py
+++ b/tests/drmcp/integration/test_files_api_tools.py
@@ -241,6 +241,21 @@ class TestMCPFilesApiMutationsIntegration:
             assert data["catalog_id"]
             assert data["path"] == f"dr://{data['catalog_id']}/"
 
+    async def test_file_manage_delete_non_empty_dir_without_recursive_rejected(self) -> None:
+        """Regression for MODEL-24055: a rejected delete must not report success."""
+        async with integration_test_mcp_session(
+            server_params=_files_api_server_params()
+        ) as session:
+            data_dir = f"dr://{STUB_CATALOG_ID}/data/"
+            result = await session.call_tool("file_manage", {"action": "delete", "path": data_dir})
+            error_text = _parse_error(result)
+            assert "recursive" in error_text.lower()
+
+            # Nothing was actually deleted.
+            listing = _parse_result(await session.call_tool("file_list", {"path": data_dir}))
+            file_names = {e["name"].split("/")[-1] for e in listing["entries"]}
+            assert "employees.csv" in file_names
+
     async def test_file_manage_copy(self) -> None:
         async with integration_test_mcp_session(
             server_params=_files_api_server_params()
@@ -287,6 +302,35 @@ class TestMCPFilesApiMutationsIntegration:
             clone_path = f"dr://{data['catalog_id']}/notes.txt"
             read_data = _parse_result(await session.call_tool("file_read", {"path": clone_path}))
             assert "hello world" in read_data["content"]
+
+    async def test_file_manage_clone_with_files_to_omit(self) -> None:
+        """Regression for MODEL-24056: files_to_omit must accept a real list argument."""
+        async with integration_test_mcp_session(
+            server_params=_files_api_server_params()
+        ) as session:
+            tools = await session.list_tools()
+            file_manage_tool = next(t for t in tools.tools if t.name == "file_manage")
+            files_to_omit_schema = file_manage_tool.inputSchema["properties"]["files_to_omit"]
+            variants = files_to_omit_schema.get("anyOf", [files_to_omit_schema])
+            assert any(v.get("type") == "array" for v in variants)
+
+            data = _parse_result(
+                await session.call_tool(
+                    "file_manage",
+                    {
+                        "action": "clone",
+                        "path": f"dr://{STUB_CATALOG_ID}/",
+                        "files_to_omit": ["notes.txt"],
+                    },
+                )
+            )
+            assert data["cloned"] is True
+            omitted_path = f"dr://{data['catalog_id']}/notes.txt"
+            kept_path = f"dr://{data['catalog_id']}/data/employees.csv"
+            omitted_result = await session.call_tool("file_read", {"path": omitted_path})
+            assert getattr(omitted_result, "isError", False)
+            kept_data = _parse_result(await session.call_tool("file_read", {"path": kept_path}))
+            assert "Alice" in kept_data["content"]
 
     async def test_file_upload_from_local(self, tmp_path: Path) -> None:
         local_file = tmp_path / "upload.txt"

--- a/tests/drmcp/unit/files_api_tools/test_file_system_store.py
+++ b/tests/drmcp/unit/files_api_tools/test_file_system_store.py
@@ -33,6 +33,7 @@ from datarobot.errors import ClientError
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 from datarobot_genai.drmcputils.files.file_system_store import DataRobotFileSystemStore
+from datarobot_genai.drmcputils.files.file_system_store import DirectoryNotEmptyError
 from datarobot_genai.drmcputils.files.file_system_store import FileEntry
 from datarobot_genai.drmcputils.files.file_system_store import FileSystemStore
 from datarobot_genai.drmcputils.files.file_system_store import extract_status_id
@@ -324,6 +325,43 @@ async def test_delete_copy_move_delegate() -> None:
         None,
         FilesOverwriteStrategy.SKIP,
     )
+
+
+async def test_delete_non_recursive_non_empty_directory_raises() -> None:
+    store, fs = _store_and_fs(
+        info={"name": "abc/dir", "type": "directory", "size": 0},
+        ls=[{"name": "abc/dir/x.txt", "type": "file", "size": 1}],
+    )
+    with pytest.raises(DirectoryNotEmptyError):
+        await store.delete("dr://abc/dir")
+    assert not hasattr(fs, "recorded")
+
+
+async def test_delete_non_recursive_empty_directory_proceeds() -> None:
+    store, fs = _store_and_fs(info={"name": "abc/", "type": "directory", "size": 0}, ls=[])
+    await store.delete("dr://abc/")
+    assert fs.recorded == ("rm", "dr://abc/", False, None)
+
+
+async def test_delete_non_recursive_file_proceeds() -> None:
+    store, fs = _store_and_fs(info={"name": "abc/x.txt", "type": "file", "size": 5})
+    await store.delete("dr://abc/x.txt")
+    assert fs.recorded == ("rm", "dr://abc/x.txt", False, None)
+
+
+async def test_delete_non_recursive_missing_path_is_silent_noop() -> None:
+    store, fs = _store_and_fs(info=FileNotFoundError("nope"))
+    await store.delete("dr://abc/missing")
+    assert fs.recorded == ("rm", "dr://abc/missing", False, None)
+
+
+async def test_delete_recursive_skips_non_empty_directory_check() -> None:
+    store, fs = _store_and_fs(
+        info={"name": "abc/dir", "type": "directory", "size": 0},
+        ls=[{"name": "abc/dir/x.txt", "type": "file", "size": 1}],
+    )
+    await store.delete("dr://abc/dir", recursive=True)
+    assert fs.recorded == ("rm", "dr://abc/dir", True, None)
 
 
 async def test_clone_returns_new_catalog_id() -> None:

--- a/tests/drmcp/unit/files_api_tools/test_mutations.py
+++ b/tests/drmcp/unit/files_api_tools/test_mutations.py
@@ -24,6 +24,8 @@ import pytest
 
 from datarobot_genai.drmcputils.constants import MAX_INLINE_SIZE
 from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drmcputils.files.file_system_store import DirectoryNotEmptyError
 from datarobot_genai.drtools.files_api import common_utils
 from datarobot_genai.drtools.files_api import mutations_tools as mut_mod
 
@@ -31,8 +33,11 @@ from datarobot_genai.drtools.files_api import mutations_tools as mut_mod
 class FakeStore:
     """Async FileSystemStore double recording calls; create_dir/clone return scripted ids."""
 
-    def __init__(self, *, new_catalog_id: str = "newcat") -> None:
+    def __init__(
+        self, *, new_catalog_id: str = "newcat", delete_error: Exception | None = None
+    ) -> None:
         self._new_catalog_id = new_catalog_id
+        self._delete_error = delete_error
         self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
 
     def _record(self, name: str, *args: Any, **kwargs: Any) -> None:
@@ -60,6 +65,8 @@ class FakeStore:
 
     async def delete(self, path: str, *, recursive: bool = False, maxdepth: Any = None) -> None:
         self._record("delete", path, recursive=recursive, maxdepth=maxdepth)
+        if self._delete_error is not None:
+            raise self._delete_error
 
     async def copy(
         self,
@@ -281,6 +288,33 @@ async def test_file_manage_delete_recursive(monkeypatch: pytest.MonkeyPatch) -> 
     assert store.calls[0] == ("delete", ("dr://abc/old/",), {"recursive": True, "maxdepth": 2})
 
 
+async def test_file_manage_delete_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _use_store(monkeypatch, FakeStore())
+    result = await mut_mod.file_manage(action="delete", path="dr://abc/a.txt")
+    assert result == {"deleted": True, "path": "dr://abc/a.txt"}
+    assert store.calls[0] == ("delete", ("dr://abc/a.txt",), {"recursive": False, "maxdepth": None})
+
+
+async def test_file_manage_delete_nonexistent_path_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _use_store(monkeypatch, FakeStore())
+    result = await mut_mod.file_manage(action="delete", path="dr://abc/missing")
+    assert result == {"deleted": True, "path": "dr://abc/missing"}
+    assert store.calls[0][0] == "delete"
+
+
+async def test_file_manage_delete_non_empty_dir_without_recursive_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_store(
+        monkeypatch, FakeStore(delete_error=DirectoryNotEmptyError("dr://abc/dir is non-empty"))
+    )
+    with pytest.raises(ToolError, match="recursive=True") as exc:
+        await mut_mod.file_manage(action="delete", path="dr://abc/dir")
+    assert exc.value.kind == ToolErrorKind.VALIDATION
+
+
 async def test_file_manage_copy(monkeypatch: pytest.MonkeyPatch) -> None:
     store = _use_store(monkeypatch, FakeStore())
     result = await mut_mod.file_manage(
@@ -332,6 +366,56 @@ async def test_file_manage_clone(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["catalog_id"] == "clone99"
     assert result["path"] == "dr://clone99/"
     assert store.calls[0] == ("clone", ("dr://abc/",), {"files_to_omit": ["secret.txt"]})
+
+
+async def test_file_manage_clone_empty_files_to_omit_normalizes_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The platform rejects an empty list; an empty omit should behave like omitting it."""
+    store = _use_store(monkeypatch, FakeStore(new_catalog_id="clone99"))
+    result = await mut_mod.file_manage(action="clone", path="dr://abc/", files_to_omit=[])
+    assert result["cloned"] is True
+    assert store.calls[0] == ("clone", ("dr://abc/",), {"files_to_omit": None})
+
+
+async def test_file_manage_clone_files_to_omit_accepts_json_encoded_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for MODEL-24056: some MCP clients send array args as a JSON string."""
+    from fastmcp.tools import Tool
+
+    store = _use_store(monkeypatch, FakeStore(new_catalog_id="clone99"))
+    tool = Tool.from_function(fn=mut_mod.file_manage)
+    result = await tool.run(
+        {"action": "clone", "path": "dr://abc/", "files_to_omit": '["secret.txt"]'}
+    )
+    assert result.structured_content["cloned"] is True
+    assert store.calls[0] == ("clone", ("dr://abc/",), {"files_to_omit": ["secret.txt"]})
+
+
+async def test_file_manage_clone_files_to_omit_json_encoded_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact Claude Desktop repro: files_to_omit sent as the JSON string '[]'."""
+    from fastmcp.tools import Tool
+
+    store = _use_store(monkeypatch, FakeStore(new_catalog_id="clone99"))
+    tool = Tool.from_function(fn=mut_mod.file_manage)
+    result = await tool.run({"action": "clone", "path": "dr://abc/", "files_to_omit": "[]"})
+    assert result.structured_content["cloned"] is True
+    assert store.calls[0] == ("clone", ("dr://abc/",), {"files_to_omit": None})
+
+
+async def test_file_manage_clone_files_to_omit_still_rejects_garbage_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastmcp.tools import Tool
+    from pydantic import ValidationError
+
+    _use_store(monkeypatch, FakeStore())
+    tool = Tool.from_function(fn=mut_mod.file_manage)
+    with pytest.raises(ValidationError):
+        await tool.run({"action": "clone", "path": "dr://abc/", "files_to_omit": "not json"})
 
 
 async def test_file_manage_copy_requires_target(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.10"
+version = "0.23.11"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -2817,17 +2817,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -2843,16 +2843,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -4040,10 +4040,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", extra = ["ws"], marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp", extra = ["ws"] },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -4059,10 +4059,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", extra = ["ws"], marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp", extra = ["ws"] },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [


### PR DESCRIPTION
file_manage(action="delete") silently reported {"deleted": true} when a non-recursive delete targeted a non-empty directory; it now raises a validation ToolError telling the caller to pass recursive=True.

Also MODEL-24056: file_manage(action="clone")'s files_to_omit now tolerates a JSON-encoded string (some MCP clients serialize array args this way) and treats an empty list the same as omitting the argument.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped changes to Files API delete/clone validation with regression tests; no auth or broad API behavior shifts beyond clearer errors for agents.
> 
> **Overview**
> Release **0.23.11** tightens `file_manage` behavior for delete and clone in the Files API MCP tools.
> 
> **Delete (MODEL-24055):** Before a non-recursive `rm`, the store now checks whether the path is a non-empty directory and raises `DirectoryNotEmptyError` without deleting anything. `file_manage(action='delete')` maps that to a validation `ToolError` that tells callers to set `recursive=True`, instead of returning `{"deleted": true}`. Missing paths still delete as a silent no-op.
> 
> **Clone (MODEL-24056):** `files_to_omit` accepts JSON-encoded array strings via a Pydantic `BeforeValidator`, and `[]` is normalized to `None` so the platform is not sent an empty list it rejects.
> 
> Tool descriptions and changelog are updated; unit and integration tests cover both regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33eac4008efd5f2e7218fded8678c63f229f9ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->