### PR TITLE
[APP-6601] Add shared FastAPI OTel/logging module to core/telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.25.2
+- `core`: Added `datarobot_genai.core.telemetry` — a shared FastAPI OTel/logging module (`OTel` singleton for tracer/meter/logger provider lifecycle, `trace`/`meter`/`span` decorators and context managers, uvicorn access/error log configuration with health-check filtering, and `RedactingFormatter`/JSON/text/readable log formatters that scrub sensitive fields like `api_key`, `access_token`, `refresh_token`). Consolidates the OTel setup previously copy-pasted per app via the `af-component-fastapi-backend` Copier template; `OTel.configure()` takes any object matching the `OTelConfig` protocol, so it stays decoupled from a specific app's config class.
+
 ## 0.25.1
 - `drtools`: `vdb_get` rejects malformed `vector_database_id` values before calling the platform and returns a clean not-found error matching the well-formed missing-ID case; API calls use `allow_redirects=False` so unexpected 3xx/HTML responses surface as structured errors instead of raw frontend pages.
 - `drtools`: `vdb_deploy` submits the deploy request and polls for the new deployment record instead of blocking on the SDK's long async wait, avoiding false MCP timeouts while the deployment is actually created.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.25.1"
+version = "0.25.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/telemetry/enums.py
+++ b/src/datarobot_genai/core/telemetry/enums.py
@@ -1,0 +1,26 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from enum import StrEnum
+from typing import Literal
+
+
+class LogLevel(StrEnum):
+    ERROR = "ERROR"
+    WARN = "WARNING"
+    WARNING = "WARNING"
+    INFO = "INFO"
+    DEBUG = "DEBUG"
+
+
+FormatType = Literal["json", "text", "readable"]

