### PR TITLE
[BUZZOK-31578] Add configurable gunicorn worker timeout to DRagent front end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.24
+- `dragent`: Raised the gunicorn worker timeout default to 600s, overridable via `AGENT_GUNICORN_WORKER_TIMEOUT`.
+
 ## 0.23.23
 - `crewai`: strip the per-tool `strict` flag on native tool calls.
 

--- a/docs/src/dragent/README.md
+++ b/docs/src/dragent/README.md
@@ -25,6 +25,7 @@ Key options:
 | `--config_file` | Path to the workflow YAML config. Falls back to `DRAGENT_CONFIG_FILE` env var. |
 | `--port` | Port to bind the server to. Falls back to `AGENT_PORT` env var. |
 | `--reload` | Enable auto-reload for development (`true`/`false`). |
+| `--use_gunicorn` | Serve under gunicorn (used in DataRobot deployments). Worker timeout defaults to 600s; override with the `AGENT_GUNICORN_WORKER_TIMEOUT` env var / runtime parameter. |
 | `--a2a` | Expose the agent via the Agent2Agent protocol (endpoints mounted under `/a2a/`). |
 | `--override` | Override config values using dot notation (e.g., `--override llms.nim_llm.temperature 0.7`). |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.23"
+version = "0.23.24"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -20,6 +20,7 @@ from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventQueue
 from a2a.types import InvalidParamsError
 from a2a.utils.errors import ServerError
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from fastapi import FastAPI
 from nat.data_models.user_info import UserInfo
 from nat.front_ends.fastapi.fastapi_front_end_plugin import FastApiFrontEndPlugin
@@ -288,6 +289,47 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             logger.info(f"Added health check endpoint at {path}")
 
 
+class _GunicornSettings(DataRobotAppFrameworkBaseSettings):
+    """Gunicorn worker settings for the dragent front end.
+
+    Controllable via prefix-free environment variables (including Runtime Parameters),
+    following the standard :class:`DataRobotAppFrameworkBaseSettings` resolution chain.
+    """
+
+    agent_gunicorn_worker_timeout: int = Field(
+        default=600,
+        gt=0,
+        description=(
+            "Gunicorn worker (and graceful) timeout in seconds for the dragent front end, "
+            "raised above gunicorn's 30s default so long agent turns aren't killed "
+            "mid-stream. Default: 600."
+        ),
+    )
+
+
+def _patch_gunicorn_worker_timeout() -> None:
+    """Raise gunicorn's 30s default worker timeout for the dragent front end.
+
+    ``nat dragent serve --use_gunicorn true`` builds gunicorn's app with a hardcoded
+    options dict (``bind``/``workers``/``worker_class`` only) and ignores
+    ``GUNICORN_CMD_ARGS``/``gunicorn.conf.py``/CLI flags, so there is no supported way to
+    raise the timeout. Agent turns make several sequential LLM calls and routinely exceed
+    30s, so the worker is SIGABRT'd mid-stream and the caller gets a silent empty response.
+    Patching the ``Setting`` class defaults before gunicorn's ``Config()`` is built changes
+    the effective timeout. Override via ``AGENT_GUNICORN_WORKER_TIMEOUT`` (seconds).
+    """
+    try:
+        import gunicorn.config as gunicorn_config
+    except ImportError:
+        # gunicorn isn't used in this mode (local dev / uvicorn) — nothing to patch.
+        return
+
+    timeout_seconds = _GunicornSettings().agent_gunicorn_worker_timeout
+    gunicorn_config.Timeout.default = timeout_seconds
+    gunicorn_config.GracefulTimeout.default = timeout_seconds
+    logger.info("Raised gunicorn worker/graceful timeout defaults to %ss", timeout_seconds)
+
+
 class DRAgentFastApiFrontEndPlugin(FastApiFrontEndPlugin):
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
@@ -302,6 +344,8 @@ class DRAgentFastApiFrontEndPlugin(FastApiFrontEndPlugin):
         from datarobot_genai.dragent.workflow_paths import publish_dragent_config_file_env
 
         publish_dragent_config_file_env()
