### PR TITLE
Disable litellm local cost map fetching to fix flakes in e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.11
+- Disable litellm local cost map fetching to fix flakes in e2e tests
+
 ## 0.26.10
 - `dragent`: NAT batch evaluation (`nat eval`) plugins for DataRobot moderation metrics — `agent_goal_accuracy`, `faithfulness`, `task_adherence`, and `agent_guideline_adherence` — scoring in-process via `datarobot-moderations` OOTB judges (no NeMo Evaluator microservice).
 

--- a/e2e-tests/dragent/Taskfile.yaml
+++ b/e2e-tests/dragent/Taskfile.yaml
@@ -4,6 +4,12 @@ version: '3'
 
 env:
   WORKFLOW_FILE: '{{.WORKFLOW_FILE | default "workflow.yaml"}}'
+  # Use LiteLLM's bundled model-cost map instead of fetching it from GitHub at
+  # runtime. The fetch is lazy and occasionally fires mid-request, exporting a
+  # GET span that roots its own trace and flakes the single-trace assertion in
+  # the tracing tests. Pinning to the local map removes the network call (and
+  # the external GitHub dependency) entirely. See otel_helpers.SETUP_HTTP_SPAN_URLS.
+  LITELLM_LOCAL_MODEL_COST_MAP: 'True'
 
 vars:
   AGENT_PORT: 8080

--- a/e2e-tests/dragent_tests/otel_helpers.py
+++ b/e2e-tests/dragent_tests/otel_helpers.py
@@ -79,6 +79,26 @@ GEN_AI_PROMPT = "gen_ai.prompt"  # Prompt column
 GEN_AI_COMPLETION = "gen_ai.completion"  # Completion column
 TOOL_NAME = "tool_name"  # Tools column
 
+# HTTP client spans that fire during import / runtime bootstrap -- before any
+# workflow trace exists -- so they legitimately root their own trace rather than
+# joining the agent trace. Matched by URL fragment and excluded from the
+# single-trace assertion (see ``_assert_single_trace_id`` / ``ignore_span_urls``).
+#   * LiteLLM lazily fetches its model-cost map from GitHub.
+#   * The DataRobot python client (used by moderation) checks the API version.
+#   * NAT probes the MCP deployment while loading tools (directAccess/mcp).
+# The inline runner captures all three because it bootstraps the whole runtime
+# inside the test window. The server-based tests normally only risk the LiteLLM
+# fetch (the others fire at server startup, before the per-test collector reset),
+# but that fetch is *lazy* and occasionally lands mid-request, orphaning the
+# trace -- so every tracing test shares this ignore list as defense in depth.
+# The server env also sets ``LITELLM_LOCAL_MODEL_COST_MAP=True`` to stop that
+# fetch at the source; this list keeps the assertion honest if it ever fires.
+SETUP_HTTP_SPAN_URLS = (
+    "model_prices_and_context_window",
+    "/api/v2/version",
+    "/directAccess/mcp",
+)
+
 
 @dataclass(frozen=True)
 class CapturedRequest:

--- a/e2e-tests/dragent_tests/test_mcp.py
+++ b/e2e-tests/dragent_tests/test_mcp.py
@@ -51,7 +51,7 @@ EXPECTED_TOOL_CALL_NAMES = {
 # trace (the NAT ``mcp_tools__*`` tool span itself still joins). A shared
 # persistent connection's I/O cannot be attributed to a single request, so we
 # exclude it from the single-trace check. Matches ``SETUP_HTTP_SPAN_URLS`` in
-# test_run_agent_inline, which already lists this same fragment.
+# otel_helpers, which already lists this same fragment.
 MCP_TRANSPORT_SPAN_URLS = ("/directAccess/mcp",)
 
 def test_mcp_tool_is_called(

--- a/e2e-tests/dragent_tests/test_run_agent_inline.py
+++ b/e2e-tests/dragent_tests/test_run_agent_inline.py
@@ -37,6 +37,7 @@ from dragent_tests.helpers import workflow_file
 from dragent_tests.otel_helpers import GEN_AI_PROMPT
 from dragent_tests.otel_helpers import OTEL_EXPORTER_OTLP_ENDPOINT
 from dragent_tests.otel_helpers import OTEL_EXPORTER_OTLP_HEADERS
+from dragent_tests.otel_helpers import SETUP_HTTP_SPAN_URLS
 from dragent_tests.otel_helpers import MockOtelCollector
 from dragent_tests.otel_helpers import assert_tracing_conventions
 
@@ -46,26 +47,6 @@ RUNNER_SCRIPT = E2E_ROOT / "dragent" / "run_agent.py"
 # how ``datarobot-user-models``'s ``run_agent.py`` roots a trace before invoking
 # the agent). See ``dragent/run_agent.py``.
 RUN_AGENT_SPAN_NAME = "run_agent"
-
-# HTTP client spans that fire during import / workflow-load -- before any
-# workflow trace exists -- so they legitimately root their own trace. Unlike the
-# server-based tests (where these fire during startup, before the collector is
-# reset), the inline runner bootstraps the whole runtime inside the test window
-# and captures them. Matched by URL fragment and excluded from the single-trace
-# assertion.
-#   * LiteLLM fetches its model-cost map from GitHub on import.
-#   * The DataRobot python client (used by moderation) checks the API version.
-#   * NAT probes the MCP deployment while loading tools (directAccess/mcp).
-#
-
-# In this particular test we intentionally ignore these spans because they are emmited before
-# the workflow trace exists.
-SETUP_HTTP_SPAN_URLS = (
-    "model_prices_and_context_window",
-    "/api/v2/version",
-    "/directAccess/mcp",
-)
-
 
 def test_run_agent_inline(tmp_path: Path, otel_collector: MockOtelCollector) -> None:
     """Inline run produces a valid ``ChatCompletion`` and exports Tracing spans.
@@ -87,6 +68,11 @@ def test_run_agent_inline(tmp_path: Path, otel_collector: MockOtelCollector) -> 
         "OTEL_EXPORTER_OTLP_HEADERS": OTEL_EXPORTER_OTLP_HEADERS,
         # Unlocks the SDK TracerProvider bootstrap (see instrument()).
         "MLOPS_DEPLOYMENT_ID": "e2e-test",
+        # Use LiteLLM's bundled cost map instead of fetching it from GitHub, so
+        # the runtime bootstrap does not emit an outbound GET span (mirrors the
+        # dragent server env). The DR version check / MCP discovery spans still
+        # root their own trace, so SETUP_HTTP_SPAN_URLS below remains required.
+        "LITELLM_LOCAL_MODEL_COST_MAP": "True",
     }
 
     # WHEN: the inline runner is executed as a subprocess

--- a/e2e-tests/dragent_tests/test_streaming.py
+++ b/e2e-tests/dragent_tests/test_streaming.py
@@ -24,6 +24,7 @@ from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import raise_if_nat_workflow_error_payload
 from dragent_tests.helpers import stream_sse_responses
+from dragent_tests.otel_helpers import SETUP_HTTP_SPAN_URLS
 from dragent_tests.otel_helpers import MockOtelCollector
 from dragent_tests.otel_helpers import assert_tracing_conventions
 
@@ -62,4 +63,6 @@ def test_generate_streaming(
 
     # THEN: the streaming run exported DataRobot Tracing-table spans
     # (gen_ai.prompt / gen_ai.completion) to the OTel ingest with DR auth headers.
-    assert_tracing_conventions(otel_collector, prompt, framework=AGENT)
+    assert_tracing_conventions(
+        otel_collector, prompt, framework=AGENT, ignore_span_urls=SETUP_HTTP_SPAN_URLS
+    )

--- a/e2e-tests/dragent_tests/test_tools.py
+++ b/e2e-tests/dragent_tests/test_tools.py
@@ -29,6 +29,7 @@ from dragent_tests.helpers import collect_ag_ui_events
 from dragent_tests.helpers import collect_text
 from dragent_tests.helpers import make_generate_payload
 from dragent_tests.helpers import stream_sse_responses
+from dragent_tests.otel_helpers import SETUP_HTTP_SPAN_URLS
 from dragent_tests.otel_helpers import MockOtelCollector
 from dragent_tests.otel_helpers import assert_tracing_conventions
 
@@ -108,6 +109,7 @@ def test_generate_objectid_tool_is_called(
         GENERATE_OBJECTID_PROMPT,
         expect_tool_name=AGENT_SUPPORTS_TOOL_CALLS_STREAMING,
         framework=AGENT,
+        ignore_span_urls=SETUP_HTTP_SPAN_URLS,
     )
 
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -898,7 +898,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.10"
+version = "0.26.11"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.10"
+version = "0.26.11"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1102,7 +1102,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.10"
+version = "0.26.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
`e2e tests` are only partially disabling the litellm local cost map stuff when the cost is requested. This is occasionally resulting in orphaned otel traces being detected and generally just being irritating. This fix moves the disable and ignore logic to make it global across the e2e tests

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e test env and OTel assertion helpers; no production runtime or auth logic is modified.
> 
> **Overview**
> Reduces flaky **single-trace** failures in dragent e2e tracing tests by stopping LiteLLM’s lazy GitHub model-cost fetch and consistently ignoring bootstrap HTTP spans that legitimately root their own traces.
> 
> **`LITELLM_LOCAL_MODEL_COST_MAP=True`** is set for the dragent server (`Taskfile.yaml`) and the inline runner subprocess so LiteLLM uses its bundled cost map instead of emitting a mid-request outbound GET span. **`SETUP_HTTP_SPAN_URLS`** is centralized in `otel_helpers` (LiteLLM cost map, DataRobot `/api/v2/version`, MCP `/directAccess/mcp`) with documentation; the duplicate tuple is removed from `test_run_agent_inline.py`. **Streaming and tool** tracing tests now pass `ignore_span_urls=SETUP_HTTP_SPAN_URLS` into `assert_tracing_conventions`, matching the inline path; MCP tests keep their transport-specific ignore list with an updated cross-reference to `otel_helpers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1e5a9b7dfb689cd7bbe4d73155fd170311f2b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->