### PR TITLE
[BUZZOK-31847] Fix datarobot moderations middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.26.17
 - Fix datarobot-moderations middleware after dome updated chunk optimization
+- `dragent`: moderated streams no longer rescan the queued source responses per moderated chunk, which made a buffered stream quadratic in delta count and stalled the event loop on long responses.
+- `dragent`: a terminal upstream `RUN_FINISHED` is now held aside like `RUN_ERROR`, so a moderation block no longer ends the stream with no terminal event, and the event can no longer overtake the last segment's trailing deltas.
 
 ## 0.26.16
 - Added `mcp_enable_unauthenticated_well_known_route` MCP config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.17
+- Fix datarobot-moderations middleware after dome updated chunk optimization
+
 ## 0.26.16
 - Added `mcp_enable_unauthenticated_well_known_route` MCP config.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.16"
+version = "0.26.17"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
@@ -69,6 +69,7 @@ from ag_ui.core import Event
 from ag_ui.core import EventType
 from ag_ui.core import RunAgentInput
 from ag_ui.core import RunErrorEvent
+from ag_ui.core import RunFinishedEvent
 from ag_ui.core import SystemMessage
 from ag_ui.core import TextMessageChunkEvent
 from ag_ui.core import TextMessageContentEvent
@@ -1126,6 +1127,26 @@ def _text_delta_message_ids(events: Iterable[Event]) -> set[str]:
     return ids
 
 
