### PR TITLE
[BUZZOK-31732] Frame unhandled streaming errors as terminal events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.13
+- `dragent`: agent `invoke` now frames a mid-run exception as a terminal AG-UI `RUN_ERROR` at the source (all frameworks), so failures surface even without middleware.
+- `dragent`: streaming agent/workflow errors now end the run with a terminal AG-UI `RUN_ERROR` (adapted to an OpenAI-shaped error chunk on `/chat/completions`) instead of NAT's bare `workflow_error` JSON that `data:`-only clients silently drop.
+- `dragent`: the agent OpenTelemetry span is now marked `ERROR` on a `RUN_ERROR` event or raised agent exception, so failed runs are no longer traced as successful.
+- `dragent`: moderation now fails closed on guard errors by emitting a terminal `RUN_ERROR` that the frontend converters adapt per route (non-streaming surfaces as HTTP 422, streaming as a framed `RUN_ERROR`), for prescore, postscore, and mid-stream failures.
+
 ## 0.26.12
 - Re-dropped the `ragas` dependency (re-applies the 0.25.3 removal, which was temporarily reverted in 0.26.2 while a `datarobot-moderations` regression was investigated). Agent pipeline interactions again come from the local `datarobot_genai.core.pipeline_interactions` module reusing the message primitives shipped by `datarobot-moderations`, and the LangGraph / LlamaIndex trace converters are the local reimplementations rather than `ragas.integrations`.
 - `dragent`: fixed moderated streaming failing with `ValueError: <Token ...> was created in a different Context`, which reached clients as a bare NAT `workflow_error` frame instead of a response. `ModerationPipeline.stream_response_async` drains the chunk iterator we hand it from inside its own feed task, while the moderation middleware's peek-ahead loop pulls the leading non-text events in the request task. NAT's `Function.astream` holds a `function_path_stack` token open across every `yield`, so splitting consumption across the two contexts made the token reset raise. The upstream stream is now pinned to a single `contextvars.Context` for the whole of its life, including teardown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-## 0.26.13
-- `drmcpbase/oauth_protected_resource_metadata`: Added OAuth protected resource metadata supports in user MCP.
 
-## 0.26.13
+## 0.26.14
 - `dragent`: agent `invoke` now frames a mid-run exception as a terminal AG-UI `RUN_ERROR` at the source (all frameworks), so failures surface even without middleware.
 - `dragent`: streaming agent/workflow errors now end the run with a terminal AG-UI `RUN_ERROR` (adapted to an OpenAI-shaped error chunk on `/chat/completions`) instead of NAT's bare `workflow_error` JSON that `data:`-only clients silently drop.
 - `dragent`: the agent OpenTelemetry span is now marked `ERROR` on a `RUN_ERROR` event or raised agent exception, so failed runs are no longer traced as successful.
 - `dragent`: moderation now fails closed on guard errors by emitting a terminal `RUN_ERROR` that the frontend converters adapt per route (non-streaming surfaces as HTTP 422, streaming as a framed `RUN_ERROR`), for prescore, postscore, and mid-stream failures.
+
+## 0.26.13
+- `drmcpbase/oauth_protected_resource_metadata`: Added OAuth protected resource metadata supports in user MCP.
 
 ## 0.26.12
 - Re-dropped the `ragas` dependency (re-applies the 0.25.3 removal, which was temporarily reverted in 0.26.2 while a `datarobot-moderations` regression was investigated). Agent pipeline interactions again come from the local `datarobot_genai.core.pipeline_interactions` module reusing the message primitives shipped by `datarobot-moderations`, and the LangGraph / LlamaIndex trace converters are the local reimplementations rather than `ragas.integrations`.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -896,7 +896,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.12"
+version = "0.26.13"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -896,7 +896,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.13"
+version = "0.26.14"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.13"
+version = "0.26.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.12"
+version = "0.26.13"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/agents/__init__.py
+++ b/src/datarobot_genai/core/agents/__init__.py
@@ -23,19 +23,25 @@ This package provides:
 """
 
 from ..mcp.config import MCPConfig
+from .base import RUN_ERROR_CODE
 from .base import BaseAgent
 from .base import InvokeReturn
 from .base import UsageMetrics
 from .base import default_usage_metrics
 from .base import extract_user_prompt_content
 from .base import make_system_prompt
+from .events import track_open_text
+from .events import track_open_text_in_events
 
 __all__ = [
     "BaseAgent",
     "make_system_prompt",
     "extract_user_prompt_content",
     "default_usage_metrics",
+    "track_open_text",
+    "track_open_text_in_events",
     "InvokeReturn",
     "UsageMetrics",
     "MCPConfig",
+    "RUN_ERROR_CODE",
 ]

--- a/src/datarobot_genai/core/agents/base.py
+++ b/src/datarobot_genai/core/agents/base.py
@@ -15,11 +15,13 @@
 from __future__ import annotations
 
 import abc
+import functools
 import json
 import logging
 import os
 import uuid
 from collections.abc import AsyncGenerator
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Generic
@@ -30,8 +32,11 @@ from typing import TypeVar
 
 from ag_ui.core import Event
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
+from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import UserMessage
 
+from datarobot_genai.core.agents.events import track_open_text
 from datarobot_genai.core.agents.history import NormalizedHistoryMessage
 from datarobot_genai.core.agents.history import build_history_summary_from_messages
 from datarobot_genai.core.agents.history import drop_unpaired_boundary_tool_turns
@@ -332,3 +337,35 @@ def default_usage_metrics() -> UsageMetrics:
         "prompt_tokens": 0,
         "total_tokens": 0,
     }
+
+
+# Client-facing ``code`` on a terminal AG-UI ``RunErrorEvent``.
+RUN_ERROR_CODE = "RUN_ERROR"
+
+
+def frame_agent_errors(invoke: Callable[..., InvokeReturn]) -> Callable[..., InvokeReturn]:
+    """Turn a mid-run exception in an agent ``invoke`` into a terminal ``RUN_ERROR`` event.
+
+    The agent owns its AG-UI lifecycle: rather than raise (which surfaces downstream as an
+    unframed NAT error that SSE clients silently drop), close any open text segments and
+    yield a terminal ``RunErrorEvent``. Decorate each framework's ``invoke`` with this.
+    """
+
+    @functools.wraps(invoke)
+    async def wrapper(self: Any, run_agent_input: RunAgentInput) -> InvokeReturn:
+        open_text_ids: set[str] = set()
+        try:
+            async for event, interactions, usage in invoke(self, run_agent_input):
+                track_open_text(open_text_ids, event)
+                yield event, interactions, usage
+        except Exception as exc:
+            logger.exception("Agent run failed; ending stream with RUN_ERROR")
+            for message_id in open_text_ids:
+                yield TextMessageEndEvent(message_id=message_id), None, default_usage_metrics()
+            yield (
+                RunErrorEvent(message=str(exc), code=RUN_ERROR_CODE),
+                None,
+                default_usage_metrics(),
+            )
+
+    return wrapper

--- a/src/datarobot_genai/core/agents/events.py
+++ b/src/datarobot_genai/core/agents/events.py
@@ -37,6 +37,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from ag_ui.core import AssistantMessage
+from ag_ui.core import Event
 from ag_ui.core import EventType
 from ag_ui.core import FunctionCall
 from ag_ui.core import Message
@@ -53,6 +54,23 @@ _REASONING_DELTA_TYPES = frozenset(
     }
 )
 _TOOL_START_TYPES = frozenset({EventType.TOOL_CALL_START, EventType.TOOL_CALL_CHUNK})
+
+
+def track_open_text(open_ids: set[str], event: Event) -> None:
+    """Track text segments started but not yet ended, so they can be closed on failure."""
+    if event.type == EventType.TEXT_MESSAGE_START:
+        open_ids.add(event.message_id)
+    elif event.type == EventType.TEXT_MESSAGE_END:
+        open_ids.discard(event.message_id)
+    elif event.type in _TEXT_DELTA_TYPES and getattr(event, "message_id", None):
+        open_ids.add(event.message_id)
+
+
+def track_open_text_in_events(open_ids: set[str], events: Iterable[Event]) -> None:
+    """Apply :func:`track_open_text` to every event in a response's event list."""
+    for event in events:
+        track_open_text(open_ids, event)
+
 
 # Keyless buckets for id-less text/reasoning turns (a provider whose chunks carry no
 # message_id keys into these). They are dropped on a tool result so a following id-less

--- a/src/datarobot_genai/core/chat/completions.py
+++ b/src/datarobot_genai/core/chat/completions.py
@@ -25,6 +25,7 @@ from uuid import uuid4
 from ag_ui.core import AssistantMessage
 from ag_ui.core import Message
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import SystemMessage
 from ag_ui.core import TextMessageChunkEvent
@@ -227,6 +228,8 @@ async def agent_chat_completion_wrapper(
                     received_run_finished = True
                     pipeline_interactions = iter_interactions
                     usage_metrics = iter_metrics
+                elif isinstance(event, RunErrorEvent):
+                    raise RuntimeError(event.message)
 
             if not received_run_finished:
                 logger.warning("Agent stream ended without RunFinishedEvent")

--- a/src/datarobot_genai/crewai/agent.py
+++ b/src/datarobot_genai/crewai/agent.py
@@ -50,6 +50,7 @@ from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
+from datarobot_genai.core.agents.base import frame_agent_errors
 from datarobot_genai.crewai.agui_stream import AGUIStreamEmitter
 from datarobot_genai.crewai.kickoff_storage import neutralize_kickoff_storage
 from datarobot_genai.crewai.logging_events import CrewAILoggingEventListener
@@ -397,6 +398,7 @@ class CrewAIAgent(BaseAgent[BaseTool], abc.ABC):
             }
         return default_usage_metrics()
 
+    @frame_agent_errors
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the CrewAI workflow with the provided completion parameters."""
         user_prompt_content = extract_user_prompt_content(run_agent_input)

--- a/src/datarobot_genai/dragent/frontends/converters.py
+++ b/src/datarobot_genai/dragent/frontends/converters.py
@@ -21,6 +21,7 @@ from typing import cast
 
 from ag_ui.core import Event
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
@@ -247,6 +248,12 @@ def convert_dragent_event_response_to_chat_response(
     (``convert_dragent_event_response_to_str`` then ``convert_str_to_chat_response``),
     dropping the moderation extra.
     """