--- a/src/datarobot_genai/core/telemetry/enums.py
+++ b/src/datarobot_genai/core/telemetry/enums.py
@@ -1,10 +1,10 @@
-# Copyright 2026 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/datarobot_genai/core/telemetry/fastapi_otel.py
+++ b/src/datarobot_genai/core/telemetry/fastapi_otel.py
@@ -1,10 +1,10 @@
-# Copyright 2025 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/datarobot_genai/core/telemetry/fastapi_otel.py
+++ b/src/datarobot_genai/core/telemetry/fastapi_otel.py
@@ -1,0 +1,826 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Open Telemetry module for DataRobot Custom Applications built on FastAPI.
+
+This module provides a reusable telemetry foundation - Logger/Tracer/Meter
+provider lifecycle, log redaction, and tracing/metering decorators - that
+FastAPI-based Custom Applications configure and extend, keeping a single
+shared implementation instead of each app carrying its own copy.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import functools
+import inspect
+import logging
+import os
+import time
+from collections.abc import AsyncGenerator
+from collections.abc import Callable
+from collections.abc import Coroutine
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Protocol
+from typing import Self
+from typing import no_type_check
+from typing import overload
+
+from opentelemetry import context
+from opentelemetry import metrics
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs import LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.metrics import Histogram
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import Span
+from typing_extensions import ParamSpec
+from typing_extensions import TypeVar
+
+from .logging import RedactingFormatter
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+# Optional imports for auto-instrumentation
+try:
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+except ImportError:
+    FastAPIInstrumentor = None  # type: ignore[assignment, misc]
+
+try:
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+except ImportError:
+    RequestsInstrumentor = None  # type: ignore[assignment, misc]
+
+try:
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+except ImportError:
+    HTTPXClientInstrumentor = None  # type: ignore[assignment, misc]
+
+try:
+    from opentelemetry.instrumentation.logging import LoggingInstrumentor
+except ImportError:
+    LoggingInstrumentor = None  # type: ignore[assignment, misc]
+
+try:
+    from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+except ImportError:
+    SQLAlchemyInstrumentor = None  # type: ignore[assignment, misc]
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+DEFAULT_EXCLUDED_TRACE_SPAN_NAMES: frozenset[str] = frozenset()
+"""Span names excluded from tracing by default.
+
+Empty by default - this is a shared library, not any one app, so it has
+no opinion on which spans are noisy. Apps add their own via the
+OTEL_EXCLUDED_TRACE_SPAN_NAMES env var (comma-separated).
+"""
+
+_otel_handler_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_otel_handler_active", default=False
+)
+
+
+class OTelConfig(Protocol):
+    """Structural type for the subset of app config `OTel.configure` needs.
+
+    Any app-specific Settings/Config class that has these three attributes
+    satisfies this protocol automatically - no inheritance required.
+    """
+
+    otel_exporter_otlp_endpoint: str
+    otel_exporter_otlp_headers: str
+    otel_sdk_disabled: bool
+
+
+class _SafeLoggingHandler(LoggingHandler):
+    """LoggingHandler with ContextVar recursion guard.
+
+    Backport of opentelemetry-python-contrib #4302.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if _otel_handler_active.get():
+            return
+        token = _otel_handler_active.set(True)
+        try:
+            super().emit(record)
+        finally:
+            _otel_handler_active.reset(token)
+
+
+class OTLPConnectionErrorFilter(logging.Filter):
+    """
+    Filter to suppress connection errors from urllib3/requests when OTLP collector is unavailable.
+
+    This prevents error spam in Chronosphere when the OTLP collector endpoint isn't properly
+    configured or available (e.g., localhost:4318 connection refused errors).
+    """
+
+    def __init__(self, warning_callback: Callable[[], None] | None = None):
+        super().__init__()
+        self.warning_callback = warning_callback
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return False to suppress the log record, True to allow it."""
+        should_suppress = False
+
+        # Suppress urllib3 connection errors related to OTLP endpoints
+        if record.name.startswith("urllib3.connectionpool"):
+            message = record.getMessage()
+            if "HTTPConnectionPool" in message and (
+                ":4318" in message  # Default OTLP port
+                or "/v1/metrics" in message
+                or "/v1/traces" in message
+                or "/v1/logs" in message
+            ):
+                should_suppress = True
+
+        # Suppress requests connection errors related to OTLP
+        if record.name.startswith("requests."):
+            message = record.getMessage()
+            if "ConnectionError" in message and ":4318" in message:
+                should_suppress = True
+
+        # Suppress opentelemetry SDK export errors caused by connection failures
+        if (
+            not should_suppress
+            and record.name.startswith("opentelemetry.sdk.")
+            and record.levelno == logging.ERROR
+        ):
+            if record.exc_info:
+                exc = record.exc_info[1]
+                while exc is not None:
+                    if type(exc).__name__ in (
+                        "ConnectionError",
+                        "NewConnectionError",
+                        "MaxRetryError",
+                    ):
+                        should_suppress = True
+                        break
+                    exc = exc.__cause__ or exc.__context__
+
+        if should_suppress:
+            if self.warning_callback:
+                self.warning_callback()
+            return False
+
+        return True
+
+
+class OTel:
+    """
+    Open Telemetry manager for DataRobot Custom Applications.
+
+    Provides OpenTelemetry configuration following datavolt patterns.
+    Implements singleton pattern to ensure only one instance exists per process.
+    """
+
+    _SERVICE_PRIORITY = "p1"
+    _METRIC_EXPORT_INTERVAL_MILLIS = 5_000
+
+    _instance: OTel | None = None
+    _initialized: bool = False
+    _auto_instrumentation_setup: bool = False
+
+    def __new__(cls, entity_type: str = "custom_application", entity_id: str | None = None) -> OTel:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, entity_type: str = "custom_application", entity_id: str | None = None):
+        if self._initialized:
+            return
+
+        self.entity_type = entity_type
+        self.entity_id = entity_id or os.environ.get("APPLICATION_ID")
+
+        self.telemetry_enabled = False
+
+        self._logger_provider: LoggerProvider | None = None
+        self._meter_provider: MeterProvider | None = None
+        self._tracer_provider: TracerProvider | None = None
+        self._resource: Resource | None = None
+        self._configured: bool = False
+        self._startup_logged: bool = False
+        self._otlp_warning_logged: bool = False
+
+        self._install_otlp_error_filter()
+
+        self._initialized = True
+
+    def configure(self, config: OTelConfig) -> None:
+        """Apply OTel settings from app Config. Call once during app startup."""
+        # Mirror config values into os.environ so OTLP exporters (which read env vars
+        # directly at construction time) use the endpoint configured via pulumi_config.json
+        # rather than falling back to localhost:4318.
+        if config.otel_exporter_otlp_endpoint:
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = config.otel_exporter_otlp_endpoint
+        if config.otel_exporter_otlp_headers:
+            os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = config.otel_exporter_otlp_headers
+
+        self.telemetry_enabled = not config.otel_sdk_disabled
+
+        if self.telemetry_enabled and not config.otel_exporter_otlp_endpoint:
+            if not os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT_INTERNAL"):
+                self.telemetry_enabled = False
+                logging.getLogger(__name__).warning(
+                    "OTEL_EXPORTER_OTLP_ENDPOINT not set. "
+                    "Disabling telemetry to prevent connection errors."
+                )
+
+        _endpoint = config.otel_exporter_otlp_endpoint
+        _is_remote = _endpoint and "localhost" not in _endpoint and "127.0.0.1" not in _endpoint
+        if self.telemetry_enabled and _is_remote and not config.otel_exporter_otlp_headers:
+            self.telemetry_enabled = False
+            logging.getLogger(__name__).error(
+                "OTEL_EXPORTER_OTLP_ENDPOINT is set to a remote URL but "
+                "OTEL_EXPORTER_OTLP_HEADERS is missing. "
+                "All telemetry requests will be rejected (401). Disabling telemetry. "
+                "Run `dr start` to get the required credentials, "
+                "then add OTEL_EXPORTER_OTLP_HEADERS to your .env file."
+            )
+
+        if self.telemetry_enabled and not self._auto_instrumentation_setup:
+            self._setup_auto_instrumentation()
+            self._auto_instrumentation_setup = True
+
+    def _get_resource(self) -> Resource:
+        if self._resource is None:
+            attrs: dict[str, str] = {
+                "datarobot.service.priority": self._SERVICE_PRIORITY,
+            }
+            # Only set service.name if the platform hasn't already provided OTEL_SERVICE_NAME.
+            # Resource.create() merges env vars at lower precedence than explicit attrs, so
+            # setting it here would shadow the platform value if they ever diverge.
+            if not os.environ.get("OTEL_SERVICE_NAME"):
+                attrs["service.name"] = f"{self.entity_type}-{self.entity_id}"
+            if self.entity_id:
+                attrs["datarobot.application.id"] = self.entity_id
+            pod_name = os.environ.get("HOSTNAME")
+            if pod_name:
+                attrs["k8s.pod.name"] = pod_name
+            version = os.environ.get("APP_VERSION") or os.environ.get("SERVICE_VERSION")
+            if version:
+                attrs["service.version"] = version
+            self._resource = Resource.create(attrs)
+        return self._resource
+
+    def _install_otlp_error_filter(self) -> None:
+        """Install logging filter to suppress OTLP connection errors."""
+        otlp_filter = OTLPConnectionErrorFilter(self._log_otlp_warning)
+
+        # Apply to urllib3 logger
+        urllib3_logger = logging.getLogger("urllib3.connectionpool")
+        urllib3_logger.addFilter(otlp_filter)
+
+        # Apply to requests logger
+        requests_logger = logging.getLogger("requests")
+        requests_logger.addFilter(otlp_filter)
+
+        # Apply to opentelemetry SDK export loggers.
+        # Names must match __name__ in the SDK modules: metrics and logs use
+        # the _internal path; traces use the public path.
+        for sdk_logger_name in (
+            "opentelemetry.sdk._logs._internal.export",
+            "opentelemetry.sdk.trace.export",
+            "opentelemetry.sdk.metrics._internal.export",
+        ):
+            logging.getLogger(sdk_logger_name).addFilter(otlp_filter)
+
+    def _log_otlp_warning(self) -> None:
+        """Log a warning about OTLP connection failure (only once)."""
+        if not self._otlp_warning_logged:
+            self._otlp_warning_logged = True
+            # Use a logger that is NOT filtered or ensure this message doesn't trigger the filter
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "OTLP collector connection failed. Telemetry data may be lost. "
+                "Suppressing further connection errors to prevent log spam. "
+                "Check OTEL_EXPORTER_OTLP_ENDPOINT configuration."
+            )
+
+    def _get_excluded_trace_span_names(self) -> frozenset[str]:
+        configured_span_names = {
+            span_name.strip()
+            for span_name in os.environ.get("OTEL_EXCLUDED_TRACE_SPAN_NAMES", "").split(",")
+            if span_name.strip()
+        }
+        return DEFAULT_EXCLUDED_TRACE_SPAN_NAMES | configured_span_names
+
+    def _is_trace_span_excluded(self, span_name: str) -> bool:
+        return span_name in self._get_excluded_trace_span_names()
+
+    def _setup_auto_instrumentation(self) -> None:
+        """
+        Set up auto-instrumentation for common libraries.
+
+        Automatically instruments:
+        - requests library (used by DataRobot client for API calls)
+        - httpx library (if installed)
+        - FastAPI (must be called separately with instrument_fastapi_app)
+        """
+        if RequestsInstrumentor is not None:
+            try:
+                RequestsInstrumentor().instrument()
+                logging.getLogger(__name__).info(
+                    "Auto-instrumentation enabled for requests library"
+                )
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    f"Failed to setup requests auto-instrumentation: {e}"
+                )
+        else:
+            logging.getLogger(__name__).warning(
+                "RequestsInstrumentor not available. "
+                "Install with: pip install opentelemetry-instrumentation-requests"
+            )
+
+        if HTTPXClientInstrumentor is not None:
+            try:
+                HTTPXClientInstrumentor().instrument()
+                logging.getLogger(__name__).info("Auto-instrumentation enabled for httpx library")
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    f"Failed to setup httpx auto-instrumentation: {e}"
+                )
+
+        if SQLAlchemyInstrumentor is not None:
+            try:
+                SQLAlchemyInstrumentor().instrument()
+                logging.getLogger(__name__).info("Auto-instrumentation enabled for SQLAlchemy")
+            except Exception as e:
+                logging.getLogger(__name__).warning(
+                    f"Failed to setup SQLAlchemy auto-instrumentation: {e}"
+                )
+
+    def instrument_fastapi_app(self, app: FastAPI) -> None:
+        """
+        Instrument a FastAPI application for automatic tracing.
+
+        This should be called after creating your FastAPI app instance.
+
+        Args:
+            app: The FastAPI application instance to instrument
+
+        Example:
+            otel = OTel()
+            app = FastAPI()
+            otel.instrument_fastapi_app(app)
+        """
+        if FastAPIInstrumentor is None:
+            logging.getLogger(__name__).warning(
+                "FastAPIInstrumentor not available. "
+                "Install with: pip install opentelemetry-instrumentation-fastapi"
+            )
+            return
+
+        try:
+            # Ensure tracer provider/exporter is configured before instrumenting FastAPI
+            if self.telemetry_enabled and not self._tracer_provider:
+                self.configure_tracing()
+
+            FastAPIInstrumentor.instrument_app(
+                app,
+                # - //[^/]+/$ matches the root path also excludes kube-probe which has
+                #  {full_path:path} route. (http://host:port/ with no further segments)
+                # - /health$ matches the health endpoint
+                # - /assets/.* matches static asset paths
+                excluded_urls=r"//[^/]+/$,/health$,/assets/.*",
+            )
+            logging.getLogger(__name__).info("Auto-instrumentation enabled for FastAPI application")
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"Failed to instrument FastAPI app: {e}")
+
+    def configure_logging(self) -> LoggerProvider:
+        """Configure OpenTelemetry logging based on DataRobot patterns."""
+        if self._logger_provider:
+            return self._logger_provider
+
+        # Create logger provider
+        logger_provider = LoggerProvider(resource=self._get_resource())
+        set_logger_provider(logger_provider)
+
+        # Create OTLP exporter
+        try:
+            otlp_exporter = OTLPLogExporter()
+            # Create batch processor
+            batch_processor = BatchLogRecordProcessor(otlp_exporter)
+            logger_provider.add_log_record_processor(batch_processor)
+        except Exception as e:
+            # Log warning but don't crash
+            logging.getLogger(__name__).warning(f"Failed to initialize OTLP logging exporter: {e}")
+
+        # Inject trace_id/span_id into every stdlib log record so stdout formatters
+        # include them automatically (picked up as extra fields by Json/TextFormatter).
+        if LoggingInstrumentor is not None:
+            LoggingInstrumentor().instrument()
+
+        # Attach to root logger so every logger in the process exports via propagation,
+        # regardless of how it was created (logging.getLogger() vs otel.get_logger()).
+        root_handler = _SafeLoggingHandler(level=logging.INFO, logger_provider=logger_provider)
+        root_handler.setFormatter(RedactingFormatter(logging.Formatter()))
+        logging.getLogger().addHandler(root_handler)
+
+        self._logger_provider = logger_provider
+        return logger_provider
+
+    def configure_metrics(self) -> MeterProvider:
+        """Configure OpenTelemetry metrics based on datavolt patterns."""
+        if self._meter_provider:
+            return self._meter_provider
+
+        # Create OTLP exporter
+        try:
+            otlp_exporter = OTLPMetricExporter(
+                preferred_aggregation={Histogram: ExponentialBucketHistogramAggregation()},
+            )
+
+            # Create metric reader
+            reader = PeriodicExportingMetricReader(
+                exporter=otlp_exporter,
+                export_interval_millis=self._METRIC_EXPORT_INTERVAL_MILLIS,
+            )
+
+            # Create meter provider
+            meter_provider = MeterProvider(
+                resource=self._get_resource(),
+                metric_readers=[
+                    reader,
+                ],
+            )
+            metrics.set_meter_provider(meter_provider)
+            self._meter_provider = meter_provider
+            return meter_provider
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"Failed to initialize OTLP metrics exporter: {e}")
+            meter_provider = MeterProvider(resource=self._get_resource())
+            metrics.set_meter_provider(meter_provider)
+            self._meter_provider = meter_provider
+            return meter_provider
+
+    def configure_tracing(self) -> TracerProvider:
+        """Configure OpenTelemetry tracing based on datavolt patterns."""
+        if self._tracer_provider:
+            return self._tracer_provider
+
+        # Create tracer provider
+        tracer_provider = TracerProvider(resource=self._get_resource())
+        trace.set_tracer_provider(tracer_provider)
+
+        # Create OTLP exporter
+        try:
+            otlp_exporter = OTLPSpanExporter()
+
+            # Create batch processor
+            batch_processor = BatchSpanProcessor(otlp_exporter)
+            tracer_provider.add_span_processor(batch_processor)
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"Failed to initialize OTLP tracing exporter: {e}")
+
+        self._tracer_provider = tracer_provider
+        return tracer_provider
+
+    def configure_all(self) -> None:
+        """Configure all telemetry providers (logging, metrics, tracing)."""
+        if self._configured:
+            return
+
+        self.configure_logging()
+        self.configure_metrics()
+        self.configure_tracing()
+
+        self._configured = True
+
+    def get_logger(self, name: str) -> logging.Logger:
+        """Get a Python logger configured to send logs through OpenTelemetry."""
+        if not self.telemetry_enabled:
+            return logging.getLogger(name)
+
+        if not self._logger_provider:
+            self.configure_logging()
+
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.INFO)
+        return logger
+
+    def get_meter(self, name: str) -> metrics.Meter:
+        """Get a meter instance for the given name using OpenTelemetry global API."""
+        if self.telemetry_enabled and not self._meter_provider:
+            self.configure_metrics()
+        return metrics.get_meter(name)
+
+    def get_tracer(self, name: str) -> trace.Tracer:
+        """Get a tracer instance for the given name using OpenTelemetry global API."""
+        if self.telemetry_enabled and not self._tracer_provider:
+            self.configure_tracing()
+        return trace.get_tracer(name)
+
+    def get_context(self) -> context.Context:
+        """
+        Return the current OTEL context. To cross thread boundaries, you'll
+        need to call get_context in the spawning thread and set_context in
+        the spawned thread.
+        """
+        return context.get_current()
+
+    def set_context(self, otel_context: context.Context) -> Any:
+        """Set the OTEL context."""
+        return context.attach(otel_context)
+
+    def reset_context(self, token: Any) -> None:
+        context.detach(token)
+
+    def shutdown(self) -> None:
+        """Gracefully shutdown all telemetry providers."""
+        if not (self._logger_provider or self._meter_provider or self._tracer_provider):
+            return
+
+        if self._logger_provider:
+            self._logger_provider.shutdown()
+        if self._meter_provider:
+            self._meter_provider.shutdown()
+        if self._tracer_provider:
+            self._tracer_provider.shutdown()
+
+    def log_application_start(self, application_name: str = "Application") -> None:
+        """
+        Log application startup event (only once per process).
+
+        Args:
+            application_name: Name of the application for logging context
+        """
+        # Only log startup once per process to prevent Streamlit rerun spam
+        if self._startup_logged:
+            return
+
+        self._startup_logged = True
+        logger = self.get_logger(f"{self.entity_type}.startup")
+        logger.info(
+            f"{application_name} starting up",
+            extra={
+                "application_id": self.entity_id,
+                "application_type": self.entity_type,
+            },
+        )
+
+    def __enter__(self) -> OTel:
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit - gracefully shutdown telemetry."""
+        self.shutdown()
+
+    @overload
+    def trace(
+        self: Self,
+        func: Callable[P, Coroutine[T, None, None]],
+    ) -> Callable[P, Coroutine[T, None, None]]: ...
+
+    @overload
+    def trace(
+        self: Self,
+        func: Callable[P, AsyncGenerator[T, None]],
+    ) -> Callable[P, AsyncGenerator[T, None]]: ...
+
+    @overload
+    def trace(
+        self: Self,
+        func: Callable[P, Generator[T, None, None]],
+    ) -> Callable[P, Generator[T, None, None]]: ...
+
+    @overload
+    def trace(self: Self, func: Callable[P, T]) -> Callable[P, T]: ...
+
+    @overload
+    def trace(self: Self, name: str) -> Callable[[Any], Any]: ...
+
+    @no_type_check
+    def trace(self: Self, func: Any) -> Any:
+        """
+        Wrap the execution of the decorated function in an OTEL span.
+
+        Accepts an optional custom span name::
+
+            @otel.trace
+            async def my_handler(): ...
+
+            @otel.trace("custom-operation-name")
+            async def my_handler(): ...
+
+        WARNING: There are sharp edges with this decorator if applied to
+        functions that are reflected on.
+        (I've seen this with methods in utils.rest_api.)
+        """
+        if isinstance(func, str):
+            return functools.partial(self._trace_with_name, span_name=func)
+        return self._trace_with_name(func)
+
+    @no_type_check
+    def _trace_with_name(self: Self, func: Any, span_name: str | None = None) -> Any:
+        name = span_name or f"{func.__module__}.{func.__qualname__}"
+
+        if self._is_trace_span_excluded(name):
+            return func
+
+        tracer = self.get_tracer("application-tracer")
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_inner(*args, **kwargs):
+                with tracer.start_as_current_span(name):
+                    return await func(*args, **kwargs)
+
+            return async_inner
+        elif inspect.isasyncgenfunction(func):
+
+            @functools.wraps(func)
+            async def inner_asyncgen(*args, **kwargs):
+                with tracer.start_as_current_span(name):
+                    async for x in func(*args, **kwargs):
+                        yield x
+
+            return inner_asyncgen
+        elif inspect.isgeneratorfunction(func):
+
+            @functools.wraps(func)
+            def inner_gen(*args, **kwargs):
+                with tracer.start_as_current_span(name):
+                    yield from func(*args, **kwargs)
+
+            return inner_gen
+        elif inspect.isfunction(func):
+
+            @functools.wraps(func)
+            def inner(*args, **kwargs):
+                with tracer.start_as_current_span(name):
+                    return func(*args, **kwargs)
+
+            return inner
+        else:
+            raise ValueError(
+                f"instrument can only decorate a function type, while {name} is a {type(func)}."
+            )
+
+    @functools.cache
+    def _function_histogram(self: Self, name: str) -> metrics.Histogram:
+        meter = self.get_meter("application-meter")
+        return meter.create_histogram(
+            f"function.{name}", "s", "A histogram recording function timings."
+        )
+
+    @contextmanager
+    def span(self, name: str, **attributes: Any) -> Generator[Span, None, None]:
+        """Create a named span as a context manager, with optional initial attributes.
+
+        Use this for ad-hoc spans within a function body where a decorator
+        would be too coarse-grained::
+
+            with otel.span("retrieve-documents", query=query_text) as span:
+                docs = retrieve(query_text)
+                span.set_attribute("doc_count", len(docs))
+        """
+        with self.get_tracer("application-tracer").start_as_current_span(name) as active_span:
+            for key, value in attributes.items():
+                active_span.set_attribute(key, value)
+            yield active_span
+
+    @contextmanager
+    def time(self, name: str) -> Generator[None, None, None]:
+        start_time = time.time_ns()
+        success = True
+        try:
+            yield
+        except Exception:
+            success = False
+            raise
+        finally:
+            end_time = time.time_ns()
+            histogram = self._function_histogram(name)
+            histogram.record((end_time - start_time) / 1e9, {"success": success})
+
+    @overload
+    def meter(
+        self: Self,
+        func: Callable[P, Coroutine[T, None, None]],
+    ) -> Callable[P, Coroutine[T, None, None]]: ...
+
+    @overload
+    def meter(
+        self: Self,
+        func: Callable[P, AsyncGenerator[T, None]],
+    ) -> Callable[P, AsyncGenerator[T, None]]: ...
+
+    @overload
+    def meter(
+        self: Self,
+        func: Callable[P, Generator[T, None, None]],
+    ) -> Callable[P, Generator[T, None, None]]: ...
+
+    @overload
+    def meter(self: Self, func: Callable[P, T]) -> Callable[P, T]: ...
+
+    @no_type_check
+    def meter(self: Self, func: Any) -> Any:
+        """
+        Wrap the execution of the decorated function in an OTEL span sharing
+        the same name as the function.
+        WARNING: There are sharp edges with this decorator if applied to
+        functions that are reflected on.
+        (I've seen this with methods in utils.rest_api.).
+        """
+        span_name = f"{func.__module__}.{func.__qualname__}"
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_inner(*args, **kwargs):
+                with self.time(span_name):
+                    return await func(*args, **kwargs)
+
+            return async_inner
+        elif inspect.isasyncgenfunction(func):
+
+            @functools.wraps(func)
+            async def inner_asyncgen(*args, **kwargs):
+                with self.time(span_name):
+                    async for x in func(*args, **kwargs):
+                        yield x
+
+            return inner_asyncgen
+        elif inspect.isgeneratorfunction(func):
+
+            @functools.wraps(func)
+            def inner_gen(*args, **kwargs):
+                with self.time(span_name):
+                    yield from func(*args, **kwargs)
+
+            return inner_gen
+        elif inspect.isfunction(func):
+
+            @functools.wraps(func)
+            def inner(*args, **kwargs):
+                with self.time(span_name):
+                    return func(*args, **kwargs)
+
+            return inner
+        else:
+            raise ValueError(
+                f"instrument can only decorate a function type, "
+                f"while {span_name} is a {type(func)}."
+            )
+
+    @overload
+    def meter_and_trace(
+        self: Self,
+        func: Callable[P, Coroutine[T, None, None]],
+    ) -> Callable[P, Coroutine[T, None, None]]: ...
+
+    @overload
+    def meter_and_trace(
+        self: Self,
+        func: Callable[P, AsyncGenerator[T, None]],
+    ) -> Callable[P, AsyncGenerator[T, None]]: ...
+
+    @overload
+    def meter_and_trace(
+        self: Self,
+        func: Callable[P, Generator[T, None, None]],
+    ) -> Callable[P, Generator[T, None, None]]: ...
+
+    @overload
+    def meter_and_trace(self: Self, func: Callable[P, T]) -> Callable[P, T]: ...
+
+    @no_type_check
+    def meter_and_trace(self: Self, func: Any) -> Any:
+        return functools.wraps(func)(self.meter(self.trace(func)))

--- a/src/datarobot_genai/core/telemetry/logging.py
+++ b/src/datarobot_genai/core/telemetry/logging.py
@@ -1,10 +1,10 @@
-# Copyright 2025 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/datarobot_genai/core/telemetry/logging.py
+++ b/src/datarobot_genai/core/telemetry/logging.py
@@ -1,0 +1,329 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import json
+import logging
+import re
+import sys
+import time
+import traceback
+from collections.abc import Callable
+from collections.abc import Coroutine
+from datetime import UTC
+from datetime import datetime
+from functools import wraps
+from typing import Any
+from typing import ParamSpec
+from typing import TypeVar
+
+from .enums import FormatType
+from .enums import LogLevel
+
+_READABLE_INDENT = "   "
+
+_STANDARD_LOG_RECORD_ATTRS = set(logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys())
+_OTHER_LOG_RECORD_ATTRS = set({"asctime", "message", "color_message"})
+_ALL_EXCLUDED_LOG_RECORD_ATTRS = _STANDARD_LOG_RECORD_ATTRS.union(_OTHER_LOG_RECORD_ATTRS)
+
+
+class JsonFormatter(logging.Formatter):
+    """
+    Custom JSON formatter for structured logging.
+    Formats log records as JSON with standard fields like timestamp, level, and message.
+    Only includes explicitly added extra parameters from the logging call.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_fields: dict[str, Callable[[logging.LogRecord], Any] | Any] = {
+            "timestamp": lambda _: datetime.now(UTC).isoformat(),
+            "level": lambda record: record.levelname,
+            "logger": lambda record: record.name,
+        }
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Format the log record as JSON.
+
+        Args:
+            record: The log record to format
+
+        Returns
+        -------
+            A JSON string containing:
+            - timestamp: ISO format UTC timestamp
+            - level: Log level name
+            - logger: Logger name
+            - message: The log message
+            - exception: Exception details (if present)
+            - Additional fields from the log record (if JSON serializable)
+        """
+        # Start with default fields
+        log_data = {
+            field: getter(record) if callable(getter) else getter
+            for field, getter in self.default_fields.items()
+        }
+
+        # Add message
+        log_data["message"] = record.getMessage()
+
+        # Add exception info if present
+        if record.exc_info and record.exc_info[0]:
+            log_data["exception"] = {
+                "type": record.exc_info[0].__name__,
+                "message": str(record.exc_info[1]),
+                "traceback": "".join(traceback.format_exception(*record.exc_info)),
+            }
+
+        # Include only explicitly added extra fields by filtering out standard attributes
+        extra_fields = {
+            k: v for k, v in record.__dict__.items() if k not in _ALL_EXCLUDED_LOG_RECORD_ATTRS
+        }
+        for key, value in extra_fields.items():
+            try:
+                json.dumps(value, default=str)
+                log_data[key] = value
+            except ValueError as e:
+                log_data[key] = f"<serialization error: {str(e)}>"
+
+        return json.dumps(log_data, ensure_ascii=False, default=str)
+
+
+class ReadableFormatter(logging.Formatter):
+    """
+    Human-readable formatter: timestamp LEVEL:logger:message (ISO UTC).
+    When present, extra fields from the log record are appended as | key=value.
+    For records with exception info, appends an indented 'exception:' block
+    with the traceback.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        ts = datetime.fromtimestamp(record.created, tz=UTC).isoformat()
+        first_line = f"{ts} {record.levelname}:{record.name}:{record.getMessage()}"
+        extra_fields = {
+            k: v for k, v in record.__dict__.items() if k not in _ALL_EXCLUDED_LOG_RECORD_ATTRS
+        }
+        if extra_fields:
+            extra_str = " | ".join(f"{k}={v}" for k, v in extra_fields.items())
+            first_line = f"{first_line} | {extra_str}"
+        if not (record.exc_info and record.exc_info[0]):
+            return first_line
+        tb_str = "".join(traceback.format_exception(*record.exc_info))
+        tb_indented = "\n".join(_READABLE_INDENT + line for line in tb_str.rstrip().split("\n"))
+        return f"{first_line}\n{_READABLE_INDENT}exception:\n{tb_indented}"
+
+
+class TextFormatter(logging.Formatter):
+    """
+    Custom text formatter that includes extra fields in the output.
+    Formats log records as text with standard fields and any additional fields
+    appended to the message in key=value format, separated by ' | '.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record as text, including extra fields."""
+        message = super().format(record)
+
+        # Include only explicitly added extra fields by filtering out standard attributes
+        extra_fields = {
+            k: v for k, v in record.__dict__.items() if k not in _ALL_EXCLUDED_LOG_RECORD_ATTRS
+        }
+        if extra_fields:
+            extra_str = " | ".join(f"{k}={v}" for k, v in extra_fields.items())
+            message = f"{message} | {extra_str}"
+
+        return message
+
+
+class RedactingFormatter(logging.Formatter):
+    """Wraps another formatter to redact sensitive values from log output."""
+
+    sensitive_keys: list[str] = ["access_token", "refresh_token", "api_key"]
+
+    def __init__(self, original_formatter: logging.Formatter):
+        super().__init__()
+        self.original_formatter = original_formatter
+        self.patterns = []
+        for key in self.sensitive_keys:
+            # Match key='value' or key="value" or key=value
+            pattern = re.compile(rf"{re.escape(key)}=(['\"]?)([^'\"\s,)}}]+)\1", re.IGNORECASE)
+            self.patterns.append((key, pattern))
+
+    def _redact_dict(self, obj: Any) -> Any:
+        """
+        Recursively redact sensitive information from dictionaries and objects.
+        Returns a new object with redacted values without mutating the original.
+        """
+        if isinstance(obj, dict):
+            return {
+                k: "[REDACTED]" if k in self.sensitive_keys else self._redact_dict(v)
+                for k, v in obj.items()
+            }
+        elif isinstance(obj, (list, tuple)):
+            return type(obj)(self._redact_dict(item) for item in obj)
+        elif hasattr(obj, "__dict__"):
+            # create a shallow copy first to avoid mutating the original
+            try:
+                obj_copy = copy.copy(obj)
+                for key in self.sensitive_keys:
+                    if hasattr(obj_copy, key):
+                        setattr(obj_copy, key, "[REDACTED]")
+                return obj_copy
+            except (TypeError, AttributeError):
+                return obj
+        return obj
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Format the record, redacting sensitive keys from attributes and
+        their string representations.
+        """
+        record = copy.copy(record)
+
+        # First, redact direct attributes on the record
+        for key in self.sensitive_keys:
+            if hasattr(record, key):
+                setattr(record, key, "[REDACTED]")
+
+        # Redact sensitive data in all extra fields
+        for key, value in list(record.__dict__.items()):
+            if key not in _ALL_EXCLUDED_LOG_RECORD_ATTRS:
+                record.__dict__[key] = self._redact_dict(value)
+
+        # Format the record
+        formatted = self.original_formatter.format(record)
+
+        # Apply regex-based redaction to catch any remaining sensitive data
+        # in string representations
+        for key, pattern in self.patterns:
+            formatted = pattern.sub(rf"{key}=\1[REDACTED]\1", formatted)
+
+        return formatted
+
+
+def _build_formatter(format_type: FormatType) -> logging.Formatter:
+    if format_type == "json":
+        return JsonFormatter()
+    if format_type == "readable":
+        return ReadableFormatter()
+    formatter = TextFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    formatter.converter = time.gmtime
+    return formatter
+
+
+def init_logging(
+    level: LogLevel = LogLevel.INFO,
+    format_type: FormatType = "text",
+    stream: Any = sys.stdout,
+) -> None:
+    """
+    Initialize the root logger globally.
+
+    This function should be called once at the application's startup to set
+    the global logging level and format. After this, any logger obtained
+    via `logging.getLogger(__name__)` will inherit these settings.
+
+    Args:
+        level: The minimum logging level (e.g., logging.INFO, 'DEBUG').
+        format_type: The format type to use ('json', 'text', or 'readable').
+        stream: The stream to write logs to (defaults to stdout).
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level.value)
+
+    # Remove existing handlers
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    # Create handler with appropriate formatter
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(RedactingFormatter(_build_formatter(format_type)))
+
+    root_logger.addHandler(handler)
+
+
+def get_logger(
+    name: str = "",
+    level: LogLevel = LogLevel.INFO,
+    stream: Any = sys.stdout,
+    format_type: FormatType = "text",
+) -> logging.Logger:
+    """
+    Get a configured logger instance.
+
+    Args:
+        name: The name of the logger
+        level: The logging level (can be int or string like 'INFO', 'DEBUG', etc.)
+        stream: The stream to write logs to (defaults to stdout)
+        format_type: The format type to use ('json', 'text', or 'readable',
+            defaults to 'text')
+
+    Returns
+    -------
+        A configured logger instance
+    """
+    # Convert string level to int if needed
+    if isinstance(level, str):
+        level = getattr(logging, level.upper())
+
+    # Create handler with appropriate formatter
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(RedactingFormatter(_build_formatter(format_type)))
+
+    # Configure logger
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = False
+
+    # Remove existing handlers
+    for existing_handler in logger.handlers[:]:
+        logger.removeHandler(existing_handler)
+
+    logger.addHandler(handler)
+    return logger
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def log_api_call(
+    func: Callable[P, Coroutine[Any, Any, T]],
+) -> Callable[P, Coroutine[Any, Any, T]]:
+    @wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        logger = get_logger()
+        request_id = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        separator = f"\n{'=' * 80}\n"
+        logger.info(f"{separator}API CALL START: {func.__name__} [{request_id}]{separator}")
+        try:
+            result = await func(*args, **kwargs)
+            logger.info(f"{separator}API CALL COMPLETE: {func.__name__} [{request_id}]{separator}")
+            return result
+        except Exception as e:
+            error_log = (
+                f"ERROR IN API CALL [{request_id}]\n"
+                "------------------------\n"
+                f"Function: {func.__name__}\n"
+                f"Error Type: {type(e).__name__}\n"
+                f"Error Message: {str(e)}\n\n"
+                "Stack Trace:\n"
+            )
+            logger.error(error_log, exc_info=True)
+            raise
+
+    return wrapper

--- a/src/datarobot_genai/core/telemetry/logging.py
+++ b/src/datarobot_genai/core/telemetry/logging.py
@@ -304,9 +304,15 @@ T = TypeVar("T")
 def log_api_call(
     func: Callable[P, Coroutine[Any, Any, T]],
 ) -> Callable[P, Coroutine[Any, Any, T]]:
+    # A plain module logger, not get_logger(): get_logger() unconditionally
+    # strips and replaces the target logger's handlers, and with the
+    # default name="" that's the root logger - destroying whatever
+    # OTel.configure_logging() attached there for OTLP export. A plain
+    # logging.getLogger() just propagates to whatever's already configured.
+    logger = logging.getLogger(func.__module__)
+
     @wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-        logger = get_logger()
         request_id = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         separator = f"\n{'=' * 80}\n"
         logger.info(f"{separator}API CALL START: {func.__name__} [{request_id}]{separator}")

--- a/src/datarobot_genai/core/telemetry/uvicorn_filter.py
+++ b/src/datarobot_genai/core/telemetry/uvicorn_filter.py
@@ -1,10 +1,10 @@
-# Copyright 2025 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/datarobot_genai/core/telemetry/uvicorn_filter.py
+++ b/src/datarobot_genai/core/telemetry/uvicorn_filter.py
@@ -1,0 +1,67 @@
+# Copyright 2025 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from .enums import FormatType
+from .logging import RedactingFormatter
+from .logging import _build_formatter
+
+
+class HealthCheckFilter(logging.Filter):
+    """Filter out health check requests from access logs."""
+
+    def __init__(self, log_level: str = "INFO"):
+        super().__init__()
+        self.log_level = log_level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        numeric_log_level = getattr(logging, self.log_level.upper())
+        # Filter out health check requests only when log level is INFO or higher
+        if numeric_log_level <= logging.DEBUG:
+            return True
+
+        if hasattr(record, "getMessage"):
+            message = record.getMessage()
+            if "/health" in message and "GET" in message:
+                return False
+        return True
+
+
+def configure_uvicorn_logging(log_format: FormatType = "text", log_level: str = "INFO") -> None:
+    """Configure uvicorn logging to use our custom formatter and filter."""
+    # Configure uvicorn access logger
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.handlers.clear()
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(RedactingFormatter(_build_formatter(log_format)))
+
+    # Add the health check filter
+    handler.addFilter(HealthCheckFilter(log_level))
+
+    access_logger.addHandler(handler)
+    access_logger.setLevel(getattr(logging, log_level.upper()))
+    access_logger.propagate = False
+
+    # Configure uvicorn error logger
+    error_logger = logging.getLogger("uvicorn.error")
+    error_logger.handlers.clear()
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(RedactingFormatter(_build_formatter(log_format)))
+
+    error_logger.addHandler(handler)
+    error_logger.setLevel(getattr(logging, log_level.upper()))
+    error_logger.propagate = False

--- a/tests/core/telemetry/test_fastapi_otel.py
+++ b/tests/core/telemetry/test_fastapi_otel.py
@@ -1,10 +1,10 @@
-# Copyright 2026 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/telemetry/test_fastapi_otel.py
+++ b/tests/core/telemetry/test_fastapi_otel.py
@@ -1,0 +1,231 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+
+import pytest
+
+from datarobot_genai.core.telemetry.fastapi_otel import DEFAULT_EXCLUDED_TRACE_SPAN_NAMES
+from datarobot_genai.core.telemetry.fastapi_otel import OTel
+
+_ENV_KEYS_TO_CLEAR = ("OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_HEADERS")
+
+_INSTRUMENTORS = []
+for _module_path, _class_name in (
+    ("opentelemetry.instrumentation.requests", "RequestsInstrumentor"),
+    ("opentelemetry.instrumentation.httpx", "HTTPXClientInstrumentor"),
+    ("opentelemetry.instrumentation.sqlalchemy", "SQLAlchemyInstrumentor"),
+):
+    try:
+        _module = __import__(_module_path, fromlist=[_class_name])
+        _INSTRUMENTORS.append(getattr(_module, _class_name))
+    except ImportError:
+        pass
+
+
+@dataclass
+class FakeOTelConfig:
+    otel_exporter_otlp_endpoint: str = ""
+    otel_exporter_otlp_headers: str = ""
+    otel_sdk_disabled: bool = False
+
+
+def _reset_otel_singleton() -> None:
+    OTel._instance = None
+    OTel._initialized = False
+    OTel._auto_instrumentation_setup = False
+
+
+def _uninstrument_all() -> None:
+    for instrumentor_cls in _INSTRUMENTORS:
+        instrumentor = instrumentor_cls()
+        if instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
+
+
+@pytest.fixture(autouse=True)
+def reset_otel_singleton(monkeypatch):
+    """Undo the process-wide side effects OTel.configure()/_setup_auto_instrumentation
+    leave behind: the singleton, env vars mirrored from config, and global
+    library auto-instrumentation. Note: the global OTel TracerProvider/
+    MeterProvider/LoggerProvider set via trace.set_tracer_provider() etc. have
+    no public "unset" API and are NOT reset here - a test that configures one
+    leaves it installed process-wide for the rest of the test session. What
+    IS handled: shutdown() is called on the current instance before it's
+    discarded, so any PeriodicExportingMetricReader/BatchSpanProcessor
+    background threads it started are stopped rather than left retrying
+    against localhost:4318 for the rest of the process's life.
+    """
+    _reset_otel_singleton()
+    for key in _ENV_KEYS_TO_CLEAR:
+        monkeypatch.delenv(key, raising=False)
+    yield
+    if OTel._instance is not None:
+        OTel._instance.shutdown()
+    _reset_otel_singleton()
+    for key in _ENV_KEYS_TO_CLEAR:
+        monkeypatch.delenv(key, raising=False)
+    _uninstrument_all()
+
+
+def test_otel_is_a_singleton() -> None:
+    assert OTel() is OTel()
+
+
+def test_configure_disabled_via_sdk_disabled() -> None:
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_sdk_disabled=True))
+    assert otel.telemetry_enabled is False
+
+
+def test_configure_disables_telemetry_without_endpoint(monkeypatch) -> None:
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT_INTERNAL", raising=False)
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_exporter_otlp_endpoint=""))
+    assert otel.telemetry_enabled is False
+
+
+def test_configure_disables_telemetry_for_remote_endpoint_without_headers() -> None:
+    otel = OTel()
+    otel.configure(
+        FakeOTelConfig(
+            otel_exporter_otlp_endpoint="https://otel.datarobot.com",
+            otel_exporter_otlp_headers="",
+        )
+    )
+    assert otel.telemetry_enabled is False
+
+
+def test_configure_enables_telemetry_for_local_endpoint_without_headers() -> None:
+    otel = OTel()
+    otel.configure(
+        FakeOTelConfig(
+            otel_exporter_otlp_endpoint="http://localhost:4318",
+            otel_exporter_otlp_headers="",
+        )
+    )
+    assert otel.telemetry_enabled is True
+
+
+def test_configure_enables_telemetry_for_remote_endpoint_with_headers() -> None:
+    otel = OTel()
+    otel.configure(
+        FakeOTelConfig(
+            otel_exporter_otlp_endpoint="https://otel.datarobot.com",
+            otel_exporter_otlp_headers="x-datarobot-api-key=abc",
+        )
+    )
+    assert otel.telemetry_enabled is True
+
+
+def test_excluded_trace_span_names_empty_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("OTEL_EXCLUDED_TRACE_SPAN_NAMES", raising=False)
+    otel = OTel()
+    assert DEFAULT_EXCLUDED_TRACE_SPAN_NAMES == frozenset()
+    assert otel._get_excluded_trace_span_names() == frozenset()
+
+
+def test_excluded_trace_span_names_reads_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("OTEL_EXCLUDED_TRACE_SPAN_NAMES", "app.noisy_span, app.other")
+    otel = OTel()
+    names = otel._get_excluded_trace_span_names()
+    assert names == {"app.noisy_span", "app.other"}
+
+
+def test_trace_decorator_skips_excluded_span_name(monkeypatch) -> None:
+    monkeypatch.setenv("OTEL_EXCLUDED_TRACE_SPAN_NAMES", "app.noisy_span")
+    otel = OTel()
+
+    def handler() -> str:
+        return "ok"
+
+    wrapped = otel.trace("app.noisy_span")(handler)
+
+    # An excluded span name means the function is returned unwrapped.
+    assert wrapped is handler
+    assert wrapped() == "ok"
+
+
+def test_shutdown_without_configuring_is_a_no_op() -> None:
+    otel = OTel()
+    otel.shutdown()  # must not raise
+
+
+def test_shutdown_calls_provider_shutdown_once_configured() -> None:
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_exporter_otlp_endpoint="http://localhost:4318"))
+    otel.configure_tracing()
+    assert otel._tracer_provider is not None
+    otel.shutdown()
+
+
+def test_trace_decorator_wraps_and_creates_span() -> None:
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_exporter_otlp_endpoint="http://localhost:4318"))
+
+    calls = []
+
+    @otel.trace
+    def handler(value: int) -> int:
+        calls.append(value)
+        return value * 2
+
+    assert handler is not None
+    assert handler(21) == 42
+    assert calls == [21]
+
+
+async def test_trace_decorator_wraps_async_function() -> None:
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_exporter_otlp_endpoint="http://localhost:4318"))
+
+    @otel.trace
+    async def handler() -> str:
+        return "ok"
+
+    assert await handler() == "ok"
+
+
+# Module-level with a short name: the `meter` decorator builds a metric
+# name as f"function.{func.__module__}.{func.__qualname__}", capped at
+# OTel's 63-char instrument name limit. A function nested inside a test
+# picks up "<locals>" in its qualname and blows that budget immediately -
+# a real, pre-existing constraint of this decorator, not something to
+# route around inside the test body.
+def _m() -> str:
+    return "ok"
+
+
+def _m_raises() -> None:
+    raise ValueError("boom")
+
+
+def test_meter_decorator_records_without_raising() -> None:
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_exporter_otlp_endpoint="http://localhost:4318"))
+    assert otel.meter(_m)() == "ok"
+
+
+def test_meter_decorator_records_on_exception() -> None:
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_exporter_otlp_endpoint="http://localhost:4318"))
+    with pytest.raises(ValueError, match="boom"):
+        otel.meter(_m_raises)()
+
+
+def test_span_context_manager_sets_attributes() -> None:
+    otel = OTel()
+    otel.configure(FakeOTelConfig(otel_exporter_otlp_endpoint="http://localhost:4318"))
+
+    with otel.span("my-span", key="value") as active_span:
+        assert active_span is not None

