### PR TITLE
feat(application-utils): ORM nested (de)serialization for persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.25.1
+- `application-utils`: **ORM nested (de)serialization** — the persistence ORM now round-trips any Pydantic-expressible type in declared session-metadata and event-body fields (nested models, `list[Model]`, `Optional[Model]`, enums, dicts) via per-field `TypeAdapter`s, instead of only JSON primitives. *Behavior change*: on read, present field values are now best-effort coerced to their declared type (e.g. a scalar declared `int` that arrives as `"3"` becomes `3`); malformed wire values fall back to the raw value (logged at `WARNING`) with no error, and all §1 backward-compat invariants (reads via `model_construct`, absent-required→`None`, `version`/`sequenceId` defaults, patch semantics, routing markers bypass serde) are preserved.
+- `application-utils`: **ORM `.list` prefix-scoping** — `DRSession.list()` now *always* filters by the subclass's `__description_prefix__`, and `_to_wire_create` always stamps at least the prefix into `description`. Previously a range-kwarg-less `.list(space)` sent no `description` filter and returned **every** session in the space regardless of subclass; trailing-slash anchoring (`//thread/` never matches `//threadx/…` nor `//loc/…`) now keeps subclasses disjoint so they can safely share one space. No behavior change for range-key-carrying classes with range-key filters supplied.
+
 ## 0.25.0
 - *Breaking change*: Deprecated `datarobot-genai.nat`. Moved:
   - `nat_tool` from `datarobot_genai.nat.tool` to `datarobot_genai.dragent.tool`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.25.0"
+version = "0.25.1"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/application_utils/persistence/_serde.py
+++ b/src/datarobot_genai/application_utils/persistence/_serde.py
@@ -38,6 +38,7 @@ from weakref import WeakKeyDictionary
 from pydantic import BaseModel
 from pydantic import TypeAdapter
 from pydantic import ValidationError
+from pydantic_core import PydanticSerializationError
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,12 @@ def serialize_field(model_cls: type[BaseModel], field_name: str, value: Any) -> 
     is ``"x"``); nested models, lists, optionals, enums and dicts are converted to
     their JSON representation.
 
+    ``patch()`` callers re-serialise every declared field, including ones the caller
+    isn't touching, so *value* may be a raw fallback previously returned by
+    :func:`deserialize_field` rather than an instance of the declared type. On any
+    serialisation failure that raw value is returned unchanged instead of raising,
+    so patching one field never crashes on an unrelated, already-malformed sibling.
+
     Parameters
     ----------
     model_cls : type[BaseModel]
@@ -96,9 +103,19 @@ def serialize_field(model_cls: type[BaseModel], field_name: str, value: Any) -> 
     Returns
     -------
     Any