+def _retain_queued_message_ids(counts: dict[str, int], ids: set[str]) -> None:
+    """Record that one more queued source response carries each id in *ids*."""
+    for message_id in ids:
+        counts[message_id] = counts.get(message_id, 0) + 1
+
+
+def _release_queued_message_ids(counts: dict[str, int], ids: set[str]) -> None:
+    """Drop one queued reference per id, deleting ids no longer carried by anything queued.
+
+    Zero-count keys are removed rather than kept so the live set stays proportional to the
+    segments still in flight instead of every message_id the stream has ever produced.
+    """
+    for message_id in ids:
+        remaining = counts.get(message_id, 0) - 1
+        if remaining > 0:
+            counts[message_id] = remaining
+        else:
+            counts.pop(message_id, None)
+
+
 def _closed_text_message_ids(response: DRAgentEventResponse) -> set[str]:
     """Collect the message_ids a buffered batch would close with ``TEXT_MESSAGE_END``."""
     return {
@@ -1246,15 +1267,30 @@ async def _moderated_dragent_stream(
     open_text_message_ids: set[str] = set()
     pending_upstream: list[DRAgentEventResponse] = []
     terminal_run_error: DRAgentEventResponse | None = None
+    terminal_run_finished: DRAgentEventResponse | None = None
     moderation_source_responses: list[DRAgentEventResponse] = []
+    # Live text message_ids carried by ``moderation_source_responses``, maintained as the queue
+    # moves. Rescanning the queue per moderated chunk made a buffered stream quadratic: dome
+    # queues one source response per upstream delta, so the scan cost grew with the stream.
+    queued_source_message_ids: dict[str, int] = {}
     last_source_response: DRAgentEventResponse | None = None
+    last_source_message_ids: set[str] = set()
     stopped_for_content_filter = False
 
     def buffer_upstream(response: DRAgentEventResponse) -> None:
-        nonlocal terminal_run_error
+        nonlocal terminal_run_error, terminal_run_finished
         if any(isinstance(event, RunErrorEvent) for event in response.events):
             # Terminal RUN_ERROR: hold it and emit last so no moderated chunk trails after it.
             terminal_run_error = response
+            return
+        if any(isinstance(event, RunFinishedEvent) for event in response.events):
+            # Terminal RUN_FINISHED: hold it out of the ordinary buffer for two reasons.
+            # A block breaks out of the moderated loop without draining the buffer, so leaving
+            # RUN_FINISHED in there ends a blocked stream with no terminal event at all and the
+            # client keeps waiting on a run that is over. It also must not be released early:
+            # unlike a TEXT_MESSAGE_END it closes no segment, so the prefix release would let it
+            # overtake the last segment's remaining moderated deltas and synthetic END.
+            terminal_run_finished = response
             return
         pending_upstream.append(response)
 
@@ -1263,17 +1299,10 @@ async def _moderated_dragent_stream(
 
         dome buffers the whole upstream stream before releasing its first moderated chunk, so
         source responses queue up far ahead of the moderated output. Anything still queued names
-        a segment whose deltas have not been emitted yet. ``last_source_response`` counts too:
+        a segment whose deltas have not been emitted yet. ``last_source_message_ids`` counts too:
         it is the message_id every further moderated chunk falls back to once the queue drains.
         """
-        live = (
-            _text_delta_message_ids(last_source_response.events)
-            if last_source_response is not None
-            else set()
-        )
-        for queued in moderation_source_responses:
-            live |= _text_delta_message_ids(queued.events)
-        return live
+        return set(queued_source_message_ids) | last_source_message_ids
 
     async def next_text_response() -> DRAgentEventResponse | None:
         async for response in upstream:
@@ -1289,6 +1318,9 @@ async def _moderated_dragent_stream(
         current: DRAgentEventResponse | None = first_text
         while current is not None:
             moderation_source_responses.append(current)
+            _retain_queued_message_ids(
+                queued_source_message_ids, _text_delta_message_ids(current.events)
+            )
             yield dragent_event_response_to_dome_chunk(current)
             current = await next_text_response()
 
@@ -1328,6 +1360,8 @@ async def _moderated_dragent_stream(
                 # synthetic chunks derive from the same upstream text message.
                 if _moderated_chunk_carries_text(moderated) and moderation_source_responses:
                     last_source_response = moderation_source_responses.pop(0)
+                    last_source_message_ids = _text_delta_message_ids(last_source_response.events)
+                    _release_queued_message_ids(queued_source_message_ids, last_source_message_ids)
                 source_response = last_source_response
                 converted = dome_chunk_to_dragent_event_response(
                     moderated,
@@ -1364,9 +1398,12 @@ async def _moderated_dragent_stream(
                 yield prescore_state.emit(item)
             for end_response in _synthetic_text_message_end_responses(open_text_message_ids):
                 yield end_response
+        # A terminal event last on every path (normal or content_filter) so a block can't mask it.
+        # RUN_ERROR wins when upstream somehow produced both: a run that errored did not finish.
         if terminal_run_error is not None:
-            # Last on every path (normal or content_filter) so a block can't mask it.
             yield prescore_state.emit(terminal_run_error)
+        elif terminal_run_finished is not None:
+            yield prescore_state.emit(terminal_run_finished)
     except Exception as exc:
         # Close open text segments, then end the stream in-band with a terminal RUN_ERROR
         # instead of raising: NAT would otherwise emit an unframed error that clients drop.

--- a/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
@@ -51,6 +51,7 @@ import uuid
 from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterator
 from collections.abc import Coroutine
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
@@ -1113,57 +1114,62 @@ def _merge_moderations_into_multi_event_response(
     )
 
 
-def _defer_until_after_moderated_chunk(event: Event) -> bool:
-    """Defer START/END until after the moderated chunk: late moderated deltas still use the prior
-    message_id.
+def _text_delta_message_ids(events: Iterable[Event]) -> set[str]:
+    """Collect the message_ids carried by assistant text deltas in *events*.
 
-    If TEXT_MESSAGE_START for the next segment is yielded before moderated content for the
-    previous segment, storage switches active_message and can drop or mis-attribute the
-    last deltas (truncation in DB). TEXT_MESSAGE_END must stay after moderated text for AG-UI.
+    ``TextMessageChunkEvent.message_id`` is optional, so ids are filtered rather than assumed.
     """
-    return event.type in (
-        EventType.TEXT_MESSAGE_END,
-        EventType.TEXT_MESSAGE_START,
-    )
+    ids: set[str] = set()
+    for event in events:
+        if isinstance(event, (TextMessageContentEvent, TextMessageChunkEvent)) and event.message_id:
+            ids.add(event.message_id)
+    return ids
 
 
-def _pending_after_moderated_chunk(
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
-) -> list[DRAgentEventResponse]:
-    """Order buffered events after a moderated chunk: a prior-segment ``TEXT_MESSAGE_END`` first
-    (keeps its id for late moderated deltas), then pass-through, then this batch's own segments in
-    upstream order so a content-less one isn't split into an ``END`` before its ``START``.
-    """
-    started_in_batch = {
-        item.events[0].message_id
-        for item in pending_deferred
-        if item.events and item.events[0].type == EventType.TEXT_MESSAGE_START
+def _closed_text_message_ids(response: DRAgentEventResponse) -> set[str]:
+    """Collect the message_ids a buffered batch would close with ``TEXT_MESSAGE_END``."""
+    return {
+        event.message_id for event in response.events if event.type == EventType.TEXT_MESSAGE_END
     }
-    prior_segment_ends: list[DRAgentEventResponse] = []
-    rest: list[DRAgentEventResponse] = []
-    for item in pending_deferred:
-        first = item.events[0] if item.events else None
-        # Only an END whose START was in an earlier batch closes a prior segment and may lead.
-        if (
-            first is not None
-            and first.type == EventType.TEXT_MESSAGE_END
-            and first.message_id not in started_in_batch
-        ):
-            prior_segment_ends.append(item)
-        else:
-            rest.append(item)
-    return prior_segment_ends + list(pending_pass_through) + rest
 
 
-def _drain_pending_after_moderated_chunk(
-    pending_deferred: list[DRAgentEventResponse],
-    pending_pass_through: list[DRAgentEventResponse],
+def _moderated_chunk_carries_text(chunk: ChatCompletionChunk) -> bool:
+    """Whether a moderated chunk carries assistant text.
+
+    dome's BLOCK/REPLACE sequence wraps the intervention message in a text-less ``role``
+    opener and a text-less terminal ``content_filter`` chunk. Those must not consume a source
+    response, or every following moderated delta would borrow the *next* segment's message_id.
+    """
+    return bool(chunk.choices and chunk.choices[0].delta.content)
+
+
+def _release_buffered_prefix(
+    pending: list[DRAgentEventResponse],
+    live_message_ids: set[str],
 ) -> list[DRAgentEventResponse]:
-    ordered = _pending_after_moderated_chunk(pending_deferred, pending_pass_through)
-    pending_deferred.clear()
-    pending_pass_through.clear()
-    return ordered
+    """Pop the leading buffered batches that are safe to emit before the next moderated delta.
+
+    Non-text upstream batches are buffered because moderated deltas lag behind the source
+    chunks they came from: emitting ``TEXT_MESSAGE_END`` as soon as upstream produces it would
+    close a segment that still has moderated content coming.
+
+    Buffered batches keep upstream order, so the first batch closing a segment in
+    *live_message_ids* (one that can still receive moderated deltas) blocks itself **and
+    everything behind it**. Releasing a later ``TEXT_MESSAGE_START`` ahead of the
+    ``TEXT_MESSAGE_END`` it follows would interleave two segments, and storage would
+    mis-attribute or truncate the earlier segment's last deltas.
+    """
+    released: list[DRAgentEventResponse] = []
+    while pending and not (_closed_text_message_ids(pending[0]) & live_message_ids):
+        released.append(pending.pop(0))
+    return released
+
+
+def _drain_buffered(pending: list[DRAgentEventResponse]) -> list[DRAgentEventResponse]:
+    """Release every remaining buffered batch: no further moderated delta can arrive."""
+    drained = list(pending)
+    pending.clear()
+    return drained
 
 
 async def _aclose_async_iterator(iterator: AsyncGenerator[Any]) -> None:
@@ -1233,33 +1239,46 @@ async def _moderated_dragent_stream(
     """Yield DRAgent stream chunks with AG-UI-safe ordering around moderated text deltas.
 
     Non-text upstream events pass through immediately until the first text delta. Text deltas are
-    moderated via ``stream_response_async``; ``TEXT_MESSAGE_START`` / ``END`` and other events read
-    during peek-ahead are buffered and emitted after each moderated chunk.
+    moderated via ``stream_response_async``; every later non-text event is buffered in upstream
+    order and released only once the moderated stream has passed the segment it closes.
     """
     stream_tool_index_map: dict[int, str] = {}
     open_text_message_ids: set[str] = set()
-    pending_deferred: list[DRAgentEventResponse] = []
-    pending_pass_through: list[DRAgentEventResponse] = []
+    pending_upstream: list[DRAgentEventResponse] = []
     terminal_run_error: DRAgentEventResponse | None = None
     moderation_source_responses: list[DRAgentEventResponse] = []
     last_source_response: DRAgentEventResponse | None = None
     stopped_for_content_filter = False
 
-    def buffer_passthrough(response: DRAgentEventResponse) -> None:
+    def buffer_upstream(response: DRAgentEventResponse) -> None:
         nonlocal terminal_run_error
         if any(isinstance(event, RunErrorEvent) for event in response.events):
             # Terminal RUN_ERROR: hold it and emit last so no moderated chunk trails after it.
             terminal_run_error = response
             return
-        if response.events and _defer_until_after_moderated_chunk(response.events[0]):
-            pending_deferred.append(response)
-        else:
-            pending_pass_through.append(response)
+        pending_upstream.append(response)
+
+    def live_moderated_message_ids() -> set[str]:
+        """Segments that can still receive a moderated delta.
+
+        dome buffers the whole upstream stream before releasing its first moderated chunk, so
+        source responses queue up far ahead of the moderated output. Anything still queued names
+        a segment whose deltas have not been emitted yet. ``last_source_response`` counts too:
+        it is the message_id every further moderated chunk falls back to once the queue drains.
+        """
+        live = (
+            _text_delta_message_ids(last_source_response.events)
+            if last_source_response is not None
+            else set()
+        )
+        for queued in moderation_source_responses:
+            live |= _text_delta_message_ids(queued.events)
+        return live
 
     async def next_text_response() -> DRAgentEventResponse | None:
         async for response in upstream:
             if not response.events or skip_event_type(response.events[0]):
-                buffer_passthrough(response)
+                buffer_upstream(response)
                 continue
             return response
         return None
@@ -1302,12 +1321,12 @@ async def _moderated_dragent_stream(
                 # ModerationIterator (moderations >= 11.2.45) no longer emits one moderated
                 # chunk per source chunk. On BLOCK/REPLACE it discards the buffered content and
                 # yields a synthetic sequence: a role opener, the message chunk, then a terminal
-                # finish chunk. Those extra chunks outnumber the source responses we appended,
-                # and the opener/terminal carry no delta text (empty AG-UI event lists). All the
-                # synthetic chunks derive from the same upstream text message, so once the source
-                # list drains we reuse the last source response to keep AG-UI message IDs
-                # consistent, and we surface only the chunks that actually carry events.
-                if moderation_source_responses:
+                # finish chunk. Only the middle one carries text, so only text-carrying chunks
+                # consume a source response -- otherwise the opener would burn the first
+                # segment's message_id and shift every later delta onto the wrong segment. Once
+                # the source list drains we reuse the last source response, since all the
+                # synthetic chunks derive from the same upstream text message.
+                if _moderated_chunk_carries_text(moderated) and moderation_source_responses:
                     last_source_response = moderation_source_responses.pop(0)
                 source_response = last_source_response
                 converted = dome_chunk_to_dragent_event_response(
@@ -1318,14 +1337,18 @@ async def _moderated_dragent_stream(
                     stream_tool_index_map=stream_tool_index_map,
                 )
                 if converted.events:
+                    # ``emit_moderated`` first: it owns the prescore-attachment bookkeeping that
+                    # ``emit`` below reads, and that ordering must not depend on what we release.
                     moderated_response = prescore_state.emit_moderated(converted)
-                    track_open_text_in_events(open_text_message_ids, moderated_response.events)
-                    yield moderated_response
-                    for item in _drain_pending_after_moderated_chunk(
-                        pending_deferred, pending_pass_through
+                    # Release buffered lifecycle *before* the delta, so this segment's
+                    # TEXT_MESSAGE_START is already open and the previous segment is closed.
+                    for item in _release_buffered_prefix(
+                        pending_upstream, live_moderated_message_ids()
                     ):
                         track_open_text_in_events(open_text_message_ids, item.events)
                         yield prescore_state.emit(item)
+                    track_open_text_in_events(open_text_message_ids, moderated_response.events)
+                    yield moderated_response
                 finish = moderated.choices[0].finish_reason if moderated.choices else None
                 if finish == "content_filter":
                     for end_response in _synthetic_text_message_end_responses(
@@ -1336,9 +1359,7 @@ async def _moderated_dragent_stream(
                     break
 
         if not stopped_for_content_filter:
-            for item in _drain_pending_after_moderated_chunk(
-                pending_deferred, pending_pass_through
-            ):
+            for item in _drain_buffered(pending_upstream):
                 track_open_text_in_events(open_text_message_ids, item.events)
                 yield prescore_state.emit(item)
             for end_response in _synthetic_text_message_end_responses(open_text_message_ids):

--- a/tests/dragent/plugins/test_datarobot_moderation_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_moderation_middleware.py
@@ -3484,6 +3484,78 @@ async def test_function_middleware_stream_keeps_segments_ordered_when_dome_buffe
     assert [ev.type for ev in flat].count(EventType.TEXT_MESSAGE_END) == 2
 
 
+async def test_function_middleware_stream_buffered_run_finished_follows_trailing_deltas(
+    builder_mock: MagicMock,
+) -> None:
+    """A buffered RUN_FINISHED must not overtake the last segment's deltas or synthetic END.
+
+    RUN_FINISHED closes no text segment, so the prefix release treats it as always safe to emit.
+    When upstream ends without a ``TEXT_MESSAGE_END`` for its last segment, nothing behind
+    RUN_FINISHED holds it back and it was released *before* that segment's remaining moderated
+    deltas, terminating the run mid-text.
+    """
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hi"))
+    moderation.stream_response_async = _buffer_whole_stream_then_emit
+    zero = default_usage_metrics()
+    mid_a, mid_b = "msg-a", "msg-b"
+
+    async def upstream() -> Any:
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_a, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_a, delta="a1")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid_a)], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_b, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_b, delta="b1")], usage_metrics=zero
+        )
+        # No TEXT_MESSAGE_END for mid_b: the middleware synthesizes it.
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in responses for ev in resp.events]
+    validate_sequence(flat)
+    assert [(ev.type, getattr(ev, "message_id", None)) for ev in flat] == [
+        (EventType.RUN_STARTED, None),
+        (EventType.TEXT_MESSAGE_START, mid_a),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_a),
+        (EventType.TEXT_MESSAGE_END, mid_a),
+        (EventType.TEXT_MESSAGE_START, mid_b),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_b),
+        (EventType.TEXT_MESSAGE_END, mid_b),
+        (EventType.RUN_FINISHED, None),
+    ]
+
+
 async def test_function_middleware_stream_block_role_opener_keeps_first_segment_message_id(
     builder_mock: MagicMock,
 ) -> None:
@@ -3575,6 +3647,99 @@ async def test_function_middleware_stream_block_role_opener_keeps_first_segment_
     assert [ev.delta for ev in content] == [blocked_text]
     # The block message belongs to the segment the client already opened, not the next one.
     assert content[0].message_id == mid_a
+
+
+async def test_function_middleware_stream_block_still_emits_upstream_run_finished(
+    builder_mock: MagicMock,
+) -> None:
+    """A block must not swallow upstream's terminal RUN_FINISHED.
+
+    ``content_filter`` breaks out of the moderated loop and skips the pending-buffer drain, so a
+    RUN_FINISHED sitting in that buffer was dropped: the blocked stream ended with no terminal
+    event and clients waited on a run that was already over. The rest of the buffer stays dropped
+    on purpose -- those batches frame text the block discarded.
+    """
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hi"))
+    zero = default_usage_metrics()
+    mid_a, mid_b = "msg-a", "msg-b"
+    blocked_text = "Blocked by moderation."
+
+    async def _block_after_buffering(completion: Any, **kwargs: Any) -> Any:
+        buffered = [chunk async for chunk in completion]
+        template = buffered[0]
+
+        def _chunk(
+            content: str | None, role: str | None, finish: str | None
+        ) -> ChatCompletionChunk:
+            return ChatCompletionChunk(
+                id=template.id,
+                choices=[
+                    OpenAIChunkChoice(
+                        index=0,
+                        delta=OpenAIChoiceDelta(content=content, role=role),
+                        finish_reason=finish,
+                    )
+                ],
+                created=template.created,
+                model=template.model,
+                object="chat.completion.chunk",
+            )
+
+        yield _chunk("", "assistant", None)
+        yield _chunk(blocked_text, None, None)
+        yield _chunk(None, None, "content_filter")
+
+    moderation.stream_response_async = _block_after_buffering
+
+    async def upstream() -> Any:
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+        for mid, text in ((mid_a, "secret"), (mid_b, "more")):
+            yield DRAgentEventResponse(
+                events=[TextMessageStartEvent(message_id=mid, role="assistant")],
+                usage_metrics=zero,
+            )
+            yield DRAgentEventResponse(
+                events=[TextMessageContentEvent(message_id=mid, delta=text)], usage_metrics=zero
+            )
+            yield DRAgentEventResponse(
+                events=[TextMessageEndEvent(message_id=mid)], usage_metrics=zero
+            )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in responses for ev in resp.events]
+    validate_sequence(flat)
+    assert [(ev.type, getattr(ev, "message_id", None)) for ev in flat] == [
+        (EventType.RUN_STARTED, None),
+        (EventType.TEXT_MESSAGE_START, mid_a),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_a),
+        (EventType.TEXT_MESSAGE_END, mid_a),
+        (EventType.RUN_FINISHED, None),
+    ]
+    # The blocked upstream text never reaches the client, and mid_b is never opened.
+    assert [ev.delta for ev in flat if isinstance(ev, TextMessageContentEvent)] == [blocked_text]
 
 
 async def test_function_middleware_stream_late_moderated_delta_stays_inside_its_segment(

--- a/tests/dragent/plugins/test_datarobot_moderation_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_moderation_middleware.py
@@ -3389,3 +3389,284 @@ async def test_function_middleware_stream_run_error_terminal_when_dome_buffers_m
     assert event_types.count(EventType.TEXT_MESSAGE_CONTENT) == 2, event_types
     assert event_types.count(EventType.RUN_ERROR) == 1, event_types
     assert event_types[-1] == EventType.RUN_ERROR, event_types
+
+
+async def _buffer_whole_stream_then_emit(completion: Any, **kwargs: Any) -> Any:
+    """Mirror dome >= 11.2.45 buffered path: drain the WHOLE source to EOF, then emit 1:1.
+
+    Any BLOCK/REPLACE postscore guard puts ``ModerationIterator`` on this path, and dome drains
+    our chunk iterator from its own feed task, so every non-text upstream event lands in the
+    pending buffer before the first moderated delta is released.
+    """
+    buffered = [chunk async for chunk in completion]
+    for chunk in buffered:
+        yield chunk
+
+
+async def test_function_middleware_stream_keeps_segments_ordered_when_dome_buffers_whole_stream(
+    builder_mock: MagicMock,
+) -> None:
+    """Buffered dome must not flush a whole segment's lifecycle after the first moderated delta.
+
+    Regression for dome #658: with the entire upstream stream buffered, the old drain released
+    every pending batch after the first moderated chunk, so the remaining deltas arrived after
+    their TEXT_MESSAGE_END (and after RUN_FINISHED). Each moderated delta must stay inside its
+    own START/END pair, in upstream order.
+    """
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hi"))
+    moderation.stream_response_async = _buffer_whole_stream_then_emit
+    zero = default_usage_metrics()
+    mid_a, mid_b = "msg-a", "msg-b"
+
+    async def upstream() -> Any:
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_a, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_a, delta="a1")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_a, delta="a2")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid_a)], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_b, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_b, delta="b1")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid_b)], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in responses for ev in resp.events]
+    # No protocol violation: every delta/END falls inside an open segment.
+    validate_sequence(flat)
+    assert [(ev.type, getattr(ev, "message_id", None)) for ev in flat] == [
+        (EventType.RUN_STARTED, None),
+        (EventType.TEXT_MESSAGE_START, mid_a),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_a),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_a),
+        (EventType.TEXT_MESSAGE_END, mid_a),
+        (EventType.TEXT_MESSAGE_START, mid_b),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_b),
+        (EventType.TEXT_MESSAGE_END, mid_b),
+        (EventType.RUN_FINISHED, None),
+    ]
+    # Exactly one END per segment: no synthetic close for a segment reopened by a late delta.
+    assert [ev.type for ev in flat].count(EventType.TEXT_MESSAGE_END) == 2
+
+
+async def test_function_middleware_stream_block_role_opener_keeps_first_segment_message_id(
+    builder_mock: MagicMock,
+) -> None:
+    """Text-less block chunks from dome must not consume a source response's message_id.
+
+    ``_build_blocked_output`` wraps the intervention message in a text-less ``role`` opener and a
+    text-less terminal ``content_filter`` chunk. Popping a source response for the opener shifted
+    the block message onto the *second* segment's id, so it was emitted for a message the client
+    had never opened.
+    """
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hi"))
+    zero = default_usage_metrics()
+    mid_a, mid_b = "msg-a", "msg-b"
+    blocked_text = "Blocked by moderation."
+
+    async def _block_after_buffering(completion: Any, **kwargs: Any) -> Any:
+        # Buffer everything (as dome does), then discard it for the 3-chunk block sequence.
+        buffered = [chunk async for chunk in completion]
+        template = buffered[0]
+
+        def _chunk(
+            content: str | None, role: str | None, finish: str | None
+        ) -> ChatCompletionChunk:
+            return ChatCompletionChunk(
+                id=template.id,
+                choices=[
+                    OpenAIChunkChoice(
+                        index=0,
+                        delta=OpenAIChoiceDelta(content=content, role=role),
+                        finish_reason=finish,
+                    )
+                ],
+                created=template.created,
+                model=template.model,
+                object="chat.completion.chunk",
+            )
+
+        yield _chunk("", "assistant", None)
+        yield _chunk(blocked_text, None, None)
+        yield _chunk(None, None, "content_filter")
+
+    moderation.stream_response_async = _block_after_buffering
+
+    async def upstream() -> Any:
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_a, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_a, delta="secret")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid_a)], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_b, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_b, delta="more")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid_b)], usage_metrics=zero
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in responses for ev in resp.events]
+    validate_sequence(flat)
+    content = [ev for ev in flat if isinstance(ev, TextMessageContentEvent)]
+    assert [ev.delta for ev in content] == [blocked_text]
+    # The block message belongs to the segment the client already opened, not the next one.
+    assert content[0].message_id == mid_a
+
+
+async def test_function_middleware_stream_late_moderated_delta_stays_inside_its_segment(
+    builder_mock: MagicMock,
+) -> None:
+    """A moderated delta beyond the source count must not land after its segment's END.
+
+    dome can release more text chunks than we fed it, and those trailing chunks fall back to the
+    last source response's message_id. With the whole upstream buffered, the old drain had already
+    emitted that segment's TEXT_MESSAGE_END (and RUN_FINISHED), so the late delta reopened a closed
+    message and the stream-end synthetic close then emitted a second, unmatched END -- the
+    ``Cannot send 'TEXT_MESSAGE_END' ... No active text message found`` e2e failure.
+    """
+    pipeline = _pipeline_mock()
+    pipeline.get_prescore_guards.return_value = [MagicMock()]
+    moderation = _moderation_mock(pipeline)
+    _set_evaluate_prompt_async_return(moderation, _prescore_df_ok("hi"))
+    zero = default_usage_metrics()
+    mid_a, mid_b = "msg-a", "msg-b"
+
+    async def _buffer_then_emit_extra_delta(completion: Any, **kwargs: Any) -> Any:
+        buffered = [chunk async for chunk in completion]
+        for chunk in buffered:
+            yield chunk
+        # One more text chunk than we were fed: it reuses the last source response's message_id.
+        template = buffered[-1]
+        yield ChatCompletionChunk(
+            id=template.id,
+            choices=[
+                OpenAIChunkChoice(
+                    index=0, delta=OpenAIChoiceDelta(content="tail"), finish_reason=None
+                )
+            ],
+            created=template.created,
+            model=template.model,
+            object="chat.completion.chunk",
+        )
+
+    moderation.stream_response_async = _buffer_then_emit_extra_delta
+
+    async def upstream() -> Any:
+        yield DRAgentEventResponse(
+            events=[RunStartedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_a, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_a, delta="a1")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid_a)], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageStartEvent(message_id=mid_b, role="assistant")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageContentEvent(message_id=mid_b, delta="b1")], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[TextMessageEndEvent(message_id=mid_b)], usage_metrics=zero
+        )
+        yield DRAgentEventResponse(
+            events=[RunFinishedEvent(thread_id="t", run_id="r")], usage_metrics=zero
+        )
+
+    stream_next = MagicMock(return_value=upstream())
+
+    with patch(
+        "datarobot_genai.dragent.plugins.datarobot_moderation_middleware.load_llm_moderation_pipeline",
+        return_value=moderation,
+    ):
+        mw = DataRobotModerationMiddleware(DataRobotModerationConfig(), builder_mock)
+        responses = [
+            response
+            async for response in mw.function_middleware_stream(
+                _make_run_input("hi"),
+                call_next=stream_next,
+                context=_fn_context(),
+            )
+        ]
+
+    flat = [ev for resp in responses for ev in resp.events]
+    validate_sequence(flat)
+    assert [(ev.type, getattr(ev, "message_id", None)) for ev in flat] == [
+        (EventType.RUN_STARTED, None),
+        (EventType.TEXT_MESSAGE_START, mid_a),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_a),
+        (EventType.TEXT_MESSAGE_END, mid_a),
+        (EventType.TEXT_MESSAGE_START, mid_b),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_b),
+        (EventType.TEXT_MESSAGE_CONTENT, mid_b),
+        (EventType.TEXT_MESSAGE_END, mid_b),
+        (EventType.RUN_FINISHED, None),
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.16"
+version = "0.26.17"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Agent responses can arrive in the frontend out of order (as a result of https://github.com/datarobot/moderations/pull/658), and the UI rejects them with `AGUIError: No active text message found`. The same problem shows up intermittently in our own e2e suite as `EventSequenceError: Cannot send 'TEXT_MESSAGE_END' event: No active text message found with ID ...`. Both are the same bug caused by https://github.com/datarobot/moderations/pull/658.

## Why is this happening?
When the agent talks, we do not send one big blob of text. We send a lifecycle: "starting message A", then a series of text deltas for A, then "message A is done". The frontend builds the chat bubble from that. If a delta shows up after we already said "A is done", the frontend has nowhere to put it and throws.

Moderation sits in the middle of this stream. It reads the agent's text, evaluates it against the configured guards, and hands back a moderated version. That takes time, so the moderated text always lags behind the raw text it came from. To cope with that lag, the middleware must hold back the lifecycle events (the "starting" and "done" markers) and releases them once the moderated text they wrap has gone out. Think of it as holding the envelope open until the letter is actually written.

The old rule for releasing was "flush everything you are holding as soon as any moderated text comes out." This was the case pre-https://github.com/datarobot/moderations/pull/658. That worked when moderation returned text at roughly the same pace it received it. It no longer does. A recent moderations change (dome #658) made the guard pipeline buffer the *entire* agent response before releasing its first moderated chunk, so that it can evaluate the whole answer and block it as a unit if needed. Moderations also reads our stream from its own background task, decoupled from what it emits.

The two together mean that by the time the first moderated delta appears, we are already holding the whole rest of the conversation. The old rule dumped all of it at once. Every "message done" marker, and even the end-of-run marker, went out ahead of the text they were supposed to close, and the remaining moderated deltas trailed in behind them. A second, smaller problem compounded it: when a guard blocks a response, moderations wraps the block message in two empty placeholder chunks, and those placeholders were consuming message IDs that belonged to real text, shifting the block message onto a message the client had never opened.

Left unfixed, any agent that produces more than one message segment, on any deployment with a BLOCK or REPLACE guard configured, can scramble its own output. The frontend surfaces it as a hard error and the response is lost, which is what the recipe app e2e test is catching.

The fix changes the release rule. Instead of "flush everything," the middleware now releases held events only up to the point moderation has actually reached, and never releases a "message done" marker for a message that can still receive more moderated text.

## CHANGES

- Replaced the release rule in `datarobot_moderation_middleware.py` with a gated one: buffered events are held in a single queue in the order the agent produced them, and released from the front only while it is safe to do so. A held "message done" marker for a message that can still receive moderated text blocks itself and everything behind it.
- Release now happens just before the moderated text is emitted rather than just after, so a message is always open before its content arrives.
- Collapsed the two separate hold-back queues into one. The split was what allowed the end-of-run marker to overtake a later message's "starting" marker.
- Empty placeholder chunks from a moderation block no longer consume a message ID, so a block message stays attached to the message the client already has open.
- Added three regression tests covering the whole-stream buffering case, the block placeholder case, and a late moderated delta arriving after its source chunks are exhausted. All three fail on the current code with the exact errors above and pass with this change.
- Bumped the version to 0.26.17.

### Verification

`tests/dragent` and `tests/core` pass (1433 tests). Lint and format are clean, and this adds no new mypy errors. The fix is verified at the unit level against a faithful model of the new moderations buffering behavior. I did not run the live e2e suite, so `test_generate_streaming` itself is not yet confirmed green against a real deployment.
t_generate_streaming`
itself is not yet confirmed green against a real deployment.


## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming moderation event ordering and message_id mapping; mistakes could break AG-UI protocol or client storage, but scope is localized with strong regression tests.
> 
> **Overview**
> **Fixes AG-UI text-message ordering** in `DataRobotModerationMiddleware` when dome (≥11.2.45) buffers the entire upstream stream before emitting moderated chunks, or when BLOCK/REPLACE yields text-less synthetic chunks.
> 
> The stream path now keeps all non-text upstream batches in a single **`pending_upstream`** queue and releases them with **`_release_buffered_prefix`** only when no segment that can still receive moderated deltas would be closed early. **`live_moderated_message_ids()`** tracks those “live” segments from queued source responses and the last consumed source. **Only moderated chunks that carry assistant text** pop a source response, so dome’s text-less `role` opener and `content_filter` terminal no longer steal the next segment’s `message_id`. Buffered **START/END** events are emitted **before** each moderated delta so segments are not interleaved or truncated in storage.
> 
> Adds regression tests for whole-stream buffering, block opener message_id attribution, and trailing moderated deltas after upstream END. Bumps package version to **0.26.17**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5ec7d3af5efff1a3201b85ead710c3a6e52ba9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->