--- a/tests/core/telemetry/test_fastapi_otel_filters.py
+++ b/tests/core/telemetry/test_fastapi_otel_filters.py
@@ -1,10 +1,10 @@
-# Copyright 2026 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/telemetry/test_fastapi_otel_filters.py
+++ b/tests/core/telemetry/test_fastapi_otel_filters.py
@@ -1,0 +1,152 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from datarobot_genai.core.telemetry.fastapi_otel import OTLPConnectionErrorFilter
+from datarobot_genai.core.telemetry.fastapi_otel import _otel_handler_active
+from datarobot_genai.core.telemetry.fastapi_otel import _SafeLoggingHandler
+
+
+def _make_record(
+    name: str, message: str, level: int = logging.ERROR, exc_info: object = None
+) -> logging.LogRecord:
+    return logging.LogRecord(
+        name=name,
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=exc_info,
+    )
+
+
+def test_suppresses_urllib3_otlp_port_connection_error() -> None:
+    record = _make_record(
+        "urllib3.connectionpool",
+        "HTTPConnectionPool(host='localhost', port=4318): Max retries exceeded "
+        "with url: /v1/traces (Caused by NewConnectionError)",
+    )
+    assert OTLPConnectionErrorFilter().filter(record) is False
+
+
+def test_suppresses_urllib3_error_matching_on_port_in_url() -> None:
+    record = _make_record(
+        "urllib3.connectionpool",
+        "HTTPConnectionPool(host='localhost', port=4318): Max retries exceeded "
+        "with url: http://localhost:4318/v1/metrics",
+    )
+    assert OTLPConnectionErrorFilter().filter(record) is False
+
+
+def test_allows_urllib3_error_for_unrelated_port() -> None:
+    record = _make_record(
+        "urllib3.connectionpool",
+        "HTTPConnectionPool(host='example.com', port=443): Max retries exceeded "
+        "with url: /some/other/path",
+    )
+    assert OTLPConnectionErrorFilter().filter(record) is True
+
+
+def test_suppresses_requests_connection_error_to_otlp_port() -> None:
+    record = _make_record(
+        "requests.adapters",
+        "ConnectionError: connection refused to http://localhost:4318/v1/traces",
+    )
+    assert OTLPConnectionErrorFilter().filter(record) is False
+
+
+def test_allows_requests_error_unrelated_to_otlp() -> None:
+    record = _make_record("requests.adapters", "ConnectionError to example.com:443")
+    assert OTLPConnectionErrorFilter().filter(record) is True
+
+
+def test_suppresses_sdk_export_error_wrapping_connection_error() -> None:
+    try:
+        raise ConnectionError("refused")
+    except ConnectionError:
+        import sys
+
+        exc_info = sys.exc_info()
+    record = _make_record("opentelemetry.sdk.trace.export", "export failed", exc_info=exc_info)
+    assert OTLPConnectionErrorFilter().filter(record) is False
+
+
+def test_suppresses_sdk_export_error_via_chained_cause() -> None:
+    try:
+        try:
+            raise ConnectionError("refused")
+        except ConnectionError as inner:
+            raise RuntimeError("export failed") from inner
+    except RuntimeError:
+        import sys
+
+        exc_info = sys.exc_info()
+    record = _make_record("opentelemetry.sdk.trace.export", "export failed", exc_info=exc_info)
+    assert OTLPConnectionErrorFilter().filter(record) is False
+
+
+def test_allows_sdk_error_unrelated_to_connection_failure() -> None:
+    try:
+        raise ValueError("something else")
+    except ValueError:
+        import sys
+
+        exc_info = sys.exc_info()
+    record = _make_record("opentelemetry.sdk.trace.export", "export failed", exc_info=exc_info)
+    assert OTLPConnectionErrorFilter().filter(record) is True
+
+
+def test_warning_callback_invoked_when_suppressing() -> None:
+    calls = []
+    otlp_filter = OTLPConnectionErrorFilter(warning_callback=lambda: calls.append(1))
+    record = _make_record(
+        "urllib3.connectionpool",
+        "HTTPConnectionPool(host='localhost', port=4318): refused, url: /v1/traces",
+    )
+    otlp_filter.filter(record)
+    assert calls == [1]
+
+
+def test_warning_callback_not_invoked_when_allowing() -> None:
+    calls = []
+    otlp_filter = OTLPConnectionErrorFilter(warning_callback=lambda: calls.append(1))
+    record = _make_record("some.other.logger", "unrelated message", level=logging.INFO)
+    otlp_filter.filter(record)
+    assert calls == []
+
+
+def test_safe_logging_handler_emits_without_a_configured_provider() -> None:
+    # No logger_provider given -> resolves the global (NoOp by default) provider.
+    # emit() must not raise even though nothing is actually configured.
+    handler = _SafeLoggingHandler()
+    handler.emit(_make_record("test", "hello", level=logging.INFO))
+
+
+def test_safe_logging_handler_recursion_guard_drops_reentrant_emit(monkeypatch) -> None:
+    handler = _SafeLoggingHandler()
+    calls = []
+
+    def fake_super_emit(self: object, record: logging.LogRecord) -> None:
+        calls.append(record.msg)
+        # A reentrant call (e.g. the export path itself logging an error)
+        # must be dropped by the guard instead of recursing.
+        handler.emit(_make_record("reentrant", "should be dropped"))
+
+    monkeypatch.setattr("opentelemetry.sdk._logs.LoggingHandler.emit", fake_super_emit)
+    handler.emit(_make_record("test", "outer", level=logging.INFO))
+
+    assert calls == ["outer"]
+    # The guard must be released after the outer emit completes.
+    assert _otel_handler_active.get() is False

