### PR TITLE
[MODEL-24082] Improve Integration Test Execution

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -86,6 +86,7 @@ tasks:
   drmcp-unit:
     desc: "Run DR MCP Library unit tests"
     cmds:
+      - task: drmcp-install
       - rm -rf .coverage .coverage.xml htmlcov
       - echo "Running DR MCP Library unit tests"
       - uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/unit/{{end}} --cov=datarobot_genai.drmcp --cov-report=xml --cov-report=html --cov-report=term-missing -s -vv
@@ -94,8 +95,11 @@ tasks:
   drmcp-integration:
     desc: "Run DR MCP Library integration tests"
     cmds:
+      - task: drmcp-install
       - echo "Running DR MCP Library integration tests"
-      - uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/integration/{{end}} -s -vv
+      # loadfile: tests from one file stay on one worker, so each worker reuses its
+      # shared MCP server subprocess instead of every worker spawning every config.
+      - uv run pytest {{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}tests/drmcp/integration/{{end}} -n auto --dist loadfile -s -vv
     silent: true
 
   drmcp-acceptance:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.3
+- `drmcp/test_utils`: integration tests reuse one MCP stdio server subprocess per server configuration (env/command) instead of spawning a fresh server (~4s) for every test; tests passing an `elicitation_callback` or `shared=False` still get an isolated server. Integration tests now run on a single session-scoped event loop, and the suite runs under `pytest-xdist` (`-n auto --dist loadfile`).
+
 ## 0.26.2
 - Revert `datarobot-moderations` to 11.2.33 due to a regression thread based in context switching.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -898,7 +898,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -1225,6 +1225,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.23.5" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "responses", specifier = ">=0.25.8" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.6.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.2"
+version = "0.26.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -112,6 +112,7 @@ dev = [
   "pre-commit",
   "twine>=5.0.0",
   "pytest-asyncio>=0.23.5",
+  "pytest-xdist>=3.5.0",
   "responses>=0.25.8",
   "ipdb>=0.13.13",
   "aioresponses>=0.7.8",

--- a/src/datarobot_genai/drmcp/test_utils/mcp_utils_integration.py
+++ b/src/datarobot_genai/drmcp/test_utils/mcp_utils_integration.py
@@ -98,20 +98,116 @@ def integration_test_server_params_with_env(
     )
 
 
+class _SharedStdioSession:
+    """A stdio MCP server subprocess + client session kept alive for reuse across tests.
+
+    The stdio_client/ClientSession context managers are entered and exited inside a
+    single dedicated task: their anyio cancel scopes must not cross task boundaries,
+    which is what would happen if a session-scoped fixture entered them in one test's
+    task and exited them in another's.
+    """
+
+    def __init__(self, server_params: StdioServerParameters, timeout: int) -> None:
+        self._server_params = server_params
+        self._timeout = timeout
+        self.session: ClientSession | None = None
+        self._ready = asyncio.Event()
+        self._closing = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._startup_error: BaseException | None = None
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._serve())
+        await self._ready.wait()
+        if self._startup_error is not None:
+            raise self._startup_error
+
+    async def _serve(self) -> None:
+        try:
+            async with stdio_client(self._server_params) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    init_result = await asyncio.wait_for(
+                        session.initialize(), timeout=self._timeout
+                    )
+                    # Store the init result for tests that need to inspect capabilities
+                    session._init_result = init_result  # type: ignore[attr-defined]
+                    self.session = session
+                    self._ready.set()
+                    await self._closing.wait()
+        except TimeoutError:
+            self._startup_error = TimeoutError(
+                f"Session initialization timed out after {self._timeout} seconds"
+            )
+        except BaseException as exc:
+            self._startup_error = exc
+        finally:
+            self._ready.set()
+
+    async def aclose(self) -> None:
+        self._closing.set()
+        if self._task is not None:
+            with contextlib.suppress(BaseException):
+                await self._task
+
+
+# Shared sessions keyed by (event loop, command, args, env) so every test that asks for
+# the same server configuration on the same loop reuses one subprocess instead of
+# paying the ~4s server startup per test.
+_shared_sessions: dict[tuple[Any, ...], _SharedStdioSession] = {}
+
+
+def _shared_session_key(server_params: StdioServerParameters) -> tuple[Any, ...]:
+    env = server_params.env or {}
+    return (
+        asyncio.get_running_loop(),
+        server_params.command,
+        tuple(server_params.args),
+        tuple(sorted(env.items())),
+    )
+
+
+async def _get_shared_stdio_session(
+    server_params: StdioServerParameters, timeout: int
+) -> _SharedStdioSession:
+    key = _shared_session_key(server_params)
+    holder = _shared_sessions.get(key)
+    if holder is None:
+        holder = _SharedStdioSession(server_params, timeout)
+        await holder.start()
+        _shared_sessions[key] = holder
+    return holder
+
+
+async def aclose_shared_stdio_sessions() -> None:
+    """Close every shared session bound to the current event loop."""
+    loop = asyncio.get_running_loop()
+    for key in [k for k in _shared_sessions if k[0] is loop]:
+        await _shared_sessions.pop(key).aclose()
+
+
 @contextlib.asynccontextmanager
 async def integration_test_mcp_session(
     server_params: StdioServerParameters | None = None,
     timeout: int = 60,
     elicitation_callback: Any | None = None,
     use_stub: bool = True,
+    shared: bool = True,
 ) -> AsyncGenerator[ClientSession, None]:
     """
     Create and connect a client for the MCP server as a context manager.
+
+    By default the underlying stdio server subprocess and client session are shared
+    across tests with the same server configuration (see _SharedStdioSession); exiting
+    the context manager does not close them. Callers that need session-level isolation
+    (a custom elicitation_callback, or tests that mutate server state) get a fresh
+    server: pass ``shared=False``, or any elicitation_callback implies it.
 
     Args:
         server_params: Parameters for configuring the server connection
         timeout: Timeout
         elicitation_callback: Optional callback for handling elicitation requests
+        shared: Reuse one server/session per configuration (default). False forces a
+            fresh, test-scoped server subprocess.
 
     Yields
     ------
@@ -123,6 +219,12 @@ async def integration_test_mcp_session(
         TimeoutError: If session initialization exceeds timeout
     """
     server_params = server_params or integration_test_mcp_server_params(use_stub=use_stub)
