### PR TITLE
BUZZOK-31662: Stream options and stop parameter fixes for crewai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.17
+- Fix stream option and stop parameter for crewai and azure
+
 ## 0.26.16
 - Added `mcp_enable_unauthenticated_well_known_route` MCP config.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.16"
+version = "0.26.17"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -214,6 +214,33 @@ class LitellmStopWordLLM(LLM):
         """CrewAI's native loop calls us with ``tools`` set and ``available_functions=None``."""
         return bool(kwargs.get("tools")) and kwargs.get("available_functions") is None
 
+    def _apply_stream_options_for_request(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Attach ``stream_options`` only when ``stream`` is enabled on this request.
+
+        Azure/OpenAI-compatible gateways reject ``stream_options`` unless ``stream=true``.
+        CrewAI stores unknown kwargs in ``additional_params``, so a persisted
+        ``stream_options`` would otherwise leak into non-streaming ``litellm.completion`` calls.
+        """
+        if params.get("stream"):
+            params.setdefault("stream_options", {"include_usage": True})
+        else:
+            params.pop("stream_options", None)
+        return params
+
+    def _prepare_completion_params(
+        self,
+        messages: str | list[Any],
+        tools: list[dict[str, Any]] | None = None,
+        skip_file_processing: bool = False,
+    ) -> dict[str, Any]:
+        params = super()._prepare_completion_params(
+            messages, tools, skip_file_processing=skip_file_processing
+        )
+        # Stop words are enforced client-side via ``_apply_stop_words``; many Azure models
+        # reject the wire ``stop`` parameter (and CrewAI's native tool path bypasses its retry).
+        params.pop("stop", None)
+        return self._apply_stream_options_for_request(params)
+
     def call(self, *args: Any, **kwargs: Any) -> Any:
         """Stream and return native tool calls ourselves — CrewAI's handler drops them.
 
@@ -226,6 +253,7 @@ class LitellmStopWordLLM(LLM):
                 tools = _strip_strict_flags(_sanitize_tool_schema(kwargs["tools"]))
                 params = self._prepare_completion_params(args[0], tools)
                 params["stream"] = True
+                params = self._apply_stream_options_for_request(params)
                 call_id = str(uuid.uuid4())
                 text: list[str] = []
                 tool_calls: list[Any] = []
@@ -270,6 +298,7 @@ class LitellmStopWordLLM(LLM):
                 tools = _strip_strict_flags(_sanitize_tool_schema(kwargs["tools"]))
                 params = self._prepare_completion_params(args[0], tools)
                 params["stream"] = True
+                params = self._apply_stream_options_for_request(params)
                 call_id = str(uuid.uuid4())
                 text: list[str] = []
                 tool_calls: list[Any] = []
@@ -298,7 +327,12 @@ class LitellmStopWordLLM(LLM):
 
 
 def _crewai_model_factory(config: dict) -> LLM:
-    config["stream_options"] = config.get("stream_options", {"include_usage": True})
+    # ``stream_options`` is applied per litellm request in LitellmStopWordLLM (only when
+    # ``stream=true``). Do not persist it in ``additional_params`` — Azure gateways reject it
+    # on non-streaming calls.
+    config.pop("stream_options", None)
+    if config.get("stream") is not False:
+        config.setdefault("stream", True)
     # Strip NAT-internal keys that cause "extra inputs" errors in litellm.
     # Multiple config types (Deployment, Component, Litellm) flow through here.
     config.pop("verify_ssl", None)

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -63,7 +63,7 @@ def test_get_datarobot_gateway_llm_returns_crewai_llm() -> None:
     assert llm.api_base == "https://example.test/genai/llmgw"
     assert llm.api_key == "sk-test-key"
     assert llm.is_litellm is True
-    assert llm.additional_params == {"stream_options": {"include_usage": True}}
+    assert llm.additional_params == {}
 
 
 def test_get_datarobot_gateway_llm_adds_datarobot_model_prefix_when_missing() -> None:
@@ -90,9 +90,7 @@ def test_get_datarobot_deployment_llm_appends_chat_completions_to_api_base() -> 
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
     assert llm.api_base == ("https://example.test/deployments/dep-abc-123/chat/completions")
-    assert llm.additional_params == {
-        "stream_options": {"include_usage": True},
-    }
+    assert llm.additional_params == {}
 
 
 def test_get_datarobot_deployment_llm_merges_parameters() -> None:
@@ -144,9 +142,7 @@ def test_get_external_llm_returns_crewai_llm() -> None:
     assert llm.api_base is None
     assert llm.api_key is None
     assert llm.is_litellm is True
-    assert llm.additional_params == {
-        "stream_options": {"include_usage": True},
-    }
+    assert llm.additional_params == {}
     assert llm.model == "default-model"
 
 
@@ -242,6 +238,30 @@ def test_litellm_stop_word_llm_is_litellm_subclass() -> None:
     llm = LitellmStopWordLLM(model="openai/gpt-4o")
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
+
+
+def test_litellm_stop_word_llm_prepare_params_omits_stream_options_when_not_streaming() -> None:
+    llm = LitellmStopWordLLM(
+        model="openai/gpt-4o",
+        stream=False,
+        stream_options={"include_usage": True},
+    )
+    params = llm._prepare_completion_params("hello")
+    assert params["stream"] is False
+    assert "stream_options" not in params
+
+
+def test_litellm_stop_word_llm_prepare_params_adds_stream_options_when_streaming() -> None:
+    llm = LitellmStopWordLLM(model="openai/gpt-4o", stream=True)
+    params = llm._prepare_completion_params("hello")
+    assert params["stream"] is True
+    assert params["stream_options"] == {"include_usage": True}
+
+
+def test_litellm_stop_word_llm_prepare_params_omits_stop_for_client_side_truncation() -> None:
+    llm = LitellmStopWordLLM(model="openai/gpt-4o", stop=["\nObservation:"])
+    params = llm._prepare_completion_params("hello")
+    assert "stop" not in params
 
 
 def test_litellm_stop_word_llm_call_applies_stop_words(

--- a/tests/crewai/test_llm_clients.py
+++ b/tests/crewai/test_llm_clients.py
@@ -66,7 +66,6 @@ async def test_datarobot_llm_deployment_crewai_with_identity_token():
             assert llm.additional_params == {
                 "max_retries": 10,
                 "extra_headers": {"X-DataRobot-Identity-Token": "identity-token-123"},
-                "stream_options": {"include_usage": True},
             }
 
 
@@ -129,7 +128,6 @@ async def test_datarobot_llm_component_crewai(
             assert llm.api_key == "some_token"
             assert llm.additional_params == {
                 "max_retries": 10,
-                "stream_options": {"include_usage": True},
             }
         elif llm_config.get_llm_type() == LLMType.DEPLOYMENT:
             assert llm.model == "datarobot/anthropic/claude-3"
@@ -139,7 +137,6 @@ async def test_datarobot_llm_component_crewai(
             assert llm.api_key == "some_token"
             assert llm.additional_params == {
                 "max_retries": 10,
-                "stream_options": {"include_usage": True},
                 "extra_headers": {"X-DataRobot-Identity-Token": "identity-token-123"},
             }
         elif llm_config.get_llm_type() == LLMType.NIM:
@@ -150,7 +147,6 @@ async def test_datarobot_llm_component_crewai(
             assert llm.api_key == "some_token"
             assert llm.additional_params == {
                 "max_retries": 10,
-                "stream_options": {"include_usage": True},
             }
         elif llm_config.get_llm_type() == LLMType.EXTERNAL:
             assert llm.model == "anthropic/claude-3"
@@ -158,7 +154,6 @@ async def test_datarobot_llm_component_crewai(
             assert llm.api_key is None
             assert llm.additional_params == {
                 "max_retries": 10,
-                "stream_options": {"include_usage": True},
             }
         else:
             raise ValueError(f"Invalid LLM type inferred from config: {llm_config.get_llm_type()}")

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.16"
+version = "0.26.17"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all CrewAI LLM completion parameter shaping (streaming usage and stop-word behavior); scope is limited to the CrewAI LiteLLM wrapper with targeted tests.
> 
> **Overview**
> Fixes CrewAI LiteLLM calls failing against Azure and similar gateways by controlling **`stream_options`** and the wire **`stop`** parameter per request instead of persisting them on the LLM config.
> 
> **`LitellmStopWordLLM`** now overrides **`_prepare_completion_params`** to drop **`stop`** (stop words stay client-side via **`_apply_stop_words`**) and to add **`stream_options: {include_usage: true}`** only when **`stream`** is true; non-streaming calls explicitly remove **`stream_options`**. The native tool-calling **`call`** / **`acall`** paths re-apply that helper after forcing **`stream=True`**.
> 
> **`_crewai_model_factory`** no longer sets **`stream_options`** in **`additional_params`** (which CrewAI would leak into every completion). It strips any incoming **`stream_options`** and defaults **`stream`** to true unless explicitly false.
> 
> Tests were updated to expect empty **`additional_params`** (aside from retries/headers) and new unit tests cover streaming vs non-streaming **`stream_options`** and omission of **`stop`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b44c53ce45302d2953b93ced11bdc3f9a0cdd05. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->