### PR TITLE
[MODEL-24077] fix(workload): use dict params in list_workload_logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.15
+- `drtools/core/clients` (MODEL-24077): fixed `WorkloadApiClient.list_workload_logs()` (used by the `workload_logs_get` tool) raising `AssertionError: Wrong type` on every call — it built its request `params` as a `list[tuple[str, Any]]` instead of the `dict[str, Any]` the DataRobot SDK's REST client requires; `includes`/`excludes` still encode as repeated query keys since `requests` accepts list-valued dict entries.
+
 ## 0.23.14
 - `e2e-tests`: acceptance E2E tests for the DataRobot Memory Service through DRAgent.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.14"
+version = "0.23.15"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_workload.py
@@ -214,23 +214,19 @@ class WorkloadApiClient:
         trace_id: str | None = None,
     ) -> dict[str, Any]:
         """GET /otel/workload/{id}/logs/ — OTel log lines for a workload."""
-        params: list[tuple[str, Any]] = [
-            ("limit", limit),
-            ("offset", offset),
-            ("level", level),
-        ]
+        params: dict[str, Any] = {"limit": limit, "offset": offset, "level": level}
         if start_time:
-            params.append(("startTime", start_time))
+            params["startTime"] = start_time
         if end_time:
-            params.append(("endTime", end_time))
-        for v in includes or []:
-            params.append(("includes", v))
-        for v in excludes or []:
-            params.append(("excludes", v))
+            params["endTime"] = end_time
+        if includes:
+            params["includes"] = includes
+        if excludes:
+            params["excludes"] = excludes
         if span_id:
-            params.append(("spanId", span_id))
+            params["spanId"] = span_id
         if trace_id:
-            params.append(("traceId", trace_id))
+            params["traceId"] = trace_id
         with request_user_dr_client() as client:
             return client.get(f"otel/workload/{workload_id}/logs/", params=params).json()
 

--- a/tests/drmcp/unit/workload_tools/test_tools.py
+++ b/tests/drmcp/unit/workload_tools/test_tools.py
@@ -18,6 +18,7 @@ Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
 """
 
 from collections.abc import Iterator
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -753,7 +754,7 @@ async def test_workload_logs_success(patched_dr_client: MagicMock) -> None:
 
     patched_dr_client.get.assert_called_once_with(
         "otel/workload/wkld-abc/logs/",
-        params=[("limit", 100), ("offset", 0), ("level", "debug")],
+        params={"limit": 100, "offset": 0, "level": "debug"},
     )
     assert result["logs"][0]["body"] == "Server started"
 
@@ -775,19 +776,54 @@ async def test_workload_logs_with_filters(patched_dr_client: MagicMock) -> None:
 
     patched_dr_client.get.assert_called_once_with(
         "otel/workload/wkld-abc/logs/",
-        params=[
-            ("limit", 100),
-            ("offset", 0),
-            ("level", "error"),
-            ("startTime", "2026-01-01T00:00:00Z"),
-            ("endTime", "2026-01-02T00:00:00Z"),
-            ("includes", "ERROR"),
-            ("includes", "FATAL"),
-            ("excludes", "healthcheck"),
-            ("spanId", "span-1"),
-            ("traceId", "trace-1"),
-        ],
+        params={
+            "limit": 100,
+            "offset": 0,
+            "level": "error",
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-02T00:00:00Z",
+            "includes": ["ERROR", "FATAL"],
+            "excludes": ["healthcheck"],
+            "spanId": "span-1",
+            "traceId": "trace-1",
+        },
     )
+
+
+@pytest.mark.asyncio
+async def test_workload_logs_params_pass_sdk_to_api_validation() -> None:
+    """Regression: the DataRobot SDK's REST client runs every ``params``
+    through ``to_api()``, which asserts ``isinstance(data, dict)`` and raises
+    ``AssertionError: Wrong type`` otherwise. list_workload_logs used to build params as a
+    list[tuple[str, Any]], which fails that assertion unconditionally. patched_dr_client
+    mocks client.get() directly and would not have caught this, since it never calls the
+    real to_api(); this test runs params through the real SDK function instead.
+    """
+    from datarobot.utils import to_api
+
+    captured: dict[str, Any] = {}
+
+    class _ToApiValidatingClient:
+        def get(self, url: str, params: Any = None, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            captured["params"] = to_api(params)
+            return MagicMock(json=lambda: {"data": [], "count": 0})
+
+    with patch(
+        "datarobot_genai.drtools.core.clients.datarobot_workload.request_user_dr_client"
+    ) as mock_cm:
+        mock_cm.return_value.__enter__.return_value = _ToApiValidatingClient()
+        mock_cm.return_value.__exit__.return_value = False
+
+        await workload_observability.workload_logs_get(
+            workload_id="wkld-abc",
+            includes=["ERROR", "FATAL"],
+            excludes=["healthcheck"],
+        )
+
+    assert captured["url"] == "otel/workload/wkld-abc/logs/"
+    assert captured["params"]["includes"] == ["ERROR", "FATAL"]
+    assert captured["params"]["excludes"] == ["healthcheck"]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ fs = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.14"
+version = "0.23.15"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
WorkloadApiClient.list_workload_logs() built its request params as a list[tuple[str, Any]], the only method in the client to do so. The DataRobot SDK's REST client runs all params through to_api(), which asserts isinstance(data, dict) and raises AssertionError: Wrong type otherwise — causing workload_logs_get to fail on every call.

Switched to a dict[str, Any], matching every other method. includes/ excludes still encode as repeated query keys since requests accepts list-valued dict entries.

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method client bugfix aligned with existing patterns; no auth or API contract changes beyond restoring a broken tool.
> 
> **Overview**
> **Fixes `workload_logs_get`** by changing `WorkloadApiClient.list_workload_logs()` to pass query parameters as a `dict[str, Any]` instead of a `list[tuple[str, Any]]`. The DataRobot SDK REST client normalizes `params` with `to_api()`, which requires a dict; the list form triggered `AssertionError: Wrong type` on every OTel logs request.
> 
> Optional filters (`startTime`/`endTime`, `includes`/`excludes`, `spanId`/`traceId`) are unchanged in behavior: list-valued `includes`/`excludes` still become repeated query keys via `requests`. Release **0.23.12** (`pyproject.toml`, `uv.lock`, `CHANGELOG.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1097edf8c4dfc2a9291ce21fbd414d07bc92a3ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->