### PR TITLE
[MODEL-23998] Add mcp protected resource metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.11
+- `drmcpbase/oauth_protected_resource_metadata`: Added OAuth protected resource metadata supports in user MCP.
+
 ## 0.26.10
 - `dragent`: NAT batch evaluation (`nat eval`) plugins for DataRobot moderation metrics — `agent_goal_accuracy`, `faithfulness`, `task_adherence`, and `agent_guideline_adherence` — scoring in-process via `datarobot-moderations` OOTB judges (no NeMo Evaluator microservice).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.10"
+version = "0.26.11"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/routes.py
+++ b/src/datarobot_genai/drmcp/core/routes.py
@@ -18,6 +18,9 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from datarobot_genai import __version__
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import (
+    MCPOAuthProtectedResourceMetadataManager,
+)
 from datarobot_genai.drmcputils.routes import register_tool_gallery_routes
 from datarobot_genai.drtools.core import get_tool_ui_metadata
 
@@ -333,4 +336,19 @@ def register_routes(mcp: DataRobotMCP) -> None:
             return JSONResponse(
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 content={"error": f"Failed to refresh prompt templates: {str(e)}"},
+            )
+
+    @mcp.custom_route(prefix_mount_path("/oauthProtectedResourceMetadata"), methods=["GET"])
+    async def oauth_protected_resource_metadata(_: Request) -> JSONResponse:
+        manager = MCPOAuthProtectedResourceMetadataManager()
+        api_response = manager.get_protected_resource_metadata_api_response()
+        if api_response:
+            return JSONResponse(
+                status_code=HTTPStatus.OK,
+                content=api_response,
+            )
+        else:
+            return JSONResponse(
+                status_code=HTTPStatus.NOT_IMPLEMENTED,
+                content={"error": "OAuth Protected Resource Metadata Not Implemented"},
             )

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/__init__.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
@@ -11,24 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
 from dataclasses import asdict
 from dataclasses import dataclass
 from typing import Any
 
+import yaml
+
 logger = logging.getLogger(__name__)
 
 
 class BaseDataClass:
-    def to_json_without_null_attribute(self) -> dict[str, Any]:
+    def to_dict_without_null_attribute(self) -> dict[str, Any]:
         return asdict(
             self,  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
             dict_factory=lambda x: {k: v for k, v in x if v is not None},
         )
 
-    def to_json_string(self) -> str:
-        return json.dumps(self.to_json_without_null_attribute())
+    def to_yaml_string(self) -> str:
+        return yaml.safe_dump(self.to_dict_without_null_attribute())
 
 
 @dataclass
@@ -37,8 +38,8 @@ class XAATokenExchangeParams(BaseDataClass):
     audience: str
 
     @classmethod
-    def from_json(cls, json_dict: dict[str, str]) -> "XAATokenExchangeParams":
-        return cls(json_dict["trusted_issuer"], json_dict["audience"])
+    def from_dict(cls, dict_input: dict[str, str]) -> "XAATokenExchangeParams":
+        return cls(dict_input["trusted_issuer"], dict_input["audience"])
 
 
 @dataclass
@@ -49,8 +50,8 @@ class XAATokenRequestParams(BaseDataClass):
     scopes: list[str]
 
     @classmethod
-    def from_json(cls, json_dict: dict[str, Any]) -> "XAATokenRequestParams":
-        return cls(json_dict["token_url"], json_dict.get("audience"), json_dict["scopes"])
+    def from_dict(cls, dict_input: dict[str, Any]) -> "XAATokenRequestParams":
+        return cls(dict_input["token_url"], dict_input.get("audience"), dict_input["scopes"])
 
 
 @dataclass
@@ -60,11 +61,11 @@ class XAAMetadata(BaseDataClass):
     token_request: XAATokenRequestParams
 
     @classmethod
-    def from_json(cls, metadata_in_json: dict[str, Any]) -> "XAAMetadata":
+    def from_dict(cls, metadata_in_dict: dict[str, Any]) -> "XAAMetadata":
         return cls(
-            metadata_in_json["token_endpoint_auth_method"],
-            XAATokenExchangeParams.from_json(metadata_in_json["token_exchange"]),
-            XAATokenRequestParams.from_json(metadata_in_json["token_request"]),
+            metadata_in_dict["token_endpoint_auth_method"],
+            XAATokenExchangeParams.from_dict(metadata_in_dict["token_exchange"]),
+            XAATokenRequestParams.from_dict(metadata_in_dict["token_request"]),
         )
 
 
@@ -76,18 +77,18 @@ class MCPOAuthProtectedResourceMetadataConfig(BaseDataClass):
     xaa_metadata: XAAMetadata | None
 
     @classmethod
