### PR TITLE
[MODEL-24276] toolGallery | filter `GET /toolGallery/tools/` by name and provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.26.23
-- `drmcputils/toolGallery`: `GET /toolGallery/tools/` now accepts `name` (exact match) and `provider` (`datarobot`/`third_party`) query filters, applied before pagination so `totalCount`/`hasMore` describe the filtered set. An unrecognised `provider` value matches nothing; blank values are ignored.
+- `drmcputils/toolGallery`: Added `name` (exact match) and `provider` (`datarobot`/`third_party`) query filters to `GET /toolGallery/tools/`, applied before pagination so `totalCount`/`hasMore` describe the filtered set. An unrecognised `provider` value matches nothing; blank values are ignored.
 
 ## 0.26.22
 - `drmcpbase/oauth_protected_resource_metadata`: the OAuth protected-resource metadata config renames `xaa_metadata` to `cross_application_access`, matching the agent-side config block of the same name. The old key is not accepted; because unknown keys are ignored, a config still using `xaa_metadata` publishes no Cross-Application Access metadata. `XAAMetadata` is renamed to `CrossApplicationAccessMetadata` with no alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.23
+- `drmcputils/toolGallery`: `GET /toolGallery/tools/` now accepts `name` (exact match) and `provider` (`datarobot`/`third_party`) query filters, applied before pagination so `totalCount`/`hasMore` describe the filtered set. An unrecognised `provider` value matches nothing; blank values are ignored.
+
 ## 0.26.22
 - `drmcpbase/oauth_protected_resource_metadata`: the OAuth protected-resource metadata config renames `xaa_metadata` to `cross_application_access`, matching the agent-side config block of the same name. The old key is not accepted; because unknown keys are ignored, a config still using `xaa_metadata` publishes no Cross-Application Access metadata. `XAAMetadata` is renamed to `CrossApplicationAccessMetadata` with no alias.
 - `drmcpbase/oauth_protected_resource_metadata`: `token_endpoint_auth_method` is now optional and defaults to `private_key_jwt` (the only implemented method). `resource`, `authorization_servers` and `scopes_supported` are optional too — nothing enforces them yet, and unset fields are omitted from the served document instead of raising `KeyError`. A config declaring only `cross_application_access` is valid.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.22"
+version = "0.26.23"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcputils/routes/tool_gallery.py
+++ b/src/datarobot_genai/drmcputils/routes/tool_gallery.py
@@ -24,8 +24,9 @@ are stripped before FastMCP registration (see ``DRTOOLS_PRIVATE_METADATA_KEYS``)
 The ``tools`` route re-attaches them via an injected ``ui_metadata_provider`` (drtools'
 ``get_tool_ui_metadata``) — injected, not imported, because ``drmcputils`` may not import
 ``drtools`` — and derives each tool's categories from the single-source-of-truth taxonomy.
