### PR TITLE
[BUZZOK-31306] e2e: NeMo guard still fails open on moderations 11.2.45

### DIFF
--- a/e2e-tests/dragent/base/nemo_guardrails/prompt/actions.py
+++ b/e2e-tests/dragent/base/nemo_guardrails/prompt/actions.py
@@ -76,7 +76,8 @@ async def self_check_input(
 
         check = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        check = check.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        check = getattr(check, "content", check).lower().strip()
         log.info(f"Input self-checking result is: `{check}`.")
 
         if "yes" in check:

--- a/e2e-tests/dragent/base/nemo_guardrails/response/actions.py
+++ b/e2e-tests/dragent/base/nemo_guardrails/response/actions.py
@@ -78,7 +78,8 @@ async def self_check_output(
 
         response = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        response = response.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        response = getattr(response, "content", response).lower().strip()
         log.info(f"Output self-checking result is: `{response}`.")
 
         if "yes" in response:

--- a/e2e-tests/dragent/crewai/nemo_guardrails/prompt/actions.py
+++ b/e2e-tests/dragent/crewai/nemo_guardrails/prompt/actions.py
@@ -76,7 +76,8 @@ async def self_check_input(
 
         check = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        check = check.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        check = getattr(check, "content", check).lower().strip()
         log.info(f"Input self-checking result is: `{check}`.")
 
         if "yes" in check:

--- a/e2e-tests/dragent/crewai/nemo_guardrails/response/actions.py
+++ b/e2e-tests/dragent/crewai/nemo_guardrails/response/actions.py
@@ -78,7 +78,8 @@ async def self_check_output(
 
         response = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        response = response.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        response = getattr(response, "content", response).lower().strip()
         log.info(f"Output self-checking result is: `{response}`.")
 
         if "yes" in response:

--- a/e2e-tests/dragent/langgraph/nemo_guardrails/prompt/actions.py
+++ b/e2e-tests/dragent/langgraph/nemo_guardrails/prompt/actions.py
@@ -76,7 +76,8 @@ async def self_check_input(
 
         check = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        check = check.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        check = getattr(check, "content", check).lower().strip()
         log.info(f"Input self-checking result is: `{check}`.")
 
         if "yes" in check:

--- a/e2e-tests/dragent/langgraph/nemo_guardrails/response/actions.py
+++ b/e2e-tests/dragent/langgraph/nemo_guardrails/response/actions.py
@@ -78,7 +78,8 @@ async def self_check_output(
 
         response = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        response = response.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        response = getattr(response, "content", response).lower().strip()
         log.info(f"Output self-checking result is: `{response}`.")
 
         if "yes" in response:

--- a/e2e-tests/dragent/llamaindex/nemo_guardrails/prompt/actions.py
+++ b/e2e-tests/dragent/llamaindex/nemo_guardrails/prompt/actions.py
@@ -76,7 +76,8 @@ async def self_check_input(
 
         check = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        check = check.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        check = getattr(check, "content", check).lower().strip()
         log.info(f"Input self-checking result is: `{check}`.")
 
         if "yes" in check:

--- a/e2e-tests/dragent/llamaindex/nemo_guardrails/response/actions.py
+++ b/e2e-tests/dragent/llamaindex/nemo_guardrails/response/actions.py
@@ -78,7 +78,8 @@ async def self_check_output(
 
         response = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        response = response.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        response = getattr(response, "content", response).lower().strip()
         log.info(f"Output self-checking result is: `{response}`.")
 
         if "yes" in response:

--- a/e2e-tests/dragent/nat/nemo_guardrails/prompt/actions.py
+++ b/e2e-tests/dragent/nat/nemo_guardrails/prompt/actions.py
@@ -76,7 +76,8 @@ async def self_check_input(
 
         check = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        check = check.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        check = getattr(check, "content", check).lower().strip()
         log.info(f"Input self-checking result is: `{check}`.")
 
         if "yes" in check:

--- a/e2e-tests/dragent/nat/nemo_guardrails/response/actions.py
+++ b/e2e-tests/dragent/nat/nemo_guardrails/response/actions.py
@@ -78,7 +78,8 @@ async def self_check_output(
 
         response = await llm_call(llm, prompt, llm_params={"temperature": 0.0})
 
-        response = response.lower().strip()
+        # nemoguardrails 0.23: llm_call returns LLMResponse, not str.
+        response = getattr(response, "content", response).lower().strip()
         log.info(f"Output self-checking result is: `{response}`.")
 
         if "yes" in response:

--- a/e2e-tests/dragent/overrides/workflow-nemo-guardrails-moderations.yaml
+++ b/e2e-tests/dragent/overrides/workflow-nemo-guardrails-moderations.yaml
@@ -24,7 +24,7 @@ middleware:
           type: nemo_guardrails
           stage: prompt
           llm_type: llmGateway
-          llm_gateway_model_id: vertex_ai/gemini-3.1-pro-preview
+          llm_gateway_model_id: anthropic/claude-opus-4-7
           intervention:
             action: block
             message: "This topic is outside the allowed scope."
@@ -35,7 +35,7 @@ middleware:
           type: nemo_guardrails
           stage: response
           llm_type: llmGateway
-          llm_gateway_model_id: vertex_ai/gemini-3.1-pro-preview
+          llm_gateway_model_id: anthropic/claude-opus-4-7
           intervention:
             action: block
             message: "This topic is outside the allowed scope."

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1343,12 +1343,13 @@ example-quickstart = [{ name = "datarobot-genai", extras = ["langgraph"], editab
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.33"
+version = "11.2.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "backoff" },
     { name = "click" },
+    { name = "litellm" },
     { name = "numpy" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -1362,7 +1363,7 @@ dependencies = [
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/26/763042a9b2ae2f6bcf10aee14a019d3a52d36becb9bb6091f8f40492d660/datarobot_moderations-11.2.33-py3-none-any.whl", hash = "sha256:1b835a8e53306b41407ff30dbd90631cbe0084cdbe5bb0bdb2b79999dc1adcf8", size = 149461, upload-time = "2026-06-03T13:33:56.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6b/b1f753df4078e2661d1c701b22e65f421ee7eea186d6bdafb178baf2b467/datarobot_moderations-11.2.45-py3-none-any.whl", hash = "sha256:7c3b9370005f8668c332af26ae8efd749b068256da3221d10ece1e250a783d6a", size = 173940, upload-time = "2026-07-16T13:35:00.241Z" },
 ]
 
 [package.optional-dependencies]
@@ -1383,7 +1384,6 @@ all = [
     { name = "nemo-microservices" },
     { name = "nemoguardrails" },
     { name = "openai" },
-    { name = "ragas" },
 ]
 
 [[package]]
@@ -4122,18 +4122,16 @@ wheels = [
 
 [[package]]
 name = "nemoguardrails"
-version = "0.21.0"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
-    { name = "fastapi" },
+    { name = "dataclasses-json" },
     { name = "fastembed" },
     { name = "httpx" },
     { name = "jinja2" },
-    { name = "langchain" },
-    { name = "langchain-community" },
-    { name = "langchain-core" },
+    { name = "jsonschema" },
     { name = "lark" },
     { name = "nest-asyncio" },
     { name = "onnxruntime" },
@@ -4145,13 +4143,10 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "simpleeval" },
-    { name = "starlette" },
     { name = "typer" },
-    { name = "uvicorn" },
-    { name = "watchdog" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/f7/e11bdc5451b06706dd7f4e02035ad7f62aafc82eec974b4091a874ec51b3/nemoguardrails-0.21.0-py3-none-any.whl", hash = "sha256:b338453b371751f5b09637415702e2ee25f0885317b691cbb0d2f2f164eeea5d", size = 11349994, upload-time = "2026-03-12T14:17:23.709Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ec/02ea37d5bea9178b192540fb9dfcfc1d7a080fb20a6465612b888e896306/nemoguardrails-0.23.0-py3-none-any.whl", hash = "sha256:91106c9718748fd760e873dd872915c6ed15d15c80300d538c8a1f4024eff92a", size = 891405, upload-time = "2026-07-01T16:24:54.322Z" },
 ]
 
 [[package]]
@@ -6895,33 +6890,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
     { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
     { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
-]
-
-[[package]]
-name = "watchdog"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
-    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
-    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
-    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
-    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
-    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# RATIONALE

Moderations #648 (BUZZOK-31306, shipped in ≥11.2.35) was expected to fix the NeMo
guardrails guard silently failing open. On the newest moderations, **11.2.45** (which
contains #648), the guard **still fails open**: #648 rebuilt `LLMRails` per event loop,
but the actual loop-bound object is the lru-cached `langchain_openai` httpx pool inside
`ChatOpenAI`, which #648 never touched. Evidence/repro PR (draft — intentionally red),
rebased onto latest main.

## CHANGES

- Bump e2e `datarobot-moderations` → **11.2.45** (newest; contains #648) + `nemoguardrails` 0.23
- Fix the nemoguardrails-0.23 `LLMResponse` issue in the e2e custom actions (all 5 frameworks): `llm_call` now returns `LLMResponse`, extract `.content` — removes the `'LLMResponse' object has no attribute 'lower'` AttributeError that masks the loop bug
- Guard model → `anthropic/claude-opus-4-7` (fast model surfaces the loop error cleanly)

## EVIDENCE

The **base** agent (no MCP) isolates it cleanly — server log:
```
RuntimeError: <asyncio.locks.Event ...> is bound to a different event loop
  → openai.APIConnectionError: Connection error
  → datarobot_dome/guard_executor.py run_nemo_guard
  → moderations.AsyncGuardExecutor: NeMo guard calculation failed   (fails open)
```
CI (11.2.45, latest main): https://github.com/datarobot-oss/datarobot-genai/actions/runs/29516633410 — see the `nemo-guardrails--base` job server log.

## NOTES

A separate, broader MCP/otel streaming-teardown issue also reds streaming tests on this bump (companion PR #563); distinct from this guard loop bug.

## Checklist
- [ ] Reviewed guideline
- [ ] Updated Changelog
