### PR TITLE
[MODEL-24138] Fix vdb_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.25.4
+- `drtools/vdb`: `vdb_query` validates that the deployment is a vector database before calling the prediction server
+
 ## 0.25.3
 - Dropped the `ragas` dependency. Agent runs still record their pipeline interactions as a `MultiTurnSample`, but that type (and the `HumanMessage` / `AIMessage` / `ToolMessage` / `ToolCall` primitives) now come from the new `datarobot_genai.core.pipeline_interactions` module, which owns a slim Pydantic `MultiTurnSample` and reuses the message primitives shipped by `datarobot-moderations` (>=11.2.45). The LangGraph and LlamaIndex trace converters, previously imported from `ragas.integrations`, are reimplemented locally. Removing `ragas` also drops its `diskcache` and `scikit-network` exclusions. The serialized `pipeline_interactions` payload is unchanged apart from a few always-null fields that are no longer emitted.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.25.3"
+version = "0.25.4"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.25.3"
+version = "0.25.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -136,11 +136,18 @@ class StubDeployment:
     """Stub DataRobot deployment object."""
 
     def __init__(
-        self, deployment_id: str, project_id: str = "test_project_123", model_id: str = "model_1"
+        self,
+        deployment_id: str,
+        project_id: str = "test_project_123",
+        model_id: str = "model_1",
+        *,
+        model: dict[str, Any] | None = None,
+        capabilities: dict[str, Any] | None = None,
     ):
         self.id = deployment_id
         self.label = f"Deployment {deployment_id}"
-        self.model = {"project_id": project_id, "id": model_id}
+        self.model = model or {"project_id": project_id, "id": model_id}
+        self.capabilities = capabilities
         self.status = "active"
         self.default_prediction_server = {
             "id": STUB_PREDICTION_SERVER_ID,
@@ -434,6 +441,16 @@ def test_create_dr_client() -> StubDRClient:
     def get_deployment(deployment_id: str | None = None, **kwargs: Any) -> StubDeployment:
         """Stub Deployment.get; accepts deployment_id as positional or keyword."""
         did = deployment_id or kwargs.get("deployment_id")
+        if did in (STUB_VDB_DEPLOYMENT_ID, STUB_VDB_DEPLOY_RESULT_ID):
+            return StubDeployment(
+                did,
+                model={
+                    "project_id": "test_project_123",
+                    "id": "model_vdb",
+                    "targetType": "VectorDatabase",
+                },
+                capabilities={"supportsVectorDatabaseQuerying": True},
+            )
         return StubDeployment(
             did or "stub_deployment_id", project_id="test_project_123", model_id="model_1"
         )

--- a/src/datarobot_genai/drtools/vdb/tools.py
+++ b/src/datarobot_genai/drtools/vdb/tools.py
@@ -166,11 +166,19 @@ def _parse_vdb_query_documents(response_data: Any) -> list[dict[str, Any]]:
     return documents
 
 
-def _is_vector_database_deployment(deployment: dict[str, Any]) -> bool:
-    model = deployment.get("model")
+def _is_vector_database_deployment(deployment: dict[str, Any] | Any) -> bool:
+    model = (
+        deployment.get("model")
+        if isinstance(deployment, dict)
+        else getattr(deployment, "model", None)
+    )
     if isinstance(model, dict) and model.get("targetType") == "VectorDatabase":
         return True
-    capabilities = deployment.get("capabilities")
+    capabilities = (
+        deployment.get("capabilities")
+        if isinstance(deployment, dict)
+        else getattr(deployment, "capabilities", None)
+    )
     return (
         isinstance(capabilities, dict)
         and capabilities.get("supportsVectorDatabaseQuerying") is True
@@ -340,6 +348,13 @@ async def vdb_query(
             deployment = dr.Deployment.get(deployment_id)
         except ClientError as e:
             raise_tool_error_for_client_error(e)
+
+        if not _is_vector_database_deployment(deployment):
+            raise ToolError(
+                f"Deployment {deployment_id} is not a vector database deployment. "
+                "Use vdb_list to find vector database deployments.",
+                kind=ToolErrorKind.VALIDATION,
+            )
 
         endpoint = get_credentials().datarobot.datarobot_endpoint
         token = get_datarobot_access_token()

--- a/tests/drmcp/unit/vdb_tools/test_tools.py
+++ b/tests/drmcp/unit/vdb_tools/test_tools.py
@@ -148,6 +148,7 @@ async def test_vdb_query_success(
 ) -> None:
     mock_deployment = SimpleNamespace(
         id="dep1",
+        model={"targetType": "VectorDatabase"},
         default_prediction_server={
             "id": "srv1",
             "url": "https://pred.example.com",
@@ -202,6 +203,7 @@ async def test_vdb_query_parses_prediction_server_response(
 ) -> None:
     mock_deployment = SimpleNamespace(
         id="dep1",
+        model={"targetType": "VectorDatabase"},
         default_prediction_server={
             "id": "srv1",
             "url": "https://pred.example.com",
@@ -266,6 +268,7 @@ async def test_vdb_query_client_error_404(
 ) -> None:
     mock_deployment = SimpleNamespace(
         id="missing-dep",
+        model={"targetType": "VectorDatabase"},
         default_prediction_server={
             "id": "srv1",
             "url": "https://pred.example.com",
@@ -293,6 +296,27 @@ async def test_vdb_query_client_error_404(
             await tools.vdb_query(deployment_id="missing-dep", query="test")
     assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
     assert "404" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
+async def test_vdb_query_rejects_non_vdb_deployment(
+    mock_get_client_context_with_token_from_request_header: Mock,
+) -> None:
+    mock_deployment = SimpleNamespace(
+        id="pred-dep",
+        model={"targetType": "Binary"},
+        capabilities={"supportsVectorDatabaseQuerying": False},
+    )
+    mock_rest_client = MagicMock()
+    mock_get_client_context_with_token_from_request_header.return_value.__enter__.return_value = (
+        mock_rest_client
+    )
+    with patch.object(dr.Deployment, "get", return_value=mock_deployment):
+        with pytest.raises(ToolError, match="not a vector database deployment") as exc_info:
+            await tools.vdb_query(deployment_id="pred-dep", query="test query")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    mock_rest_client.request.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.25.3"
+version = "0.25.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- `vdb_query` validates that the deployment is a vector database before calling the prediction server

## TESTING
<img width="831" height="744" alt="Screenshot 2026-07-17 at 3 44 38 PM" src="https://github.com/user-attachments/assets/5c59e074-f1a2-4895-bcaa-5624d63b8c54" />

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized VDB tool validation with clearer errors and no change to successful query paths; low risk to unrelated MCP or predictive flows.
> 
> **Overview**
> **`vdb_query` now rejects non–vector-database deployments** before it builds auth headers or POSTs to the prediction server, returning a validation `ToolError` that points callers to `vdb_list`.
> 
> **`_is_vector_database_deployment`** accepts both deployment dicts (from list APIs) and SDK `Deployment` objects from `dr.Deployment.get`, reading `model.targetType` and `capabilities.supportsVectorDatabaseQuerying` via `.get()` or `getattr()`.
> 
> Test/stub updates align with the guard: VDB-shaped `StubDeployment` records, unit test `test_vdb_query_rejects_non_vdb_deployment`, and existing `vdb_query` success paths mock VDB metadata. Release **0.25.4** and changelog entry document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040d474240641095a63cc8a316b05b88fb39bbcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->