-    def from_json(
-        cls, metadata_in_json: dict[str, Any]
+    def from_dict(
+        cls, metadata_in_dict: dict[str, Any]
     ) -> "MCPOAuthProtectedResourceMetadataConfig":
         xaa_metadata = (
-            XAAMetadata.from_json(metadata_in_json["xaa_metadata"])
-            if metadata_in_json.get("xaa_metadata")
+            XAAMetadata.from_dict(metadata_in_dict["xaa_metadata"])
+            if metadata_in_dict.get("xaa_metadata")
             else None
         )
         return cls(
-            metadata_in_json["resource"],
-            metadata_in_json["authorization_servers"],
-            metadata_in_json["scopes_supported"],
+            metadata_in_dict["resource"],
+            metadata_in_dict["authorization_servers"],
+            metadata_in_dict["scopes_supported"],
             xaa_metadata,
         )
 

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
@@ -1,0 +1,120 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+from dataclasses import asdict
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class BaseDataClass:
+    def to_json_without_null_attribute(self) -> dict[str, Any]:
+        return asdict(
+            self,  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+            dict_factory=lambda x: {k: v for k, v in x if v is not None},
+        )
+
+    def to_json_string(self) -> str:
+        return json.dumps(self.to_json_without_null_attribute())
+
+
+@dataclass
+class XAATokenExchangeParams(BaseDataClass):
+    trusted_issuer: str
+    audience: str
+
+    @classmethod
+    def from_json(cls, json_dict: dict[str, str]) -> "XAATokenExchangeParams":
+        return cls(json_dict["trusted_issuer"], json_dict["audience"])
+
+
+@dataclass
+class XAATokenRequestParams(BaseDataClass):
+    token_url: str
+    # audience can be None if it is not setup for AuthN & AuthZ check (as resource) in IdP.
+    audience: str | None
+    scopes: list[str]
+
+    @classmethod
+    def from_json(cls, json_dict: dict[str, Any]) -> "XAATokenRequestParams":
+        return cls(json_dict["token_url"], json_dict.get("audience"), json_dict["scopes"])
+
+
+@dataclass
+class XAAMetadata(BaseDataClass):
+    token_endpoint_auth_method: str
+    token_exchange: XAATokenExchangeParams
+    token_request: XAATokenRequestParams
+
+    @classmethod
+    def from_json(cls, metadata_in_json: dict[str, Any]) -> "XAAMetadata":
+        return cls(
+            metadata_in_json["token_endpoint_auth_method"],
+            XAATokenExchangeParams.from_json(metadata_in_json["token_exchange"]),
+            XAATokenRequestParams.from_json(metadata_in_json["token_request"]),
+        )
+
+
+@dataclass
+class MCPOAuthProtectedResourceMetadataConfig(BaseDataClass):
+    resource: str
+    authorization_servers: list[str]
+    scopes_supported: list[str]
+    xaa_metadata: XAAMetadata | None
+
+    @classmethod
+    def from_json(
+        cls, metadata_in_json: dict[str, Any]
+    ) -> "MCPOAuthProtectedResourceMetadataConfig":
+        xaa_metadata = (
+            XAAMetadata.from_json(metadata_in_json["xaa_metadata"])
+            if metadata_in_json.get("xaa_metadata")
+            else None
+        )
+        return cls(
+            metadata_in_json["resource"],
+            metadata_in_json["authorization_servers"],
+            metadata_in_json["scopes_supported"],
+            xaa_metadata,
+        )
+
+
+@dataclass
+class MCPOAuthProtectedResourceMetadataAdminConfig(BaseDataClass):
+    bearer_methods_supported: list[str]
+
+
+@dataclass
+class MCPOAuthProtectedResourceMetadata(BaseDataClass):
+    resource: str
+    authorization_servers: list[str]
+    bearer_methods_supported: list[str]
+    scopes_supported: list[str]
+    xaa_metadata: XAAMetadata | None
+
+    @classmethod
+    def build(
+        cls,
+        user_config: MCPOAuthProtectedResourceMetadataConfig,
+        admin_config: MCPOAuthProtectedResourceMetadataAdminConfig,
+    ) -> "MCPOAuthProtectedResourceMetadata":
+        return cls(
+            user_config.resource,
+            user_config.authorization_servers,
+            admin_config.bearer_methods_supported,
+            user_config.scopes_supported,
+            user_config.xaa_metadata,
+        )

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
@@ -1,0 +1,81 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+import os
+from enum import Enum
+from enum import auto
+from typing import Any
+
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    MCPOAuthProtectedResourceMetadata,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    MCPOAuthProtectedResourceMetadataAdminConfig,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    MCPOAuthProtectedResourceMetadataConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SupportedMethodsToSendBearerToken(Enum):
+    HEADER = auto()
+
+    def get_name_in_lower_case(self) -> str:
+        return self.name.lower()
+
+    @classmethod
+    def get_complete_list_of_supported_methods(cls) -> list[str]:
+        return [supported_method.get_name_in_lower_case() for supported_method in cls]
+
+
+class ContainerEnvVar(Enum):
+    MCP_OAUTH_PROTECTED_RESOURCE_METADATA = auto()
+
+    def get_env_var_value(self) -> str | None:
+        return os.getenv(self.name)
+
+
+class MCPOAuthProtectedResourceMetadataManager:
+    @staticmethod
+    def load_config() -> MCPOAuthProtectedResourceMetadataConfig | None:
+        metadata_in_json_str = (
+            ContainerEnvVar.MCP_OAUTH_PROTECTED_RESOURCE_METADATA.get_env_var_value()
+        )
+        if metadata_in_json_str:
+            metadata_in_json = json.loads(metadata_in_json_str)
+            return MCPOAuthProtectedResourceMetadataConfig.from_json(metadata_in_json)
+        else:
+            return None
+
+    @staticmethod
+    def get_admin_config() -> MCPOAuthProtectedResourceMetadataAdminConfig:
+        return MCPOAuthProtectedResourceMetadataAdminConfig(
+            [SupportedMethodsToSendBearerToken.HEADER.get_name_in_lower_case()]
+        )
+
+    def get_protected_resource_metadata(self) -> MCPOAuthProtectedResourceMetadata | None:
+        metadata_config = self.load_config()
+        if not metadata_config:
+            return None
+        admin_config = self.get_admin_config()
+        return MCPOAuthProtectedResourceMetadata.build(metadata_config, admin_config)
+
+    def get_protected_resource_metadata_api_response(self) -> dict[str, Any] | None:
+        metadata = self.get_protected_resource_metadata()
+        if not metadata:
+            return None
+        return metadata.to_json_without_null_attribute()

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
 import os
 from enum import Enum
 from enum import auto
 from typing import Any
+
+import yaml
 
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadata,
@@ -56,8 +57,8 @@ class MCPOAuthProtectedResourceMetadataManager:
             ContainerEnvVar.MCP_OAUTH_PROTECTED_RESOURCE_METADATA.get_env_var_value()
         )
         if metadata_in_json_str:
