### PR TITLE
[MODEL-23815] Enable Files API and Workload API Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.5
+- `drmcputils/global_mcp_tools`: register `files_api` and `workload` packages for global-mcp (`DR_FILE` and `DR_WORKLOAD` categories); `file_upload` remains excluded.
+
 ## 0.26.4
 - `drmcp/test_utils`: integration tests reuse one MCP stdio server subprocess per server configuration (env/command) instead of spawning a fresh server (~4s) for every test; tests passing an `elicitation_callback` or `shared=False` still get an isolated server. Integration tests now run on a single session-scoped event loop, and the suite runs under `pytest-xdist` (`-n auto --dist loadfile`).
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -898,7 +898,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.4"
+version = "0.26.5"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.4"
+version = "0.26.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/ard_catalog.py
+++ b/src/datarobot_genai/drmcputils/ard_catalog.py
@@ -24,8 +24,9 @@ source of truth in :mod:`datarobot_genai.drmcputils.global_mcp_tools`
 which packages to load. So ARD and registration cannot drift: enabling/disabling a package or
 excluding a tool is a one-line edit there, reflected in both. Today's enabled surface is
 predictive (catalog / modeling / deployments / predictions), use_case, perplexity, tavily,
-dr_docs, and vdb; connectors, files_api, workload, panels, hosted/dynamic categories, and the
-``dr_mcpapps`` placeholder are not registered, so they are not advertised.
+dr_docs, vdb, files_api, and workload; connectors, panels, hosted/dynamic categories, and the
+``dr_mcpapps`` placeholder are not registered, so they are not advertised. ``file_upload`` is
+excluded from files_api (needs local disk access).
 
 A cross-check test in global-mcp asserts this catalog matches ``register_all_drtools`` output,
 so a taxonomy/rename mismatch still fails CI.

--- a/src/datarobot_genai/drmcputils/global_mcp_tools.py
+++ b/src/datarobot_genai/drmcputils/global_mcp_tools.py
@@ -48,6 +48,8 @@ GLOBAL_MCP_PACKAGE_CATEGORIES: dict[str, frozenset[MCPToolCategory]] = {
     "tavily": frozenset({MCPToolCategory.DR_WEB_SEARCH_TAVILY}),
     "dr_docs": frozenset({MCPToolCategory.DR_DOCUMENTATION}),
     "vdb": frozenset({MCPToolCategory.DR_VDB}),
+    "files_api": frozenset({MCPToolCategory.DR_FILE}),
+    "workload": frozenset({MCPToolCategory.DR_WORKLOAD}),
 }
 
 # Per-tool opt-out applied on top of the enabled packages — the single place a specific tool is

--- a/tests/drmcputils/test_ard_catalog.py
+++ b/tests/drmcputils/test_ard_catalog.py
@@ -74,6 +74,8 @@ _ENABLED_CATEGORIES = {
     "dr_web_search_tavily",
     "dr_documentation",
     "dr_vdb",
+    "dr_file",
+    "dr_workload",
 }
 
 
@@ -91,9 +93,9 @@ class TestExcludedSurface:
             }
         )
 
-    def test_files_workload_panels_excluded(self, names: set[str]) -> None:
-        # Not registered in global-mcp yet → not advertised (incl. file_upload).
-        assert not (names & {"file_import", "file_upload", "workload_list", "list_panels"})
+    def test_panels_and_file_upload_excluded(self, names: set[str]) -> None:
+        # Panels not registered in global-mcp yet; file_upload needs local disk access.
+        assert not (names & {"file_upload", "list_panels"})
 
     def test_hosted_and_placeholder_categories_excluded(self, categories: set[str]) -> None:
         assert not (categories & {"dr_dynamic_tools", "dr_proxied_user_mcp", "dr_mcpapps"})
@@ -119,6 +121,15 @@ class TestIncludedSurface:
             "search_datarobot_agentic_docs",
             "vdb_list",
         } <= names
+
+    def test_files_workload_included(self, names: set[str]) -> None:
+        assert {
+            "file_import",
+            "file_list",
+            "workload_list",
+            "artifact_get",
+        } <= names
+        assert "file_upload" not in names
 
 
 class TestMcpUrl:

--- a/tests/drmcputils/test_global_mcp_tools.py
+++ b/tests/drmcputils/test_global_mcp_tools.py
@@ -34,6 +34,8 @@ class TestEnabledPackages:
             "tavily",
             "dr_docs",
             "vdb",
+            "files_api",
+            "workload",
         }
 
 
@@ -57,7 +59,7 @@ class TestLeafCategories:
 class TestExcludedTools:
     def test_contains_file_upload(self) -> None:
         # file_upload needs local disk access → blocked from global-mcp here (the single
-        # source of truth for exclusions), even though files_api isn't enabled yet.
+        # source of truth for exclusions), even though files_api is enabled.
         assert "file_upload" in GLOBAL_MCP_EXCLUDED_TOOLS
 
     def test_excluded_tools_never_advertised_by_ard(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.4"
+version = "0.26.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the production global-mcp tool surface to Files API and Workload operations (user-scoped platform access); exclusion of `file_upload` limits local-disk risk but agents gain broader mutating capabilities.
> 
> **Overview**
> Turns on **global-mcp** registration and ARD advertisement for the `files_api` and `workload` drtools packages (`DR_FILE` and `DR_WORKLOAD`), so agents can discover and use tools such as `file_list`, `file_import`, `workload_list`, and `artifact_get` through the shared `GLOBAL_MCP_PACKAGE_CATEGORIES` map in `global_mcp_tools.py`.
> 
> **`file_upload` stays on `GLOBAL_MCP_EXCLUDED_TOOLS`** because it needs local disk access and must not be exposed on global-mcp. ARD catalog docs and unit tests were updated so enabled categories and representative tool names match the new surface; version is bumped to **0.26.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc875b10754c45d1c539d6a07591508ac18865b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->