### PR TITLE
[APP-6300] Add typed 429 and transport errors to DRMemoryServiceClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.25.5
-- `application_utils/persistence`: `429` responses raise the new `DRMemoryRateLimitError` carrying `retry_after` (whole seconds parsed from `Retry-After`; `None` for the trial storage-cap 429, which sends no header by design). Request timeouts and transport failures raise the new `DRMemoryUnavailableError` instead of escaping as raw `httpx` exceptions — the original is preserved as `__cause__`; catch sites handling raw `httpx` errors around client calls should switch to the typed error. Shared-`http_client` injection is now documented as a supported production pattern (one pool, per-principal thin clients).
+## 0.26.0
+- *Breaking change*: `application_utils/persistence`: request timeouts and transport failures raise the new `DRMemoryUnavailableError` instead of escaping `DRMemoryServiceClient.request()` as raw `httpx` exceptions — the original is preserved as `__cause__`; catch sites handling raw `httpx.ConnectError`/`TimeoutException` around client calls must switch to the typed error.
+- `application_utils/persistence`: `429` responses raise the new `DRMemoryRateLimitError` carrying `retry_after` (whole seconds parsed from `Retry-After`; `None` for the trial storage-cap 429, which sends no header by design).
+- `application_utils/persistence`: shared-`http_client` injection is now documented as a supported production pattern (one pool, per-principal thin clients).
 
 ## 0.25.4
 - `drtools/vdb`: `vdb_query` validates that the deployment is a vector database before calling the prediction server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.25.5
+- `application_utils/persistence`: `429` responses raise the new `DRMemoryRateLimitError` carrying `retry_after` (whole seconds parsed from `Retry-After`; `None` for the trial storage-cap 429, which sends no header by design). Request timeouts and transport failures raise the new `DRMemoryUnavailableError` instead of escaping as raw `httpx` exceptions — the original is preserved as `__cause__`; catch sites handling raw `httpx` errors around client calls should switch to the typed error. Shared-`http_client` injection is now documented as a supported production pattern (one pool, per-principal thin clients).
+
 ## 0.25.4
 - `drtools/vdb`: `vdb_query` validates that the deployment is a vector database before calling the prediction server
 

--- a/docs/application_utils/README.md
+++ b/docs/application_utils/README.md
@@ -279,7 +279,16 @@ accepted by the service.
 | `DRMemoryConflictError` | 409 | Deduplication conflict on create (ORM auto-adopts) |
 | `DRMemoryVersionConflictError` | 409 / 422 | Stale If-Match or createdAt token |
 | `DRMemoryValidationError` | 422 | Schema validation error |
+| `DRMemoryRateLimitError` | 429 | Quota or rate limit exceeded; `retry_after` carries whole seconds from `Retry-After` when the service sends it (trial quota yes, storage cap no) |
+| `DRMemoryUnavailableError` | — (no response) | Request timeout or transport failure; the original `httpx` exception is on `__cause__` |
 | `DRMemoryServiceError` | other 4xx/5xx | Unexpected error |
+
+> **Behavior note:** transport failures (timeouts, connection errors) raise
+> `DRMemoryUnavailableError` instead of escaping as raw `httpx` exceptions.
+> `except DRMemoryServiceError` now covers an unreachable service too; code
+> that previously caught `httpx.ConnectError` / `httpx.TimeoutException`
+> directly should catch `DRMemoryUnavailableError` (the original exception
+> remains available as `__cause__`).
 
 ## Public API
 