-        A JSON-serialisable Python object.
+        A JSON-serialisable Python object, or *value* unchanged when it cannot be
+        serialised.
     """
-    return field_type_adapter(model_cls, field_name).dump_python(value, mode="json")
+    try:
+        return field_type_adapter(model_cls, field_name).dump_python(value, mode="json")
+    except PydanticSerializationError:
+        logger.warning(
+            "Could not serialize value for %s.%s to its declared type; "
+            "returning the raw value unchanged.",
+            model_cls.__name__,
+            field_name,
+        )
+        return value
 
 
 def deserialize_field(model_cls: type[BaseModel], field_name: str, raw: Any) -> Any:

--- a/src/datarobot_genai/application_utils/persistence/_serde.py
+++ b/src/datarobot_genai/application_utils/persistence/_serde.py
@@ -1,0 +1,137 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-field (de)serialisation for ``DRSession`` metadata and ``DREvent`` body fields.
+
+The Memory Service ORM stores declared fields as JSON — session ``metadata.<f>``
+and event ``body.<f>``.  The base serializer only handled JSON primitives, so a
+nested Pydantic model (e.g. ``list[ToolCall]``) would either raise on write or come
+back as a raw ``dict`` on read.
+
+These helpers build one cached :class:`pydantic.TypeAdapter` per ``(model class,
+field name)`` and use it to:
+
+* **write** — dump any Pydantic-expressible value (nested models, lists, optionals,
+  enums, dicts) to a JSON-compatible Python object (scalars pass through unchanged);
+* **read** — validate/coerce the raw wire value back into the declared type, falling
+  back to the raw value when the wire payload cannot be validated (robustness first —
+  the server is the source of truth and reads must never raise).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from weakref import WeakKeyDictionary
+
+from pydantic import BaseModel
+from pydantic import TypeAdapter
+from pydantic import ValidationError
+
+logger = logging.getLogger(__name__)
+
+# One TypeAdapter per (model class, field name).  Keyed weakly on the class so the
+# adapters are collected together with a transient subclass; ``TypeAdapter``
+# construction is not free, so this cache keeps the hot (de)serialisation paths cheap.
+_ADAPTER_CACHE: WeakKeyDictionary[type, dict[str, TypeAdapter[Any]]] = WeakKeyDictionary()
+
+
+def field_type_adapter(model_cls: type[BaseModel], field_name: str) -> TypeAdapter[Any]:
+    """Return a cached :class:`~pydantic.TypeAdapter` for one declared field.
+
+    Parameters
+    ----------
+    model_cls : type[BaseModel]
+        The ``DRSession``/``DREvent`` subclass owning the field.
+    field_name : str
+        Name of a declared field on *model_cls*.
+
+    Returns
+    -------
+    TypeAdapter
+        Adapter built from the field's annotation, built once and reused.
+    """
+    per_class = _ADAPTER_CACHE.get(model_cls)
+    if per_class is None:
+        per_class = {}
+        _ADAPTER_CACHE[model_cls] = per_class
+
+    adapter = per_class.get(field_name)
+    if adapter is None:
+        annotation = model_cls.model_fields[field_name].annotation
+        # A field always carries an annotation in practice; fall back to ``Any`` so a
+        # pathological untyped field still round-trips rather than raising here.
+        adapter = TypeAdapter(annotation if annotation is not None else Any)
+        per_class[field_name] = adapter
+    return adapter
+
+
+def serialize_field(model_cls: type[BaseModel], field_name: str, value: Any) -> Any:
+    """Serialise *value* to a JSON-compatible Python object for the wire.
+
+    Scalars are returned unchanged (``TypeAdapter(str).dump_python("x", mode="json")``
+    is ``"x"``); nested models, lists, optionals, enums and dicts are converted to
+    their JSON representation.
+
+    Parameters
+    ----------
+    model_cls : type[BaseModel]
+        The model subclass owning the field.
+    field_name : str
+        Name of the declared field.
+    value : Any
+        The value to serialise.
+
+    Returns
+    -------
+    Any
+        A JSON-serialisable Python object.
+    """
+    return field_type_adapter(model_cls, field_name).dump_python(value, mode="json")
+
+
+def deserialize_field(model_cls: type[BaseModel], field_name: str, raw: Any) -> Any:
+    """Validate/coerce a raw wire value into the field's declared type.
+
+    On any validation failure the raw value is returned unchanged so reads remain
+    robust to malformed or foreign-written wire data (the server is the source of
+    truth and reads must never raise).
+
+    Parameters
+    ----------
+    model_cls : type[BaseModel]
+        The model subclass owning the field.
+    field_name : str
+        Name of the declared field.
+    raw : Any
+        The raw value taken from the wire ``metadata``/``body`` object.
+
+    Returns
+    -------
+    Any
+        The coerced value, or *raw* unchanged when it cannot be validated.
+    """
+    try:
+        return field_type_adapter(model_cls, field_name).validate_python(raw)
+    except (ValidationError, TypeError, ValueError):
+        # Reads must never raise, so the raw value is returned as a last resort;
+        # log it so a malformed/foreign-written field is observable rather than
+        # silently surfacing as a downstream type error on the raw value.
+        logger.warning(
+            "Could not coerce wire value for %s.%s to its declared type; "
+            "returning the raw value unchanged.",
+            model_cls.__name__,
+            field_name,
+        )
+        return raw

--- a/src/datarobot_genai/application_utils/persistence/event.py
+++ b/src/datarobot_genai/application_utils/persistence/event.py
@@ -86,6 +86,8 @@ from pydantic import PrivateAttr
 from datarobot_genai.application_utils.persistence._routing import _EVENT_RESERVED
 from datarobot_genai.application_utils.persistence._routing import EventRoutingTable
 from datarobot_genai.application_utils.persistence._routing import build_event_routing
+from datarobot_genai.application_utils.persistence._serde import deserialize_field
+from datarobot_genai.application_utils.persistence._serde import serialize_field
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryBadRequestError
 
 if TYPE_CHECKING:
@@ -188,7 +190,7 @@ class DREvent(BaseModel):
         body: dict[str, Any] = {"content": kwargs["content"]}
         for fname in routing.body_fields:
             if fname in kwargs:
-                body[fname] = kwargs[fname]
+                body[fname] = serialize_field(cls, fname, kwargs[fname])
         return body
 
     @staticmethod
@@ -223,7 +225,7 @@ class DREvent(BaseModel):
         # default are left for model_construct to fill.
         for fname in routing.body_fields:
             if fname in body:
-                init_kwargs[fname] = body[fname]
+                init_kwargs[fname] = deserialize_field(cls, fname, body[fname])
             elif cls.model_fields[fname].is_required():
                 init_kwargs[fname] = None
 
@@ -243,7 +245,7 @@ class DREvent(BaseModel):
             self.content = body["content"]
         for fname in routing.body_fields:
             if fname in body:
-                setattr(self, fname, body[fname])
+                setattr(self, fname, deserialize_field(type(self), fname, body[fname]))
         emitter_type = data.get("emitterType")
         if emitter_type is not None:
             self.emitter_type = emitter_type
@@ -522,7 +524,7 @@ class DREvent(BaseModel):
             for fname in routing.body_fields:
                 new_val = kwargs.get(fname, getattr(self, fname, None))
                 if new_val is not None:
-                    body[fname] = new_val
+                    body[fname] = serialize_field(type(self), fname, new_val)
 
         payload: dict[str, Any] = {}
         if body is not None:
@@ -617,7 +619,9 @@ class DREvent(BaseModel):
             content = kwargs.get("content")
             emitter_type = kwargs.get("emitter_type")
             emitter_id = kwargs.get("emitter_id")
-            body_kwargs = {k: v for k, v in kwargs.items() if k in routing.body_fields}
+            body_kwargs = {
+                k: serialize_field(cls, k, v) for k, v in kwargs.items() if k in routing.body_fields
+            }
 
             item: dict[str, Any] = {"sequenceId": event.sequence_id}
             if event.created_at:

--- a/src/datarobot_genai/application_utils/persistence/session.py
+++ b/src/datarobot_genai/application_utils/persistence/session.py
@@ -83,6 +83,8 @@ from datarobot_genai.application_utils.persistence._encoding import parse_descri
 from datarobot_genai.application_utils.persistence._encoding import validate_range_key
 from datarobot_genai.application_utils.persistence._routing import SessionRoutingTable
 from datarobot_genai.application_utils.persistence._routing import build_session_routing
+from datarobot_genai.application_utils.persistence._serde import deserialize_field
+from datarobot_genai.application_utils.persistence._serde import serialize_field
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryConflictError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryNotFoundError
 from datarobot_genai.application_utils.persistence.markers import DEFAULT_SESSION_TTL_SECONDS
@@ -219,27 +221,26 @@ class DRSession(BaseModel):
                 raise ValueError(f"Deduplication key {routing.dedup_field!r} must not be None.")
             dedup_key = str(dedup_value)
 
-        # Description from range keys
-        description: str | None = None
-        if routing.range_fields:
-            range_values: list[str] = []
-            for fname in routing.range_fields:
-                val = kwargs.get(fname, "")
-                validate_range_key(fname, val)
-                range_values.append(str(val))
-            description = build_description(cls._prefix(), range_values)
+        # Description always carries at least the class prefix, so every subclass is
+        # prefix-identifiable on the wire and ``list()`` can scope its results to one
+        # subclass.  Declared range keys extend the prefix into a hierarchical path.
+        range_values: list[str] = []
+        for fname in routing.range_fields:
+            val = kwargs.get(fname, "")
+            validate_range_key(fname, val)
+            range_values.append(str(val))
+        description = build_description(cls._prefix(), range_values)
 
         # Metadata from plain fields
         metadata: dict[str, Any] = {}
         for fname in routing.metadata_fields:
             if fname in kwargs:
-                metadata[fname] = kwargs[fname]
+                metadata[fname] = serialize_field(cls, fname, kwargs[fname])
 
         payload: dict[str, Any] = {"participants": participants}
         if dedup_key is not None:
             payload["deduplicationKey"] = dedup_key
-        if description is not None:
-            payload["description"] = description
+        payload["description"] = description
         if metadata:
             payload["metadata"] = metadata
         payload["lifecycleStrategies"] = cls.__lifecycle_strategies__
@@ -294,7 +295,7 @@ class DRSession(BaseModel):
         metadata = data.get("metadata") or {}
         for fname in routing.metadata_fields:
             if fname in metadata:
-                init_kwargs[fname] = metadata[fname]
+                init_kwargs[fname] = deserialize_field(cls, fname, metadata[fname])
             elif cls.model_fields[fname].is_required():
                 init_kwargs[fname] = None
 
@@ -332,7 +333,7 @@ class DRSession(BaseModel):
         metadata = data.get("metadata") or {}
         for fname in routing.metadata_fields:
             if fname in metadata:
-                setattr(self, fname, metadata[fname])
+                setattr(self, fname, deserialize_field(type(self), fname, metadata[fname]))
 
         # Sync range fields from description
         for fname, val in type(self)._decode_range_fields(routing, data).items():
@@ -477,6 +478,10 @@ class DRSession(BaseModel):
     ) -> builtins.list[DRSession]:
         """List sessions matching a range-key prefix and/or participant filter.
 