-It returns the full catalog (not the per-request filtered/CodeMode view), paginated via
-``limit``/``offset``.
+It returns the full catalog (not the per-request filtered/CodeMode view), optionally
+filtered by ``name`` (exact) and ``provider`` (``datarobot``/``third_party``) and paginated
+via ``limit``/``offset``.
 """
 
 import logging
@@ -75,6 +76,46 @@ def _parse_pagination(request: Request) -> tuple[int, int]:
         return value if value >= 0 else default
 
     return _non_negative_int("limit", _DEFAULT_LIMIT), _non_negative_int("offset", 0)
+
+
+# Providers accepted by the ``provider`` filter; anything else matches no tools.
+_KNOWN_PROVIDERS = frozenset({"datarobot", "third_party"})
+
+
+def _parse_filters(request: Request) -> tuple[str | None, str | None]:
+    """Read the optional ``name`` and ``provider`` filters from the query string.
+
+    Both are absent by default (return ``None`` → no filtering on that field). A blank
+    value is treated as absent so a malformed query never 500s the gallery, matching
+    ``_parse_pagination``. ``provider`` is passed through verbatim; an unrecognised value
+    simply matches nothing (see ``_apply_filters``).
+    """
+
+    def _non_blank(name: str) -> str | None:
+        raw = request.query_params.get(name)
+        if raw is None:
+            return None
+        raw = raw.strip()
+        return raw or None
+
+    return _non_blank("name"), _non_blank("provider")
+
+
+def _apply_filters(
+    items: list[dict[str, Any]], name: str | None, provider: str | None
+) -> list[dict[str, Any]]:
+    """Filter gallery *items* by exact ``name`` and/or ``provider`` (match-any).
+
+    A ``provider`` value outside :data:`_KNOWN_PROVIDERS` matches no tools (empty result),
+    rather than raising, so an unknown filter yields an empty page instead of a 500.
+    """
+    if name is not None:
+        items = [item for item in items if item.get("name") == name]
+    if provider is not None:
+        if provider not in _KNOWN_PROVIDERS:
+            return []
+        items = [item for item in items if item.get("provider") == provider]
+    return items
 
 
 def register_tool_gallery_routes(
@@ -148,6 +189,10 @@ def _make_tools_handler(
         ui_metadata = ui_metadata_provider() if ui_metadata_provider is not None else {}
         merged = [merge_tool_info(tool, ui_metadata) for tool in tools]
         items = build_tool_gallery_items(merged)
+
+        # Filter before counting/paginating so totalCount/hasMore reflect the filtered set.
+        name, provider = _parse_filters(request)
+        items = _apply_filters(items, name, provider)
 
         total_count = len(items)
         limit, offset = _parse_pagination(request)

--- a/tests/drmcpbase/routes/test_tool_gallery_http.py
+++ b/tests/drmcpbase/routes/test_tool_gallery_http.py
@@ -171,6 +171,81 @@ class TestToolGalleryRoute:
             assert client.get("/toolGallery/tools/").status_code == 404
 
 
+class TestToolGalleryFilters:
+    """``name`` and ``provider`` query filters, applied before pagination."""
+
+    def _server(self) -> FastMCP:
+        # jira gets an auth_provider (→ third_party); perplexity has none (→ datarobot),
+        # so the two tools land in different providers for filter assertions.
+        mcp = FastMCP("tool-gallery-filters")
+
+        @mcp.tool
+        def jira_search_issues(a: int) -> int:
+            """Search."""
+            return a
+
+        @mcp.tool
+        def perplexity_search(q: str) -> str:
+            """Search web."""
+            return q
+
+        def provider() -> dict[str, dict[str, Any]]:
+            return {"jira_search_issues": {"auth_provider": "jira"}}
+
+        register_tool_gallery_routes(mcp, ui_metadata_provider=provider)
+        return mcp
+
+    def test_name_filter_returns_exact_match(self) -> None:
+        with TestClient(self._server().http_app()) as client:
+            body = client.get("/toolGallery/tools/", params={"name": "jira_search_issues"}).json()
+        assert body["totalCount"] == 1
+        assert [t["name"] for t in body["tools"]] == ["jira_search_issues"]
+
+    def test_name_filter_unknown_returns_empty(self) -> None:
+        with TestClient(self._server().http_app()) as client:
+            body = client.get("/toolGallery/tools/", params={"name": "nope"}).json()
+        assert body["tools"] == []
+        assert body["totalCount"] == 0
+        assert body["hasMore"] is False
+
+    def test_provider_filter_third_party(self) -> None:
+        with TestClient(self._server().http_app()) as client:
+            body = client.get("/toolGallery/tools/", params={"provider": "third_party"}).json()
+        assert [t["name"] for t in body["tools"]] == ["jira_search_issues"]
+        assert body["totalCount"] == 1
+
+    def test_provider_filter_datarobot(self) -> None:
+        with TestClient(self._server().http_app()) as client:
+            body = client.get("/toolGallery/tools/", params={"provider": "datarobot"}).json()
+        assert [t["name"] for t in body["tools"]] == ["perplexity_search"]
+        assert body["totalCount"] == 1
+
+    def test_unknown_provider_returns_empty_page(self) -> None:
+        # An unrecognised provider matches nothing rather than 500ing.
+        with TestClient(self._server().http_app()) as client:
+            resp = client.get("/toolGallery/tools/", params={"provider": "nope"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["tools"] == []
+        assert body["totalCount"] == 0
+
+    def test_blank_filters_are_ignored(self) -> None:
+        # Blank values behave like absent params — the full catalog is returned.
+        with TestClient(self._server().http_app()) as client:
+            body = client.get("/toolGallery/tools/", params={"name": "", "provider": ""}).json()
+        assert body["totalCount"] == 2
+
+    def test_filter_totalcount_reflects_filtered_set_before_pagination(self) -> None:
+        # totalCount/hasMore describe the filtered set, not the whole catalog.
+        with TestClient(self._server().http_app()) as client:
+            body = client.get(
+                "/toolGallery/tools/", params={"provider": "third_party", "limit": 1}
+            ).json()
+        assert body["totalCount"] == 1
+        assert body["count"] == 1
+        assert body["hasMore"] is False
+
+
 class TestUiMetadataProvider:
     """The route re-attaches UI fields from the injected ``ui_metadata_provider``."""
 


### PR DESCRIPTION
### RATIONALE

The Tool Gallery REST endpoint (GET /toolGallery/tools/) already exists and returns the full tool catalog with limit/offset pagination, but it has no way to narrow results. The [Tool Sets](https://datarobot.atlassian.net/wiki/spaces/DM1/pages/7785709643/Tool+Sets#2.-Tool-Gallery-REST-endpoint) design requires the gallery to support filtering so the UI can drive its filter panel without pulling and filtering the entire catalog client-side.

This PR adds the name and provider query filters. It is deliberately scoped to filtering only — the remaining spec items (single flat-5 category model, drOAuthProviderType field rename, and a per-tool version field) are being deferred to follow-up PRs, since they involve a taxonomy decision and a response-schema change that warrant separate review. The existing per-tool response contract is unchanged, so this is a backward-compatible (patch) release.

### CHANGES

- drmcputils/toolGallery: GET /toolGallery/tools/ now accepts two optional query params:
-- name — exact match on tool name
-- provider — match-any, one of datarobot / third_party
- Filters are applied before counting and pagination, so totalCount and hasMore describe the filtered result set, not the whole catalog.
- Edge-case behavior mirrors the existing "malformed query never 500s" convention: blank values are treated as absent (no filtering), and an unrecognised provider value returns an empty page rather than an error.
- Added TestToolGalleryFilters HTTP integration coverage: name match / no-match, provider third_party / datarobot, unknown provider → empty page, blank filters ignored, and filter combined with pagination.
- Bumped version 0.26.12 → 0.26.13 and added a CHANGELOG.md entry.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3deffada737e10c07703c67391e852b9f9bf4912. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->