+        if self.front_end_config.use_gunicorn:
+            _patch_gunicorn_worker_timeout()
         await super().run()
 
     def get_worker_class(self) -> type[FastApiFrontEndPluginWorker]:

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -290,38 +290,25 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
 
 class _GunicornSettings(DataRobotAppFrameworkBaseSettings):
-    """Gunicorn worker settings for the dragent front end.
-
-    Controllable via prefix-free environment variables (including Runtime Parameters),
-    following the standard :class:`DataRobotAppFrameworkBaseSettings` resolution chain.
-    """
+    """Gunicorn worker settings for the dragent front end (prefix-free env / Runtime Parameters)."""
 
     agent_gunicorn_worker_timeout: int = Field(
         default=600,
         gt=0,
-        description=(
-            "Gunicorn worker (and graceful) timeout in seconds for the dragent front end, "
-            "raised above gunicorn's 30s default so long agent turns aren't killed "
-            "mid-stream. Default: 600."
-        ),
+        description="Gunicorn worker/graceful timeout (seconds) for the dragent front end.",
     )
 
 
 def _patch_gunicorn_worker_timeout() -> None:
-    """Raise gunicorn's 30s default worker timeout for the dragent front end.
+    """Raise gunicorn's 30s default worker timeout so long agent turns aren't SIGABRT'd mid-stream.
 