-            metadata_in_json = json.loads(metadata_in_json_str)
-            return MCPOAuthProtectedResourceMetadataConfig.from_json(metadata_in_json)
+            metadata_in_json = yaml.safe_load(metadata_in_json_str)
+            return MCPOAuthProtectedResourceMetadataConfig.from_dict(metadata_in_json)
         else:
             return None
 
@@ -78,4 +79,4 @@ class MCPOAuthProtectedResourceMetadataManager:
         metadata = self.get_protected_resource_metadata()
         if not metadata:
             return None
-        return metadata.to_json_without_null_attribute()
+        return metadata.to_dict_without_null_attribute()

--- a/tests/drmcp/unit/test_routes.py
+++ b/tests/drmcp/unit/test_routes.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 from collections.abc import Callable
+from collections.abc import Iterator
 from http import HTTPStatus
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
@@ -24,6 +25,9 @@ from fastmcp.prompts import Prompt
 from datarobot_genai import __version__ as drmcp_genai_version
 from datarobot_genai.drmcp.core.routes import _tools_gallery_enabled
 from datarobot_genai.drmcp.core.routes import register_routes
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import (
+    MCPOAuthProtectedResourceMetadataManager,
+)
 
 
 class TestRoutesCoverage:
@@ -883,3 +887,64 @@ class TestToolsGalleryGate:
         with patch(GATE_FLAG, new=AsyncMock(return_value=enabled)) as mock_flag:
             assert await _tools_gallery_enabled(Mock()) is enabled
         mock_flag.assert_awaited_once_with()
