### PR TITLE
[-] CrewAI: strip per-tool strict flag on native tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.23.23
+- `crewai`: strip crewai's hardcoded per-tool `strict: True` before native tool calls. Bedrock (via the gateway) caps strict tools at 20, so crews with 21+ tools failed with "Too many strict tools". This brings crewai in line with the langgraph/llamaindex adapters, which never mark tools strict.
+
 ## 0.23.22
 - Fix streaming interruption with response guards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.23.23
-- `crewai`: strip crewai's hardcoded per-tool `strict: True` before native tool calls. Bedrock (via the gateway) caps strict tools at 20, so crews with 21+ tools failed with "Too many strict tools". This brings crewai in line with the langgraph/llamaindex adapters, which never mark tools strict.
+- `crewai`: strip the per-tool `strict` flag on native tool calls.
 
 ## 0.23.22
 - Fix streaming interruption with response guards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.23.22"
+version = "0.23.23"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -70,6 +70,18 @@ def _sanitize_tool_schema(node: Any) -> Any:
     return node
 
 
+def _strip_strict_flags(tools: list[Any]) -> list[Any]:
+    """Drop crewai's per-tool ``strict: True`` (bedrock caps strict tools at 20).
+
+    Strips the function-level flag only, never a tool *parameter* named ``strict``.
+    """
+    for tool in tools:
+        function = tool.get("function")
+        if isinstance(function, dict):
+            function.pop("strict", None)
+    return tools
+
+
 # Instrumentation scope name; matches the CrewAI instrumentor so these spans
 # share the same scope as the sync/async spans emitted from telemetry.py.
 _INSTRUMENTATION_NAME = "opentelemetry.instrumentation.crewai"
@@ -211,7 +223,7 @@ class LitellmStopWordLLM(LLM):
             import litellm  # noqa: PLC0415
 
             with _llm_span(self.model):
-                tools = _sanitize_tool_schema(kwargs["tools"])
+                tools = _strip_strict_flags(_sanitize_tool_schema(kwargs["tools"]))
                 params = self._prepare_completion_params(args[0], tools)
                 params["stream"] = True
                 call_id = str(uuid.uuid4())
@@ -255,7 +267,7 @@ class LitellmStopWordLLM(LLM):
             import litellm  # noqa: PLC0415
 
             with _llm_span(self.model):
-                tools = _sanitize_tool_schema(kwargs["tools"])
+                tools = _strip_strict_flags(_sanitize_tool_schema(kwargs["tools"]))
                 params = self._prepare_completion_params(args[0], tools)
                 params["stream"] = True
                 call_id = str(uuid.uuid4())

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -464,6 +464,80 @@ def test_sanitize_tool_schema_keeps_valid_schema() -> None:
     assert crewai_llm._sanitize_tool_schema(schema) == schema
 
 
+def test_strip_strict_flags_drops_function_strict_but_keeps_param_named_strict() -> None:
+    """Drop the function-level ``strict`` flag, but keep a tool *parameter* named ``strict``."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "toggle",
+                "strict": True,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"strict": {"type": "boolean"}},
+                    "required": ["strict"],
+                },
+            },
+        }
+    ]
+    cleaned = crewai_llm._strip_strict_flags(tools)
+    assert "strict" not in cleaned[0]["function"]
+    assert cleaned[0]["function"]["parameters"]["properties"] == {"strict": {"type": "boolean"}}
+    assert cleaned[0]["function"]["parameters"]["required"] == ["strict"]
+
+
+def test_litellm_stop_word_llm_call_strips_strict_from_native_tools(
+    stop_word_llm: LitellmStopWordLLM,
+) -> None:
+    """The native call strips crewai's per-tool ``strict`` before calling litellm."""
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "t1", "parameters": {"type": "object"}, "strict": True},
+        },
+        {
+            "type": "function",
+            "function": {"name": "t2", "parameters": {"type": "object"}, "strict": True},
+        },
+    ]
+    captured: dict[str, object] = {}
+
+    def fake_completion(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return iter([_delta(content="ok")])
+
+    with patch("litellm.completion", side_effect=fake_completion):
+        stop_word_llm.call("m", tools=tools, available_functions=None)
+
+    assert all("strict" not in tool["function"] for tool in captured["tools"])
+
+
+async def test_litellm_stop_word_llm_acall_strips_strict_from_native_tools(
+    stop_word_llm: LitellmStopWordLLM,
+) -> None:
+    """The async native path strips ``strict`` from tools like the sync path."""
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "t1", "parameters": {"type": "object"}, "strict": True},
+        },
+    ]
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        captured.update(kwargs)
+
+        async def gen() -> object:
+            yield _delta(content="ok")
+
+        return gen()
+
+    with patch("litellm.acompletion", fake_acompletion):
+        await stop_word_llm.acall("m", tools=tools, available_functions=None)
+
+    assert all("strict" not in tool["function"] for tool in captured["tools"])
+
+
 def test_litellm_stop_word_llm_call_stop_word_absent_returns_unchanged(
     stop_word_llm: LitellmStopWordLLM,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.23.22"
+version = "0.23.23"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

CrewAI stamps `strict: True` on every tool (`convert_tools_to_openai_schema`, no off-switch). Once native tool calling was enabled for gateway models, those tool schemas reach Bedrock, which caps strict tools at 20 — so a crew with 21+ tools fails with `Too many strict tools (N). The maximum number of strict tools supported is 20`. Reported for a CrewAI + bedrock/claude agent that combined memory, MCP, and user tools. LangGraph and LlamaIndex never mark tools strict, so this only affects CrewAI.

## CHANGES

- `crewai/llm.py`: strip the per-tool `strict` flag on the native `call()`/`acall()` path before calling litellm.
- Strip at the function-object level only, never a tool *parameter* named `strict`.
- Add unit tests: the `_strip_strict_flags` helper plus both native paths.
- Bump version to `0.23.23`; add changelog entry.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (N/A — no new tools)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to CrewAI native tool-call schema shaping before LiteLLM; no auth, data, or routing changes. Slight behavioral shift if a provider relied on strict mode for validation.
> 
> **Overview**
> Fixes CrewAI agents with **21+ tools** failing on Bedrock-backed gateway models with **"Too many strict tools"** (Bedrock allows at most 20 strict tools). CrewAI always adds `strict: True` on each tool schema; that now gets removed on the **native** `LitellmStopWordLLM` `call`/`acall` path immediately before LiteLLM, alongside the existing schema sanitization.
> 
> The new `_strip_strict_flags` helper removes only the **function-level** `strict` key and leaves a tool **parameter** named `strict` untouched. LangGraph/LlamaIndex adapters were already not marking tools strict. Release **0.23.23** with changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54be49be54ea5993f79bd721013ac485cfca928f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->