+
+    if shared and elicitation_callback is None:
+        holder = await _get_shared_stdio_session(server_params, timeout)
+        assert holder.session is not None
+        yield holder.session
+        return
 
     try:
         async with stdio_client(server_params) as (read_stream, write_stream):

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -563,6 +563,7 @@ def test_create_dr_client() -> StubDRClient:
 
     # --- REST method stubs for dr_module.client.get_client() ---
     def _stub_get_non_workload(url: str, params: dict | None) -> StubRestResponse:
+        nonlocal _vdb_deploy_posted
         response = StubRestResponse({"data": [], "next": None})
         if "predictionResults" in url:
             limit = (params or {}).get("limit", 100)
@@ -611,6 +612,12 @@ def test_create_dr_client() -> StubDRClient:
                 },
             ]
             if _vdb_deploy_posted:
+                # Consume-once: vdb_deploy polls the deployments list exactly until a
+                # new VDB deployment id appears, so expose the launching record for a
+                # single listing and then drop it. This keeps stub state test-order
+                # independent (vdb_list results are unaffected by a prior vdb_deploy),
+                # which matters when tests share one long-lived stub server.
+                _vdb_deploy_posted = False
                 all_deployments.append(
                     {
                         "id": STUB_VDB_DEPLOY_RESULT_ID,

--- a/tests/drmcp/conftest.py
+++ b/tests/drmcp/conftest.py
@@ -27,6 +27,7 @@ from datarobot.context import Context as DRContext
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubDeployment
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubModel
 from datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs import StubProject
+from datarobot_genai.drmcputils import credentials as credentials_module
 from datarobot_genai.drmcputils.credentials import get_credentials
 from tests.drmcp.stub_credentials import STUB_DATAROBOT_API_TOKEN
 from tests.drmcp.stub_credentials import force_stub_datarobot_credentials_env
@@ -62,6 +63,7 @@ def _make_dr_client() -> Any:
     # Integration tests enable stub mode so credentials from a developer's .env are never used.
     if os.environ.get("MCP_USE_CLIENT_STUBS", "false").lower() == "true":
         force_stub_datarobot_credentials_env()
+        credentials_module._credentials = None
     elif not os.environ.get("DATAROBOT_API_TOKEN"):
         raise ValueError("Tests need DATAROBOT_API_TOKEN environment variable set.")
     creds = get_credentials()

--- a/tests/drmcp/integration/conftest.py
+++ b/tests/drmcp/integration/conftest.py
@@ -27,9 +27,13 @@ from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERS
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_WITHOUT_VERSION
 from tests.drmcp.integration.helper import get_or_create_prompt_template
 from tests.drmcp.integration.helper import get_or_create_prompt_template_version
+from tests.drmcp.stub_credentials import configure_integration_stub_credentials
 
-# Integration tests must not pick up DATAROBOT_* from .env; acceptance tests load .env
+# Integration tests must not pick up DATAROBOT_* from .env; acceptance tests load .env.
+# Configure stub credentials at import time so session fixtures (e.g. dr_client) and
+# per-module fixtures (e.g. datarobot_endpoint) never cache an empty singleton first.
 os.environ["MCP_USE_CLIENT_STUBS"] = "true"
+configure_integration_stub_credentials()
 
 _INTEGRATION_DIR = Path(__file__).parent
 

--- a/tests/drmcp/integration/conftest.py
+++ b/tests/drmcp/integration/conftest.py
@@ -11,11 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import inspect
 import os
+from pathlib import Path
 from typing import Any
 
 import pytest
+import pytest_asyncio
 
+from datarobot_genai.drmcp.test_utils.mcp_utils_integration import aclose_shared_stdio_sessions
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_NO_VARS
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_NO_VARS_TEXT
 from datarobot_genai.drmcp.test_utils.stubs.prompt_stubs import STUB_PROMPT_VERSION_WITH_VARS
@@ -26,6 +30,28 @@ from tests.drmcp.integration.helper import get_or_create_prompt_template_version
 
 # Integration tests must not pick up DATAROBOT_* from .env; acceptance tests load .env
 os.environ["MCP_USE_CLIENT_STUBS"] = "true"
+
+_INTEGRATION_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    # Run every integration test on one session-scoped event loop so the shared MCP
+    # stdio sessions (one server subprocess per env configuration, see
+    # mcp_utils_integration) stay usable across tests. Prepended (append=False) so it
+    # wins over module/class-level asyncio markers as the closest marker.
+    session_loop_marker = pytest.mark.asyncio(loop_scope="session")
+    for item in items:
+        if not inspect.iscoroutinefunction(getattr(item, "function", None)):
+            continue
+        if _INTEGRATION_DIR not in item.path.parents:
+            continue
+        item.add_marker(session_loop_marker, append=False)
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
+async def _close_shared_mcp_sessions() -> Any:
+    yield
+    await aclose_shared_stdio_sessions()
 
 
 @pytest.fixture(scope="session")

--- a/tests/drmcp/integration/test_dynamic_tools.py
+++ b/tests/drmcp/integration/test_dynamic_tools.py
@@ -23,7 +23,7 @@ from datarobot_genai.drmcp.core.dynamic_tools.deployment.register import (
 )
 from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 from datarobot_genai.drmcp.core.mcp_instance import mcp
-from datarobot_genai.drmcputils.credentials import get_credentials
+from datarobot_genai.drmcp.test_utils.stub_credentials import STUB_DATAROBOT_ENDPOINT
 
 
 @pytest.fixture
@@ -194,7 +194,7 @@ def expected_input_schema() -> dict:
 
 @pytest.fixture
 def datarobot_endpoint() -> str:
-    return get_credentials().datarobot.datarobot_endpoint
+    return STUB_DATAROBOT_ENDPOINT
 
 
 @pytest.fixture

--- a/tests/drmcp/stub_credentials.py
+++ b/tests/drmcp/stub_credentials.py
@@ -30,3 +30,16 @@ def force_stub_datarobot_credentials_env() -> None:
     """Set stub DATAROBOT_* env (integration tests must not use .env credentials)."""
     os.environ["DATAROBOT_API_TOKEN"] = STUB_DATAROBOT_API_TOKEN
     os.environ["DATAROBOT_ENDPOINT"] = STUB_DATAROBOT_ENDPOINT
+
+
+def reset_credentials_cache() -> None:
+    """Drop the cached ToolsAuthCredentials singleton so env changes take effect."""
+    from datarobot_genai.drmcputils import credentials
+
+    credentials._credentials = None
+
+
+def configure_integration_stub_credentials() -> None:
+    """Apply stub DATAROBOT_* env and refresh the credentials singleton."""
+    force_stub_datarobot_credentials_env()
+    reset_credentials_cache()

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1334,6 +1334,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "responses" },
     { name = "respx" },
     { name = "ruff" },
@@ -1558,6 +1559,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.23.5" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "responses", specifier = ">=0.25.8" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.6.0" },


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Integration tests reuse one MCP stdio server subprocess per server configuration and the suite runs under `pytest-xdist`.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- `mcp_utils_integration.py` — `integration_test_mcp_session()` now draws from a pool of shared server subprocesses keyed by (event loop, command, args, env). Passing `elicitation_callback` or `shared=False` still gets an isolated server.
- `conftest.py` — a collection hook pins every integration test to one session-scoped event loop (prepended marker, so it wins over existing class-level @pytest.mark.asyncio), plus an autouse fixture that closes the shared sessions at session end. Unit tests are untouched — no global pytest-asyncio config changed.
- `drmcp.yml` — drmcp-integration now runs -n auto --dist loadfile. loadfile keeps each file's tests on one worker so workers reuse their server pool instead of every worker spawning every config.