+
+
+class TestOAuthProtectedResourceMetadataRoute:
+    @pytest.fixture
+    def mock_mcp(self) -> Mock:
+        mock_mcp_object = Mock()
+        mock_mcp_object.registered_routes = {}
+
+        def mock_custom_route(route_path: str, methods: list[str]):
+            def decorator(handler: Callable):
+                for method in methods:
+                    mock_mcp_object.registered_routes[(method, route_path)] = handler
+                return handler
+
+            return decorator
+
+        mock_mcp_object.custom_route = mock_custom_route
+        return mock_mcp_object
+
+    @pytest.fixture(autouse=True)
+    def mock_mcp_register_routes(self, mock_mcp: Mock) -> Iterator[None]:
+        register_routes(mock_mcp)
+        yield
+
+    @pytest.fixture
+    def mock_get_protected_resource_metadata_api_response(self) -> Iterator[Mock]:
+        with patch.object(
+            MCPOAuthProtectedResourceMetadataManager,
+            "get_protected_resource_metadata_api_response",
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.mark.asyncio
+    async def test_get_return_metadata(
+        self,
+        mock_get_protected_resource_metadata_api_response: Mock,
+        mock_mcp: Mock,
+    ) -> None:
+        mock_get_protected_resource_metadata_api_response.return_value = {"mock": "mock"}
+
+        metadata_handler = mock_mcp.registered_routes["GET", "/oauthProtectedResourceMetadata"]
+        response = await metadata_handler(Mock())
+
+        assert response.status_code == HTTPStatus.OK
+        response_data = json.loads(response.body.decode("utf-8"))
+        assert response_data == {"mock": "mock"}
+
+    @pytest.mark.asyncio
+    async def test_get_return_not_implemented_error(
+        self,
+        mock_get_protected_resource_metadata_api_response: Mock,
+        mock_mcp: Mock,
+    ) -> None:
+        mock_get_protected_resource_metadata_api_response.return_value = None
+
+        metadata_handler = mock_mcp.registered_routes["GET", "/oauthProtectedResourceMetadata"]
+        response = await metadata_handler(Mock())
+
+        assert response.status_code == HTTPStatus.NOT_IMPLEMENTED
+        response_data = json.loads(response.body.decode("utf-8"))
+        assert response_data == {"error": "OAuth Protected Resource Metadata Not Implemented"}

--- a/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_entities.py
+++ b/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_entities.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 from dataclasses import dataclass
 from typing import Any
 
 import pytest
+import yaml
 
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import BaseDataClass
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
@@ -76,7 +76,7 @@ def mock_token_request_scopes() -> list[str]:
 
 
 @pytest.fixture
-def xaa_metadata_in_json(
+def xaa_metadata_in_dict(
     mock_token_endpoint_auth_method: str,
     mock_token_exchange_trusted_issuer: str,
     mock_token_exchange_audience: str,
@@ -99,17 +99,17 @@ def xaa_metadata_in_json(
 
 
 @pytest.fixture
-def metadata_in_json(
+def metadata_in_dict(
     mock_mcp_as_resource_server_url: str,
     mock_authorization_server_urls: list[str],
     mock_scopes_supported: list[str],
-    xaa_metadata_in_json: dict[str, Any],
+    xaa_metadata_in_dict: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "resource": mock_mcp_as_resource_server_url,
         "authorization_servers": mock_authorization_server_urls,
         "scopes_supported": mock_scopes_supported,
-        "xaa_metadata": xaa_metadata_in_json,
+        "xaa_metadata": xaa_metadata_in_dict,
     }
 
 
@@ -120,27 +120,27 @@ class DummyDataClassInheritingBaseDataClass(BaseDataClass):
 
 
 class TestBaseDataClass:
-    def test_to_json_without_null_attribute(self) -> None:
+    def test_to_dict_without_null_attribute(self) -> None:
         dataclass_object = DummyDataClassInheritingBaseDataClass(1, None)
-        assert dataclass_object.to_json_without_null_attribute() == {"attribute": 1}
+        assert dataclass_object.to_dict_without_null_attribute() == {"attribute": 1}
 
-    def test_to_json_string(self) -> None:
+    def test_to_yaml_string(self) -> None:
         dataclass_object = DummyDataClassInheritingBaseDataClass(1, None)
-        assert dataclass_object.to_json_string() == '{"attribute": 1}'
+        assert dataclass_object.to_yaml_string() == "attribute: 1\n"
 
 
 class TestXAAMetadata:
     @pytest.fixture
     def metadata_without_token_request_audience(
         self,
-        xaa_metadata_in_json: dict[str, Any],
+        xaa_metadata_in_dict: dict[str, Any],
     ) -> dict[str, Any]:
-        xaa_metadata_in_json["token_request"].pop("audience")
-        return xaa_metadata_in_json
+        xaa_metadata_in_dict["token_request"].pop("audience")
+        return xaa_metadata_in_dict
 
-    def test_load_from_json(
+    def test_load_from_dict(
         self,
-        xaa_metadata_in_json: dict[str, Any],
+        xaa_metadata_in_dict: dict[str, Any],
         mock_token_endpoint_auth_method: str,
         mock_token_exchange_trusted_issuer: str,
         mock_token_exchange_audience: str,
@@ -148,7 +148,7 @@ class TestXAAMetadata:
         mock_token_request_audience: str,
         mock_token_request_scopes: list[str],
     ) -> None:
-        metadata = XAAMetadata.from_json(xaa_metadata_in_json)
+        metadata = XAAMetadata.from_dict(xaa_metadata_in_dict)
 
         assert isinstance(metadata, XAAMetadata)
         assert metadata.token_endpoint_auth_method == mock_token_endpoint_auth_method
@@ -162,36 +162,36 @@ class TestXAAMetadata:
         assert token_request_params.audience == mock_token_request_audience
         assert token_request_params.scopes == mock_token_request_scopes
 
-    def test_load_from_json_without_token_request_audience(
+    def test_load_from_dict_without_token_request_audience(
         self,
         metadata_without_token_request_audience: dict[str, Any],
     ) -> None:
-        metadata = XAAMetadata.from_json(metadata_without_token_request_audience)
+        metadata = XAAMetadata.from_dict(metadata_without_token_request_audience)
 
         assert isinstance(metadata, XAAMetadata)
         assert metadata.token_request.audience is None
 
-    def test_to_json_string(self, xaa_metadata_in_json: dict[str, Any]) -> None:
-        metadata = XAAMetadata.from_json(xaa_metadata_in_json)
-        assert metadata.to_json_string() == json.dumps(xaa_metadata_in_json)
+    def test_to_yaml_string(self, xaa_metadata_in_dict: dict[str, Any]) -> None:
+        metadata = XAAMetadata.from_dict(xaa_metadata_in_dict)
+        assert metadata.to_yaml_string() == yaml.safe_dump(xaa_metadata_in_dict)
 
 
 class TestMCPOAuthProtectedResourceMetadataConfig:
-    def test_load_from_json(
+    def test_load_from_dict(
         self,
-        metadata_in_json: dict[str, Any],
+        metadata_in_dict: dict[str, Any],
         mock_mcp_as_resource_server_url: str,
         mock_authorization_server_urls: list[str],
         mock_scopes_supported: list[str],
-        xaa_metadata_in_json: dict[str, Any],
+        xaa_metadata_in_dict: dict[str, Any],
     ) -> None:
-        metadata = MCPOAuthProtectedResourceMetadataConfig.from_json(metadata_in_json)
+        metadata = MCPOAuthProtectedResourceMetadataConfig.from_dict(metadata_in_dict)
 
         assert metadata.resource == mock_mcp_as_resource_server_url
         assert metadata.authorization_servers == mock_authorization_server_urls
         assert metadata.scopes_supported == mock_scopes_supported
         assert isinstance(metadata.xaa_metadata, XAAMetadata)
 
-    def test_to_json_string(self, metadata_in_json: dict[str, Any]) -> None:
-        metadata = MCPOAuthProtectedResourceMetadataConfig.from_json(metadata_in_json)
-        assert metadata.to_json_string() == json.dumps(metadata_in_json)
+    def test_to_yaml_string(self, metadata_in_dict: dict[str, Any]) -> None:
+        metadata = MCPOAuthProtectedResourceMetadataConfig.from_dict(metadata_in_dict)
+        assert metadata.to_yaml_string() == yaml.safe_dump(metadata_in_dict)

--- a/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_entities.py
+++ b/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_entities.py
@@ -1,0 +1,197 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import BaseDataClass
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    MCPOAuthProtectedResourceMetadataConfig,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import XAAMetadata
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    XAATokenExchangeParams,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    XAATokenRequestParams,
+)
+
+
+@pytest.fixture
+def mock_mcp_as_resource_server_url() -> str:
+    return "https://foo/bar/mcp_resource_server"
+
+
+@pytest.fixture
+def mock_authorization_server_urls() -> list[str]:
+    return ["https://foo/bar/authorization_server"]
+
+
+@pytest.fixture
+def mock_scopes_supported() -> list[str]:
+    return ["scope"]
+
+
+@pytest.fixture
+def mock_token_endpoint_auth_method() -> str:
+    return "private_key_jwt"
+
+
+@pytest.fixture
+def mock_token_exchange_trusted_issuer() -> str:
+    return "https://foo/bar/issuer"
+
+
+@pytest.fixture
+def mock_token_exchange_audience() -> str:
+    return "https://foo/bar/token_exchange_audience"
+
+
+@pytest.fixture
+def mock_token_request_token_url() -> str:
+    return "https://foo/bar/token"
+
+
+@pytest.fixture
+def mock_token_request_audience() -> str:
+    return "https://foo/bar/token_request_audience"
+
+
+@pytest.fixture
+def mock_token_request_scopes() -> list[str]:
+    return ["scope"]
+
+
+@pytest.fixture
+def xaa_metadata_in_json(
+    mock_token_endpoint_auth_method: str,
+    mock_token_exchange_trusted_issuer: str,
+    mock_token_exchange_audience: str,
+    mock_token_request_token_url: str,
+    mock_token_request_audience: str,
+    mock_token_request_scopes: list[str],
+) -> dict[str, Any]:
+    return {
+        "token_endpoint_auth_method": mock_token_endpoint_auth_method,
+        "token_exchange": {
+            "trusted_issuer": mock_token_exchange_trusted_issuer,
+            "audience": mock_token_exchange_audience,
+        },
+        "token_request": {
+            "token_url": mock_token_request_token_url,
+            "audience": mock_token_request_audience,
+            "scopes": mock_token_request_scopes,
+        },
+    }
+
+
+@pytest.fixture
+def metadata_in_json(
+    mock_mcp_as_resource_server_url: str,
+    mock_authorization_server_urls: list[str],
+    mock_scopes_supported: list[str],
+    xaa_metadata_in_json: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "resource": mock_mcp_as_resource_server_url,
+        "authorization_servers": mock_authorization_server_urls,
+        "scopes_supported": mock_scopes_supported,
+        "xaa_metadata": xaa_metadata_in_json,
+    }
+
+
+@dataclass
+class DummyDataClassInheritingBaseDataClass(BaseDataClass):
+    attribute: int
+    nullable_attribute: int | None
+
+
+class TestBaseDataClass:
+    def test_to_json_without_null_attribute(self) -> None:
+        dataclass_object = DummyDataClassInheritingBaseDataClass(1, None)
+        assert dataclass_object.to_json_without_null_attribute() == {"attribute": 1}
+
+    def test_to_json_string(self) -> None:
+        dataclass_object = DummyDataClassInheritingBaseDataClass(1, None)
+        assert dataclass_object.to_json_string() == '{"attribute": 1}'
+
+
+class TestXAAMetadata:
+    @pytest.fixture
+    def metadata_without_token_request_audience(
+        self,
+        xaa_metadata_in_json: dict[str, Any],
+    ) -> dict[str, Any]:
+        xaa_metadata_in_json["token_request"].pop("audience")
+        return xaa_metadata_in_json
+
+    def test_load_from_json(
+        self,
+        xaa_metadata_in_json: dict[str, Any],
+        mock_token_endpoint_auth_method: str,
+        mock_token_exchange_trusted_issuer: str,
+        mock_token_exchange_audience: str,
+        mock_token_request_token_url: str,
+        mock_token_request_audience: str,
+        mock_token_request_scopes: list[str],
+    ) -> None:
+        metadata = XAAMetadata.from_json(xaa_metadata_in_json)
+
+        assert isinstance(metadata, XAAMetadata)
+        assert metadata.token_endpoint_auth_method == mock_token_endpoint_auth_method
+        token_exchange_params = metadata.token_exchange
+        assert isinstance(token_exchange_params, XAATokenExchangeParams)
+        assert token_exchange_params.trusted_issuer == mock_token_exchange_trusted_issuer
+        assert token_exchange_params.audience == mock_token_exchange_audience
+        token_request_params = metadata.token_request
+        assert isinstance(token_request_params, XAATokenRequestParams)
+        assert token_request_params.token_url == mock_token_request_token_url
+        assert token_request_params.audience == mock_token_request_audience
+        assert token_request_params.scopes == mock_token_request_scopes
+
+    def test_load_from_json_without_token_request_audience(
+        self,
+        metadata_without_token_request_audience: dict[str, Any],
+    ) -> None:
+        metadata = XAAMetadata.from_json(metadata_without_token_request_audience)
+
+        assert isinstance(metadata, XAAMetadata)
+        assert metadata.token_request.audience is None
+
+    def test_to_json_string(self, xaa_metadata_in_json: dict[str, Any]) -> None:
+        metadata = XAAMetadata.from_json(xaa_metadata_in_json)
+        assert metadata.to_json_string() == json.dumps(xaa_metadata_in_json)
+
+
+class TestMCPOAuthProtectedResourceMetadataConfig:
+    def test_load_from_json(
+        self,
+        metadata_in_json: dict[str, Any],
+        mock_mcp_as_resource_server_url: str,
+        mock_authorization_server_urls: list[str],
+        mock_scopes_supported: list[str],
+        xaa_metadata_in_json: dict[str, Any],
+    ) -> None:
+        metadata = MCPOAuthProtectedResourceMetadataConfig.from_json(metadata_in_json)
+
+        assert metadata.resource == mock_mcp_as_resource_server_url
+        assert metadata.authorization_servers == mock_authorization_server_urls
+        assert metadata.scopes_supported == mock_scopes_supported
+        assert isinstance(metadata.xaa_metadata, XAAMetadata)
+
+    def test_to_json_string(self, metadata_in_json: dict[str, Any]) -> None:
+        metadata = MCPOAuthProtectedResourceMetadataConfig.from_json(metadata_in_json)
+        assert metadata.to_json_string() == json.dumps(metadata_in_json)

--- a/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
+++ b/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import os
 from collections.abc import Iterator
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadata,
@@ -70,8 +70,8 @@ class TestSupportedMethodsToSendBearerToken:
 
 class TestMCPOAuthProtectedResourceMetadataManager:
     @pytest.fixture
-    def mock_json_loads(self) -> Iterator[Mock]:
-        with patch.object(json, "loads") as mock_func:
+    def mock_yaml_safe_load(self) -> Iterator[Mock]:
+        with patch.object(yaml, "safe_load") as mock_func:
             yield mock_func
 
     @pytest.fixture
@@ -83,8 +83,8 @@ class TestMCPOAuthProtectedResourceMetadataManager:
             yield mock_func
 
     @pytest.fixture
-    def mock_mcp_oauth_protected_resource_metadata_user_config_from_json(self) -> Iterator[Mock]:
-        with patch.object(MCPOAuthProtectedResourceMetadataConfig, "from_json") as mock_func:
+    def mock_mcp_oauth_protected_resource_metadata_user_config_from_dict(self) -> Iterator[Mock]:
+        with patch.object(MCPOAuthProtectedResourceMetadataConfig, "from_dict") as mock_func:
             yield mock_func
 
     @pytest.fixture
@@ -114,9 +114,9 @@ class TestMCPOAuthProtectedResourceMetadataManager:
 
     def test_load_config(
         self,
-        mock_json_loads: Mock,
+        mock_yaml_safe_load: Mock,
         mock_load_mcp_oauth_protected_resource_metadata_from_env_var: Mock,
-        mock_mcp_oauth_protected_resource_metadata_user_config_from_json: Mock,
+        mock_mcp_oauth_protected_resource_metadata_user_config_from_dict: Mock,
     ) -> None:
         manager = MCPOAuthProtectedResourceMetadataManager()
         output = manager.load_config()
@@ -125,12 +125,12 @@ class TestMCPOAuthProtectedResourceMetadataManager:
         mock_metadata_json_string = (
             mock_load_mcp_oauth_protected_resource_metadata_from_env_var.return_value
         )
-        mock_json_loads.assert_called_once_with(mock_metadata_json_string)
-        mock_mcp_oauth_protected_resource_metadata_user_config_from_json.assert_called_once_with(
-            mock_json_loads.return_value
+        mock_yaml_safe_load.assert_called_once_with(mock_metadata_json_string)
+        mock_mcp_oauth_protected_resource_metadata_user_config_from_dict.assert_called_once_with(
+            mock_yaml_safe_load.return_value
         )
         assert (
-            output == mock_mcp_oauth_protected_resource_metadata_user_config_from_json.return_value
+            output == mock_mcp_oauth_protected_resource_metadata_user_config_from_dict.return_value
         )
 
     def test_get_admin_config(self) -> None:
@@ -180,8 +180,8 @@ class TestMCPOAuthProtectedResourceMetadataManager:
         output = manager.get_protected_resource_metadata_api_response()
 
         mock_metadata = mock_get_protected_resource_metadata.return_value
-        mock_metadata.to_json_without_null_attribute.assert_called_once_with()
-        assert output == mock_metadata.to_json_without_null_attribute.return_value
+        mock_metadata.to_dict_without_null_attribute.assert_called_once_with()
+        assert output == mock_metadata.to_dict_without_null_attribute.return_value
 
     def test_get_protected_resource_metadata_api_response_return_none(
         self,

--- a/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
+++ b/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
@@ -1,0 +1,195 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+from collections.abc import Iterator
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    MCPOAuthProtectedResourceMetadata,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    MCPOAuthProtectedResourceMetadataAdminConfig,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    MCPOAuthProtectedResourceMetadataConfig,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import ContainerEnvVar
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import (
+    MCPOAuthProtectedResourceMetadataManager,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import (
+    SupportedMethodsToSendBearerToken,
+)
+
+
+class TestContainerEnvVar:
+    @pytest.fixture
+    def mock_os_getenv(self) -> Iterator[Mock]:
+        with patch.object(os, "getenv") as mock_func:
+            yield mock_func
+
+    @pytest.mark.parametrize("env_var_enum", ContainerEnvVar, ids=str)
+    def test_get_env_var_value(self, env_var_enum: ContainerEnvVar, mock_os_getenv: Mock) -> None:
+        env_var_enum.get_env_var_value()
+
+        mock_os_getenv.assert_called_once_with(env_var_enum.name)
+
+
+class TestSupportedMethodsToSendBearerToken:
+    @pytest.mark.parametrize("supported_method_enum", SupportedMethodsToSendBearerToken, ids=str)
+    def test_get_name_in_lower_case(
+        self,
+        supported_method_enum: SupportedMethodsToSendBearerToken,
+    ) -> None:
+        enum_and_names = {
+            SupportedMethodsToSendBearerToken.HEADER: "header",
+        }
+        assert (
+            supported_method_enum.get_name_in_lower_case() == enum_and_names[supported_method_enum]
+        )
+
+    def test_get_complete_list_of_supported_methods(self) -> None:
+        outputs = SupportedMethodsToSendBearerToken.get_complete_list_of_supported_methods()
+        assert outputs == ["header"]
+
+
+class TestMCPOAuthProtectedResourceMetadataManager:
+    @pytest.fixture
+    def mock_json_loads(self) -> Iterator[Mock]:
+        with patch.object(json, "loads") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_load_mcp_oauth_protected_resource_metadata_from_env_var(self) -> Iterator[Mock]:
+        with patch.object(
+            ContainerEnvVar.MCP_OAUTH_PROTECTED_RESOURCE_METADATA,
+            "get_env_var_value",
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_mcp_oauth_protected_resource_metadata_user_config_from_json(self) -> Iterator[Mock]:
+        with patch.object(MCPOAuthProtectedResourceMetadataConfig, "from_json") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_build_mcp_oauth_protected_resource_metadata(self) -> Iterator[Mock]:
+        with patch.object(MCPOAuthProtectedResourceMetadata, "build") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_load_config(self) -> Iterator[Mock]:
+        with patch.object(MCPOAuthProtectedResourceMetadataManager, "load_config") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_admin_config(self) -> Iterator[Mock]:
+        with patch.object(
+            MCPOAuthProtectedResourceMetadataManager, "get_admin_config"
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_protected_resource_metadata(self) -> Iterator[Mock]:
+        with patch.object(
+            MCPOAuthProtectedResourceMetadataManager,
+            "get_protected_resource_metadata",
+        ) as mock_func:
+            yield mock_func
+
+    def test_load_config(
+        self,
+        mock_json_loads: Mock,
+        mock_load_mcp_oauth_protected_resource_metadata_from_env_var: Mock,
+        mock_mcp_oauth_protected_resource_metadata_user_config_from_json: Mock,
+    ) -> None:
+        manager = MCPOAuthProtectedResourceMetadataManager()
+        output = manager.load_config()
+
+        mock_load_mcp_oauth_protected_resource_metadata_from_env_var.assert_called_once_with()
+        mock_metadata_json_string = (
+            mock_load_mcp_oauth_protected_resource_metadata_from_env_var.return_value
+        )
+        mock_json_loads.assert_called_once_with(mock_metadata_json_string)
+        mock_mcp_oauth_protected_resource_metadata_user_config_from_json.assert_called_once_with(
+            mock_json_loads.return_value
+        )
+        assert (
+            output == mock_mcp_oauth_protected_resource_metadata_user_config_from_json.return_value
+        )
+
+    def test_get_admin_config(self) -> None:
+        output = MCPOAuthProtectedResourceMetadataManager().get_admin_config()
+
+        assert isinstance(output, MCPOAuthProtectedResourceMetadataAdminConfig)
+        assert output.bearer_methods_supported == ["header"]
+
+    def test_get_protected_resource_metadata(
+        self,
+        mock_build_mcp_oauth_protected_resource_metadata: Mock,
+        mock_get_admin_config: Mock,
+        mock_load_config: Mock,
+    ) -> None:
+        manager = MCPOAuthProtectedResourceMetadataManager()
+        output = manager.get_protected_resource_metadata()
+
+        mock_load_config.assert_called_once_with()
+        mock_get_admin_config.assert_called_once_with()
+        mock_build_mcp_oauth_protected_resource_metadata.assert_called_once_with(
+            mock_load_config.return_value,
+            mock_get_admin_config.return_value,
+        )
+        assert output == mock_build_mcp_oauth_protected_resource_metadata.return_value
+
+    def test_get_protected_resource_metadata_return_none(
+        self,
+        mock_build_mcp_oauth_protected_resource_metadata: Mock,
+        mock_get_admin_config: Mock,
+        mock_load_config: Mock,
+    ) -> None:
+        mock_load_config.return_value = None
+
+        manager = MCPOAuthProtectedResourceMetadataManager()
+        output = manager.get_protected_resource_metadata()
+
+        mock_load_config.assert_called_once_with()
+        mock_get_admin_config.assert_not_called()
+        mock_build_mcp_oauth_protected_resource_metadata.assert_not_called()
+        assert output is None
+
+    def test_get_protected_resource_metadata_api_response(
+        self,
+        mock_get_protected_resource_metadata: Mock,
+    ) -> None:
+        manager = MCPOAuthProtectedResourceMetadataManager()
+        output = manager.get_protected_resource_metadata_api_response()
+
+        mock_metadata = mock_get_protected_resource_metadata.return_value
+        mock_metadata.to_json_without_null_attribute.assert_called_once_with()
+        assert output == mock_metadata.to_json_without_null_attribute.return_value
+
+    def test_get_protected_resource_metadata_api_response_return_none(
+        self,
+        mock_get_protected_resource_metadata: Mock,
+    ) -> None:
+        mock_get_protected_resource_metadata.return_value = None
+
+        manager = MCPOAuthProtectedResourceMetadataManager()
+        output = manager.get_protected_resource_metadata_api_response()
+
+        assert output is None

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.10"
+version = "0.26.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This PR added OAuth protected resource metadata supports in user MCP.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an OAuth discovery surface and parses deployment config from an env var; behavior is opt-in and read-only, but misconfiguration could expose incorrect auth metadata to clients.
> 
> **Overview**
> **Adds OAuth protected resource metadata** for user MCP deployments so OAuth clients can discover how to authenticate to the MCP resource server.
> 
> A new `drmcpbase/oauth_protected_resource_metadata` package defines dataclasses for resource metadata (resource URL, authorization servers, scopes, optional XAA token exchange/request fields) and a manager that loads user-supplied config from the `MCP_OAUTH_PROTECTED_RESOURCE_METADATA` container env var (YAML), merges in admin defaults (`bearer_methods_supported`: `header`), and serializes the document with null fields omitted.
> 
> User MCP registers **GET** `{mount}/oauthProtectedResourceMetadata`: returns **200** with the metadata when configured, or **501** with a not-implemented error when the env var is unset.
> 
> Version is bumped to **0.26.10** with changelog; unit tests cover entities, the manager, and the route handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d1b905b30ceef9741934f00fdecba1f25310de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->