-    ``nat dragent serve --use_gunicorn true`` builds gunicorn's app with a hardcoded
-    options dict (``bind``/``workers``/``worker_class`` only) and ignores
-    ``GUNICORN_CMD_ARGS``/``gunicorn.conf.py``/CLI flags, so there is no supported way to
-    raise the timeout. Agent turns make several sequential LLM calls and routinely exceed
-    30s, so the worker is SIGABRT'd mid-stream and the caller gets a silent empty response.
-    Patching the ``Setting`` class defaults before gunicorn's ``Config()`` is built changes
-    the effective timeout. Override via ``AGENT_GUNICORN_WORKER_TIMEOUT`` (seconds).
+    ``nat dragent serve`` ignores gunicorn's timeout config, so patch the ``Setting`` class
+    defaults before ``Config()`` is built. Override via ``AGENT_GUNICORN_WORKER_TIMEOUT``.
     """
     try:
         import gunicorn.config as gunicorn_config
     except ImportError:
-        # gunicorn isn't used in this mode (local dev / uvicorn) — nothing to patch.
+        # gunicorn not used in this mode (local dev / uvicorn).
         return
 
     timeout_seconds = _GunicornSettings().agent_gunicorn_worker_timeout

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import os
+import sys
+import types
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -30,6 +32,7 @@ from nat.data_models.config import GeneralConfig
 from nat.data_models.user_info import UserInfo
 from nat.front_ends.fastapi.fastapi_front_end_config import FastApiFrontEndConfig
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
+from pydantic import ValidationError
 
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_EXTENSION_DESCRIPTION
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_FLOW_REF
@@ -45,6 +48,8 @@ from datarobot_genai.dragent.frontends.a2a import get_a2a_endpoint_url
 from datarobot_genai.dragent.frontends.fastapi import DATAROBOT_EXPECTED_HEALTH_ROUTES
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPlugin
 from datarobot_genai.dragent.frontends.fastapi import DRAgentFastApiFrontEndPluginWorker
+from datarobot_genai.dragent.frontends.fastapi import _GunicornSettings
+from datarobot_genai.dragent.frontends.fastapi import _patch_gunicorn_worker_timeout
 from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
 from datarobot_genai.dragent.frontends.fastapi import _resolve_identity_from_headers
 from datarobot_genai.dragent.frontends.register import DRAgentA2AConfig
@@ -1050,3 +1055,111 @@ class TestDRAgentFastApiFrontEndPlugin:
             patch("uvicorn.Server.serve", fake_serve),
         ):
             await plugin.run()
+
+
+class TestGunicornSettings:
+    _ENV = "AGENT_GUNICORN_WORKER_TIMEOUT"
+    _RUNTIME_PARAM_ENV = "MLOPS_RUNTIME_PARAM_AGENT_GUNICORN_WORKER_TIMEOUT"
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        monkeypatch.delenv(self._ENV, raising=False)
+        monkeypatch.delenv(self._RUNTIME_PARAM_ENV, raising=False)
+
+    def test_default(self):
+        assert _GunicornSettings().agent_gunicorn_worker_timeout == 600
+
+    def test_plain_env_override(self, monkeypatch):
+        monkeypatch.setenv(self._ENV, "300")
+        assert _GunicornSettings().agent_gunicorn_worker_timeout == 300
+
+    def test_numeric_runtime_param_float_payload(self, monkeypatch):
+        """A DataRobot numeric runtime param delivers a float payload; it coerces to int."""
+        monkeypatch.setenv(self._RUNTIME_PARAM_ENV, '{"type": "numeric", "payload": 300.0}')
+        assert _GunicornSettings().agent_gunicorn_worker_timeout == 300
+
+    def test_invalid_value_raises(self, monkeypatch):
+        monkeypatch.setenv(self._ENV, "not-a-number")
+        with pytest.raises(ValidationError):
+            _GunicornSettings()
+
+    def test_non_positive_raises(self, monkeypatch):
+        monkeypatch.setenv(self._ENV, "0")
+        with pytest.raises(ValidationError):
+            _GunicornSettings()
+
+
+class TestPatchGunicornWorkerTimeout:
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        monkeypatch.delenv("AGENT_GUNICORN_WORKER_TIMEOUT", raising=False)
+        monkeypatch.delenv("MLOPS_RUNTIME_PARAM_AGENT_GUNICORN_WORKER_TIMEOUT", raising=False)
+
+    @pytest.fixture
+    def fake_gunicorn(self, monkeypatch):
+        """Install a stand-in ``gunicorn.config`` (gunicorn is not a genai dependency)."""
+
+        class Timeout:
+            default = 30
+
+        class GracefulTimeout:
+            default = 30
+
+        config_mod = types.ModuleType("gunicorn.config")
+        config_mod.Timeout = Timeout
+        config_mod.GracefulTimeout = GracefulTimeout
+        pkg = types.ModuleType("gunicorn")
+        pkg.config = config_mod
+        monkeypatch.setitem(sys.modules, "gunicorn", pkg)
+        monkeypatch.setitem(sys.modules, "gunicorn.config", config_mod)
+        return config_mod
+
+    def test_applies_default(self, fake_gunicorn):
+        _patch_gunicorn_worker_timeout()
+        assert fake_gunicorn.Timeout.default == 600
+        assert fake_gunicorn.GracefulTimeout.default == 600
+
+    def test_applies_override(self, fake_gunicorn, monkeypatch):
+        monkeypatch.setenv("AGENT_GUNICORN_WORKER_TIMEOUT", "300")
+        _patch_gunicorn_worker_timeout()
+        assert fake_gunicorn.Timeout.default == 300
+        assert fake_gunicorn.GracefulTimeout.default == 300
+
+    def test_noop_when_gunicorn_not_installed(self, monkeypatch):
+        """The real genai env has no gunicorn; the helper must no-op, not raise."""
+        monkeypatch.setitem(sys.modules, "gunicorn", None)  # forces ImportError
+        _patch_gunicorn_worker_timeout()  # must not raise
+
+
+class TestRunGunicornTimeoutGating:
+    _SUPER_RUN = "nat.front_ends.fastapi.fastapi_front_end_plugin.FastApiFrontEndPlugin.run"
+    _PATCH_FN = "datarobot_genai.dragent.frontends.fastapi._patch_gunicorn_worker_timeout"
+    _PUBLISH = "datarobot_genai.dragent.workflow_paths.publish_dragent_config_file_env"
+
+    @pytest.mark.asyncio
+    async def test_run_patches_timeout_when_use_gunicorn(self):
+        config = Config(
+            general=GeneralConfig(front_end=DRAgentFastApiFrontEndConfig(use_gunicorn=True))
+        )
+        plugin = DRAgentFastApiFrontEndPlugin(full_config=config)
+        with (
+            patch(self._PUBLISH),
+            patch(self._PATCH_FN) as mock_patch,
+            patch(self._SUPER_RUN, new_callable=AsyncMock),
+        ):
+            await plugin.run()
+        mock_patch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_skips_patch_without_use_gunicorn(self):
+        config = Config(
+            general=GeneralConfig(front_end=DRAgentFastApiFrontEndConfig(use_gunicorn=False))
+        )
+        plugin = DRAgentFastApiFrontEndPlugin(full_config=config)
+        with (
+            patch(self._PUBLISH),
+            patch(self._PATCH_FN) as mock_patch,
+            patch(self._SUPER_RUN, new_callable=AsyncMock),
+        ):
+            await plugin.run()
+        mock_patch.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.23"
+version = "0.23.24"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

Deployed DRAgent agents served via `nat dragent serve --use_gunicorn true` were returning silent empty responses. NAT builds gunicorn with a hardcoded options dict (`bind`/`workers`/`worker_class` only) and its `StandaloneApplication.load_config()` ignores `GUNICORN_CMD_ARGS`, `gunicorn.conf.py`, and CLI flags, so the worker runs at gunicorn's 30s default timeout. Agent turns make several sequential LLM calls and routinely exceed 30s, so the worker is `SIGABRT`'d mid-stream and the caller gets an empty response with no error. This lands the fix in `datarobot-genai` (which owns the DRAgent front end) so every DRAgent app benefits, replacing the app-level workaround in recipe-talk-to-my-docs#[442](https://github.com/datarobot/recipe-talk-to-my-docs/pull/442).

## CHANGES

- Added `_GunicornSettings` (`DataRobotAppFrameworkBaseSettings`) with `agent_gunicorn_worker_timeout` — default 600s, override via `AGENT_GUNICORN_WORKER_TIMEOUT` (env var / numeric runtime parameter).
- Added `_patch_gunicorn_worker_timeout()`, which raises gunicorn's `Timeout`/`GracefulTimeout` class defaults before `Config()` is built; called from `DRAgentFastApiFrontEndPlugin.run()` only when `use_gunicorn` is set. No-ops when gunicorn isn't installed (local dev / uvicorn).
- Added unit tests: settings resolution (default, env override, numeric runtime-param payload, invalid/non-positive → `ValidationError`), patch application, and `run()` gating on `use_gunicorn`.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require integration/acceptance tests (N/A — no new drtools tools)

## RELATED
- Bug: APP-6577
- Replaces app-level workaround: datarobot/recipe-talk-to-my-docs#442

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production HTTP serving (gunicorn worker lifecycle) via a global patch to gunicorn config defaults; misconfiguration could leave workers running too long or still timing out, though defaults are conservative and gated on `use_gunicorn`.
> 
> **Overview**
> Fixes **silent empty responses** when DRAgent is served with `nat dragent serve --use_gunicorn true`: NAT only passes bind/workers/worker_class into gunicorn, so workers still used the **30s** default and were killed during multi-LLM turns.
> 
> **`DRAgentFastApiFrontEndPlugin.run()`** now calls **`_patch_gunicorn_worker_timeout()`** when `use_gunicorn` is enabled, raising gunicorn **`Timeout`** and **`GracefulTimeout`** class defaults before `Config()` is built (no-op if gunicorn is not installed). Timeout comes from **`_GunicornSettings`** (`DataRobotAppFrameworkBaseSettings`): default **600s**, overridable via **`AGENT_GUNICORN_WORKER_TIMEOUT`** (env or DataRobot numeric runtime param).
> 
> Release **0.23.19** with changelog; unit tests cover settings resolution, patch behavior, and gunicorn-only gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe116dc0f6ad937b287f5672822b9805901d9773. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->