### PR TITLE
[BUZZOK-31395] Strip parallel_tool_calls for OpenAI o-series in LlamaIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.8
+- `llama_index`: strip `parallel_tool_calls` from tool requests for OpenAI o-series reasoning models (o1/o3/o4-mini), which reject it. gpt-5/gpt-4o keep it. Fixes tool-using agents failing on o-series with `Unsupported parameter: 'parallel_tool_calls'`.
+
 ## 0.26.7
 - `dragent`: Improve forward header logic in `OAuth2CrossApplicationAccessOAuth2AuthProvider`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.7"
+version = "0.26.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/llm_parameters.py
+++ b/src/datarobot_genai/core/llm_parameters.py
@@ -30,6 +30,10 @@ _OPENAI_REASONING_MODEL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# OpenAI o-series reasoning models (o1, o3, o4-mini, ...) reject the
+# ``parallel_tool_calls`` request parameter.
+_OPENAI_NO_PARALLEL_TOOL_CALLS_RE = re.compile(r"(?:^|/)o[1-9]", re.IGNORECASE)
+
 _ANTHROPIC_SONNET_EXTRA_BODY = {
     "thinking": {"type": "enabled", "budget_tokens": 1024},
 }
@@ -62,6 +66,14 @@ def default_reasoning_extra_body(model_name: str | None) -> dict[str, Any]:
         return dict(_OPENAI_EXTRA_BODY)
 
     return dict(_ANTHROPIC_SONNET_EXTRA_BODY)