@@ -300,6 +309,8 @@ from datarobot_genai.application_utils.persistence import (
     DRMemoryValidationError,
     DRMemoryConflictError,
     DRMemoryVersionConflictError,
+    DRMemoryRateLimitError,
+    DRMemoryUnavailableError,
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.25.4"
+version = "0.25.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.25.5"
+version = "0.26.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/application_utils/persistence/__init__.py
+++ b/src/datarobot_genai/application_utils/persistence/__init__.py
@@ -61,7 +61,9 @@ from datarobot_genai.application_utils.persistence.event import DREvent
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryBadRequestError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryConflictError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryNotFoundError
+from datarobot_genai.application_utils.persistence.exceptions import DRMemoryRateLimitError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryServiceError
+from datarobot_genai.application_utils.persistence.exceptions import DRMemoryUnavailableError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryValidationError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryVersionConflictError
 from datarobot_genai.application_utils.persistence.markers import DEFAULT_SESSION_TTL_SECONDS
@@ -88,4 +90,6 @@ __all__ = [
     "DRMemoryValidationError",
     "DRMemoryConflictError",
     "DRMemoryVersionConflictError",
+    "DRMemoryRateLimitError",
+    "DRMemoryUnavailableError",
 ]

--- a/src/datarobot_genai/application_utils/persistence/_client.py
+++ b/src/datarobot_genai/application_utils/persistence/_client.py
@@ -24,6 +24,10 @@ All routes include trailing slashes — the Memory Service runs with
 
 from __future__ import annotations
 
+import math
+from datetime import UTC
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 import httpx
@@ -34,7 +38,9 @@ from datarobot_genai.application_utils.persistence._config import resolve_endpoi
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryBadRequestError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryConflictError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryNotFoundError
+from datarobot_genai.application_utils.persistence.exceptions import DRMemoryRateLimitError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryServiceError
+from datarobot_genai.application_utils.persistence.exceptions import DRMemoryUnavailableError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryValidationError
 from datarobot_genai.application_utils.persistence.exceptions import DRMemoryVersionConflictError
 
@@ -47,7 +53,14 @@ class DRMemoryServiceClient:
 
     Resolves ``DATAROBOT_ENDPOINT`` and ``DATAROBOT_API_TOKEN`` from the
     environment (overridable via constructor arguments).  Owns an
-    ``httpx.AsyncClient`` unless one is injected (for testing).
+    ``httpx.AsyncClient`` unless one is injected.
+
+    The instance itself is lightweight — the resolved base URL plus a headers
+    dict.  Applications that act on behalf of many principals (a different
+    API token per end user) are supported by constructing one
+    ``DRMemoryServiceClient`` per principal over a single shared
+    ``http_client``: the shared pool carries the connections, each instance
+    carries only an identity.
 
     Parameters
     ----------
@@ -56,18 +69,27 @@ class DRMemoryServiceClient:
         Defaults to the ``DATAROBOT_ENDPOINT`` environment variable.
     api_token : str | None
         DataRobot API token.  Defaults to the ``DATAROBOT_API_TOKEN``
-        environment variable.
+        environment variable.  Multi-principal applications must pass this
+        explicitly — the environment fallback is the *application's* own
+        credential, not the requesting user's.
     base_path : str
         Sub-path appended to the endpoint.  Defaults to ``"memory"`` — the
         Tyk gateway mount path for the Memory Service (``/api/v2/memory``).
     http_client : httpx.AsyncClient | None
-        Injected async client (for testing with ``respx``).  When supplied,
-        the ``DRMemoryServiceClient`` will **not** close it on ``aclose()``.
+        Injected async client.  When supplied, the ``DRMemoryServiceClient``
+        will **not** close it on ``aclose()`` — the caller owns its lifetime.
+        This is a supported production pattern (share one connection pool
+        across many per-principal client instances) as well as the hook for
+        testing with ``respx``.  When omitted, the client creates and owns a
+        pool of its own.
     timeout : float
-        Default per-request timeout in seconds.
+        Default per-request timeout in seconds.  Ignored when ``http_client``
+        is injected — configure the timeout on the injected client instead.
 
     Examples
     --------
+    One client, one credential (scripts, single-principal apps):
+
     .. code-block:: python
 
         import asyncio
@@ -82,6 +104,26 @@ class DRMemoryServiceClient:
                 print(space.id)
 
         asyncio.run(main())
+
+    One shared pool, one thin client per principal (multi-user web apps):
+
+    .. code-block:: python
+
+        import httpx
+
+        # App startup.  Do not set default auth headers on the shared pool —
+        # identity belongs on each DRMemoryServiceClient, not the transport.
+        shared_http = httpx.AsyncClient(timeout=30.0)
+
+        def client_for(user_token: str) -> DRMemoryServiceClient:
+            # Cheap: per-request construction, no new connections.
+            return DRMemoryServiceClient(
+                api_token=user_token,
+                http_client=shared_http,
+            )
+
+        async def shutdown() -> None:
+            await shared_http.aclose()  # close the pool once, at app shutdown
     """
 
     def __init__(
@@ -155,19 +197,35 @@ class DRMemoryServiceClient:
             with the event-version detail.
         DRMemoryValidationError
             HTTP 422 — schema validation error.
+        DRMemoryRateLimitError
+            HTTP 429 — quota or rate limit exceeded; carries ``retry_after``
+            seconds parsed from the ``Retry-After`` response header.
+        DRMemoryUnavailableError
+            No response received — request timeout or transport failure
+            (connection refused, DNS, TLS).  The original ``httpx`` exception
+            is preserved as ``__cause__``.
         DRMemoryServiceError
             Any other 4xx/5xx error.
         """
         headers = {**self._auth_headers, **(extra_headers or {})}
         url = self._url(path)
 
-        resp = await self._http_client.request(
-            method,
-            url,
-            params=params,
-            json=json,
-            headers=headers,
-        )
+        try:
+            resp = await self._http_client.request(
+                method,
+                url,
+                params=params,
+                json=json,
+                headers=headers,
+            )
+        except httpx.TimeoutException as exc:
+            raise DRMemoryUnavailableError(
+                f"Memory Service request timed out ({method} {url}): {exc!r}"
+            ) from exc
+        except httpx.TransportError as exc:
+            raise DRMemoryUnavailableError(
+                f"Memory Service unreachable ({method} {url}): {exc!r}"
+            ) from exc
 
         if resp.status_code < 400:
             return resp
@@ -218,6 +276,14 @@ class DRMemoryServiceClient:
                 raise DRMemoryVersionConflictError(detail, status_code=422, payload=body)
             raise DRMemoryValidationError(detail, status_code=422, payload=body)
 
+        if resp.status_code == 429:
+            raise DRMemoryRateLimitError(
+                detail,
+                status_code=429,
+                payload=body,
+                retry_after=_parse_retry_after(resp.headers.get("Retry-After")),
+            )
+
         raise DRMemoryServiceError(detail, status_code=resp.status_code, payload=body)
 
     async def aclose(self) -> None:
@@ -232,6 +298,31 @@ class DRMemoryServiceClient:
     async def __aexit__(self, *args: Any) -> None:
         """Close the client on context exit."""
         await self.aclose()
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    """Parse a ``Retry-After`` header into whole seconds.
+
+    Accepts both RFC 9110 forms: delta-seconds (``"30"``) and HTTP-date
+    (``"Wed, 22 Jul 2026 07:28:00 GMT"``, rounded up).  Whole seconds so the
+    value can be propagated verbatim into another ``Retry-After`` header —
+    RFC 9110 delay-seconds and the service's OpenAPI contract are integers,
+    and ``"30.0"`` would be rejected by digit-gated parsers.  Returns ``None``
+    when the header is absent or unparseable; never returns a negative number.
+    """
+    if not value:
+        return None
+    try:
+        return max(0, int(value.strip()))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    return max(0, math.ceil((when - datetime.now(UTC)).total_seconds()))
 
 
 def _extract_detail(body: dict[str, Any], fallback: str) -> str:

--- a/src/datarobot_genai/application_utils/persistence/_client.py
+++ b/src/datarobot_genai/application_utils/persistence/_client.py
@@ -318,7 +318,9 @@ def _parse_retry_after(value: str | None) -> int | None:
         pass
     try:
         when = parsedate_to_datetime(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: years beyond C-long range slip past the parser into
+        # the datetime constructor on Python <= 3.13 (CPython gh-153406).
         return None
     if when.tzinfo is None:
         when = when.replace(tzinfo=UTC)

--- a/src/datarobot_genai/application_utils/persistence/exceptions.py
+++ b/src/datarobot_genai/application_utils/persistence/exceptions.py
@@ -26,7 +26,9 @@ Exception hierarchy
     ├── DRMemoryBadRequestError      (HTTP 400)
     ├── DRMemoryValidationError      (HTTP 422, schema validation)
     ├── DRMemoryConflictError        (HTTP 409, deduplication conflict)
-    └── DRMemoryVersionConflictError (HTTP 409 session stale / 422 event stale)
+    ├── DRMemoryVersionConflictError (HTTP 409 session stale / 422 event stale)
+    ├── DRMemoryRateLimitError       (HTTP 429, quota / rate limit)
+    └── DRMemoryUnavailableError     (no response: timeout / connection failure)
 """
 
 from __future__ import annotations
@@ -121,4 +123,54 @@ class DRMemoryVersionConflictError(DRMemoryServiceError):
     and as HTTP 422 for event ``patch()`` (stale ``createdAt`` token).
 
     Resolution: re-read the resource to get the current version, then retry.
+    """
+
+
+class DRMemoryRateLimitError(DRMemoryServiceError):
+    """Raised when the service rejects a request due to quota or rate limits (HTTP 429).
+
+    The Memory Service enforces per-tenant trial quotas: monthly read/write
+    counts answer ``429`` with a ``Retry-After`` header (seconds until the
+    window resets), while the storage cap answers ``429`` *without*
+    ``Retry-After`` — storage is a level, not a windowed quota, so freeing
+    data (or upgrading) is the remedy rather than waiting.
+
+    Resolution: when ``retry_after`` is set, wait that many seconds before
+    retrying or propagate the value to your own HTTP response so the caller
+    can back off correctly.  When it is ``None``, retrying later will not
+    help by itself — inspect ``detail`` for the limit that was hit.
+
+    Parameters
+    ----------
+    retry_after : int | None
+        Whole seconds to wait before retrying, parsed from the ``Retry-After``
+        response header (supports both delta-seconds and HTTP-date forms;
+        integer so it can be propagated verbatim into another ``Retry-After``
+        header).  ``None`` when the service did not send the header (e.g. the
+        trial storage-cap ``429``).
+    """
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        status_code: int | None = None,
+        payload: dict[str, Any] | None = None,
+        retry_after: int | None = None,
+    ) -> None:
+        super().__init__(detail, status_code=status_code, payload=payload)
+        self.retry_after = retry_after
+
+
+class DRMemoryUnavailableError(DRMemoryServiceError):
+    """Raised when no HTTP response was received from the service.
+
+    Covers request timeouts and transport failures (connection refused, DNS
+    resolution, TLS errors, protocol violations).  The original ``httpx``
+    exception is preserved as ``__cause__``.
+
+    ``status_code`` is always ``None``: the failure happened before a status
+    code existed.  Catching ``DRMemoryServiceError`` therefore covers both
+    service-side errors *and* an unreachable service, without importing
+    ``httpx`` at call sites.
     """

--- a/tests/application_utils/persistence/unit/test_client.py
+++ b/tests/application_utils/persistence/unit/test_client.py
@@ -345,6 +345,26 @@ async def test_429_unparseable_retry_after_is_none() -> None:
 
 
 @respx.mock
+async def test_429_overflow_year_retry_after_is_none() -> None:
+    """GIVEN a Retry-After date whose year overflows C long THEN retry_after is None (no crash).
+
+    On Python <= 3.13 ``parsedate_to_datetime`` raises ``OverflowError`` (not
+    ``ValueError``) for years beyond C-long range (CPython gh-153406).
+    """
+    respx.get(f"{MEMORY_BASE}/space/").mock(
+        return_value=httpx.Response(
+            429,
+            json={"detail": "Rate limited"},
+            headers={"Retry-After": "Thu, 01 Jan 99999999999999999999 00:00:00 GMT"},
+        )
+    )
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryRateLimitError) as exc_info:
+        await client.request("GET", "space/")
+    assert exc_info.value.retry_after is None
+
+
+@respx.mock
 async def test_429_is_catchable_as_base_service_error() -> None:
     """GIVEN a 429 THEN except DRMemoryServiceError still catches it (hierarchy intact)."""
     respx.get(f"{MEMORY_BASE}/space/").mock(

--- a/tests/application_utils/persistence/unit/test_client.py
+++ b/tests/application_utils/persistence/unit/test_client.py
@@ -17,6 +17,10 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from email.utils import format_datetime
 
 import httpx
 import pytest
@@ -25,7 +29,9 @@ import respx
 from datarobot_genai.application_utils.persistence import DRMemoryBadRequestError
 from datarobot_genai.application_utils.persistence import DRMemoryConflictError
 from datarobot_genai.application_utils.persistence import DRMemoryNotFoundError
+from datarobot_genai.application_utils.persistence import DRMemoryRateLimitError
 from datarobot_genai.application_utils.persistence import DRMemoryServiceError
+from datarobot_genai.application_utils.persistence import DRMemoryUnavailableError
 from datarobot_genai.application_utils.persistence import DRMemoryValidationError
 from datarobot_genai.application_utils.persistence import DRMemoryVersionConflictError
 from datarobot_genai.application_utils.persistence._client import DRMemoryServiceClient
@@ -233,6 +239,157 @@ async def test_500_raises_base_memory_service_error() -> None:
     with pytest.raises(DRMemoryServiceError) as exc_info:
         await client.request("GET", "anything/")
     assert exc_info.value.status_code == 500
+
+
+@respx.mock
+async def test_429_quota_raises_rate_limit_error_with_retry_after_seconds() -> None:
+    """GIVEN the trial-quota 429 (Retry-After + X-RateLimit-*) THEN DRMemoryRateLimitError."""
+    # Payload shape mirrors memoryservice middleware/trial_limits.py (quota branch).
+    respx.post(f"{MEMORY_BASE}/space/sessions/").mock(
+        return_value=httpx.Response(
+            429,
+            json={
+                "detail": (
+                    "Trial write request limit reached for this month."
+                    " Upgrade your plan to continue."
+                )
+            },
+            headers={
+                "Retry-After": "30",
+                "X-RateLimit-Limit": "1000",
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": "1785542400",
+            },
+        )
+    )
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryRateLimitError) as exc_info:
+        await client.request("POST", "space/sessions/")
+    err = exc_info.value
+    assert err.status_code == 429
+    # Whole seconds: "30.0" would be rejected by digit-gated Retry-After parsers.
+    assert err.retry_after == 30
+    assert isinstance(err.retry_after, int)
+    assert "limit reached" in err.detail.lower()
+
+
+@respx.mock
+async def test_429_parses_past_http_date_retry_after_as_zero() -> None:
+    """GIVEN a 429 with a past HTTP-date Retry-After THEN retry_after clamps to 0."""
+    respx.get(f"{MEMORY_BASE}/space/").mock(
+        return_value=httpx.Response(
+            429,
+            json={"detail": "Rate limited"},
+            headers={"Retry-After": "Wed, 01 Jan 2020 00:00:00 GMT"},  # in the past
+        )
+    )
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryRateLimitError) as exc_info:
+        await client.request("GET", "space/")
+    assert exc_info.value.retry_after == 0
+
+
+@respx.mock
+async def test_429_parses_future_http_date_retry_after_as_positive_delta() -> None:
+    """GIVEN a 429 with a future HTTP-date Retry-After THEN retry_after is the ceil'd delta."""
+    future = datetime.now(UTC) + timedelta(seconds=3600)
+    respx.get(f"{MEMORY_BASE}/space/").mock(
+        return_value=httpx.Response(
+            429,
+            json={"detail": "Rate limited"},
+            headers={"Retry-After": format_datetime(future, usegmt=True)},
+        )
+    )
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryRateLimitError) as exc_info:
+        await client.request("GET", "space/")
+    retry_after = exc_info.value.retry_after
+    assert retry_after is not None
+    assert 3590 <= retry_after <= 3601
+    assert isinstance(retry_after, int)
+
+
+@respx.mock
+async def test_429_storage_cap_without_retry_after_header() -> None:
+    """GIVEN the trial storage-cap 429 (no Retry-After by design) THEN retry_after is None."""
+    # Payload shape mirrors memoryservice middleware/trial_limits.py (storage branch):
+    # storage is a level, not a windowed quota, so the service sends no Retry-After.
+    respx.post(f"{MEMORY_BASE}/space/sessions/").mock(
+        return_value=httpx.Response(
+            429,
+            json={"detail": "Trial storage limit reached. Delete data or upgrade your plan."},
+            headers={"X-RateLimit-Limit": "1073741824", "X-RateLimit-Remaining": "0"},
+        )
+    )
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryRateLimitError) as exc_info:
+        await client.request("POST", "space/sessions/")
+    assert exc_info.value.retry_after is None
+    assert "storage limit" in exc_info.value.detail.lower()
+
+
+@respx.mock
+async def test_429_unparseable_retry_after_is_none() -> None:
+    """GIVEN a 429 with a garbage Retry-After value THEN retry_after is None (no crash)."""
+    respx.get(f"{MEMORY_BASE}/space/").mock(
+        return_value=httpx.Response(
+            429,
+            json={"detail": "Rate limited"},
+            headers={"Retry-After": "soon"},
+        )
+    )
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryRateLimitError) as exc_info:
+        await client.request("GET", "space/")
+    assert exc_info.value.retry_after is None
+
+
+@respx.mock
+async def test_429_is_catchable_as_base_service_error() -> None:
+    """GIVEN a 429 THEN except DRMemoryServiceError still catches it (hierarchy intact)."""
+    respx.get(f"{MEMORY_BASE}/space/").mock(
+        return_value=httpx.Response(429, json={"detail": "Rate limited"})
+    )
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryServiceError):
+        await client.request("GET", "space/")
+
+
+# ── Transport failures → DRMemoryUnavailableError ─────────────────────────────
+
+
+@respx.mock
+async def test_timeout_raises_unavailable_error() -> None:
+    """GIVEN the request times out THEN DRMemoryUnavailableError with httpx cause."""
+    respx.get(f"{MEMORY_BASE}/slow/").mock(side_effect=httpx.ReadTimeout("read timed out"))
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryUnavailableError) as exc_info:
+        await client.request("GET", "slow/")
+    err = exc_info.value
+    assert err.status_code is None
+    assert "timed out" in err.detail
+    assert isinstance(err.__cause__, httpx.ReadTimeout)
+
+
+@respx.mock
+async def test_connect_error_raises_unavailable_error() -> None:
+    """GIVEN the connection fails THEN DRMemoryUnavailableError with httpx cause."""
+    respx.get(f"{MEMORY_BASE}/down/").mock(side_effect=httpx.ConnectError("connection refused"))
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryUnavailableError) as exc_info:
+        await client.request("GET", "down/")
+    err = exc_info.value
+    assert err.status_code is None
+    assert isinstance(err.__cause__, httpx.ConnectError)
+
+
+@respx.mock
+async def test_transport_failure_is_catchable_as_base_service_error() -> None:
+    """GIVEN a transport failure THEN except DRMemoryServiceError covers it, no httpx import."""
+    respx.get(f"{MEMORY_BASE}/down/").mock(side_effect=httpx.ConnectError("connection refused"))
+    client = DRMemoryServiceClient(endpoint=BASE, api_token="tok", http_client=httpx.AsyncClient())
+    with pytest.raises(DRMemoryServiceError):
+        await client.request("GET", "down/")
 
 
 @respx.mock

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.25.5"
+version = "0.26.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.25.4"
+version = "0.25.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Two gaps in the `persistence` client's error mapping, hit while wiring the TTMDocs chat-history migration (APP-6300) to this library:

- **429 → `DRMemoryRateLimitError`** with `retry_after: int | None` parsed from `Retry-After` (delta-seconds or HTTP-date, rounded up). Whole seconds so it can be propagated verbatim into another `Retry-After` header. `None` for the trial storage-cap 429, which sends no header by design.
- **Timeouts/transport failures → `DRMemoryUnavailableError`** instead of raw `httpx` exceptions escaping the typed hierarchy; the original is kept as `__cause__`. ⚠️ Breaking change (minor bump to `0.26.0`): catch sites handling raw `httpx.ConnectError`/`TimeoutException` around client calls must switch to the typed error.
- Docs: `http_client` injection documented as a supported production pattern (one shared pool, per-principal thin clients) with a runnable example; README error table/exports updated.

Tests mirror the memoryservice `trial_limits.py` payload shapes (quota vs storage-cap). Possible follow-up, deliberately out of scope: expose `X-RateLimit-*` values on the exception.