### PR TITLE
[MODEL-24218] Improve header forward logic in OAuth2CrossApplicationAccessOAuth2AuthProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.7
+- `dragent`: Improve forward header logic in `OAuth2CrossApplicationAccessOAuth2AuthProvider`.
+
 ## 0.26.6
 - `drmcpbase`: added `x-datarobot-mcp-mode: search` — the catalog collapses to a synthetic `tool_search` (BM25 lexical ranking over the catalog, no new dependencies) plus a `call_tool` proxy that executes discovered tools, so generic MCP clients need no re-listing loop. Allowlisted tools stay pinned in the listing. Ranking is pluggable via `ToolSearchBackend` (`register_mcp_catalog_transform(mcp, tool_search_backend=...)`) so a semantic backend can replace the lexical default later.
 - `drmcpbase`: the tool allowlist (`x-datarobot-mcp-tools`) is now a hard cap in every mode. Security fix: code mode used to skip it, so switching the mode header made every non-allowlisted tool resolvable and callable again; the synthetic discovery tools also read the catalog through a bypass that skipped both the allowlist and the category gates. Gates and the allowlist now apply to listing, resolution/calling, and the catalog the synthetic discovery/search/execute tools read; the synthetic mode-interface tools themselves stay exempt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.6"
+version = "0.26.7"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xaa_client.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xaa_client.py
@@ -74,9 +74,9 @@ class MCPClientWithXAASupportConfig(  # type: ignore[call-arg]
     )
 
     forward_inbound_headers: bool = Field(
-        default=True,
+        default=False,
         description=(
-            "If set to True, all HTTP headers of inbound request are forwarded "
+            "If set to True, selected x-datarobot-* HTTP headers of inbound request are forwarded "
             "except for reserved headers configured in auth_provider."
         ),
     )