--- a/tests/core/telemetry/test_logging.py
+++ b/tests/core/telemetry/test_logging.py
@@ -1,10 +1,10 @@
-# Copyright 2026 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/core/telemetry/test_logging.py
+++ b/tests/core/telemetry/test_logging.py
@@ -23,6 +23,7 @@ from datarobot_genai.core.telemetry.logging import RedactingFormatter
 from datarobot_genai.core.telemetry.logging import TextFormatter
 from datarobot_genai.core.telemetry.logging import get_logger
 from datarobot_genai.core.telemetry.logging import init_logging
+from datarobot_genai.core.telemetry.logging import log_api_call
 
 
 def _make_record(message: str = "hello", **extra: object) -> logging.LogRecord:
@@ -141,3 +142,46 @@ def test_get_logger_readable_format() -> None:
     logger = get_logger("test.readable", format_type="readable", stream=stream)
     logger.info("hello")
     assert "INFO:test.readable:hello" in stream.getvalue()
+
+
+async def test_log_api_call_does_not_strip_root_logger_handlers() -> None:
+    # Regression test: log_api_call used to call get_logger() (default
+    # name="") on every invocation, which resolves to the root logger and
+    # unconditionally replaces its handlers - destroying whatever
+    # OTel.configure_logging() attached there for OTLP export.
+    root_logger = logging.getLogger()
+    sentinel_handler = logging.NullHandler()
+    root_logger.addHandler(sentinel_handler)
+    try:
+
+        @log_api_call
+        async def call() -> str:
+            return "ok"
+
+        assert await call() == "ok"
+        assert sentinel_handler in root_logger.handlers
+    finally:
+        root_logger.removeHandler(sentinel_handler)
+
+
+async def test_log_api_call_logs_start_and_complete(caplog) -> None:
+    @log_api_call
+    async def call() -> str:
+        return "ok"
+
+    with caplog.at_level(logging.INFO):
+        assert await call() == "ok"
+
+    assert any("API CALL START" in r.message for r in caplog.records)
+    assert any("API CALL COMPLETE" in r.message for r in caplog.records)
+
+
+async def test_log_api_call_logs_error_and_reraises(caplog) -> None:
+    @log_api_call
+    async def call() -> None:
+        raise ValueError("boom")
+
+    with caplog.at_level(logging.INFO), pytest.raises(ValueError, match="boom"):
+        await call()
+
+    assert any("ERROR IN API CALL" in r.message for r in caplog.records)

