### PR TITLE
[MODEL-24221] Fix vdb_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.9
+- `drtools/vdb`: fixed `vdb_query` falsely rejecting valid vector database deployments when validating via `dr.Deployment.get()`
+
 ## 0.26.8
 - `llama_index`: strip `parallel_tool_calls` from tool requests for OpenAI o-series reasoning models (o1/o3/o4-mini), which reject it. gpt-5/gpt-4o keep it. Fixes tool-using agents failing on o-series with `Unsupported parameter: 'parallel_tool_calls'`.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -898,7 +898,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.6"
+version = "0.26.9"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.8"
+version = "0.26.9"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drtools/vdb/tools.py
+++ b/src/datarobot_genai/drtools/vdb/tools.py
@@ -172,17 +172,21 @@ def _is_vector_database_deployment(deployment: dict[str, Any] | Any) -> bool:
         if isinstance(deployment, dict)
         else getattr(deployment, "model", None)
     )
-    if isinstance(model, dict) and model.get("targetType") == "VectorDatabase":
-        return True
+    if isinstance(model, dict):
+        target_type = model.get("targetType") or model.get("target_type")
+        if target_type == "VectorDatabase":
+            return True
     capabilities = (
         deployment.get("capabilities")
         if isinstance(deployment, dict)
         else getattr(deployment, "capabilities", None)
     )
-    return (
-        isinstance(capabilities, dict)
-        and capabilities.get("supportsVectorDatabaseQuerying") is True
-    )
+    if isinstance(capabilities, dict):
+        return (
+            capabilities.get("supportsVectorDatabaseQuerying") is True
+            or capabilities.get("supports_vector_database_querying") is True
+        )
+    return False
 
 
 def _list_vdb_deployments(rest_client: Any) -> list[dict[str, Any]]:

--- a/tests/drmcp/unit/vdb_tools/test_tools.py
+++ b/tests/drmcp/unit/vdb_tools/test_tools.py
@@ -31,6 +31,27 @@ from datarobot_genai.drtools.vdb import tools
 VDB_ID = "69cbb73789723b6936c6c9e1"
 
 
+def _vdb_sdk_deployment(
+    deployment_id: str,
+    *,
+    label: str = "My VDB Deployment",
+    status: str = "launching",
+) -> SimpleNamespace:
+    """Deployment object shape returned by dr.Deployment.get() (snake_case keys)."""
+    return SimpleNamespace(
+        id=deployment_id,
+        label=label,
+        status=status,
+        model={"target_type": "VectorDatabase"},
+        default_prediction_server={
+            "id": "srv1",
+            "url": "https://pred.example.com",
+            "datarobot-key": "key1",
+        },
+        prediction_environment=None,
+    )
+
+
 def _vdb_deployment_record(
     deployment_id: str,
     *,
@@ -43,6 +64,24 @@ def _vdb_deployment_record(
         "status": status,
         "model": {"targetType": "VectorDatabase"},
     }
+
+
+@pytest.mark.parametrize(
+    ("deployment", "expected"),
+    [
+        ({"model": {"targetType": "VectorDatabase"}}, True),
+        ({"model": {"target_type": "VectorDatabase"}}, True),
+        ({"capabilities": {"supportsVectorDatabaseQuerying": True}}, True),
+        ({"capabilities": {"supports_vector_database_querying": True}}, True),
+        ({"model": {"targetType": "Binary"}}, False),
+        ({"model": {"target_type": "Binary"}}, False),
+        (SimpleNamespace(model={"target_type": "VectorDatabase"}), True),
+        (SimpleNamespace(model={"targetType": "VectorDatabase"}), True),
+        (SimpleNamespace(model={"target_type": "Binary"}), False),
+    ],
+)
+def test_is_vector_database_deployment(deployment: object, expected: bool) -> None:
+    assert tools._is_vector_database_deployment(deployment) is expected
 
 
 @pytest.fixture
@@ -146,16 +185,7 @@ async def test_vdb_list_empty() -> None:
 async def test_vdb_query_success(
     mock_get_client_context_with_token_from_request_header: Mock,
 ) -> None:
-    mock_deployment = SimpleNamespace(
-        id="dep1",
-        model={"targetType": "VectorDatabase"},
-        default_prediction_server={
-            "id": "srv1",
-            "url": "https://pred.example.com",
-            "datarobot-key": "key1",
-        },
-        prediction_environment=None,
-    )
+    mock_deployment = _vdb_sdk_deployment("dep1")
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": [
@@ -201,16 +231,7 @@ async def test_vdb_query_success(
 async def test_vdb_query_parses_prediction_server_response(
     mock_get_client_context_with_token_from_request_header: Mock,
 ) -> None:
-    mock_deployment = SimpleNamespace(
-        id="dep1",
-        model={"targetType": "VectorDatabase"},
-        default_prediction_server={
-            "id": "srv1",
-            "url": "https://pred.example.com",
-            "datarobot-key": "key1",
-        },
-        prediction_environment=None,
-    )
+    mock_deployment = _vdb_sdk_deployment("dep1")
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": [
@@ -268,7 +289,7 @@ async def test_vdb_query_client_error_404(
 ) -> None:
     mock_deployment = SimpleNamespace(
         id="missing-dep",
-        model={"targetType": "VectorDatabase"},
+        model={"target_type": "VectorDatabase"},
         default_prediction_server={
             "id": "srv1",
             "url": "https://pred.example.com",
@@ -305,8 +326,8 @@ async def test_vdb_query_rejects_non_vdb_deployment(
 ) -> None:
     mock_deployment = SimpleNamespace(
         id="pred-dep",
-        model={"targetType": "Binary"},
-        capabilities={"supportsVectorDatabaseQuerying": False},
+        model={"target_type": "Binary"},
+        capabilities={"supports_vector_database_querying": False},
     )
     mock_rest_client = MagicMock()
     mock_get_client_context_with_token_from_request_header.return_value.__enter__.return_value = (

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.8"
+version = "0.26.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
`vdb_query` rejects valid VDB deployments: deployment-type check uses camelCase keys against a snake_cased SDK object.

<!--


For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## TESTING
<img width="558" height="652" alt="Screenshot 2026-07-23 at 12 58 27 PM" src="https://github.com/user-attachments/assets/ee945637-2be5-46a4-ac42-d93b170d6500" />

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