+
+
+def supports_parallel_tool_calls(model_name: str | None) -> bool:
+    """Whether ``model_name`` accepts the ``parallel_tool_calls`` request param.
+
+    OpenAI o-series reasoning models reject it; everything else accepts it.
+    """
+    return not _OPENAI_NO_PARALLEL_TOOL_CALLS_RE.search(_normalize_model_name(model_name))
 
 
 def apply_reasoning_to_parameters(

--- a/src/datarobot_genai/core/llm_parameters.py
+++ b/src/datarobot_genai/core/llm_parameters.py
@@ -30,9 +30,8 @@ _OPENAI_REASONING_MODEL_RE = re.compile(
     re.IGNORECASE,
 )
 
-# OpenAI o-series reasoning models (o1, o3, o4-mini, ...) reject the
-# parallel_tool_calls request param. gpt-5 is a reasoning model but accepts it,
-# so it is intentionally excluded here (unlike _OPENAI_REASONING_MODEL_RE above).
+# OpenAI o-series (o1/o3/o4-mini, ...) reject the parallel_tool_calls param.
+# gpt-5 is a reasoning model but accepts it, so it is deliberately not matched here.
 _OPENAI_NO_PARALLEL_TOOL_CALLS_RE = re.compile(r"(?:^|/)o[1-9]", re.IGNORECASE)
 
 _ANTHROPIC_SONNET_EXTRA_BODY = {

--- a/src/datarobot_genai/core/llm_parameters.py
+++ b/src/datarobot_genai/core/llm_parameters.py
@@ -31,7 +31,8 @@ _OPENAI_REASONING_MODEL_RE = re.compile(
 )
 
 # OpenAI o-series reasoning models (o1, o3, o4-mini, ...) reject the
-# ``parallel_tool_calls`` request parameter.
+# parallel_tool_calls request param. gpt-5 is a reasoning model but accepts it,
+# so it is intentionally excluded here (unlike _OPENAI_REASONING_MODEL_RE above).
 _OPENAI_NO_PARALLEL_TOOL_CALLS_RE = re.compile(r"(?:^|/)o[1-9]", re.IGNORECASE)
 
 _ANTHROPIC_SONNET_EXTRA_BODY = {

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -29,18 +29,19 @@ from datarobot_genai.core.llm_parameters import supports_parallel_tool_calls
 
 
 def _strip_unsupported_tool_params(
-    result: dict[str, Any], model_name: str | None
+    result: dict[str, Any], *, supports_parallel: bool
 ) -> dict[str, Any]:
     """Drop tool kwargs LlamaIndex always emits but some backends reject.
 
     Some DR LLM gateway backends (e.g. Azure/GPT) reject ``tool_choice`` and
     ``parallel_tool_calls`` when no tools are present. OpenAI o-series reasoning
-    models reject ``parallel_tool_calls`` even with tools present.
+    models reject ``parallel_tool_calls`` even with tools present, so callers
+    pass ``supports_parallel=False`` when any target model is o-series.
     """
     if not result.get("tools"):
         result.pop("tool_choice", None)
         result.pop("parallel_tool_calls", None)
-    elif not supports_parallel_tool_calls(model_name):
+    elif not supports_parallel:
         result.pop("parallel_tool_calls", None)
     return result
 
@@ -84,7 +85,8 @@ def _create_datarobot_litellm(config: dict[str, Any]) -> Any:
 
         def _prepare_chat_with_tools(self, tools: Any, **kwargs: Any) -> Any:
             result = super()._prepare_chat_with_tools(tools, **kwargs)
-            return _strip_unsupported_tool_params(result, self.model)
+            supports_parallel = supports_parallel_tool_calls(self.model)
+            return _strip_unsupported_tool_params(result, supports_parallel=supports_parallel)
 
     extra_body = config.pop("extra_body", None)
     if extra_body is not None:
@@ -207,7 +209,14 @@ def get_router_llm(
     from datarobot_genai.core.router import build_litellm_router  # noqa: PLC0415
 
     router = build_litellm_router(primary, fallbacks, router_settings)
-    primary_model_name = primary.to_litellm_params().get("model")
+    # The request is shaped once but litellm reuses the same kwargs when it fails
+    # over to a fallback, so parallel_tool_calls must be stripped if ANY model in
+    # the group is o-series (else the o-series fallback leg 400s). Safe for the
+    # rest: the param is optional and defaults to parallel-enabled.
+    supports_parallel = all(
+        supports_parallel_tool_calls(c.to_litellm_params().get("model"))
+        for c in [primary, *fallbacks]
+    )
 
     def _tool_calls_kwargs(message: Any) -> dict:
         if not message.tool_calls:
@@ -238,7 +247,7 @@ def get_router_llm(
 
         def _prepare_chat_with_tools(self, tools: Any, **kwargs: Any) -> Any:
             result = super()._prepare_chat_with_tools(tools, **kwargs)
-            return _strip_unsupported_tool_params(result, primary_model_name)
+            return _strip_unsupported_tool_params(result, supports_parallel=supports_parallel)
 
         def _chat(self, messages: Any, **kwargs: Any) -> Any:
             from llama_index.core.base.llms.types import ChatMessage  # noqa: PLC0415

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -25,6 +25,24 @@ from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
+from datarobot_genai.core.llm_parameters import supports_parallel_tool_calls
+
+
+def _strip_unsupported_tool_params(
+    result: dict[str, Any], model_name: str | None
+) -> dict[str, Any]:
+    """Drop tool kwargs LlamaIndex always emits but some backends reject.
+
+    Some DR LLM gateway backends (e.g. Azure/GPT) reject ``tool_choice`` and
+    ``parallel_tool_calls`` when no tools are present. OpenAI o-series reasoning
+    models reject ``parallel_tool_calls`` even with tools present.
+    """
+    if not result.get("tools"):
+        result.pop("tool_choice", None)
+        result.pop("parallel_tool_calls", None)
+    elif not supports_parallel_tool_calls(model_name):
+        result.pop("parallel_tool_calls", None)
+    return result
 
 
 def _create_datarobot_litellm(config: dict[str, Any]) -> Any:
@@ -66,13 +84,7 @@ def _create_datarobot_litellm(config: dict[str, Any]) -> Any:
 
         def _prepare_chat_with_tools(self, tools: Any, **kwargs: Any) -> Any:
             result = super()._prepare_chat_with_tools(tools, **kwargs)
-            # Some DR LLM gateway backends (e.g. Azure/GPT) reject tool_choice
-            # and parallel_tool_calls when no tools are present. LlamaIndex
-            # always emits both, so strip them.
-            if not result.get("tools"):
-                result.pop("tool_choice", None)
-                result.pop("parallel_tool_calls", None)
-            return result
+            return _strip_unsupported_tool_params(result, self.model)
 
     extra_body = config.pop("extra_body", None)
     if extra_body is not None:
@@ -195,6 +207,7 @@ def get_router_llm(
     from datarobot_genai.core.router import build_litellm_router  # noqa: PLC0415
 
     router = build_litellm_router(primary, fallbacks, router_settings)
+    primary_model_name = primary.to_litellm_params().get("model")
 
     def _tool_calls_kwargs(message: Any) -> dict:
         if not message.tool_calls:
@@ -225,13 +238,7 @@ def get_router_llm(
 
         def _prepare_chat_with_tools(self, tools: Any, **kwargs: Any) -> Any:
             result = super()._prepare_chat_with_tools(tools, **kwargs)
-            # Some DR LLM gateway backends (e.g. Azure/GPT) reject tool_choice
-            # and parallel_tool_calls when no tools are present. LlamaIndex
-            # always emits both, so strip them.
-            if not result.get("tools"):
-                result.pop("tool_choice", None)
-                result.pop("parallel_tool_calls", None)
-            return result
+            return _strip_unsupported_tool_params(result, primary_model_name)
 
         def _chat(self, messages: Any, **kwargs: Any) -> Any:
             from llama_index.core.base.llms.types import ChatMessage  # noqa: PLC0415

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -33,10 +33,8 @@ def _strip_unsupported_tool_params(
 ) -> dict[str, Any]:
     """Drop tool kwargs LlamaIndex always emits but some backends reject.
 
-    Some DR LLM gateway backends (e.g. Azure/GPT) reject ``tool_choice`` and
-    ``parallel_tool_calls`` when no tools are present. OpenAI o-series reasoning
-    models reject ``parallel_tool_calls`` even with tools present, so callers
-    pass ``supports_parallel=False`` when any target model is o-series.
+    DataRobot LLMGW (e.g. Azure/GPT) reject ``tool_choice``/``parallel_tool_calls``
+    with no tools; o-series reject ``parallel_tool_calls`` even with tools present.
     """
     if not result.get("tools"):
         result.pop("tool_choice", None)
@@ -209,10 +207,9 @@ def get_router_llm(
     from datarobot_genai.core.router import build_litellm_router  # noqa: PLC0415
 
     router = build_litellm_router(primary, fallbacks, router_settings)
-    # The request is shaped once but litellm reuses the same kwargs when it fails
-    # over to a fallback, so parallel_tool_calls must be stripped if ANY model in
-    # the group is o-series (else the o-series fallback leg 400s). Safe for the
-    # rest: the param is optional and defaults to parallel-enabled.
+    # litellm reuses the same kwargs across the failover chain, so strip
+    # parallel_tool_calls if ANY model is o-series (else the o-series fallback
+    # leg 400s). Safe otherwise: the param is optional and defaults to enabled.
     supports_parallel = all(
         supports_parallel_tool_calls(c.to_litellm_params().get("model"))
         for c in [primary, *fallbacks]

--- a/tests/core/test_llm_parameters.py
+++ b/tests/core/test_llm_parameters.py
@@ -18,7 +18,28 @@ import pytest
 
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 from datarobot_genai.core.llm_parameters import default_reasoning_extra_body
+from datarobot_genai.core.llm_parameters import supports_parallel_tool_calls
 from datarobot_genai.langgraph.llm import get_datarobot_gateway_llm
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("azure/o3", False),
+        ("openai/o1", False),
+        ("o1-mini", False),
+        ("datarobot/azure/o4-mini", False),
+        ("azure/gpt-5", True),
+        ("azure/gpt-4o", True),
+        ("gpt-4o-mini", True),
+        ("anthropic/claude-sonnet-4-6", True),
+        ("vertex_ai/gemini-2.5-pro", True),
+        ("some-custom-deployment", True),
+        (None, True),
+    ],
+)
+def test_supports_parallel_tool_calls(model_name: str | None, expected: bool) -> None:
+    assert supports_parallel_tool_calls(model_name) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -257,3 +258,35 @@ def test_get_llm_forwards_model_name_and_parameters() -> None:
         llm = llama_index_llm.get_llm(model_name="azure/gpt-4", parameters={"temperature": 0.5})
     assert llm.model == "datarobot/azure/gpt-4"
     assert llm.temperature == 0.5
+
+
+def _echo_tool() -> Any:
+    from llama_index.core.tools import FunctionTool  # noqa: PLC0415
+
+    return FunctionTool.from_defaults(fn=lambda text: text, name="echo")
+
+
+def test_prepare_chat_with_tools_strips_parallel_tool_calls_for_o_series() -> None:
+    """OpenAI o-series models reject ``parallel_tool_calls`` even with tools present."""
+    llm = llama_index_llm.get_datarobot_gateway_llm("azure/o3")
+    result = llm._prepare_chat_with_tools([_echo_tool()], allow_parallel_tool_calls=True)
+    assert result["tools"]
+    assert "parallel_tool_calls" not in result
+    assert result["tool_choice"] == "auto"
+
+
+def test_prepare_chat_with_tools_keeps_parallel_tool_calls_for_gpt() -> None:
+    """gpt-4o / gpt-5 support ``parallel_tool_calls``, so it is left untouched."""
+    for model in ("azure/gpt-4o", "azure/gpt-5"):
+        llm = llama_index_llm.get_datarobot_gateway_llm(model)
+        result = llm._prepare_chat_with_tools([_echo_tool()], allow_parallel_tool_calls=True)
+        assert result["parallel_tool_calls"] is True
+
+
+def test_prepare_chat_with_tools_strips_both_params_when_no_tools() -> None:
+    """With no tools, both tool_choice and parallel_tool_calls are stripped for any model."""
+    llm = llama_index_llm.get_datarobot_gateway_llm("azure/gpt-4o")
+    result = llm._prepare_chat_with_tools([], allow_parallel_tool_calls=True)
+    assert not result.get("tools")
+    assert "parallel_tool_calls" not in result
+    assert "tool_choice" not in result

--- a/tests/llamaindex/test_router_llm.py
+++ b/tests/llamaindex/test_router_llm.py
@@ -201,3 +201,54 @@ async def test_get_router_llm_astream_chat_yields_chunks() -> None:
     gen = await llm._astream_chat([ChatMessage(role="user", content="hi")])
     results = [r async for r in gen]
     assert len(results) == 2
+
+
+def _echo_tool() -> Any:
+    from llama_index.core.tools import FunctionTool  # noqa: PLC0415
+
+    return FunctionTool.from_defaults(fn=lambda text: text, name="echo")
+
+
+def _gateway_cfg(model: str) -> LLMConfig:
+    return LLMConfig(use_datarobot_llm_gateway=True, llm_default_model=model)
+
+
+@pytest.mark.parametrize(
+    ("primary_model", "fallback_model", "expected_stripped"),
+    [
+        ("azure/gpt-4o", "azure/o3", True),  # o-series fallback -> strip for the whole group
+        ("azure/o3", "azure/gpt-4o", True),  # o-series primary -> strip
+        ("azure/gpt-4o", "azure/gpt-5", False),  # no o-series anywhere -> keep
+    ],
+)
+def test_router_prepare_chat_with_tools_strips_parallel_for_o_series_group(
+    primary_model: str, fallback_model: str, expected_stripped: bool
+) -> None:
+    """parallel_tool_calls is stripped if ANY model in {primary, *fallbacks} is o-series.
+
+    litellm reuses the same kwargs on failover, so an o-series fallback would 400
+    unless the param is stripped up front.
+    """
+    from datarobot_genai.llama_index.llm import get_router_llm
+
+    with patch("litellm.Router", return_value=MagicMock()):
+        llm = get_router_llm(_gateway_cfg(primary_model), [_gateway_cfg(fallback_model)])
+
+    result = llm._prepare_chat_with_tools([_echo_tool()], allow_parallel_tool_calls=True)
+    assert result["tools"]
+    assert ("parallel_tool_calls" not in result) is expected_stripped
+    if not expected_stripped:
+        assert result["parallel_tool_calls"] is True
+
+
+def test_router_prepare_chat_with_tools_strips_both_params_when_no_tools() -> None:
+    """With no tools, both tool_choice and parallel_tool_calls are stripped for any model."""
+    from datarobot_genai.llama_index.llm import get_router_llm
+
+    with patch("litellm.Router", return_value=MagicMock()):
+        llm = get_router_llm(_gateway_cfg("azure/gpt-4o"), [_gateway_cfg("azure/gpt-4o")])
+
+    result = llm._prepare_chat_with_tools([], allow_parallel_tool_calls=True)
+    assert not result.get("tools")
+    assert "parallel_tool_calls" not in result
+    assert "tool_choice" not in result

--- a/tests/llamaindex/test_router_llm.py
+++ b/tests/llamaindex/test_router_llm.py
@@ -214,25 +214,24 @@ def _gateway_cfg(model: str) -> LLMConfig:
 
 
 @pytest.mark.parametrize(
-    ("primary_model", "fallback_model", "expected_stripped"),
+    ("primary_model", "fallback_models", "expected_stripped"),
     [
-        ("azure/gpt-4o", "azure/o3", True),  # o-series fallback -> strip for the whole group
-        ("azure/o3", "azure/gpt-4o", True),  # o-series primary -> strip
-        ("azure/gpt-4o", "azure/gpt-5", False),  # no o-series anywhere -> keep
+        ("azure/gpt-4o", ["azure/o3"], True),  # o-series fallback -> strip for the whole group
+        ("azure/o3", ["azure/gpt-4o"], True),  # o-series primary -> strip
+        ("azure/gpt-4o", ["azure/gpt-4o", "azure/o3"], True),  # o-series later fallback -> strip
+        ("azure/gpt-4o", ["azure/gpt-5"], False),  # no o-series anywhere -> keep
     ],
 )
 def test_router_prepare_chat_with_tools_strips_parallel_for_o_series_group(
-    primary_model: str, fallback_model: str, expected_stripped: bool
+    primary_model: str, fallback_models: list[str], expected_stripped: bool
 ) -> None:
-    """parallel_tool_calls is stripped if ANY model in {primary, *fallbacks} is o-series.
-
-    litellm reuses the same kwargs on failover, so an o-series fallback would 400
-    unless the param is stripped up front.
-    """
+    """parallel_tool_calls is stripped when any model in {primary, *fallbacks} is o-series."""
     from datarobot_genai.llama_index.llm import get_router_llm
 
     with patch("litellm.Router", return_value=MagicMock()):
-        llm = get_router_llm(_gateway_cfg(primary_model), [_gateway_cfg(fallback_model)])
+        llm = get_router_llm(
+            _gateway_cfg(primary_model), [_gateway_cfg(m) for m in fallback_models]
+        )
 
     result = llm._prepare_chat_with_tools([_echo_tool()], allow_parallel_tool_calls=True)
     assert result["tools"]

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.7"
+version = "0.26.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

LlamaIndex's LiteLLM integration always sends `parallel_tool_calls` on tool requests. OpenAI o-series reasoning models (o1/o3/o4-mini) served through the DR LLM gateway reject that parameter, so any tool-using LlamaIndex agent on o3 fails with `Unsupported parameter: 'parallel_tool_calls' is not supported with this model`. Our existing override only stripped it when no tools were present, so the normal agent-with-tools case still broke.

## CHANGES

- Add `supports_parallel_tool_calls()` in `core/llm_parameters.py` (o-series reject it; gpt-5/gpt-4o/Claude/Gemini keep it).
- Strip `parallel_tool_calls` for o-series in LlamaIndex tool requests even when tools are present; dedupe the strip logic into a shared `_strip_unsupported_tool_params()` used by both the gateway and router LLM subclasses.
- Add tests for the predicate and both strip paths (with/without tools).
- Bump version to 0.26.2 + changelog.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require integration/acceptance tests (N/A — no new tools)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow LlamaIndex request sanitization and a small model-name helper; behavior change is limited to o-series tool calls and existing no-tools stripping, with tests.
> 
> **Overview**
> **Fixes tool-using LlamaIndex agents on OpenAI o-series models** (o1/o3/o4-mini) that failed with `Unsupported parameter: 'parallel_tool_calls'`. LlamaIndex always sends that flag on tool requests; the prior override only removed it when no tools were present.
> 
> Adds **`supports_parallel_tool_calls()`** in `core/llm_parameters.py` (o-series → false; gpt-5/gpt-4o and other providers → true) and centralizes request shaping in **`_strip_unsupported_tool_params()`**, used by both gateway `DataRobotLiteLLM` and router `RouterDataRobotLiteLLM`. With tools: o-series drops `parallel_tool_calls` only; other models keep it. With no tools: still strips `tool_choice` and `parallel_tool_calls` for gateway backends that reject them.
> 
> Release **0.26.2** with changelog; unit tests cover the predicate and LlamaIndex `_prepare_chat_with_tools` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df3c9826d5a6cac5597bdea93ac5c2a30fda1274. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->