## TESTING

<img width="307" height="21" alt="Screenshot 2026-07-21 at 11 46 40 AM" src="https://github.com/user-attachments/assets/45282000-f34a-407f-a5e8-171997ae5f2f" />

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness, Taskfile, changelog, and stub test behavior; production MCP library runtime is unchanged.
> 
> **Overview**
> **Speeds up DRMCP integration tests** by reusing one long-lived MCP stdio subprocess per server configuration instead of paying ~4s startup per test. `integration_test_mcp_session()` now pools sessions via `_SharedStdioSession` (stdio lifecycle kept in a dedicated task for anyio cancel-scope safety); callers with `elicitation_callback` or `shared=False` still get isolated servers.
> 
> Integration **conftest** pins async tests to a **session-scoped event loop** and tears down shared sessions at session end. **`task drmcp-integration`** runs **`pytest-xdist`** (`-n auto --dist loadfile`) so each file’s tests stay on one worker and reuse that worker’s server pool; unit/integration tasks also run **`drmcp-install`** first. **`pytest-xdist`** is added to dev deps; version **0.26.3**.
> 
> Stub **`vdb_deploy`** listing behavior is **consume-once** so shared-server runs stay order-independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ee566bf8a6a0b5704e27666f3e2adc561a5e8b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->