### PR TITLE
[MODEL-22424][MODEL-23787] Add tool sets MongoDB persistence and migration foundation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,8 +44,19 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       SESSION_SECRET_KEY: acceptance-test-secret
+      MONGO_URI: mongodb://localhost:27017
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ override-dependencies = [
   "PyJWT>=2.13.0",
   "litellm>=1.91.1,<2.0.0",
   "ragas>=0.4.3,<0.5.0",
+  # dr-msf (all stable releases) pins uvicorn<0.30.0 and rich<13.0.0.
+  # These overrides force the versions the rest of the stack requires.
+  # Remove once dr-msf relaxes its upper bounds.
+  "uvicorn>=0.38,<1.0.0",
+  "rich>=13.0.0,<16.0.0",
   # Align the whole OpenTelemetry stack at the latest release train (core 1.43.x /
   # instrumentation 0.64b0) so the traceloop instrumentors (crewai/langchain/llamaindex
   # 0.62.1) resolve. These overrides force the family to stay version-synchronized
@@ -102,6 +107,20 @@ exclude-dependencies = [
   # nemo-evaluator-launcher bloat
   "leptonai",                 # Lepton AI cloud backend pulled in by nemo-evaluator-launcher; not used, pins httpx==0.27.2 which conflicts with auth extra
 ]
+
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+
+[[tool.uv.index]]
+name = "dr-artifactory"
+url = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple"
+explicit = true
+
+[tool.uv.sources]
+dr-msf = { index = "dr-artifactory" }
+dr-mongo-migrations = { index = "dr-artifactory" }
 
 [dependency-groups]
 dev = [

--- a/sbin/drmcp-migrate-db
+++ b/sbin/drmcp-migrate-db
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Migration runner for the MCP server.
+#
+# Delegates to the Python migration module which resolves configuration via
+# DRMcpServiceConfig.
+#
+# Prerequisites
+# -----------
+# dr-msf and dr-mongo-migrations are resolved from DataRobot Artifactory via
+# pyproject.toml ([[tool.uv.index]] dr-artifactory). Install with:
+#
+#   uv sync --extra drmcp
+#
+# Usage:
+#   MONGO_URI=mongodb://localhost:27017/drmcp sbin/drmcp-migrate-db
+#   MONGO_URI=mongodb://localhost:27017/drmcp sbin/drmcp-migrate-db list
+#   MONGO_URI=mongodb://localhost:27017/drmcp sbin/drmcp-migrate-db latest
+
+set -e
+cd "$(dirname "$0")/.."
+exec uv run python -m datarobot_genai.drmcp.migrations "$@"

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,10 @@ drmcp = drmcpbase + drtools + [
     "opentelemetry-exporter-otlp>=1.43.0,<2.0.0",
     "opentelemetry-exporter-otlp-proto-http>=1.43.0,<2.0.0",
     "async-lru>=2.3.0",
+    "motor>=3.7.0,<4.0.0",
+    "pymongo>=4.10.0,<5.0.0",
+    "dr-msf>=3.0.0,<4.0.0",
+    "dr-mongo-migrations>=0.2.3,<1.0.0",
 ]
 
 extras_require = {

--- a/src/datarobot_genai/drmcp/core/tool_sets/__init__.py
+++ b/src/datarobot_genai/drmcp/core/tool_sets/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool Sets domain package."""
+
+from datarobot_genai.drmcp.core.tool_sets.exceptions import ToolSetNameConflictError
+from datarobot_genai.drmcp.core.tool_sets.exceptions import ToolSetNotFoundError
+from datarobot_genai.drmcp.core.tool_sets.models import ToolEntry
+from datarobot_genai.drmcp.core.tool_sets.models import ToolSet
+
+__all__ = [
+    "ToolEntry",
+    "ToolSet",
+    "ToolSetNameConflictError",
+    "ToolSetNotFoundError",
+]

--- a/src/datarobot_genai/drmcp/core/tool_sets/exceptions.py
+++ b/src/datarobot_genai/drmcp/core/tool_sets/exceptions.py
@@ -1,0 +1,23 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tool Set domain exceptions."""
+
+
+class ToolSetNotFoundError(Exception):
+    """Raised when a Tool Set with the requested ID or name does not exist."""
+
+
+class ToolSetNameConflictError(Exception):
+    """Raised when a Tool Set with the same (created_by, name) already exists."""

--- a/src/datarobot_genai/drmcp/core/tool_sets/models.py
+++ b/src/datarobot_genai/drmcp/core/tool_sets/models.py
@@ -1,0 +1,61 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain models for Tool Sets persisted in MongoDB.
+
+Data model
+----------
+ToolSet
+    A named, user-owned collection of tool references.
+ToolEntry
+    A single tool reference: ``{name, version}``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from msf.databases.mongodb.entity import MongoEntity
+from msf.dataclasses import DataClass
+from msf.dataclasses.fields import ObjectId
+from pydantic import Field
+from pydantic import field_validator
+
+
+class ToolEntry(DataClass):
+    """A single tool reference within a Tool Set."""
+
+    name: str
+    version: str | None = None
+
+
+class ToolSet(MongoEntity):
+    """A user-owned, named collection of tool references persisted in MongoDB."""
+
+    __collection__ = "tool_sets"
+
+    name: str
+    description: str | None = None
+    tools: list[ToolEntry] = Field(min_length=1)
+    created_by: ObjectId
+    created_at: datetime
+
+    @field_validator("tools")
+    @classmethod
+    def tools_are_unique_and_sorted_by_name(cls, tools: list[ToolEntry]) -> list[ToolEntry]:
+        """Deduplicate by tool name and sort alphabetically."""
+        tools_by_name: dict[str, ToolEntry] = {}
+        for tool in sorted(tools, key=lambda entry: entry.name):
+            tools_by_name.setdefault(tool.name, tool)
+        return list(tools_by_name.values())

--- a/src/datarobot_genai/drmcp/core/tool_sets/tool_sets_repo.py
+++ b/src/datarobot_genai/drmcp/core/tool_sets/tool_sets_repo.py
@@ -1,0 +1,57 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MongoDB repository for Tool Sets."""
+
+from __future__ import annotations
+
+import logging
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from msf.databases.mongodb.repository import MongoRepository
+from msf.types import DictStrAny
+from pymongo import ASCENDING
+from pymongo import IndexModel
+
+from datarobot_genai.drmcp.core.tool_sets.models import ToolSet
+
+logger = logging.getLogger(__name__)
+
+
+def tool_set_index_models() -> list[IndexModel]:
+    """Index definitions for the ``tool_sets`` collection."""
+    return [
+        IndexModel(
+            [("created_by", ASCENDING), ("name", ASCENDING)],
+            unique=True,
+            name="tool_sets_owner_name_unique",
+        ),
+        IndexModel(
+            [("created_by", ASCENDING)],
+            name="tool_sets_by_owner",
+        ),
+    ]
+
+
+class ToolSetRepository(MongoRepository[ToolSet]):
+    """Data access layer for Tool Sets persisted in MongoDB."""
+
+    @classmethod
+    def new(cls, db: AsyncIOMotorDatabase[DictStrAny]) -> ToolSetRepository:
+        return cls(ToolSet, db)
+
+    async def create_indexes(self) -> None:
+        """Create indexes on the tool sets collection (idempotent)."""
+        await self._collection.create_indexes(tool_set_index_models())  # noqa: MSF001
+        logger.info("Indexes ensured on collection '%s'", ToolSet.__collection__)

--- a/src/datarobot_genai/drmcp/db_migrations/__init__.py
+++ b/src/datarobot_genai/drmcp/db_migrations/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/datarobot_genai/drmcp/db_migrations/migration_20260722120000_create_tool_sets.py
+++ b/src/datarobot_genai/drmcp/db_migrations/migration_20260722120000_create_tool_sets.py
@@ -1,0 +1,85 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Migration: create_tool_sets.
+
+Created: 2026-07-22 12:00:00
+
+Background/Rationale
+====================
+Tool Sets are user-owned, named collections of MCP tool references persisted
+in a dedicated MongoDB database owned by the MCP server.
+
+What the migration does
+-----------------------
+Creates the ``tool_sets`` collection and its two indexes:
+
+- ``tool_sets_owner_name_unique`` — unique compound index on
+  ``(created_by, name)``, enforcing that a user cannot create two tool sets
+  with the same name.
+- ``tool_sets_by_owner`` — single-field index on ``created_by`` for
+  efficient per-user list queries.
+
+Rollback
+--------
+Drops the entire ``tool_sets`` collection.
+
+Expected runtime and performance considerations
+-----------------------------------------------
+Collection and index creation on an empty database is near-instant.
+"""
+
+import logging
+from typing import Any
+
+from dr_mongo_migrations.analysis import CollectionAnalysis
+from dr_mongo_migrations.analysis import MigrationAnalysis
+from pymongo.database import Database
+
+from datarobot_genai.drmcp.core.tool_sets import ToolSet
+from datarobot_genai.drmcp.core.tool_sets.tool_sets_repo import tool_set_index_models
+
+logger = logging.getLogger(__name__)
+
+
+def analyze(db: Database[Any]) -> MigrationAnalysis:
+    """Report the current state of the ``tool_sets`` collection."""
+    analysis = MigrationAnalysis(migration_name=__name__, collections_impacted=[])
+    analysis.collections_impacted.append(
+        CollectionAnalysis(
+            db_name=db.name,
+            collection_name=ToolSet.__collection__,
+            documents_affected=0,
+            total_documents=db[ToolSet.__collection__].estimated_document_count()
+            if ToolSet.__collection__ in db.list_collection_names()
+            else 0,
+        )
+    )
+    return analysis
+
+
+def run(db: Database[Any]) -> bool:
+    """Create the ``tool_sets`` collection and its indexes."""
+    logger.info("Applying migration: create %s", ToolSet.__collection__)
+    db[ToolSet.__collection__].create_indexes(tool_set_index_models())
+    logger.info("Collection '%s' and indexes created", ToolSet.__collection__)
+    return True
+
+
+def rollback(db: Database[Any]) -> bool:
+    """Drop the ``tool_sets`` collection."""
+    logger.info("Rolling back migration: dropping %s", ToolSet.__collection__)
+    db.drop_collection(ToolSet.__collection__)
+    logger.info("Collection '%s' dropped", ToolSet.__collection__)
+    return True

--- a/src/datarobot_genai/drmcp/migrations/__init__.py
+++ b/src/datarobot_genai/drmcp/migrations/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/datarobot_genai/drmcp/migrations/__main__.py
+++ b/src/datarobot_genai/drmcp/migrations/__main__.py
@@ -1,0 +1,66 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Migration runner entry point for the MCP server.
+
+Invoke via ``sbin/drmcp-migrate-db`` (which delegates here) or directly:
+
+    uv run python -m datarobot_genai.drmcp.migrations          # apply pending migrations
+    uv run python -m datarobot_genai.drmcp.migrations list     # list migrations
+    uv run python -m datarobot_genai.drmcp.migrations latest   # show latest applied
+
+Configuration is resolved via ``DRMcpServiceConfig``.
+See ``drmcp/platform/mongo_config.py`` and ``sbin/drmcp-migrate-db`` for prerequisites.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+from dr_mongo_migrations.cli import cli
+
+from datarobot_genai.drmcp.platform.mongo_config import DRMcpServiceConfig
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Resolve MSF configuration and delegate to the dr-mongo-migrations CLI."""
+    config = DRMcpServiceConfig()
+    mongo_uri = config.mongo.mongo_uri.get_secret_value().strip()
+    if not mongo_uri:
+        sys.exit("MONGO_URI environment variable is required")
+
+    db_name = config.database_name
+    migrations_dir = Path(__file__).resolve().parent.parent / "db_migrations"
+
+    logger.info("Running migrations (db=%s, dir=%s)", db_name, migrations_dir)
+
+    args = (
+        "--migrations-dir",
+        str(migrations_dir),
+        "--mongo-uri",
+        mongo_uri,
+        "--migration-db",
+        db_name,
+        "--db-name",
+        db_name,
+        *sys.argv[1:],
+    )
+    sys.exit(cli(args))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/src/datarobot_genai/drmcp/platform/__init__.py
+++ b/src/datarobot_genai/drmcp/platform/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/datarobot_genai/drmcp/platform/__service__.py
+++ b/src/datarobot_genai/drmcp/platform/__service__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Service metadata for MSF configuration namespacing."""
+
+__service__ = "drmcp"

--- a/src/datarobot_genai/drmcp/platform/mongo_config.py
+++ b/src/datarobot_genai/drmcp/platform/mongo_config.py
@@ -1,0 +1,49 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MSF service configuration for MongoDB."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from msf.config import ServiceConfig
+from msf.databases.mongodb.connection import MongodbConfig
+from pydantic import Field
+
+from datarobot_genai.drmcp.platform.__service__ import __service__
+
+
+class DRMcpMongoConfig(MongodbConfig):
+    """MongoDB connection settings for the MCP server."""
+
+    transactions_enabled: bool = Field(default=False, env="MONGO_TRANSACTIONS_ENABLED")
+
+
+class DRMcpServiceConfig(ServiceConfig):
+    """Declarative MSF config for drmcp MongoDB access and migrations."""
+
+    mongo: DRMcpMongoConfig = Field(default_factory=DRMcpMongoConfig, no_nesting=True)
+
+    class Config:
+        namespace = __service__
+        secrets_dir = "/var/run/drmcp"
+
+    @property
+    def database_name(self) -> str:
+        """Resolve the logical database name from ``MONGO_URI`` or MSF fallback."""
+        uri_path = urlparse(self.mongo.mongo_uri.get_secret_value()).path.lstrip("/")
+        if uri_path:
+            return uri_path
+        return self.mongo.database_name

--- a/src/datarobot_genai/drmcp/platform/runtime.py
+++ b/src/datarobot_genai/drmcp/platform/runtime.py
@@ -1,0 +1,70 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MSF service runtime for drmcp."""
+
+from __future__ import annotations
+
+from msf.databases.mongodb.connection import AsyncMongodbConnectionProvider
+from msf.runtime import AsyncProviderT
+from msf.runtime import ServiceRuntime
+from msf.runtime import Singleton
+
+from datarobot_genai.drmcp.core.tool_sets.tool_sets_repo import ToolSetRepository
+from datarobot_genai.drmcp.platform.mongo_config import DRMcpServiceConfig
+
+_runtime: Runtime | None = None
+
+
+class Runtime(ServiceRuntime):
+    """Runtime wiring for MongoDB repositories."""
+
+    config: Singleton[DRMcpServiceConfig] = Singleton(DRMcpServiceConfig)
+    database = AsyncMongodbConnectionProvider(config=config.provided.mongo)
+
+    tool_set_repository: AsyncProviderT[ToolSetRepository] = Singleton(
+        ToolSetRepository.new,
+        db=database,
+    )
+
+
+def get_runtime() -> Runtime:
+    """Return the module-level ``Runtime`` singleton."""
+    global _runtime
+    if _runtime is None:
+        _runtime = Runtime()
+    return _runtime
+
+
+def reset_runtime() -> None:
+    """Reset the module-level runtime (for tests and shutdown)."""
+    global _runtime
+    _runtime = None
+
+
+async def close_runtime() -> None:
+    """Close the Motor client and reset the runtime.
+
+    Notebooks MSF services do not define a shared runtime shutdown hook; closing the
+    underlying Motor client is the standard cleanup for async Mongo access.
+    """
+    global _runtime
+    if _runtime is None:
+        return
+
+    try:
+        db = await _runtime.database()
+        db.client.close()
+    finally:
+        _runtime = None

--- a/tests/drmcp/integration/test_migration_create_tool_sets.py
+++ b/tests/drmcp/integration/test_migration_create_tool_sets.py
@@ -1,0 +1,134 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Integration tests for the create_tool_sets migration.
+
+These tests require a real MongoDB instance.  They are marked
+``@pytest.mark.integration`` and are excluded from the default ``task test``
+and ``task drmcp-unit`` runs (which ignore ``tests/drmcp/integration``).
+
+Running locally
+---------------
+    docker run -d --name mongo-drmcp -p 27017:27017 mongo:7
+    export MONGO_URI=mongodb://localhost:27017/drmcp_migration_test
+    uv sync --extra drmcp --dev
+    uv run pytest tests/drmcp/integration/test_migration_create_tool_sets.py -v
+"""
+
+import os
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from msf.dataclasses.fields import ObjectId
+from pymongo import MongoClient
+from pymongo.database import Database
+
+import datarobot_genai.drmcp.db_migrations.migration_20260722120000_create_tool_sets as migration
+from datarobot_genai.drmcp.core.tool_sets import ToolSet
+
+_TEST_DB_NAME = "drmcp_migration_test"
+_COLLECTION = ToolSet.__collection__
+
+
+@pytest.fixture
+def db() -> Generator[Database[Any], None, None]:
+    """Connect to a real MongoDB, drop the test DB before and after each test."""
+    mongo_uri = os.environ.get("MONGO_URI")
+    if not mongo_uri:
+        pytest.skip("MONGO_URI not set — skipping migration integration test")
+
+    client: MongoClient[Any] = MongoClient(mongo_uri)
+    database = client[_TEST_DB_NAME]
+    client.drop_database(_TEST_DB_NAME)
+    yield database
+    client.drop_database(_TEST_DB_NAME)
+    client.close()
+
+
+@pytest.mark.integration
+def test_run_creates_collection(db: Database[Any]) -> None:
+    """GIVEN an empty database, WHEN the migration runs, THEN the collection exists."""
+    migration.run(db)
+    assert _COLLECTION in db.list_collection_names()
+
+
+@pytest.mark.integration
+def test_run_creates_unique_owner_name_index(db: Database[Any]) -> None:
+    """GIVEN a fresh DB, WHEN the migration runs, THEN the owner+name unique index is created."""
+    migration.run(db)
+    index_names = {idx["name"] for idx in db[_COLLECTION].list_indexes()}
+    assert "tool_sets_owner_name_unique" in index_names
+
+
+@pytest.mark.integration
+def test_run_creates_owner_index(db: Database[Any]) -> None:
+    """GIVEN a fresh DB, WHEN the migration runs, THEN the created_by index exists."""
+    migration.run(db)
+    index_names = {idx["name"] for idx in db[_COLLECTION].list_indexes()}
+    assert "tool_sets_by_owner" in index_names
+
+
+@pytest.mark.integration
+def test_unique_index_enforced(db: Database[Any]) -> None:
+    """GIVEN the migration has run, WHEN two docs with the same (created_by, name) are inserted.
+
+    THEN the second insert raises a DuplicateKeyError.
+    """
+    from pymongo.errors import DuplicateKeyError
+
+    migration.run(db)
+    owner_id = ObjectId()
+    doc = {
+        "created_by": owner_id,
+        "name": "my-set",
+        "tools": [{"name": "catalog_list_datasets"}],
+        "created_at": "2026-07-22T12:00:00Z",
+    }
+    db[_COLLECTION].insert_one(doc.copy())
+    with pytest.raises(DuplicateKeyError):
+        db[_COLLECTION].insert_one(doc.copy())
+
+
+@pytest.mark.integration
+def test_run_is_idempotent(db: Database[Any]) -> None:
+    """GIVEN the migration has already run, WHEN it runs again, THEN no error is raised."""
+    migration.run(db)
+    migration.run(db)
+    assert _COLLECTION in db.list_collection_names()
+
+
+@pytest.mark.integration
+def test_rollback_drops_collection(db: Database[Any]) -> None:
+    """GIVEN the migration has run, WHEN rollback runs, THEN the collection is gone."""
+    migration.run(db)
+    assert _COLLECTION in db.list_collection_names()
+    migration.rollback(db)
+    assert _COLLECTION not in db.list_collection_names()
+
+
+@pytest.mark.integration
+def test_rollback_on_empty_db_is_safe(db: Database[Any]) -> None:
+    """GIVEN no collection exists, WHEN rollback runs, THEN no error is raised."""
+    migration.rollback(db)
+
+
+@pytest.mark.integration
+def test_analyze_returns_migration_analysis(db: Database[Any]) -> None:
+    """GIVEN a fresh DB, WHEN analyze runs, THEN a MigrationAnalysis is returned."""
+    result = migration.analyze(db)
+    assert result is not None
+    assert len(result.collections_impacted) == 1
+    assert result.collections_impacted[0].collection_name == _COLLECTION
+    assert result.collections_impacted[0].total_documents == 0

--- a/tests/drmcp/integration/test_tool_sets_repository.py
+++ b/tests/drmcp/integration/test_tool_sets_repository.py
@@ -1,0 +1,129 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Integration tests for ToolSetRepository against a real MongoDB instance.
+
+Running locally
+---------------
+    docker run -d --name mongo-drmcp -p 27017:27017 mongo:7
+    export MONGO_URI=mongodb://localhost:27017
+    uv sync --extra drmcp --dev
+    uv run pytest tests/drmcp/integration/test_tool_sets_repository.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from datetime import UTC
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+from msf.dataclasses.fields import ObjectId
+from pymongo import MongoClient
+from pymongo.errors import DuplicateKeyError
+
+import datarobot_genai.drmcp.db_migrations.migration_20260722120000_create_tool_sets as migration
+from datarobot_genai.drmcp.core.tool_sets import ToolEntry
+from datarobot_genai.drmcp.core.tool_sets import ToolSet
+from datarobot_genai.drmcp.core.tool_sets.tool_sets_repo import ToolSetRepository
+
+_TEST_DB_NAME = "drmcp_migration_test"
+
+
+def _host_mongo_uri(mongo_uri: str) -> str:
+    """Strip any database path so tests can target a dedicated DB name."""
+    parsed = urlparse(mongo_uri)
+    return urlunparse((parsed.scheme, parsed.netloc, "", parsed.params, parsed.query, parsed.fragment))
+
+
+@pytest.fixture
+async def repository() -> AsyncGenerator[ToolSetRepository, None]:
+    """Provide a repository wired to a disposable test database."""
+    mongo_uri = os.environ.get("MONGO_URI")
+    if not mongo_uri:
+        pytest.skip("MONGO_URI not set — skipping tool_sets repository integration test")
+
+    host_uri = _host_mongo_uri(mongo_uri)
+    sync_client: MongoClient[Any] = MongoClient(host_uri)
+    sync_client.drop_database(_TEST_DB_NAME)
+    migration.run(sync_client[_TEST_DB_NAME])
+    sync_client.close()
+
+    motor_client = AsyncIOMotorClient(host_uri)
+    db = motor_client[_TEST_DB_NAME]
+    repo = ToolSetRepository.new(db)
+    try:
+        yield repo
+    finally:
+        motor_client.close()
+        cleanup_client: MongoClient[Any] = MongoClient(host_uri)
+        cleanup_client.drop_database(_TEST_DB_NAME)
+        cleanup_client.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_create_indexes_is_idempotent(repository: ToolSetRepository) -> None:
+    """GIVEN a migrated database, WHEN create_indexes runs twice, THEN no error is raised."""
+    await repository.create_indexes()
+    await repository.create_indexes()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_create_and_get_tool_set(repository: ToolSetRepository) -> None:
+    """GIVEN a repository, WHEN a tool set is created, THEN it can be fetched by id."""
+    owner_id = ObjectId()
+    tool_set = ToolSet(
+        name="integration-test-set",
+        tools=[ToolEntry(name="catalog_list_datasets")],
+        created_by=owner_id,
+        created_at=datetime.now(UTC),
+    )
+    created = await repository.create(tool_set)
+    assert created.id is not None
+
+    fetched = await repository.get(created.id)
+    assert fetched is not None
+    assert fetched.name == "integration-test-set"
+    assert fetched.created_by == owner_id
+    assert [tool.name for tool in fetched.tools] == ["catalog_list_datasets"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_owner_name_raises(repository: ToolSetRepository) -> None:
+    """GIVEN an existing tool set, WHEN another with the same owner+name is created, THEN it fails."""
+    owner_id = ObjectId()
+    now = datetime.now(UTC)
+    first = ToolSet(
+        name="duplicate-name",
+        tools=[ToolEntry(name="catalog_list_datasets")],
+        created_by=owner_id,
+        created_at=now,
+    )
+    duplicate = ToolSet(
+        name="duplicate-name",
+        tools=[ToolEntry(name="modeling_get_modeldetails")],
+        created_by=owner_id,
+        created_at=now,
+    )
+    await repository.create(first)
+    with pytest.raises(DuplicateKeyError):
+        await repository.create(duplicate)

--- a/tests/drmcp/unit/tool_sets/__init__.py
+++ b/tests/drmcp/unit/tool_sets/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/drmcp/unit/tool_sets/test_models.py
+++ b/tests/drmcp/unit/tool_sets/test_models.py
@@ -1,0 +1,99 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Tool Set domain models.
+
+No MongoDB connection required — all tests operate on plain Python objects.
+"""
+
+from datetime import UTC
+from datetime import datetime
+
+import pytest
+from msf.dataclasses.fields import ObjectId
+from pydantic import ValidationError
+
+from datarobot_genai.drmcp.core.tool_sets import ToolEntry
+from datarobot_genai.drmcp.core.tool_sets import ToolSet
+
+
+def test_collection_name_on_entity() -> None:
+    """GIVEN ToolSet, WHEN __collection__ is read, THEN it matches the agreed name."""
+    assert ToolSet.__collection__ == "tool_sets"
+
+
+def test_tool_entry_defaults_version_to_none() -> None:
+    """GIVEN a ToolEntry with only a name, WHEN created, THEN version is None."""
+    entry = ToolEntry(name="catalog_list_datasets")
+    assert entry.name == "catalog_list_datasets"
+    assert entry.version is None
+
+
+def test_tool_set_validates_full_schema() -> None:
+    """GIVEN valid field values, WHEN ToolSet is constructed, THEN all schema fields are set."""
+    tool_set_id = ObjectId()
+    user_id = ObjectId()
+    created_at = datetime(2026, 7, 6, 12, 0, 0, tzinfo=UTC)
+    tool_set = ToolSet(
+        id=tool_set_id,
+        name="data-science-workbench",
+        description="Core modeling and catalog tools for exploratory workflows",
+        tools=[
+            ToolEntry(name="modeling_get_modeldetails", version="1.0.0"),
+            ToolEntry(name="catalog_list_datasets"),
+        ],
+        created_by=user_id,
+        created_at=created_at,
+    )
+
+    assert tool_set.id == tool_set_id
+    assert tool_set.name == "data-science-workbench"
+    assert tool_set.description == "Core modeling and catalog tools for exploratory workflows"
+    assert tool_set.created_by == user_id
+    assert tool_set.created_at == created_at
+    assert len(tool_set.tools) == 2
+    assert tool_set.tools[0].name == "catalog_list_datasets"
+    assert tool_set.tools[0].version is None
+    assert tool_set.tools[1].name == "modeling_get_modeldetails"
+    assert tool_set.tools[1].version == "1.0.0"
+
+
+def test_tool_set_rejects_empty_tools() -> None:
+    """GIVEN an empty tools list, WHEN ToolSet is created, THEN validation fails."""
+    with pytest.raises(ValidationError):
+        ToolSet(
+            name="empty-set",
+            tools=[],
+            created_by=ObjectId(),
+            created_at=datetime(2026, 7, 22, 12, 0, 0, tzinfo=UTC),
+        )
+
+
+def test_tool_set_dedupes_and_sorts_tools() -> None:
+    """GIVEN duplicate tool names, WHEN ToolSet is created, THEN tools are unique and sorted."""
+    now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=UTC)
+    tool_set = ToolSet(
+        name="deployment-ops",
+        tools=[
+            ToolEntry(name="deployment_list_deployments"),
+            ToolEntry(name="modeling_get_modeldetails"),
+            ToolEntry(name="modeling_get_modeldetails", version="2.0.0"),
+        ],
+        created_by=ObjectId(),
+        created_at=now,
+    )
+    assert [tool.name for tool in tool_set.tools] == [
+        "deployment_list_deployments",
+        "modeling_get_modeldetails",
+    ]

--- a/tests/drmcp/unit/tool_sets/test_repository.py
+++ b/tests/drmcp/unit/tool_sets/test_repository.py
@@ -1,0 +1,38 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Tool Set repository."""
+
+import pytest
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from datarobot_genai.drmcp.core.tool_sets.tool_sets_repo import ToolSetRepository
+from datarobot_genai.drmcp.core.tool_sets import ToolSet
+
+
+@pytest.mark.asyncio
+async def test_create_indexes_calls_collection_create_indexes() -> None:
+    """GIVEN a repository, WHEN create_indexes runs, THEN indexes are created on the collection."""
+    collection = MagicMock()
+    collection.create_indexes = AsyncMock()
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    await ToolSetRepository.new(db).create_indexes()
+
+    db.__getitem__.assert_called_once_with(ToolSet.__collection__)
+    collection.create_indexes.assert_awaited_once()
+    index_names = [index.document["name"] for index in collection.create_indexes.await_args.args[0]]
+    assert index_names == ["tool_sets_owner_name_unique", "tool_sets_by_owner"]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
+    "python_full_version >= '3.12.2' and python_full_version < '3.13'",
+    "python_full_version >= '3.12' and python_full_version < '3.12.2'",
     "python_full_version < '3.12'",
 ]
 
@@ -28,6 +29,8 @@ overrides = [
     { name = "opentelemetry-sdk", specifier = ">=1.43.0,<2.0.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "ragas", specifier = ">=0.4.3,<0.5.0" },
+    { name = "rich", specifier = ">=13.0.0,<16.0.0" },
+    { name = "uvicorn", specifier = ">=0.38,<1.0.0" },
 ]
 excludes = [
     "build",
@@ -90,6 +93,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/57/71/96c21ae7e2fb9b610c1a90d38bd2de8b6e5b2900a63001f3882f43e519af/ag_ui_protocol-0.1.15.tar.gz", hash = "sha256:5e23c1042c7d4e364d685e68d2fb74d37c16bc83c66d270102d8eaedce56ad82", size = 6269, upload-time = "2026-04-01T15:44:33.136Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/a0/a73398d30bb0f9ad70cd70426151a4a19527a7296e48a3a16a50e1d5db05/ag_ui_protocol-0.1.15-py3-none-any.whl", hash = "sha256:85cde077023ccbc37b5ce2ad953537883c262d210320f201fc2ec4e85408b06a", size = 8661, upload-time = "2026-04-01T15:44:32.079Z" },
+]
+
+[[package]]
+name = "aio-pika"
+version = "9.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiormq" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/63/56354526f2e6e915c93bee6e4dedb35888fe82d6bc1a19f35f5a77e795ff/aio_pika-9.6.2.tar.gz", hash = "sha256:c49e9246080dc8ffa1bb0e4aca407bf3d8ad78c3ee3a93df88b68fe65d7a49b9", size = 70851, upload-time = "2026-03-22T19:03:20.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/05/256fa313f48bed075056d13593b92ce804be05d75f4f312be24edb82860a/aio_pika-9.6.2-py3-none-any.whl", hash = "sha256:2a5478af920d169795071c9c09c7542cd8cdece60438cf7804533dcbcce93b7f", size = 56269, upload-time = "2026-03-22T19:03:19.558Z" },
 ]
 
 [[package]]
@@ -270,6 +286,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiormq"
+version = "6.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pamqp" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0e/db90154d52d399108903fe603e5110a533c42065180265dd003788264080/aiormq-6.9.4.tar.gz", hash = "sha256:0e7c01b662804e1cc7ace9a17794e8c1192a27fc2afa96162362a6e61ae8e8ef", size = 49232, upload-time = "2026-03-23T09:18:19.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/48/1ce3773f392f02ceda37aee168fade9d725483a9592c202d06044cd093ff/aiormq-6.9.4-py3-none-any.whl", hash = "sha256:726a8586695e863fba68cf88842065ab12348c9438dcebdfc9d0bddaf6083277", size = 32166, upload-time = "2026-03-23T09:18:17.523Z" },
+]
+
+[[package]]
 name = "aiorwlock"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -385,12 +414,33 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/6b/eeff360196bb20b312c9e762a820fd1b2c6d809466c755ef57863478e454/apscheduler-3.11.3.tar.gz", hash = "sha256:cd2fcc9330039a81a5893472ad49facf23a6d5604cbe1d918c835c6de7834d5a", size = 110312, upload-time = "2026-06-28T19:39:22.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/c9/8638db32514dbb9157b3d82680c6faea89283523edf9ed2415ea3884f2ae/apscheduler-3.11.3-py3-none-any.whl", hash = "sha256:bbeb2ec02d23d3c06a6c07ed7f0f3939ada6680eb121fae809a69bb42c537a30", size = 66024, upload-time = "2026-06-28T19:39:20.982Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
 ]
 
 [[package]]
@@ -409,6 +459,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "4.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/d6/21b30a550dafea84b1b8eee21b5e23fa16d010ae006011221f33dcd8d7f8/async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f", size = 8345, upload-time = "2023-08-10T16:35:56.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028", size = 5721, upload-time = "2023-08-10T16:35:55.203Z" },
 ]
 
 [[package]]
