### PR TITLE
MODEL-23999: fix config name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-## 0.27.0
+## 0.26.15
 - `drmcpbase/mcp_oauth_metadata`: Renamed mcp_oauth_protected_resource_metadata into mcp_oauth_metadata.
 ## 0.26.14
 - `dragent`: agent `invoke` now frames a mid-run exception as a terminal AG-UI `RUN_ERROR` at the source (all frameworks), so failures surface even without middleware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-
+## 0.26.15
+- `drmcpbase/mcp_oauth_metadata`: Renamed mcp_oauth_protected_resource_metadata into mcp_oauth_metadata.
 ## 0.26.14
 - `dragent`: agent `invoke` now frames a mid-run exception as a terminal AG-UI `RUN_ERROR` at the source (all frameworks), so failures surface even without middleware.
 - `dragent`: streaming agent/workflow errors now end the run with a terminal AG-UI `RUN_ERROR` (adapted to an OpenAI-shaped error chunk on `/chat/completions`) instead of NAT's bare `workflow_error` JSON that `data:`-only clients silently drop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-## 0.26.15
+## 0.27.0
 - `drmcpbase/mcp_oauth_metadata`: Renamed mcp_oauth_protected_resource_metadata into mcp_oauth_metadata.
 ## 0.26.14
 - `dragent`: agent `invoke` now frames a mid-run exception as a terminal AG-UI `RUN_ERROR` at the source (all frameworks), so failures surface even without middleware.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -896,7 +896,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.0"
+version = "0.26.15"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -896,7 +896,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.14"
+version = "0.26.15"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -896,7 +896,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.15"
+version = "0.27.0"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.15"
+version = "0.27.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.27.0"
+version = "0.26.15"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.14"
+version = "0.26.15"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/mcp/config.py
+++ b/src/datarobot_genai/core/mcp/config.py
@@ -32,10 +32,6 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
 
     Derived values are exposed as properties rather than stored, avoiding
     Pydantic field validation/serialization concerns for internal helpers.
-
-    Fields resolve from env vars (including ``MLOPS_RUNTIME_PARAM_`` runtime
-    parameters), ``.env``, file secrets, and ``pulumi_config.json``. For example,
-    ``mcp_oauth_metadata`` reads ``MCP_OAUTH_METADATA``.
     """
 
     external_mcp_url: str | None = None
@@ -47,7 +43,6 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
     authorization_context: dict[str, Any] | None = None
     forwarded_headers: dict[str, str] | None = None
     mcp_server_port: int | None = None
-    mcp_oauth_metadata: str | None = None
 
     _auth_context_handler: AuthContextHeaderHandler | None = None
     _server_config: dict[str, Any] | None = None

--- a/src/datarobot_genai/core/mcp/config.py
+++ b/src/datarobot_genai/core/mcp/config.py
@@ -32,6 +32,10 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
 
     Derived values are exposed as properties rather than stored, avoiding
     Pydantic field validation/serialization concerns for internal helpers.
+
+    Fields resolve from env vars (including ``MLOPS_RUNTIME_PARAM_`` runtime
+    parameters), ``.env``, file secrets, and ``pulumi_config.json``. For example,
+    ``mcp_oauth_metadata`` reads ``MCP_OAUTH_METADATA``.
     """
 
     external_mcp_url: str | None = None
@@ -43,6 +47,7 @@ class MCPConfig(DataRobotAppFrameworkBaseSettings):
     authorization_context: dict[str, Any] | None = None
     forwarded_headers: dict[str, str] | None = None
     mcp_server_port: int | None = None
+    mcp_oauth_metadata: str | None = None
 
     _auth_context_handler: AuthContextHeaderHandler | None = None
     _server_config: dict[str, Any] | None = None

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -140,6 +140,10 @@ class MCPServerConfig(DataRobotAppFrameworkBaseSettings):
         default="INFO",
         description="App log level",
     )
+    mcp_oauth_metadata: str | None = Field(
+        default=None,
+        description="YAML configuration for OAuth protected resource metadata",
+    )
     # When the server is run in a custom model, it is important to mount all routes under the
     # prefix provided in the URL_PREFIX
     mount_path: str = Field(default="/", alias="URL_PREFIX")

--- a/src/datarobot_genai/drmcp/core/routes.py
+++ b/src/datarobot_genai/drmcp/core/routes.py
@@ -340,7 +340,9 @@ def register_routes(mcp: DataRobotMCP) -> None:
 
     @mcp.custom_route(prefix_mount_path("/.well-known/oauth-protected-resource"), methods=["GET"])
     async def oauth_protected_resource_metadata(_: Request) -> JSONResponse:
