### PR TITLE
[MODEL-24115] Make target resource optional in nat xaa config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.24.2
+- `dragent`: Made audience attribute optional in `class CrossAppTokenRequest`.
+
 ## 0.24.1
 - `application-utils`: **Memory Service Light ORM** — new standalone extra `datarobot-genai[application-utils]` that wraps the DataRobot Agentic Memory Service with a Pydantic v2 / SQLModel-style async ORM.  Declare typed session and event models with annotation-driven routing markers (`DRDeduplicationKey`, `DRRangeKey`, `DRConcurrencyField`); the ORM handles wire serialization, camelCase mapping, description-path encoding for range-key prefix queries, optimistic concurrency (`If-Match` for sessions; `createdAt` token for events), and idempotent create via 409-adopt.  Public import: `from datarobot_genai.application_utils.persistence import DRMemorySpace, DRSession, DREvent`.  Dependencies: `httpx>=0.28.1,<1.0.0` + `pydantic>=2.6.1,<3.0.0` only (no core / OTel weight).  Unit tests cover encoding, routing, transport, space CRUD, session CRUD, and event CRUD.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.24.1"
+version = "0.24.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/cross_app_access_config.py
+++ b/src/datarobot_genai/dragent/cross_app_access_config.py
@@ -50,7 +50,8 @@ class CrossAppTokenRequest(BaseModel):
             "Published as ``securitySchemes.oauth2.flows.clientCredentials.tokenUrl``."
         ),
     )
