### PR TITLE
Added  MCP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## 0.26.16
+- Added `mcp_enable_unauthenticated_well_known_route` MCP config.
+
 ## 0.26.15
 - `drmcpbase/mcp_oauth_metadata`: Renamed mcp_oauth_protected_resource_metadata into mcp_oauth_metadata.
+
 ## 0.26.14
 - `dragent`: agent `invoke` now frames a mid-run exception as a terminal AG-UI `RUN_ERROR` at the source (all frameworks), so failures surface even without middleware.
 - `dragent`: streaming agent/workflow errors now end the run with a terminal AG-UI `RUN_ERROR` (adapted to an OpenAI-shaped error chunk on `/chat/completions`) instead of NAT's bare `workflow_error` JSON that `data:`-only clients silently drop.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -896,7 +896,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.15"
+version = "0.26.16"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.15"
+version = "0.26.16"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -144,6 +144,10 @@ class MCPServerConfig(DataRobotAppFrameworkBaseSettings):
         default=None,
         description="YAML configuration for OAuth protected resource metadata",
     )
+    mcp_enable_unauthenticated_well_known_route: bool = Field(
+        default=False,
+        description="Enable/disable unauthenticated well known route",
+    )
     # When the server is run in a custom model, it is important to mount all routes under the
     # prefix provided in the URL_PREFIX
     mount_path: str = Field(default="/", alias="URL_PREFIX")

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -63,9 +63,43 @@ def test_config_defaults() -> None:
         assert config.tool_config.enable_vdb_tools is False
         assert config.tool_config.enable_code_execution_tools is False
         assert config.tool_config.enable_optimization_tools is False
-
+        assert config.mcp_enable_unauthenticated_well_known_route is False
         # Clean up the cached config after the test
         config_module._config = None
+
+
+class TestUnauthenticatedWellKnownRouteConfig:
+    """Test mcp_enable_unauthenticated_well_known_route configuration."""
+
+    def test_default_is_false(self) -> None:
+        with patch.dict(os.environ, clear=True):
+            config_module._config = None
+            config = MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
+            assert config.mcp_enable_unauthenticated_well_known_route is False
+            config_module._config = None
+
+    @pytest.mark.parametrize("env_value,expected", [("true", True), ("false", False)])
+    def test_setting_via_env_var(self, env_value: str, expected: bool) -> None:
+        with patch.dict(
+            os.environ,
+            {"MCP_ENABLE_UNAUTHENTICATED_WELL_KNOWN_ROUTE": env_value},
+            clear=False,
+        ):
+            config = MCPServerConfig()
+            assert config.mcp_enable_unauthenticated_well_known_route is expected
+
+    def test_setting_via_runtime_param_env_var(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "MLOPS_RUNTIME_PARAM_MCP_ENABLE_UNAUTHENTICATED_WELL_KNOWN_ROUTE": (
+                    '{"type":"boolean","payload":true}'
+                ),
+            },
+            clear=False,
+        ):
+            config = MCPServerConfig()
+            assert config.mcp_enable_unauthenticated_well_known_route is True
 
 
 class TestDuplicateBehavior:

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.15"
+version = "0.26.16"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with secure default (false); no runtime behavior change until future code reads the flag.
> 
> **Overview**
> Release **0.26.16** adds **`mcp_enable_unauthenticated_well_known_route`** on `MCPServerConfig`, default **`false`**, so operators can opt in to serving OAuth/well-known discovery without auth when needed.
> 
> The flag is configurable via **`MCP_ENABLE_UNAUTHENTICATED_WELL_KNOWN_ROUTE`** and the usual **`MLOPS_RUNTIME_PARAM_`** boolean runtime parameter. Unit tests cover defaults, env parsing, and runtime params; the default-config test also asserts the new field.
> 
> This PR does **not** include route or middleware wiring—only the configuration surface and changelog/version bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633978c747632a8b25b6b831f0f18af0b4312a10. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->