--- a/tests/core/telemetry/test_logging.py
+++ b/tests/core/telemetry/test_logging.py
@@ -1,0 +1,143 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import io
+import json
+import logging
+
+import pytest
+
+from datarobot_genai.core.telemetry.logging import JsonFormatter
+from datarobot_genai.core.telemetry.logging import ReadableFormatter
+from datarobot_genai.core.telemetry.logging import RedactingFormatter
+from datarobot_genai.core.telemetry.logging import TextFormatter
+from datarobot_genai.core.telemetry.logging import get_logger
+from datarobot_genai.core.telemetry.logging import init_logging
+
+
+def _make_record(message: str = "hello", **extra: object) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+def test_json_formatter_includes_extra_fields() -> None:
+    record = _make_record("hello", user_id="u1")
+    data = json.loads(JsonFormatter().format(record))
+    assert data["message"] == "hello"
+    assert data["user_id"] == "u1"
+    assert data["level"] == "INFO"
+
+
+def test_json_formatter_serializes_arbitrary_object_via_str_fallback() -> None:
+    class Widget:
+        def __str__(self) -> str:
+            return "widget-repr"
+
+    record = _make_record("hello", widget=Widget())
+    data = json.loads(JsonFormatter().format(record))
+    assert data["widget"] == "widget-repr"
+
+
+def test_json_formatter_reports_circular_reference_error() -> None:
+    circular: dict[str, object] = {}
+    circular["self"] = circular
+    record = _make_record("hello", circular=circular)
+    data = json.loads(JsonFormatter().format(record))
+    assert "serialization error" in data["circular"]
+
+
+def test_text_formatter_appends_extra_fields() -> None:
+    formatter = TextFormatter("%(message)s")
+    record = _make_record("hello", user_id="u1")
+    assert formatter.format(record) == "hello | user_id=u1"
+
+
+def test_readable_formatter_single_line_without_exception() -> None:
+    record = _make_record("hello")
+    output = ReadableFormatter().format(record)
+    assert output.endswith("INFO:test.logger:hello")
+    assert "\n" not in output
+
+
+def test_readable_formatter_indents_traceback() -> None:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+
+        record = _make_record("failed")
+        record.exc_info = sys.exc_info()
+    output = ReadableFormatter().format(record)
+    assert "exception:" in output
+    assert "ValueError: boom" in output
+
+
+@pytest.mark.parametrize("sensitive_key", ["access_token", "refresh_token", "api_key"])
+def test_redacting_formatter_redacts_direct_attribute(sensitive_key: str) -> None:
+    record = _make_record("hello", **{sensitive_key: "super-secret"})
+    formatted = RedactingFormatter(TextFormatter("%(message)s")).format(record)
+    assert "super-secret" not in formatted
+    assert "[REDACTED]" in formatted
+
+
+def test_redacting_formatter_redacts_nested_dict() -> None:
+    record = _make_record("hello", payload={"api_key": "super-secret", "ok": "value"})
+    formatted = RedactingFormatter(TextFormatter("%(message)s")).format(record)
+    assert "super-secret" not in formatted
+    assert "value" in formatted
+
+
+def test_redacting_formatter_regex_catches_string_representation() -> None:
+    record = _make_record("request failed with api_key='super-secret'")
+    formatted = RedactingFormatter(TextFormatter("%(message)s")).format(record)
+    assert "super-secret" not in formatted
+
+
+def test_redacting_formatter_does_not_mutate_original_record() -> None:
+    record = _make_record("hello", api_key="super-secret")
+    RedactingFormatter(TextFormatter("%(message)s")).format(record)
+    assert record.api_key == "super-secret"
+
+
+def test_init_logging_wires_redacting_formatter_by_default() -> None:
+    root_logger = logging.getLogger()
+    original_handlers = root_logger.handlers[:]
+    stream = io.StringIO()
+    try:
+        init_logging(stream=stream)
+        logging.getLogger("test.init").info("secret api_key=super-secret here")
+        output = stream.getvalue()
+        assert "super-secret" not in output
+        assert "[REDACTED]" in output
+    finally:
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+
+
+def test_get_logger_readable_format() -> None:
+    stream = io.StringIO()
+    logger = get_logger("test.readable", format_type="readable", stream=stream)
+    logger.info("hello")
+    assert "INFO:test.readable:hello" in stream.getvalue()