-    audience: str = Field(
+    audience: str | None = Field(
+        default=None,
         description=(
             "Final resource identifier for the agent. "
             "Published in ``capabilities.extensions[].params.token_request.audience``."

--- a/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xxa_client.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xxa_client.py
@@ -39,15 +39,15 @@ def parse_xaa_params_from_mcp_auth_server_metadata(
 ) -> _CrossAppFlowParams:
     xaa_metadata = mcp_auth_server_metadata["urn:datarobot:nat_mcp_xaa_client"]
     token_endpoint_auth_method = xaa_metadata["token_endpoint_auth_method"]
-    token_exchange_metata = xaa_metadata["token_exchange"]
-    token_request_metata = xaa_metadata["token_request"]
+    token_exchange_metadata = xaa_metadata["token_exchange"]
+    token_request_metadata = xaa_metadata["token_request"]
 
     return _CrossAppFlowParams(
-        trusted_issuer=token_exchange_metata["trusted_issuer"],
-        exchange_audience=token_exchange_metata["audience"],
-        token_url=token_request_metata["token_url"],
-        target_audience=token_request_metata["audience"],
-        id_jag_scopes=token_request_metata["scopes"],
+        trusted_issuer=token_exchange_metadata["trusted_issuer"],
+        exchange_audience=token_exchange_metadata["audience"],
+        token_url=token_request_metadata["token_url"],
+        target_audience=token_request_metadata.get("audience"),
+        id_jag_scopes=token_request_metadata["scopes"],
         token_endpoint_auth_method=token_endpoint_auth_method,
     )
 

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -793,7 +793,7 @@ class _TokenRequestParams(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     grant_type: str = Field(validation_alias=AliasChoices("grantType", "grant_type"))
-    audience: str
+    audience: str | None = Field(default=None)
 
 
 class _CrossAppExtensionFields(BaseModel):

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -302,9 +302,10 @@ class _CrossAppFlowParams:
     Passed as ``audience`` in Step 1 so the org AS issues an ID-JAG scoped
     to this authorization server."""
 
-    target_audience: str
+    target_audience: str | None
     """Final resource identifier (e.g. ``https://api.example.com/``).
-    Passed as ``resource`` in Step 1 (HTTP impl only; SDK derives from AS policy)."""
+    Passed as ``resource`` in Step 1 (HTTP impl only; SDK derives from AS policy).
+    When it is None, no ``resource`` field is passed in the payload of Step 1. """
 
     token_endpoint_auth_method: str
     """Client auth method — ``"private_key_jwt"`` triggers signed JWT assertions."""
@@ -412,6 +413,15 @@ class OktaTokenExchange(XAATokenExchange):
     def __init__(self, config: OAuth2CrossApplicationAccessAuthProviderConfig) -> None:
         self.config = config
 
+    @staticmethod
+    def get_oauth2_client_additional_parameters(
+        cross_app_flow_params: _CrossAppFlowParams,
+    ) -> dict[str, str]:
+        additional_parameters = {}
+        if cross_app_flow_params.target_audience:
+            additional_parameters.update({"resource": cross_app_flow_params.target_audience})
+        return additional_parameters
+
     async def exchange_token(self, params: _CrossAppFlowParams, subject_token: str) -> str:
         if not _HAS_OKTA_SDK:
             raise RuntimeError(
@@ -439,11 +449,10 @@ class OktaTokenExchange(XAATokenExchange):
             audience=org_token_url,
             expires_in=300,
         )
-        additional_parameters = {"resource": params.target_audience}
         client = OAuth2Client(
             configuration=OAuth2ClientConfiguration(
                 issuer=params.trusted_issuer,
-                additional_parameters=additional_parameters,
+                additional_parameters=self.get_oauth2_client_additional_parameters(params),
                 client_authorization=ClientAssertionAuthorization(
                     assertion_claims=claims,
                     key_provider=key_provider,
@@ -496,6 +505,26 @@ class ApiTokenExchange(XAATokenExchange):
     def __init__(self, config: OAuth2CrossApplicationAccessAuthProviderConfig) -> None:
         self.config = config
 
+    @staticmethod
+    def get_xaa_token_exchange_request_payload(
+        cross_app_flow_params: _CrossAppFlowParams,
+        subject_token: str,
+        client_assertion: str,
+    ) -> dict[str, str]:
+        payload = {
+            "grant_type": _TOKEN_EXCHANGE_GRANT_TYPE,
+            "subject_token": subject_token,
+            "subject_token_type": _SUBJECT_TOKEN_TYPE,
+            "requested_token_type": _REQUESTED_TOKEN_TYPE,
+            "audience": cross_app_flow_params.exchange_audience,
+            "scope": " ".join(cross_app_flow_params.id_jag_scopes),
+            "client_assertion_type": _CLIENT_ASSERTION_TYPE,
+            "client_assertion": client_assertion,
+        }
+        if cross_app_flow_params.target_audience:
+            payload["resource"] = cross_app_flow_params.target_audience
+        return payload
+
     async def exchange_token(self, params: _CrossAppFlowParams, subject_token: str) -> str:
         if not self.config.principal_id:
             raise ValueError("principal_id is required for the XAA flow")
@@ -528,17 +557,7 @@ class ApiTokenExchange(XAATokenExchange):
             )
             resp1 = await http.post(
                 org_as_token_url,
-                data={
-                    "grant_type": _TOKEN_EXCHANGE_GRANT_TYPE,
-                    "subject_token": subject_token,
-                    "subject_token_type": _SUBJECT_TOKEN_TYPE,
-                    "requested_token_type": _REQUESTED_TOKEN_TYPE,
-                    "audience": params.exchange_audience,
-                    "resource": params.target_audience,
-                    "scope": " ".join(params.id_jag_scopes),
-                    "client_assertion_type": _CLIENT_ASSERTION_TYPE,
-                    "client_assertion": assertion1,
-                },
+                data=self.get_xaa_token_exchange_request_payload(params, subject_token, assertion1),
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
                 timeout=_TOKEN_EXCHANGE_TIMEOUT,
             )

--- a/tests/dragent/plugins/test_a2a_xaa_auth_impl.py
+++ b/tests/dragent/plugins/test_a2a_xaa_auth_impl.py
@@ -25,6 +25,7 @@ The SDK tests inject a fake ``NetworkInterface`` into the real
 import base64
 import json
 from dataclasses import dataclass
+from unittest.mock import Mock
 from unittest.mock import patch
 from urllib.parse import parse_qs
 
@@ -34,6 +35,10 @@ import respx
 from cryptography.hazmat.primitives.asymmetric import rsa
 from httpx import Response
 
+from datarobot_genai.dragent.plugins.okta_a2a_auth import _CLIENT_ASSERTION_TYPE
+from datarobot_genai.dragent.plugins.okta_a2a_auth import _REQUESTED_TOKEN_TYPE
+from datarobot_genai.dragent.plugins.okta_a2a_auth import _SUBJECT_TOKEN_TYPE
+from datarobot_genai.dragent.plugins.okta_a2a_auth import _TOKEN_EXCHANGE_GRANT_TYPE
 from datarobot_genai.dragent.plugins.okta_a2a_auth import ApiTokenExchange
 from datarobot_genai.dragent.plugins.okta_a2a_auth import (
     OAuth2CrossApplicationAccessAuthProviderConfig,
@@ -254,6 +259,42 @@ class TestApiTokenExchangeFormFields:
 
         body = parse_qs(step1.calls.last.request.content.decode())
         assert body["scope"] == ["dr.impersonation openid"]
+
+    def test_get_xaa_token_exchange_request_payload(self) -> None:
+        cross_app_flow_params = Mock()
+        cross_app_flow_params.id_jag_scopes = ["dsafafds"]
+        subject_token = Mock()
+        client_assertion = Mock()
+        output = ApiTokenExchange.get_xaa_token_exchange_request_payload(
+            cross_app_flow_params,
+            subject_token,
+            client_assertion,
+        )
+
+        expected_payload = {
+            "grant_type": _TOKEN_EXCHANGE_GRANT_TYPE,
+            "subject_token": subject_token,
+            "subject_token_type": _SUBJECT_TOKEN_TYPE,
+            "requested_token_type": _REQUESTED_TOKEN_TYPE,
+            "audience": cross_app_flow_params.exchange_audience,
+            "scope": " ".join(cross_app_flow_params.id_jag_scopes),
+            "client_assertion_type": _CLIENT_ASSERTION_TYPE,
+            "client_assertion": client_assertion,
+            "resource": cross_app_flow_params.target_audience,
+        }
+        assert output == expected_payload
+
+    def test_get_xaa_token_exchange_request_payload_without_resource_in_payload(self) -> None:
+        cross_app_flow_params = Mock()
+        cross_app_flow_params.target_audience = None
+        cross_app_flow_params.id_jag_scopes = ["dsafafds"]
+        output = ApiTokenExchange.get_xaa_token_exchange_request_payload(
+            cross_app_flow_params,
+            Mock(),
+            Mock(),
+        )
+
+        assert "resource" not in output
 
 
 # ---------------------------------------------------------------------------
@@ -627,3 +668,16 @@ class TestOktaTokenExchangeSdkHttpRequests:
         with patch(f"{_MODULE}._HAS_OKTA_SDK", False):
             with pytest.raises(RuntimeError, match="okta-client-python is not installed"):
                 await exchange.exchange_token(flow_params, "token")
+
+    def test_get_oauth2_client_additional_parameters(self) -> None:
+        cross_app_flow_params = Mock()
+
+        output = OktaTokenExchange.get_oauth2_client_additional_parameters(cross_app_flow_params)
+        assert output == {"resource": cross_app_flow_params.target_audience}
+
+    def test_get_oauth2_client_additional_parameters_without_resource_param(self) -> None:
+        cross_app_flow_params = Mock()
+        cross_app_flow_params.target_audience = None
+
+        output = OktaTokenExchange.get_oauth2_client_additional_parameters(cross_app_flow_params)
+        assert "resource" not in output

--- a/tests/dragent/plugins/test_datarobot_user_mcp_xxa_client.py
+++ b/tests/dragent/plugins/test_datarobot_user_mcp_xxa_client.py
@@ -110,6 +110,37 @@ class TestMCPAuthServerMetadataDiscovery:
             token_endpoint_auth_method=mock_token_endpoint_auth_method,
         )
 
+    def test_parse_xaa_params_from_mcp_auth_server_metadata_without_token_request_audience(
+        self,
+    ) -> None:
+        mock_token_endpoint_auth_method = Mock()
+        mock_trust_issuer = Mock()
+        mock_exchange_audience = Mock()
+        mock_token_url = Mock()
+        mock_scopes = [Mock()]
+        mcp_auth_server_metadata = {
+            "urn:datarobot:nat_mcp_xaa_client": {
+                "token_endpoint_auth_method": mock_token_endpoint_auth_method,
+                "token_exchange": {
+                    "trusted_issuer": mock_trust_issuer,
+                    "audience": mock_exchange_audience,
+                },
+                "token_request": {
+                    "token_url": mock_token_url,
+                    "scopes": mock_scopes,
+                },
+            }
+        }
+        output = parse_xaa_params_from_mcp_auth_server_metadata(mcp_auth_server_metadata)
+        assert output == _CrossAppFlowParams(
+            trusted_issuer=mock_trust_issuer,
+            exchange_audience=mock_exchange_audience,
+            token_url=mock_token_url,
+            target_audience=None,
+            id_jag_scopes=mock_scopes,
+            token_endpoint_auth_method=mock_token_endpoint_auth_method,
+        )
+
     @pytest.mark.asyncio
     async def test_get_xaa_params_from_mcp_auth_server_metadata(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
The `audience` attribute of `class CrossAppTokenRequest` is the XAA token request (Step 2) config. It holds the target audience (e.g., what you will access) which is the part of the claims to be validated/authorized by IdP during the XAA token exchange request (Step 1). Once it is validated/authorized, the IdP will return signed claims which will be used to retrieve the access token during XAA token request (Step 2)

In the Dell case, the Agent will access MCP through the XAA protocol. At this moment (aka. crawl phase of Okta MCP registration support), the target audience of MCP is still not supported. This presents a new business need that we should not send the `resource` in the payload during the XAA token exchange (Step 1) if it is not supported. This PR made the following updates to cater to this business need:

- Make `target_audience` attribute optional in `class _CrossAppFlowParams`
- Make `audience` attribute optional in `class CrossAppTokenRequest`
- In `def exchange_token()` of `class OktaTokenExchange` and `class ApiTokenExchange`, only update `resource` in the payload when it is present (not None).


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token-exchange request shape for XAA when audience is omitted; incorrect omission could cause auth failures, but behavior is gated on explicit None/missing audience and is covered by new tests.
> 
> **Overview**
> Makes the **target resource / audience** optional in Cross-Application Access (XAA) NAT configuration so deployments can omit `token_request.audience` when the authorization server does not require a `resource` on Step 1 token exchange.
> 
> **`CrossAppTokenRequest.audience`** is now `str | None` (default `None`). **`_CrossAppFlowParams.target_audience`** is optional, and MCP metadata parsing uses `.get("audience")` when reading `urn:datarobot:nat_mcp_xaa_client`.
> 
> **HTTP and Okta SDK** token exchange paths only add the OAuth **`resource`** parameter when `target_audience` is set—via `ApiTokenExchange.get_xaa_token_exchange_request_payload` and `OktaTokenExchange.get_oauth2_client_additional_parameters`—instead of always sending `resource`. Minor typo fixes in MCP XAA metadata variable names.
> 
> Bumps package version to **0.23.28** with changelog; adds unit tests for optional-audience parsing and payload builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cccfa6380f2b8f85a266a13c40719a883668b65. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->