@@ -143,7 +143,7 @@ async def setup_auth_provider(
     auth_provider.set_cross_app_flow_params(xaa_params)
 
     if config.forward_inbound_headers:
-        auth_provider.set_forward_inbound_http_headers(True)
+        auth_provider.set_forward_inbound_x_datarobot_http_headers(True)
 
     return auth_provider
 

--- a/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
+++ b/src/datarobot_genai/dragent/plugins/okta_a2a_auth.py
@@ -625,13 +625,13 @@ class OAuth2CrossApplicationAccessOAuth2AuthProvider(
     def __init__(self, config: OAuth2CrossApplicationAccessAuthProviderConfig) -> None:
         super().__init__(config)
         self._flow_params: _CrossAppFlowParams | None = None
-        self._forward_inbound_http_headers: bool = False
+        self._forward_inbound_x_datarobot_http_headers: bool = False
 
     def set_cross_app_flow_params(self, cross_app_flow_params: _CrossAppFlowParams) -> None:
         self._flow_params = cross_app_flow_params
 
-    def set_forward_inbound_http_headers(self, enabled: bool) -> None:
-        self._forward_inbound_http_headers = enabled
+    def set_forward_inbound_x_datarobot_http_headers(self, enabled: bool) -> None:
+        self._forward_inbound_x_datarobot_http_headers = enabled
 
     async def authenticate_for_discovery(self, user_id: str | None = None) -> dict[str, str]:
         token = self._extract_token()
@@ -660,13 +660,17 @@ class OAuth2CrossApplicationAccessOAuth2AuthProvider(
         excluded_header_keys.update(header.lower() for header in self.config.fallback_token_headers)
         return excluded_header_keys
 
-    def get_forwardable_headers_from_inbound_request(self) -> list[HeaderCred]:
+    def get_forwardable_x_datarobot_headers_from_inbound_request(self) -> list[HeaderCred]:
         headers: dict[str, str] = Context.get().metadata.headers or {}
 
         return [
             HeaderCred(name=header_key, value=SecretStr(header_value))
             for header_key, header_value in headers.items()
-            if header_key not in self.get_non_forwardable_header_keys() and header_value is not None
+            if (
+                header_key.find("x-datarobot-") == 0
+                and header_key not in self.get_non_forwardable_header_keys()
+                and header_value is not None
+            )
         ]
 
     async def get_exchanged_token(self) -> BearerTokenCred:
@@ -689,8 +693,10 @@ class OAuth2CrossApplicationAccessOAuth2AuthProvider(
         """
         auth_request_credentials: list[HeaderCred | BearerTokenCred] = []
 
-        if self._forward_inbound_http_headers:
-            forwardable_header_creds = self.get_forwardable_headers_from_inbound_request()
+        if self._forward_inbound_x_datarobot_http_headers:
+            forwardable_header_creds = (
+                self.get_forwardable_x_datarobot_headers_from_inbound_request()
+            )
             auth_request_credentials.extend(forwardable_header_creds)
         bearer_token_cred = await self.get_exchanged_token()
         auth_request_credentials.append(bearer_token_cred)

--- a/tests/dragent/plugins/test_datarobot_user_mcp_xaa_client.py
+++ b/tests/dragent/plugins/test_datarobot_user_mcp_xaa_client.py
@@ -252,7 +252,9 @@ class TestSetupAuthProvider:
         mock_auth_provider.set_cross_app_flow_params.assert_called_once_with(
             mock_get_xaa_params.return_value,
         )
-        mock_auth_provider.set_forward_inbound_http_headers.assert_called_once_with(True)
+        mock_auth_provider.set_forward_inbound_x_datarobot_http_headers.assert_called_once_with(
+            True
+        )
 
     @pytest.mark.asyncio
     async def test_setup_auth_provider_without_inbound_headers_forwarded(

--- a/tests/dragent/plugins/test_okta_a2a_auth.py
+++ b/tests/dragent/plugins/test_okta_a2a_auth.py
@@ -412,10 +412,10 @@ class TestAuthenticate:
         return provider
 
     @pytest.fixture
-    def mock_get_forwardable_headers_from_inbound_request(self) -> Iterator[Mock]:
+    def mock_get_forwardable_x_datarobot_headers_from_inbound_request(self) -> Iterator[Mock]:
         with patch.object(
             OAuth2CrossApplicationAccessOAuth2AuthProvider,
-            "get_forwardable_headers_from_inbound_request",
+            "get_forwardable_x_datarobot_headers_from_inbound_request",
         ) as mock_func:
             mock_func.return_value = [HeaderCred(name="afda", value="sdafas")]
             yield mock_func
@@ -533,7 +533,7 @@ class TestAuthenticate:
     @pytest.mark.asyncio
     async def test_not_forward_inbound_headers_during_authenticate(
         self,
-        mock_get_forwardable_headers_from_inbound_request: Mock,
+        mock_get_forwardable_x_datarobot_headers_from_inbound_request: Mock,
         mock_get_exchanged_token: AsyncMock,
     ) -> None:
         auth_provider = OAuth2CrossApplicationAccessOAuth2AuthProvider(
@@ -542,28 +542,28 @@ class TestAuthenticate:
         auth_provider.set_cross_app_flow_params(Mock())
         output = await auth_provider.authenticate()
 
-        mock_get_forwardable_headers_from_inbound_request.assert_not_called()
+        mock_get_forwardable_x_datarobot_headers_from_inbound_request.assert_not_called()
         mock_get_exchanged_token.assert_called_once_with()
         assert output == AuthResult(credentials=[mock_get_exchanged_token.return_value])
 
     @pytest.mark.asyncio
-    async def test_forward_inbound_headers_during_authenticate(
+    async def test_set_forward_inbound_x_datarobot_http_headers(
         self,
-        mock_get_forwardable_headers_from_inbound_request: Mock,
+        mock_get_forwardable_x_datarobot_headers_from_inbound_request: Mock,
         mock_get_exchanged_token: AsyncMock,
     ) -> None:
         auth_provider = OAuth2CrossApplicationAccessOAuth2AuthProvider(
             OAuth2CrossApplicationAccessAuthProviderConfig()
         )
         auth_provider.set_cross_app_flow_params(Mock())
-        auth_provider.set_forward_inbound_http_headers(True)
+        auth_provider.set_forward_inbound_x_datarobot_http_headers(True)
         output = await auth_provider.authenticate()
 
-        mock_get_forwardable_headers_from_inbound_request.assert_called_once_with()
+        mock_get_forwardable_x_datarobot_headers_from_inbound_request.assert_called_once_with()
         mock_get_exchanged_token.assert_called_once_with()
         assert output == AuthResult(
             credentials=[
-                *mock_get_forwardable_headers_from_inbound_request.return_value,
+                *mock_get_forwardable_x_datarobot_headers_from_inbound_request.return_value,
                 mock_get_exchanged_token.return_value,
             ]
         )
@@ -607,12 +607,12 @@ class TestOAuth2CrossApplicationAccessOAuth2AuthProvider:
 
         assert auth_provider._flow_params == cross_app_params
 
-    def test_set_forward_inbound_http_headers(self) -> None:
+    def test_set_forward_inbound_x_datarobot_http_headers(self) -> None:
         auth_provider = OAuth2CrossApplicationAccessOAuth2AuthProvider(Mock())
         enabled = Mock()
-        auth_provider.set_forward_inbound_http_headers(enabled)
+        auth_provider.set_forward_inbound_x_datarobot_http_headers(enabled)
 
-        assert auth_provider._forward_inbound_http_headers == enabled
+        assert auth_provider._forward_inbound_x_datarobot_http_headers == enabled
 
     def test_get_non_forwardable_header_keys(self) -> None:
         auth_provider_config = OAuth2CrossApplicationAccessAuthProviderConfig()
@@ -621,14 +621,19 @@ class TestOAuth2CrossApplicationAccessOAuth2AuthProvider:
         output = auth_provider.get_non_forwardable_header_keys()
         assert output == {"x-datarobot-external-access-token", "authorization"}
 
-    def test_get_forwardable_headers_from_inbound_request(self, mock_nat_context_get: Mock) -> None:
+    def test_get_forwardable_x_datarobot_headers_from_inbound_request(
+        self,
+        mock_nat_context_get: Mock,
+    ) -> None:
         auth_provider_config = OAuth2CrossApplicationAccessAuthProviderConfig()
         auth_provider = OAuth2CrossApplicationAccessOAuth2AuthProvider(auth_provider_config)
-        headers = {"afda": "sdafas"}
+        headers = {"x-datarobot-adfsa": "sdafas", "non-forwarded-header": "0"}
         mock_nat_context_get.return_value.metadata.headers = headers
-        output = auth_provider.get_forwardable_headers_from_inbound_request()
+        output = auth_provider.get_forwardable_x_datarobot_headers_from_inbound_request()
 
-        assert output == [HeaderCred(name="afda", value=SecretStr(headers["afda"]))]
+        assert output == [
+            HeaderCred(name="x-datarobot-adfsa", value=SecretStr(headers["x-datarobot-adfsa"]))
+        ]
 
     @pytest.mark.asyncio
     async def test_get_exchanged_token(

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.6"
+version = "0.26.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This PR improved the header forward logic in `class OAuth2CrossApplicationAccessOAuth2AuthProvider`.
- Before 
It will forward ALL inbound header except for the reserved ones in `okta_token_header`/`fallback_token_headers` of `okta_cross_app_access` NAT config. This is risky. Because the request specific header such as `Content-Type` and `Content-Length` will be mistakenly forwarded.

- After
It will only forward ALL `x-datarobot-*`  headers except for the reserved ones in `okta_token_header`/`fallback_token_headers` of `okta_cross_app_access` NAT config.


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication outbound header behavior and defaults for XAA MCP clients; opt-in forwarding reduces accidental leakage but deployments that relied on forwarding non–`x-datarobot-*` headers will need explicit config review.
> 
> **Overview**
> **Tightens cross-app OAuth header forwarding** so outbound XAA/MCP calls no longer relay arbitrary inbound HTTP headers (e.g. `Content-Type`, `Content-Length`), which could leak or break downstream requests.
> 
> `OAuth2CrossApplicationAccessOAuth2AuthProvider` now forwards only headers whose names start with `x-datarobot-`, still excluding reserved token headers (`okta_token_header` and fallbacks). The enable flag and helpers are renamed to `set_forward_inbound_x_datarobot_http_headers` / `get_forwardable_x_datarobot_headers_from_inbound_request`. **`mcp_client_with_xaa_support`** wires the same behavior and **`forward_inbound_headers` defaults to `false`** (was `true`), so forwarding is opt-in. Release **0.26.7** and tests updated for the filtered header set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f6c031d0a7f2e09163425999d05f78d8bc6a46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->