+    error_event = _run_error_event(response.events)
+    if error_event is not None:
+        # Raise so the failure surfaces instead of an empty-success response. RuntimeError, not
+        # ValueError, to stay distinct from NAT's own "no conversion path" ValueError.
+        raise RuntimeError(error_event.message)
+
     content = convert_dragent_event_response_to_str(response)
 
     model = response.model
@@ -300,9 +307,36 @@ def _backfill_chunk_model(chunk: ChatResponseChunk) -> ChatResponseChunk:
     return chunk.model_copy(update={"model": model})
 
 
+def _run_error_event(events: list[Any]) -> RunErrorEvent | None:
+    """Return the first ``RunErrorEvent`` in a response, if any."""
+    for event in events:
+        if isinstance(event, RunErrorEvent):
+            return event
+    return None
+
+
+def _chat_response_chunk_from_run_error(event: RunErrorEvent) -> ChatResponseChunk:
+    """OpenAI-shaped error chunk for a terminal ``RunErrorEvent``.
+
+    Uses OpenAI's error-chunk convention (empty ``choices`` plus a top-level ``error`` object)
+    so a ``RUN_ERROR`` reaches the client as a recognized failure, not an empty successful chunk.
+    """
+    chunk = ChatResponseChunk(
+        id=uuid.uuid4().hex,
+        choices=[],
+        created=datetime.datetime.now(datetime.UTC),
+    )
+    return chunk.model_copy(
+        update={"error": {"message": event.message, "type": "workflow_error", "code": event.code}}
+    )
+
+
 def convert_dragent_event_response_to_chat_response_chunk(
     response: DRAgentEventResponse,
 ) -> ChatResponseChunk:
+    error_event = _run_error_event(response.events)
+    if error_event is not None:
+        return _backfill_chunk_model(_chat_response_chunk_from_run_error(error_event))
     if response.original_chunk is not None:
         chunk = response.original_chunk
     else:

--- a/src/datarobot_genai/dragent/frontends/response.py
+++ b/src/datarobot_genai/dragent/frontends/response.py
@@ -16,9 +16,13 @@
 from typing import Any
 
 from ag_ui.core import Event
+from ag_ui.core import RunErrorEvent
 from nat.data_models.api_server import ChatResponseChunk
 from nat.data_models.api_server import ResponseBaseModelOutput
 from pydantic import Field
+
+from datarobot_genai.core.agents import RUN_ERROR_CODE
+from datarobot_genai.core.agents import default_usage_metrics
 
 
 class DRAgentEventResponse(ResponseBaseModelOutput):
@@ -32,4 +36,12 @@ class DRAgentEventResponse(ResponseBaseModelOutput):
             "Serialized guard pipeline output (scores, token counts, etc.) "
             "when moderation is enabled."
         ),
+    )
+
+
+def run_error_response(message: str, *, code: str = RUN_ERROR_CODE) -> DRAgentEventResponse:
+    """Terminal AG-UI ``RUN_ERROR`` response, so a run can end in-band instead of raising."""
+    return DRAgentEventResponse(
+        events=[RunErrorEvent(message=message, code=code)],
+        usage_metrics=default_usage_metrics(),
     )

--- a/src/datarobot_genai/dragent/plugins/datarobot_dragent_normalization.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_dragent_normalization.py
@@ -56,12 +56,15 @@ from nat.middleware.middleware import CallNext
 from nat.middleware.middleware import CallNextStream
 from nat.middleware.middleware import FunctionMiddlewareContext
 
+from datarobot_genai.core.agents import RUN_ERROR_CODE
 from datarobot_genai.core.agents import default_usage_metrics
+from datarobot_genai.core.agents import track_open_text_in_events
 from datarobot_genai.dragent.frontends.converters import (
     convert_chat_response_to_dragent_event_response,
 )
 from datarobot_genai.dragent.frontends.converters import convert_str_to_dragent_text_response
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.dragent.frontends.response import run_error_response
 from datarobot_genai.dragent.frontends.tool_call_registry import mark_args_done
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
 
@@ -187,7 +190,7 @@ async def convert_chunks_to_agui_events(
     if active_message_id is not None:
         end.append(TextMessageEndEvent(message_id=active_message_id))
     if error is not None:
-        end.append(RunErrorEvent(message=str(error), code="STREAM_ERROR"))
+        end.append(RunErrorEvent(message=str(error), code=RUN_ERROR_CODE))
     if end:
         yield DRAgentEventResponse(events=end, usage_metrics=zero)
 
@@ -257,11 +260,24 @@ class DataRobotDRAgentNormalizationMiddleware(FunctionMiddleware):
             except StopAsyncIteration:
                 return
 
-            # dragent-native agents already emit DRAgentEventResponse -> passthrough.
+            # dragent-native agents already emit DRAgentEventResponse -> passthrough. Frame a
+            # mid-run failure as a terminal RUN_ERROR
             if isinstance(first, DRAgentEventResponse):
-                yield first
-                async for chunk in iterator:
-                    yield chunk
+                open_text_ids: set[str] = set()
+                try:
+                    track_open_text_in_events(open_text_ids, first.events)
+                    yield first
+                    async for chunk in iterator:
+                        track_open_text_in_events(open_text_ids, chunk.events)
+                        yield chunk
+                except Exception as exc:
+                    logger.exception("Agent stream failed; ending with RUN_ERROR")
+                    for message_id in open_text_ids:
+                        yield DRAgentEventResponse(
+                            events=[TextMessageEndEvent(message_id=message_id)],
+                            usage_metrics=default_usage_metrics(),
+                        )
+                    yield run_error_response(str(exc))
                 return
 
             # Native NAT agents emit ChatResponseChunk -> convert to AG-UI events. Reuse

--- a/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
@@ -67,11 +67,11 @@ from ag_ui.core import AssistantMessage
 from ag_ui.core import Event
 from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import SystemMessage
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
-from ag_ui.core import TextMessageStartEvent
 from ag_ui.core import ToolCallArgsEvent
 from ag_ui.core import ToolCallChunkEvent
 from ag_ui.core import ToolCallEndEvent
@@ -118,6 +118,7 @@ from openai.types.chat.chat_completion_message_tool_call import Function as Open
 from pydantic import Field
 
 from datarobot_genai.core.agents import default_usage_metrics
+from datarobot_genai.core.agents import track_open_text_in_events
 from datarobot_genai.core.telemetry.nat_context import use_nat_workflow_trace_context
 from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
 from datarobot_genai.dragent.frontends.converters import build_assistant_text_events
@@ -126,6 +127,7 @@ from datarobot_genai.dragent.frontends.converters import (
 )
 from datarobot_genai.dragent.frontends.converters import convert_dragent_event_response_to_str
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.dragent.frontends.response import run_error_response
 from datarobot_genai.dragent.frontends.tool_call_registry import register_tool_call
 from datarobot_genai.dragent.plugins.datarobot_dragent_normalization import (
     resolve_streaming_tool_call_id,
@@ -1068,17 +1070,6 @@ def skip_event_type(event: Event) -> bool:
     }
 
 
-def _track_open_text_message(open_message_ids: set[str], event: Event) -> None:
-    """Track assistant text segments that started or received content but did not end."""
-    if isinstance(event, TextMessageStartEvent):
-        open_message_ids.add(event.message_id)
-    elif isinstance(event, TextMessageEndEvent):
-        open_message_ids.discard(event.message_id)
-    elif isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)):
-        if event.message_id:
-            open_message_ids.add(event.message_id)
-
-
 def _synthetic_text_message_end_events(
     open_message_ids: set[str],
 ) -> list[TextMessageEndEvent]:
@@ -1097,13 +1088,6 @@ def _synthetic_text_message_end_responses(
         DRAgentEventResponse(events=[end_event], usage_metrics=zero)
         for end_event in _synthetic_text_message_end_events(open_message_ids)
     ]
-
-
-def _track_dragent_response_events(
-    open_message_ids: set[str], response: DRAgentEventResponse
-) -> None:
-    for event in response.events:
-        _track_open_text_message(open_message_ids, event)
 
 
 def _response_has_assistant_text_deltas(response: DRAgentEventResponse) -> bool:
@@ -1255,17 +1239,17 @@ async def _moderated_dragent_stream(
     open_text_message_ids: set[str] = set()
     pending_deferred: list[DRAgentEventResponse] = []
     pending_pass_through: list[DRAgentEventResponse] = []
+    terminal_run_error: DRAgentEventResponse | None = None
     moderation_source_responses: list[DRAgentEventResponse] = []
     last_source_response: DRAgentEventResponse | None = None
     stopped_for_content_filter = False
-    prescore_state = _StreamingPrescoreModerationState(
-        prescore_moderations=_prescore_datarobot_moderations_from_df(
-            moderation._pipeline,
-            stream_state.prescore_df,
-        ),
-    )
 
     def buffer_passthrough(response: DRAgentEventResponse) -> None:
+        nonlocal terminal_run_error
+        if any(isinstance(event, RunErrorEvent) for event in response.events):
+            # Terminal RUN_ERROR: hold it and emit last so no moderated chunk trails after it.
+            terminal_run_error = response
+            return
         if response.events and _defer_until_after_moderated_chunk(response.events[0]):
             pending_deferred.append(response)
         else:
@@ -1290,11 +1274,17 @@ async def _moderated_dragent_stream(
 
     first_text: DRAgentEventResponse | None = None
     try:
+        prescore_state = _StreamingPrescoreModerationState(
+            prescore_moderations=_prescore_datarobot_moderations_from_df(
+                moderation._pipeline,
+                stream_state.prescore_df,
+            ),
+        )
         async for response in upstream:
             if response.events and not skip_event_type(response.events[0]):
                 first_text = response
                 break
-            _track_dragent_response_events(open_text_message_ids, response)
+            track_open_text_in_events(open_text_message_ids, response.events)
             yield prescore_state.emit(response)
         if first_text is None:
             return
@@ -1328,12 +1318,12 @@ async def _moderated_dragent_stream(
                 )
                 if converted.events:
                     moderated_response = prescore_state.emit_moderated(converted)
-                    _track_dragent_response_events(open_text_message_ids, moderated_response)
+                    track_open_text_in_events(open_text_message_ids, moderated_response.events)
                     yield moderated_response
                     for item in _drain_pending_after_moderated_chunk(
                         pending_deferred, pending_pass_through
                     ):
-                        _track_dragent_response_events(open_text_message_ids, item)
+                        track_open_text_in_events(open_text_message_ids, item.events)
                         yield prescore_state.emit(item)
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
@@ -1348,10 +1338,20 @@ async def _moderated_dragent_stream(
             for item in _drain_pending_after_moderated_chunk(
                 pending_deferred, pending_pass_through
             ):
-                _track_dragent_response_events(open_text_message_ids, item)
+                track_open_text_in_events(open_text_message_ids, item.events)
                 yield prescore_state.emit(item)
             for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
                 yield end_response
+        if terminal_run_error is not None:
+            # Last on every path (normal or content_filter) so a block can't mask it.
+            yield prescore_state.emit(terminal_run_error)
+    except Exception as exc:
+        # Close open text segments, then end the stream in-band with a terminal RUN_ERROR
+        # instead of raising: NAT would otherwise emit an unframed error that clients drop.
+        _logger.exception("Error while producing moderated stream")
+        for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
+            yield end_response
+        yield run_error_response(str(exc))
     finally:
         await _aclose_async_iterator(upstream)
 
@@ -1438,6 +1438,10 @@ class DataRobotModerationMiddleware(
         ``call_next`` after ``pre_invoke``. When prescore blocks, ``pre_invoke`` sets
         ``ctx.output`` to the guard response; we return it immediately so ``call_next``
         (and thus the LLM) is never invoked.
+
+        On a moderation failure, ``pre_invoke``/``post_invoke`` set ``ctx.output`` to a terminal
+        ``RUN_ERROR``; converters adapt it per route (non-streaming raises, NAT returns 422;
+        streaming frames it). Mid-stream: ``_moderated_dragent_stream``.
         """
         ctx = InvocationContext(
             function_context=context,
@@ -1477,42 +1481,48 @@ class DataRobotModerationMiddleware(
         if moderation is None:
             return None
 
-        pipeline = moderation._pipeline
+        try:
+            pipeline = moderation._pipeline
 
-        prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
-        prompt = moderation_prompt_from_workflow_input(workflow_input)
+            prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
+            prompt = moderation_prompt_from_workflow_input(workflow_input)
 
-        # Step 1: Prescore via ``ModerationPipeline.evaluate_prompt_async`` (non-blocking).
-        # Wrap in the NAT workflow trace context: dome emits its ``evaluate_prompt`` span via
-        # its own tracer provider, which our ``NatWorkflowTracer`` wrapper never patches. Without
-        # an active workflow parent in context here (moderation is the outer middleware, so this
-        # runs before the ``datarobot_agent`` span exists) that span would start a disconnected
-        # trace.
-        with use_nat_workflow_trace_context():
-            prompt_eval, prescore_latency, prescore_df = await moderation.evaluate_prompt_async(
-                prompt
+            # Step 1: Prescore via ``ModerationPipeline.evaluate_prompt_async`` (non-blocking).
+            # Wrap in the NAT workflow trace context: dome emits its ``evaluate_prompt`` span via
+            # its own tracer provider, which our ``NatWorkflowTracer`` wrapper never patches.
+            # Without an active workflow parent in context here (moderation is the outer middleware,
+            # so this runs before the ``datarobot_agent`` span exists) that span would start a
+            # disconnected trace.
+            with use_nat_workflow_trace_context():
+                prompt_eval, prescore_latency, prescore_df = await moderation.evaluate_prompt_async(
+                    prompt
+                )
+
+            if prompt_eval.blocked:
+                # If all prompts in the input are blocked, means history as well as the prompt
+                # are not worthy to be sent to LLM. No invoke state: post_invoke / streaming never
+                # run.
+                context.output = _dragent_event_response_from_blocked_prompt_eval(prompt_eval)
+                return context
+
+            prompt_sent, workflow_rewritten = _prompt_sent_after_prescore_replacement(
+                workflow_input,
+                original_prompt=prompt,
+                prompt_eval=prompt_eval,
+                prescore_df=prescore_df,
+                prompt_column=prompt_column_name,
             )
-
-        if prompt_eval.blocked:
-            # If all prompts in the input are blocked, means history as well as the prompt
-            # are not worthy to be sent to LLM. No invoke state: post_invoke / streaming never run.
-            context.output = _dragent_event_response_from_blocked_prompt_eval(prompt_eval)
+            _set_moderation_invoke_state(
+                prompt=prompt_sent,
+                prescore_df=prescore_df,
+                latency_so_far=prescore_latency,
+            )
+            # Return context only when workflow input was rewritten (signals modified_args to NAT).
+            return context if workflow_rewritten else None
+        except Exception as exc:
+            _logger.exception("Moderation prescore failed")
+            context.output = run_error_response(f"Moderation failed: {exc}")
             return context
-
-        prompt_sent, workflow_rewritten = _prompt_sent_after_prescore_replacement(
-            workflow_input,
-            original_prompt=prompt,
-            prompt_eval=prompt_eval,
-            prescore_df=prescore_df,
-            prompt_column=prompt_column_name,
-        )
-        _set_moderation_invoke_state(
-            prompt=prompt_sent,
-            prescore_df=prescore_df,
-            latency_so_far=prescore_latency,
-        )
-        # Return context only when workflow input was rewritten (signals modified_args to NAT).
-        return context if workflow_rewritten else None
 
     async def post_invoke(self, context: InvocationContext) -> InvocationContext | None:
         """Post-invocation hook called after the function returns.
@@ -1548,52 +1558,57 @@ class DataRobotModerationMiddleware(
         if state is None:
             return None
 
-        # ==================================================================
-        # Step 3: Postscore via ``ModerationPipeline.evaluate_response`` (same path as
-        # ``_run_stage`` in dome) when response text is present.
-        prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
-        # Wrap in the NAT workflow trace context so dome's ``evaluate_response`` span joins the
-        # request trace (see the pre_invoke prescore call for the full rationale).
-        with use_nat_workflow_trace_context():
-            response_eval, _, _postscore_df = await moderation.evaluate_response_async(
-                response_text,
-                prompt=state.prompt,
+        try:
+            # ==================================================================
+            # Step 3: Postscore via ``ModerationPipeline.evaluate_response`` (same path as
+            # ``_run_stage`` in dome) when response text is present.
+            prompt_column_name = pipeline.get_input_column(GuardStage.PROMPT)
+            # Wrap in the NAT workflow trace context so dome's ``evaluate_response`` span joins the
+            # request trace (see the pre_invoke prescore call for the full rationale).
+            with use_nat_workflow_trace_context():
+                response_eval, _, _postscore_df = await moderation.evaluate_response_async(
+                    response_text,
+                    prompt=state.prompt,
+                )
+
+            prompt_eval = _from_dataframe(state.prescore_df, prompt_column_name)
+
+            if response_eval.blocked:
+                response_message = response_eval.blocked_message or ""
+                finish_reason = "content_filter"
+            elif response_eval.replaced:
+                response_message = response_eval.replacement or ""
+                finish_reason = "content_filter"
+            else:
+                response_message = response_text
+                finish_reason = "stop"
+
+            moderated_dr = _dragent_event_response_from_postscore_assistant_text(
+                response_message,
+                finish_reason,
+                response_eval,
+                upstream_model=_upstream_model_from_dragent_response(original_output),
+                prompt_eval=prompt_eval,
             )
-
-        prompt_eval = _from_dataframe(state.prescore_df, prompt_column_name)
-
-        if response_eval.blocked:
-            response_message = response_eval.blocked_message or ""
-            finish_reason = "content_filter"
-        elif response_eval.replaced:
-            response_message = response_eval.replacement or ""
-            finish_reason = "content_filter"
-        else:
-            response_message = response_text
-            finish_reason = "stop"
-
-        moderated_dr = _dragent_event_response_from_postscore_assistant_text(
-            response_message,
-            finish_reason,
-            response_eval,
-            upstream_model=_upstream_model_from_dragent_response(original_output),
-            prompt_eval=prompt_eval,
-        )
-        preserve_ag_ui_envelope = (
-            len(original_output.events) > 1
-            and finish_reason == "stop"
-            and not response_eval.blocked
-            and not response_eval.replaced
-            and response_message == response_text
-        )
-        if preserve_ag_ui_envelope:
-            context.output = _merge_moderations_into_multi_event_response(
-                original_output, moderated_dr
+            preserve_ag_ui_envelope = (
+                len(original_output.events) > 1
+                and finish_reason == "stop"
+                and not response_eval.blocked
+                and not response_eval.replaced
+                and response_message == response_text
             )
-        else:
-            context.output = moderated_dr
+            if preserve_ag_ui_envelope:
+                context.output = _merge_moderations_into_multi_event_response(
+                    original_output, moderated_dr
+                )
+            else:
+                context.output = moderated_dr
 
-        return context
+            return context
+        except Exception as exc:
+            _logger.exception("Moderation postscore failed")
+            context.output = run_error_response(f"Moderation failed: {exc}")
+            return context
 
     async def function_middleware_stream(
         self,
@@ -1645,6 +1660,9 @@ class DataRobotModerationMiddleware(
             # Prescore populates invoke state. If ``pre_invoke`` returned early (e.g. no
             # workflow input / prescore skipped), pass the stream through unchanged.
             stream_state = _moderation_invoke_state_ctx.get()
+            # Clear at read time, in the context that set it (pre_invoke): the reset token is only
+            # valid here. Deferring to the generator ``finally`` runs in a different context.
+            _clear_moderation_invoke_state_if_set()
             if stream_state is None:
                 async with contextlib.aclosing(
                     cast(

--- a/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
@@ -1131,28 +1131,29 @@ def _pending_after_moderated_chunk(
     pending_deferred: list[DRAgentEventResponse],
     pending_pass_through: list[DRAgentEventResponse],
 ) -> list[DRAgentEventResponse]:
-    """Order buffered events after a moderated text chunk.
-
-    Deferred ``TEXT_MESSAGE_END`` closes the prior segment first. Pass-through events (for example
-    ``STEP_FINISHED`` / ``STEP_STARTED``) keep upstream order. Deferred ``TEXT_MESSAGE_START`` for
-    the next segment follows so step boundaries stay valid for AG-UI verification.
+    """Order buffered events after a moderated chunk: a prior-segment ``TEXT_MESSAGE_END`` first
+    (keeps its id for late moderated deltas), then pass-through, then this batch's own segments in
+    upstream order so a content-less one isn't split into an ``END`` before its ``START``.
     """
-    deferred_ends = [
-        item
-        for item in pending_deferred
-        if item.events and item.events[0].type == EventType.TEXT_MESSAGE_END
-    ]
-    deferred_starts = [
-        item
+    started_in_batch = {
+        item.events[0].message_id
         for item in pending_deferred
         if item.events and item.events[0].type == EventType.TEXT_MESSAGE_START
-    ]
-    deferred_other = [
-        item
-        for item in pending_deferred
-        if item not in deferred_ends and item not in deferred_starts
-    ]
-    return deferred_ends + list(pending_pass_through) + deferred_starts + deferred_other
+    }
+    prior_segment_ends: list[DRAgentEventResponse] = []
+    rest: list[DRAgentEventResponse] = []
+    for item in pending_deferred:
+        first = item.events[0] if item.events else None
+        # Only an END whose START was in an earlier batch closes a prior segment and may lead.
+        if (
+            first is not None
+            and first.type == EventType.TEXT_MESSAGE_END
+            and first.message_id not in started_in_batch
+        ):
+            prior_segment_ends.append(item)
+        else:
+            rest.append(item)
+    return prior_segment_ends + list(pending_pass_through) + rest
 
 
 def _drain_pending_after_moderated_chunk(

--- a/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
+from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import UserMessage
 from nat.builder.builder import Builder
@@ -30,9 +31,15 @@ from nat.middleware.middleware import CallNext
 from nat.middleware.middleware import CallNextStream
 from nat.middleware.middleware import FunctionMiddlewareContext
 from opentelemetry import trace
+from opentelemetry.trace import Status
+from opentelemetry.trace import StatusCode
 
+from datarobot_genai.core.agents import RUN_ERROR_CODE
+from datarobot_genai.core.agents import default_usage_metrics
+from datarobot_genai.core.agents import track_open_text_in_events
 from datarobot_genai.core.telemetry.nat_context import use_nat_workflow_trace_context
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.dragent.frontends.response import run_error_response
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +53,7 @@ AGENT_SPAN_NAME = "datarobot_agent"
 GEN_AI_PROMPT = "gen_ai.prompt"  # Prompt column
 GEN_AI_COMPLETION = "gen_ai.completion"  # Completion column
 TOOL_NAME = "tool_name"  # Tools column
+ERROR_TYPE = "error.type"  # Failed span classification
 
 # AG-UI event types that carry assistant text deltas.
 _TEXT_EVENT_TYPES = (EventType.TEXT_MESSAGE_CONTENT, EventType.TEXT_MESSAGE_CHUNK)
@@ -83,6 +91,15 @@ def _ag_ui_last_user_message_content(run_agent_input: RunAgentInput) -> str | No
 def _response_text(response: DRAgentEventResponse) -> str:
     """Join assistant text deltas from a DRAgentEventResponse's AG-UI events."""
     return "".join(event.delta for event in response.events if event.type in _TEXT_EVENT_TYPES)
+
+
+def _mark_span_error_on_run_error(span: trace.Span, response: DRAgentEventResponse) -> None:
+    """Mark the span failed when the response carries a ``RUN_ERROR`` event."""
+    for event in response.events:
+        if event.type == EventType.RUN_ERROR:
+            span.set_attribute(ERROR_TYPE, event.code or RUN_ERROR_CODE)
+            span.set_status(Status(StatusCode.ERROR, event.message or "workflow run error"))
+            return
 
 
 def _emit_tool_call_spans(response: DRAgentEventResponse) -> None:
@@ -157,6 +174,7 @@ class DataRobotOtelConventionsMiddleware(
             output = await call_next(*args, **kwargs)
             if isinstance(output, DRAgentEventResponse):
                 _emit_tool_call_spans(output)
+                _mark_span_error_on_run_error(span, output)
             completion = self._completion_from_output(output)
             if completion is not None:
                 span.set_attribute(GEN_AI_COMPLETION, completion)
@@ -178,14 +196,29 @@ class DataRobotOtelConventionsMiddleware(
                 span.set_attribute(GEN_AI_PROMPT, prompt)
             # Per-invocation accumulator; no cross-session state to manage.
             parts: list[str] = []
+            open_text_ids: set[str] = set()
             try:
                 async for chunk in call_next(*args, **kwargs):
                     if isinstance(chunk, DRAgentEventResponse):
                         _emit_tool_call_spans(chunk)
+                        _mark_span_error_on_run_error(span, chunk)
+                        track_open_text_in_events(open_text_ids, chunk.events)
                         text = _response_text(chunk)
                         if text:
                             parts.append(text)
                     yield chunk
+            except Exception as exc:
+                # Close open text segments, then end the run with a terminal RUN_ERROR instead of
+                # propagating (matches the moderation middleware's failure path).
+                logger.exception("Agent stream failed")
+                for message_id in open_text_ids:
+                    yield DRAgentEventResponse(
+                        events=[TextMessageEndEvent(message_id=message_id)],
+                        usage_metrics=default_usage_metrics(),
+                    )
+                error_response = run_error_response(str(exc))
+                _mark_span_error_on_run_error(span, error_response)
+                yield error_response
             finally:
                 # Attach the completion in ``finally`` so it survives early teardown.
                 # Downstream moderation may stop consuming and ``aclose()`` this generator

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -54,6 +54,7 @@ from datarobot_genai.core.agents.base import BaseAgent
 from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
+from datarobot_genai.core.agents.base import frame_agent_errors
 from datarobot_genai.core.agents.reasoning import flatten_to_text
 from datarobot_genai.langgraph.history import ag_ui_history_to_langchain
 from datarobot_genai.langgraph.reasoning import iter_message_blocks
@@ -309,6 +310,7 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
         )
         return current_messages[:insert_at] + history + current_messages[insert_at:]
 
+    @frame_agent_errors
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the agent with the provided input.
 

--- a/src/datarobot_genai/llama_index/agent.py
+++ b/src/datarobot_genai/llama_index/agent.py
@@ -49,6 +49,7 @@ from datarobot_genai.core.agents.base import InvokeReturn
 from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import default_usage_metrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
+from datarobot_genai.core.agents.base import frame_agent_errors
 from datarobot_genai.core.agents.base import prepend_streaming_memory_to_prompt
 from datarobot_genai.llama_index.history import ag_ui_history_to_chat_messages
 
@@ -158,6 +159,7 @@ class LlamaIndexAgent(BaseAgent[BaseTool], abc.ABC):
         """Extract final response text from workflow state and/or events."""
         raise NotImplementedError
 
+    @frame_agent_errors
     async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
         """Run the LlamaIndex workflow with the provided completion parameters."""
         user_prompt_content = extract_user_prompt_content(run_agent_input)

--- a/tests/core/agents/test_base.py
+++ b/tests/core/agents/test_base.py
@@ -470,3 +470,65 @@ async def test_invoke_single_message_builds_run_input_with_user_message() -> Non
     assert agent.last_input.messages[0].content == "hello world"
     assert agent.last_input.state == []
     assert agent.last_input.tools == []
+
+
+def _single_user_run_input() -> RunAgentInput:
+    return RunAgentInput(
+        thread_id="t",
+        run_id="r",
+        messages=[UserMessage(id="u", role="user", content="hi")],
+        state=[],
+        tools=[],
+        context=[],
+        forwardedProps=None,
+    )
+
+
+async def test_frame_agent_errors_emits_terminal_run_error() -> None:
+    from ag_ui.core import RunErrorEvent
+    from ag_ui.core import RunStartedEvent
+    from ag_ui.core import TextMessageEndEvent
+    from ag_ui.core import TextMessageStartEvent
+
+    from datarobot_genai.core.agents.base import frame_agent_errors
+
+    # GIVEN an invoke that opens a text segment then raises mid-run
+    @frame_agent_errors
+    async def invoke(self: Any, run_agent_input: RunAgentInput) -> Any:
+        yield RunStartedEvent(thread_id="t", run_id="r"), None, default_usage_metrics()
+        yield (
+            TextMessageStartEvent(message_id="m1", role="assistant"),
+            None,
+            default_usage_metrics(),
+        )
+        raise ValueError("boom")
+
+    # WHEN it is consumed
+    events = [ev async for ev, _, _ in invoke(object(), _single_user_run_input())]
+
+    # THEN the open segment is closed and the stream ends with a terminal RUN_ERROR
+    assert [type(ev).__name__ for ev in events] == [
+        "RunStartedEvent",
+        "TextMessageStartEvent",
+        "TextMessageEndEvent",
+        "RunErrorEvent",
+    ]
+    assert isinstance(events[-2], TextMessageEndEvent) and events[-2].message_id == "m1"
+    assert isinstance(events[-1], RunErrorEvent) and events[-1].message == "boom"
+
+
+async def test_frame_agent_errors_passthrough_without_exception() -> None:
+    from ag_ui.core import RunFinishedEvent
+    from ag_ui.core import RunStartedEvent
+
+    from datarobot_genai.core.agents.base import frame_agent_errors
+
+    # GIVEN an invoke that completes normally
+    @frame_agent_errors
+    async def invoke(self: Any, run_agent_input: RunAgentInput) -> Any:
+        yield RunStartedEvent(thread_id="t", run_id="r"), None, default_usage_metrics()
+        yield RunFinishedEvent(thread_id="t", run_id="r"), None, default_usage_metrics()
+
+    # WHEN consumed THEN events pass through unchanged and no RUN_ERROR is appended
+    kinds = [type(ev).__name__ async for ev, _, _ in invoke(object(), _single_user_run_input())]
+    assert kinds == ["RunStartedEvent", "RunFinishedEvent"]

--- a/tests/core/chat/test_completions.py
+++ b/tests/core/chat/test_completions.py
@@ -20,6 +20,7 @@ import pytest
 from ag_ui.core import AssistantMessage
 from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
 from ag_ui.core import SystemMessage
@@ -445,3 +446,42 @@ async def test_agent_chat_completion_wrapper_non_streaming() -> None:
 )
 def test_backfill_model(current: str | None, requested: str | None, expected: str | None) -> None:
     assert backfill_model(current, requested) == expected
+
+
+class ErroringAGUIAgent(BaseAgent):
+    """Agent that frames a mid-run failure as a terminal RUN_ERROR, as the invoke decorator does."""
+
+    async def invoke(self, run_agent_input: RunAgentInput) -> InvokeReturn:
+        yield (
+            RunStartedEvent(thread_id=run_agent_input.thread_id, run_id=run_agent_input.run_id),
+            None,
+            UsageMetrics(),
+        )
+        yield (TextMessageStartEvent(message_id="m0"), None, UsageMetrics())
+        yield (TextMessageContentEvent(message_id="m0", delta="partial"), None, UsageMetrics())
+        yield (TextMessageEndEvent(message_id="m0"), None, UsageMetrics())
+        yield (RunErrorEvent(message="boom", code="RUN_ERROR"), None, UsageMetrics())
+
+
+async def test_agent_chat_completion_wrapper_non_streaming_raises_on_run_error() -> None:
+    # GIVEN an agent that ends the run with a terminal RUN_ERROR
+    params = {"messages": [{"role": "user", "content": "hi"}], "stream": False}
+
+    # WHEN/THEN the non-streaming wrapper surfaces it as a failure, not a partial success
+    with pytest.raises(RuntimeError, match="boom"):
+        await agent_chat_completion_wrapper(ErroringAGUIAgent(), params, noop_mcp_tools_factory)
+
+
+async def test_agent_chat_completion_wrapper_streaming_forwards_run_error() -> None:
+    # GIVEN an agent that ends the run with a terminal RUN_ERROR
+    params = {"messages": [{"role": "user", "content": "hi"}], "stream": True}
+
+    # WHEN the streaming wrapper is consumed
+    generator = await agent_chat_completion_wrapper(
+        ErroringAGUIAgent(), params, noop_mcp_tools_factory
+    )
+    events = [event async for event, _, _ in generator]
+
+    # THEN the RUN_ERROR is forwarded as the terminal event (converters adapt it per route)
+    assert events[-1].type == EventType.RUN_ERROR
+    assert events[-1].message == "boom"

--- a/tests/crewai/test_agent.py
+++ b/tests/crewai/test_agent.py
@@ -29,6 +29,7 @@ from ag_ui.core import ReasoningMessageEndEvent
 from ag_ui.core import ReasoningMessageStartEvent
 from ag_ui.core import ReasoningStartEvent
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
 from ag_ui.core import StepFinishedEvent
@@ -729,12 +730,9 @@ async def test_invoke_streaming_closes_open_step_and_message_when_stream_aborts(
     agent._crew_for_test = CrewForTest(_AbortingStream())
 
     # WHEN the stream aborts mid-run
-    events = []
-    with pytest.raises(RuntimeError, match="boom"):
-        async for e, _, _ in agent.invoke(run_agent_input):
-            events.append(e)
+    events = [e async for e, _, _ in agent.invoke(run_agent_input)]
 
-    # THEN every opened step and message was closed before the error propagated
+    # THEN every opened step and message was closed before the terminal error
     starts = [e for e in events if isinstance(e, StepStartedEvent)]
     finishes = [e for e in events if isinstance(e, StepFinishedEvent)]
     text_starts = [e for e in events if isinstance(e, TextMessageStartEvent)]
@@ -743,13 +741,12 @@ async def test_invoke_streaming_closes_open_step_and_message_when_stream_aborts(
     assert [s.step_name for s in finishes] == ["Planner"]  # step closed on abort
     assert len(text_starts) == len(text_ends) == 1  # message closed on abort
 
-    # AND the partial stream is well-formed AND still accepts a terminal event -- nothing is left
-    # open. validate_sequence rejects RUN_FINISHED while a step/message is active, so appending it
-    # is what proves finish() closed the step on abort (balanced counts would pass even with
-    # STEP_FINISHED emitted before TEXT_MESSAGE_END).
+    # AND the agent owns its lifecycle: the run ends with a terminal RUN_ERROR carrying the
+    # failure instead of raising (an unframed exception would surface downstream as a dropped
+    # NAT error). The partial stream stays well-formed -- nothing left open before the error.
+    assert isinstance(events[-1], RunErrorEvent)
+    assert "boom" in events[-1].message
     validate_sequence(events)
-    terminal = RunFinishedEvent(thread_id=run_agent_input.thread_id, run_id=run_agent_input.run_id)
-    validate_sequence([*events, terminal])
     assert events.index(text_ends[0]) < events.index(finishes[0])  # message closed before its step
 
 

--- a/tests/dragent/frontends/test_converters.py
+++ b/tests/dragent/frontends/test_converters.py
@@ -16,6 +16,7 @@ import datetime
 from unittest.mock import patch
 
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import StepStartedEvent
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
@@ -558,6 +559,28 @@ def test_convert_dragent_event_response_to_chat_response_chunk_empty_events() ->
 
     # THEN content is empty but structure is still valid
     assert result.choices[0].delta.content == ""
+
+
+def test_convert_dragent_event_response_to_chat_response_chunk_surfaces_run_error() -> None:
+    # GIVEN a response whose events carry a terminal RunErrorEvent
+    response = DRAgentEventResponse(
+        original_chunk=None,
+        events=[RunErrorEvent(message="workflow blew up", code="ValueError")],
+    )
+
+    # WHEN converting to ChatResponseChunk
+    result = convert_dragent_event_response_to_chat_response_chunk(response)
+
+    # THEN the chunk carries the OpenAI-shaped error extra and no content choices
+    assert isinstance(result, ChatResponseChunk)
+    assert result.choices == []
+    assert getattr(result, "error", None) == {
+        "message": "workflow blew up",
+        "type": "workflow_error",
+        "code": "ValueError",
+    }
+    # AND the model is backfilled to the configured model, not NAT's "unknown-model" placeholder
+    assert result.model not in (None, "unknown-model")
 
 
 def test_convert_dragent_event_response_to_chat_response_chunk_returns_original_chunk() -> None:

--- a/tests/dragent/frontends/test_stream_run_error_e2e.py
+++ b/tests/dragent/frontends/test_stream_run_error_e2e.py
@@ -1,0 +1,143 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end: an agent that fails mid-stream surfaces as a framed terminal error on the wire.
+
+Exercises the no-guards chain a failing dragent-native agent hits on the streaming routes:
+``datarobot_otel_conventions`` (always-on, catches the exception -> terminal RUN_ERROR) ->
+the route serializer. The guards-on chain (moderation wrapping otel) is covered by
+``test_datarobot_moderation_middleware`` (stacked real-chain case). ``/generate/stream`` uses
+NAT's interactive runner (a ``data:`` AG-UI RUN_ERROR); ``/chat/completions`` converts each item
+to an OpenAI chunk via the registered converter. Nothing here is mocked except the runner's
+execution-store/session plumbing.
+"""
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import TextMessageContentEvent
+from ag_ui.core import TextMessageStartEvent
+from nat.data_models.api_server import ChatResponse
+from nat.data_models.api_server import ChatResponseChunk
+from nat.data_models.api_server import GlobalTypeConverter
+from nat.front_ends.fastapi.http_interactive_runner import HTTPInteractiveRunner
+
+# Importing register applies the DRAgentEventResponse -> ChatResponseChunk converter registration.
+import datarobot_genai.dragent.frontends.register  # noqa: E402, F401
+from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
+from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import (
+    DataRobotOtelConventionsMiddleware,
+)
+
+
+async def _failing_agent(*args: Any, **kwargs: Any) -> AsyncIterator[DRAgentEventResponse]:
+    """dragent-native agent: streams a partial answer, then fails mid-stream."""
+    yield DRAgentEventResponse(events=[TextMessageStartEvent(message_id="m1")])
+    yield DRAgentEventResponse(
+        events=[TextMessageContentEvent(message_id="m1", delta="partial answer")]
+    )
+    raise RuntimeError("tool timed out")
+
+
+def _otel_wrapped_failing_stream() -> AsyncIterator[DRAgentEventResponse]:
+    """Return the failing agent wrapped by the always-on otel middleware."""
+    otel = DataRobotOtelConventionsMiddleware(MagicMock(), MagicMock())
+    return otel.function_middleware_stream(
+        MagicMock(), call_next=_failing_agent, context=MagicMock()
+    )
+
+
+def _interactive_runner() -> HTTPInteractiveRunner:
+    """Build a real HTTPInteractiveRunner with only execution-store/session plumbing mocked."""
+    store = MagicMock()
+    store.create_execution = AsyncMock(return_value=MagicMock())
+
+    @asynccontextmanager
+    async def _fake_session(**kwargs: Any) -> AsyncIterator[Any]:
+        yield MagicMock()
+
+    session_manager = MagicMock()
+    session_manager.session = _fake_session
+    return HTTPInteractiveRunner(
+        execution_store=store, session_manager=session_manager, http_flow_handler=None
+    )
+
+
+async def test_generate_stream_failure_is_agui_run_error_data_frame() -> None:
+    """/generate/stream (interactive): a mid-stream failure is a ``data:`` AG-UI RUN_ERROR.
+
+    Not NAT's ``event: error`` frame, which AG-UI clients don't recognize as a run failure.
+    """
+    runner = _interactive_runner()
+    frames = [
+        frame
+        async for frame in runner._streaming_generator_impl(
+            MagicMock(),
+            workflow_gen_factory=lambda _session: _otel_wrapped_failing_stream(),
+            error_log_message="test",
+            passthrough_str_items=False,
+        )
+    ]
+
+    assert frames, "expected streamed frames"
+    assert not any("event: error" in frame for frame in frames), frames
+    terminal = frames[-1]
+    assert terminal.startswith("data:")
+    payload = json.loads(terminal[len("data: ") :])
+    error_event = payload["events"][0]
+    assert error_event["type"] == "RUN_ERROR"
+    assert error_event["message"] == "tool timed out"
+    assert error_event["code"] == "RUN_ERROR"
+
+
+async def test_chat_completions_failure_is_openai_error_chunk() -> None:
+    """/chat/completions: the same failure adapts to an OpenAI-shaped error chunk.
+
+    Mirrors NAT's chat serializer (``result_stream(to_type=ChatResponseChunk)`` -> converter).
+    """
+    responses = [response async for response in _otel_wrapped_failing_stream()]
+    frames = [
+        GlobalTypeConverter.convert(response, to_type=ChatResponseChunk).get_stream_data()
+        for response in responses
+    ]
+
+    assert frames, "expected converted frames"
+    error = json.loads(frames[-1][len("data: ") :])
+    assert error["object"] == "chat.completion.chunk"
+    assert error["choices"] == []
+    assert error["error"] == {
+        "message": "tool timed out",
+        "type": "workflow_error",
+        "code": "RUN_ERROR",
+    }
+    # OpenAI-adapted frame, not a raw AG-UI RUN_ERROR event (which would carry an ``events`` list).
+    assert "events" not in error
+
+
+async def test_chat_completions_non_streaming_failure_raises_through_type_converter() -> None:
+    """Non-streaming /chat/completions: the aggregated RUN_ERROR raises through NAT's
+    ``GlobalTypeConverter`` (``to_type=ChatResponse``), which the route returns as HTTP 422,
+    not a swallowed empty-success.
+    """
+    responses = [response async for response in _otel_wrapped_failing_stream()]
+    aggregated = DRAgentEventResponse(
+        events=[event for response in responses for event in response.events],
+    )
+
+    with pytest.raises(RuntimeError, match="tool timed out"):
+        GlobalTypeConverter.convert(aggregated, to_type=ChatResponse)

--- a/tests/dragent/plugins/test_datarobot_dragent_normalization_stream.py
+++ b/tests/dragent/plugins/test_datarobot_dragent_normalization_stream.py
@@ -14,6 +14,7 @@
 
 import datetime
 from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
 
 import pytest
 from ag_ui.core import RunErrorEvent
@@ -29,11 +30,18 @@ from nat.data_models.api_server import ChoiceDelta
 from nat.data_models.api_server import ChoiceDeltaToolCall
 from nat.data_models.api_server import ChoiceDeltaToolCallFunction
 
+from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.tool_call_registry import bind_tool_call
 from datarobot_genai.dragent.frontends.tool_call_registry import defer_tool_end
 from datarobot_genai.dragent.frontends.tool_call_registry import is_args_done
 from datarobot_genai.dragent.frontends.tool_call_registry import pop_tool_call
 from datarobot_genai.dragent.frontends.tool_call_registry import reset as reset_registry
+from datarobot_genai.dragent.plugins.datarobot_dragent_normalization import (
+    DataRobotDRAgentNormalizationConfig,
+)
+from datarobot_genai.dragent.plugins.datarobot_dragent_normalization import (
+    DataRobotDRAgentNormalizationMiddleware,
+)
 from datarobot_genai.dragent.plugins.datarobot_dragent_normalization import (
     convert_chunks_to_agui_events,
 )
@@ -303,7 +311,7 @@ class TestErrorHandling:
         error_events = [e for e in events if isinstance(e, RunErrorEvent)]
         assert len(error_events) == 1
         assert error_events[0].message == "upstream error"
-        assert error_events[0].code == "STREAM_ERROR"
+        assert error_events[0].code == "RUN_ERROR"
 
     @pytest.mark.asyncio
     async def test_aclose_during_stream_does_not_raise(self):
@@ -434,3 +442,39 @@ class TestToolCallRegistry:
         await _collect(convert_chunks_to_agui_events(_async_iter(chunk)))
 
         assert is_args_done("tc-1")
+
+
+class TestPassthroughErrorHandling:
+    """DRAgentEventResponse passthrough (undecorated agents) is framed on failure too."""
+
+    @pytest.mark.asyncio
+    async def test_passthrough_stream_frames_midrun_error_as_run_error(self):
+        # GIVEN an undecorated agent that emits DRAgentEventResponse, opens a text segment,
+        # then raises mid-stream (no @frame_agent_errors decorator to catch it at the source).
+        async def _failing_passthrough(*args, **kwargs):
+            yield DRAgentEventResponse(events=[TextMessageStartEvent(message_id="m1")])
+            yield DRAgentEventResponse(
+                events=[TextMessageContentEvent(message_id="m1", delta="partial")]
+            )
+            raise RuntimeError("agent boom")
+
+        mw = DataRobotDRAgentNormalizationMiddleware(
+            DataRobotDRAgentNormalizationConfig(), MagicMock()
+        )
+
+        # WHEN the passthrough stream is consumed
+        responses = await _collect(
+            mw.function_middleware_stream(
+                MagicMock(), call_next=_failing_passthrough, context=MagicMock()
+            )
+        )
+
+        # THEN the run ends with a terminal RUN_ERROR instead of propagating, and the open text
+        # segment is closed before it so it stays terminal.
+        events = _flat_events(responses)
+        assert isinstance(events[-1], RunErrorEvent)
+        assert events[-1].message == "agent boom"
+        assert events[-1].code == "RUN_ERROR"
+        ends = [e for e in events if isinstance(e, TextMessageEndEvent)]
+        assert ends
+        assert events.index(ends[-1]) < len(events) - 1

--- a/tests/dragent/plugins/test_datarobot_moderation_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_moderation_middleware.py
@@ -36,6 +36,7 @@ from ag_ui.core import AssistantMessage
 from ag_ui.core import EventType
 from ag_ui.core import FunctionCall
 from ag_ui.core import ReasoningMessage
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import RunFinishedEvent
 from ag_ui.core import RunStartedEvent
 from ag_ui.core import StepFinishedEvent
@@ -79,6 +80,9 @@ from openai.types.chat.chat_completion_chunk import (
 from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.core.agents.verify import validate_sequence
 from datarobot_genai.dragent.constants import DRAGENT_CONFIG_FILE_ENV
+from datarobot_genai.dragent.frontends.converters import (
+    convert_dragent_event_response_to_chat_response_chunk,
+)
 from datarobot_genai.dragent.frontends.request import DRAgentRunAgentInput
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.plugins.datarobot_dragent_normalization import (
@@ -129,6 +133,9 @@ from datarobot_genai.dragent.plugins.datarobot_moderation_middleware import (
 )
 from datarobot_genai.dragent.plugins.datarobot_moderation_middleware import (
     workflow_input_to_completion_dict,
+)
+from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import (
+    DataRobotOtelConventionsMiddleware,
 )
 
 
@@ -2314,6 +2321,44 @@ async def test_function_middleware_stream_echoes_single_text_chunk(builder_mock:
     assert any(ev.type == EventType.TEXT_MESSAGE_END for resp in chunks for ev in resp.events)
 
 
+async def test_function_middleware_stream_clears_invoke_state_in_setting_context(
+    builder_mock: MagicMock,
+) -> None:
+    """Invoke state is cleared at read time, in the context that set it, not at teardown.
+
+    The reset token is only valid in the context that ran ``.set()`` (pre_invoke). Deferring the
+    reset to the async-generator ``finally`` runs it in a different context and raises
+    ``Token created in a different Context``; clearing here keeps set and reset colocated.
+    """
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hi"))
+
+    async def upstream():
+        yield _text_response("delta-one")
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        gen = mw.function_middleware_stream(
+            _make_run_input("hi"),
+            call_next=stream_next,
+            context=_fn_context(),
+        )
+        try:
+            # Drive one step: prescore sets the invoke state, then it is read + cleared in-context.
+            # The set leaks into this caller context, so we can observe the clear directly.
+            await gen.__anext__()
+            assert _moderation_invoke_state_ctx.get() is None
+        finally:
+            await gen.aclose()
+
+
 async def test_function_middleware_stream_synthesizes_text_message_end_on_content_filter(
     builder_mock: MagicMock,
 ) -> None:
@@ -2363,6 +2408,77 @@ async def test_function_middleware_stream_synthesizes_text_message_end_on_conten
             DRAgentEventResponse(events=flat, usage_metrics=zero)
         )
         == blocked_text
+    )
+
+
+async def _content_filter_empty_block_stream(completion: Any, **kwargs: Any) -> Any:
+    """Drain the source (drives peek-ahead buffering), then block with an empty message.
+
+    Mirrors a block whose message is empty (the schema default): the terminal content_filter
+    chunk carries no delta, so it converts to no AG-UI events and the in-loop drain is skipped.
+    """
+    async for _ in completion:
+        pass
+    yield ChatCompletionChunk(
+        id="blocked",
+        choices=[
+            OpenAIChunkChoice(index=0, delta=OpenAIChoiceDelta(), finish_reason="content_filter")
+        ],
+        created=1,
+        model="m",
+        object="chat.completion.chunk",
+    )
+
+
+async def test_function_middleware_stream_content_filter_does_not_mask_run_error(
+    builder_mock: MagicMock,
+) -> None:
+    """An empty content_filter block must not silently drop an agent RUN_ERROR buffered mid-stream.
+
+    The block's early break skips the final drain; without surfacing the buffered RUN_ERROR the
+    real failure would be masked as an (empty) block.
+    """
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    moderation.stream_response_async = _content_filter_empty_block_stream
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hi"))
+    zero = default_usage_metrics()
+
+    async def upstream():
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id="m", role="assistant")],
+            usage_metrics=zero,
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id="m", delta="partial")],
+            usage_metrics=zero,
+        )
+        # Agent errors after producing text; framing emits a terminal RUN_ERROR (buffered).
+        yield DRAgentEventResponse(
+            events=[RunErrorEvent(message="tool timed out", code="RUN_ERROR")],
+            usage_metrics=zero,
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        chunks = [
+            item
+            async for item in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in chunks for ev in resp.events]
+    assert any(isinstance(ev, RunErrorEvent) and ev.message == "tool timed out" for ev in flat), (
+        f"content_filter break dropped the buffered RUN_ERROR: {[e.type for e in flat]}"
     )
 
 
@@ -2895,3 +3011,365 @@ def test_streaming_text_events_from_openai_chunk_ignores_non_text_source_event()
 
     assert len(events) == 1
     assert events[0].message_id != "start-msg"
+
+
+async def test_function_middleware_invoke_prescore_failure_returns_run_error(
+    builder_mock: MagicMock,
+) -> None:
+    """Prescore failures return a terminal RUN_ERROR before ``call_next`` (converters adapt it)."""
+    pipeline = _pipeline_mock()
+    moderation = _moderation_mock(pipeline)
+    moderation.evaluate_prompt_async.side_effect = RuntimeError("dome prescore boom")
+
+    call_next = AsyncMock()
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        output = await mw.function_middleware_invoke(
+            _make_run_input("hello"),
+            call_next=call_next,
+            context=_fn_context(),
+        )
+
+    assert len(output.events) == 1
+    assert output.events[0].type == EventType.RUN_ERROR
+    assert output.events[0].code == "RUN_ERROR"
+    assert "Moderation failed:" in output.events[0].message
+    assert "boom" in output.events[0].message
+    call_next.assert_not_awaited()
+    assert _moderation_invoke_state_ctx.get() is None
+
+
+async def test_function_middleware_invoke_postscore_failure_returns_run_error(
+    builder_mock: MagicMock,
+) -> None:
+    """Postscore failures return a terminal RUN_ERROR (converters adapt it)."""
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    pipeline.get_postscore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hello"))
+    moderation.evaluate_response_async.side_effect = RuntimeError("dome postscore boom")
+
+    call_next = AsyncMock(return_value=_text_response("un-moderated agent text"))
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        output = await mw.function_middleware_invoke(
+            _make_run_input("hello"),
+            call_next=call_next,
+            context=_fn_context(),
+        )
+
+    assert len(output.events) == 1
+    assert output.events[0].type == EventType.RUN_ERROR
+    assert output.events[0].code == "RUN_ERROR"
+    assert "Moderation failed:" in output.events[0].message
+    assert "boom" in output.events[0].message
+    call_next.assert_awaited_once()
+    assert _moderation_invoke_state_ctx.get() is None
+
+
+async def test_function_middleware_stream_prescore_failure_yields_run_error(
+    builder_mock: MagicMock,
+) -> None:
+    """Streaming prescore failures end the stream with a terminal RUN_ERROR, not an exception.
+
+    Prescore runs before the agent starts; raising here would reach clients as NAT's unframed
+    error, so the streaming path ends in-band with a RUN_ERROR (symmetric with mid-stream).
+    """
+    pipeline = _pipeline_mock()
+    moderation = _moderation_mock(pipeline)
+    moderation.evaluate_prompt_async.side_effect = RuntimeError("dome prescore boom")
+
+    stream_next = MagicMock()
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    assert len(responses) == 1
+    terminal = responses[-1]
+    assert len(terminal.events) == 1
+    assert terminal.events[0].type == EventType.RUN_ERROR
+    assert terminal.events[0].code == "RUN_ERROR"
+    assert "Moderation failed:" in terminal.events[0].message
+    assert "boom" in terminal.events[0].message
+    stream_next.assert_not_called()  # agent never starts when prescore fails
+    assert _moderation_invoke_state_ctx.get() is None
+
+
+async def test_function_middleware_stream_moderation_failure_yields_run_error(
+    builder_mock: MagicMock,
+) -> None:
+    """Mid-stream moderation failures end the stream with a terminal RUN_ERROR, not an exception."""
+    pipeline = _pipeline_mock()
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hello"))
+
+    async def _raising_stream_response_async(completion: Any, **kwargs: Any) -> Any:
+        if False:  # pragma: no cover - marks this an async generator
+            yield
+        raise RuntimeError("dome streaming boom")
+
+    moderation.stream_response_async = _raising_stream_response_async
+
+    async def upstream() -> Any:
+        yield _text_response("partial answer")
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with (
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+            return_value=moderation,
+        ),
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware."
+            "build_moderations_attribute_for_completion",
+            return_value={},
+        ),
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    terminal = responses[-1]
+    assert len(terminal.events) == 1
+    assert terminal.events[0].type == EventType.RUN_ERROR
+    assert terminal.events[0].message == "dome streaming boom"
+    assert terminal.events[0].code == "RUN_ERROR"
+
+
+async def test_function_middleware_stream_run_error_terminal_with_second_open_message(
+    builder_mock: MagicMock,
+) -> None:
+    """RUN_ERROR stays terminal when a second text message is opened, then the run fails.
+
+    The failure tail (a bare TEXT_MESSAGE_START for the next segment, its close, and the
+    RUN_ERROR) is buffered in one drain batch. The reorder must not place the deferred START
+    after the terminal RUN_ERROR.
+    """
+    pipeline = _pipeline_mock()
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hello"))
+
+    async def _passthrough_stream_response_async(completion: Any, **kwargs: Any) -> Any:
+        async for chunk in completion:
+            yield chunk
+
+    moderation.stream_response_async = _passthrough_stream_response_async
+
+    async def upstream() -> Any:
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id="msg-1")],
+            usage_metrics=default_usage_metrics(),
+        )
+        yield _text_response("partial answer")
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id="msg-1")],
+            usage_metrics=default_usage_metrics(),
+        )
+        # A second segment is opened then closed by the framing layer as it fails.
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id="msg-2")],
+            usage_metrics=default_usage_metrics(),
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id="msg-2")],
+            usage_metrics=default_usage_metrics(),
+        )
+        yield DRAgentEventResponse(
+            events=[RunErrorEvent(message="tool timed out", code="RUN_ERROR")],
+            usage_metrics=default_usage_metrics(),
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with (
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+            return_value=moderation,
+        ),
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware."
+            "build_moderations_attribute_for_completion",
+            return_value={},
+        ),
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in responses for ev in resp.events]
+    event_types = [ev.type for ev in flat]
+    # RUN_ERROR is terminal: last event, and the second segment's START/END land before it
+    # (the reorder must not push a deferred START past the terminal error).
+    assert event_types[-1] == EventType.RUN_ERROR, event_types
+    assert event_types.count(EventType.RUN_ERROR) == 1, event_types
+    run_error_idx = event_types.index(EventType.RUN_ERROR)
+    assert all(t != EventType.RUN_ERROR for t in event_types[:run_error_idx])
+    second_starts = [i for i, ev in enumerate(flat) if getattr(ev, "message_id", None) == "msg-2"]
+    assert second_starts and max(second_starts) < run_error_idx, event_types
+
+
+async def test_real_chain_moderation_over_otel_failing_agent_run_error_terminal(
+    builder_mock: MagicMock,
+) -> None:
+    """Stacked real chain: moderation (prescore active) -> real otel -> a failing agent.
+
+    Uses the real otel middleware as moderation's ``call_next`` (not a mocked upstream), so the
+    production order (moderation outer, otel inner) is exercised end to end. Asserts RUN_ERROR stays
+    terminal on both routes: AG-UI event order for ``/generate/stream`` and the OpenAI error chunk
+    for ``/chat/completions``. Only dome is mocked.
+    """
+    pipeline = _pipeline_mock()
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hello"))
+
+    async def _passthrough_stream_response_async(completion: Any, **kwargs: Any) -> Any:
+        async for chunk in completion:
+            yield chunk
+
+    moderation.stream_response_async = _passthrough_stream_response_async
+
+    async def failing_agent(*args: Any, **kwargs: Any) -> Any:
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id="m1")],
+            usage_metrics=default_usage_metrics(),
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id="m1", delta="partial")],
+            usage_metrics=default_usage_metrics(),
+        )
+        raise RuntimeError("tool timed out")
+
+    otel = DataRobotOtelConventionsMiddleware(MagicMock(), MagicMock())
+
+    def otel_call_next(*args: Any, **kwargs: Any) -> Any:
+        return otel.function_middleware_stream(
+            *args, call_next=failing_agent, context=_fn_context()
+        )
+
+    with (
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+            return_value=moderation,
+        ),
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware."
+            "build_moderations_attribute_for_completion",
+            return_value={},
+        ),
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=otel_call_next,
+                context=_fn_context(),
+            )
+        ]
+
+    # /generate/stream (AG-UI): the open text segment is closed before a terminal RUN_ERROR.
+    kinds = [type(ev) for resp in responses for ev in resp.events]
+    assert kinds[-1] is RunErrorEvent, kinds
+    assert TextMessageEndEvent in kinds
+    assert kinds.index(TextMessageEndEvent) < kinds.index(RunErrorEvent)
+
+    # /chat/completions (OpenAI): the terminal chunk is the error chunk with empty choices.
+    chunks = [convert_dragent_event_response_to_chat_response_chunk(r) for r in responses]
+    assert chunks[-1].choices == []
+    assert getattr(chunks[-1], "error", None) == {
+        "message": "tool timed out",
+        "type": "workflow_error",
+        "code": "RUN_ERROR",
+    }
+
+
+async def test_function_middleware_stream_run_error_terminal_when_dome_buffers_multichunk(
+    builder_mock: MagicMock,
+) -> None:
+    """A buffered terminal RUN_ERROR stays last even when dome releases >=2 moderated chunks.
+
+    Real dome drains the caller's chunk iterator from its own feed task, so a BLOCK/REPLACE or
+    threshold guard buffers the whole input to EOF (the terminal RUN_ERROR lands in the pending
+    buffer) before releasing the moderated deltas as separate chunks. Regression: the RUN_ERROR
+    must not be emitted mid-stream ahead of the trailing moderated chunks.
+    """
+    pipeline = _pipeline_mock()
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hello"))
+
+    async def _buffer_all_then_emit(completion: Any, **kwargs: Any) -> Any:
+        chunks = [chunk async for chunk in completion]
+        for chunk in chunks:
+            yield chunk
+
+    moderation.stream_response_async = _buffer_all_then_emit
+
+    async def upstream() -> Any:
+        yield _text_response("A")
+        yield _text_response("B")
+        yield DRAgentEventResponse(
+            events=[RunErrorEvent(message="tool timed out", code="RUN_ERROR")],
+            usage_metrics=default_usage_metrics(),
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with (
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+            return_value=moderation,
+        ),
+        patch(
+            "datarobot_genai.dragent.plugins.datarobot_moderation_middleware."
+            "build_moderations_attribute_for_completion",
+            return_value={},
+        ),
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hello"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    event_types = [ev.type for resp in responses for ev in resp.events]
+    # Both moderated text chunks are delivered, and the RUN_ERROR is the single terminal event.
+    assert event_types.count(EventType.TEXT_MESSAGE_CONTENT) == 2, event_types
+    assert event_types.count(EventType.RUN_ERROR) == 1, event_types
+    assert event_types[-1] == EventType.RUN_ERROR, event_types

--- a/tests/dragent/plugins/test_datarobot_moderation_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_moderation_middleware.py
@@ -3239,6 +3239,22 @@ async def test_function_middleware_stream_run_error_terminal_with_second_open_me
     assert all(t != EventType.RUN_ERROR for t in event_types[:run_error_idx])
     second_starts = [i for i, ev in enumerate(flat) if getattr(ev, "message_id", None) == "msg-2"]
     assert second_starts and max(second_starts) < run_error_idx, event_types
+    # The second segment's own lifecycle must be well-formed: exactly one START before exactly one
+    # END (the reorder must not hoist its END ahead of its START or synthesize a duplicate END).
+    m2_starts = [
+        i
+        for i, ev in enumerate(flat)
+        if ev.type == EventType.TEXT_MESSAGE_START and getattr(ev, "message_id", None) == "msg-2"
+    ]
+    m2_ends = [
+        i
+        for i, ev in enumerate(flat)
+        if ev.type == EventType.TEXT_MESSAGE_END and getattr(ev, "message_id", None) == "msg-2"
+    ]
+    assert len(m2_starts) == 1 and len(m2_ends) == 1, event_types
+    assert m2_starts[0] < m2_ends[0], event_types
+    # Whole AG-UI lifecycle stays valid (RUN_STARTED prepended to mirror the real stream framing).
+    validate_sequence([RunStartedEvent(thread_id="t", run_id="r"), *flat])
 
 
 async def test_real_chain_moderation_over_otel_failing_agent_run_error_terminal(

--- a/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
@@ -30,9 +30,11 @@ from unittest.mock import MagicMock
 import pytest
 from ag_ui.core import AssistantMessage
 from ag_ui.core import RunAgentInput
+from ag_ui.core import RunErrorEvent
 from ag_ui.core import StepStartedEvent
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
+from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import UserMessage
 from nat.data_models.api_server import ChatRequestOrMessage
@@ -41,10 +43,12 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 import datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware as mod
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import AGENT_SPAN_NAME
+from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import ERROR_TYPE
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import GEN_AI_COMPLETION
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import GEN_AI_PROMPT
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import TOOL_NAME
@@ -341,6 +345,89 @@ async def test_stream_aggregates_completion_across_chunks(
     span = _span_named(span_exporter, AGENT_SPAN_NAME)
     assert span.attributes[GEN_AI_PROMPT] == "greet me"
     assert span.attributes[GEN_AI_COMPLETION] == "Hello"
+
+
+async def test_stream_marks_span_error_on_run_error_event(
+    middleware: DataRobotOtelConventionsMiddleware,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """``RUN_ERROR`` chunks mark the span ERROR."""
+    chunks = [
+        DRAgentEventResponse(events=[TextMessageContentEvent(message_id="m1", delta="partial")]),
+        DRAgentEventResponse(events=[RunErrorEvent(message="boom", code="RUN_ERROR")]),
+    ]
+
+    yielded = await _drain(
+        middleware.function_middleware_stream(
+            _nat_input("hi"),
+            call_next=_call_next_stream(chunks),
+            context=MagicMock(),
+        )
+    )
+
+    assert yielded == chunks
+    span = _span_named(span_exporter, AGENT_SPAN_NAME)
+    assert span.status.status_code == StatusCode.ERROR
+    assert "boom" in (span.status.description or "")
+    assert span.attributes[ERROR_TYPE] == "RUN_ERROR"
+
+
+async def test_stream_failure_yields_terminal_run_error(
+    middleware: DataRobotOtelConventionsMiddleware,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """A mid-stream agent failure ends the run with a terminal RUN_ERROR, not a raised exception."""
+
+    async def _failing_call_next(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id="m1", delta="partial")]
+        )
+        raise RuntimeError("tool timed out")
+
+    yielded = await _drain(
+        middleware.function_middleware_stream(
+            _nat_input("hi"),
+            call_next=_failing_call_next,
+            context=MagicMock(),
+        )
+    )
+
+    terminal = yielded[-1]
+    assert isinstance(terminal, DRAgentEventResponse)
+    assert len(terminal.events) == 1
+    assert isinstance(terminal.events[0], RunErrorEvent)
+    assert terminal.events[0].message == "tool timed out"
+    assert terminal.events[0].code == "RUN_ERROR"
+
+    # The open text segment (m1) is closed before the terminal RUN_ERROR so it stays last.
+    kinds = [type(ev) for resp in yielded for ev in resp.events]
+    assert kinds[-1] is RunErrorEvent
+    assert TextMessageEndEvent in kinds
+    assert kinds.index(TextMessageEndEvent) < kinds.index(RunErrorEvent)
+
+    span = _span_named(span_exporter, AGENT_SPAN_NAME)
+    assert span.status.status_code == StatusCode.ERROR
+    assert "tool timed out" in (span.status.description or "")
+    assert span.attributes[ERROR_TYPE] == "RUN_ERROR"
+
+
+async def test_invoke_marks_span_error_on_run_error_event(
+    middleware: DataRobotOtelConventionsMiddleware,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Aggregated ``RUN_ERROR`` output marks the span ERROR."""
+    response = DRAgentEventResponse(events=[RunErrorEvent(message="kaboom", code="RUN_ERROR")])
+
+    await middleware.function_middleware_invoke(
+        _nat_input("hi"),
+        call_next=_call_next(response),
+        context=MagicMock(),
+    )
+
+    span = _span_named(span_exporter, AGENT_SPAN_NAME)
+    assert span.status.status_code == StatusCode.ERROR
+    assert "kaboom" in (span.status.description or "")
+    assert span.attributes[ERROR_TYPE] == "RUN_ERROR"
 
 
 async def test_stream_sets_completion_when_closed_early_after_text(

--- a/tests/dragent/plugins/test_streaming_memory_agent.py
+++ b/tests/dragent/plugins/test_streaming_memory_agent.py
@@ -25,6 +25,7 @@ from ag_ui.core import RunAgentInput
 from ag_ui.core import SystemMessage as AgUiSystemMessage
 from ag_ui.core import UserMessage as AgUiUserMessage
 from ag_ui.core.events import EventType
+from ag_ui.core.events import RunErrorEvent
 from ag_ui.core.events import TextMessageContentEvent
 from nat.data_models.agent import AgentBaseConfig
 from nat.data_models.component_ref import FunctionRef
@@ -528,6 +529,30 @@ class TestStreamFnSavesUserMessage:
 
         assert out  # streaming still happened
         assert any("memory.add_items(user) failed" in rec.message for rec in caplog.records)
+
+    async def test_saves_partial_assistant_text_when_run_errors(self, context_user_id):
+        # Inner agent streams partial text, then frames a mid-run failure as a terminal RUN_ERROR.
+        config = _make_config(memory_name="mem0", save_user_messages_to_memory=False)
+        memory_editor = AsyncMock()
+        memory_editor.search.return_value = []
+        chunks = [
+            _chunk("partial answer"),
+            DRAgentEventResponse(events=[RunErrorEvent(message="boom", code="RUN_ERROR")]),
+        ]
+        builder = _make_builder(memory_editor=memory_editor, inner_agent_chunks=chunks)
+
+        async with streaming_memory_agent(config, builder) as fn_info:
+            # Must not raise even though the aggregated events carry a terminal RUN_ERROR.
+            out = await _drain(fn_info.stream_fn(_input(_user("hi"))))
+
+        assert out  # the stream (including the RUN_ERROR) still passed through
+        # Partial assistant text is still persisted: extraction must not raise on RUN_ERROR.
+        assistant_saves = [
+            call.args[0][0].conversation
+            for call in memory_editor.add_items.await_args_list
+            if call.args[0][0].conversation[0]["role"] == "assistant"
+        ]
+        assert assistant_saves == [[{"role": "assistant", "content": "partial answer"}]]
 
 
 class TestStreamFnRetrievesMemory:

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -1141,3 +1141,38 @@ async def test_stream_reasoning_content_kwarg_emits_reasoning_chunks(run_agent_i
 
     text_deltas = [e.delta for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT]
     assert text_deltas == ["answer"]
+
+
+class AbortingLangGraphAgent(SimpleLangGraphAgent):
+    """LangGraph agent whose graph stream opens a text message then fails mid-run."""
+
+    @cached_property
+    def workflow(self) -> Any:
+        async def mock_stream_generator():  # type: ignore[no-untyped-def]
+            yield (
+                "final_agent",
+                "messages",
+                (AIMessageChunk(content="half a thought", id="222"), {}),
+            )
+            raise ValueError("boom")
+
+        mock_graph_stream = Mock(astream=Mock(return_value=mock_stream_generator()))
+        return Mock(compile=Mock(return_value=mock_graph_stream))
+
+
+async def test_langgraph_invoke_frames_midstream_error_as_run_error(
+    run_agent_input: RunAgentInput,
+) -> None:
+    # GIVEN a graph that opens a text message then raises mid-stream
+    agent = AbortingLangGraphAgent()
+
+    # WHEN the agent is invoked
+    events = [e[0] async for e in agent.invoke(run_agent_input)]
+
+    # THEN the run ends with a terminal RUN_ERROR instead of raising
+    assert events[-1].type == EventType.RUN_ERROR
+    assert "boom" in events[-1].message
+    # AND any opened text segment was closed before the error
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    assert len(starts) == len(ends)

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.12"
+version = "0.26.13"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.13"
+version = "0.26.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Rationale

A mid-run failure surfaced as NAT's bare unframed `workflow_error` JSON, which `data:`-only SSE clients (and our tests) silently drop - so a failed run looked successful. Frame failures as a terminal AG-UI `RUN_ERROR`.

## Changes

Catch in three layers, each emitting a terminal `RUN_ERROR`; `converters` adapt per route (no NAT monkeypatch, no type inference in the middleware).

- **Agent `invoke`** (langgraph/crewai/llama_index): a mid-run exception closes open text and yields a terminal `RUN_ERROR` at the source.
- **otel middleware**: same for stream failures; marks the agent OTel span `ERROR`.
- **moderation middleware**: guard failures raise (non-streaming → HTTP 422) or yield `RUN_ERROR` (streaming); a `content_filter` block no longer masks a buffered `RUN_ERROR`; ContextVar teardown fix.
- **converters** (adapter): `/chat/completions` streaming → OpenAI error chunk, non-streaming → raise → 422; `/generate/stream` serializes `RUN_ERROR` natively.

A2A/console error surfacing is tracked separately.