--- a/tests/core/telemetry/test_uvicorn_filter.py
+++ b/tests/core/telemetry/test_uvicorn_filter.py
@@ -1,0 +1,81 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from datarobot_genai.core.telemetry.logging import JsonFormatter
+from datarobot_genai.core.telemetry.logging import ReadableFormatter
+from datarobot_genai.core.telemetry.logging import RedactingFormatter
+from datarobot_genai.core.telemetry.uvicorn_filter import HealthCheckFilter
+from datarobot_genai.core.telemetry.uvicorn_filter import configure_uvicorn_logging
+
+
+def _make_record(message: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_health_check_filter_suppresses_health_get_at_info() -> None:
+    health_filter = HealthCheckFilter(log_level="INFO")
+    record = _make_record('"GET /health HTTP/1.1" 200 OK')
+    assert health_filter.filter(record) is False
+
+
+def test_health_check_filter_allows_health_get_at_debug() -> None:
+    health_filter = HealthCheckFilter(log_level="DEBUG")
+    record = _make_record('"GET /health HTTP/1.1" 200 OK')
+    assert health_filter.filter(record) is True
+
+
+def test_health_check_filter_allows_other_requests() -> None:
+    health_filter = HealthCheckFilter(log_level="INFO")
+    record = _make_record('"GET /api/chats HTTP/1.1" 200 OK')
+    assert health_filter.filter(record) is True
+
+
+def test_configure_uvicorn_logging_json_format() -> None:
+    configure_uvicorn_logging(log_format="json", log_level="INFO")
+    access_logger = logging.getLogger("uvicorn.access")
+    formatter = access_logger.handlers[0].formatter
+    assert isinstance(formatter, RedactingFormatter)
+    assert isinstance(formatter.original_formatter, JsonFormatter)
+    assert any(isinstance(f, HealthCheckFilter) for f in access_logger.handlers[0].filters)
+
+
+def test_configure_uvicorn_logging_readable_format() -> None:
+    configure_uvicorn_logging(log_format="readable", log_level="INFO")
+    error_logger = logging.getLogger("uvicorn.error")
+    formatter = error_logger.handlers[0].formatter
+    assert isinstance(formatter, RedactingFormatter)
+    assert isinstance(formatter.original_formatter, ReadableFormatter)
+
+
+def test_configure_uvicorn_logging_redacts_secrets_in_access_log() -> None:
+    configure_uvicorn_logging(log_format="text", log_level="INFO")
+    access_logger = logging.getLogger("uvicorn.access")
+    record = _make_record('"GET /api/chats?api_key=super-secret HTTP/1.1" 200 OK')
+    formatted = access_logger.handlers[0].formatter.format(record)
+    assert "super-secret" not in formatted
+
+
+def test_configure_uvicorn_logging_does_not_propagate() -> None:
+    configure_uvicorn_logging(log_format="text", log_level="INFO")
+    assert logging.getLogger("uvicorn.access").propagate is False
+    assert logging.getLogger("uvicorn.error").propagate is False

--- a/tests/core/telemetry/test_uvicorn_filter.py
+++ b/tests/core/telemetry/test_uvicorn_filter.py
@@ -1,10 +1,10 @@
-# Copyright 2026 DataRobot, Inc.
+# Copyright 2026 DataRobot, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
# RATIONALE

Multiple downstream repos (`data-analyst`, `diffington`, `recipe-talk-to-my-docs`, and others) each carry their own copy of a FastAPI OTel module (Logger/Tracer/Meter provider lifecycle) and log-formatting/ redaction utilities, originally distributed via the `af-component-fastapi-backend` base template. This has caused repeated propagation pain: one repo forked the code out of Copier's reach entirely, and template-synced repos still needed manual per-repo fixes when upstream changes landed.

## CHANGES

Add four new files under `datarobot_genai/core/telemetry`: `enums.py`, `logging.py`, `uvicorn_filter.py`, `fastapi_otel.py`, porting the OTel class and log formatters so future fixes propagate via a version bump instead of a template merge-conflict-and-patch cycle per repo.

Notable changes from the ported source:
- `OTel.configure()` decoupled from any per-app Config type via a new OTelConfig Protocol (structural typing, no per-app inheritance needed).
- Folded in three features one downstream fork (data-analyst) had independently added and the others lacked: a `ReadableFormatter`, an api_key entry in `RedactingFormatter`'s default sensitive_keys, and env-var-driven trace-span exclusion. All generically useful, config-driven, not app-specific.
- Dropped the module-level `otel = OTel()` singleton pre-instantiation (avoids import-time side effects in a shared library; OTel() still returns the same process-wide singleton) and a redundant time.sleep(1) in shutdown() (BatchSpanProcessor.shutdown() already blocks until fully drained).
- Fixed a real bug present in all 3 source copies: get_logger mutated logger.handlers while iterating it, silently skipping handlers.
- Wrapped uvicorn's access/error log formatters in `RedactingFormatter` and de-duplicated the formatter-building logic duplicated across logging.py and uvicorn_filter.py.
- `DEFAULT_EXCLUDED_TRACE_SPAN_NAMES` is empty, not hardcoded to a span name from data-analyst's own middleware, apps opt in via OTEL_EXCLUDED_TRACE_SPAN_NAMES.

No tests existed anywhere to port from. Added 49 new tests covering formatters, redaction, the uvicorn filter, `OTel.configure` validation logic, trace-exclusion, the `OTLPConnectionErrorFilter`'s branches, the `_SafeLoggingHandler` recursion guard, and the trace/meter decorators' happy path.


## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New shared observability path affects global logging/OTel providers and env vars at startup; misconfiguration could disable telemetry or alter log output across consuming apps, though validation and redaction reduce credential leakage risk.
> 
> **Overview**
> Introduces a **shared `datarobot_genai/core/telemetry` stack** for FastAPI custom apps so OTel and logging fixes ship via library version bumps instead of per-repo Copier copies.
> 
> **`fastapi_otel.py`** adds a process-wide `OTel` singleton with OTLP logging/metrics/tracing setup, optional auto-instrumentation (requests/httpx/SQLAlchemy/FastAPI), `OTelConfig` protocol-based `configure()` (endpoint/headers mirroring, disable when remote endpoint lacks headers), trace/meter decorators, span helpers, OTLP connection-error log suppression, and a recursion-safe OTel logging handler.
> 
> **`logging.py`**, **`enums.py`**, and **`uvicorn_filter.py`** add JSON/text/readable formatters, **`RedactingFormatter`** (tokens/`api_key`), root/`get_logger` init, health-check access-log filtering, and redacted uvicorn access/error logging.
> 
> Porting tweaks include no import-time `otel` singleton, empty default trace-span exclusions (`OTEL_EXCLUDED_TRACE_SPAN_NAMES`), fixed handler iteration in `get_logger`, and shared `_build_formatter` for uvicorn. **~49 tests** cover configure rules, filters, redaction, and decorators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c9bc5c2d29b3cef1c8895d636e45d07fff78f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->