### PR TITLE
docs(application-utils): publish and split the Application Utils docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.25.4
+- `docs`: **Application Utils docs published & split** — moved the `application_utils` docs from the unpublished `docs/application_utils/` into the published `docs/src/` tree and split them into a section-index `README.md`, the lifted `memory_orm.md` (Memory Service ORM), and a new `chat_history.md`, with a matching `Application Utils` nav block in `properdocs.yml`. Documents the always-prefix-scoped `.list` and the dedup-keyed `EntityLocator` secondary index (consistency trade-off + orphan policy). Corrected the stale `persistence/integration` test path to `persistence/acceptance -m integration`. Added `tests/docs` regression tests guarding the published layout and nav.
+
 ## 0.25.3
 - `application-utils`: **AG-UI chat-history storage** — completes the `chat_history` sub-package with the AG-UI storage layer over the models/repositories. Adds the overridable `AGUIStorageAgent` state machine (build-hook, event-dispatch registry, category-handler, and repo-protocol extensibility points) with `translate_messages` history rebuild, and a `StreamPersistenceManager`/`RunHandle` pair for disconnect-survival and cancellation (`interrupted`) with a never-hang final flush. Public import: `from datarobot_genai.application_utils.chat_history import AGUIStorageAgent, StreamPersistenceManager`. Adds the `ag-ui-protocol~=0.1.15` dependency to the `application-utils` extra (the `persistence` sub-package still never imports `ag_ui`).
 

--- a/docs/properdocs.yml
+++ b/docs/properdocs.yml
@@ -118,6 +118,10 @@ nav:
     - drtools/README.md
     - Authentication: drtools/auth.md
     - Atlassian Auth: drtools/auth-atlassian.md
+  - Application Utils:
+    - application_utils/README.md
+    - Memory Service ORM: application_utils/memory_orm.md
+    - Chat History: application_utils/chat_history.md
   - Design:
     - design/nat-1.6-streaming.md
   - API Reference: api/

--- a/docs/src/application_utils/README.md
+++ b/docs/src/application_utils/README.md
@@ -1,0 +1,28 @@
+# Application Utils
+
+`datarobot-genai[application-utils]` provides building blocks for stateful agent
+applications on top of the DataRobot Agentic Memory Service — a typed async ORM
+and an AG-UI chat-history layer built on it.  Both use your existing
+`DATAROBOT_ENDPOINT` / `DATAROBOT_API_TOKEN` credentials.
+
+## Installation
+
+```bash
+pip install "datarobot-genai[application-utils]"
+```
+
+## Guides
+
+| Doc | Focus |
+|---|---|
+| [memory_orm.md](memory_orm.md) | The Memory Service light ORM: `DRMemorySpace`, `DRSession`, `DREvent`, range-key encoding, optimistic concurrency, batch ops, typed (de)serialization. |
+| [chat_history.md](chat_history.md) | The AG-UI chat-history layer: `Chat` / `Message` models, repositories, the `AGUIStorageAgent` state machine, disconnect survival and cancellation via `StreamPersistenceManager`, and the four extensibility points. |
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `DATAROBOT_ENDPOINT` | Full DataRobot API base URL, e.g. `https://app.datarobot.com/api/v2`. |
+| `DATAROBOT_API_TOKEN` | DataRobot API bearer token. |
+
+Both are resolved automatically; pass them as constructor arguments to override.

