### PR TITLE
[MODEL-24001] Improve xaa retrieval logic in `mcp_client_with_xaa_support` type MCP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.24.3
+- `dragent`: Improved XAA parameter retrieval logic in `mcp_client_with_xaa_support` type MCP client.
+
 ## 0.24.2
 - `dragent`: Made audience attribute optional in `class CrossAppTokenRequest`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.24.2"
+version = "0.24.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xaa_client.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xaa_client.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 from typing import Literal
@@ -32,6 +33,8 @@ from datarobot_genai.dragent.plugins.okta_a2a_auth import (
     OAuth2CrossApplicationAccessOAuth2AuthProvider,
 )
 from datarobot_genai.dragent.plugins.okta_a2a_auth import _CrossAppFlowParams
+
+logger = logging.getLogger(__name__)
 
 
 def parse_xaa_params_from_mcp_auth_server_metadata(
@@ -109,11 +112,13 @@ async def get_xaa_params_from_mcp_auth_server_metadata(
         try:
             resp = await http_client.get(mcp_auth_server_metadata_url)
             resp.raise_for_status()
-        except httpx.HTTPError as exc:
-            raise RuntimeError(
+        except httpx.HTTPStatusError as exc:
+            error_message = (
                 "Failed to fetch MCP auth server metadata from "
                 f"{mcp_auth_server_metadata_url}: {exc}"
             )
+            logger.exception(error_message)
+            raise exc
 
     return parse_xaa_params_from_mcp_auth_server_metadata(resp.json())
 
@@ -130,9 +135,15 @@ def get_xaa_params_from_config(xaa_config: CrossApplicationAccessConfig) -> _Cro
 
 
 async def get_xaa_params(config: MCPClientWithXAASupportConfig) -> _CrossAppFlowParams:
-    if config.cross_application_access:
-        return get_xaa_params_from_config(config.cross_application_access)
-    return await get_xaa_params_from_mcp_auth_server_metadata(config)
+    try:
+        return await get_xaa_params_from_mcp_auth_server_metadata(config)
+    except httpx.HTTPStatusError:
+        if config.cross_application_access:
+            logger.info("Fall back to load XAA params from NAT workflow.yaml")
+            return get_xaa_params_from_config(config.cross_application_access)
+        raise RuntimeError(
+            "Failed to load XAA params from both MCP well-known metadata and NAT workflow.yaml."
+        )
 
 
 async def setup_auth_provider(

--- a/tests/dragent/plugins/test_datarobot_user_mcp_xaa_client.py
+++ b/tests/dragent/plugins/test_datarobot_user_mcp_xaa_client.py
@@ -17,22 +17,23 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+from httpx import HTTPStatusError
 
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import (
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import (
     get_mcp_auth_server_metadata_url,
 )
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import get_xaa_params
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import get_xaa_params_from_config
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import (
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import get_xaa_params
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import get_xaa_params_from_config
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import (
     get_xaa_params_from_mcp_auth_server_metadata,
 )
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import (
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import (
     mcp_client_with_xaa_support_function_group,
 )
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import (
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import (
     parse_xaa_params_from_mcp_auth_server_metadata,
 )
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import setup_auth_provider
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import setup_auth_provider
 from datarobot_genai.dragent.plugins.okta_a2a_auth import (
     OAuth2CrossApplicationAccessOAuth2AuthProvider,
 )
@@ -41,7 +42,7 @@ from datarobot_genai.dragent.plugins.okta_a2a_auth import _CrossAppFlowParams
 
 @pytest.fixture
 def module_under_test() -> str:
-    return "datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client"
+    return "datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client"
 
 
 class TestMCPAuthServerMetadataDiscovery:
@@ -163,6 +164,33 @@ class TestMCPAuthServerMetadataDiscovery:
             mock_resp.json.return_value,
         )
 
+    @pytest.mark.asyncio
+    async def test_get_xaa_params_from_mcp_auth_server_metadata_raise_error(
+        self,
+        mock_async_http_client: Mock,
+        mock_get_mcp_auth_server_metadata_url: Mock,
+        mock_get_retriable_async_http_client: Mock,
+        mock_parse_xaa_params_from_mcp_auth_server_metadata: Mock,
+    ) -> None:
+        mock_resp = mock_async_http_client.get.return_value
+        mock_resp.raise_for_status.side_effect = HTTPStatusError(
+            "opps",
+            request=Mock(),
+            response=Mock(),
+        )
+
+        config = Mock()
+        with pytest.raises(HTTPStatusError):
+            await get_xaa_params_from_mcp_auth_server_metadata(config)
+
+        mock_get_mcp_auth_server_metadata_url.assert_called_once_with(config)
+        mock_get_retriable_async_http_client.assert_called_once_with()
+        mock_async_http_client.get.assert_called_once_with(
+            mock_get_mcp_auth_server_metadata_url.return_value
+        )
+        mock_resp.raise_for_status.assert_called_once_with()
+        mock_parse_xaa_params_from_mcp_auth_server_metadata.assert_not_called()
+
 
 class TestSetupAuthProvider:
     @pytest.fixture
@@ -227,7 +255,7 @@ class TestSetupAuthProvider:
         assert output == mock_get_xaa_params_from_mcp_auth_server_metadata.return_value
 
     @pytest.mark.asyncio
-    async def test_get_xaa_params_from_local_config(
+    async def test_get_xaa_params_from_remote_mcp_auth_metadata(
         self,
         mock_get_xaa_params_from_config: Mock,
         mock_get_xaa_params_from_mcp_auth_server_metadata: AsyncMock,
@@ -235,8 +263,27 @@ class TestSetupAuthProvider:
         config = Mock()
         output = await get_xaa_params(config)
 
+        mock_get_xaa_params_from_mcp_auth_server_metadata.assert_called_once_with(config)
+        mock_get_xaa_params_from_config.assert_not_called()
+        assert output == mock_get_xaa_params_from_mcp_auth_server_metadata.return_value
+
+    @pytest.mark.asyncio
+    async def test_get_xaa_params_from_local_config(
+        self,
+        mock_get_xaa_params_from_config: Mock,
+        mock_get_xaa_params_from_mcp_auth_server_metadata: AsyncMock,
+    ) -> None:
+        mock_get_xaa_params_from_mcp_auth_server_metadata.side_effect = HTTPStatusError(
+            "opps",
+            request=Mock(),
+            response=Mock(),
+        )
+
+        config = Mock()
+        output = await get_xaa_params(config)
+
+        mock_get_xaa_params_from_mcp_auth_server_metadata.assert_called_once_with(config)
         mock_get_xaa_params_from_config.assert_called_once_with(config.cross_application_access)
-        mock_get_xaa_params_from_mcp_auth_server_metadata.assert_not_called()
         assert output == mock_get_xaa_params_from_config.return_value
 
     @pytest.mark.asyncio

--- a/tests/nat/test_datarobot_user_mcp_xaa_client.py
+++ b/tests/nat/test_datarobot_user_mcp_xaa_client.py
@@ -17,9 +17,9 @@ import pytest
 from nat.data_models.config import Config
 from nat.runtime.loader import load_config
 
-import datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client  # noqa: F401 — registers mcp_client_with_xaa_support
+import datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client  # noqa: F401 — registers mcp_client_with_xaa_support
 import datarobot_genai.dragent.plugins.okta_a2a_auth  # noqa: F401 — registers okta_cross_app_access
-from datarobot_genai.dragent.plugins.datarobot_user_mcp_xxa_client import (
+from datarobot_genai.dragent.plugins.datarobot_user_mcp_xaa_client import (
     MCPClientWithXAASupportConfig,
 )
 from datarobot_genai.dragent.plugins.okta_a2a_auth import (

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
The changes of this PR are summarized as follows:

- `def get_xaa_params()`
This function first reads XAA parameters from local config before it retrieves them from the remote MCP well-known metadata endpoint. This PR updated the logic as follows
1) It first reads XAA parameters from the remote MCP well-known metadata endpoint.
2) If it failed, it reads the XAA parameters from the local config.

- Fix the typo of `xxa` to `xaa`
Rename `src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xxa_client.py`  to `src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xaa_client.py`

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth/XAA bootstrap order and error propagation for per-user MCP clients; misconfigured metadata or missing fallback YAML could break MCP auth at runtime.
> 
> **Overview**
> **`mcp_client_with_xaa_support`** now resolves cross-application access settings by fetching the MCP **oauth-protected-resource** well-known metadata first, and only uses **`cross_application_access` in `workflow.yaml`** when that HTTP call fails with a status error.
> 
> Metadata fetch failures are logged and **`HTTPStatusError`** is re-raised (instead of a generic **`RuntimeError`**); if there is no local config, **`get_xaa_params`** raises a clear error that both sources failed.
> 
> The plugin module and tests are renamed from **`xxa`** to **`xaa`**. Release **0.24.3** (changelog and lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2aef3a1733fbde8b900ee6071efd8318c84ae2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->