### PR TITLE
[MODEL-24089] Run the live Files/Panels integration suite nightly in CI

### DIFF
--- a/.github/workflows/live-integration.yml
+++ b/.github/workflows/live-integration.yml
@@ -1,0 +1,58 @@
+name: Live Integration (Files API)
+
+# Runs the opt-in live integration suite (tests/drtools/integration/) against
+# a real DataRobot environment. These tests write to (and clean up in) the
+# account's shared `panels` Files container, so they are excluded from the
+# credential-less per-PR jobs and run here instead:
+#
+#   - nightly, to catch server-side API drift (e.g. listing-prefix semantics
+#     that the in-memory unit fakes can only model — the 0.26.1 escape)
+#   - on demand via workflow_dispatch, recommended before any release that
+#     touches drmcputils/files or drmcputils/panels
+#
+# No pull_request trigger by design: this job needs API credentials, and
+# secrets must never be exposed to fork PR code.
+
+on:
+  schedule:
+    - cron: '17 7 * * *'  # nightly, 07:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  files-live-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --extra drmcputils --dev
+
+      - name: Run live integration suite
+        env:
+          DR_FILES_LIVE_INTEGRATION: '1'
+          DATAROBOT_API_TOKEN: ${{ secrets.E2E_DATAROBOT_API_TOKEN }}
+          DATAROBOT_ENDPOINT: ${{ secrets.E2E_DATAROBOT_ENDPOINT }}
+        run: |
+          mkdir -p test_results
+          uv run pytest tests/drtools/integration/ -m integration -v \
+            --junitxml=test_results/live-integration.xml --durations=0
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-integration-results
+          path: test_results/


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/live-integration.yml`: runs the existing **opt-in live integration suite** (`tests/drtools/integration/` — blob-store round-trip + the scoped PanelStore round-trip added in [#578](https://github.com/datarobot-oss/datarobot-genai/pull/578)) against a real DataRobot environment, **nightly (07:17 UTC) + `workflow_dispatch`**.
- Reuses the existing `E2E_DATAROBOT_API_TOKEN` / `E2E_DATAROBOT_ENDPOINT` repo secrets — no new provisioning. Suite runtime is ~25s; tests isolate per run (unique conversation/source segments) and clean up after themselves, including on failure.
- **No `pull_request` trigger by design**: the job needs API credentials, and secrets must never be exposed to fork PR code. Nightly + pre-release dispatch catches server-side API drift without importing live-API flake into every merge.

## Rationale
0.26.1 shipped a panels bug ([#578](https://github.com/datarobot-oss/datarobot-genai/pull/578)) that every per-PR job missed: the unit fakes modeled the Files listing-prefix semantics wrong, the per-PR "integration" job is in-process (no live API), acceptance has no panels coverage (blocked on an `ENABLE_MCP_SANDBOX`-entitled env), and e2e doesn't touch panels. The live suite existed but only ran when someone remembered to run it. This makes it run itself.

## Test plan
- [x] Workflow YAML validated; suite verified green against live staging locally (2 passed, 22s) with the same env-var contract the job uses
- [x] First scheduled run will confirm secrets wiring; can also be triggered immediately via `workflow_dispatch` after merge

## Checklist
- [x] No changelog entry — CI-only change, no package release
- Follow-ups tracked in Jira: panels acceptance-test coverage + the entitled staging env it needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow addition; no application code changes, reuses established repo secrets on scheduled/dispatch runs only.
> 
> **Overview**
> Adds **`.github/workflows/live-integration.yml`** so the opt-in live suite under `tests/drtools/integration/` runs against a real DataRobot environment on a **nightly schedule (07:17 UTC)** and via **`workflow_dispatch`**, without a **`pull_request`** trigger so fork PRs never see API secrets.
> 
> The job installs with `uv sync --extra drmcputils --dev`, sets `DR_FILES_LIVE_INTEGRATION=1`, and wires **`E2E_DATAROBOT_API_TOKEN`** / **`E2E_DATAROBOT_ENDPOINT`** (same as existing e2e workflows), then runs `pytest … -m integration` and uploads JUnit results as an artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc339d6f19323b4528356430e9ff6c8155c1d0ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->