--- a/docs/src/application_utils/chat_history.md
+++ b/docs/src/application_utils/chat_history.md
@@ -1,0 +1,281 @@
+# AG-UI Chat History
+
+The chat-history layer turns an AG-UI agent's event stream into durable,
+typed chat history on top of the [Memory Service ORM](memory_orm.md).  It gives
+you three things:
+
+- **Typed chat models** — `Chat` (a `DRSession`) and `Message` (a `DREvent`),
+  with nested `ToolCall` / `Reasoning` models living inside a single message
+  event body.  One Memory Service event per logical message.
+- **A transparent storage wrapper** — `AGUIStorageAgent` forwards an inner
+  agent's events verbatim (in real time) while a background task folds the same
+  stream into persisted history: inbound user messages are stored, prior history
+  is replayed into the run, and every text / tool-call / reasoning delta is
+  captured.
+- **Disconnect survival and cancellation** — `StreamPersistenceManager` runs the
+  storage agent behind an unbounded queue so persistence completes even if the
+  client stops reading, and exposes cancellation that marks in-flight records
+  `interrupted`.
+
+Everything is imported from a single package:
+
+```python
+from datarobot_genai.application_utils.chat_history import (
+    AGUIAgent,
+    AGUIStorageAgent,
+    ChatRepository,
+    ChatSessionRegistry,
+    MessageRepository,
+    RunHandle,
+    StreamPersistenceManager,
+)
+```
+
+The chat-history package depends on `persistence` **and** `ag_ui`; the
+`persistence` sub-package never imports `ag_ui`, so the ORM stays
+transport-agnostic.
+
+## Quick-start
+
+Wire the repositories, wrap your inner agent, and run it through the manager.
+`StreamPersistenceManager.run` returns a `RunHandle` you iterate for the
+client-facing stream, cancel, or await to completion.
+
+```python
+import asyncio
+from uuid import uuid4
+
+from ag_ui.core import RunAgentInput, UserMessage
+
+from datarobot_genai.application_utils.chat_history import (
+    AGUIStorageAgent,
+    ChatRepository,
+    ChatSessionRegistry,
+    MessageRepository,
+    StreamPersistenceManager,
+)
+from datarobot_genai.application_utils.persistence import DRMemoryServiceClient, DRMemorySpace
+
+
+async def main(inner_agent) -> None:
+    user_id = uuid4()
+
+    async with DRMemoryServiceClient() as client:
+        space = await DRMemorySpace.post(client, deduplication_key="my-chat-app-v1")
+
+        # A registry shares the chat_uuid -> session_id cache across repos.
+        registry = ChatSessionRegistry(space)
+        chat_repo = ChatRepository(space, registry)
+        message_repo = MessageRepository(space, registry)
+
+        # The factory builds a fresh storage agent per run; the manager owns the
+        # in-flight-run registry keyed by (thread_id, run_id).
+        manager = StreamPersistenceManager(
+            lambda: AGUIStorageAgent(
+                "assistant", user_id, chat_repo, message_repo, inner_agent
+            )
+        )
+
+        input = RunAgentInput(
+            thread_id="thread-1",
+            run_id="run-1",
+            messages=[UserMessage(id="m1", role="user", content="Hello!")],
+            tools=[],
+            context=[],
+            state={},
+            forwarded_props={},
+        )
+
+        handle = await manager.run(input)
+
+        # Stream events to the client. Stopping early (a disconnect) does NOT
+        # abort persistence — the producer keeps draining behind the scenes.
+        async for event in handle.events():
+            ...  # forward `event` to your UI / SSE response
+
+        # Wait for the background persistence to finish, then read history back.
+        await handle.wait()
+        history = await message_repo.get_chat_messages(
+            (await chat_repo.get_chat_by_thread_id(user_id, "thread-1")).chat_uuid
+        )
+        for message in history:
+            print(message.role, message.content, message.tool_calls, message.reasonings)
+
+
+# `inner_agent` is any AGUIAgent: `run(input) -> AsyncGenerator[BaseEvent]`.
+asyncio.run(main(inner_agent=...))
+```
+
+Cancel a run through the handle (or `manager.cancel(thread_id, run_id)`):
+
+```python
+handle = await manager.run(input)
+...
+handle.cancel()      # -> True if a live run was found, False otherwise
+await handle.wait()  # in-flight records are finalised as `interrupted`
+```
+
+## Data model
+
+| Model | Base | Stored as |
+|---|---|---|
+| `Chat` | `DRSession` | One session per thread. `thread_id` is a range key (indexed `//thread/{thread_id}/` lookup); `dedup_key = sha256("chat"\0user_uuid\0thread_id)` makes create idempotent. Metadata: `name`, `chat_uuid`, `user_uuid`. |
+| `Message` | `DREvent` (`event_type="message"`) | One event per logical message. Body carries `v`, `role`, `status`, `in_progress`, and the nested `tool_calls: list[ToolCall]` / `reasonings: list[Reasoning]`. |
+| `ToolCall` | `BaseModel` | Nested in a message body — `tool_call_id`, `name`, `arguments`, `content`, `status`. |
+| `Reasoning` | `BaseModel` | Nested in a message body — `name`, `content`, `status`. |
+
+The nested models round-trip through the Memory Service ORM's typed
+serialization (see [Memory Service ORM](memory_orm.md)); empty `content` /
+`arguments` are transparently encoded to a zero-width placeholder to satisfy the
+service's `min_length=1`.
+
+`Role` values: `developer`, `system`, `assistant`, `user`, `tool`, `reasoning`.
+`MessageStatus` values: `active`, `complete`, `interrupted`, `errored`.
+
+`ChatRepository` and `MessageRepository` are the CRUD facades (create/adopt a
+chat idempotently, append messages, mutate nested tool-calls / reasonings,
+read history sorted by sequence id).  `ChatSessionRegistry` resolves
+`chat_uuid → session_id` via a bounded in-process cache, then an indexed
+`chat:<uuid>` [`EntityLocator`](#secondary-index-and-consistency) point lookup —
+never a full-space scan.
+
+## Secondary index and consistency
+
+The Memory Service has no cross-session event query, so resolving an entity by
+its application UUID — `chat_uuid → session`, `message_uuid → chat`, or a
+tool-call / reasoning `uuid → parent message` — could otherwise only be done by
+scanning every session in the space.  Instead the layer keeps a dedup-keyed
+secondary index: one `EntityLocator` (itself a `DRSession`) per locatable entity,
+looked up by the exact key `"<kind>:<uuid>"` (`kind` is one of `chat`, `message`,
+`tool_call`, `reasoning`).  Every cold lookup is a single indexed point `get` —
+there are **no full-space scans**.
+
+Locators live in the **same** Memory Space as the chats; their `//loc/`
+description prefix keeps them out of every `Chat.list` result (and vice-versa),
+so no second space is needed.
+
+### Best-effort writes and the consistency trade-off
+
+Each create writes the entity first (the event or session — the **source of
+truth**), then writes its locator best-effort.  A locator write that fails is
+logged and swallowed; it never fails the operation.  The deliberate consequences:
+
+- The worker that created the entity is unaffected — its in-process cache is warm.
+- If a locator write is **lost**, a *different* replica (or a lookup after a
+  restart) that addresses the entity **by uuid** — `get_message`,
+  `update_message`, a tool-call / reasoning update — may report "not found" for
+  an entity that actually exists.
+- The data is **not** lost: `get_chat_messages` lists the chat's events directly
+  and still returns the message.
+
+This backend therefore offers **no strong cross-replica read-after-write
+consistency for uuid-addressed lookups**.  A caller that cannot tolerate that
+needs a transactional backend, not this one.
+
+### Orphans
+
+`delete_chat` soft-deletes the session (and its events) in one shot; there is no
+per-message delete, and it deliberately does **not** walk and delete the chat's
+locators.  Those locators are left as **orphans** — cheap, bounded by the same
+soft-delete TTL as the sessions they point at, and harmless: a stale locator
+resolves to a dead session and is treated as not-found, and because UUIDs never
+collide it can never resurrect or mis-route a new entity.
+
+## Run-outcome status semantics
+
+Every message / tool-call / reasoning record carries a `status`.  How a run ends
+determines the terminal status of the records that were still `in_progress`:
+
+| How the run ends | Terminal status | Mechanism |
+|---|---|---|
+| **Normal completion** | `complete` | The inner agent emits `RunFinishedEvent`; `handle_run_lifecycle` flips the active message (and its tool-calls / reasonings) to `in_progress=False`, `status=complete`. |
+| **Explicit cancel** | `interrupted` | `RunHandle.cancel()` / `StreamPersistenceManager.cancel()` cancels the producer task; the `CancelledError` propagates into `AGUIStorageAgent.run`, whose `finally` calls `_finalize_interrupted` to flip every still-`in_progress` record to `status=interrupted`. |
+| **Inner-agent raw crash** | `errored` | The inner agent raises (rather than emitting a terminal `RunErrorEvent`).  `AGUIStorageAgent.run` records the exception, its `finally` calls `_finalize_errored` to flip still-active records to `status=errored`, then re-raises — the manager's producer catches it and synthesizes a client-facing `RunErrorEvent(code=INTERNAL_ERROR)` so the client never hangs. |
+| **Client disconnect** | `complete` | The client stops reading `RunHandle.events()`, but the producer drains the inner agent into its **unbounded** queue regardless, so the run finishes normally and persists as `complete`.  `await handle.wait()` blocks until that drain finishes. |
+
+> An in-band `RunErrorEvent` emitted *by the inner agent* is a normal terminal
+> event: `handle_run_lifecycle` records those records as `errored` directly.
+> `_finalize_errored` is specifically the safety net for a **raw exception** that
+> escaped the inner agent without a terminal event.
+
+## Extensibility
+
+`AGUIStorageAgent` is an *open* state machine: every seam a consumer might want
+to customise is an overridable method, and it depends only on repository
+Protocols.  There are four extension points.
+
+### 1. Event-dispatch registry
+
+`event_handlers()` maps each AG-UI event type to a handler-method name.  Extend
+it (walking the MRO, so subclasses of known events resolve automatically) to
+persist brand-new or custom event types; unrecognised events fall through to
+`handle_unknown_event` (a no-op by default).
+
+```python
+class MyStorageAgent(AGUIStorageAgent):
+    @classmethod
+    def event_handlers(cls):
+        return {**super().event_handlers(), MyCustomEvent: "handle_my_custom_event"}
+
+    async def handle_my_custom_event(self, state, chat, event):
+        ...  # persist the custom event
+```
+
+### 2. Category handlers
+
+`handle_text_message`, `handle_tool_call`, `handle_reasoning`,
+`handle_run_lifecycle` and `handle_step` own each event family.  Override one to
+change how a whole category is stored — e.g. to extract structured content
+instead of appending raw text deltas.
+
+```python
+class StructuredTextAgent(AGUIStorageAgent):
+    async def handle_text_message(self, state, chat, event):
+        # e.g. parse `event` into structured fields before buffering / flushing
+        await super().handle_text_message(state, chat, event)
+```
+
+### 3. Message-build hooks
+
+`build_message_create`, `build_tool_call_create`, `build_reasoning_create` and
+`message_update_fields` construct the DTOs the repository persists.  Override
+them to populate extra fields declared on your `Message` / `ToolCall` /
+`Reasoning` subclasses.
+
+```python
+class TaggedStorageAgent(AGUIStorageAgent):
+    def build_message_create(self, state, chat, agui_id, role):
+        base = super().build_message_create(state, chat, agui_id, role)
+        return MyMessageCreate(**base.model_dump(), team="research")
+
+    def message_update_fields(self, state, event):
+        return {"finished_at": state.current_event_timestamp}
+```
+
+### 4. Repository coupling (Protocols)
+
+The agent references only `ChatRepositoryLike` / `MessageRepositoryLike`
+(`runtime_checkable` `typing.Protocol`s), so any conforming backend — a SQL
+store, an in-memory fake for tests — is a drop-in replacement with no imports of
+the concrete classes.
+
+```python
+class InMemoryChatRepo:  # structurally satisfies ChatRepositoryLike
+    async def get_chat_by_thread_id(self, user_uuid, thread_id): ...
+    async def create_chat(self, chat_data): ...
+    # ...remaining protocol methods...
+
+agent = AGUIStorageAgent("assistant", user_id, InMemoryChatRepo(), my_message_repo, inner)
+```
+
+## Running acceptance tests
+
+The chat-history acceptance suite drives a scripted inner agent against a live
+Memory Service.  It is skipped by default and requires credentials:
+
+```bash
+export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
+export DATAROBOT_API_TOKEN="<your-token>"
+
+uv run pytest tests/application_utils/chat_history/acceptance -m integration -vv
+```

--- a/docs/src/application_utils/memory_orm.md
+++ b/docs/src/application_utils/memory_orm.md
@@ -1,4 +1,4 @@
-# application-utils — Memory Service Light ORM
+# Memory Service ORM
 
 `datarobot-genai[application-utils]` ships a lightweight async ORM over the
 DataRobot Agentic Memory Service.  Think of it as a typed, Pydantic v2-style
@@ -177,6 +177,12 @@ class ChatMessage(DREvent, session=ChatSession):
     score: float = 0.0
 ```
 
+Declared fields round-trip through **any** Pydantic-expressible type — nested
+models, `list[Model]`, `Optional[Model]`, enums and dicts all serialize into the
+event `body` (and session `metadata`) and validate back on read.  This is what
+lets the [chat-history layer](chat_history.md) nest typed `ToolCall` / `Reasoning`
+models inside a single message event.
+
 ## Range-key encoding
 
 Range keys are encoded in the session `description` field using a hierarchical
@@ -201,6 +207,15 @@ service side is equivalent to a hierarchy prefix query.
 Query `list(tenant="acme")` sends `description=//chat/acme/` which matches
 **both**.  Query `list(tenant="acme", topic="billing")` sends
 `description=//chat/acme/billing/` which matches **only the first**.
+
+A subclass's `.list` **always** sends at least its `//<prefix>/` description
+filter — even with no range-key arguments — so `ChatSession.list(space)` returns
+only `chat`-prefixed sessions, never sessions of another `DRSession` subclass
+that happens to share the same space.  (Trailing-slash anchoring keeps prefixes
+disjoint, so `//chat/` never matches a `//chatx/…` or `//loc/…` session.)  This
+subclass isolation is what lets the [chat-history layer](chat_history.md) keep
+its `Chat` sessions and its `EntityLocator` index sessions (prefix `loc`) in one
+space without either bleeding into the other's `.list` results.
 
 > ⚠️ **Case-insensitive caveat** — the service performs a case-insensitive
 > substring match, so `Acme` and `acme` are treated as the same tenant.
@@ -310,7 +325,6 @@ Integration tests are skipped by default.  To run them against a live endpoint:
 ```bash
 export DATAROBOT_ENDPOINT="https://app.datarobot.com/api/v2"
 export DATAROBOT_API_TOKEN="<your-token>"
-export DR_MEMORY_LIVE_INTEGRATION="1"
 
-uv run pytest tests/application_utils/persistence/integration -vv
+uv run pytest tests/application_utils/persistence/acceptance -m integration -vv
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.25.3"
+version = "0.25.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/tests/docs/__init__.py
+++ b/tests/docs/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/docs/test_docs_structure.py
+++ b/tests/docs/test_docs_structure.py
@@ -1,0 +1,165 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the published documentation layout and nav.
+
+Only files under ``docs/src`` are published (``properdocs.yml`` sets
+``docs_dir: src``).  These tests pin the Application Utils section — the
+memory-ORM/chat-history split — and guard the whole nav against references
+to files that do not exist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Repo root: this file is <root>/tests/docs/test_docs_structure.py
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCS = _REPO_ROOT / "docs"
+
+
+def _load_nav_config() -> dict:
+    """Parse ``docs/properdocs.yml`` into a dict."""
+    return yaml.safe_load((_DOCS / "properdocs.yml").read_text())
+
+
+def _nav_leaves(node: object) -> list[str]:
+    """Return every string leaf (page path) reachable from a nav *node*."""
+    leaves: list[str] = []
+    if isinstance(node, dict):
+        for value in node.values():
+            leaves.extend(_nav_leaves(value))
+    elif isinstance(node, list):
+        for value in node:
+            leaves.extend(_nav_leaves(value))
+    elif isinstance(node, str):
+        leaves.append(node)
+    return leaves
+
+
+def test_application_utils_docs_are_published_and_split() -> None:
+    """
+    GIVEN the docs move/split.
+
+    WHEN the published ``docs/src/application_utils`` directory is inspected.
+
+    THEN it contains the section-index README plus the memory-ORM and
+    chat-history pages.
+    """
+    section = _DOCS / "src" / "application_utils"
+
+    assert (section / "README.md").is_file()
+    assert (section / "memory_orm.md").is_file()
+    assert (section / "chat_history.md").is_file()
+
+
+def test_old_unpublished_application_utils_dir_is_removed() -> None:
+    """
+    GIVEN the prior PR mistakenly placed the docs outside ``docs/src``.
+
+    WHEN the repository is inspected after the application_utils move.
+
+    THEN the unpublished ``docs/application_utils`` directory no longer exists.
+    """
+    assert not (_DOCS / "application_utils").exists()
+
+
+def test_application_utils_nav_block_follows_section_index_convention() -> None:
+    """
+    GIVEN the ``properdocs.yml`` navigation.
+
+    WHEN the "Application Utils" block is located.
+
+    THEN the section-index README is listed first, then the memory-ORM and
+    chat-history pages in order.
+    """
+    nav = _load_nav_config()["nav"]
+
+    app_utils_block = next(
+        (
+            entry["Application Utils"]
+            for entry in nav
+            if isinstance(entry, dict) and "Application Utils" in entry
+        ),
+        None,
+    )
+
+    assert app_utils_block is not None, "properdocs.yml is missing an 'Application Utils' nav block"
+    assert app_utils_block[0] == "application_utils/README.md"
+    assert {"Memory Service ORM": "application_utils/memory_orm.md"} in app_utils_block
+    assert {"Chat History": "application_utils/chat_history.md"} in app_utils_block
+
+
+def test_every_nav_page_resolves_to_a_published_file() -> None:
+    """
+    GIVEN the full ``properdocs.yml`` navigation.
+
+    WHEN each page reference is resolved against ``docs_dir``.
+
+    THEN every entry points at a real file (the auto-generated ``api/`` tree,
+    produced at build time by ``gen_ref_pages.py``, is exempt).
+    """
+    config = _load_nav_config()
+    docs_dir = _DOCS / config.get("docs_dir", "src")
+
+    missing = [
+        page
+        for page in _nav_leaves(config["nav"])
+        if not page.endswith("/") and not (docs_dir / page).is_file()
+    ]
+
+    assert missing == [], f"nav references non-existent pages: {missing}"
+
+
+def test_stale_persistence_integration_path_is_corrected() -> None:
+    """
+    GIVEN the old README pointed at a non-existent ``persistence/integration`` dir.
+
+    WHEN the split memory-ORM page is read.
+
+    THEN it points at the real ``persistence/acceptance -m integration`` suite.
+    """
+    memory_orm = (_DOCS / "src" / "application_utils" / "memory_orm.md").read_text()
+
+    assert "persistence/integration" not in memory_orm
+    assert "persistence/acceptance -m integration" in memory_orm
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        # Run-outcome status semantics carried forward from the storage agent.
+        "`complete`",
+        "`interrupted`",
+        "`errored`",
+        "_finalize_errored",
+        "StreamPersistenceManager",
+        "RunHandle",
+    ],
+)
+def test_chat_history_documents_status_semantics_and_quickstart(needle: str) -> None:
+    """
+    GIVEN the new chat-history page.
+
+    WHEN it is read.
+
+    THEN it documents the run-outcome status semantics and the
+    ``StreamPersistenceManager`` / ``RunHandle`` quick-start surface.
+    """
+    chat_history = (_DOCS / "src" / "application_utils" / "chat_history.md").read_text()
+
+    assert needle in chat_history

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.25.3"
+version = "0.25.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
### 📚 Stack — review bottom → top (merge in order)

Splits #553 into 4 reviewable layers. Each PR is based on the one below it.

1. #557 — `_serde` for persistence — ORM nested (de)serialization (0.24.2)
2. #558 — chat_history models & repositories (0.24.3)
3. #559 — AG-UI storage & stream manager (0.24.4)
4. **#560 — docs cleanup — publish & split Application Utils docs (0.24.5) 👈 you are here**

---

Move the application_utils docs from the unpublished docs/application_utils/
into the published docs/src/ tree (properdocs.yml sets docs_dir: src) and split
them three ways:

- README.md   — slim section index (section-index + literate-nav convention).
- memory_orm.md — the lifted Memory Service ORM content; corrects the stale
  persistence/integration test path to persistence/acceptance -m integration.
- chat_history.md — new page: models, repositories, the AGUIStorageAgent
  extensibility points, and the StreamPersistenceManager/RunHandle quick-start.

Adds an Application Utils nav block to properdocs.yml and tests/docs regression
tests guarding the published layout, nav resolution, and status semantics.
Also strips a trailing-whitespace lint error latent in the test file.

Bumps version to 0.24.5. Fourth of a 4-PR stack.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, navigation, and test-only changes with no library runtime behavior modified.
> 
> **Overview**
> **Publishes** Application Utils documentation by moving it from unpublished `docs/application_utils/` into `docs/src/application_utils/` and adding an **Application Utils** nav section in `properdocs.yml`.
> 
> The content is **split** into a section index (`README.md`), the Memory Service ORM guide (`memory_orm.md`, retitled and lightly extended for nested serde + chat-history cross-link), and a new **AG-UI chat history** guide (`chat_history.md`) covering models/repos, `StreamPersistenceManager`/`RunHandle`, status semantics, and extensibility.
> 
> **Docs fix:** persistence integration instructions now point at `tests/application_utils/persistence/acceptance -m integration` instead of the stale `persistence/integration` path.
> 
> **Regression tests** under `tests/docs/` pin the published file layout, nav ordering, full-nav file resolution, and key chat-history doc strings. **Version** bumped to **0.24.5** (`CHANGELOG`, `pyproject.toml`, `uv.lock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb80e093abd5d76824451fe95612fc55993cb07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