@@ -800,7 +859,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
     { name = "typing-extensions" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/48/11851dddeadad6abe36ee071fedc99b5bdd2c324df3afa8cb952ae02798b/chromadb-1.1.1.tar.gz", hash = "sha256:ebfce0122753e306a76f1e291d4ddaebe5f01b5979b97ae0bc80b1d4024ff223", size = 1338109, upload-time = "2025-10-05T02:49:14.834Z" }
 wheels = [
@@ -1195,8 +1254,12 @@ drmcp = [
     { name = "datarobot", extra = ["auth", "fs"] },
     { name = "datarobot-asgi-middleware" },
     { name = "datarobot-predict" },
+    { name = "dr-mongo-migrations", version = "0.2.11", source = { registry = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" }, marker = "python_full_version < '3.12.2'" },
+    { name = "dr-mongo-migrations", version = "0.2.15", source = { registry = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" }, marker = "python_full_version >= '3.12.2'" },
+    { name = "dr-msf" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "motor" },
     { name = "okta-client-python" },
     { name = "openai" },
     { name = "opentelemetry-api" },
@@ -1212,6 +1275,7 @@ drmcp = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "pymongo" },
     { name = "pypdf" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -1398,6 +1462,8 @@ requires-dist = [
     { name = "datarobot-predict", marker = "extra == 'drtools'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'langgraph'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'llamaindex'", specifier = ">=1.13.2,<2.0.0" },
+    { name = "dr-mongo-migrations", marker = "extra == 'drmcp'", specifier = ">=0.2.3,<1.0.0", index = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" },
+    { name = "dr-msf", marker = "extra == 'drmcp'", specifier = ">=3.0.0,<4.0.0", index = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" },
     { name = "fastmcp", marker = "extra == 'drmcp'", specifier = ">=3.4.1,<4.0.0" },
     { name = "fastmcp", marker = "extra == 'drmcpbase'", specifier = ">=3.4.1,<4.0.0" },
     { name = "httpx", marker = "extra == 'auth'", specifier = ">=0.28.1,<1.0.0" },
@@ -1425,6 +1491,7 @@ requires-dist = [
     { name = "llama-index-tools-mcp", marker = "extra == 'llamaindex'", specifier = ">=0.1.0,<0.5.0" },
     { name = "mcpadapt", marker = "extra == 'crewai'", specifier = ">=0.1.9" },
     { name = "mem0ai", marker = "extra == 'dragent'", specifier = ">=1.0.4,<2.0.0" },
+    { name = "motor", marker = "extra == 'drmcp'", specifier = ">=3.7.0,<4.0.0" },
     { name = "nemo-evaluator-launcher", marker = "extra == 'eval'" },
     { name = "nvidia-nat", marker = "extra == 'dragent'", specifier = "==1.7.0" },
     { name = "nvidia-nat-a2a", marker = "extra == 'dragent'", specifier = "==1.7.0" },
@@ -1518,6 +1585,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'drmcpbase'", specifier = ">=2.12.0,<3.0.0" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'drmcputils'", specifier = ">=2.12.0,<3.0.0" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'drtools'", specifier = ">=2.12.0,<3.0.0" },
+    { name = "pymongo", marker = "extra == 'drmcp'", specifier = ">=4.10.0,<5.0.0" },
     { name = "pypdf", marker = "extra == 'drmcp'", specifier = ">=6.10.1,<7.0.0" },
     { name = "pypdf", marker = "extra == 'drtools'", specifier = ">=6.10.1,<7.0.0" },
     { name = "pypdf", marker = "extra == 'llamaindex'", specifier = ">=6.10.1,<7.0.0" },
@@ -1632,7 +1700,7 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "4.8.3"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
@@ -1650,9 +1718,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/74/0c5f29109e02c4c33e8634e31d5cd7d90ecc3ed7c95e1b377ece08354068/datasets-4.8.3.tar.gz", hash = "sha256:882fb1bb514772bec17fbcad2e32985893954d0a0ecf42266e5091386be1f3b7", size = 604294, upload-time = "2026-03-19T17:43:59.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/c6/b8298394a8926f8af21c059f4ec794b61f9cf64ade561184027b94110639/datasets-4.8.3-py3-none-any.whl", hash = "sha256:a66cb506097bfce8461b076fb9e86ea216e00fd622387ba19909d9c1689ff8f9", size = 526834, upload-time = "2026-03-19T17:43:57.337Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/73034ad30b59f13439b75e620989dacba4c047256e358ba7c2e9ec98ea22/datasets-5.0.0-py3-none-any.whl", hash = "sha256:7dd34927a0fd7046e98aad5cb9430e699c373238a15befa7b9bf22b991a7fee6", size = 555084, upload-time = "2026-06-05T13:18:24.435Z" },
 ]
 
 [[package]]
@@ -1710,6 +1778,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "dependency-injector"
+version = "4.45.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/32/beb8a8aed8a07273bbc2afc6e823d2d70e5f898ed9a8cc413c45aec5642a/dependency_injector-4.45.0.tar.gz", hash = "sha256:7effdb9e45f5c2813e2fd9dc2ef2c446dd59716f66f9c772ab27b9ed16efc894", size = 1117514, upload-time = "2025-01-06T01:04:55.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/f1/8151f38a1b62651ebf089974c8c393d81c2901f2fce44eeb0b9828edcca4/dependency_injector-4.45.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9a76ab1e114402f284c71039391826d9e43083169d88568ede109ff4fc85de1e", size = 1859197, upload-time = "2025-01-06T01:01:46.294Z" },
+    { url = "https://files.pythonhosted.org/packages/97/da/4013b6ea6b358cb60f1aca64b80368a4d2ddcb5e1c14d197eabb75049d46/dependency_injector-4.45.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4aefc511be8ba97d823a71fb52a3b0ccaa7f9387cb51444862ebcb919822cae", size = 7069850, upload-time = "2025-01-06T01:01:49.444Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/10/9f299641f1c03a2b202c988261416531ffc1f816710f0bd9aa4971f680ea/dependency_injector-4.45.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a013c93a870a3a1ce9829dd272bd02b194ea286df48dfb9d059cf34526738b8", size = 7106114, upload-time = "2025-01-06T01:01:53.738Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/58/3aefb686a5dc25ab2f376904ac37e7a04c5b9054bfd57ce8f57121129355/dependency_injector-4.45.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1641f25faf543df14b2395a3cea51bd0610bc7b2c1cb6ed1c13ec4bec0063e2", size = 6636391, upload-time = "2025-01-06T01:01:55.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/08/66bcefa816e09deb771233e5f095721c2e061ed9406383f6ebad31379dfc/dependency_injector-4.45.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:97dc40a527e488df23e9fb5b33a85f9176b730449ad2e498d6cc556dcad540ae", size = 6718172, upload-time = "2025-01-06T01:01:57.896Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/62/ed699aa2d4db0d44a8f91fb730d705c6da696b63711c82d3c2be91567c00/dependency_injector-4.45.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9396c71f25744fd0ded9b171fee05ea3ca13a87c12512ddd8b7e4330f70647eb", size = 6538136, upload-time = "2025-01-06T01:01:59.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ec/ed00a79e89984edde7d16313c9379c9c4eea8d9d5e0d5a2071e940f33236/dependency_injector-4.45.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d98a490f8a2decf40ca2aa69d0559d01dd96131422fa2086626fd5949837335a", size = 6897940, upload-time = "2025-01-06T01:02:03.323Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/72/9ced97efda3ed48e803b942482b4c195caaebd09504604ff3b1d662b3c73/dependency_injector-4.45.0-cp311-cp311-win32.whl", hash = "sha256:4cec41b8dd678555ea025ad320e6354cad92b18b6433f8cd0b423b02989668c3", size = 1665406, upload-time = "2025-01-06T01:02:06.432Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/af/1690e57fae9eaf8ec285f0de409d13566759059cc5d0f6fdc42857431f95/dependency_injector-4.45.0-cp311-cp311-win_amd64.whl", hash = "sha256:5eb99c2ea049ac1065a0b4cf06166f70fac697049ddd342b88cb6a264f106faf", size = 1800647, upload-time = "2025-01-06T01:02:08.739Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9f/57324d953301136b5f709e807532183c82ee15a9982d7da8972c0223d8ae/dependency_injector-4.45.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2144948b5218f480ca94c11e848762aa305539ec67406ccecfbcb556d06a61dd", size = 1865841, upload-time = "2025-01-06T01:02:11.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7d/02ec92c0cef097047867712d702f7edefcb566f681dac87fdd1e121f3ee2/dependency_injector-4.45.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82a0c665ee9bbb9434497a9b97bbb2018a9c427c0d014bff77dda2e0586c9020", size = 6818546, upload-time = "2025-01-06T01:02:14.868Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0e/abea9847d5a6bc3ecb4b0057842661e895c02524503bb41963f0b6b3d033/dependency_injector-4.45.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:403f44e2073986138dd95f4a8ac864453524b18385c44b838cba8a2f7f742f2e", size = 6946584, upload-time = "2025-01-06T01:02:17.027Z" },
+    { url = "https://files.pythonhosted.org/packages/00/9a/87155cc98e2afda2deb9f81309698f756f4ab6e9f8522ce386e65dc02fb8/dependency_injector-4.45.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2a38cf7826ff253d30958c35bc1e121af292f0f12fb5ffd1ad3ea5377b63e3b", size = 6400998, upload-time = "2025-01-06T01:02:20.733Z" },
+    { url = "https://files.pythonhosted.org/packages/31/fd/60262f2d61d0b049107f5e3bca8f6f3321858bac3190f143e61c0dcbca29/dependency_injector-4.45.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2b18413b2f965793f8e401996a6cc01e0aa0336568805fc822285cdc72cfb7d9", size = 6493477, upload-time = "2025-01-06T01:02:24.002Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/dc/ac111c2e17f764c9584a99be2310c9593195fe694e6db905d8c71f22ce09/dependency_injector-4.45.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ed3e60296b3b9d29c3eb57cb44a82d7627da1a7eac68ac97fbf9bbd9e2a5cb99", size = 6317674, upload-time = "2025-01-06T01:02:26.047Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/26/6546f8acc6d3da46b3adab2fa790ffa6739c236604533f4c05e66e3a7fcd/dependency_injector-4.45.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd1afbbf03ed97007f6d4cb11944776e79207d9d7634ba5c4f897f4802b382ae", size = 6724126, upload-time = "2025-01-06T01:02:29.124Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c2/5580c731fd550327d9f66ff62824cb04b4a0530b5ca6997f5dd2905b383f/dependency_injector-4.45.0-cp312-cp312-win32.whl", hash = "sha256:2bfca5875aedb5a0995a4b2e5a928aef5791a58f4280d0c3003cb0720385f546", size = 1660532, upload-time = "2025-01-06T01:02:30.886Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4d/185a604a96d766f7bb8ea1017ad66a136c78593d15a294163ac258778e4a/dependency_injector-4.45.0-cp312-cp312-win_amd64.whl", hash = "sha256:5510a68445741fce2af071fd7fda177c4249f2b576d2b2b2b5af23083e4208e8", size = 1776903, upload-time = "2025-01-06T01:02:32.673Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/41/e8dc964575ef0f6e7abb90942be9e6f265d770616518216368165d3079d7/dependency_injector-4.45.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16c17b17d1974a288b16f0d9b4eda7fae892dc2823ff1d95a93207723b681b9a", size = 1856812, upload-time = "2025-01-06T01:02:34.336Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e3/ccfe9ad88d7ee197a12954290697a8c503a0f8f049cd1e4e81f294861053/dependency_injector-4.45.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a1cfd84779e718974b8d40eefc2d664ba69c142ca676ed97f487de05e733e9e", size = 6819924, upload-time = "2025-01-06T01:02:36.309Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e7/c3e392f005ba3072d4c6e7a5ff60391648df0f0664ad25b3570f3283c270/dependency_injector-4.45.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b03382b9423f008bf307d4dee7e56ea1e070fc0e23481e4e327b01b9b463a9d", size = 6957754, upload-time = "2025-01-06T01:02:39.906Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/87/c6907e001a0504678c5e5ed62bc6c5c86d1668302fccd5c159d2542bef58/dependency_injector-4.45.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcba70e44a3d6436196f1ffebad0b02f0a72a7c8014d85617f21bd8535434bf4", size = 6406441, upload-time = "2025-01-06T01:02:42.22Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a7/2b003dc0e9e8624e3948289f7764aa87b59cbff392ca06c7f41d28be43b6/dependency_injector-4.45.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:73d52ba9efdbb6a1c0ba49d9c68be9cedb0abfa0e6fbdfb942371c642cb30541", size = 6558807, upload-time = "2025-01-06T01:02:45.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a6/5b8f21957af82488ce2e70e321c45c3ba3707004c211c0e6b261e1c77afc/dependency_injector-4.45.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9ebcefa9218941337466cf0985bdcd5d38cf84ab1d3a4d7a3cc91845e38c0d1e", size = 6354444, upload-time = "2025-01-06T01:02:48.689Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2f/bae5beaf6ac9c5464e6016d0f94d10898c192b4528e2978a2ada44af0c21/dependency_injector-4.45.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d785dacb136479b0536e8b05f83a7375f09404d63eabd1be9b694eca6defea4", size = 6762151, upload-time = "2025-01-06T01:02:51.513Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6f/068b17dc76765e5344c72b85d46711a596eca1d4ee441bac7b7275dadc94/dependency_injector-4.45.0-cp313-cp313-win32.whl", hash = "sha256:3df40ff15bd31058b24cd79781b1dc2f31e0c157ee2067566dfd7a92191969e9", size = 1660060, upload-time = "2025-01-06T01:02:53.46Z" },
+    { url = "https://files.pythonhosted.org/packages/53/d3/890c4be056256e56e97264e72b376ecad273cfa8c8dc70ce5eb623f06472/dependency_injector-4.45.0-cp313-cp313-win_amd64.whl", hash = "sha256:f018f634edf57d4b4214e007eaa2432d2410f304b170f5684bd3fdbffd244b1f", size = 1775930, upload-time = "2025-01-06T01:02:55.259Z" },
 ]
 
 [[package]]
@@ -1799,6 +1902,96 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "dr-mongo-migrations"
+version = "0.2.11"
+source = { registry = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.12.2'",
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "motor", marker = "python_full_version < '3.12.2'" },
+    { name = "pymongo", marker = "python_full_version < '3.12.2'" },
+]
+sdist = { url = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/dr-mongo-migrations/0.2.11/dr_mongo_migrations-0.2.11.tar.gz", hash = "sha256:2f476043f2c68847ddfc893221fc665622b26d40a16941f98bf7da7c82d95835" }
+wheels = [
+    { url = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/dr-mongo-migrations/0.2.11/dr_mongo_migrations-0.2.11-py3-none-any.whl", hash = "sha256:c87d63c2420e95f30fac7601b14d8d58d0d1ebc3b31dd2ec8f3701ad32ff9aaa" },
+]
+
+[[package]]
+name = "dr-mongo-migrations"
+version = "0.2.15"
+source = { registry = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.12.2' and python_full_version < '3.13'",
+]
+dependencies = [
+    { name = "pymongo", marker = "python_full_version >= '3.12.2'" },
+]
+sdist = { url = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/dr-mongo-migrations/0.2.15/dr_mongo_migrations-0.2.15.tar.gz", hash = "sha256:35f21af5c6d07c99f007d1da2dd87eea9fb05f4906a7fac2e9e3cd7e51e53b46" }
+wheels = [
+    { url = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/dr-mongo-migrations/0.2.15/dr_mongo_migrations-0.2.15-py3-none-any.whl", hash = "sha256:43e77fb4fc17b973e18d0e2cbf9c29e9896283028413a701b9e6c6096f5d8ccf" },
+]
+
+[[package]]
+name = "dr-msf"
+version = "3.0.1"
+source = { registry = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/simple" }
+dependencies = [
+    { name = "aio-pika" },
+    { name = "apscheduler" },
+    { name = "async-timeout" },
+    { name = "backoff" },
+    { name = "dependency-injector" },
+    { name = "ecs-logging" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "motor" },
+    { name = "openapi-pydantic" },
+    { name = "openapi-spec-validator" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-aio-pika" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-pymongo" },
+    { name = "opentelemetry-instrumentation-starlette" },
+    { name = "opentelemetry-sdk" },
+    { name = "orjson" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyhumps" },
+    { name = "pymongo" },
+    { name = "python-multipart" },
+    { name = "pytz" },
+    { name = "rich" },
+    { name = "setuptools" },
+    { name = "starlette" },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+    { name = "uvloop" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/dr-msf/3.0.1/dr_msf-3.0.1.tar.gz", hash = "sha256:32046b9676a402300287cd2f0be54596e6497ec2208d3a68c8fd3abbdcdbae67" }
+wheels = [
+    { url = "https://artifactory.devinfra.drdev.io/artifactory/api/pypi/python-all/dr-msf/3.0.1/dr_msf-3.0.1-py3-none-any.whl", hash = "sha256:fe08248803136708c920652a9215dabab2dba50d88a333dead43e3681d974ae8" },
+]
+
+[[package]]
+name = "ecs-logging"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/9e/ea78919dd88d06a4bf622717e0127c763d3017bdb550e42d9f4b3e4007b1/ecs_logging-2.3.0.tar.gz", hash = "sha256:be7f618e71e10c33a61165aea58813ebd702f6c0044538155871cb9a1609ab4e", size = 11498, upload-time = "2026-01-19T10:28:29.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6f/187826c34511e73c7b9f9595465fd8a029ed467c8c2e57ef76f7dbc8a810/ecs_logging-2.3.0-py3-none-any.whl", hash = "sha256:42da72191a98bd724d105e126ca8d7c81fc82b0d7bbbe4bb1584c34e61042cfc", size = 14791, upload-time = "2026-01-19T10:28:27.408Z" },
 ]
 
 [[package]]
@@ -2536,35 +2729,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httptools"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
-    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
-    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
-    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
-]
-
-[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2783,7 +2947,8 @@ version = "9.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
+    "python_full_version >= '3.12.2' and python_full_version < '3.13'",
+    "python_full_version >= '3.12' and python_full_version < '3.12.2'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
@@ -3043,16 +3208,17 @@ wheels = [
 
 [[package]]
 name = "jsonschema-path"
-version = "0.4.5"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "attrs" },
     { name = "pathable" },
     { name = "pyyaml" },
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
 ]
 
 [[package]]
@@ -3410,6 +3576,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/b3/4684b1e128a87821e485f5a901b179790e6b5bc02f89b7ee19c23be36ef3/lazy_object_proxy-1.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1cf69cd1a6c7fe2dbcc3edaa017cf010f4192e53796538cc7d5e1fedbfa4bcff", size = 26656, upload-time = "2025-08-22T13:42:30.605Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/03/1bdc21d9a6df9ff72d70b2ff17d8609321bea4b0d3cffd2cea92fb2ef738/lazy_object_proxy-1.12.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:efff4375a8c52f55a145dc8487a2108c2140f0bec4151ab4e1843e52eb9987ad", size = 68832, upload-time = "2025-08-22T13:42:31.675Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4b/5788e5e8bd01d19af71e50077ab020bc5cce67e935066cd65e1215a09ff9/lazy_object_proxy-1.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1192e8c2f1031a6ff453ee40213afa01ba765b3dc861302cd91dbdb2e2660b00", size = 69148, upload-time = "2025-08-22T13:42:32.876Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0e/090bf070f7a0de44c61659cb7f74c2fe02309a77ca8c4b43adfe0b695f66/lazy_object_proxy-1.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3605b632e82a1cbc32a1e5034278a64db555b3496e0795723ee697006b980508", size = 67800, upload-time = "2025-08-22T13:42:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d2/b320325adbb2d119156f7c506a5fbfa37fcab15c26d13cf789a90a6de04e/lazy_object_proxy-1.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a61095f5d9d1a743e1e20ec6d6db6c2ca511961777257ebd9b288951b23b44fa", size = 68085, upload-time = "2025-08-22T13:42:35.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/48/4b718c937004bf71cd82af3713874656bcb8d0cc78600bf33bb9619adc6c/lazy_object_proxy-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:997b1d6e10ecc6fb6fe0f2c959791ae59599f41da61d652f6c903d1ee58b7370", size = 26535, upload-time = "2025-08-22T13:42:36.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1b/b5f5bd6bda26f1e15cd3232b223892e4498e34ec70a7f4f11c401ac969f1/lazy_object_proxy-1.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ee0d6027b760a11cc18281e702c0309dd92da458a74b4c15025d7fc490deede", size = 26746, upload-time = "2025-08-22T13:42:37.572Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/314889b618075c2bfc19293ffa9153ce880ac6153aacfd0a52fcabf21a66/lazy_object_proxy-1.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ab2c584e3cc8be0dfca422e05ad30a9abe3555ce63e9ab7a559f62f8dbc6ff9", size = 71457, upload-time = "2025-08-22T13:42:38.743Z" },
+    { url = "https://files.pythonhosted.org/packages/11/53/857fc2827fc1e13fbdfc0ba2629a7d2579645a06192d5461809540b78913/lazy_object_proxy-1.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14e348185adbd03ec17d051e169ec45686dcd840a3779c9d4c10aabe2ca6e1c0", size = 71036, upload-time = "2025-08-22T13:42:40.184Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/24/e581ffed864cd33c1b445b5763d617448ebb880f48675fc9de0471a95cbc/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c4fcbe74fb85df8ba7825fa05eddca764138da752904b378f0ae5ab33a36c308", size = 69329, upload-time = "2025-08-22T13:42:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/78/be/15f8f5a0b0b2e668e756a152257d26370132c97f2f1943329b08f057eff0/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:563d2ec8e4d4b68ee7848c5ab4d6057a6d703cb7963b342968bb8758dda33a23", size = 70690, upload-time = "2025-08-22T13:42:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/aa/f02be9bbfb270e13ee608c2b28b8771f20a5f64356c6d9317b20043c6129/lazy_object_proxy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:53c7fd99eb156bbb82cbc5d5188891d8fdd805ba6c1e3b92b90092da2a837073", size = 26563, upload-time = "2025-08-22T13:42:43.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload-time = "2025-08-22T13:42:44.982Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload-time = "2025-08-22T13:42:46.141Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload-time = "2025-08-22T13:42:47.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload-time = "2025-08-22T13:42:48.49Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload-time = "2025-08-22T13:42:49.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload-time = "2025-08-22T13:42:57.719Z" },
+    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload-time = "2025-08-22T13:42:50.62Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload-time = "2025-08-22T13:42:51.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload-time = "2025-08-22T13:42:53.225Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload-time = "2025-08-22T13:42:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload-time = "2025-08-22T13:42:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload-time = "2025-08-22T13:42:56.793Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a0/b91504515c1f9a299fc157967ffbd2f0321bce0516a3d5b89f6f4cad0355/lazy_object_proxy-1.12.0-pp39.pp310.pp311.graalpy311-none-any.whl", hash = "sha256:c3b2e0af1f7f77c4263759c4824316ce458fabe0fceadcd24ef8ca08b2d1e402", size = 15072, upload-time = "2025-08-22T13:50:05.498Z" },
 ]
 
 [[package]]
@@ -3963,7 +4162,7 @@ dependencies = [
     { name = "starlette" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+    { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
@@ -3999,7 +4198,8 @@ version = "0.1.20"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
+    "python_full_version >= '3.12.2' and python_full_version < '3.13'",
+    "python_full_version >= '3.12' and python_full_version < '3.12.2'",
 ]
 dependencies = [
     { name = "jsonref", marker = "python_full_version >= '3.12'" },
@@ -4119,6 +4319,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "motor"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymongo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ae/96b88362d6a84cb372f7977750ac2a8aed7b2053eed260615df08d5c84f4/motor-3.7.1.tar.gz", hash = "sha256:27b4d46625c87928f331a6ca9d7c51c2f518ba0e270939d395bc1ddc89d64526", size = 280997, upload-time = "2025-05-14T18:56:33.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/9a/35e053d4f442addf751ed20e0e922476508ee580786546d699b0567c4c67/motor-3.7.1-py3-none-any.whl", hash = "sha256:8a63b9049e38eeeb56b4fdd57c3312a6d1f25d01db717fe7d82222393c410298", size = 74996, upload-time = "2025-05-14T18:56:31.665Z" },
 ]
 
 [[package]]
@@ -4595,7 +4807,7 @@ dependencies = [
     { name = "tabulate" },
     { name = "tzlocal" },
     { name = "urllib3" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/cf/634983c35ab78e410d0b625181d1b1dfad5a28cbddabd31ca8c33fa8ab68/nvidia_nat_core-1.7.0-py3-none-any.whl", hash = "sha256:fb4691ad3437e0e8b8d84256d36da18085ba1fc6dd47861e7a7e64c6a808390c", size = 808487, upload-time = "2026-05-21T19:01:41.952Z" },
@@ -4826,6 +5038,40 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-schema-validator"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/e8/ab3f27dbca54ec645f7fab714b640907d5d36c2ebb07e87eebd30bd5c81b/openapi_schema_validator-0.9.0.tar.gz", hash = "sha256:b72db64315b89d21834cd3ffef37e3e6893bc876327be2d366e8424b1029afd3", size = 24686, upload-time = "2026-04-27T17:31:27.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/c0/5467967d95378b2cfce312e09cbd0c9ab64354a0922379b734f793edd04f/openapi_schema_validator-0.9.0-py3-none-any.whl", hash = "sha256:faa3bbe7c3aa8ca2087ad83f709dc3b7d920283153a570c03e24ea182558aa25", size = 19980, upload-time = "2026-04-27T17:31:25.965Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/d2/640b5149cd5688bc0ad1fdbb4df6a2f7b84a093c8d787c27d566132f8b8b/openapi_spec_validator-0.9.0.tar.gz", hash = "sha256:6d648cff6490ebb799dcfe273792f2941c050158854c721f086599d845da78b8", size = 1756839, upload-time = "2026-05-20T09:23:18.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/d8/321ff889330acca2e3097f3d4f80a40bcc41b6d34d302978ab32c449520b/openapi_spec_validator-0.9.0-py3-none-any.whl", hash = "sha256:222fecffc7714f6d0a6ad62c0e4b66cc2b7dbfafb7b93acfc6c308abbdb51af8", size = 50328, upload-time = "2026-05-20T09:23:17.017Z" },
+]
+
+[[package]]
 name = "openevals"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4938,6 +5184,21 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-aio-pika"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/e7/38a8f8c7fabe8dce1d51ba6c3b7451e639d34f051d739710c09bb49c1a36/opentelemetry_instrumentation_aio_pika-0.64b0.tar.gz", hash = "sha256:79bb25ad6a113bb4bee27bc11295c2c761f0b3468890d1d7c9ff1203ae4076f6", size = 10190, upload-time = "2026-06-24T15:19:13.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/ab/88dc22f4ff64935a91bf0e9f0b2309a608df96e724cc6e9acf131b92e35c/opentelemetry_instrumentation_aio_pika-0.64b0-py3-none-any.whl", hash = "sha256:b5d36d411a3e7bf1e6cd6c8359cbad3aba7edc34bf947469c0ee6e5f0291aebf", size = 11676, upload-time = "2026-06-24T15:18:18.321Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-aiohttp-client"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
@@ -4951,6 +5212,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/7c/1124a723ea77d866fae5cb1df78bea6133a06d93c132a8bd6d6bf08424cc/opentelemetry_instrumentation_aiohttp_client-0.64b0.tar.gz", hash = "sha256:ff03428052766c604e59ab802279d265841dd0d59eb78662da0a2878c48ac840", size = 19041, upload-time = "2026-06-24T15:19:14.386Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/55/87e9d0a3b9fc9fbecf044a67547b42d5423a7a3bb502113495b9a95a5e71/opentelemetry_instrumentation_aiohttp_client-0.64b0-py3-none-any.whl", hash = "sha256:661b1420b0012e43a92dca042f43bb8abafb80a952184ef256128fd9c12bb7ee", size = 13675, upload-time = "2026-06-24T15:18:19.296Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/0c/71c696fccb86d37af383ea1604af4729fabad0af2fabaf203e4c79c1e859/opentelemetry_instrumentation_asgi-0.64b0.tar.gz", hash = "sha256:4dd3eee566a4303f8e6b9b84f2a0a7abc57a6640df768926c68a3868bf5b2090", size = 26136, upload-time = "2026-06-24T15:19:17.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/20/218b65a63d847a7ed28d1bea84c39234689160b74480b8702272e37f4240/opentelemetry_instrumentation_asgi-0.64b0-py3-none-any.whl", hash = "sha256:e0840b66e15303a9254b0540946010bd008aa0504f4d89b8e1b7fb63490a36f0", size = 15906, upload-time = "2026-06-24T15:18:23.107Z" },
 ]
 
 [[package]]
@@ -5031,6 +5308,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-pymongo"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/01/a7d7a8ee30e7b42c9358ef32b500a2ba92e4c0dae68f6da03d59e4e6749e/opentelemetry_instrumentation_pymongo-0.64b0.tar.gz", hash = "sha256:4c7a63ffea7e2ac13e83364bd4ac7216953c5f90b63942b19d5e844e35626571", size = 10206, upload-time = "2026-06-24T15:19:35.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/3b/48eff9527600ae4a6127f2659286b13a7d40f0de6f16691418f9d5895634/opentelemetry_instrumentation_pymongo-0.64b0-py3-none-any.whl", hash = "sha256:cb9c49963899fe3a47cba10ac054d87d3de5b180845b87c69adc689bf84c0e4f", size = 10290, upload-time = "2026-06-24T15:18:50.471Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-requests"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
@@ -5043,6 +5334,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/97/d5fb7b3f329c24ff2f6478f1a0c0c516ba942d3df2acbb197d276af31816/opentelemetry_instrumentation_requests-0.64b0.tar.gz", hash = "sha256:8213a20b6578c41aa05cc5b48419aea75e1584924a4904dfcf36524597e7cc96", size = 18106, upload-time = "2026-06-24T15:19:39.522Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/b2/f0f32ec327bdd76d245d28975dfb446d62eea2d267c06b6cb6c1a9b7e7d4/opentelemetry_instrumentation_requests-0.64b0-py3-none-any.whl", hash = "sha256:dcad4324ad97d785a5a3b9500acf3af3965b4c1d1b95776fa5e275b173d9541c", size = 13385, upload-time = "2026-06-24T15:18:56.163Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-starlette"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/49/e4621a8bd31f744543024242a9d5d77d203dcb2322749d8f0bec3d4dabad/opentelemetry_instrumentation_starlette-0.64b0.tar.gz", hash = "sha256:bdcc4ec3cbb9173539674bd151628332091f8c079afe86c4f98036e91d7fcd6c", size = 14384, upload-time = "2026-06-24T15:19:41.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/11/e353e0a10ba092342795ea3f3b999b7883d0a720a9f3f32bb85a682108ef/opentelemetry_instrumentation_starlette-0.64b0-py3-none-any.whl", hash = "sha256:900d2e377c62e9c213da03ede901eb6714644db99751d22fad7a1e5d74b43377", size = 11106, upload-time = "2026-06-24T15:18:59.039Z" },
 ]
 
 [[package]]
@@ -5227,6 +5534,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pamqp"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/62/35bbd3d3021e008606cd0a9532db7850c65741bbf69ac8a3a0d8cfeb7934/pamqp-3.3.0.tar.gz", hash = "sha256:40b8795bd4efcf2b0f8821c1de83d12ca16d5760f4507836267fd7a02b06763b", size = 30993, upload-time = "2024-01-12T20:37:25.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/8d/c1e93296e109a320e508e38118cf7d1fc2a4d1c2ec64de78565b3c445eb5/pamqp-3.3.0-py2.py3-none-any.whl", hash = "sha256:c901a684794157ae39b52cbf700db8c9aae7a470f13528b9d7b4e5f7202f8eb0", size = 33848, upload-time = "2024-01-12T20:37:21.359Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5278,11 +5594,11 @@ wheels = [
 
 [[package]]
 name = "pathable"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -6038,12 +6354,62 @@ wheels = [
 ]
 
 [[package]]
+name = "pyhumps"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/ef/129d47c6177ad08b650b6bbf0da964d0c208347da6bc4c83aa40d0ecbe78/pyhumps-3.7.2.tar.gz", hash = "sha256:cadfffd84e8cf93cf5566ed351bbd0d5356e04ffc03de7d2aa262660c144b775", size = 8441, upload-time = "2022-06-24T21:28:49.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/5a/0b9af2c8d9ce7c121745a3aaf7687060ad512ac20c62f3db9828a33e6d52/pyhumps-3.7.2-py3-none-any.whl", hash = "sha256:f554bc742138c01ef85176534a411b105c3e7b20133b3c68bd4e613dcb425241", size = 5725, upload-time = "2022-06-24T21:28:47.904Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/e2/336d86f221cf1b56b2ed9330d4a3b98f9f38f0b37829ae9a9184617d5419/pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df", size = 874668, upload-time = "2026-04-20T16:37:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8e/75d3c6c935d187ab59c61e9c15d9aab3f274b563eaf1706e8cae5f508dec/pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433", size = 875294, upload-time = "2026-04-20T16:37:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ec/62e855744489dbcd54fd778aae4d80fa4c4819e8fb228ca0cf6f21a03997/pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918", size = 1496233, upload-time = "2026-04-20T16:37:45.518Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e8/93e4e5e5ce8fdf8929dabeefe24aafa5ce046028eed0dfa8eeb936e72c49/pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9", size = 1522927, upload-time = "2026-04-20T16:37:47.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/425dc1d21e0f17bdea0072fc463f662f7fa06d2852af52975c9eced3c07c/pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72", size = 1583468, upload-time = "2026-04-20T16:37:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9d/f08b07eeffda1a43c1759f0fa625e88ae12360996eb56d42aad832fa7dff/pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff", size = 1572787, upload-time = "2026-04-20T16:37:51.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c2/6855a07aafa7b894929af23675b6fb9634800ce43122b76a62f6eeb8da2a/pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969", size = 1526184, upload-time = "2026-04-20T16:37:53.358Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
+    { url = "https://files.pythonhosted.org/packages/98/90/60bcb508840135d5ee46b51b1a950f548338aa8145a8366dbe6639ae51ac/pymongo-4.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53ffa94b2340dbf6b055e09a0090618c60482c158ecfc9565642fc996bf0944", size = 930529, upload-time = "2026-04-20T16:38:00.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/313840f1e52c6dfac47f704428cbfbce59956ebe7633bffc92b03f74f0ad/pymongo-4.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe0de9d0f6791abce3471230b32b4817bf89d27b1182b6a550e1ec0fa72aa9a", size = 930665, upload-time = "2026-04-20T16:38:02.915Z" },
+    { url = "https://files.pythonhosted.org/packages/78/35/9d3565ea45b1606f635c1e2cd2563c28d66caafdc50f7ad7d979fcd1b363/pymongo-4.17.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e537e95514dae1aaa718f481ec03151a0f0394bcd05f1322896d8fc1330cb729", size = 1762369, upload-time = "2026-04-20T16:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ee/149b0d4b1a11c38bff6f14c23d5814c9b0843fd6dc38ad40596bdb1a62d2/pymongo-4.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37a8385c29881b43eab31f584100fa0eaddedd5607adf010147ba1810118be90", size = 1798044, upload-time = "2026-04-20T16:38:07.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d4/4cee4a7b8d8f6f0550ef6cd2fea42455c5ed619a220cb6ba4fb40d6a5bc8/pymongo-4.17.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3ee3d241ed77a4fc99ce3cff3b289c3ebce37f61fdd7349d3592c23b82c8784", size = 1878567, upload-time = "2026-04-20T16:38:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ef/7fe366c84952619ee2f69973566c214775e083dd4df465751912153e4b72/pymongo-4.17.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9eb5d63a3c518cb0804ed678f5e2b875af032d89a7cf57a57360322cf6a4d222", size = 1864881, upload-time = "2026-04-20T16:38:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/b577d82c6d1be7aee7ac7e249bc86f7847998345042e5f8360de238e177b/pymongo-4.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e97e03fa13327c87e3fdc5656acd01e71817f0c1dc3221cd8f30de136bf4ec3", size = 1800349, upload-time = "2026-04-20T16:38:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/dafcf04f66e130ddd91aeb92e7a692480eda46dcd04ec1dbe82c06619e10/pymongo-4.17.0-cp312-cp312-win32.whl", hash = "sha256:6877214bff5f06f6884a9fc8d9016a4a7a5f51f537f5c51ac3a576f93e7dfb32", size = 900518, upload-time = "2026-04-20T16:38:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/11/35/5c9262a459f988b4eb2605f70815240b77a0d4131136c4326d18f1822b89/pymongo-4.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:9828485f72f63c7d802e0ec41f71906f633c2692621ab3af55ca990186b091b1", size = 920335, upload-time = "2026-04-20T16:38:17.665Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/e9c7265ee176faccf4e52c4797837e794d93569a1046f6b19a4acc36e5ad/pymongo-4.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:1195370a77baf003b59b10e91ecc4706297197f0dd9d29c840cc556dc08f7cee", size = 903289, upload-time = "2026-04-20T16:38:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/c1206879708b94e82fcd8b9653440ec271f79a3674d122192df383047f5a/pymongo-4.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:809ec74de3b9148ae43fa8df9faf53470f511c8d384f13b99d6f671f2a379f15", size = 985829, upload-time = "2026-04-20T16:38:21.031Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/bb044ed85160e5c40f568c7c4f4e8ea16f40764ff5d302e5befbe8f6f814/pymongo-4.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a431b737816bf4cddd4fa0fcef04e424ad36b7692734a64150f872fb8f3208be", size = 985899, upload-time = "2026-04-20T16:38:23.409Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0a/f6dfd5ea3901e5d6888da8de8ba728971a1d447debab681cfc56f90d1208/pymongo-4.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4fab10f8403169ce92f3cea921609d9ee81107306caae06c08f592d4b8ad2b5", size = 2028569, upload-time = "2026-04-20T16:38:25.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c5/081f59a1c02ae8c0dc73ae58e563838c44eec81aeafa7d0b93a637841c9b/pymongo-4.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20323b0b1c1d33770ad1fc68d429c757734ce9ad3594421c3d6618f10572b1b9", size = 2072916, upload-time = "2026-04-20T16:38:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/31/42/6e41d434297ffe8b30d9c3717916591a4a7be9075a0dcc2fafdfaaaa62ed/pymongo-4.17.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5a5de048e6da5c18e27cc2437e8c15b3b0cdc8385c15b41178b0caa3322a09c2", size = 2173234, upload-time = "2026-04-20T16:38:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cf/1e4a7db352ef9485831c7268dfe8402f0117b32a9ad54b16e810699e3617/pymongo-4.17.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dff3de1294fbbc1db0ba6b511f77b8e540601d092538a31312e99c8a91a78b1e", size = 2156784, upload-time = "2026-04-20T16:38:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/12/10/6195be29962a61ebb5f4bd9e4c7519890b172f7968a0a0d880398c6ddb02/pymongo-4.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf03e4c2aafd6de626dbd30ba246d369ae33f47f10629d1bbe40f72115027a6", size = 2074446, upload-time = "2026-04-20T16:38:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/33410b8819837ed370c738587306bdf060b59cef11823be212f4a07703c5/pymongo-4.17.0-cp313-cp313-win32.whl", hash = "sha256:c9786665926a09630c5d420c79762cfadbff35a9438bcbc4c81a9fb5ab9228b7", size = 948435, upload-time = "2026-04-20T16:38:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/77/c0ed522f798a286b99acaa7914ed8d9c80ab091f97f57c59ffed72906e5e/pymongo-4.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:5960519b4d7168f1ecdd3ea10c81b2aedeb9423651aca953cfbc8e76705d3b38", size = 972847, upload-time = "2026-04-20T16:38:37.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f0/c39480a2db385fde23861d0c8acda41cdaf1d43e46579db72c5c013a2e81/pymongo-4.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:0ff6bd2f735ab5356541e3e57d5b7dbfbc3f2ee1ccb10b6b0f82d58af69d1d8e", size = 951575, upload-time = "2026-04-20T16:38:40.544Z" },
 ]
 
 [[package]]
@@ -6507,6 +6873,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
 ]
 
 [[package]]
@@ -7036,6 +7414,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -7135,17 +7522,26 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.23.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
+    { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]
@@ -7270,17 +7666,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
-]
-
-[package.optional-dependencies]
-standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Introduce MongoDB config/runtime under drmcp/platform, ToolSet domain models and repository, and dr-mongo-migrations. Tool set is a named, user-owned collection of MCP tool references. 

## CHANGES
Foundation for persisting Tool Sets in MongoDB on the MCP server. models, repository, MSF config/runtime, schema migrations, and tests.

- Domain and data access
`core/tool_sets/ `  ToolSet / ToolEntry models, repository, exceptions
Collection: `tool_sets` with `unique (created_by, name)` index
- Platform
drmcp/platform/: DRMcpServiceConfig, Mongo config, runtime wiring for ToolSetRepository
- Migrations
db_migrations/migration_20260722120000_create_tool_sets.py:  creates collection + indexes
migrations/__main__.py + sbin/drmcp-migrate-db:  migration CLI entrypoint
- Dependencies
dr-msf>=3.0.0, dr-mongo-migrations, motor, pymongo
pyproject.toml overrides for uvicorn and rich (dr-msf stale pins)
- Tests
Unit: tests/drmcp/unit/tool_sets/ (6 tests)



## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Mongo persistence path and dependency overrides (dr-msf, Artifactory) affect drmcp installs and CI; no HTTP/API surface yet, but migrations and unique indexes will govern production data shape.
> 
> **Overview**
> Adds **MongoDB-backed Tool Sets** for drmcp: named, user-owned collections of MCP tool references (`ToolEntry` / `ToolSet`), with MSF models, `ToolSetRepository`, and platform wiring (`DRMcpServiceConfig`, async runtime + `ToolSetRepository` provider).
> 
> Introduces **schema migrations** via `dr-mongo-migrations`: `create_tool_sets` creates the `tool_sets` collection with unique `(created_by, name)` and owner indexes; **`sbin/drmcp-migrate-db`** and `python -m datarobot_genai.drmcp.migrations` run the CLI using `MONGO_URI`.
> 
> **Dependencies**: `motor`, `pymongo`, `dr-msf`, `dr-mongo-migrations` on the `drmcp` extra; Artifactory index for internal packages; uv overrides for `uvicorn`/`rich` (dr-msf pins). **CI**: drmcp integration job gets a **mongo:7** service and `MONGO_URI`. Unit and integration tests cover models, repository indexes, migration apply/rollback, and duplicate-key behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c55dcce2e1646511de40ee5c48e665ba4d6b69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->