+        The query is **always** scoped to this subclass by its
+        ``__description_prefix__`` (so ``list()`` never returns sessions of a
+        different subclass sharing the space); range-key kwargs narrow it further.
+
         Range-key kwargs must form a **contiguous leading prefix** of the
         declared ``DRRangeKey`` fields (e.g. for fields ``[tenant, topic]`` you
         may filter on ``tenant=`` alone or on ``tenant=`` + ``topic=``, but not
@@ -522,16 +527,18 @@ class DRSession(BaseModel):
         # Build query params
         query_params: dict[str, Any] = {}
 
-        # Build description filter from range key kwargs
+        # Always filter by the class description prefix so list() returns only this
+        # subclass's sessions.  Without this, a range-kwarg-less list() would send no
+        # description filter and the service would return every session in the space
+        # regardless of subclass.  Leading range-key kwargs extend the prefix filter.
+        range_values: list[str] = []
         if kwargs and routing.range_fields:
-            range_values: list[str] = []
             for fname in routing.range_fields:
                 if fname in kwargs:
                     value = kwargs[fname]
                     validate_range_key(fname, value)
                     range_values.append(str(value))
-            if range_values:
-                query_params["description"] = build_query_description(cls._prefix(), range_values)
+        query_params["description"] = build_query_description(cls._prefix(), range_values)
 
         if participant is not None:
             query_params["participants"] = participant
@@ -632,11 +639,11 @@ class DRSession(BaseModel):
             new_metadata: dict[str, Any] = {}
             for fname in routing.metadata_fields:
                 if fname in kwargs:
-                    new_metadata[fname] = kwargs[fname]
+                    new_metadata[fname] = serialize_field(type(self), fname, kwargs[fname])
                 else:
                     current_val = getattr(self, fname, None)
                     if current_val is not None:
-                        new_metadata[fname] = current_val
+                        new_metadata[fname] = serialize_field(type(self), fname, current_val)
             payload["metadata"] = new_metadata
 
         # The description encodes the range keys; only rebuild and send it when a

--- a/tests/application_utils/persistence/unit/test_encoding.py
+++ b/tests/application_utils/persistence/unit/test_encoding.py
@@ -166,6 +166,28 @@ def test_different_prefix_does_not_match() -> None:
     assert query.lower() not in stored.lower()
 
 
+def test_prefix_is_not_matched_by_a_longer_prefix_sharing_its_start() -> None:
+    """GIVEN prefixes 'thread' and 'threadx' WHEN cross-querying THEN neither matches.
+
+    Trailing-slash anchoring keeps prefixes disjoint even when one is a raw-string
+    prefix of the other — the reason ``EntityLocator`` (prefix ``loc``) can share a
+    space with ``Chat`` (prefix ``thread``) without ``.list`` bleeding across them.
+    """
+    stored_thread = build_description("thread", ["acme"])  # //thread/acme/
+    stored_threadx = build_description("threadx", ["acme"])  # //threadx/acme/
+    # A no-value query for one prefix must not substring-match the other's storage.
+    assert build_query_description("thread", []).lower() not in stored_threadx.lower()
+    assert build_query_description("threadx", []).lower() not in stored_thread.lower()
+
+
+def test_loc_prefix_disjoint_from_thread_prefix() -> None:
+    """GIVEN 'loc' and 'thread' prefixes WHEN cross-querying THEN no substring match."""
+    stored_chat = build_description("thread", ["acme", "billing"])
+    stored_loc = build_description("loc", ["chat:some-uuid"])
+    assert build_query_description("loc", []).lower() not in stored_chat.lower()
+    assert build_query_description("thread", []).lower() not in stored_loc.lower()
+
+
 # ── parse_description ─────────────────────────────────────────────────────────
 
 

--- a/tests/application_utils/persistence/unit/test_serde.py
+++ b/tests/application_utils/persistence/unit/test_serde.py
@@ -1,0 +1,494 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nested (de)serialisation tests for the persistence ORM.
+
+Declared ``DREvent`` body fields and ``DRSession`` metadata fields must round-trip
+through any Pydantic-expressible type — nested models, ``list[Model]``,
+``Optional[Model]``, enums and dicts — while remaining byte-identical for scalars and
+robust (raw fallback) against malformed wire payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from enum import StrEnum
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from pydantic import BaseModel
+
+from datarobot_genai.application_utils.persistence import DREvent
+from datarobot_genai.application_utils.persistence import DRMemoryServiceClient
+from datarobot_genai.application_utils.persistence import DRMemorySpace
+from datarobot_genai.application_utils.persistence import DRSession
+from tests.application_utils.persistence.unit.conftest import PARTICIPANT
+from tests.application_utils.persistence.unit.conftest import SESSION_ID
+from tests.application_utils.persistence.unit.conftest import SPACE_ID
+from tests.application_utils.persistence.unit.conftest import ChatSession
+
+BASE = "https://app.datarobot.com/api/v2"
+MEMORY_BASE = f"{BASE}/memory"
+SESSIONS_URL = f"{MEMORY_BASE}/{SPACE_ID}/sessions/"
+SESSION_URL = f"{SESSIONS_URL}{SESSION_ID}/"
+EVENTS_URL = f"{SESSION_URL}events/"
+EVENT_URL = f"{EVENTS_URL}5/"
+
+
+# ── Nested types under test ───────────────────────────────────────────────────
+
+
+class Color(StrEnum):
+    """Simple string enum for enum round-trip coverage."""
+
+    red = "red"
+    green = "green"
+
+
+class Widget(BaseModel):
+    """Nested Pydantic model persisted inside a body/metadata field."""
+
+    name: str
+    size: int
+    color: Color = Color.red
+
+
+class RichMessage(DREvent, session=ChatSession):
+    """Event whose body carries nested models, lists, optionals, enums and dicts."""
+
+    __event_type__ = "message"
+
+    widget: Widget | None = None
+    widgets: list[Widget] = []
+    color: Color = Color.red
+    attrs: dict[str, Any] = {}
+
+
+class RichSession(DRSession):
+    """Session whose metadata carries nested models, lists, optionals, enums and dicts."""
+
+    __description_prefix__ = "rich"
+
+    widget: Widget | None = None
+    widgets: list[Widget] = []
+    color: Color = Color.red
+    attrs: dict[str, Any] = {}
+
+
+class ScalarSession(DRSession):
+    """Session with only scalar metadata fields (byte-identity check)."""
+
+    __description_prefix__ = "scalar"
+
+    s: str = ""
+    n: int = 0
+    f: float = 0.0
+    b: bool = False
+
+
+# ── Test infrastructure ────────────────────────────────────────────────────────
+
+
+def _client() -> DRMemoryServiceClient:
+    return DRMemoryServiceClient(endpoint=BASE, api_token="t", http_client=httpx.AsyncClient())
+
+
+def _space() -> DRMemorySpace:
+    return DRMemorySpace._from_wire(
+        _client(),
+        {"memorySpaceId": SPACE_ID, "userId": "u", "tenantId": "t", "createdAt": ""},
+    )
+
+
+def _session() -> ChatSession:
+    wire = {
+        "id": SESSION_ID,
+        "participants": [PARTICIPANT],
+        "description": "//chat/acme/billing/",
+        "deduplicationKey": "chat-001",
+        "metadata": {"title": "T"},
+        "version": 1,
+        "createdAt": "2026-06-30T00:00:00Z",
+    }
+    return ChatSession._from_wire(_space(), wire)  # type: ignore[return-value]
+
+
+def _echo_event(captured: dict[str, Any]) -> Callable[[httpx.Request], httpx.Response]:
+    """Return a respx side-effect that echoes the posted body back as an EventResponse."""
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        payload = json.loads(req.content)
+        captured["body"] = payload
+        return httpx.Response(
+            201,
+            json={
+                "sequenceId": 5,
+                "createdAt": "2026-06-30T00:00:01Z",
+                "eventType": payload["type"],
+                "emitterType": payload["emitter"]["type"],
+                "emitterId": payload["emitter"].get("id"),
+                "body": payload["body"],
+            },
+        )
+
+    return _handler
+
+
+def _echo_session(captured: dict[str, Any]) -> Callable[[httpx.Request], httpx.Response]:
+    """Return a respx side-effect that echoes the posted metadata back as a SessionResponse."""
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        payload = json.loads(req.content)
+        captured["body"] = payload
+        return httpx.Response(
+            201,
+            json={
+                "id": SESSION_ID,
+                "participants": payload.get("participants", [PARTICIPANT]),
+                "metadata": payload.get("metadata", {}),
+                "version": 1,
+                "createdAt": "2026-06-30T00:00:00Z",
+            },
+        )
+
+    return _handler
+
+
+# ── Body: nested single model ───────────────────────────────────────────────────
+
+
+@respx.mock
+async def test_body_nested_model_round_trips() -> None:
+    """GIVEN a nested Widget body field WHEN post THEN wire is JSON and read is typed."""
+    captured: dict[str, Any] = {}
+    respx.post(EVENTS_URL).mock(side_effect=_echo_event(captured))
+
+    widget = Widget(name="gizmo", size=3, color=Color.green)
+    event = await RichMessage.post(_session(), content="hi", emitter_type="agent", widget=widget)
+
+    assert captured["body"]["body"]["widget"] == {"name": "gizmo", "size": 3, "color": "green"}
+    assert isinstance(event.widget, Widget)
+    assert event.widget == widget
+
+
+# ── Body: list[Model] ────────────────────────────────────────────────────────────
+
+
+@respx.mock
+async def test_body_list_of_models_round_trips() -> None:
+    """GIVEN a list[Widget] body field WHEN post THEN wire is a list of dicts, read is typed."""
+    captured: dict[str, Any] = {}
+    respx.post(EVENTS_URL).mock(side_effect=_echo_event(captured))
+
+    widgets = [Widget(name="a", size=1), Widget(name="b", size=2, color=Color.green)]
+    event = await RichMessage.post(_session(), content="hi", emitter_type="agent", widgets=widgets)
+
+    assert captured["body"]["body"]["widgets"] == [
+        {"name": "a", "size": 1, "color": "red"},
+        {"name": "b", "size": 2, "color": "green"},
+    ]
+    assert event.widgets == widgets
+    assert all(isinstance(w, Widget) for w in event.widgets)
+
+
+# ── Body: Optional[Model] ────────────────────────────────────────────────────────
+
+
+@respx.mock
+async def test_body_optional_model_round_trips_value_and_none() -> None:
+    """GIVEN an Optional[Widget] WHEN post with a value and with None THEN both round-trip."""
+    captured: dict[str, Any] = {}
+    respx.post(EVENTS_URL).mock(side_effect=_echo_event(captured))
+
+    with_value = await RichMessage.post(
+        _session(),
+        content="hi",
+        emitter_type="agent",
+        widget=Widget(name="w", size=9),
+    )
+    assert isinstance(with_value.widget, Widget)
+
+    with_none = await RichMessage.post(_session(), content="hi", emitter_type="agent", widget=None)
+    assert captured["body"]["body"]["widget"] is None
+    assert with_none.widget is None
+
+
+# ── Body: enum ───────────────────────────────────────────────────────────────────
+
+
+@respx.mock
+async def test_body_enum_round_trips() -> None:
+    """GIVEN an enum body field WHEN post THEN wire stores the value and read is the enum."""
+    captured: dict[str, Any] = {}
+    respx.post(EVENTS_URL).mock(side_effect=_echo_event(captured))
+
+    event = await RichMessage.post(
+        _session(), content="hi", emitter_type="agent", color=Color.green
+    )
+
+    assert captured["body"]["body"]["color"] == "green"
+    assert event.color is Color.green
+
+
+# ── Body: dict ───────────────────────────────────────────────────────────────────
+
+
+@respx.mock
+async def test_body_dict_round_trips() -> None:
+    """GIVEN a dict body field WHEN post THEN it round-trips verbatim."""
+    captured: dict[str, Any] = {}
+    respx.post(EVENTS_URL).mock(side_effect=_echo_event(captured))
+
+    attrs = {"k": 1, "nested": {"x": [1, 2, 3]}}
+    event = await RichMessage.post(_session(), content="hi", emitter_type="agent", attrs=attrs)
+
+    assert captured["body"]["body"]["attrs"] == attrs
+    assert event.attrs == attrs
+
+
+# ── Metadata: nested model / list / optional / enum / dict ──────────────────────
+
+
+@respx.mock
+async def test_metadata_nested_model_round_trips() -> None:
+    """GIVEN a nested Widget metadata field WHEN post THEN wire is JSON and read is typed."""
+    captured: dict[str, Any] = {}
+    respx.post(SESSIONS_URL).mock(side_effect=_echo_session(captured))
+
+    widget = Widget(name="cfg", size=7, color=Color.green)
+    session = await RichSession.post(_space(), widget=widget)
+
+    assert captured["body"]["metadata"]["widget"] == {"name": "cfg", "size": 7, "color": "green"}
+    assert isinstance(session.widget, Widget)
+    assert session.widget == widget
+
+
+@respx.mock
+async def test_metadata_list_enum_and_dict_round_trip() -> None:
+    """GIVEN list/enum/dict metadata fields WHEN post THEN each round-trips through metadata."""
+    captured: dict[str, Any] = {}
+    respx.post(SESSIONS_URL).mock(side_effect=_echo_session(captured))
+
+    widgets = [Widget(name="a", size=1)]
+    attrs = {"flag": True, "count": 2}
+    session = await RichSession.post(_space(), widgets=widgets, color=Color.green, attrs=attrs)
+
+    assert captured["body"]["metadata"]["widgets"] == [{"name": "a", "size": 1, "color": "red"}]
+    assert captured["body"]["metadata"]["color"] == "green"
+    assert captured["body"]["metadata"]["attrs"] == attrs
+    assert session.widgets == widgets
+    assert session.color is Color.green
+    assert session.attrs == attrs
+
+
+@respx.mock
+async def test_metadata_optional_model_none_round_trips() -> None:
+    """GIVEN an Optional[Widget] metadata field WHEN post with None THEN it round-trips as None."""
+    captured: dict[str, Any] = {}
+    respx.post(SESSIONS_URL).mock(side_effect=_echo_session(captured))
+
+    session = await RichSession.post(_space(), widget=None)
+
+    assert captured["body"]["metadata"]["widget"] is None
+    assert session.widget is None
+
+
+# ── Graceful raw fallback on malformed wire ─────────────────────────────────────
+
+
+def test_body_malformed_wire_falls_back_to_raw() -> None:
+    """GIVEN a body value that cannot validate WHEN _from_wire THEN the raw value is kept."""
+    wire = {
+        "sequenceId": 5,
+        "createdAt": "2026-06-30T00:00:01Z",
+        "emitterType": "agent",
+        "emitterId": None,
+        "body": {"content": "hi", "widgets": "not-a-list"},
+    }
+    event = RichMessage._from_wire(_session(), wire)  # type: ignore[assignment]
+    assert event.widgets == "not-a-list"  # raw preserved, no ValidationError raised
+
+
+def test_metadata_malformed_wire_falls_back_to_raw() -> None:
+    """GIVEN a metadata value that cannot validate WHEN _from_wire THEN the raw value is kept."""
+    wire = {
+        "id": SESSION_ID,
+        "participants": [PARTICIPANT],
+        "metadata": {"widget": "not-a-widget"},
+        "version": 1,
+        "createdAt": "",
+    }
+    session = RichSession._from_wire(_space(), wire)  # type: ignore[assignment]
+    assert session.widget == "not-a-widget"  # raw preserved, no ValidationError raised
+
+
+def test_malformed_wire_fallback_logs_a_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """GIVEN an uncoercible field WHEN _from_wire THEN the raw fallback is logged at WARNING.
+
+    The raw value crashes downstream consumers that expect the declared type, so
+    the fallback must be observable rather than silent.
+    """
+    wire = {
+        "sequenceId": 5,
+        "createdAt": "2026-06-30T00:00:01Z",
+        "emitterType": "agent",
+        "emitterId": None,
+        "body": {"content": "hi", "widgets": "not-a-list"},
+    }
+    serde_logger = "datarobot_genai.application_utils.persistence._serde"
+    with caplog.at_level(logging.WARNING, logger=serde_logger):
+        event = RichMessage._from_wire(_session(), wire)  # type: ignore[assignment]
+
+    assert event.widgets == "not-a-list"
+    assert any(
+        r.name == serde_logger and "widgets" in r.getMessage() and "raw value" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+# ── patch preserves an unpatched nested field ───────────────────────────────────
+
+
+@respx.mock
+async def test_patch_preserves_unpatched_nested_field() -> None:
+    """GIVEN an event with a nested widget WHEN patching only the enum THEN widget is resent."""
+    captured: dict[str, Any] = {}
+
+    def _capture(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.content)
+        return httpx.Response(
+            200,
+            json={
+                "sequenceId": 5,
+                "createdAt": "2026-06-30T00:00:02Z",
+                "emitterType": "agent",
+                "emitterId": None,
+                "body": {"content": "hi", "widget": {"name": "w", "size": 1, "color": "red"}},
+            },
+        )
+
+    respx.patch(EVENT_URL).mock(side_effect=_capture)
+
+    wire = {
+        "sequenceId": 5,
+        "createdAt": "2026-06-30T00:00:01Z",
+        "emitterType": "agent",
+        "emitterId": None,
+        "body": {"content": "hi", "widget": {"name": "w", "size": 1, "color": "green"}},
+    }
+    event = RichMessage._from_wire(_session(), wire)  # type: ignore[assignment]
+
+    await event.patch(color=Color.red)
+
+    # The unpatched nested widget is re-serialised and resent (JSON dict, not a model).
+    assert captured["body"]["body"]["widget"] == {"name": "w", "size": 1, "color": "green"}
+    assert captured["body"]["body"]["color"] == "red"
+
+
+# ── Scalars are byte-identical to a raw passthrough ─────────────────────────────
+
+
+def test_scalar_metadata_serialisation_is_identical_to_raw() -> None:
+    """GIVEN scalar metadata fields WHEN building the wire THEN values and types are unchanged."""
+    payload = ScalarSession._to_wire_create({"s": "x", "n": 3, "f": 0.5, "b": True})
+
+    metadata = payload["metadata"]
+    assert metadata == {"s": "x", "n": 3, "f": 0.5, "b": True}
+    assert type(metadata["s"]) is str
+    assert type(metadata["n"]) is int
+    assert type(metadata["f"]) is float
+    assert type(metadata["b"]) is bool
+
+
+def test_scalar_body_serialisation_is_identical_to_raw() -> None:
+    """GIVEN a scalar body field WHEN building the wire THEN the value and type are unchanged."""
+    from tests.application_utils.persistence.unit.conftest import ChatMessage
+
+    body = ChatMessage._to_wire_body({"content": "hi", "score": 0.9})
+    assert body["score"] == 0.9
+    assert type(body["score"]) is float
+
+
+# ── Full serialise → deserialise cycle equality ─────────────────────────────────
+
+
+def test_full_cycle_equality_for_all_field_kinds() -> None:
+    """GIVEN mixed field kinds WHEN serialised to the wire and read back THEN they compare equal."""
+    original = RichMessage.model_construct(
+        content="hi",
+        emitter_type="agent",
+        emitter_id=None,
+        widget=Widget(name="w", size=1, color=Color.green),
+        widgets=[Widget(name="a", size=2)],
+        color=Color.green,
+        attrs={"k": "v"},
+    )
+
+    wire_body = RichMessage._to_wire_body(
+        {
+            "content": original.content,
+            "widget": original.widget,
+            "widgets": original.widgets,
+            "color": original.color,
+            "attrs": original.attrs,
+        }
+    )
+    event = RichMessage._from_wire(  # type: ignore[assignment]
+        _session(),
+        {
+            "sequenceId": 5,
+            "createdAt": "2026-06-30T00:00:01Z",
+            "emitterType": "agent",
+            "emitterId": None,
+            "body": wire_body,
+        },
+    )
+
+    assert event.widget == original.widget
+    assert event.widgets == original.widgets
+    assert event.color is Color.green
+    assert event.attrs == original.attrs
+
+
+# ── Adapter caching ──────────────────────────────────────────────────────────────
+
+
+def test_field_type_adapter_is_cached_per_field() -> None:
+    """GIVEN repeated adapter requests WHEN fetched twice THEN the same instance is returned."""
+    from datarobot_genai.application_utils.persistence._serde import field_type_adapter
+
+    first = field_type_adapter(RichMessage, "widget")
+    second = field_type_adapter(RichMessage, "widget")
+    assert first is second
+
+
+def test_deserialize_field_returns_raw_on_validation_error() -> None:
+    """GIVEN a value that cannot validate WHEN deserialize_field THEN the raw value is returned."""
+    from datarobot_genai.application_utils.persistence._serde import deserialize_field
+
+    assert deserialize_field(RichMessage, "widgets", 123) == 123
+
+
+@pytest.mark.parametrize("value", ["plain", 7, 1.5, True, None])
+def test_deserialize_field_scalar_identity(value: object) -> None:
+    """GIVEN a matching-shaped scalar WHEN round-tripped THEN it survives serialise+deserialise."""
+    from datarobot_genai.application_utils.persistence._serde import deserialize_field
+    from datarobot_genai.application_utils.persistence._serde import serialize_field
+
+    wire = serialize_field(RichSession, "attrs", {"v": value})
+    assert deserialize_field(RichSession, "attrs", wire) == {"v": value}

--- a/tests/application_utils/persistence/unit/test_session.py
+++ b/tests/application_utils/persistence/unit/test_session.py
@@ -37,6 +37,8 @@ from tests.application_utils.persistence.unit.conftest import SESSION_ID
 from tests.application_utils.persistence.unit.conftest import SPACE_ID
 from tests.application_utils.persistence.unit.conftest import SYSTEM_OID
 from tests.application_utils.persistence.unit.conftest import ChatSession
+from tests.application_utils.persistence.unit.conftest import DedupeOnlySession
+from tests.application_utils.persistence.unit.conftest import MinimalSession
 
 BASE = "https://app.datarobot.com/api/v2"
 MEMORY_BASE = f"{BASE}/memory"
@@ -224,6 +226,40 @@ async def test_post_encodes_range_keys_as_description() -> None:
 
 
 @respx.mock
+async def test_post_range_key_less_session_stamps_prefix_description() -> None:
+    """GIVEN a session with no range keys WHEN post THEN description is the bare prefix.
+
+    Every subclass must be prefix-identifiable on the wire so ``.list`` can scope
+    by subclass, even when the subclass declares no ``DRRangeKey`` fields.
+    """
+    captured: dict = {}
+
+    def _capture(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.content)
+        return httpx.Response(201, json=_session_wire())
+
+    respx.post(SESSIONS_URL).mock(side_effect=_capture)
+    space = _make_space()
+    await DedupeOnlySession.post(space, key="k1", notes="hello")
+    assert captured["body"]["description"] == "//dedup-only/"
+
+
+@respx.mock
+async def test_post_range_key_less_session_defaults_prefix_to_class_name() -> None:
+    """GIVEN a session with no prefix and no range keys WHEN post THEN prefix = class name."""
+    captured: dict = {}
+
+    def _capture(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.content)
+        return httpx.Response(201, json=_session_wire())
+
+    respx.post(SESSIONS_URL).mock(side_effect=_capture)
+    space = _make_space()
+    await MinimalSession.post(space, label="x")
+    assert captured["body"]["description"] == "//MinimalSession/"
+
+
+@respx.mock
 async def test_post_puts_metadata_fields_in_metadata() -> None:
     """GIVEN title (metadata field) WHEN post THEN metadata dict contains title."""
     captured: dict = {}
@@ -384,6 +420,41 @@ async def test_list_returns_all_sessions() -> None:
     space = _make_space()
     sessions = await ChatSession.list(space)
     assert len(sessions) == 2
+
+
+@respx.mock
+async def test_list_without_range_keys_sends_prefix_scoped_description() -> None:
+    """GIVEN list() with no kwargs WHEN GET THEN description=//chat/ scopes to the subclass.
+
+    Without the prefix filter the service would return every session in the space
+    regardless of subclass — the latent bug the repository-index change fixes.
+    """
+    captured: dict = {}
+
+    def _capture(req: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(req.url.params)
+        return httpx.Response(200, json={"items": [], "total": 0})
+
+    respx.get(SESSIONS_URL).mock(side_effect=_capture)
+    space = _make_space()
+    await ChatSession.list(space)
+    assert captured["params"]["description"] == "//chat/"
+
+
+@respx.mock
+async def test_list_participant_only_still_sends_prefix_description() -> None:
+    """GIVEN list(participant=oid) with no range kwargs WHEN GET THEN prefix filter present."""
+    captured: dict = {}
+
+    def _capture(req: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(req.url.params)
+        return httpx.Response(200, json={"items": [], "total": 0})
+
+    respx.get(SESSIONS_URL).mock(side_effect=_capture)
+    space = _make_space()
+    await ChatSession.list(space, participant=PARTICIPANT)
+    assert captured["params"]["description"] == "//chat/"
+    assert captured["params"]["participants"] == PARTICIPANT
 
 
 @respx.mock

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
### 📚 Stack — review bottom → top (merge in order)

Splits #553 into 4 reviewable layers. Each PR is based on the one below it.

1. **#557 — `_serde` for persistence — ORM nested (de)serialization (0.24.2) 👈 you are here**
2. #558 — chat_history models & repositories (0.24.3)
3. #559 — AG-UI storage & stream manager (0.24.4)
4. #560 — docs cleanup — publish & split Application Utils docs (0.24.5)

---

Extend the persistence ORM so declared session-metadata and event-body
fields round-trip any Pydantic-expressible type (nested models, list[Model],
Optional[Model], enums, dicts) via per-field TypeAdapters, instead of only
JSON primitives. New persistence/_serde.py provides the field-adapter cache;
event.py/session.py route all write and read sites through it.

Behavior change: on read, present field values are best-effort coerced to
their declared type; malformed wire values fall back to the raw value (logged
at WARNING). All backward-compat invariants are preserved (reads via
model_construct, absent-required->None, version/sequenceId defaults, patch
semantics, routing markers bypass serde).

Bumps version to 0.24.2. First of a 4-PR stack splitting the AG-UI
chat-history feature.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence ORM read/write semantics for metadata and body fields (including coercion and silent raw fallback on bad wire data), which can affect agents storing nested chat/tool payloads in Memory Service.
> 
> **Overview**
> Adds **`persistence/_serde.py`** with cached per-field `TypeAdapter`s and routes all **session `metadata`** and **event `body`** wire paths in `session.py` / `event.py` through `serialize_field` / `deserialize_field` (create, read, patch, and batch patch).
> 
> Nested Pydantic models, `list[Model]`, optionals, enums, and dicts now round-trip as typed values instead of raw dicts or write failures; routing-marker fields (`description`, `deduplicationKey`, etc.) are unchanged.
> 
> **Read behavior:** present wire values are best-effort coerced to the declared type (e.g. `"3"` → `int`); invalid payloads return the raw value and log **WARNING** without raising. Version **0.24.2**; new unit tests in `test_serde.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54de56676a461635a3743a2d24a65f2c0851043e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