-        manager = MCPOAuthProtectedResourceMetadataManager()
+        manager = MCPOAuthProtectedResourceMetadataManager(
+            mcp_oauth_metadata=get_config().mcp_oauth_metadata,
+        )
         api_response = manager.get_protected_resource_metadata_api_response()
         if api_response:
             return JSONResponse(

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
 from enum import Enum
 from enum import auto
 from typing import Any
 
 import yaml
 
+from datarobot_genai.core.mcp.config import MCPConfig
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadata,
 )
@@ -43,24 +43,21 @@ class SupportedMethodsToSendBearerToken(Enum):
         return [supported_method.get_name_in_lower_case() for supported_method in cls]
 
 
-class ContainerEnvVar(Enum):
-    MCP_OAUTH_PROTECTED_RESOURCE_METADATA = auto()
-
-    def get_env_var_value(self) -> str | None:
-        return os.getenv(self.name)
-
-
 class MCPOAuthProtectedResourceMetadataManager:
-    @staticmethod
-    def load_config() -> MCPOAuthProtectedResourceMetadataConfig | None:
-        metadata_in_json_str = (
-            ContainerEnvVar.MCP_OAUTH_PROTECTED_RESOURCE_METADATA.get_env_var_value()
-        )
+    def __init__(self, mcp_config: MCPConfig | None = None) -> None:
+        self._mcp_config = mcp_config
+
+    def _get_mcp_config(self) -> MCPConfig:
+        if self._mcp_config is None:
+            self._mcp_config = MCPConfig()
+        return self._mcp_config
+
+    def load_config(self) -> MCPOAuthProtectedResourceMetadataConfig | None:
+        metadata_in_json_str = self._get_mcp_config().mcp_oauth_metadata
         if metadata_in_json_str:
             metadata_in_json = yaml.safe_load(metadata_in_json_str)
             return MCPOAuthProtectedResourceMetadataConfig.from_dict(metadata_in_json)
-        else:
-            return None
+        return None
 
     @staticmethod
     def get_admin_config() -> MCPOAuthProtectedResourceMetadataAdminConfig:

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/manager.py
@@ -18,7 +18,6 @@ from typing import Any
 
 import yaml
 
-from datarobot_genai.core.mcp.config import MCPConfig
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadata,
 )
@@ -44,18 +43,12 @@ class SupportedMethodsToSendBearerToken(Enum):
 
 
 class MCPOAuthProtectedResourceMetadataManager:
-    def __init__(self, mcp_config: MCPConfig | None = None) -> None:
-        self._mcp_config = mcp_config
-
-    def _get_mcp_config(self) -> MCPConfig:
-        if self._mcp_config is None:
-            self._mcp_config = MCPConfig()
-        return self._mcp_config
+    def __init__(self, mcp_oauth_metadata: str | None = None) -> None:
+        self._mcp_oauth_metadata = mcp_oauth_metadata
 
     def load_config(self) -> MCPOAuthProtectedResourceMetadataConfig | None:
-        metadata_in_json_str = self._get_mcp_config().mcp_oauth_metadata
-        if metadata_in_json_str:
-            metadata_in_json = yaml.safe_load(metadata_in_json_str)
+        if self._mcp_oauth_metadata:
+            metadata_in_json = yaml.safe_load(self._mcp_oauth_metadata)
             return MCPOAuthProtectedResourceMetadataConfig.from_dict(metadata_in_json)
         return None
 

--- a/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
+++ b/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from collections.abc import Iterator
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -19,6 +18,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
+from datarobot_genai.core.mcp.config import MCPConfig
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadata,
 )
@@ -28,26 +28,12 @@ from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadataConfig,
 )
-from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import ContainerEnvVar
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import (
     MCPOAuthProtectedResourceMetadataManager,
 )
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.manager import (
     SupportedMethodsToSendBearerToken,
 )
-
-
-class TestContainerEnvVar:
-    @pytest.fixture
-    def mock_os_getenv(self) -> Iterator[Mock]:
-        with patch.object(os, "getenv") as mock_func:
-            yield mock_func
-
-    @pytest.mark.parametrize("env_var_enum", ContainerEnvVar, ids=str)
-    def test_get_env_var_value(self, env_var_enum: ContainerEnvVar, mock_os_getenv: Mock) -> None:
-        env_var_enum.get_env_var_value()
-
-        mock_os_getenv.assert_called_once_with(env_var_enum.name)
 
 
 class TestSupportedMethodsToSendBearerToken:
@@ -75,12 +61,8 @@ class TestMCPOAuthProtectedResourceMetadataManager:
             yield mock_func
 
     @pytest.fixture
-    def mock_load_mcp_oauth_protected_resource_metadata_from_env_var(self) -> Iterator[Mock]:
-        with patch.object(
-            ContainerEnvVar.MCP_OAUTH_PROTECTED_RESOURCE_METADATA,
-            "get_env_var_value",
-        ) as mock_func:
-            yield mock_func
+    def mock_mcp_config(self) -> Mock:
+        return Mock(spec=MCPConfig)
 
     @pytest.fixture
     def mock_mcp_oauth_protected_resource_metadata_user_config_from_dict(self) -> Iterator[Mock]:
@@ -115,17 +97,14 @@ class TestMCPOAuthProtectedResourceMetadataManager:
     def test_load_config(
         self,
         mock_yaml_safe_load: Mock,
-        mock_load_mcp_oauth_protected_resource_metadata_from_env_var: Mock,
+        mock_mcp_config: Mock,
         mock_mcp_oauth_protected_resource_metadata_user_config_from_dict: Mock,
     ) -> None:
-        manager = MCPOAuthProtectedResourceMetadataManager()
+        mock_mcp_config.mcp_oauth_metadata = "mock-metadata"
+        manager = MCPOAuthProtectedResourceMetadataManager(mcp_config=mock_mcp_config)
         output = manager.load_config()
 
-        mock_load_mcp_oauth_protected_resource_metadata_from_env_var.assert_called_once_with()
-        mock_metadata_json_string = (
-            mock_load_mcp_oauth_protected_resource_metadata_from_env_var.return_value
-        )
-        mock_yaml_safe_load.assert_called_once_with(mock_metadata_json_string)
+        mock_yaml_safe_load.assert_called_once_with("mock-metadata")
         mock_mcp_oauth_protected_resource_metadata_user_config_from_dict.assert_called_once_with(
             mock_yaml_safe_load.return_value
         )

--- a/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
+++ b/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_manager.py
@@ -18,7 +18,6 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from datarobot_genai.core.mcp.config import MCPConfig
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadata,
 )
@@ -61,10 +60,6 @@ class TestMCPOAuthProtectedResourceMetadataManager:
             yield mock_func
 
     @pytest.fixture
-    def mock_mcp_config(self) -> Mock:
-        return Mock(spec=MCPConfig)
-
-    @pytest.fixture
     def mock_mcp_oauth_protected_resource_metadata_user_config_from_dict(self) -> Iterator[Mock]:
         with patch.object(MCPOAuthProtectedResourceMetadataConfig, "from_dict") as mock_func:
             yield mock_func
@@ -97,11 +92,9 @@ class TestMCPOAuthProtectedResourceMetadataManager:
     def test_load_config(
         self,
         mock_yaml_safe_load: Mock,
-        mock_mcp_config: Mock,
         mock_mcp_oauth_protected_resource_metadata_user_config_from_dict: Mock,
     ) -> None:
-        mock_mcp_config.mcp_oauth_metadata = "mock-metadata"
-        manager = MCPOAuthProtectedResourceMetadataManager(mcp_config=mock_mcp_config)
+        manager = MCPOAuthProtectedResourceMetadataManager(mcp_oauth_metadata="mock-metadata")
         output = manager.load_config()
 
         mock_yaml_safe_load.assert_called_once_with("mock-metadata")

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.15"
+version = "0.27.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.0"
+version = "0.26.15"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.14"
+version = "0.26.15"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploys must switch to the new env/runtime param name or OAuth protected-resource metadata will not load; behavior is otherwise limited to configuration plumbing.
> 
> **Overview**
> **0.26.15** renames how user MCP OAuth protected-resource metadata is configured: the dedicated env var **`MCP_OAUTH_PROTECTED_RESOURCE_METADATA`** is replaced by **`MCP_OAUTH_METADATA`**, exposed on **`MCPConfig`** as **`mcp_oauth_metadata`** (same resolution path as other MCP settings: runtime params, `.env`, secrets, `pulumi_config.json`).
> 
> **`MCPOAuthProtectedResourceMetadataManager`** no longer reads the env directly via **`ContainerEnvVar`**; it takes an optional **`MCPConfig`** (default **`MCPConfig()`**) and **`load_config()`** reads **`mcp_oauth_metadata`**. Unit tests were updated to mock **`MCPConfig`** instead of **`os.getenv`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9678771cb1b6c5a0548c8f90be26cee4df8d4a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->