### PR TITLE
Prototype injection seam

### DIFF
--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Callable
 from enum import StrEnum
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
@@ -125,6 +127,69 @@ class Config(LLMConfig, DataRobotAppFrameworkBaseSettings):
     )
 
 
+# --- App config injection seam ---------------------------------------------
+#
+# The application (e.g. an af-component-* agent) owns the authoritative config:
+# a ``DataRobotAppFrameworkBaseSettings`` subclass in its ``config.py``. That is
+# the single source users edit and reason about, and it is the only place that
+# guarantees a value resolves across local dev, deployment, and dynamic env vars.
+#
+# genai is a library and cannot import the app's ``config.py`` directly, so the
+# app registers a provider (a zero-arg callable returning an ``LLMConfig``) at
+# import time. The app package is imported during NAT plugin discovery, which
+# runs before NAT validates the workflow config, so the provider is in place by
+# the time genai's defaults are read. When a provider is registered (and the
+# opt-in gate is enabled) genai reads the app's config instead of building its
+# own env-only ``Config()``; otherwise it falls back to the previous behavior so
+# nothing changes for callers that have not opted in.
+
+_CONFIG_INJECTION_ENV_VAR = "DATAROBOT_GENAI_CONFIG_INJECTION"
+
+# Module-level holder for the app config provider. A dict avoids the ``global``
+# statement (discouraged, and unused elsewhere in this package) while keeping the
+# registration mutable at runtime.
+_provider_registry: dict[str, Callable[[], LLMConfig] | None] = {"provider": None}
+
+
+def register_config_provider(provider: Callable[[], LLMConfig] | None) -> None:
+    """Register the app's authoritative config source, or clear it with ``None``.
+
+    ``provider`` is a zero-arg callable returning an ``LLMConfig`` (typically the
+    app's ``Config`` class itself, or ``lambda: Config()``). It is called each
+    time genai resolves config, so values re-resolve through the app's settings
+    sources (env / .env / secrets / Pulumi) on every read.
+    """
+    _provider_registry["provider"] = provider
+
+
+def config_injection_enabled() -> bool:
+    """Whether the app-config injection seam is active.
+
+    Opt-in for now via ``DATAROBOT_GENAI_CONFIG_INJECTION`` so the seam can ship
+    and be validated without changing behavior for anyone who has not enabled it.
+    """
+    return os.environ.get(_CONFIG_INJECTION_ENV_VAR, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def resolve_config() -> LLMConfig:
+    """Return the authoritative config genai should read from.
+
+    The app-injected config when a provider is registered and the gate is on,
+    otherwise genai's own env-reading ``Config()`` (the pre-injection behavior).
+    """
+    provider = _provider_registry["provider"]
+    if config_injection_enabled() and provider is not None:
+        provided = provider()
+        if provided is not None:
+            return provided
+    return Config()
+
+
 def get_max_history_messages_default() -> int:
     """Return the default maximum number of history messages.
 
@@ -137,13 +202,12 @@ def get_max_history_messages_default() -> int:
 
 
 def default_api_key() -> str | None:
-    config = Config()
+    config = resolve_config()
     return config.datarobot_api_token if config.datarobot_api_token else None
 
 
 def default_model_name() -> str | None:
-    config = Config()
-    return config.llm_default_model
+    return resolve_config().llm_default_model
 
 
 def default_response_model() -> str:
@@ -162,8 +226,7 @@ def default_response_model() -> str:
 
 
 def default_use_datarobot_llm_gateway() -> bool:
-    config = Config()
-    return config.use_datarobot_llm_gateway
+    return resolve_config().use_datarobot_llm_gateway
 
 
 def deployment_url(deployment_id: str, datarobot_endpoint: str) -> str:
@@ -189,10 +252,8 @@ def default_datarobot_llm_gateway_url() -> str:
 
 
 def default_llm_deployment_id() -> str | None:
-    config = Config()
-    return config.llm_deployment_id
+    return resolve_config().llm_deployment_id
 
 
 def default_nim_deployment_id() -> str | None:
-    config = Config()
-    return config.nim_deployment_id
+    return resolve_config().nim_deployment_id

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -32,13 +32,13 @@ from opentelemetry.trace.status import Status
 from opentelemetry.trace.status import StatusCode
 
 from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
-from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
+from datarobot_genai.core.config import resolve_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 from datarobot_genai.core.model_info import get_model_info
 
@@ -519,7 +519,7 @@ def get_llm(
     parameters: dict | None = None,
     reasoning: bool = False,
 ) -> LLM:
-    config = Config()
+    config = resolve_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -21,13 +21,13 @@ from langchain_core.messages import BaseMessage  # noqa: TC002
 from langchain_core.outputs import ChatGenerationChunk  # noqa: TC002
 
 from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
-from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
+from datarobot_genai.core.config import resolve_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 
 
@@ -245,7 +245,7 @@ def get_llm(
     streaming: bool = True,
     reasoning: bool = False,
 ) -> BaseChatModel:
-    config = Config()
+    config = resolve_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, streaming, reasoning)

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -17,13 +17,13 @@ from typing import Any
 from llama_index.llms.litellm import LiteLLM
 
 from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
-from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
+from datarobot_genai.core.config import resolve_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 
 
@@ -345,7 +345,7 @@ def get_llm(
     parameters: dict | None = None,
     reasoning: bool = False,
 ) -> LiteLLM:
-    config = Config()
+    config = resolve_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -19,7 +19,9 @@ import pytest
 from datarobot_genai.core import config as config_mod
 from datarobot_genai.core.config import DEFAULT_MAX_HISTORY_MESSAGES
 from datarobot_genai.core.config import Config
+from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
+from datarobot_genai.core.config import config_injection_enabled
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
@@ -31,6 +33,8 @@ from datarobot_genai.core.config import default_use_datarobot_llm_gateway
 from datarobot_genai.core.config import deployment_url
 from datarobot_genai.core.config import get_max_history_messages_default
 from datarobot_genai.core.config import llm_gateway_url
+from datarobot_genai.core.config import register_config_provider
+from datarobot_genai.core.config import resolve_config
 
 
 def _make_config(**overrides: object) -> Config:
@@ -254,3 +258,108 @@ def test_default_nim_deployment_id_returns_none_when_unset() -> None:
     cfg = _make_config(nim_deployment_id=None)
     with patch.object(config_mod, "Config", return_value=cfg):
         assert default_nim_deployment_id() is None
+
+
+# --- App config injection seam ---------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_provider() -> object:
+    """Ensure the injection provider never leaks between tests."""
+    register_config_provider(None)
+    yield
+    register_config_provider(None)
+
+
+def _enable_injection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATAROBOT_GENAI_CONFIG_INJECTION", "1")
+
+
+def test_injection_gate_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATAROBOT_GENAI_CONFIG_INJECTION", raising=False)
+    assert config_injection_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_injection_gate_on_for_truthy_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("DATAROBOT_GENAI_CONFIG_INJECTION", value)
+    assert config_injection_enabled() is True
+
+
+def test_resolve_config_falls_back_to_env_config_when_no_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_injection(monkeypatch)
+    sentinel = _make_config(llm_default_model="from-env-config")
+    with patch.object(config_mod, "Config", return_value=sentinel):
+        # No provider registered -> genai's own Config() is used.
+        assert resolve_config() is sentinel
+
+
+def test_resolve_config_ignores_provider_when_gate_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DATAROBOT_GENAI_CONFIG_INJECTION", raising=False)
+    injected = _make_config(llm_default_model="from-app-config")
+    env_cfg = _make_config(llm_default_model="from-env-config")
+    register_config_provider(lambda: injected)
+    with patch.object(config_mod, "Config", return_value=env_cfg):
+        # Gate off -> provider ignored, genai's Config() wins (unchanged behavior).
+        assert resolve_config() is env_cfg
+
+
+def test_resolve_config_uses_injected_provider_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_injection(monkeypatch)
+    injected = _make_config(llm_default_model="from-app-config")
+    register_config_provider(lambda: injected)
+    # Even if genai builds its own Config, the injected provider takes precedence.
+    with patch.object(config_mod, "Config", return_value=_make_config()):
+        assert resolve_config() is injected
+
+
+def test_injected_config_overrides_env_for_user_intent_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the hammer case.
+
+    A user hardcodes values in the app config and sets NO env var. genai must
+    read the app's values, not its own env-only defaults.
+    """
+    _enable_injection(monkeypatch)
+    # App config: gateway off, a deployment target, and a specific model, all set
+    # as plain values, exactly as a user would hardcode them in config.py.
+    app_config = LLMConfig(
+        use_datarobot_llm_gateway=False,
+        llm_deployment_id="dep-from-app",
+        llm_default_model="anthropic/claude-sonnet-4-20250514",
+    )
+    register_config_provider(lambda: app_config)
+
+    # genai's own env-only Config would say the opposite (gateway on, no model).
+    env_only = _make_config(use_datarobot_llm_gateway=True, llm_default_model=None)
+    with patch.object(config_mod, "Config", return_value=env_only):
+        assert default_use_datarobot_llm_gateway() is False
+        assert default_llm_deployment_id() == "dep-from-app"
+        assert default_model_name() == "anthropic/claude-sonnet-4-20250514"
+        assert resolve_config().get_llm_type() == LLMType.DEPLOYMENT
+
+
+def test_provider_is_called_each_resolve_for_dynamic_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider is a factory: re-read picks up changed values (dynamic env vars)."""
+    _enable_injection(monkeypatch)
+    calls = {"n": 0}
+
+    def _provider() -> LLMConfig:
+        calls["n"] += 1
+        return _make_config(llm_default_model=f"model-{calls['n']}")
+
+    register_config_provider(_provider)
+    with patch.object(config_mod, "Config", return_value=_make_config()):
+        assert default_model_name() == "model-1"
+        assert default_model_name() == "model-2"


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When injection is enabled, LLM routing (gateway vs deployment, model, deployment IDs) follows the app provider and can diverge from genai’s env-only defaults; the feature is gated off by default.
> 
> **Overview**
> Adds an **opt-in injection seam** so host applications can register their authoritative `LLMConfig` (typically from the app’s `config.py`) instead of genai always instantiating its own env-only `Config()`.
> 
> Apps call `register_config_provider()` at import time; when `DATAROBOT_GENAI_CONFIG_INJECTION` is enabled, `resolve_config()` returns the provider’s config (re-invoked on each read). Otherwise behavior stays the same via `Config()`.
> 
> **Wiring changes:** `default_api_key`, `default_model_name`, gateway/deployment/NIM defaults, and `get_llm()` in CrewAI, LangGraph, and LlamaIndex now go through `resolve_config()` rather than `Config()` directly. Endpoint URL helpers such as `default_deployment_url` / `default_datarobot_llm_gateway_url` still use `Config()` only.
> 
> Tests cover the env gate, fallback when no provider, ignoring the provider when the gate is off, injected overrides for user-intent fields, and per-resolve provider calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ad7b9c49ce40d9f88fef1724366865eae40c59. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->