### PR TITLE
[BUZZOK-31738] EXPERIMENT (do not merge): swap datarobot for datarobot-early-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.20
+- **EXPERIMENT, NOT FOR MERGE**: swapped the `datarobot` dependency for `datarobot-early-access` across the `core`, `auth`, and `drmcputils` extras to measure the CI blast radius. The two distributions share the `datarobot` import path and are mutually exclusive, so stable `datarobot` is added to `[tool.uv].exclude-dependencies` in both the root and `e2e-tests` projects to stop `datarobot-predict` and `datarobot-moderations[all]` pulling it back in transitively. Intended to be reverted to `datarobot` before this lands.
+
 ## 0.26.19
 - Fix datarobot-moderations middleware after dome updated chunk optimization
 - `dragent`: moderated streams no longer rescan the queued source responses per moderated chunk, which made a buffered stream quadratic in delta count and stalled the event loop on long responses.

--- a/CONFIG_INJECTION_MIGRATION_PLAN.md
+++ b/CONFIG_INJECTION_MIGRATION_PLAN.md
@@ -1,0 +1,354 @@
+# Config injection migration plan (config.py as the single source of truth)
+
+Working plan for making the application's `config.py` the absolute authority for
+LLM configuration across `af-component-agent`, `datarobot-genai`, and
+`af-component-llm`. Written 2026-07-20, rewritten 2026-07-21 after nailing down
+the corrected object model. Prototype (Step 1a) lives on the genai branch
+`mattn/BUZZOK-31738-authority`.
+
+Re-read this at the start of each work session. The steps are scoped so each can
+be planned and executed on its own.
+
+---
+
+## The problem in one paragraph
+
+Every `af-component-*` ships a `config.py` with `class Config(DataRobotAppFrameworkBaseSettings)`.
+Users treat that as the one authoritative config, because that base class is the
+only thing guaranteeing a variable resolves the same way across local dev, a
+deployment, and a deployment with dynamic env vars. `datarobot-genai` quietly
+deviated: it built its OWN `Config` and reads it independently, so the app's
+`config.py` is never consulted for LLM routing. When a user hardcodes a value in
+`config.py` without also exporting the matching env var (the "hit it with a
+hammer" case), genai's private config never sees it and the change is silently
+ignored.
+
+## The deeper root cause (why the naive fix is wrong)
+
+`LLMConfig` in `core/config.py` was designed to be a per-LLM value object you
+have MANY of. The proof is still in the tree:
+`build_litellm_router(primary: LLMConfig, fallbacks: list[LLMConfig])` in
+`core/router.py` expects a `list[LLMConfig]`.
+
+Then `LLMConfig` got inherited as a mixin into the singleton
+`class Config(LLMConfig, DataRobotAppFrameworkBaseSettings)`. That collapse does
+two kinds of damage:
+
+1. It reduces `LLMConfig` to exactly one instance (the singleton app config), so
+   a `list[LLMConfig]` is impossible. Fallbacks and multiple LLMs are dead on
+   arrival.
+2. In the collapse, the two true globals (`datarobot_endpoint`,
+   `datarobot_api_token`) landed on `LLMConfig` instead of on the global
+   `Config`, and `datarobot_endpoint` ended up duplicated on `Config`.
+
+So the mixin is the bug, not the fix. Any plan that re-adds
+`class Config(LLMConfig, ...)` re-commits the original mistake. This is why the
+earlier version of this plan, which proposed exactly that mixin, was discarded.
+
+## The naming model (the core insight)
+
+Only two field names are true, fixed, ecosystem-wide absolutes, enforced
+identically in Python, Terraform, Pulumi, and LiteLLM:
+
+- `datarobot_endpoint`
+- `datarobot_api_token`
+
+Everything else is namespaced by the LLM component instance name. `llm` is just
+the DEFAULT instance name, never an absolute. `LLM_DEPLOYMENT_ID` and
+`LLM_DEFAULT_MODEL` are the default instance's env vars, not canonical field
+names. A user runs `dr component add llm`, names the instance (say "bob"), and
+gets `BOB_DEPLOYMENT_ID` and `BOB_DEFAULT_MODEL`, repeatable infinitely. You
+cannot hardcode "bob" into a library, so the library cannot treat any per-LLM
+name as absolute.
+
+`use_datarobot_llm_gateway` is per-LLM too (`{name}_use_datarobot_llm_gateway`),
+because two LLMs in one app can route differently. This also satisfies Anatolii's
+open ticket to namespace `USE_DATAROBOT_LLM_GATEWAY`.
+
+The library MAY default. `get_llm()` with no arguments resolves the default
+instance ("llm") as a convenience, and defaulting is normal library behavior.
+What it must never do is treat the default as the only option. If a flow uses two
+LLMs, the user is responsible for disambiguating with `get_llm(name="bob")`. That
+is the only answer that can work, and the responsibility rightly sits with the
+user.
+
+## The corrected object model
+
+Two distinct objects, cleanly separated.
+
+```python
+# The app's config.py — the single global authority (exactly one of these)
+class Config(DataRobotAppFrameworkBaseSettings):
+    datarobot_endpoint: str = "https://app.datarobot.com/api/v2"  # true absolute
+    datarobot_api_token: str | None = None                        # true absolute
+
+    # per-LLM fields, flat and namespaced by instance ("llm" is the default name)
+    llm_default_model: str = "..."
+    llm_deployment_id: str | None = None
+    llm_use_datarobot_llm_gateway: bool = True
+    # bob_default_model, bob_deployment_id, bob_use_datarobot_llm_gateway, ...
+
+    def resolve_llm(self, name: str = "llm") -> "LLMConfig":
+        # map {name}_* flat fields + the two globals into an LLMConfig
+        ...
+
+# Per-LLM value object — you can have many
+class LLMConfig(BaseModel):
+    model: str | None = None
+    deployment_id: str | None = None
+    nim_deployment_id: str | None = None
+    use_datarobot_llm_gateway: bool = True
+    # endpoint/token are owned by Config; see the interim note below
+```
+
+The injection seam gives genai a name-aware resolver, not the app `Config`
+itself. genai only ever receives a fully-formed `LLMConfig` and never sees
+`llm_*` or the app `Config` shape. It ships default-only first; the `name=`
+extension is built later.
+
+## Why it is possible under NAT (the mechanism)
+
+NAT's `load_workflow` -> `load_config` (`nat/runtime/loader.py`) does two ordered
+steps:
+
+1. `discover_and_register_plugins(CONFIG_OBJECT)` imports every `nat.plugins`
+   entry point. The app registers itself here (recipe `agent/pyproject.toml`:
+   `[project.entry-points.'nat.plugins'] langgraph_agent = "agent.register"`),
+   which imports `agent/__init__.py` -> `from agent.config import Config`.
+2. `validate_schema(config_yaml, Config)` eagerly instantiates every `_type`
+   block. The empty `datarobot-llm-component` block fires genai's
+   `default_factory` fields, which read config.
+
+The app package is imported in step 1, before step 2 reads config. That import
+ordering is the injection seam. It holds identically in local dev (`task dev`)
+and in a deployment (`start.sh` runs `nat dragent serve --config_file workflow.yaml`
+under gunicorn; each worker runs the same load sequence).
+
+---
+
+## Locked decisions (2026-07-21)
+
+- **Enforcement: type + runtime check.** genai requires the injected provider to
+  return an `LLMConfig` (isinstance guarantee), plus a light runtime assertion
+  that the required fields exist and are correctly typed, raising a clear error
+  otherwise. Belt and suspenders, and it directly answers Anatolii's strict-typing
+  concern.
+- **genai's private `Config()` stays as the no-provider fallback.** Single flow,
+  no env-var gate (removed 2026-07-21 at Matt's call). If the app registers a
+  provider, genai reads it; if not (standalone genai with no app around it), genai
+  builds its own env-only `Config()` exactly as before. Nothing breaks if the user
+  defines nothing.
+- **Multi-LLM is designed-for now, built late.** The naming model must stay
+  namespace-capable from the start, but `get_llm(name=...)` lands after the
+  single-default path is proven.
+- **Router / fallbacks wrapper is a downstream cleanup.** The real defect is
+  `LLMConfig`-collapsed-to-a-singleton. Restoring it as a value object un-breaks
+  `fallbacks` for free. Whether to keep the wrapper or move to LiteLLM's native
+  router (Anatolii's lean) is decided later, not a gate on this plan.
+- **endpoint/token on the resolved `LLMConfig`: interim populate-from-global.**
+  For now `resolve_llm()` copies the two globals onto the resolved `LLMConfig` so
+  it is self-contained for the client builder. A later cleanup keeps them strictly
+  off `LLMConfig` and has the builder take `(llm_config, global_config)`.
+
+---
+
+## The plan, structured on the four steps
+
+### Step 1 — Inject and elevate config.py to authoritative
+
+Make the app's `config.py` the thing genai actually reads, end to end.
+
+- **1a. genai injection seam (DONE, branch `mattn/BUZZOK-31738-authority`).**
+  `register_config_provider()` and `resolve_config()`. Routed the user-intent
+  helpers (`default_api_key`, `default_model_name`,
+  `default_use_datarobot_llm_gateway`, `default_llm_deployment_id`,
+  `default_nim_deployment_id`) and the three `get_llm()` facades through
+  `resolve_config()`. Config tests pass, ruff clean. Single flow, no env-var gate
+  (removed 2026-07-21): a registered provider means injection; no provider means
+  genai's own env-only `Config()`.
+- **1b. af-component-agent wiring (DONE 2026-07-21, working branch).** The app
+  `config.py.jinja` now declares the two globals (`datarobot_endpoint`,
+  `datarobot_api_token`), adds `nim_deployment_id`, keeps the namespaced per-LLM
+  fields, adds `resolve_llm(name=<llm_app_name>)` mapping them into a genai
+  `LLMConfig`, and registers `lambda: Config().resolve_llm()` at import. Validated
+  at the library level (hammer case + non-default / dashed instance names). Version
+  floor bump still pending a genai release. Remaining below.
+  - `template/{{agent_app_name}}/agent/config.py.jinja`: keep
+    `class Config(DataRobotAppFrameworkBaseSettings)` (NOT the mixin). Ensure the
+    two globals (`datarobot_endpoint`, `datarobot_api_token`) are present, keep
+    the per-LLM namespaced flat fields (the existing `{{llm_app_name}}_*` Jinja
+    already produces `llm_*` for the default), and add a `resolve_llm(name="llm")`
+    method that maps `{name}_*` + globals into an `LLMConfig` (populating
+    endpoint/token from the globals, per the interim decision).
+  - Register a resolver-backed provider at import (guarded with try/except on the
+    genai import for version compatibility). Default-only for now, resolver shaped
+    so `name=` is a clean later extension.
+  - Bump the genai version floor. Today the agent pins `datarobot-genai...==0.24.0`
+    (exact). The seam is unreleased (post-0.26.1), so this step splits: land the
+    wiring now against an editable genai, do the floor bump once genai cuts a
+    release with the seam.
+- **1c. Validate end to end.** Render the template (default `llm_app_name == "llm"`),
+  byte-compile, confirm the provider registers. Run the hammer case: hardcode a
+  model in `config.py`, no env vars, and confirm `get_llm()` uses it. Then
+  `nat dragent serve` locally to prove the load-order seam through real NAT plugin
+  discovery. Then confirm in a deployment (`start.sh` under gunicorn).
+  (Library-level hammer validation DONE 2026-07-21; the `nat dragent serve` and
+  deployment checks remain.)
+- **1d. Extend injection to any remaining read site on the default NAT path (DONE 2026-07-21).**
+  Routed `default_deployment_url` and `default_datarobot_llm_gateway_url` through
+  `resolve_config()` so the endpoint (a true global) is authoritative from the app
+  config too, not just the user-intent fields. Extracted `DEFAULT_DATAROBOT_ENDPOINT`
+  as the shared default and coalesce fallback. The router path
+  (`to_litellm_params`, `core/router.py`) stays intentionally deferred to the
+  downstream router cleanup.
+
+### Step 2 — Clean out old and unused config referencing
+
+Remove what the injected resolver now supersedes, and undo the collapse damage.
+
+**Mixin broken + two-resolver split DONE 2026-07-21 (the central untangle).**
+`Config` no longer inherits `LLMConfig`. `resolve_config() -> Config` is the global
+(the two globals + app-wide + default-instance fields); `resolve_llm_config(name)
+-> LLMConfig` is one LLM's config, mapped from it and wired into the `get_llm`
+dispatch and every `default_*` helper (previously dead code). Nothing in genai
+reads a config attribute directly: the globals go through
+`resolve_datarobot_endpoint()` / `resolve_datarobot_api_token()`, per-LLM through
+`resolve_llm_config()`. The provider now registers the global `Config` plus a
+`default_llm_name`; `_validate_global_config` duck-type-checks it. Still deferred:
+3d canonical de-prefixing of `LLMConfig` (it keeps `llm_*` field names for now),
+and the router path (`to_litellm_params` / `core/router.py`).
+
+- **2a.** Move `datarobot_endpoint` and `datarobot_api_token` ownership to the
+  global `Config` and off `LLMConfig` as authored fields. Remove the duplicate
+  `datarobot_endpoint` declaration on genai's `Config`. (Interim: `resolve_llm`
+  still populates them onto the resolved object; the strict removal is the
+  downstream cleanup.)
+- **2b.** Delete genai's env-only reads that the injected resolver replaces on the
+  default path, keeping the private `Config()` only as the no-injection fallback.
+- **2c.** Retire the hardcoded `llm_*`-as-absolute assumptions in genai
+  (`get_llm_type`, the leaf builders) wherever they are now dead.
+- **2d.** In `af-component-llm`, inventory the band-aids that injection makes
+  redundant, but defer their removal to Step 4 / downstream so the currently
+  shipping env-var contract does not break mid-migration.
+
+### Step 3 — Define the default-fallback naming contract
+
+Write down the rules so nobody relitigates them, and make them enforceable.
+
+**Largely DONE 2026-07-21 (universal namespacing landed).** All per-LLM env vars
+are now instance-namespaced `{NAME}_*` across the three repos in one move (partial
+namespacing silently breaks the standalone path). `resolve_llm` moved into
+`datarobot_genai.core.config.resolve_llm(app_config, name)`; the app registers
+`lambda: resolve_llm(Config(), "<llm_app_name>")`. genai `LLMConfig` fields are now
+`llm_deployment_id / llm_nim_deployment_id / llm_use_datarobot_llm_gateway /
+llm_default_model` plus the two globals; af-component-llm emits `{NAME}_*`
+everywhere; default gateway flag = True everywhere, `"0"` written per non-gateway
+blueprint. Still to do: 3f enforcement (type + runtime check) and 3g observability
+logging. The final canonical de-prefixing of the value object (3d, strip `llm_`
+off `LLMConfig` by separating it from the env reader) remains a later cleanup.
+
+- **3a.** Codify the two true globals: `datarobot_endpoint`, `datarobot_api_token`,
+  fixed names, ecosystem-wide.
+- **3b.** Codify per-LLM namespacing: `{name}_default_model`,
+  `{name}_deployment_id`, `{name}_nim_deployment_id`,
+  `{name}_use_datarobot_llm_gateway`. `llm` is the default instance name, not an
+  absolute.
+- **3c.** Define the resolver mapping: flat `{name}_*` fields plus the two globals
+  produce an `LLMConfig(model, deployment_id, nim_deployment_id,
+  use_datarobot_llm_gateway [+ endpoint/token folded in, interim])`.
+- **3d.** Canonicalize `LLMConfig` field names to logical, unprefixed forms
+  (`model`, `deployment_id`), so the namespace lives only in the env-var names and
+  the resolver, never in the value object. This is the correctly-framed "kill the
+  `llm_*` coupling" work.
+- **3e.** Confirm the gateway flag is per-LLM (`{name}_use_datarobot_llm_gateway`)
+  and coordinate with Anatolii's namespace ticket.
+- **3f.** Enforcement (the locked type + runtime check): provider must return an
+  `LLMConfig`; a runtime assertion checks required fields are present and typed,
+  with a clear error message otherwise.
+- **3g.** Observability: log at resolve time which source won (injected provider
+  vs env fallback) and the resolved LLM identity (redacted). This answers
+  Anatolii's traceability / too-many-hops concern.
+
+### Step 4 — Route default-entity access through functions
+
+Make "which LLM" a function argument, never a hardcoded global read.
+
+- **4a.** `get_llm(name="llm")` resolves the default via the resolver;
+  `get_llm(name="bob")` selects a non-default instance; `get_llm(config=...)`
+  accepts an explicit `LLMConfig`.
+- **4b.** Restore `LLMConfig` as a true multi-instance value object (many
+  constructible). This is what un-breaks `fallbacks`.
+- **4c.** Multi-LLM support (build-late): the seam provider becomes name-aware;
+  `af-component-llm` composes each added instance's namespaced fields into the app
+  `Config`; `get_llm(name=...)` selects among them.
+- **4d.** Audit that no code reads a hardcoded global `llm_*` off a singleton; all
+  default-entity access goes through the resolver or `get_llm`.
+
+---
+
+## Downstream cleanups (explicitly deferred, tracked here so they are not lost)
+
+- **Router / fallbacks wrapper.** Decide keep-vs-deprecate in favor of LiteLLM's
+  native router. `LLMConfig`-as-value-object un-breaks it either way.
+- **endpoint/token strictly off `LLMConfig`.** Final state: owned only by `Config`,
+  builder takes `(llm_config, global_config)`.
+- **`af-component-llm` band-aid removal.** Drop/shrink `ensure_datarobot_prefix`,
+  stop force-exporting the prefix, simplify `verify_llm`; revisit C5 runtime-param
+  convergence; finish deferred C3, E4, F1, F3, F4 (see `LLM_FIX_TRACKING.md` in
+  af-component-llm).
+- **Prefix normalization at the genai client boundary (Carson).** Then components
+  stop prefixing. Reference implementations without genai: data-analyst
+  `core/constants.py`, recipe-talk-to-my-docs `web/app/api/v1/chat.py`.
+- **Shared config schema extraction (dovetail APP-6588).** Extract the LLM config
+  schema into a shared place both genai and the app import, so the agent
+  `config.py` is genuinely the master and genai depends on the schema, not the
+  reverse.
+- **Retire the `datarobot-deployed-llm` stub** once a real default model is always
+  resolvable.
+
+---
+
+## Backward-compatibility invariant
+
+There is one flow, selected by whether a provider is registered (no env-var gate).
+A standalone genai with no app registering a provider builds its own env-only
+`Config()` exactly as today. Any app on the new `config.py` template registers a
+provider at import, so genai reads that config. This is the intended end state,
+not a temporary opt-in. Consequence to watch: adopting the template makes the app
+config's defaults authoritative immediately, which surfaces the
+`use_datarobot_llm_gateway` default conflict (app False vs genai True) for the
+local / no-env case. Real deployments set the env var via af-component-llm, so env
+still wins there; the default reconciliation is tracked as Phase 1 work.
+
+## Cross-repo coordination
+
+- **Carson Gee:** APP-6588 (libllm extraction), prefix-at-client-boundary, the
+  "baby tech spec" tying libllm and config extraction. The downstream schema and
+  prefix cleanups depend on alignment here.
+- **Anatolii Stehnii:** endorsed the injection approach as more in-line with other
+  components; owns the `USE_DATAROBOT_LLM_GATEWAY` namespace ticket; leans toward
+  using LiteLLM's router directly over the wrapper. He was skeptical injection was
+  possible under NAT; Step 1a plus the mechanism section are the counter-proof.
+- Genai version floors must move together across genai + agent + recipe.
+
+## Validation strategy per step
+
+- **Unit:** genai `tests/core/test_config.py` for the seam and the resolver; add
+  framework-level tests as read paths change.
+- **Integration:** render the agent template, `nat dragent serve` locally with the
+  gate on, exercise the hammer case (hardcode in `config.py`, no env).
+- **Deployment:** confirm the `start.sh` load path honors injection under gunicorn.
+
+## Risks and watch items
+
+- **Settings-source alias gotcha (verified 2026-07-21).**
+  `DataRobotAppFrameworkBaseSettings` runs three env sources; two of them
+  (`GetenvSettingsSource` for Runtime Parameters, `PulumiConfigSettingsSource`)
+  iterate by `field_name.upper()` and ignore pydantic `validation_alias`. Only the
+  standard env source honors aliases. So do not rely on `validation_alias` for
+  prefixed env vars in a deployment; field names must match the env-var names.
+- NAT eager-validation order is relied upon. If NAT changes plugin-discovery vs
+  validation ordering, the import-time seam needs a different hook.
+- genai version floors must move together across repos.
+- Squash-merge policy: reference PRs / tickets in durable notes, never
+  feature-branch SHAs.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -145,7 +145,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.12"
+version = "0.26.20"
 source = { editable = "../" }
 
 [package.metadata]
@@ -177,21 +177,21 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.17.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.19.0,<4.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },
@@ -267,6 +267,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'langgraph'", specifier = ">=0.64b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-aiohttp-client", marker = "extra == 'llamaindex'", specifier = ">=0.64b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-crewai", marker = "extra == 'crewai'", specifier = ">=0.62.1,<1.0.0" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'dragent'", specifier = ">=0.64b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'core'", specifier = ">=0.64b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'crewai'", specifier = ">=0.64b0,<1.0.0" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'dragent'", specifier = ">=0.64b0,<1.0.0" },

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -67,6 +67,10 @@ override-dependencies = [
     "opentelemetry-instrumentation>=0.64b0,<0.65",
 ]
 exclude-dependencies = [
+    # EXPERIMENT (do not merge): keep in sync with the root project. datarobot-genai now
+    # depends on `datarobot-early-access`, which shares the `datarobot` import path, so
+    # stable `datarobot` must be excluded here too or the e2e venv gets both.
+    "datarobot",
     "annoy",                    # nemoguardrails ANN index; sdist -march=native build SIGILLs on non-AVX-512 runners (BUZZOK-31265)
     "llama-index-llms-azure-openai",
     "llama-index-llms-bedrock",

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -22,6 +22,7 @@ overrides = [
 excludes = [
     "annoy",
     "build",
+    "datarobot",
     "flask",
     "kubernetes",
     "lancedb",
@@ -875,8 +876,8 @@ wheels = [
 ]
 
 [[package]]
-name = "datarobot"
-version = "3.17.0"
+name = "datarobot-early-access"
+version = "3.19.0.2026.8.3.173957"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -891,9 +892,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/2e/2d72db2fe202e2f5151a3d465a026c7ffa0f06ec0900260973daeb2cf69c/datarobot-3.17.0.tar.gz", hash = "sha256:a3587725adb06bfc58942dec0f7cd26e7ba0918e11b6e72a6848636ba5fb58fa", size = 834279, upload-time = "2026-06-30T12:52:39.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/8f/1429881723f1f8e9830000928961623bae4d5a4f10d863c7d79f2d79e81d/datarobot_early_access-3.19.0.2026.8.3.173957.tar.gz", hash = "sha256:1c6b23ef585c586d291aa0e49e2436cbc36d775b0f4f3a62bbed5ef15966f1a2", size = 1081255, upload-time = "2026-08-03T17:40:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/bb/9771102c62cea69f9e1ade151a23855d93c959109d30668fba598272d9ab/datarobot-3.17.0-py3-none-any.whl", hash = "sha256:c54471022ea29324fe8a21b34b9473d1d75da1599de66ad8ef8d28dde47b08b0", size = 902398, upload-time = "2026-06-30T12:52:37.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e4/f6f957e0ff148dba43a19ec0813695c0a069d8c813fd7e78a7c7617ff8a9/datarobot_early_access-3.19.0.2026.8.3.173957-py3-none-any.whl", hash = "sha256:c3861352a8458ff45572ebb2a44daaddd42e60422eb5ffb0e86ce2688a837685", size = 1248514, upload-time = "2026-08-03T17:39:59.919Z" },
 ]
 
 [package.optional-dependencies]
@@ -905,7 +906,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.17"
+version = "0.26.20"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -916,7 +917,7 @@ crewai = [
     { name = "colorama" },
     { name = "crewai", extra = ["litellm"] },
     { name = "crewai-tools", extra = ["mcp"] },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -940,7 +941,7 @@ dragent = [
     { name = "ag-ui-protocol" },
     { name = "anyio" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -965,7 +966,7 @@ dragent = [
 langgraph = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -988,7 +989,7 @@ langgraph = [
 llamaindex = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1041,21 +1042,21 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.17.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.19.0,<4.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },
@@ -1329,7 +1330,6 @@ wheels = [
 
 [package.optional-dependencies]
 all = [
-    { name = "datarobot" },
     { name = "datarobot-predict" },
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
@@ -1353,7 +1353,6 @@ version = "1.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "datarobot" },
     { name = "pandas" },
     { name = "py4j" },
     { name = "requests" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.19"
+version = "0.26.20"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
@@ -82,6 +82,12 @@ override-dependencies = [
   "opentelemetry-instrumentation>=0.64b0,<0.65",
 ]
 exclude-dependencies = [
+  # EXPERIMENT (do not merge): we depend on `datarobot-early-access` instead of
+  # `datarobot`. The two unpack into the same top-level `datarobot` package, so having
+  # both installed corrupts the import path. datarobot-predict (`datarobot>=2.17`) and
+  # datarobot-moderations[all] (`datarobot>=3.6.0`) both request stable `datarobot`
+  # transitively, so it has to be excluded for the swap to hold.
+  "datarobot",
   "uv",                       # package manager bundled by crewai; runtime unnecessary
   "langchain-milvus",         # Milvus vector DB adapter pulled in by nvidia-nat-langchain; not used
   "pymilvus",                 # Milvus client pulled in by langchain-milvus; not used

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ from setuptools import setup
 # Core dependencies shared across extras. These are merged into other extras except standalone extras.
 core = [
     "requests>=2.32.4,<3.0.0",
-    "datarobot[core]>=3.17.0,<4.0.0",
+    # 3.18.0 is the first release with datarobot.core.config.LLMConfig / LLMType,
+    # which datarobot_genai.core.config now consumes instead of redefining.
+    "datarobot[core]>=3.18.0,<4.0.0",
     "datarobot-predict>=1.13.2,<2.0.0",
     "openai>=2.0.0,<3.0.0",
     "pyjwt>=2.12.0,<3.0.0",  # CVE-2026-32597 fixed in 2.12.0
@@ -90,7 +92,7 @@ dragent = core + [
 
 # auth is standalone set of dependencies for auth utilities only
 auth = [
-  "datarobot[auth]>=3.17.0,<4.0.0",
+  "datarobot[auth]>=3.18.0,<4.0.0",
   "aiohttp>=3.13.3,<4.0.0",  # CVE-2025-69229 & CVE-2025-69230 fixed in 3.13.3
   "pydantic>=2.6.1,<3.0.0",
   "httpx>=0.28.1,<1.0.0",
@@ -100,7 +102,7 @@ auth = [
 
 # drmcputils is a leaf subpackage: no imports from other datarobot_genai subpackages.
 drmcputils = auth + [
-    "datarobot[fs]>=3.17.0,<4.0.0",
+    "datarobot[fs]>=3.18.0,<4.0.0",
 ]
 
 # drtools: no subpackages dependencies other than auth and drmcputils.

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,14 @@ from setuptools import setup
 # Core dependencies shared across extras. These are merged into other extras except standalone extras.
 core = [
     "requests>=2.32.4,<3.0.0",
-    # 3.18.0 is the first release with datarobot.core.config.LLMConfig / LLMType,
-    # which datarobot_genai.core.config now consumes instead of redefining.
-    "datarobot[core]>=3.18.0,<4.0.0",
+    # EXPERIMENT (do not merge): swapped from `datarobot` to `datarobot-early-access`.
+    # Both distributions install into the same top-level `datarobot` package and are
+    # mutually exclusive, so every pin below has to move together, and stable
+    # `datarobot` is excluded in [tool.uv].exclude-dependencies to stop
+    # datarobot-predict / datarobot-moderations[all] pulling it back in transitively.
+    # Reason for the probe: the LLMConfig legacy-param bridge genai delegates to only
+    # exists in 3.19, which is early-access-only today.
+    "datarobot-early-access[core]>=3.19.0,<4.0.0",
     "datarobot-predict>=1.13.2,<2.0.0",
     "openai>=2.0.0,<3.0.0",
     "pyjwt>=2.12.0,<3.0.0",  # CVE-2026-32597 fixed in 2.12.0
@@ -92,7 +97,7 @@ dragent = core + [
 
 # auth is standalone set of dependencies for auth utilities only
 auth = [
-  "datarobot[auth]>=3.18.0,<4.0.0",
+  "datarobot-early-access[auth]>=3.19.0,<4.0.0",  # EXPERIMENT: see note in `core`
   "aiohttp>=3.13.3,<4.0.0",  # CVE-2025-69229 & CVE-2025-69230 fixed in 3.13.3
   "pydantic>=2.6.1,<3.0.0",
   "httpx>=0.28.1,<1.0.0",
@@ -102,7 +107,7 @@ auth = [
 
 # drmcputils is a leaf subpackage: no imports from other datarobot_genai subpackages.
 drmcputils = auth + [
-    "datarobot[fs]>=3.18.0,<4.0.0",
+    "datarobot-early-access[fs]>=3.19.0,<4.0.0",  # EXPERIMENT: see note in `core`
 ]
 
 # drtools: no subpackages dependencies other than auth and drmcputils.

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
 from enum import StrEnum
 
@@ -138,12 +137,9 @@ class Config(LLMConfig, DataRobotAppFrameworkBaseSettings):
 # app registers a provider (a zero-arg callable returning an ``LLMConfig``) at
 # import time. The app package is imported during NAT plugin discovery, which
 # runs before NAT validates the workflow config, so the provider is in place by
-# the time genai's defaults are read. When a provider is registered (and the
-# opt-in gate is enabled) genai reads the app's config instead of building its
-# own env-only ``Config()``; otherwise it falls back to the previous behavior so
-# nothing changes for callers that have not opted in.
-
-_CONFIG_INJECTION_ENV_VAR = "DATAROBOT_GENAI_CONFIG_INJECTION"
+# the time genai's defaults are read. There is exactly one flow: if a provider is
+# registered, genai reads the app's config; if not, genai falls back to its own
+# env-only ``Config()`` (a standalone genai with no app registered around it).
 
 # Module-level holder for the app config provider. A dict avoids the ``global``
 # statement (discouraged, and unused elsewhere in this package) while keeping the
@@ -154,36 +150,22 @@ _provider_registry: dict[str, Callable[[], LLMConfig] | None] = {"provider": Non
 def register_config_provider(provider: Callable[[], LLMConfig] | None) -> None:
     """Register the app's authoritative config source, or clear it with ``None``.
 
-    ``provider`` is a zero-arg callable returning an ``LLMConfig`` (typically the
-    app's ``Config`` class itself, or ``lambda: Config()``). It is called each
-    time genai resolves config, so values re-resolve through the app's settings
-    sources (env / .env / secrets / Pulumi) on every read.
+    ``provider`` is a zero-arg callable returning an ``LLMConfig`` (typically
+    ``lambda: Config()`` over the app's own config). It is called each time genai
+    resolves config, so values re-resolve through the app's settings sources
+    (env / .env / secrets / Pulumi) on every read.
     """
     _provider_registry["provider"] = provider
-
-
-def config_injection_enabled() -> bool:
-    """Whether the app-config injection seam is active.
-
-    Opt-in for now via ``DATAROBOT_GENAI_CONFIG_INJECTION`` so the seam can ship
-    and be validated without changing behavior for anyone who has not enabled it.
-    """
-    return os.environ.get(_CONFIG_INJECTION_ENV_VAR, "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
 
 
 def resolve_config() -> LLMConfig:
     """Return the authoritative config genai should read from.
 
-    The app-injected config when a provider is registered and the gate is on,
-    otherwise genai's own env-reading ``Config()`` (the pre-injection behavior).
+    The app-injected config when a provider is registered, otherwise genai's own
+    env-reading ``Config()`` (a standalone genai with no app registered).
     """
     provider = _provider_registry["provider"]
-    if config_injection_enabled() and provider is not None:
+    if provider is not None:
         provided = provider()
         if provided is not None:
             return provided

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from enum import StrEnum
+from typing import Any
+from typing import cast
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from pydantic import BaseModel
@@ -24,6 +26,7 @@ from pydantic import Field
 DEFAULT_MAX_HISTORY_MESSAGES = 20
 DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM = "datarobot/datarobot-deployed-llm"
 DEFAULT_DATAROBOT_ENDPOINT = "https://app.datarobot.com/api/v2"
+DEFAULT_LLM_NAME = "llm"
 
 
 class LLMType(StrEnum):
@@ -38,12 +41,19 @@ def _with_datarobot_prefix(model_name: str) -> str:
 
 
 class LLMConfig(BaseModel):
-    """Pure LLM connection parameters — no env-var machinery, no NAT base class.
+    """One LLM instance's resolved connection parameters. A value object.
 
-    Used as a base for ``Config`` (adds env reading) and
-    ``DataRobotLLMComponentModelConfig`` (adds NAT schema), and as the
-    primary/fallback type accepted by the router so ``core`` has no NAT
-    dependency.
+    There can be MANY of these, one per configured LLM instance. It carries only
+    per-LLM routing fields (which LLM, how to reach it), never app-wide settings.
+    Produce one with :func:`resolve_llm_config` (mapped from the global
+    :class:`Config`), or accept one directly (the router does this). The two
+    ``datarobot_*`` globals are copied in for self-containment so the client
+    builder does not have to reach back to the global config.
+
+    This is deliberately NOT the same object as :class:`Config`. ``Config`` is the
+    one global; ``LLMConfig`` is one-of-many. Keeping them separate is what lets
+    ``resolve_config`` (the global) and ``resolve_llm_config`` (a single LLM) be
+    genuinely different things.
     """
 
     datarobot_endpoint: str | None = None
@@ -66,24 +76,24 @@ class LLMConfig(BaseModel):
     def to_litellm_params(self) -> dict:
         """Return a litellm_params dict suitable for ``litellm.Router``'s model_list.
 
-        Falls back to env-loaded ``Config`` values for endpoint and api_key
+        Endpoint and api_key fall back to the resolved globals
+        (:func:`resolve_datarobot_endpoint` / :func:`resolve_datarobot_api_token`)
         when they are not set on this instance directly.
         """
-        env = Config()
         api_key = (
             self.datarobot_api_token
             if self.datarobot_api_token is not None
-            else env.datarobot_api_token
+            else resolve_datarobot_api_token()
         )
         endpoint = (
             self.datarobot_endpoint
             if self.datarobot_endpoint is not None
-            else env.datarobot_endpoint
+            else resolve_datarobot_endpoint()
         )
         model_name = (
             getattr(self, "model_name", None)
             or self.llm_default_model
-            or env.llm_default_model
+            or default_model_name()
             or "datarobot-deployed-llm"
         )
         llm_type = self.get_llm_type()
@@ -113,103 +123,195 @@ class LLMConfig(BaseModel):
             }
 
 
-class Config(LLMConfig, DataRobotAppFrameworkBaseSettings):
-    """
-    Finds variables in the priority order of: env
-    variables (including Runtime Parameters), .env, file_secrets, then
-    Pulumi output variables.
+class Config(DataRobotAppFrameworkBaseSettings):
+    """The single GLOBAL application config. There is exactly one.
+
+    Finds variables in priority order: env vars (including Runtime Parameters),
+    .env, file secrets, then Pulumi outputs. It holds the two ecosystem-wide
+    globals, app-wide settings, and the default LLM instance's flat,
+    instance-namespaced fields so a standalone genai (no app registered) can still
+    resolve the default LLM from the environment.
+
+    This is NOT an :class:`LLMConfig`. genai never reads LLM routing fields off it
+    directly; those are mapped into an :class:`LLMConfig` by
+    :func:`resolve_llm_config`, and the two globals are read only through
+    :func:`resolve_datarobot_endpoint` / :func:`resolve_datarobot_api_token`.
     """
 
+    # True ecosystem-wide globals. Fixed names, shared by every LLM instance.
     datarobot_endpoint: str = DEFAULT_DATAROBOT_ENDPOINT
+    datarobot_api_token: str | None = None
 
+    # App-wide setting (genai-specific tunable).
     max_history_messages: int = Field(
         default=DEFAULT_MAX_HISTORY_MESSAGES, ge=0, alias="datarobot_genai_max_history_messages"
     )
 
+    # Default LLM instance ("llm") fields, namespaced by instance name, so a
+    # standalone genai reads them from the environment. An app registers its own
+    # config, which may namespace by a different instance name; see the seam below.
+    llm_deployment_id: str | None = None
+    llm_nim_deployment_id: str | None = None
+    llm_use_datarobot_llm_gateway: bool = True
+    llm_default_model: str | None = None
+
 
 # --- App config injection seam ---------------------------------------------
 #
-# The application (e.g. an af-component-* agent) owns the authoritative config:
-# a ``DataRobotAppFrameworkBaseSettings`` subclass in its ``config.py``. That is
-# the single source users edit and reason about, and it is the only place that
-# guarantees a value resolves across local dev, deployment, and dynamic env vars.
+# There are exactly two config objects and two resolvers, and they are NOT the
+# same thing:
 #
-# genai is a library and cannot import the app's ``config.py`` directly, so the
-# app registers a provider (a zero-arg callable returning an ``LLMConfig``) at
-# import time. The app package is imported during NAT plugin discovery, which
-# runs before NAT validates the workflow config, so the provider is in place by
-# the time genai's defaults are read. There is exactly one flow: if a provider is
-# registered, genai reads the app's config; if not, genai falls back to its own
-# env-only ``Config()`` (a standalone genai with no app registered around it).
+#   Config       - the single GLOBAL app config (endpoint, token, app-wide
+#                  settings, and per-instance LLM fields). resolve_config() -> Config.
+#   LLMConfig    - ONE LLM instance's routing config. resolve_llm_config(name) -> LLMConfig,
+#                  mapped from the global config's {name}_* fields plus the two globals.
+#
+# The application (an af-component-* app) owns the authoritative global config: a
+# DataRobotAppFrameworkBaseSettings subclass in its config.py. genai cannot import
+# that class, so the app registers a provider (a zero-arg callable returning that
+# global config) at import time. The app package is imported during NAT plugin
+# discovery, before NAT validates the workflow config, so the provider is in place
+# before genai first reads config. One flow: a registered provider means genai
+# reads the app's global config; otherwise it falls back to its own env-only
+# Config().
+#
+# The invariant that keeps this from getting twisted again: NOTHING in genai reads
+# a config attribute directly. The two globals go through resolve_datarobot_endpoint()
+# / resolve_datarobot_api_token(); per-LLM routing goes through resolve_llm_config().
 
-# Module-level holder for the app config provider. A dict avoids the ``global``
-# statement (discouraged, and unused elsewhere in this package) while keeping the
-# registration mutable at runtime.
-_provider_registry: dict[str, Callable[[], LLMConfig] | None] = {"provider": None}
+_provider_registry: dict[str, Any] = {"provider": None, "default_llm_name": DEFAULT_LLM_NAME}
 
 
-def register_config_provider(provider: Callable[[], LLMConfig] | None) -> None:
-    """Register the app's authoritative config source, or clear it with ``None``.
+def register_config_provider(
+    provider: Callable[[], object | None] | None,
+    default_llm_name: str = DEFAULT_LLM_NAME,
+) -> None:
+    """Register the app's authoritative GLOBAL config source, or clear it with ``None``.
 
-    ``provider`` is a zero-arg callable returning an ``LLMConfig`` (typically
-    ``lambda: Config()`` over the app's own config). It is called each time genai
-    resolves config, so values re-resolve through the app's settings sources
-    (env / .env / secrets / Pulumi) on every read.
+    ``provider`` is a zero-arg callable returning the app's global config object
+    (typically ``lambda: Config()`` over the app's own ``Config``). It is called
+    each time genai resolves config, so values re-resolve through the app's
+    settings sources (env / .env / secrets / Pulumi) on every read.
+
+    ``default_llm_name`` is the app's default LLM instance name (the prefix on its
+    per-LLM fields). ``resolve_llm_config()`` with no explicit name uses it, so a
+    non-"llm" component name still works for a bare ``get_llm()``.
     """
     _provider_registry["provider"] = provider
+    _provider_registry["default_llm_name"] = default_llm_name
 
 
-def resolve_config() -> LLMConfig:
-    """Return the authoritative config genai should read from.
+def _validate_global_config(config: object) -> None:
+    """Fail loud if an injected global config is missing the required globals.
 
-    The app-injected config when a provider is registered, otherwise genai's own
-    env-reading ``Config()`` (a standalone genai with no app registered).
+    genai cannot ``isinstance``-check the app's ``Config`` (a different class it
+    cannot import), so this is a structural (duck-typed) check that the injected
+    object at least exposes the two globals every consumer relies on.
+    """
+    missing = [
+        name for name in ("datarobot_endpoint", "datarobot_api_token") if not hasattr(config, name)
+    ]
+    if missing:
+        raise TypeError(
+            f"Registered config provider returned {type(config).__name__}, which is "
+            f"missing required global field(s): {', '.join(missing)}. The app config "
+            "must expose datarobot_endpoint and datarobot_api_token."
+        )
+
+
+def resolve_config() -> Config:
+    """Return the single GLOBAL application config.
+
+    The registered app config when a provider is registered, otherwise genai's own
+    env-reading :class:`Config` (a standalone genai with no app around it). Only
+    the two globals are read off this, and only via
+    :func:`resolve_datarobot_endpoint` / :func:`resolve_datarobot_api_token`. For
+    LLM routing use :func:`resolve_llm_config`.
     """
     provider = _provider_registry["provider"]
     if provider is not None:
         provided = provider()
         if provided is not None:
-            return provided
+            _validate_global_config(provided)
+            # The app's Config is a structurally-compatible settings object; genai
+            # only reads it through the resolver helpers (getattr), so treat it as
+            # a Config for typing purposes.
+            return cast(Config, provided)
     return Config()
+
+
+def resolve_datarobot_endpoint() -> str:
+    """Resolve the DataRobot endpoint global. The only place it is read off config."""
+    endpoint: str | None = getattr(resolve_config(), "datarobot_endpoint", None)
+    return endpoint or DEFAULT_DATAROBOT_ENDPOINT
+
+
+def resolve_datarobot_api_token() -> str | None:
+    """Resolve the DataRobot API token global. The only place it is read off config."""
+    token: str | None = getattr(resolve_config(), "datarobot_api_token", None)
+    return token or None
+
+
+def resolve_llm_config(name: str | None = None) -> LLMConfig:
+    """Resolve ONE LLM instance's config from the global config.
+
+    ``name`` is the LLM component instance name; when omitted it is the app's
+    registered default (``"llm"`` for a standalone genai). Reads the instance's
+    ``{name}_*`` fields off :func:`resolve_config` and folds in the two globals,
+    producing a self-contained :class:`LLMConfig`. This is the one machine that
+    turns app config into an LLM config, and it is what ``get_llm`` runs on.
+    """
+    config = resolve_config()
+    instance = name if name is not None else cast(str, _provider_registry["default_llm_name"])
+    # Read everything off a single resolve_config() so the provider is invoked
+    # exactly once per resolution (values still re-resolve on the next call).
+    endpoint: str | None = getattr(config, "datarobot_endpoint", None)
+    api_token: str | None = getattr(config, "datarobot_api_token", None)
+    return LLMConfig(
+        datarobot_endpoint=endpoint or DEFAULT_DATAROBOT_ENDPOINT,
+        datarobot_api_token=api_token or None,
+        llm_deployment_id=getattr(config, f"{instance}_deployment_id", None),
+        llm_nim_deployment_id=getattr(config, f"{instance}_nim_deployment_id", None),
+        llm_use_datarobot_llm_gateway=getattr(
+            config, f"{instance}_use_datarobot_llm_gateway", True
+        ),
+        llm_default_model=getattr(config, f"{instance}_default_model", None),
+    )
 
 
 def get_max_history_messages_default() -> int:
     """Return the default maximum number of history messages.
 
-    This can be overridden globally via the
-    ``DATAROBOT_GENAI_MAX_HISTORY_MESSAGES`` environment variable.
-    Invalid values fall back to the built-in default. Negative values are
-    treated as 0 (disable history).
+    This is a genai-internal tunable (``DATAROBOT_GENAI_MAX_HISTORY_MESSAGES``),
+    read off genai's own :class:`Config`, not per-LLM config. Invalid values fall
+    back to the built-in default; negative values are treated as 0 (disable history).
     """
     return max(Config().max_history_messages, 0)
 
 
 def default_api_key() -> str | None:
-    config = resolve_config()
-    return config.datarobot_api_token if config.datarobot_api_token else None
+    return resolve_datarobot_api_token()
 
 
 def default_model_name() -> str | None:
-    return resolve_config().llm_default_model
+    return resolve_llm_config().llm_default_model
 
 
 def default_response_model() -> str:
     """Return the configured model to report in OpenAI ``chat/completions`` responses.
 
     dragent agents ignore the request's ``model`` and run the LLM configured in
-    ``workflow.yaml`` / env, so the response should report that actual model — not
+    ``workflow.yaml`` / env, so the response should report that actual model, not
     echo the caller's string (which need not be sent at all) nor NAT's
     ``"unknown-model"`` placeholder. Resolves the same way the LLM client does
-    (:meth:`LLMConfig.to_litellm_params`): ``LLM_DEFAULT_MODEL`` env, else the
-    deployed-LLM default; always ``datarobot/``-prefixed and never ``None`` so the
-    response can never regress to ``"unknown-model"``. (A per-LLM ``model_name`` set
-    inline in ``workflow.yaml`` is not reflected here — env/global config only.)
+    (the default LLM's model), always ``datarobot/``-prefixed and never ``None`` so
+    the response can never regress to ``"unknown-model"``.
     """
     return _with_datarobot_prefix(default_model_name() or "datarobot-deployed-llm")
 
 
 def default_use_datarobot_llm_gateway() -> bool:
-    return resolve_config().llm_use_datarobot_llm_gateway
+    return resolve_llm_config().llm_use_datarobot_llm_gateway
 
 
 def deployment_url(deployment_id: str, datarobot_endpoint: str) -> str:
@@ -217,13 +319,11 @@ def deployment_url(deployment_id: str, datarobot_endpoint: str) -> str:
 
 
 def default_deployment_url(deployment_id: str | None = None) -> str:
-    config = resolve_config()
-    default_deployment_id = deployment_id or config.llm_deployment_id
-    if default_deployment_id is None:
+    resolved_id = deployment_id or resolve_llm_config().llm_deployment_id
+    if resolved_id is None:
         raise ValueError("Neither deployment ID nor default deployment ID is set")
 
-    endpoint = config.datarobot_endpoint or DEFAULT_DATAROBOT_ENDPOINT
-    return deployment_url(default_deployment_id, endpoint)
+    return deployment_url(resolved_id, resolve_datarobot_endpoint())
 
 
 def llm_gateway_url(datarobot_endpoint: str) -> str:
@@ -231,36 +331,12 @@ def llm_gateway_url(datarobot_endpoint: str) -> str:
 
 
 def default_datarobot_llm_gateway_url() -> str:
-    endpoint = resolve_config().datarobot_endpoint or DEFAULT_DATAROBOT_ENDPOINT
-    return llm_gateway_url(endpoint)
+    return llm_gateway_url(resolve_datarobot_endpoint())
 
 
 def default_llm_deployment_id() -> str | None:
-    return resolve_config().llm_deployment_id
+    return resolve_llm_config().llm_deployment_id
 
 
 def default_nim_deployment_id() -> str | None:
-    return resolve_config().llm_nim_deployment_id
-
-
-def resolve_llm(app_config: object, name: str = "llm") -> LLMConfig:
-    """Map an application config's instance-namespaced fields into an ``LLMConfig``.
-
-    The application owns the authoritative config (a
-    ``DataRobotAppFrameworkBaseSettings`` subclass). genai never reads that class
-    directly; the app registers a provider that hands genai a fully formed
-    ``LLMConfig`` built by this function. ``name`` is the LLM component instance
-    name (``"llm"`` by default); per-LLM values are read as ``{name}_*`` while the
-    two ecosystem-wide globals are shared across instances. Missing fields fall
-    back to the same defaults as a standalone ``LLMConfig``.
-    """
-    return LLMConfig(
-        datarobot_endpoint=getattr(app_config, "datarobot_endpoint", None),
-        datarobot_api_token=getattr(app_config, "datarobot_api_token", None),
-        llm_deployment_id=getattr(app_config, f"{name}_deployment_id", None),
-        llm_nim_deployment_id=getattr(app_config, f"{name}_nim_deployment_id", None),
-        llm_use_datarobot_llm_gateway=getattr(
-            app_config, f"{name}_use_datarobot_llm_gateway", True
-        ),
-        llm_default_model=getattr(app_config, f"{name}_default_model", None),
-    )
+    return resolve_llm_config().llm_nim_deployment_id

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -14,14 +14,18 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from enum import StrEnum
 from typing import Any
 from typing import cast
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from datarobot.core.config import getenv
 from pydantic import BaseModel
 from pydantic import Field
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_HISTORY_MESSAGES = 20
 DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM = "datarobot/datarobot-deployed-llm"
@@ -252,6 +256,53 @@ def resolve_datarobot_api_token() -> str | None:
     return token or None
 
 
+# --- Deprecated LLM config parameter bridge (REMOVE IN A FUTURE RELEASE) -------
+#
+# Two per-LLM params were renamed to the universal ``{instance}_`` namespace:
+#   nim_deployment_id          -> {instance}_nim_deployment_id
+#   use_datarobot_llm_gateway  -> {instance}_use_datarobot_llm_gateway
+#
+# Old deployments still carry the pre-rename bare runtime-parameter names. Those
+# bare names are no longer declared config fields, and the settings base class is
+# ``extra="ignore"``, so they never land on the resolved config object; they can
+# only be read straight from the environment. This bridge does exactly that, then
+# warns loudly. It WILL BE REMOVED IN A FUTURE RELEASE. New deployments set only
+# the namespaced params and never reach this path.
+
+
+def _coerce_bool(value: object) -> bool:
+    """Coerce a runtime-parameter value (a bool, or a ``"1"``/``"0"`` string) to bool."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def _deprecated_param(old_name: str, new_name: str) -> object | None:
+    """Read a renamed LLM param from its pre-rename runtime-parameter name.
+
+    Returns ``None`` when the old param is absent. When present, emits a loud,
+    hard-to-miss deprecation warning and returns the old value. REMOVE IN A
+    FUTURE RELEASE together with the rest of this bridge.
+    """
+    old_value = getenv(old_name)
+    if old_value is None:
+        return None
+    banner = "!" * 88
+    logger.warning(
+        "\n%s\n"
+        "DEPRECATED LLM CONFIG PARAMETER IN USE\n"
+        "  Runtime parameter %r is DEPRECATED and WILL BE REMOVED IN A FUTURE RELEASE.\n"
+        "  Rename it to %r as soon as possible.\n"
+        "  Falling back to the deprecated value for now.\n"
+        "%s",
+        banner,
+        old_name,
+        new_name,
+        banner,
+    )
+    return old_value
+
+
 def resolve_llm_config(name: str | None = None) -> LLMConfig:
     """Resolve ONE LLM instance's config from the global config.
 
@@ -267,14 +318,34 @@ def resolve_llm_config(name: str | None = None) -> LLMConfig:
     # exactly once per resolution (values still re-resolve on the next call).
     endpoint: str | None = getattr(config, "datarobot_endpoint", None)
     api_token: str | None = getattr(config, "datarobot_api_token", None)
+
+    # --- deprecated-name backwards-compat bridge (REMOVE IN A FUTURE RELEASE) ---
+    # Fall back to the pre-rename bare param names only when the namespaced field
+    # was not explicitly provided. ``model_fields_set`` is what distinguishes an
+    # explicit value from a default (required for the bool, whose default is True).
+    set_fields = getattr(config, "model_fields_set", ())
+
+    llm_nim_deployment_id = getattr(config, f"{instance}_nim_deployment_id", None)
+    if f"{instance}_nim_deployment_id" not in set_fields:
+        old = _deprecated_param("NIM_DEPLOYMENT_ID", f"{instance.upper()}_NIM_DEPLOYMENT_ID")
+        if old is not None:
+            llm_nim_deployment_id = str(old)
+
+    llm_use_datarobot_llm_gateway = getattr(config, f"{instance}_use_datarobot_llm_gateway", True)
+    if f"{instance}_use_datarobot_llm_gateway" not in set_fields:
+        old = _deprecated_param(
+            "USE_DATAROBOT_LLM_GATEWAY", f"{instance.upper()}_USE_DATAROBOT_LLM_GATEWAY"
+        )
+        if old is not None:
+            llm_use_datarobot_llm_gateway = _coerce_bool(old)
+    # --- end bridge ---
+
     return LLMConfig(
         datarobot_endpoint=endpoint or DEFAULT_DATAROBOT_ENDPOINT,
         datarobot_api_token=api_token or None,
         llm_deployment_id=getattr(config, f"{instance}_deployment_id", None),
-        llm_nim_deployment_id=getattr(config, f"{instance}_nim_deployment_id", None),
-        llm_use_datarobot_llm_gateway=getattr(
-            config, f"{instance}_use_datarobot_llm_gateway", True
-        ),
+        llm_nim_deployment_id=llm_nim_deployment_id,
+        llm_use_datarobot_llm_gateway=llm_use_datarobot_llm_gateway,
         llm_default_model=getattr(config, f"{instance}_default_model", None),
     )
 

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -49,16 +49,16 @@ class LLMConfig(BaseModel):
     datarobot_endpoint: str | None = None
     datarobot_api_token: str | None = None
     llm_deployment_id: str | None = None
-    nim_deployment_id: str | None = None
-    use_datarobot_llm_gateway: bool = True
+    llm_nim_deployment_id: str | None = None
+    llm_use_datarobot_llm_gateway: bool = True
     llm_default_model: str | None = None
 
     def get_llm_type(self) -> LLMType:
-        if self.use_datarobot_llm_gateway:
+        if self.llm_use_datarobot_llm_gateway:
             return LLMType.GATEWAY
         elif self.llm_deployment_id:
             return LLMType.DEPLOYMENT
-        elif self.nim_deployment_id:
+        elif self.llm_nim_deployment_id:
             return LLMType.NIM
         else:
             return LLMType.EXTERNAL
@@ -103,7 +103,7 @@ class LLMConfig(BaseModel):
         elif llm_type == LLMType.NIM:
             return {
                 "model": _with_datarobot_prefix(model_name),
-                "api_base": deployment_url(self.nim_deployment_id, endpoint),  # type: ignore[arg-type]
+                "api_base": deployment_url(self.llm_nim_deployment_id, endpoint),  # type: ignore[arg-type]
                 "api_key": api_key,
             }
         else:  # EXTERNAL
@@ -209,7 +209,7 @@ def default_response_model() -> str:
 
 
 def default_use_datarobot_llm_gateway() -> bool:
-    return resolve_config().use_datarobot_llm_gateway
+    return resolve_config().llm_use_datarobot_llm_gateway
 
 
 def deployment_url(deployment_id: str, datarobot_endpoint: str) -> str:
@@ -240,4 +240,27 @@ def default_llm_deployment_id() -> str | None:
 
 
 def default_nim_deployment_id() -> str | None:
-    return resolve_config().nim_deployment_id
+    return resolve_config().llm_nim_deployment_id
+
+
+def resolve_llm(app_config: object, name: str = "llm") -> LLMConfig:
+    """Map an application config's instance-namespaced fields into an ``LLMConfig``.
+
+    The application owns the authoritative config (a
+    ``DataRobotAppFrameworkBaseSettings`` subclass). genai never reads that class
+    directly; the app registers a provider that hands genai a fully formed
+    ``LLMConfig`` built by this function. ``name`` is the LLM component instance
+    name (``"llm"`` by default); per-LLM values are read as ``{name}_*`` while the
+    two ecosystem-wide globals are shared across instances. Missing fields fall
+    back to the same defaults as a standalone ``LLMConfig``.
+    """
+    return LLMConfig(
+        datarobot_endpoint=getattr(app_config, "datarobot_endpoint", None),
+        datarobot_api_token=getattr(app_config, "datarobot_api_token", None),
+        llm_deployment_id=getattr(app_config, f"{name}_deployment_id", None),
+        llm_nim_deployment_id=getattr(app_config, f"{name}_nim_deployment_id", None),
+        llm_use_datarobot_llm_gateway=getattr(
+            app_config, f"{name}_use_datarobot_llm_gateway", True
+        ),
+        llm_default_model=getattr(app_config, f"{name}_default_model", None),
+    )

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Callable
 from enum import StrEnum
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
@@ -125,6 +127,69 @@ class Config(LLMConfig, DataRobotAppFrameworkBaseSettings):
     )
 
 
+# --- App config injection seam ---------------------------------------------
+#
+# The application (e.g. an af-component-* agent) owns the authoritative config:
+# a ``DataRobotAppFrameworkBaseSettings`` subclass in its ``config.py``. That is
+# the single source users edit and reason about, and it is the only place that
+# guarantees a value resolves across local dev, deployment, and dynamic env vars.
+#
+# genai is a library and cannot import the app's ``config.py`` directly, so the
+# app registers a provider (a zero-arg callable returning an ``LLMConfig``) at
+# import time. The app package is imported during NAT plugin discovery, which
+# runs before NAT validates the workflow config, so the provider is in place by
+# the time genai's defaults are read. When a provider is registered (and the
+# opt-in gate is enabled) genai reads the app's config instead of building its
+# own env-only ``Config()``; otherwise it falls back to the previous behavior so
+# nothing changes for callers that have not opted in.
+
+_CONFIG_INJECTION_ENV_VAR = "DATAROBOT_GENAI_CONFIG_INJECTION"
+
+# Module-level holder for the app config provider. A dict avoids the ``global``
+# statement (discouraged, and unused elsewhere in this package) while keeping the
+# registration mutable at runtime.
+_provider_registry: dict[str, Callable[[], LLMConfig] | None] = {"provider": None}
+
+
+def register_config_provider(provider: Callable[[], LLMConfig] | None) -> None:
+    """Register the app's authoritative config source, or clear it with ``None``.
+
+    ``provider`` is a zero-arg callable returning an ``LLMConfig`` (typically the
+    app's ``Config`` class itself, or ``lambda: Config()``). It is called each
+    time genai resolves config, so values re-resolve through the app's settings
+    sources (env / .env / secrets / Pulumi) on every read.
+    """
+    _provider_registry["provider"] = provider
+
+
+def config_injection_enabled() -> bool:
+    """Whether the app-config injection seam is active.
+
+    Opt-in for now via ``DATAROBOT_GENAI_CONFIG_INJECTION`` so the seam can ship
+    and be validated without changing behavior for anyone who has not enabled it.
+    """
+    return os.environ.get(_CONFIG_INJECTION_ENV_VAR, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def resolve_config() -> LLMConfig:
+    """Return the authoritative config genai should read from.
+
+    The app-injected config when a provider is registered and the gate is on,
+    otherwise genai's own env-reading ``Config()`` (the pre-injection behavior).
+    """
+    provider = _provider_registry["provider"]
+    if config_injection_enabled() and provider is not None:
+        provided = provider()
+        if provided is not None:
+            return provided
+    return Config()
+
+
 def get_max_history_messages_default() -> int:
     """Return the default maximum number of history messages.
 
@@ -137,13 +202,12 @@ def get_max_history_messages_default() -> int:
 
 
 def default_api_key() -> str | None:
-    config = Config()
+    config = resolve_config()
     return config.datarobot_api_token if config.datarobot_api_token else None
 
 
 def default_model_name() -> str | None:
-    config = Config()
-    return config.llm_default_model
+    return resolve_config().llm_default_model
 
 
 def default_response_model() -> str:
@@ -162,8 +226,7 @@ def default_response_model() -> str:
 
 
 def default_use_datarobot_llm_gateway() -> bool:
-    config = Config()
-    return config.use_datarobot_llm_gateway
+    return resolve_config().use_datarobot_llm_gateway
 
 
 def deployment_url(deployment_id: str, datarobot_endpoint: str) -> str:
@@ -189,10 +252,8 @@ def default_datarobot_llm_gateway_url() -> str:
 
 
 def default_llm_deployment_id() -> str | None:
-    config = Config()
-    return config.llm_deployment_id
+    return resolve_config().llm_deployment_id
 
 
 def default_nim_deployment_id() -> str | None:
-    config = Config()
-    return config.nim_deployment_id
+    return resolve_config().nim_deployment_id

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -23,6 +23,7 @@ from pydantic import Field
 
 DEFAULT_MAX_HISTORY_MESSAGES = 20
 DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM = "datarobot/datarobot-deployed-llm"
+DEFAULT_DATAROBOT_ENDPOINT = "https://app.datarobot.com/api/v2"
 
 
 class LLMType(StrEnum):
@@ -119,7 +120,7 @@ class Config(LLMConfig, DataRobotAppFrameworkBaseSettings):
     Pulumi output variables.
     """
 
-    datarobot_endpoint: str = "https://app.datarobot.com/api/v2"
+    datarobot_endpoint: str = DEFAULT_DATAROBOT_ENDPOINT
 
     max_history_messages: int = Field(
         default=DEFAULT_MAX_HISTORY_MESSAGES, ge=0, alias="datarobot_genai_max_history_messages"
@@ -216,12 +217,13 @@ def deployment_url(deployment_id: str, datarobot_endpoint: str) -> str:
 
 
 def default_deployment_url(deployment_id: str | None = None) -> str:
-    config = Config()
+    config = resolve_config()
     default_deployment_id = deployment_id or config.llm_deployment_id
     if default_deployment_id is None:
         raise ValueError("Neither deployment ID nor default deployment ID is set")
 
-    return deployment_url(default_deployment_id, config.datarobot_endpoint)
+    endpoint = config.datarobot_endpoint or DEFAULT_DATAROBOT_ENDPOINT
+    return deployment_url(default_deployment_id, endpoint)
 
 
 def llm_gateway_url(datarobot_endpoint: str) -> str:
@@ -229,8 +231,8 @@ def llm_gateway_url(datarobot_endpoint: str) -> str:
 
 
 def default_datarobot_llm_gateway_url() -> str:
-    config = Config()
-    return llm_gateway_url(config.datarobot_endpoint)
+    endpoint = resolve_config().datarobot_endpoint or DEFAULT_DATAROBOT_ENDPOINT
+    return llm_gateway_url(endpoint)
 
 
 def default_llm_deployment_id() -> str | None:

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from enum import StrEnum
 from typing import Any
 from typing import cast
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from datarobot.core.config import LLMConfig as CoreLLMConfig
+from datarobot.core.config import LLMType
+from datarobot.core.config import deployment_url
 from datarobot.core.config import getenv
-from pydantic import BaseModel
+from datarobot.core.config import llm_gateway_url
 from pydantic import Field
 
 logger = logging.getLogger(__name__)
@@ -33,26 +35,22 @@ DEFAULT_DATAROBOT_ENDPOINT = "https://app.datarobot.com/api/v2"
 DEFAULT_LLM_NAME = "llm"
 
 
-class LLMType(StrEnum):
-    GATEWAY = "gateway"
-    DEPLOYMENT = "deployment"
-    NIM = "nim"
-    EXTERNAL = "external"
-
-
 def _with_datarobot_prefix(model_name: str) -> str:
     return model_name if model_name.startswith("datarobot/") else "datarobot/" + model_name
 
 
-class LLMConfig(BaseModel):
+class LLMConfig(CoreLLMConfig):
     """One LLM instance's resolved connection parameters. A value object.
+
+    The fields, the :class:`LLMType` routing enum, and :meth:`get_llm_type` all
+    come from :class:`datarobot.core.config.LLMConfig`; there is one canonical LLM
+    value object for the whole ecosystem and genai consumes it rather than
+    redefining it. genai extends it only to override :meth:`to_litellm_params`.
 
     There can be MANY of these, one per configured LLM instance. It carries only
     per-LLM routing fields (which LLM, how to reach it), never app-wide settings.
     Produce one with :func:`resolve_llm_config` (mapped from the global
-    :class:`Config`), or accept one directly (the router does this). The two
-    ``datarobot_*`` globals are copied in for self-containment so the client
-    builder does not have to reach back to the global config.
+    :class:`Config`), or accept one directly (the router does this).
 
     This is deliberately NOT the same object as :class:`Config`. ``Config`` is the
     one global; ``LLMConfig`` is one-of-many. Keeping them separate is what lets
@@ -60,29 +58,15 @@ class LLMConfig(BaseModel):
     genuinely different things.
     """
 
-    datarobot_endpoint: str | None = None
-    datarobot_api_token: str | None = None
-    llm_deployment_id: str | None = None
-    llm_nim_deployment_id: str | None = None
-    llm_use_datarobot_llm_gateway: bool = True
-    llm_default_model: str | None = None
-
-    def get_llm_type(self) -> LLMType:
-        if self.llm_use_datarobot_llm_gateway:
-            return LLMType.GATEWAY
-        elif self.llm_deployment_id:
-            return LLMType.DEPLOYMENT
-        elif self.llm_nim_deployment_id:
-            return LLMType.NIM
-        else:
-            return LLMType.EXTERNAL
-
     def to_litellm_params(self) -> dict:
         """Return a litellm_params dict suitable for ``litellm.Router``'s model_list.
 
-        Endpoint and api_key fall back to the resolved globals
-        (:func:`resolve_datarobot_endpoint` / :func:`resolve_datarobot_api_token`)
-        when they are not set on this instance directly.
+        This overrides core's self-contained implementation because the router
+        path builds ``LLMConfig`` objects straight from ``workflow.yaml`` without
+        the two globals set. Endpoint and api_key therefore fall back to the
+        resolved globals (:func:`resolve_datarobot_endpoint` /
+        :func:`resolve_datarobot_api_token`), and the model name falls back to the
+        default LLM's model, when they are not set on this instance directly.
         """
         api_key = (
             self.datarobot_api_token
@@ -385,20 +369,12 @@ def default_use_datarobot_llm_gateway() -> bool:
     return resolve_llm_config().llm_use_datarobot_llm_gateway
 
 
-def deployment_url(deployment_id: str, datarobot_endpoint: str) -> str:
-    return f"{datarobot_endpoint}/deployments/{deployment_id}/chat/completions"
-
-
 def default_deployment_url(deployment_id: str | None = None) -> str:
     resolved_id = deployment_id or resolve_llm_config().llm_deployment_id
     if resolved_id is None:
         raise ValueError("Neither deployment ID nor default deployment ID is set")
 
     return deployment_url(resolved_id, resolve_datarobot_endpoint())
-
-
-def llm_gateway_url(datarobot_endpoint: str) -> str:
-    return datarobot_endpoint.removesuffix("/api/v2")
 
 
 def default_datarobot_llm_gateway_url() -> str:

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -14,20 +14,16 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from typing import Any
 from typing import cast
 
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
-from datarobot.core.config import LLMConfig as CoreLLMConfig
-from datarobot.core.config import LLMType
+from datarobot.core.config import LLMConfig
+from datarobot.core.config import LLMType  # noqa: F401  # re-exported for genai consumers
 from datarobot.core.config import deployment_url
-from datarobot.core.config import getenv
 from datarobot.core.config import llm_gateway_url
 from pydantic import Field
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_HISTORY_MESSAGES = 20
 DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM = "datarobot/datarobot-deployed-llm"
@@ -37,78 +33,6 @@ DEFAULT_LLM_NAME = "llm"
 
 def _with_datarobot_prefix(model_name: str) -> str:
     return model_name if model_name.startswith("datarobot/") else "datarobot/" + model_name
-
-
-class LLMConfig(CoreLLMConfig):
-    """One LLM instance's resolved connection parameters. A value object.
-
-    The fields, the :class:`LLMType` routing enum, and :meth:`get_llm_type` all
-    come from :class:`datarobot.core.config.LLMConfig`; there is one canonical LLM
-    value object for the whole ecosystem and genai consumes it rather than
-    redefining it. genai extends it only to override :meth:`to_litellm_params`.
-
-    There can be MANY of these, one per configured LLM instance. It carries only
-    per-LLM routing fields (which LLM, how to reach it), never app-wide settings.
-    Produce one with :func:`resolve_llm_config` (mapped from the global
-    :class:`Config`), or accept one directly (the router does this).
-
-    This is deliberately NOT the same object as :class:`Config`. ``Config`` is the
-    one global; ``LLMConfig`` is one-of-many. Keeping them separate is what lets
-    ``resolve_config`` (the global) and ``resolve_llm_config`` (a single LLM) be
-    genuinely different things.
-    """
-
-    def to_litellm_params(self) -> dict:
-        """Return a litellm_params dict suitable for ``litellm.Router``'s model_list.
-
-        This overrides core's self-contained implementation because the router
-        path builds ``LLMConfig`` objects straight from ``workflow.yaml`` without
-        the two globals set. Endpoint and api_key therefore fall back to the
-        resolved globals (:func:`resolve_datarobot_endpoint` /
-        :func:`resolve_datarobot_api_token`), and the model name falls back to the
-        default LLM's model, when they are not set on this instance directly.
-        """
-        api_key = (
-            self.datarobot_api_token
-            if self.datarobot_api_token is not None
-            else resolve_datarobot_api_token()
-        )
-        endpoint = (
-            self.datarobot_endpoint
-            if self.datarobot_endpoint is not None
-            else resolve_datarobot_endpoint()
-        )
-        model_name = (
-            getattr(self, "model_name", None)
-            or self.llm_default_model
-            or default_model_name()
-            or "datarobot-deployed-llm"
-        )
-        llm_type = self.get_llm_type()
-
-        if llm_type == LLMType.GATEWAY:
-            return {
-                "model": _with_datarobot_prefix(model_name),
-                "api_base": llm_gateway_url(endpoint),
-                "api_key": api_key,
-            }
-        elif llm_type == LLMType.DEPLOYMENT:
-            return {
-                "model": _with_datarobot_prefix(model_name),
-                "api_base": deployment_url(self.llm_deployment_id, endpoint),  # type: ignore[arg-type]
-                "api_key": api_key,
-            }
-        elif llm_type == LLMType.NIM:
-            return {
-                "model": _with_datarobot_prefix(model_name),
-                "api_base": deployment_url(self.llm_nim_deployment_id, endpoint),  # type: ignore[arg-type]
-                "api_key": api_key,
-            }
-        else:  # EXTERNAL
-            return {
-                "model": model_name.removeprefix("datarobot/"),
-                "api_key": api_key,
-            }
 
 
 class Config(DataRobotAppFrameworkBaseSettings):
@@ -122,8 +46,8 @@ class Config(DataRobotAppFrameworkBaseSettings):
 
     This is NOT an :class:`LLMConfig`. genai never reads LLM routing fields off it
     directly; those are mapped into an :class:`LLMConfig` by
-    :func:`resolve_llm_config`, and the two globals are read only through
-    :func:`resolve_datarobot_endpoint` / :func:`resolve_datarobot_api_token`.
+    :func:`resolve_llm_config`, and the two globals through the base class's
+    ``resolve_datarobot_endpoint`` / ``resolve_datarobot_api_token`` methods.
     """
 
     # True ecosystem-wide globals. Fixed names, shared by every LLM instance.
@@ -164,8 +88,10 @@ class Config(DataRobotAppFrameworkBaseSettings):
 # Config().
 #
 # The invariant that keeps this from getting twisted again: NOTHING in genai reads
-# a config attribute directly. The two globals go through resolve_datarobot_endpoint()
-# / resolve_datarobot_api_token(); per-LLM routing goes through resolve_llm_config().
+# a config attribute directly. Everything is resolved off the config object through
+# the datarobot.core base class methods (resolve_datarobot_endpoint /
+# resolve_datarobot_api_token / resolve_llm_config); resolve_llm_config() below is
+# the only genai wrapper, and only to inject the registered default instance name.
 
 _provider_registry: dict[str, Any] = {"provider": None, "default_llm_name": DEFAULT_LLM_NAME}
 
@@ -210,10 +136,10 @@ def resolve_config() -> Config:
     """Return the single GLOBAL application config.
 
     The registered app config when a provider is registered, otherwise genai's own
-    env-reading :class:`Config` (a standalone genai with no app around it). Only
-    the two globals are read off this, and only via
-    :func:`resolve_datarobot_endpoint` / :func:`resolve_datarobot_api_token`. For
-    LLM routing use :func:`resolve_llm_config`.
+    env-reading :class:`Config` (a standalone genai with no app around it).
+    Everything is resolved off the returned config through the ``datarobot.core``
+    base class methods (``resolve_datarobot_endpoint`` / ``resolve_datarobot_api_token``);
+    for LLM routing use :func:`resolve_llm_config`.
     """
     provider = _provider_registry["provider"]
     if provider is not None:
@@ -227,119 +153,23 @@ def resolve_config() -> Config:
     return Config()
 
 
-def resolve_datarobot_endpoint() -> str:
-    """Resolve the DataRobot endpoint global. The only place it is read off config.
-
-    Delegates to :meth:`DataRobotAppFrameworkBaseSettings.resolve_datarobot_endpoint`,
-    the canonical resolver that now lives on the settings base class in
-    ``datarobot.core``.
-    """
-    return resolve_config().resolve_datarobot_endpoint()
-
-
-def resolve_datarobot_api_token() -> str | None:
-    """Resolve the DataRobot API token global. The only place it is read off config.
-
-    Delegates to :meth:`DataRobotAppFrameworkBaseSettings.resolve_datarobot_api_token`.
-    """
-    return resolve_config().resolve_datarobot_api_token()
-
-
-# --- Deprecated LLM config parameter bridge (REMOVE IN A FUTURE RELEASE) -------
-#
-# Two per-LLM params were renamed to the universal ``{instance}_`` namespace:
-#   nim_deployment_id          -> {instance}_nim_deployment_id
-#   use_datarobot_llm_gateway  -> {instance}_use_datarobot_llm_gateway
-#
-# Old deployments still carry the pre-rename bare runtime-parameter names. Those
-# bare names are no longer declared config fields, and the settings base class is
-# ``extra="ignore"``, so they never land on the resolved config object; they can
-# only be read straight from the environment. This bridge does exactly that, then
-# warns loudly. It WILL BE REMOVED IN A FUTURE RELEASE. New deployments set only
-# the namespaced params and never reach this path.
-
-
-def _coerce_bool(value: object) -> bool:
-    """Coerce a runtime-parameter value (a bool, or a ``"1"``/``"0"`` string) to bool."""
-    if isinstance(value, bool):
-        return value
-    return str(value).strip().lower() in {"1", "true", "t", "yes", "y", "on"}
-
-
-def _deprecated_param(old_name: str, new_name: str) -> object | None:
-    """Read a renamed LLM param from its pre-rename runtime-parameter name.
-
-    Returns ``None`` when the old param is absent. When present, emits a loud,
-    hard-to-miss deprecation warning and returns the old value. REMOVE IN A
-    FUTURE RELEASE together with the rest of this bridge.
-    """
-    old_value = getenv(old_name)
-    if old_value is None:
-        return None
-    banner = "!" * 88
-    logger.warning(
-        "\n%s\n"
-        "DEPRECATED LLM CONFIG PARAMETER IN USE\n"
-        "  Runtime parameter %r is DEPRECATED and WILL BE REMOVED IN A FUTURE RELEASE.\n"
-        "  Rename it to %r as soon as possible.\n"
-        "  Falling back to the deprecated value for now.\n"
-        "%s",
-        banner,
-        old_name,
-        new_name,
-        banner,
-    )
-    return old_value
-
-
 def resolve_llm_config(name: str | None = None) -> LLMConfig:
     """Resolve ONE LLM instance's config from the global config.
 
+    Thin seam glue: it injects genai's global config (:func:`resolve_config`) and
+    the app's registered default instance name, then defers the entire mapping to
+    :meth:`DataRobotAppFrameworkBaseSettings.resolve_llm_config` in ``datarobot.core``.
+    That base method folds the instance's ``{name}_*`` fields together with the two
+    globals and applies the deprecated-name backwards-compat bridge, so genai holds
+    no LLM-config logic of its own.
+
     ``name`` is the LLM component instance name; when omitted it is the app's
-    registered default (``"llm"`` for a standalone genai). The mapping itself, the
-    instance's ``{name}_*`` fields folded together with the two globals, is done by
-    :meth:`DataRobotAppFrameworkBaseSettings.resolve_llm_config` in ``datarobot.core``;
-    genai layers only the deprecated-name backwards-compat bridge on top. This is
-    the one machine that turns app config into an LLM config, and it is what
-    ``get_llm`` runs on.
+    registered default (``"llm"`` for a standalone genai). Core's base method
+    defaults to ``"llm"`` too, but only genai knows the registered override, which
+    is the one thing this wrapper still contributes.
     """
-    config = resolve_config()
     instance = name if name is not None else cast(str, _provider_registry["default_llm_name"])
-    # Delegate the base mapping (globals + {instance}_* fields) to the settings
-    # base class, invoking the provider exactly once per resolution.
-    resolved = config.resolve_llm_config(instance)
-
-    # --- deprecated-name backwards-compat bridge (REMOVE IN A FUTURE RELEASE) ---
-    # Fall back to the pre-rename bare param names only when the namespaced field
-    # was not explicitly provided. ``model_fields_set`` is what distinguishes an
-    # explicit value from a default (required for the bool, whose default is True).
-    set_fields = getattr(config, "model_fields_set", ())
-
-    llm_nim_deployment_id = resolved.llm_nim_deployment_id
-    if f"{instance}_nim_deployment_id" not in set_fields:
-        old = _deprecated_param("NIM_DEPLOYMENT_ID", f"{instance.upper()}_NIM_DEPLOYMENT_ID")
-        if old is not None:
-            llm_nim_deployment_id = str(old)
-
-    llm_use_datarobot_llm_gateway = resolved.llm_use_datarobot_llm_gateway
-    if f"{instance}_use_datarobot_llm_gateway" not in set_fields:
-        old = _deprecated_param(
-            "USE_DATAROBOT_LLM_GATEWAY", f"{instance.upper()}_USE_DATAROBOT_LLM_GATEWAY"
-        )
-        if old is not None:
-            llm_use_datarobot_llm_gateway = _coerce_bool(old)
-    # --- end bridge ---
-
-    # Rebuild as genai's LLMConfig (not core's) so the router's ambient
-    # to_litellm_params travels with the result, applying any bridge overrides.
-    return LLMConfig(
-        datarobot_endpoint=resolved.datarobot_endpoint,
-        datarobot_api_token=resolved.datarobot_api_token,
-        llm_deployment_id=resolved.llm_deployment_id,
-        llm_nim_deployment_id=llm_nim_deployment_id,
-        llm_use_datarobot_llm_gateway=llm_use_datarobot_llm_gateway,
-        llm_default_model=resolved.llm_default_model,
-    )
+    return resolve_config().resolve_llm_config(instance)
 
 
 def get_max_history_messages_default() -> int:
@@ -353,7 +183,7 @@ def get_max_history_messages_default() -> int:
 
 
 def default_api_key() -> str | None:
-    return resolve_datarobot_api_token()
+    return resolve_config().resolve_datarobot_api_token()
 
 
 def default_model_name() -> str | None:
@@ -382,11 +212,11 @@ def default_deployment_url(deployment_id: str | None = None) -> str:
     if resolved_id is None:
         raise ValueError("Neither deployment ID nor default deployment ID is set")
 
-    return deployment_url(resolved_id, resolve_datarobot_endpoint())
+    return deployment_url(resolved_id, resolve_config().resolve_datarobot_endpoint())
 
 
 def default_datarobot_llm_gateway_url() -> str:
-    return llm_gateway_url(resolve_datarobot_endpoint())
+    return llm_gateway_url(resolve_config().resolve_datarobot_endpoint())
 
 
 def default_llm_deployment_id() -> str | None:

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -190,20 +190,19 @@ def register_config_provider(
 
 
 def _validate_global_config(config: object) -> None:
-    """Fail loud if an injected global config is missing the required globals.
+    """Fail loud if an injected global config is not a settings object.
 
-    genai cannot ``isinstance``-check the app's ``Config`` (a different class it
-    cannot import), so this is a structural (duck-typed) check that the injected
-    object at least exposes the two globals every consumer relies on.
+    The app's global config must be a :class:`DataRobotAppFrameworkBaseSettings`
+    subclass: genai resolves the endpoint, API token, and per-LLM config off it
+    through that base class's ``resolve_*`` methods. genai can now import the base
+    class from ``datarobot.core``, so this is a real ``isinstance`` check rather
+    than the duck-typed field check it used to be.
     """
-    missing = [
-        name for name in ("datarobot_endpoint", "datarobot_api_token") if not hasattr(config, name)
-    ]
-    if missing:
+    if not isinstance(config, DataRobotAppFrameworkBaseSettings):
         raise TypeError(
-            f"Registered config provider returned {type(config).__name__}, which is "
-            f"missing required global field(s): {', '.join(missing)}. The app config "
-            "must expose datarobot_endpoint and datarobot_api_token."
+            f"Registered config provider returned {type(config).__name__}, which is not a "
+            "DataRobotAppFrameworkBaseSettings. The app config must subclass it so genai can "
+            "resolve the DataRobot endpoint, API token, and LLM config off it."
         )
 
 
@@ -221,23 +220,29 @@ def resolve_config() -> Config:
         provided = provider()
         if provided is not None:
             _validate_global_config(provided)
-            # The app's Config is a structurally-compatible settings object; genai
-            # only reads it through the resolver helpers (getattr), so treat it as
-            # a Config for typing purposes.
+            # provided is a DataRobotAppFrameworkBaseSettings subclass (validated
+            # above); genai resolves everything off it through its resolve_* methods.
+            # Cast to Config for typing since genai cannot import the app's class.
             return cast(Config, provided)
     return Config()
 
 
 def resolve_datarobot_endpoint() -> str:
-    """Resolve the DataRobot endpoint global. The only place it is read off config."""
-    endpoint: str | None = getattr(resolve_config(), "datarobot_endpoint", None)
-    return endpoint or DEFAULT_DATAROBOT_ENDPOINT
+    """Resolve the DataRobot endpoint global. The only place it is read off config.
+
+    Delegates to :meth:`DataRobotAppFrameworkBaseSettings.resolve_datarobot_endpoint`,
+    the canonical resolver that now lives on the settings base class in
+    ``datarobot.core``.
+    """
+    return resolve_config().resolve_datarobot_endpoint()
 
 
 def resolve_datarobot_api_token() -> str | None:
-    """Resolve the DataRobot API token global. The only place it is read off config."""
-    token: str | None = getattr(resolve_config(), "datarobot_api_token", None)
-    return token or None
+    """Resolve the DataRobot API token global. The only place it is read off config.
+
+    Delegates to :meth:`DataRobotAppFrameworkBaseSettings.resolve_datarobot_api_token`.
+    """
+    return resolve_config().resolve_datarobot_api_token()
 
 
 # --- Deprecated LLM config parameter bridge (REMOVE IN A FUTURE RELEASE) -------
@@ -291,17 +296,18 @@ def resolve_llm_config(name: str | None = None) -> LLMConfig:
     """Resolve ONE LLM instance's config from the global config.
 
     ``name`` is the LLM component instance name; when omitted it is the app's
-    registered default (``"llm"`` for a standalone genai). Reads the instance's
-    ``{name}_*`` fields off :func:`resolve_config` and folds in the two globals,
-    producing a self-contained :class:`LLMConfig`. This is the one machine that
-    turns app config into an LLM config, and it is what ``get_llm`` runs on.
+    registered default (``"llm"`` for a standalone genai). The mapping itself, the
+    instance's ``{name}_*`` fields folded together with the two globals, is done by
+    :meth:`DataRobotAppFrameworkBaseSettings.resolve_llm_config` in ``datarobot.core``;
+    genai layers only the deprecated-name backwards-compat bridge on top. This is
+    the one machine that turns app config into an LLM config, and it is what
+    ``get_llm`` runs on.
     """
     config = resolve_config()
     instance = name if name is not None else cast(str, _provider_registry["default_llm_name"])
-    # Read everything off a single resolve_config() so the provider is invoked
-    # exactly once per resolution (values still re-resolve on the next call).
-    endpoint: str | None = getattr(config, "datarobot_endpoint", None)
-    api_token: str | None = getattr(config, "datarobot_api_token", None)
+    # Delegate the base mapping (globals + {instance}_* fields) to the settings
+    # base class, invoking the provider exactly once per resolution.
+    resolved = config.resolve_llm_config(instance)
 
     # --- deprecated-name backwards-compat bridge (REMOVE IN A FUTURE RELEASE) ---
     # Fall back to the pre-rename bare param names only when the namespaced field
@@ -309,13 +315,13 @@ def resolve_llm_config(name: str | None = None) -> LLMConfig:
     # explicit value from a default (required for the bool, whose default is True).
     set_fields = getattr(config, "model_fields_set", ())
 
-    llm_nim_deployment_id = getattr(config, f"{instance}_nim_deployment_id", None)
+    llm_nim_deployment_id = resolved.llm_nim_deployment_id
     if f"{instance}_nim_deployment_id" not in set_fields:
         old = _deprecated_param("NIM_DEPLOYMENT_ID", f"{instance.upper()}_NIM_DEPLOYMENT_ID")
         if old is not None:
             llm_nim_deployment_id = str(old)
 
-    llm_use_datarobot_llm_gateway = getattr(config, f"{instance}_use_datarobot_llm_gateway", True)
+    llm_use_datarobot_llm_gateway = resolved.llm_use_datarobot_llm_gateway
     if f"{instance}_use_datarobot_llm_gateway" not in set_fields:
         old = _deprecated_param(
             "USE_DATAROBOT_LLM_GATEWAY", f"{instance.upper()}_USE_DATAROBOT_LLM_GATEWAY"
@@ -324,13 +330,15 @@ def resolve_llm_config(name: str | None = None) -> LLMConfig:
             llm_use_datarobot_llm_gateway = _coerce_bool(old)
     # --- end bridge ---
 
+    # Rebuild as genai's LLMConfig (not core's) so the router's ambient
+    # to_litellm_params travels with the result, applying any bridge overrides.
     return LLMConfig(
-        datarobot_endpoint=endpoint or DEFAULT_DATAROBOT_ENDPOINT,
-        datarobot_api_token=api_token or None,
-        llm_deployment_id=getattr(config, f"{instance}_deployment_id", None),
+        datarobot_endpoint=resolved.datarobot_endpoint,
+        datarobot_api_token=resolved.datarobot_api_token,
+        llm_deployment_id=resolved.llm_deployment_id,
         llm_nim_deployment_id=llm_nim_deployment_id,
         llm_use_datarobot_llm_gateway=llm_use_datarobot_llm_gateway,
-        llm_default_model=getattr(config, f"{instance}_default_model", None),
+        llm_default_model=resolved.llm_default_model,
     )
 
 

--- a/src/datarobot_genai/core/router.py
+++ b/src/datarobot_genai/core/router.py
@@ -72,10 +72,32 @@ def build_litellm_router(
     """
     import litellm
 
+    from datarobot_genai.core.config import resolve_config
+
+    # The router's primary/fallbacks are parsed straight from workflow.yaml with the
+    # two globals unset, so fill the endpoint and API token from the ambient global
+    # config before rendering. Core's LLMConfig.to_litellm_params is self-contained
+    # (it never reaches back into genai), so this hydration is what supplies them.
+    global_config = resolve_config()
+    endpoint = global_config.resolve_datarobot_endpoint()
+    token = global_config.resolve_datarobot_api_token()
+
+    def _hydrate(cfg: LLMConfig) -> LLMConfig:
+        return cfg.model_copy(
+            update={
+                "datarobot_endpoint": (
+                    cfg.datarobot_endpoint if cfg.datarobot_endpoint is not None else endpoint
+                ),
+                "datarobot_api_token": (
+                    cfg.datarobot_api_token if cfg.datarobot_api_token is not None else token
+                ),
+            }
+        )
+
     model_list = [
-        {"model_name": "primary", "litellm_params": primary.to_litellm_params()},
+        {"model_name": "primary", "litellm_params": _hydrate(primary).to_litellm_params()},
         *[
-            {"model_name": f"fallback_{i}", "litellm_params": c.to_litellm_params()}
+            {"model_name": f"fallback_{i}", "litellm_params": _hydrate(c).to_litellm_params()}
             for i, c in enumerate(fallbacks)
         ],
     ]

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -32,13 +32,13 @@ from opentelemetry.trace.status import Status
 from opentelemetry.trace.status import StatusCode
 
 from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
-from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
+from datarobot_genai.core.config import resolve_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 from datarobot_genai.core.model_info import get_model_info
 
@@ -553,7 +553,7 @@ def get_llm(
     parameters: dict | None = None,
     reasoning: bool = False,
 ) -> LLM:
-    config = Config()
+    config = resolve_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -38,7 +38,7 @@ from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
-from datarobot_genai.core.config import resolve_config
+from datarobot_genai.core.config import resolve_llm_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 from datarobot_genai.core.model_info import get_model_info
 
@@ -552,8 +552,9 @@ def get_llm(
     model_name: str | None = None,
     parameters: dict | None = None,
     reasoning: bool = False,
+    name: str | None = None,
 ) -> LLM:
-    config = resolve_config()
+    config = resolve_llm_config(name)
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -552,9 +552,15 @@ def get_llm(
     model_name: str | None = None,
     parameters: dict | None = None,
     reasoning: bool = False,
-    name: str | None = None,
+    config: LLMConfig | None = None,
 ) -> LLM:
-    config = resolve_llm_config(name)
+    """Build the framework LLM for a given (or the default) LLM config.
+
+    Pass ``config`` (for example ``resolve_config().resolve_llm_config("bob")``) to
+    build a specific configured LLM instance; omit it to build the app's default LLM.
+    """
+    if config is None:
+        config = resolve_llm_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/src/datarobot_genai/crewai/llm.py
+++ b/src/datarobot_genai/crewai/llm.py
@@ -566,7 +566,7 @@ def get_llm(
         )
     elif llm_type == LLMType.NIM:
         return get_datarobot_nim_llm(
-            config.nim_deployment_id,  # type: ignore[arg-type]
+            config.llm_nim_deployment_id,  # type: ignore[arg-type]
             model_name,
             parameters,
             reasoning,

--- a/src/datarobot_genai/crewai/llm_clients.py
+++ b/src/datarobot_genai/crewai/llm_clients.py
@@ -85,7 +85,7 @@ async def datarobot_nim_crewai(
     validate_no_responses_api(llm_config, LLMFrameworkEnum.CREWAI)
 
     config = prepare_llm_parameters(llm_config)
-    client = get_datarobot_nim_llm(llm_config.nim_deployment_id, llm_config.model_name, config)
+    client = get_datarobot_nim_llm(llm_config.llm_nim_deployment_id, llm_config.model_name, config)
     yield patch_llm_based_on_config(client, config)
 
 
@@ -115,7 +115,11 @@ async def datarobot_llm_component_crewai(
             config,
         )
     elif llm_type == LLMType.NIM:
-        client = get_datarobot_nim_llm(llm_config.nim_deployment_id, llm_config.model_name, config)  # type: ignore[arg-type]
+        client = get_datarobot_nim_llm(
+            llm_config.llm_nim_deployment_id,  # type: ignore[arg-type]
+            llm_config.model_name,
+            config,
+        )
     elif llm_type == LLMType.EXTERNAL:
         client = get_external_llm(llm_config.model_name, config)
     else:

--- a/src/datarobot_genai/dragent/plugins/llm_clients.py
+++ b/src/datarobot_genai/dragent/plugins/llm_clients.py
@@ -59,8 +59,8 @@ EXCLUDE_FIELDS = {
     "reasoning",
     "api_type",
     "llm_deployment_id",
-    "nim_deployment_id",
-    "use_datarobot_llm_gateway",
+    "llm_nim_deployment_id",
+    "llm_use_datarobot_llm_gateway",
     # Fields inherited from LLMConfig that are not framework-level LLM kwargs:
     "datarobot_api_token",
     "datarobot_endpoint",
@@ -177,7 +177,7 @@ async def datarobot_nim_langchain(
 
     config = prepare_llm_parameters(llm_config)
     client = get_datarobot_nim_llm(
-        llm_config.nim_deployment_id, llm_config.model_name, parameters=config
+        llm_config.llm_nim_deployment_id, llm_config.model_name, parameters=config
     )
     yield langchain_patch_llm_based_on_config(client, config)
 
@@ -210,7 +210,11 @@ async def datarobot_llm_component_langchain(
             config,
         )
     elif llm_type == LLMType.NIM:
-        client = get_datarobot_nim_llm(llm_config.nim_deployment_id, llm_config.model_name, config)  # type: ignore[arg-type]
+        client = get_datarobot_nim_llm(
+            llm_config.llm_nim_deployment_id,  # type: ignore[arg-type]
+            llm_config.model_name,
+            config,
+        )
     elif llm_type == LLMType.EXTERNAL:
         client = get_external_llm(llm_config.model_name, config)
     else:

--- a/src/datarobot_genai/dragent/plugins/llm_providers.py
+++ b/src/datarobot_genai/dragent/plugins/llm_providers.py
@@ -57,7 +57,7 @@ class DataRobotLLMComponentModelConfig(
         ),
         default=None,
     )
-    use_datarobot_llm_gateway: bool = Field(
+    llm_use_datarobot_llm_gateway: bool = Field(
         default_factory=default_use_datarobot_llm_gateway,
         description="Whether to use the DataRobot LLM gateway.",
     )
@@ -65,7 +65,7 @@ class DataRobotLLMComponentModelConfig(
         description="The LLM deployment ID.",
         default_factory=default_llm_deployment_id,
     )
-    nim_deployment_id: str | None = Field(
+    llm_nim_deployment_id: str | None = Field(
         description="The NIM deployment ID.",
         default_factory=default_nim_deployment_id,
     )
@@ -130,7 +130,7 @@ class DataRobotNIMModelConfig(DataRobotReasoningMixin, NIMModelConfig, name="dat
         description="The model name to pass through to the NIM deployment.",
         default=None,
     )
-    nim_deployment_id: str = Field(
+    llm_nim_deployment_id: str = Field(
         description="The LLM deployment ID.",
         default_factory=default_nim_deployment_id,
     )
@@ -170,10 +170,10 @@ class DataRobotLLMRouterConfig(OpenAIModelConfig, name="datarobot-llm-router"): 
           _type: datarobot-llm-router
           primary:
             llm_deployment_id: "abc123"
-            use_datarobot_llm_gateway: false
+            llm_use_datarobot_llm_gateway: false
           fallbacks:
             - llm_deployment_id: "def456"
-              use_datarobot_llm_gateway: false
+              llm_use_datarobot_llm_gateway: false
           num_retries: 3
     """
 

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -259,7 +259,7 @@ def get_llm(
         )
     elif llm_type == LLMType.NIM:
         return get_datarobot_nim_llm(
-            config.nim_deployment_id,  # type: ignore[arg-type]
+            config.llm_nim_deployment_id,  # type: ignore[arg-type]
             model_name,
             parameters,
             streaming,

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -21,13 +21,13 @@ from langchain_core.messages import BaseMessage  # noqa: TC002
 from langchain_core.outputs import ChatGenerationChunk  # noqa: TC002
 
 from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
-from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
+from datarobot_genai.core.config import resolve_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 
 
@@ -245,7 +245,7 @@ def get_llm(
     streaming: bool = True,
     reasoning: bool = False,
 ) -> BaseChatModel:
-    config = Config()
+    config = resolve_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, streaming, reasoning)

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -27,7 +27,7 @@ from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
-from datarobot_genai.core.config import resolve_config
+from datarobot_genai.core.config import resolve_llm_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 
 
@@ -244,8 +244,9 @@ def get_llm(
     parameters: dict | None = None,
     streaming: bool = True,
     reasoning: bool = False,
+    name: str | None = None,
 ) -> BaseChatModel:
-    config = resolve_config()
+    config = resolve_llm_config(name)
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, streaming, reasoning)

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -244,9 +244,15 @@ def get_llm(
     parameters: dict | None = None,
     streaming: bool = True,
     reasoning: bool = False,
-    name: str | None = None,
+    config: LLMConfig | None = None,
 ) -> BaseChatModel:
-    config = resolve_llm_config(name)
+    """Build the framework LLM for a given (or the default) LLM config.
+
+    Pass ``config`` (for example ``resolve_config().resolve_llm_config("bob")``) to
+    build a specific configured LLM instance; omit it to build the app's default LLM.
+    """
+    if config is None:
+        config = resolve_llm_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, streaming, reasoning)

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -17,13 +17,13 @@ from typing import Any
 from llama_index.llms.litellm import LiteLLM
 
 from datarobot_genai.core.config import DEFAULT_MODEL_NAME_FOR_DEPLOYED_LLM
-from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
+from datarobot_genai.core.config import resolve_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 from datarobot_genai.core.llm_parameters import supports_parallel_tool_calls
 
@@ -358,7 +358,7 @@ def get_llm(
     parameters: dict | None = None,
     reasoning: bool = False,
 ) -> LiteLLM:
-    config = Config()
+    config = resolve_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -357,9 +357,15 @@ def get_llm(
     model_name: str | None = None,
     parameters: dict | None = None,
     reasoning: bool = False,
-    name: str | None = None,
+    config: LLMConfig | None = None,
 ) -> LiteLLM:
-    config = resolve_llm_config(name)
+    """Build the framework LLM for a given (or the default) LLM config.
+
+    Pass ``config`` (for example ``resolve_config().resolve_llm_config("bob")``) to
+    build a specific configured LLM instance; omit it to build the app's default LLM.
+    """
+    if config is None:
+        config = resolve_llm_config()
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -371,7 +371,7 @@ def get_llm(
         )
     elif llm_type == LLMType.NIM:
         return get_datarobot_nim_llm(
-            config.nim_deployment_id,  # type: ignore[arg-type]
+            config.llm_nim_deployment_id,  # type: ignore[arg-type]
             model_name,
             parameters,
             reasoning,

--- a/src/datarobot_genai/llama_index/llm.py
+++ b/src/datarobot_genai/llama_index/llm.py
@@ -23,7 +23,7 @@ from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
 from datarobot_genai.core.config import default_model_name
-from datarobot_genai.core.config import resolve_config
+from datarobot_genai.core.config import resolve_llm_config
 from datarobot_genai.core.llm_parameters import apply_reasoning_to_parameters
 from datarobot_genai.core.llm_parameters import supports_parallel_tool_calls
 
@@ -357,8 +357,9 @@ def get_llm(
     model_name: str | None = None,
     parameters: dict | None = None,
     reasoning: bool = False,
+    name: str | None = None,
 ) -> LiteLLM:
-    config = resolve_config()
+    config = resolve_llm_config(name)
     llm_type = config.get_llm_type()
     if llm_type == LLMType.GATEWAY:
         return get_datarobot_gateway_llm(model_name, parameters, reasoning)

--- a/src/datarobot_genai/llama_index/llm_clients.py
+++ b/src/datarobot_genai/llama_index/llm_clients.py
@@ -90,9 +90,9 @@ async def datarobot_nim_llamaindex(
     validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
 
     config = prepare_llm_parameters(llm_config)
-    if not llm_config.nim_deployment_id:
-        raise ValueError("nim_deployment_id is required")
-    client = get_datarobot_nim_llm(llm_config.nim_deployment_id, llm_config.model_name, config)
+    if not llm_config.llm_nim_deployment_id:
+        raise ValueError("llm_nim_deployment_id is required")
+    client = get_datarobot_nim_llm(llm_config.llm_nim_deployment_id, llm_config.model_name, config)
     yield patch_llm_based_on_config(client, config)
 
 
@@ -126,7 +126,11 @@ async def datarobot_llm_component_llamaindex(
             config,
         )
     elif llm_type == LLMType.NIM:
-        client = get_datarobot_nim_llm(llm_config.nim_deployment_id, llm_config.model_name, config)  # type: ignore[arg-type]
+        client = get_datarobot_nim_llm(
+            llm_config.llm_nim_deployment_id,  # type: ignore[arg-type]
+            llm_config.model_name,
+            config,
+        )
     elif llm_type == LLMType.EXTERNAL:
         client = get_external_llm(llm_config.model_name, config)
     else:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -19,7 +19,9 @@ import pytest
 from datarobot_genai.core import config as config_mod
 from datarobot_genai.core.config import DEFAULT_MAX_HISTORY_MESSAGES
 from datarobot_genai.core.config import Config
+from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
+from datarobot_genai.core.config import config_injection_enabled
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
@@ -31,6 +33,8 @@ from datarobot_genai.core.config import default_use_datarobot_llm_gateway
 from datarobot_genai.core.config import deployment_url
 from datarobot_genai.core.config import get_max_history_messages_default
 from datarobot_genai.core.config import llm_gateway_url
+from datarobot_genai.core.config import register_config_provider
+from datarobot_genai.core.config import resolve_config
 
 
 def _make_config(**overrides: object) -> Config:
@@ -254,3 +258,108 @@ def test_default_nim_deployment_id_returns_none_when_unset() -> None:
     cfg = _make_config(nim_deployment_id=None)
     with patch.object(config_mod, "Config", return_value=cfg):
         assert default_nim_deployment_id() is None
+
+
+# --- App config injection seam ---------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_provider() -> object:
+    """Ensure the injection provider never leaks between tests."""
+    register_config_provider(None)
+    yield
+    register_config_provider(None)
+
+
+def _enable_injection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATAROBOT_GENAI_CONFIG_INJECTION", "1")
+
+
+def test_injection_gate_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATAROBOT_GENAI_CONFIG_INJECTION", raising=False)
+    assert config_injection_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_injection_gate_on_for_truthy_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("DATAROBOT_GENAI_CONFIG_INJECTION", value)
+    assert config_injection_enabled() is True
+
+
+def test_resolve_config_falls_back_to_env_config_when_no_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_injection(monkeypatch)
+    sentinel = _make_config(llm_default_model="from-env-config")
+    with patch.object(config_mod, "Config", return_value=sentinel):
+        # No provider registered -> genai's own Config() is used.
+        assert resolve_config() is sentinel
+
+
+def test_resolve_config_ignores_provider_when_gate_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DATAROBOT_GENAI_CONFIG_INJECTION", raising=False)
+    injected = _make_config(llm_default_model="from-app-config")
+    env_cfg = _make_config(llm_default_model="from-env-config")
+    register_config_provider(lambda: injected)
+    with patch.object(config_mod, "Config", return_value=env_cfg):
+        # Gate off -> provider ignored, genai's Config() wins (unchanged behavior).
+        assert resolve_config() is env_cfg
+
+
+def test_resolve_config_uses_injected_provider_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_injection(monkeypatch)
+    injected = _make_config(llm_default_model="from-app-config")
+    register_config_provider(lambda: injected)
+    # Even if genai builds its own Config, the injected provider takes precedence.
+    with patch.object(config_mod, "Config", return_value=_make_config()):
+        assert resolve_config() is injected
+
+
+def test_injected_config_overrides_env_for_user_intent_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the hammer case.
+
+    A user hardcodes values in the app config and sets NO env var. genai must
+    read the app's values, not its own env-only defaults.
+    """
+    _enable_injection(monkeypatch)
+    # App config: gateway off, a deployment target, and a specific model, all set
+    # as plain values, exactly as a user would hardcode them in config.py.
+    app_config = LLMConfig(
+        use_datarobot_llm_gateway=False,
+        llm_deployment_id="dep-from-app",
+        llm_default_model="anthropic/claude-sonnet-4-20250514",
+    )
+    register_config_provider(lambda: app_config)
+
+    # genai's own env-only Config would say the opposite (gateway on, no model).
+    env_only = _make_config(use_datarobot_llm_gateway=True, llm_default_model=None)
+    with patch.object(config_mod, "Config", return_value=env_only):
+        assert default_use_datarobot_llm_gateway() is False
+        assert default_llm_deployment_id() == "dep-from-app"
+        assert default_model_name() == "anthropic/claude-sonnet-4-20250514"
+        assert resolve_config().get_llm_type() == LLMType.DEPLOYMENT
+
+
+def test_provider_is_called_each_resolve_for_dynamic_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider is a factory: re-read picks up changed values (dynamic env vars)."""
+    _enable_injection(monkeypatch)
+    calls = {"n": 0}
+
+    def _provider() -> LLMConfig:
+        calls["n"] += 1
+        return _make_config(llm_default_model=f"model-{calls['n']}")
+
+    register_config_provider(_provider)
+    with patch.object(config_mod, "Config", return_value=_make_config()):
+        assert default_model_name() == "model-1"
+        assert default_model_name() == "model-2"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -70,31 +70,31 @@ def test_get_max_history_messages_default_env_positive(monkeypatch: pytest.Monke
     assert get_max_history_messages_default() == 7
 
 
-# --- Config.get_llm_type ---
+# --- LLMConfig.get_llm_type (routing lives on the per-LLM value object) ---
 
 
 def test_get_llm_type_returns_gateway_when_use_gateway_true() -> None:
-    cfg = _make_config(llm_use_datarobot_llm_gateway=True)
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True)
     assert cfg.get_llm_type() == LLMType.GATEWAY
 
 
 def test_get_llm_type_returns_deployment_when_gateway_false_and_deployment_id_set() -> None:
-    cfg = _make_config(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-123")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-123")
     assert cfg.get_llm_type() == LLMType.DEPLOYMENT
 
 
 def test_get_llm_type_returns_nim_when_gateway_false_and_nim_id_set() -> None:
-    cfg = _make_config(llm_use_datarobot_llm_gateway=False, llm_nim_deployment_id="nim-456")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_nim_deployment_id="nim-456")
     assert cfg.get_llm_type() == LLMType.NIM
 
 
 def test_get_llm_type_returns_external_when_nothing_else_set() -> None:
-    cfg = _make_config(llm_use_datarobot_llm_gateway=False)
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False)
     assert cfg.get_llm_type() == LLMType.EXTERNAL
 
 
 def test_get_llm_type_deployment_takes_priority_over_nim() -> None:
-    cfg = _make_config(
+    cfg = LLMConfig(
         llm_use_datarobot_llm_gateway=False,
         llm_deployment_id="dep-123",
         llm_nim_deployment_id="nim-456",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -42,8 +42,8 @@ def _make_config(**overrides: object) -> Config:
         "datarobot_endpoint": "https://app.datarobot.com/api/v2",
         "datarobot_api_token": None,
         "llm_deployment_id": None,
-        "nim_deployment_id": None,
-        "use_datarobot_llm_gateway": True,
+        "llm_nim_deployment_id": None,
+        "llm_use_datarobot_llm_gateway": True,
         "llm_default_model": None,
     }
     defaults.update(overrides)
@@ -74,30 +74,30 @@ def test_get_max_history_messages_default_env_positive(monkeypatch: pytest.Monke
 
 
 def test_get_llm_type_returns_gateway_when_use_gateway_true() -> None:
-    cfg = _make_config(use_datarobot_llm_gateway=True)
+    cfg = _make_config(llm_use_datarobot_llm_gateway=True)
     assert cfg.get_llm_type() == LLMType.GATEWAY
 
 
 def test_get_llm_type_returns_deployment_when_gateway_false_and_deployment_id_set() -> None:
-    cfg = _make_config(use_datarobot_llm_gateway=False, llm_deployment_id="dep-123")
+    cfg = _make_config(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-123")
     assert cfg.get_llm_type() == LLMType.DEPLOYMENT
 
 
 def test_get_llm_type_returns_nim_when_gateway_false_and_nim_id_set() -> None:
-    cfg = _make_config(use_datarobot_llm_gateway=False, nim_deployment_id="nim-456")
+    cfg = _make_config(llm_use_datarobot_llm_gateway=False, llm_nim_deployment_id="nim-456")
     assert cfg.get_llm_type() == LLMType.NIM
 
 
 def test_get_llm_type_returns_external_when_nothing_else_set() -> None:
-    cfg = _make_config(use_datarobot_llm_gateway=False)
+    cfg = _make_config(llm_use_datarobot_llm_gateway=False)
     assert cfg.get_llm_type() == LLMType.EXTERNAL
 
 
 def test_get_llm_type_deployment_takes_priority_over_nim() -> None:
     cfg = _make_config(
-        use_datarobot_llm_gateway=False,
+        llm_use_datarobot_llm_gateway=False,
         llm_deployment_id="dep-123",
-        nim_deployment_id="nim-456",
+        llm_nim_deployment_id="nim-456",
     )
     assert cfg.get_llm_type() == LLMType.DEPLOYMENT
 
@@ -159,13 +159,13 @@ def test_default_response_model_falls_back_to_deployed_llm_when_unset() -> None:
 
 
 def test_default_use_datarobot_llm_gateway_true_by_default() -> None:
-    cfg = _make_config(use_datarobot_llm_gateway=True)
+    cfg = _make_config(llm_use_datarobot_llm_gateway=True)
     with patch.object(config_mod, "Config", return_value=cfg):
         assert default_use_datarobot_llm_gateway() is True
 
 
 def test_default_use_datarobot_llm_gateway_respects_config() -> None:
-    cfg = _make_config(use_datarobot_llm_gateway=False)
+    cfg = _make_config(llm_use_datarobot_llm_gateway=False)
     with patch.object(config_mod, "Config", return_value=cfg):
         assert default_use_datarobot_llm_gateway() is False
 
@@ -248,13 +248,13 @@ def test_default_llm_deployment_id_returns_none_when_unset() -> None:
 
 
 def test_default_nim_deployment_id_returns_configured_value() -> None:
-    cfg = _make_config(nim_deployment_id="nim-999")
+    cfg = _make_config(llm_nim_deployment_id="nim-999")
     with patch.object(config_mod, "Config", return_value=cfg):
         assert default_nim_deployment_id() == "nim-999"
 
 
 def test_default_nim_deployment_id_returns_none_when_unset() -> None:
-    cfg = _make_config(nim_deployment_id=None)
+    cfg = _make_config(llm_nim_deployment_id=None)
     with patch.object(config_mod, "Config", return_value=cfg):
         assert default_nim_deployment_id() is None
 
@@ -302,14 +302,14 @@ def test_injected_config_overrides_env_for_user_intent_fields() -> None:
     # App config: gateway off, a deployment target, and a specific model, all set
     # as plain values, exactly as a user would hardcode them in config.py.
     app_config = LLMConfig(
-        use_datarobot_llm_gateway=False,
+        llm_use_datarobot_llm_gateway=False,
         llm_deployment_id="dep-from-app",
         llm_default_model="anthropic/claude-sonnet-4-20250514",
     )
     register_config_provider(lambda: app_config)
 
     # genai's own env-only Config would say the opposite (gateway on, no model).
-    env_only = _make_config(use_datarobot_llm_gateway=True, llm_default_model=None)
+    env_only = _make_config(llm_use_datarobot_llm_gateway=True, llm_default_model=None)
     with patch.object(config_mod, "Config", return_value=env_only):
         assert default_use_datarobot_llm_gateway() is False
         assert default_llm_deployment_id() == "dep-from-app"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -329,3 +329,26 @@ def test_provider_is_called_each_resolve_for_dynamic_values() -> None:
     with patch.object(config_mod, "Config", return_value=_make_config()):
         assert default_model_name() == "model-1"
         assert default_model_name() == "model-2"
+
+
+def test_injected_config_drives_endpoint_helpers() -> None:
+    """The endpoint (a true global) is authoritative from the app config too.
+
+    A provider supplies a custom endpoint and deployment id; genai's own env-only
+    Config would say the defaults. The URL builders must use the injected values.
+    """
+    app_config = LLMConfig(
+        datarobot_endpoint="https://custom.datarobot.example/api/v2",
+        llm_deployment_id="dep-injected",
+    )
+    register_config_provider(lambda: app_config)
+    env_only = _make_config(
+        datarobot_endpoint="https://app.datarobot.com/api/v2",
+        llm_deployment_id="dep-env",
+    )
+    with patch.object(config_mod, "Config", return_value=env_only):
+        assert default_deployment_url() == (
+            "https://custom.datarobot.example/api/v2"
+            "/deployments/dep-injected/chat/completions"
+        )
+        assert default_datarobot_llm_gateway_url() == "https://custom.datarobot.example"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -34,6 +35,7 @@ from datarobot_genai.core.config import get_max_history_messages_default
 from datarobot_genai.core.config import llm_gateway_url
 from datarobot_genai.core.config import register_config_provider
 from datarobot_genai.core.config import resolve_config
+from datarobot_genai.core.config import resolve_llm_config
 
 
 def _make_config(**overrides: object) -> Config:
@@ -352,3 +354,175 @@ def test_injected_config_drives_endpoint_helpers() -> None:
             "/deployments/dep-injected/chat/completions"
         )
         assert default_datarobot_llm_gateway_url() == "https://custom.datarobot.example"
+
+
+# --- Deprecated LLM param bridge (REMOVE WITH THE BRIDGE IN A FUTURE RELEASE) --
+#
+# resolve_llm_config falls back to the pre-rename bare runtime-parameter names
+# (nim_deployment_id / use_datarobot_llm_gateway) when the namespaced field was
+# not explicitly provided, warning loudly. These tests pin the four cases per
+# param: new-only (silent), old-only (fallback + warning), both (new wins,
+# silent), and neither (default, silent).
+
+_NIM_BANNER = "DEPRECATED LLM CONFIG PARAMETER IN USE"
+
+
+def _config_fields_set(fields_set: set[str], **values: object) -> Config:
+    """Build a Config while controlling which fields count as explicitly set.
+
+    model_fields_set is the signal the deprecation bridge keys off. Config()
+    normally derives it from its settings sources; here we set it directly so a
+    test can model "the namespaced field was (not) provided" precisely.
+    """
+    base = {
+        "datarobot_endpoint": "https://app.datarobot.com/api/v2",
+        "datarobot_api_token": None,
+        "llm_deployment_id": None,
+        "llm_nim_deployment_id": None,
+        "llm_use_datarobot_llm_gateway": True,
+        "llm_default_model": None,
+    }
+    base.update(values)
+    return Config.model_construct(_fields_set=set(fields_set), **base)
+
+
+@pytest.fixture
+def clear_legacy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear both the runtime-param and bare forms of the deprecated names."""
+    for name in ("NIM_DEPLOYMENT_ID", "USE_DATAROBOT_LLM_GATEWAY"):
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(f"MLOPS_RUNTIME_PARAM_{name}", raising=False)
+
+
+# nim_deployment_id
+
+
+def test_bridge_nim_new_only_is_used_silently(
+    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = _config_fields_set({"llm_nim_deployment_id"}, llm_nim_deployment_id="new-nim")
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_nim_deployment_id == "new-nim"
+    assert _NIM_BANNER not in caplog.text
+
+
+def test_bridge_nim_falls_back_to_old_name_with_warning(
+    clear_legacy_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_NIM_DEPLOYMENT_ID", "legacy-nim")
+    cfg = _config_fields_set(set())  # new name not explicitly provided
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_nim_deployment_id == "legacy-nim"
+    assert _NIM_BANNER in caplog.text
+    assert "NIM_DEPLOYMENT_ID" in caplog.text
+    assert "LLM_NIM_DEPLOYMENT_ID" in caplog.text
+
+
+def test_bridge_nim_new_wins_over_old_silently(
+    clear_legacy_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_NIM_DEPLOYMENT_ID", "legacy-nim")
+    cfg = _config_fields_set({"llm_nim_deployment_id"}, llm_nim_deployment_id="new-nim")
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_nim_deployment_id == "new-nim"
+    assert _NIM_BANNER not in caplog.text
+
+
+def test_bridge_nim_neither_set_defaults_to_none_silently(
+    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = _config_fields_set(set())
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_nim_deployment_id is None
+    assert _NIM_BANNER not in caplog.text
+
+
+# use_datarobot_llm_gateway (bool; default True, so model_fields_set is the signal)
+
+
+def test_bridge_gateway_new_only_is_used_silently(
+    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = _config_fields_set(
+        {"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False
+    )
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_use_datarobot_llm_gateway is False
+    assert _NIM_BANNER not in caplog.text
+
+
+def test_bridge_gateway_falls_back_to_old_name_with_warning(
+    clear_legacy_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Old value "0" must override the truthy default AND be coerced to a real bool.
+    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_USE_DATAROBOT_LLM_GATEWAY", "0")
+    cfg = _config_fields_set(set())  # new name not explicitly provided (default True)
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_use_datarobot_llm_gateway is False
+    assert _NIM_BANNER in caplog.text
+    assert "USE_DATAROBOT_LLM_GATEWAY" in caplog.text
+
+
+def test_bridge_gateway_new_wins_over_old_silently(
+    clear_legacy_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_USE_DATAROBOT_LLM_GATEWAY", "1")
+    cfg = _config_fields_set(
+        {"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False
+    )
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_use_datarobot_llm_gateway is False
+    assert _NIM_BANNER not in caplog.text
+
+
+def test_bridge_gateway_neither_set_defaults_to_true_silently(
+    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg = _config_fields_set(set())
+    with patch.object(config_mod, "Config", return_value=cfg):
+        with caplog.at_level(logging.WARNING):
+            result = resolve_llm_config()
+    assert result.llm_use_datarobot_llm_gateway is True
+    assert _NIM_BANNER not in caplog.text
+
+
+def test_bridge_uses_instance_namespace_but_bare_legacy_name(
+    clear_legacy_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-default instance name still falls back to the bare legacy param.
+
+    The namespaced field is ``{instance}_...`` but the deprecated param was always
+    bare, so the fallback and the warning's target name reflect the instance.
+    """
+    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_NIM_DEPLOYMENT_ID", "legacy-nim")
+    # The provider takes precedence over Config(); its object has an empty
+    # model_fields_set, so the namespaced field reads as "not provided".
+    register_config_provider(LLMConfig, default_llm_name="myagent")
+    with caplog.at_level(logging.WARNING):
+        result = resolve_llm_config()
+    assert result.llm_nim_deployment_id == "legacy-nim"
+    assert "MYAGENT_NIM_DEPLOYMENT_ID" in caplog.text

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -21,7 +21,6 @@ from datarobot_genai.core.config import DEFAULT_MAX_HISTORY_MESSAGES
 from datarobot_genai.core.config import Config
 from datarobot_genai.core.config import LLMConfig
 from datarobot_genai.core.config import LLMType
-from datarobot_genai.core.config import config_injection_enabled
 from datarobot_genai.core.config import default_api_key
 from datarobot_genai.core.config import default_datarobot_llm_gateway_url
 from datarobot_genai.core.config import default_deployment_url
@@ -271,49 +270,22 @@ def _reset_config_provider() -> object:
     register_config_provider(None)
 
 
-def _enable_injection(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("DATAROBOT_GENAI_CONFIG_INJECTION", "1")
-
-
-def test_injection_gate_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("DATAROBOT_GENAI_CONFIG_INJECTION", raising=False)
-    assert config_injection_enabled() is False
-
-
-@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
-def test_injection_gate_on_for_truthy_values(
-    monkeypatch: pytest.MonkeyPatch, value: str
-) -> None:
-    monkeypatch.setenv("DATAROBOT_GENAI_CONFIG_INJECTION", value)
-    assert config_injection_enabled() is True
-
-
-def test_resolve_config_falls_back_to_env_config_when_no_provider(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _enable_injection(monkeypatch)
+def test_resolve_config_falls_back_to_env_config_when_no_provider() -> None:
     sentinel = _make_config(llm_default_model="from-env-config")
     with patch.object(config_mod, "Config", return_value=sentinel):
         # No provider registered -> genai's own Config() is used.
         assert resolve_config() is sentinel
 
 
-def test_resolve_config_ignores_provider_when_gate_off(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("DATAROBOT_GENAI_CONFIG_INJECTION", raising=False)
-    injected = _make_config(llm_default_model="from-app-config")
+def test_resolve_config_falls_back_when_provider_returns_none() -> None:
     env_cfg = _make_config(llm_default_model="from-env-config")
-    register_config_provider(lambda: injected)
+    register_config_provider(lambda: None)
     with patch.object(config_mod, "Config", return_value=env_cfg):
-        # Gate off -> provider ignored, genai's Config() wins (unchanged behavior).
+        # A provider that yields nothing -> genai's own Config() is used.
         assert resolve_config() is env_cfg
 
 
-def test_resolve_config_uses_injected_provider_when_enabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _enable_injection(monkeypatch)
+def test_resolve_config_uses_injected_provider_when_registered() -> None:
     injected = _make_config(llm_default_model="from-app-config")
     register_config_provider(lambda: injected)
     # Even if genai builds its own Config, the injected provider takes precedence.
@@ -321,15 +293,12 @@ def test_resolve_config_uses_injected_provider_when_enabled(
         assert resolve_config() is injected
 
 
-def test_injected_config_overrides_env_for_user_intent_fields(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_injected_config_overrides_env_for_user_intent_fields() -> None:
     """Verify the hammer case.
 
     A user hardcodes values in the app config and sets NO env var. genai must
     read the app's values, not its own env-only defaults.
     """
-    _enable_injection(monkeypatch)
     # App config: gateway off, a deployment target, and a specific model, all set
     # as plain values, exactly as a user would hardcode them in config.py.
     app_config = LLMConfig(
@@ -348,11 +317,8 @@ def test_injected_config_overrides_env_for_user_intent_fields(
         assert resolve_config().get_llm_type() == LLMType.DEPLOYMENT
 
 
-def test_provider_is_called_each_resolve_for_dynamic_values(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_provider_is_called_each_resolve_for_dynamic_values() -> None:
     """Provider is a factory: re-read picks up changed values (dynamic env vars)."""
-    _enable_injection(monkeypatch)
     calls = {"n": 0}
 
     def _provider() -> LLMConfig:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from unittest.mock import patch
 
 import pytest
@@ -355,21 +354,20 @@ def test_injected_config_drives_endpoint_helpers() -> None:
         assert default_datarobot_llm_gateway_url() == "https://custom.datarobot.example"
 
 
-# --- Deprecated LLM param bridge (REMOVE WITH THE BRIDGE IN A FUTURE RELEASE) --
+# --- Deprecated LLM param bridge (now owned by datarobot.core) ----------------
 #
-# resolve_llm_config falls back to the pre-rename bare runtime-parameter names
-# (nim_deployment_id / use_datarobot_llm_gateway) when the namespaced field was
-# not explicitly provided, warning loudly. These tests pin the four cases per
-# param: new-only (silent), old-only (fallback + warning), both (new wins,
-# silent), and neither (default, silent).
-
-_NIM_BANNER = "DEPRECATED LLM CONFIG PARAMETER IN USE"
+# The legacy bare-name fallback (NIM_DEPLOYMENT_ID / USE_DATAROBOT_LLM_GATEWAY)
+# and its deprecation warning live in
+# DataRobotAppFrameworkBaseSettings.resolve_llm_config and are covered in
+# public_api_client. genai's resolve_llm_config only delegates, so these check the
+# delegation carries the fallback through and honors the registered default
+# instance name; the warning contract itself is core's.
 
 
 def _config_fields_set(fields_set: set[str], **values: object) -> Config:
     """Build a Config while controlling which fields count as explicitly set.
 
-    model_fields_set is the signal the deprecation bridge keys off. Config()
+    model_fields_set is the signal core's deprecation bridge keys off. Config()
     normally derives it from its settings sources; here we set it directly so a
     test can model "the namespaced field was (not) provided" precisely.
     """
@@ -393,132 +391,38 @@ def clear_legacy_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(f"MLOPS_RUNTIME_PARAM_{name}", raising=False)
 
 
-# nim_deployment_id
-
-
-def test_bridge_nim_new_only_is_used_silently(
-    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
+def test_resolve_llm_config_delegates_legacy_fallback(
+    clear_legacy_env: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    cfg = _config_fields_set({"llm_nim_deployment_id"}, llm_nim_deployment_id="new-nim")
-    with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
-            result = resolve_llm_config()
-    assert result.llm_nim_deployment_id == "new-nim"
-    assert _NIM_BANNER not in caplog.text
-
-
-def test_bridge_nim_falls_back_to_old_name_with_warning(
-    clear_legacy_env: None,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+    """Delegation reaches core's bridge: a legacy bare param still resolves."""
     monkeypatch.setenv("MLOPS_RUNTIME_PARAM_NIM_DEPLOYMENT_ID", "legacy-nim")
-    cfg = _config_fields_set(set())  # new name not explicitly provided
+    cfg = _config_fields_set(set())  # namespaced field not explicitly provided
     with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
+        with pytest.warns(Warning):
             result = resolve_llm_config()
     assert result.llm_nim_deployment_id == "legacy-nim"
-    assert _NIM_BANNER in caplog.text
-    assert "NIM_DEPLOYMENT_ID" in caplog.text
-    assert "LLM_NIM_DEPLOYMENT_ID" in caplog.text
 
 
-def test_bridge_nim_new_wins_over_old_silently(
-    clear_legacy_env: None,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
+def test_resolve_llm_config_namespaced_field_wins_over_legacy(
+    clear_legacy_env: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("MLOPS_RUNTIME_PARAM_NIM_DEPLOYMENT_ID", "legacy-nim")
     cfg = _config_fields_set({"llm_nim_deployment_id"}, llm_nim_deployment_id="new-nim")
     with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
-            result = resolve_llm_config()
+        result = resolve_llm_config()
     assert result.llm_nim_deployment_id == "new-nim"
-    assert _NIM_BANNER not in caplog.text
 
 
-def test_bridge_nim_neither_set_defaults_to_none_silently(
-    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
+def test_resolve_llm_config_uses_registered_default_instance_name(
+    clear_legacy_env: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    cfg = _config_fields_set(set())
-    with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
-            result = resolve_llm_config()
-    assert result.llm_nim_deployment_id is None
-    assert _NIM_BANNER not in caplog.text
+    """The registered default instance name is genai's one remaining contribution.
 
-
-# use_datarobot_llm_gateway (bool; default True, so model_fields_set is the signal)
-
-
-def test_bridge_gateway_new_only_is_used_silently(
-    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
-) -> None:
-    cfg = _config_fields_set({"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False)
-    with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
-            result = resolve_llm_config()
-    assert result.llm_use_datarobot_llm_gateway is False
-    assert _NIM_BANNER not in caplog.text
-
-
-def test_bridge_gateway_falls_back_to_old_name_with_warning(
-    clear_legacy_env: None,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    # Old value "0" must override the truthy default AND be coerced to a real bool.
-    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_USE_DATAROBOT_LLM_GATEWAY", "0")
-    cfg = _config_fields_set(set())  # new name not explicitly provided (default True)
-    with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
-            result = resolve_llm_config()
-    assert result.llm_use_datarobot_llm_gateway is False
-    assert _NIM_BANNER in caplog.text
-    assert "USE_DATAROBOT_LLM_GATEWAY" in caplog.text
-
-
-def test_bridge_gateway_new_wins_over_old_silently(
-    clear_legacy_env: None,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    monkeypatch.setenv("MLOPS_RUNTIME_PARAM_USE_DATAROBOT_LLM_GATEWAY", "1")
-    cfg = _config_fields_set({"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False)
-    with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
-            result = resolve_llm_config()
-    assert result.llm_use_datarobot_llm_gateway is False
-    assert _NIM_BANNER not in caplog.text
-
-
-def test_bridge_gateway_neither_set_defaults_to_true_silently(
-    clear_legacy_env: None, caplog: pytest.LogCaptureFixture
-) -> None:
-    cfg = _config_fields_set(set())
-    with patch.object(config_mod, "Config", return_value=cfg):
-        with caplog.at_level(logging.WARNING):
-            result = resolve_llm_config()
-    assert result.llm_use_datarobot_llm_gateway is True
-    assert _NIM_BANNER not in caplog.text
-
-
-def test_bridge_uses_instance_namespace_but_bare_legacy_name(
-    clear_legacy_env: None,
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A non-default instance name still falls back to the bare legacy param.
-
-    The namespaced field is ``{instance}_...`` but the deprecated param was always
-    bare, so the fallback and the warning's target name reflect the instance.
+    A non-"llm" default name selects that instance's namespace when resolving, which
+    the bare legacy fallback then targets.
     """
     monkeypatch.setenv("MLOPS_RUNTIME_PARAM_NIM_DEPLOYMENT_ID", "legacy-nim")
-    # The provider takes precedence over Config(). Its Config has an empty
-    # model_fields_set and no myagent_* fields, so the namespaced field reads as
-    # "not provided" and the bridge falls back to the bare legacy param.
     register_config_provider(lambda: _config_fields_set(set()), default_llm_name="myagent")
-    with caplog.at_level(logging.WARNING):
+    with pytest.warns(Warning):
         result = resolve_llm_config()
     assert result.llm_nim_deployment_id == "legacy-nim"
-    assert "MYAGENT_NIM_DEPLOYMENT_ID" in caplog.text

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -303,7 +303,7 @@ def test_injected_config_overrides_env_for_user_intent_fields() -> None:
     """
     # App config: gateway off, a deployment target, and a specific model, all set
     # as plain values, exactly as a user would hardcode them in config.py.
-    app_config = LLMConfig(
+    app_config = _make_config(
         llm_use_datarobot_llm_gateway=False,
         llm_deployment_id="dep-from-app",
         llm_default_model="anthropic/claude-sonnet-4-20250514",
@@ -316,7 +316,7 @@ def test_injected_config_overrides_env_for_user_intent_fields() -> None:
         assert default_use_datarobot_llm_gateway() is False
         assert default_llm_deployment_id() == "dep-from-app"
         assert default_model_name() == "anthropic/claude-sonnet-4-20250514"
-        assert resolve_config().get_llm_type() == LLMType.DEPLOYMENT
+        assert resolve_llm_config().get_llm_type() == LLMType.DEPLOYMENT
 
 
 def test_provider_is_called_each_resolve_for_dynamic_values() -> None:
@@ -339,7 +339,7 @@ def test_injected_config_drives_endpoint_helpers() -> None:
     A provider supplies a custom endpoint and deployment id; genai's own env-only
     Config would say the defaults. The URL builders must use the injected values.
     """
-    app_config = LLMConfig(
+    app_config = _make_config(
         datarobot_endpoint="https://custom.datarobot.example/api/v2",
         llm_deployment_id="dep-injected",
     )
@@ -350,8 +350,7 @@ def test_injected_config_drives_endpoint_helpers() -> None:
     )
     with patch.object(config_mod, "Config", return_value=env_only):
         assert default_deployment_url() == (
-            "https://custom.datarobot.example/api/v2"
-            "/deployments/dep-injected/chat/completions"
+            "https://custom.datarobot.example/api/v2/deployments/dep-injected/chat/completions"
         )
         assert default_datarobot_llm_gateway_url() == "https://custom.datarobot.example"
 
@@ -455,9 +454,7 @@ def test_bridge_nim_neither_set_defaults_to_none_silently(
 def test_bridge_gateway_new_only_is_used_silently(
     clear_legacy_env: None, caplog: pytest.LogCaptureFixture
 ) -> None:
-    cfg = _config_fields_set(
-        {"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False
-    )
+    cfg = _config_fields_set({"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False)
     with patch.object(config_mod, "Config", return_value=cfg):
         with caplog.at_level(logging.WARNING):
             result = resolve_llm_config()
@@ -487,9 +484,7 @@ def test_bridge_gateway_new_wins_over_old_silently(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setenv("MLOPS_RUNTIME_PARAM_USE_DATAROBOT_LLM_GATEWAY", "1")
-    cfg = _config_fields_set(
-        {"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False
-    )
+    cfg = _config_fields_set({"llm_use_datarobot_llm_gateway"}, llm_use_datarobot_llm_gateway=False)
     with patch.object(config_mod, "Config", return_value=cfg):
         with caplog.at_level(logging.WARNING):
             result = resolve_llm_config()
@@ -519,9 +514,10 @@ def test_bridge_uses_instance_namespace_but_bare_legacy_name(
     bare, so the fallback and the warning's target name reflect the instance.
     """
     monkeypatch.setenv("MLOPS_RUNTIME_PARAM_NIM_DEPLOYMENT_ID", "legacy-nim")
-    # The provider takes precedence over Config(); its object has an empty
-    # model_fields_set, so the namespaced field reads as "not provided".
-    register_config_provider(LLMConfig, default_llm_name="myagent")
+    # The provider takes precedence over Config(). Its Config has an empty
+    # model_fields_set and no myagent_* fields, so the namespaced field reads as
+    # "not provided" and the bridge falls back to the bare legacy param.
+    register_config_provider(lambda: _config_fields_set(set()), default_llm_name="myagent")
     with caplog.at_level(logging.WARNING):
         result = resolve_llm_config()
     assert result.llm_nim_deployment_id == "legacy-nim"

--- a/tests/core/test_llm_config_router.py
+++ b/tests/core/test_llm_config_router.py
@@ -33,8 +33,8 @@ def _make_env_config(**overrides: object) -> config_mod.Config:
         "datarobot_endpoint": "https://app.datarobot.com/api/v2",
         "datarobot_api_token": "env-token",
         "llm_deployment_id": None,
-        "nim_deployment_id": None,
-        "use_datarobot_llm_gateway": True,
+        "llm_nim_deployment_id": None,
+        "llm_use_datarobot_llm_gateway": True,
         "llm_default_model": None,
     }
     defaults.update(overrides)
@@ -54,21 +54,21 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_llm_config_get_llm_type_gateway() -> None:
-    assert LLMConfig(use_datarobot_llm_gateway=True).get_llm_type() == LLMType.GATEWAY
+    assert LLMConfig(llm_use_datarobot_llm_gateway=True).get_llm_type() == LLMType.GATEWAY
 
 
 def test_llm_config_get_llm_type_deployment() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
     assert cfg.get_llm_type() == LLMType.DEPLOYMENT
 
 
 def test_llm_config_get_llm_type_nim() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=False, nim_deployment_id="nim-1")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_nim_deployment_id="nim-1")
     assert cfg.get_llm_type() == LLMType.NIM
 
 
 def test_llm_config_get_llm_type_external() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=False)
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False)
     assert cfg.get_llm_type() == LLMType.EXTERNAL
 
 
@@ -78,7 +78,7 @@ def test_llm_config_get_llm_type_external() -> None:
 
 
 def test_to_litellm_params_gateway() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=True)
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True)
     params = cfg.to_litellm_params()
     assert params["model"].startswith("datarobot/")
     assert params["api_base"] == "https://app.datarobot.com"
@@ -86,7 +86,7 @@ def test_to_litellm_params_gateway() -> None:
 
 
 def test_to_litellm_params_deployment() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-abc")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-abc")
     params = cfg.to_litellm_params()
     assert params["model"].startswith("datarobot/")
     assert "dep-abc" in params["api_base"]
@@ -94,34 +94,34 @@ def test_to_litellm_params_deployment() -> None:
 
 
 def test_to_litellm_params_nim() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=False, nim_deployment_id="nim-xyz")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_nim_deployment_id="nim-xyz")
     params = cfg.to_litellm_params()
     assert "nim-xyz" in params["api_base"]
     assert params["api_key"] == "env-token"
 
 
 def test_to_litellm_params_external() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=False, llm_default_model="gpt-4")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_default_model="gpt-4")
     params = cfg.to_litellm_params()
     assert params["model"] == "gpt-4"
     assert "api_base" not in params
 
 
 def test_to_litellm_params_external_strips_datarobot_prefix() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=False, llm_default_model="datarobot/azure/gpt-4")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_default_model="datarobot/azure/gpt-4")
     params = cfg.to_litellm_params()
     assert params["model"] == "azure/gpt-4"
 
 
 def test_to_litellm_params_uses_explicit_api_key_over_env() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=True, datarobot_api_token="explicit-key")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True, datarobot_api_token="explicit-key")
     params = cfg.to_litellm_params()
     assert params["api_key"] == "explicit-key"
 
 
 def test_to_litellm_params_uses_explicit_endpoint() -> None:
     cfg = LLMConfig(
-        use_datarobot_llm_gateway=True,
+        llm_use_datarobot_llm_gateway=True,
         datarobot_endpoint="https://custom.host/api/v2",
     )
     params = cfg.to_litellm_params()
@@ -129,13 +129,13 @@ def test_to_litellm_params_uses_explicit_endpoint() -> None:
 
 
 def test_to_litellm_params_gateway_adds_datarobot_prefix_when_missing() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=True, llm_default_model="azure/gpt-4o")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True, llm_default_model="azure/gpt-4o")
     params = cfg.to_litellm_params()
     assert params["model"] == "datarobot/azure/gpt-4o"
 
 
 def test_to_litellm_params_gateway_does_not_double_prefix() -> None:
-    cfg = LLMConfig(use_datarobot_llm_gateway=True, llm_default_model="datarobot/azure/gpt-4o")
+    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True, llm_default_model="datarobot/azure/gpt-4o")
     params = cfg.to_litellm_params()
     assert params["model"] == "datarobot/azure/gpt-4o"
 
@@ -148,8 +148,8 @@ def test_to_litellm_params_gateway_does_not_double_prefix() -> None:
 def test_build_litellm_router_model_list_structure() -> None:
     from datarobot_genai.core.router import build_litellm_router
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    fallback = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    fallback = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
 
     with patch("litellm.Router") as mock_router_cls:
         mock_router_cls.return_value = MagicMock()
@@ -167,9 +167,9 @@ def test_build_litellm_router_model_list_structure() -> None:
 def test_build_litellm_router_fallbacks_chain() -> None:
     from datarobot_genai.core.router import build_litellm_router
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    fb0 = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
-    fb1 = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-3")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    fb0 = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    fb1 = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-3")
 
     with patch("litellm.Router") as mock_router_cls:
         mock_router_cls.return_value = MagicMock()
@@ -182,10 +182,10 @@ def test_build_litellm_router_fallbacks_chain() -> None:
 def test_build_litellm_router_multiple_fallbacks() -> None:
     from datarobot_genai.core.router import build_litellm_router
 
-    primary = LLMConfig(use_datarobot_llm_gateway=True)
-    fb0 = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    fb1 = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
-    fb2 = LLMConfig(use_datarobot_llm_gateway=True, llm_default_model="gpt-4")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=True)
+    fb0 = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    fb1 = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    fb2 = LLMConfig(llm_use_datarobot_llm_gateway=True, llm_default_model="gpt-4")
 
     with patch("litellm.Router") as mock_router_cls:
         mock_router_cls.return_value = MagicMock()
@@ -204,8 +204,8 @@ def test_build_litellm_router_multiple_fallbacks() -> None:
 def test_build_litellm_router_passes_settings() -> None:
     from datarobot_genai.core.router import build_litellm_router
 
-    primary = LLMConfig(use_datarobot_llm_gateway=True)
-    fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=True)
+    fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
 
     with patch("litellm.Router") as mock_router_cls:
         mock_router_cls.return_value = MagicMock()
@@ -295,8 +295,8 @@ def test_router_propagates_exception_when_all_models_fail() -> None:
     """When litellm.Router exhausts all fallbacks it raises; wrappers must not swallow it."""
     from datarobot_genai.core.router import build_litellm_router
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-bad")
-    fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-also-bad")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-bad")
+    fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-also-bad")
 
     mock_router_instance = MagicMock()
     mock_router_instance.completion.side_effect = RuntimeError("all models failed")

--- a/tests/core/test_llm_config_router.py
+++ b/tests/core/test_llm_config_router.py
@@ -73,71 +73,54 @@ def test_llm_config_get_llm_type_external() -> None:
 
 
 # ---------------------------------------------------------------------------
-# LLMConfig.to_litellm_params — all four LLMTypes
+# build_litellm_router hydration
+#
+# to_litellm_params itself now lives in datarobot.core and is self-contained (it
+# never reaches back into genai); it is covered in public_api_client. genai's
+# responsibility is to hydrate the router's primary/fallbacks, which are parsed
+# from workflow.yaml with the two globals unset, from the ambient global config
+# before rendering them.
 # ---------------------------------------------------------------------------
 
 
-def test_to_litellm_params_gateway() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True)
-    params = cfg.to_litellm_params()
-    assert params["model"].startswith("datarobot/")
-    assert params["api_base"] == "https://app.datarobot.com"
-    assert params["api_key"] == "env-token"
+def test_build_litellm_router_hydrates_globals_from_ambient_config() -> None:
+    from datarobot_genai.core.router import build_litellm_router
+
+    # Bare configs: no endpoint/token set, exactly as parsed from workflow.yaml.
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=True)
+    fallback = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+
+    with patch("litellm.Router") as mock_router_cls:
+        mock_router_cls.return_value = MagicMock()
+        build_litellm_router(primary, [fallback])
+
+    model_list = mock_router_cls.call_args.kwargs["model_list"]
+    # api_key + api_base come from the patched ambient Config (env-token / default
+    # endpoint), not from the bare configs themselves.
+    assert model_list[0]["litellm_params"]["api_key"] == "env-token"
+    assert model_list[0]["litellm_params"]["api_base"] == "https://app.datarobot.com"
+    assert model_list[1]["litellm_params"]["api_key"] == "env-token"
+    assert "dep-1" in model_list[1]["litellm_params"]["api_base"]
 
 
-def test_to_litellm_params_deployment() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-abc")
-    params = cfg.to_litellm_params()
-    assert params["model"].startswith("datarobot/")
-    assert "dep-abc" in params["api_base"]
-    assert params["api_key"] == "env-token"
+def test_build_litellm_router_keeps_explicit_config_credentials() -> None:
+    from datarobot_genai.core.router import build_litellm_router
 
-
-def test_to_litellm_params_nim() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_nim_deployment_id="nim-xyz")
-    params = cfg.to_litellm_params()
-    assert "nim-xyz" in params["api_base"]
-    assert params["api_key"] == "env-token"
-
-
-def test_to_litellm_params_external() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_default_model="gpt-4")
-    params = cfg.to_litellm_params()
-    assert params["model"] == "gpt-4"
-    assert "api_base" not in params
-
-
-def test_to_litellm_params_external_strips_datarobot_prefix() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_default_model="datarobot/azure/gpt-4")
-    params = cfg.to_litellm_params()
-    assert params["model"] == "azure/gpt-4"
-
-
-def test_to_litellm_params_uses_explicit_api_key_over_env() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True, datarobot_api_token="explicit-key")
-    params = cfg.to_litellm_params()
-    assert params["api_key"] == "explicit-key"
-
-
-def test_to_litellm_params_uses_explicit_endpoint() -> None:
-    cfg = LLMConfig(
+    # An explicit token/endpoint on the config wins over the ambient globals.
+    primary = LLMConfig(
         llm_use_datarobot_llm_gateway=True,
+        datarobot_api_token="explicit-key",
         datarobot_endpoint="https://custom.host/api/v2",
     )
-    params = cfg.to_litellm_params()
-    assert params["api_base"] == "https://custom.host"
+    fallback = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
 
+    with patch("litellm.Router") as mock_router_cls:
+        mock_router_cls.return_value = MagicMock()
+        build_litellm_router(primary, [fallback])
 
-def test_to_litellm_params_gateway_adds_datarobot_prefix_when_missing() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True, llm_default_model="azure/gpt-4o")
-    params = cfg.to_litellm_params()
-    assert params["model"] == "datarobot/azure/gpt-4o"
-
-
-def test_to_litellm_params_gateway_does_not_double_prefix() -> None:
-    cfg = LLMConfig(llm_use_datarobot_llm_gateway=True, llm_default_model="datarobot/azure/gpt-4o")
-    params = cfg.to_litellm_params()
-    assert params["model"] == "datarobot/azure/gpt-4o"
+    model_list = mock_router_cls.call_args.kwargs["model_list"]
+    assert model_list[0]["litellm_params"]["api_key"] == "explicit-key"
+    assert model_list[0]["litellm_params"]["api_base"] == "https://custom.host"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -166,7 +166,7 @@ def test_get_external_llm_merges_parameters() -> None:
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(crewai_llm, "resolve_config", return_value=config):
+    with patch.object(crewai_llm, "resolve_llm_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -177,7 +177,7 @@ def test_get_llm_routes_to_deployment() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.DEPLOYMENT
     config.llm_deployment_id = "dep-123"
-    with patch.object(crewai_llm, "resolve_config", return_value=config):
+    with patch.object(crewai_llm, "resolve_llm_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -188,7 +188,7 @@ def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
     config.llm_nim_deployment_id = "nim-456"
-    with patch.object(crewai_llm, "resolve_config", return_value=config):
+    with patch.object(crewai_llm, "resolve_llm_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -198,7 +198,7 @@ def test_get_llm_routes_to_nim() -> None:
 def test_get_llm_routes_to_external() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.EXTERNAL
-    with patch.object(crewai_llm, "resolve_config", return_value=config):
+    with patch.object(crewai_llm, "resolve_llm_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -208,7 +208,7 @@ def test_get_llm_routes_to_external() -> None:
 def test_get_llm_raises_on_unknown_type() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = "unknown"
-    with patch.object(crewai_llm, "resolve_config", return_value=config):
+    with patch.object(crewai_llm, "resolve_llm_config", return_value=config):
         with pytest.raises(ValueError, match="Invalid LLM type"):
             crewai_llm.get_llm()
 
@@ -216,7 +216,7 @@ def test_get_llm_raises_on_unknown_type() -> None:
 def test_get_llm_forwards_model_name_and_parameters() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(crewai_llm, "resolve_config", return_value=config):
+    with patch.object(crewai_llm, "resolve_llm_config", return_value=config):
         llm = crewai_llm.get_llm(model_name="azure/gpt-4", parameters={"temperature": 0.5})
     assert llm.model == "datarobot/azure/gpt-4"
     assert llm.is_litellm is True

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -187,7 +187,7 @@ def test_get_llm_routes_to_deployment() -> None:
 def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
-    config.nim_deployment_id = "nim-456"
+    config.llm_nim_deployment_id = "nim-456"
     with patch.object(crewai_llm, "resolve_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)

--- a/tests/crewai/test_llm.py
+++ b/tests/crewai/test_llm.py
@@ -166,7 +166,7 @@ def test_get_external_llm_merges_parameters() -> None:
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(crewai_llm, "Config", return_value=config):
+    with patch.object(crewai_llm, "resolve_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -177,7 +177,7 @@ def test_get_llm_routes_to_deployment() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.DEPLOYMENT
     config.llm_deployment_id = "dep-123"
-    with patch.object(crewai_llm, "Config", return_value=config):
+    with patch.object(crewai_llm, "resolve_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -188,7 +188,7 @@ def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
     config.nim_deployment_id = "nim-456"
-    with patch.object(crewai_llm, "Config", return_value=config):
+    with patch.object(crewai_llm, "resolve_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -198,7 +198,7 @@ def test_get_llm_routes_to_nim() -> None:
 def test_get_llm_routes_to_external() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.EXTERNAL
-    with patch.object(crewai_llm, "Config", return_value=config):
+    with patch.object(crewai_llm, "resolve_config", return_value=config):
         llm = crewai_llm.get_llm()
     assert isinstance(llm, LLM)
     assert llm.is_litellm is True
@@ -208,7 +208,7 @@ def test_get_llm_routes_to_external() -> None:
 def test_get_llm_raises_on_unknown_type() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = "unknown"
-    with patch.object(crewai_llm, "Config", return_value=config):
+    with patch.object(crewai_llm, "resolve_config", return_value=config):
         with pytest.raises(ValueError, match="Invalid LLM type"):
             crewai_llm.get_llm()
 
@@ -216,7 +216,7 @@ def test_get_llm_raises_on_unknown_type() -> None:
 def test_get_llm_forwards_model_name_and_parameters() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(crewai_llm, "Config", return_value=config):
+    with patch.object(crewai_llm, "resolve_config", return_value=config):
         llm = crewai_llm.get_llm(model_name="azure/gpt-4", parameters={"temperature": 0.5})
     assert llm.model == "datarobot/azure/gpt-4"
     assert llm.is_litellm is True

--- a/tests/crewai/test_llm_clients.py
+++ b/tests/crewai/test_llm_clients.py
@@ -71,7 +71,7 @@ async def test_datarobot_llm_deployment_crewai_with_identity_token():
 
 async def test_datarobot_nim_crewai():
     llm_config = DataRobotNIMModelConfig(
-        nim_deployment_id="123",
+        llm_nim_deployment_id="123",
         model_name="azure/gpt-4o-2024-11-20",
         temperature=0.0,
         api_key="some_token",
@@ -104,9 +104,9 @@ async def test_datarobot_llm_component_crewai(
     ):
         llm_config = DataRobotLLMComponentModelConfig(
             model_name="anthropic/claude-3",
-            use_datarobot_llm_gateway=use_datarobot_llm_gateway,
+            llm_use_datarobot_llm_gateway=use_datarobot_llm_gateway,
             llm_deployment_id=llm_deployment_id,
-            nim_deployment_id=nim_deployment_id,
+            llm_nim_deployment_id=nim_deployment_id,
             temperature=0.2,
         )
         identity_patch = patch(

--- a/tests/crewai/test_router_llm.py
+++ b/tests/crewai/test_router_llm.py
@@ -34,8 +34,8 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
         datarobot_endpoint="https://app.datarobot.com/api/v2",
         datarobot_api_token="env-token",
         llm_deployment_id=None,
-        nim_deployment_id=None,
-        use_datarobot_llm_gateway=True,
+        llm_nim_deployment_id=None,
+        llm_use_datarobot_llm_gateway=True,
         llm_default_model=None,
     )
     monkeypatch.setattr(config_mod, "Config", lambda: env)
@@ -57,8 +57,8 @@ def _make_tool_chunk() -> Any:
 def test_get_router_llm_returns_llm_instance() -> None:
     from datarobot_genai.crewai.llm import get_router_llm
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    _fallback = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    _fallback = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
 
     with patch("litellm.Router") as mock_router_cls:
         mock_router_cls.return_value = MagicMock()
@@ -77,8 +77,8 @@ def test_router_llm_call_streams_and_accumulates() -> None:
     mock_router.completion.return_value = iter(chunks)
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     result = llm.call(messages=[{"role": "user", "content": "hi"}])
@@ -97,8 +97,8 @@ def test_router_llm_call_returns_tool_call_list_not_json_string() -> None:
     mock_router = MagicMock()
     mock_router.completion.return_value = iter([_make_tool_chunk()])
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     result = llm.call(messages=[{"role": "user", "content": "hi"}], tools=[{"type": "function"}])
@@ -119,8 +119,8 @@ async def test_router_llm_acall_returns_tool_call_list_not_json_string() -> None
     mock_router = MagicMock()
     mock_router.acompletion = fake_acompletion
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     result = await llm.acall(
@@ -138,9 +138,13 @@ def test_router_llm_supports_function_calling_scans_failover_chain() -> None:
 
     with patch("litellm.Router", return_value=MagicMock()):
         primary = LLMConfig(
-            use_datarobot_llm_gateway=True, llm_default_model="invalid-model-that-does-not-exist"
+            llm_use_datarobot_llm_gateway=True,
+            llm_default_model="invalid-model-that-does-not-exist",
         )
-        fb = LLMConfig(use_datarobot_llm_gateway=True, llm_default_model="azure/gpt-4o-2024-11-20")
+        fb = LLMConfig(
+            llm_use_datarobot_llm_gateway=True,
+            llm_default_model="azure/gpt-4o-2024-11-20",
+        )
         llm = get_router_llm(primary, [fb])
 
     assert llm.supports_function_calling() is True
@@ -154,8 +158,8 @@ def test_router_llm_call_invokes_callbacks_per_chunk() -> None:
     mock_router.completion.return_value = iter(chunks)
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     callback = MagicMock()
@@ -176,8 +180,8 @@ def test_router_llm_call_emits_llm_stream_chunk_events() -> None:
     mock_router.completion.return_value = iter(chunks)
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     emitted: list[LLMStreamChunkEvent] = []
@@ -212,8 +216,8 @@ async def test_router_llm_acall_streams_and_accumulates() -> None:
     mock_router.acompletion = fake_acompletion
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [fb])
 
     result = await llm.acall(messages=[{"role": "user", "content": "hi"}])
@@ -241,8 +245,8 @@ async def test_router_llm_acall_emits_llm_stream_chunk_events() -> None:
     mock_router.acompletion = fake_acompletion
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [fb])
 
     emitted: list[LLMStreamChunkEvent] = []

--- a/tests/dragent/plugins/test_llm_clients.py
+++ b/tests/dragent/plugins/test_llm_clients.py
@@ -79,7 +79,7 @@ def test_apply_reasoning_config_nim_provider() -> None:
     llm_config = DataRobotNIMModelConfig(
         reasoning=True,
         temperature=0,
-        nim_deployment_id="123",
+        llm_nim_deployment_id="123",
         model_name="anthropic/claude-sonnet-4-6",
         api_key="some_token",
     )
@@ -154,7 +154,7 @@ async def test_datarobot_llm_deployment_langchain_with_identity_token():
 
 async def test_datarobot_nim_langchain():
     llm_config = DataRobotNIMModelConfig(
-        nim_deployment_id="123",
+        llm_nim_deployment_id="123",
         model_name="azure/gpt-4o-2024-11-20",
         temperature=0.0,
         api_key="some_token",
@@ -197,9 +197,9 @@ async def test_datarobot_llm_component_langchain(
     ):
         llm_config = DataRobotLLMComponentModelConfig(
             model_name="anthropic/claude-3",
-            use_datarobot_llm_gateway=use_datarobot_llm_gateway,
+            llm_use_datarobot_llm_gateway=use_datarobot_llm_gateway,
             llm_deployment_id=llm_deployment_id,
-            nim_deployment_id=nim_deployment_id,
+            llm_nim_deployment_id=nim_deployment_id,
             temperature=0.2,
         )
         identity_patch = patch(

--- a/tests/langgraph/test_llm.py
+++ b/tests/langgraph/test_llm.py
@@ -170,7 +170,7 @@ def test_get_llm_routes_to_deployment() -> None:
 def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
-    config.nim_deployment_id = "nim-456"
+    config.llm_nim_deployment_id = "nim-456"
     with patch.object(langgraph_llm, "resolve_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)

--- a/tests/langgraph/test_llm.py
+++ b/tests/langgraph/test_llm.py
@@ -151,7 +151,7 @@ def test_get_external_llm_merges_parameters() -> None:
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(langgraph_llm, "resolve_config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_llm_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.api_base == "https://example.test/genai/llmgw"
@@ -161,7 +161,7 @@ def test_get_llm_routes_to_deployment() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.DEPLOYMENT
     config.llm_deployment_id = "dep-123"
-    with patch.object(langgraph_llm, "resolve_config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_llm_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.api_base == "https://example.test/deployments/dep-123/chat/completions"
@@ -171,7 +171,7 @@ def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
     config.llm_nim_deployment_id = "nim-456"
-    with patch.object(langgraph_llm, "resolve_config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_llm_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.api_base == "https://example.test/deployments/nim-456/chat/completions"
@@ -180,7 +180,7 @@ def test_get_llm_routes_to_nim() -> None:
 def test_get_llm_routes_to_external() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.EXTERNAL
-    with patch.object(langgraph_llm, "resolve_config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_llm_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.model == "default-model"
@@ -189,7 +189,7 @@ def test_get_llm_routes_to_external() -> None:
 def test_get_llm_raises_on_unknown_type() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = "unknown"
-    with patch.object(langgraph_llm, "resolve_config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_llm_config", return_value=config):
         with pytest.raises(ValueError, match="Invalid LLM type"):
             langgraph_llm.get_llm()
 
@@ -197,7 +197,7 @@ def test_get_llm_raises_on_unknown_type() -> None:
 def test_get_llm_forwards_model_name_and_parameters() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(langgraph_llm, "resolve_config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_llm_config", return_value=config):
         llm = langgraph_llm.get_llm(model_name="azure/gpt-4", parameters={"temperature": 0.5})
     assert llm.model == "datarobot/azure/gpt-4"
     assert llm.temperature == 0.5
@@ -237,7 +237,7 @@ def test_factory_omits_model_kwargs_when_no_extra_body() -> None:
 def test_get_llm_forwards_streaming_flag() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(langgraph_llm, "resolve_config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_llm_config", return_value=config):
         llm = langgraph_llm.get_llm(streaming=False)
     assert llm.streaming is False
 

--- a/tests/langgraph/test_llm.py
+++ b/tests/langgraph/test_llm.py
@@ -151,7 +151,7 @@ def test_get_external_llm_merges_parameters() -> None:
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(langgraph_llm, "Config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.api_base == "https://example.test/genai/llmgw"
@@ -161,7 +161,7 @@ def test_get_llm_routes_to_deployment() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.DEPLOYMENT
     config.llm_deployment_id = "dep-123"
-    with patch.object(langgraph_llm, "Config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.api_base == "https://example.test/deployments/dep-123/chat/completions"
@@ -171,7 +171,7 @@ def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
     config.nim_deployment_id = "nim-456"
-    with patch.object(langgraph_llm, "Config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.api_base == "https://example.test/deployments/nim-456/chat/completions"
@@ -180,7 +180,7 @@ def test_get_llm_routes_to_nim() -> None:
 def test_get_llm_routes_to_external() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.EXTERNAL
-    with patch.object(langgraph_llm, "Config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_config", return_value=config):
         llm = langgraph_llm.get_llm()
     assert isinstance(llm, BaseChatModel)
     assert llm.model == "default-model"
@@ -189,7 +189,7 @@ def test_get_llm_routes_to_external() -> None:
 def test_get_llm_raises_on_unknown_type() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = "unknown"
-    with patch.object(langgraph_llm, "Config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_config", return_value=config):
         with pytest.raises(ValueError, match="Invalid LLM type"):
             langgraph_llm.get_llm()
 
@@ -197,7 +197,7 @@ def test_get_llm_raises_on_unknown_type() -> None:
 def test_get_llm_forwards_model_name_and_parameters() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(langgraph_llm, "Config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_config", return_value=config):
         llm = langgraph_llm.get_llm(model_name="azure/gpt-4", parameters={"temperature": 0.5})
     assert llm.model == "datarobot/azure/gpt-4"
     assert llm.temperature == 0.5
@@ -237,7 +237,7 @@ def test_factory_omits_model_kwargs_when_no_extra_body() -> None:
 def test_get_llm_forwards_streaming_flag() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(langgraph_llm, "Config", return_value=config):
+    with patch.object(langgraph_llm, "resolve_config", return_value=config):
         llm = langgraph_llm.get_llm(streaming=False)
     assert llm.streaming is False
 

--- a/tests/langgraph/test_router_llm.py
+++ b/tests/langgraph/test_router_llm.py
@@ -34,8 +34,8 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
         datarobot_endpoint="https://app.datarobot.com/api/v2",
         datarobot_api_token="env-token",
         llm_deployment_id=None,
-        nim_deployment_id=None,
-        use_datarobot_llm_gateway=True,
+        llm_nim_deployment_id=None,
+        llm_use_datarobot_llm_gateway=True,
         llm_default_model=None,
     )
     monkeypatch.setattr(config_mod, "Config", lambda: env)
@@ -44,8 +44,8 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_get_router_llm_returns_base_chat_model() -> None:
     from datarobot_genai.langgraph.llm import get_router_llm
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    _fallback = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    _fallback = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
 
     with patch("litellm.Router") as mock_router_cls:
         mock_router_cls.return_value = MagicMock(model_list=[{"model_name": "primary"}])
@@ -59,8 +59,8 @@ def test_get_router_llm_supports_bind_tools() -> None:
 
     from datarobot_genai.langgraph.llm import get_router_llm
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    _fallback = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    _fallback = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
 
     @tool
     def dummy_tool(x: str) -> str:
@@ -80,8 +80,8 @@ async def test_get_router_llm_strips_tool_calls_from_additional_kwargs() -> None
     """Streaming chunks must not carry raw tool-call deltas in additional_kwargs."""
     from datarobot_genai.langgraph.llm import get_router_llm
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    fallback = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    fallback = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
 
     fake_chunk = {
         "choices": [

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -205,7 +205,7 @@ def test_factory_does_not_add_extra_body_when_absent() -> None:
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(llama_index_llm, "resolve_config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_llm_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     extras = llm.additional_kwargs
@@ -216,7 +216,7 @@ def test_get_llm_routes_to_deployment() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.DEPLOYMENT
     config.llm_deployment_id = "dep-123"
-    with patch.object(llama_index_llm, "resolve_config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_llm_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     extras = llm.additional_kwargs
@@ -227,7 +227,7 @@ def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
     config.llm_nim_deployment_id = "nim-456"
-    with patch.object(llama_index_llm, "resolve_config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_llm_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     extras = llm.additional_kwargs
@@ -237,7 +237,7 @@ def test_get_llm_routes_to_nim() -> None:
 def test_get_llm_routes_to_external() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.EXTERNAL
-    with patch.object(llama_index_llm, "resolve_config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_llm_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     assert llm.model == "default-model"
@@ -246,7 +246,7 @@ def test_get_llm_routes_to_external() -> None:
 def test_get_llm_raises_on_unknown_type() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = "unknown"
-    with patch.object(llama_index_llm, "resolve_config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_llm_config", return_value=config):
         with pytest.raises(ValueError, match="Invalid LLM type"):
             llama_index_llm.get_llm()
 
@@ -254,7 +254,7 @@ def test_get_llm_raises_on_unknown_type() -> None:
 def test_get_llm_forwards_model_name_and_parameters() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(llama_index_llm, "resolve_config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_llm_config", return_value=config):
         llm = llama_index_llm.get_llm(model_name="azure/gpt-4", parameters={"temperature": 0.5})
     assert llm.model == "datarobot/azure/gpt-4"
     assert llm.temperature == 0.5

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -205,7 +205,7 @@ def test_factory_does_not_add_extra_body_when_absent() -> None:
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(llama_index_llm, "Config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     extras = llm.additional_kwargs
@@ -216,7 +216,7 @@ def test_get_llm_routes_to_deployment() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.DEPLOYMENT
     config.llm_deployment_id = "dep-123"
-    with patch.object(llama_index_llm, "Config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     extras = llm.additional_kwargs
@@ -227,7 +227,7 @@ def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
     config.nim_deployment_id = "nim-456"
-    with patch.object(llama_index_llm, "Config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     extras = llm.additional_kwargs
@@ -237,7 +237,7 @@ def test_get_llm_routes_to_nim() -> None:
 def test_get_llm_routes_to_external() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.EXTERNAL
-    with patch.object(llama_index_llm, "Config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)
     assert llm.model == "default-model"
@@ -246,7 +246,7 @@ def test_get_llm_routes_to_external() -> None:
 def test_get_llm_raises_on_unknown_type() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = "unknown"
-    with patch.object(llama_index_llm, "Config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_config", return_value=config):
         with pytest.raises(ValueError, match="Invalid LLM type"):
             llama_index_llm.get_llm()
 
@@ -254,7 +254,7 @@ def test_get_llm_raises_on_unknown_type() -> None:
 def test_get_llm_forwards_model_name_and_parameters() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY
-    with patch.object(llama_index_llm, "Config", return_value=config):
+    with patch.object(llama_index_llm, "resolve_config", return_value=config):
         llm = llama_index_llm.get_llm(model_name="azure/gpt-4", parameters={"temperature": 0.5})
     assert llm.model == "datarobot/azure/gpt-4"
     assert llm.temperature == 0.5

--- a/tests/llamaindex/test_llm.py
+++ b/tests/llamaindex/test_llm.py
@@ -226,7 +226,7 @@ def test_get_llm_routes_to_deployment() -> None:
 def test_get_llm_routes_to_nim() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.NIM
-    config.nim_deployment_id = "nim-456"
+    config.llm_nim_deployment_id = "nim-456"
     with patch.object(llama_index_llm, "resolve_config", return_value=config):
         llm = llama_index_llm.get_llm()
     assert isinstance(llm, LiteLLM)

--- a/tests/llamaindex/test_llm_clients.py
+++ b/tests/llamaindex/test_llm_clients.py
@@ -78,7 +78,7 @@ async def test_datarobot_llm_deployment_llamaindex_with_identity_token():
 
 async def test_datarobot_nim_llamaindex():
     llm_config = DataRobotNIMModelConfig(
-        nim_deployment_id="123",
+        llm_nim_deployment_id="123",
         model_name="azure/gpt-4o-2024-11-20",
         temperature=0.0,
         api_key="some_token",
@@ -112,9 +112,9 @@ async def test_datarobot_llm_component_llamaindex(
     ):
         llm_config = DataRobotLLMComponentModelConfig(
             model_name="azure/gpt-5-mini",
-            use_datarobot_llm_gateway=use_datarobot_llm_gateway,
+            llm_use_datarobot_llm_gateway=use_datarobot_llm_gateway,
             llm_deployment_id=llm_deployment_id,
-            nim_deployment_id=nim_deployment_id,
+            llm_nim_deployment_id=nim_deployment_id,
             temperature=0.2,
         )
         identity_patch = patch(

--- a/tests/llamaindex/test_router_llm.py
+++ b/tests/llamaindex/test_router_llm.py
@@ -34,8 +34,8 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch) -> None:
         datarobot_endpoint="https://app.datarobot.com/api/v2",
         datarobot_api_token="env-token",
         llm_deployment_id=None,
-        nim_deployment_id=None,
-        use_datarobot_llm_gateway=True,
+        llm_nim_deployment_id=None,
+        llm_use_datarobot_llm_gateway=True,
         llm_default_model=None,
     )
     monkeypatch.setattr(config_mod, "Config", lambda: env)
@@ -80,8 +80,8 @@ def _make_tool_call_chunks() -> list[Any]:
 def test_get_router_llm_returns_litellm_instance() -> None:
     from datarobot_genai.llama_index.llm import get_router_llm
 
-    primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-    _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+    primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+    _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
 
     with patch("litellm.Router") as mock_cls:
         mock_cls.return_value = MagicMock()
@@ -100,8 +100,8 @@ def test_get_router_llm_stream_chat_yields_chunks() -> None:
     mock_router.completion.return_value = iter(chunks)
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     from llama_index.core.base.llms.types import ChatMessage
@@ -120,8 +120,8 @@ def test_get_router_llm_stream_chat_accumulates_tool_calls() -> None:
     mock_router.completion.return_value = iter(_make_tool_call_chunks())
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     from llama_index.core.base.llms.types import ChatMessage
@@ -156,8 +156,8 @@ async def test_get_router_llm_astream_chat_accumulates_tool_calls() -> None:
     mock_router.acompletion = fake_acompletion
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     from llama_index.core.base.llms.types import ChatMessage
@@ -192,8 +192,8 @@ async def test_get_router_llm_astream_chat_yields_chunks() -> None:
     mock_router.acompletion = fake_acompletion
 
     with patch("litellm.Router", return_value=mock_router):
-        primary = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
-        _fb = LLMConfig(use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
+        primary = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-1")
+        _fb = LLMConfig(llm_use_datarobot_llm_gateway=False, llm_deployment_id="dep-2")
         llm = get_router_llm(primary, [_fb])
 
     from llama_index.core.base.llms.types import ChatMessage

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ overrides = [
 ]
 excludes = [
     "build",
+    "datarobot",
     "flask",
     "kubernetes",
     "lancedb",
@@ -1059,8 +1060,20 @@ wheels = [
 ]
 
 [[package]]
-name = "datarobot"
-version = "3.18.0"
+name = "datarobot-asgi-middleware"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/10/b7651ffa919c76ec808db0af521e30e43adb18af9f4ee2413a4f854e7b6f/datarobot_asgi_middleware-0.2.0.tar.gz", hash = "sha256:44588d6b16a8420ed8b6b8a198a8326be61f48d39a27f7df1a6511dc319b467b", size = 14018, upload-time = "2025-06-17T02:03:29.82Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/9c/df8319321f8b606580cc0dab2884dcf58373aa567b8539c4a0681c96dfcc/datarobot_asgi_middleware-0.2.0-py3-none-any.whl", hash = "sha256:ac6f999a568c04964673d6f2f5134e2ce4ad67ef3eebb4c2896981c0f5291493", size = 8034, upload-time = "2025-06-17T02:03:29.047Z" },
+]
+
+[[package]]
+name = "datarobot-early-access"
+version = "3.19.0.2026.8.3.173957"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -1075,9 +1088,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/87/fe696ed62eb8f72a29b036a71086434e39db7ef096a280526c8073017652/datarobot-3.18.0.tar.gz", hash = "sha256:47f289b65211416fba37b384b57a0ec82efdb76546aabda95c1ff7076b41e72c", size = 834279, upload-time = "2026-07-28T18:34:22.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/8f/1429881723f1f8e9830000928961623bae4d5a4f10d863c7d79f2d79e81d/datarobot_early_access-3.19.0.2026.8.3.173957.tar.gz", hash = "sha256:1c6b23ef585c586d291aa0e49e2436cbc36d775b0f4f3a62bbed5ef15966f1a2", size = 1081255, upload-time = "2026-08-03T17:40:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/5a/999f30688e3f352110e02034681f3393133a0fcc2db2bc88ee92377b15c8/datarobot-3.18.0-py3-none-any.whl", hash = "sha256:c1272693b9ebb3cbf6e4e4066bb714e003208cb3957d4489d751a380e7062a97", size = 900686, upload-time = "2026-07-28T18:34:20.498Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e4/f6f957e0ff148dba43a19ec0813695c0a069d8c813fd7e78a7c7617ff8a9/datarobot_early_access-3.19.0.2026.8.3.173957-py3-none-any.whl", hash = "sha256:c3861352a8458ff45572ebb2a44daaddd42e60422eb5ffb0e86ce2688a837685", size = 1248514, upload-time = "2026-08-03T17:39:59.919Z" },
 ]
 
 [package.optional-dependencies]
@@ -1095,26 +1108,14 @@ fs = [
 ]
 
 [[package]]
-name = "datarobot-asgi-middleware"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/10/b7651ffa919c76ec808db0af521e30e43adb18af9f4ee2413a4f854e7b6f/datarobot_asgi_middleware-0.2.0.tar.gz", hash = "sha256:44588d6b16a8420ed8b6b8a198a8326be61f48d39a27f7df1a6511dc319b467b", size = 14018, upload-time = "2025-06-17T02:03:29.82Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/9c/df8319321f8b606580cc0dab2884dcf58373aa567b8539c4a0681c96dfcc/datarobot_asgi_middleware-0.2.0-py3-none-any.whl", hash = "sha256:ac6f999a568c04964673d6f2f5134e2ce4ad67ef3eebb4c2896981c0f5291493", size = 8034, upload-time = "2025-06-17T02:03:29.047Z" },
-]
-
-[[package]]
 name = "datarobot-genai"
-version = "0.26.19"
+version = "0.26.20"
 source = { editable = "." }
 
 [package.optional-dependencies]
 auth = [
     { name = "aiohttp" },
-    { name = "datarobot", extra = ["auth"] },
+    { name = "datarobot-early-access", extra = ["auth"] },
     { name = "httpx" },
     { name = "okta-client-python" },
     { name = "pydantic" },
@@ -1123,7 +1124,7 @@ auth = [
 core = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1144,7 +1145,7 @@ crewai = [
     { name = "colorama" },
     { name = "crewai", extra = ["litellm"] },
     { name = "crewai-tools", extra = ["mcp"] },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1168,7 +1169,7 @@ dragent = [
     { name = "ag-ui-protocol" },
     { name = "anyio" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1196,8 +1197,8 @@ drmcp = [
     { name = "async-lru" },
     { name = "beautifulsoup4" },
     { name = "cachetools" },
-    { name = "datarobot", extra = ["auth", "fs"] },
     { name = "datarobot-asgi-middleware" },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "datarobot-predict" },
     { name = "fastmcp" },
     { name = "httpx" },
@@ -1228,7 +1229,7 @@ drmcpbase = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
     { name = "cachetools" },
-    { name = "datarobot", extra = ["auth", "fs"] },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "okta-client-python" },
@@ -1241,7 +1242,7 @@ drmcpbase = [
 ]
 drmcputils = [
     { name = "aiohttp" },
-    { name = "datarobot", extra = ["auth", "fs"] },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "httpx" },
     { name = "okta-client-python" },
     { name = "pydantic" },
@@ -1250,7 +1251,7 @@ drmcputils = [
 drtools = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
-    { name = "datarobot", extra = ["auth", "fs"] },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "datarobot-predict" },
     { name = "httpx" },
     { name = "okta-client-python" },
@@ -1274,7 +1275,7 @@ eval = [
 langgraph = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1297,7 +1298,7 @@ langgraph = [
 llamaindex = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1373,21 +1374,21 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.19.0,<4.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },
@@ -1592,7 +1593,6 @@ wheels = [
 
 [package.optional-dependencies]
 all = [
-    { name = "datarobot" },
     { name = "datarobot-predict" },
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
@@ -1617,7 +1617,6 @@ version = "1.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "datarobot" },
     { name = "pandas" },
     { name = "py4j" },
     { name = "requests" },

--- a/uv.lock
+++ b/uv.lock
@@ -1060,7 +1060,7 @@ wheels = [
 
 [[package]]
 name = "datarobot"
-version = "3.17.0"
+version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -1075,9 +1075,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/2e/2d72db2fe202e2f5151a3d465a026c7ffa0f06ec0900260973daeb2cf69c/datarobot-3.17.0.tar.gz", hash = "sha256:a3587725adb06bfc58942dec0f7cd26e7ba0918e11b6e72a6848636ba5fb58fa", size = 834279, upload-time = "2026-06-30T12:52:39.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/87/fe696ed62eb8f72a29b036a71086434e39db7ef096a280526c8073017652/datarobot-3.18.0.tar.gz", hash = "sha256:47f289b65211416fba37b384b57a0ec82efdb76546aabda95c1ff7076b41e72c", size = 834279, upload-time = "2026-07-28T18:34:22.698Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/bb/9771102c62cea69f9e1ade151a23855d93c959109d30668fba598272d9ab/datarobot-3.17.0-py3-none-any.whl", hash = "sha256:c54471022ea29324fe8a21b34b9473d1d75da1599de66ad8ef8d28dde47b08b0", size = 902398, upload-time = "2026-06-30T12:52:37.68Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5a/999f30688e3f352110e02034681f3393133a0fcc2db2bc88ee92377b15c8/datarobot-3.18.0-py3-none-any.whl", hash = "sha256:c1272693b9ebb3cbf6e4e4066bb714e003208cb3957d4489d751a380e7062a97", size = 900686, upload-time = "2026-07-28T18:34:20.498Z" },
 ]
 
 [package.optional-dependencies]
@@ -1373,20 +1373,20 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.17.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.17.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
+    { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },


### PR DESCRIPTION
## Do not merge

This is a throwaway probe. The point is to let the CI/CD pipelines tell us what breaks when genai depends on `datarobot-early-access` instead of `datarobot`, especially in the e2e and integration jobs that never run locally. The intent is to revert the dependency back to `datarobot` before anything here lands.

Stacked on top of `mattn/BUZZOK-31738-authority` (PR #585), rebased onto current `main`, so the diff against `main` includes that work too. The probe itself is the last commit.

## Why we looked at this

The `datarobot` stable package releases slowly. `datarobot-early-access` releases weekly. BUZZOK-31738 moved genai's `core/config.py` onto `datarobot.core.config`, and the piece genai delegates to (the legacy `NIM_DEPLOYMENT_ID` / `USE_DATAROBOT_LLM_GATEWAY` bridge in `resolve_llm_config`) only exists in 3.19. Stable is at 3.18.0. So today the branch cannot go green on a published stable release:

```
FAILED tests/core/test_config.py::test_resolve_llm_config_delegates_legacy_fallback
FAILED tests/core/test_config.py::test_resolve_llm_config_uses_registered_default_instance_name
2 failed, 35 passed
```

Early-access `3.19.0.2026.8.3.173957` does have it. Its `datarobot/core/config.py` is byte-identical to the `public_api_client` checkout we have been developing against.

## The thing that makes this a fundamental change

`datarobot` and `datarobot-early-access` are two distributions that both unpack into the same top-level `datarobot/` package. Only one can be installed at a time. Think of it as two different tenants with keys to the same apartment: whoever moves in last owns the furniture, and the mailbox still lists both names.

Changing genai's own pins is not enough to guarantee that, because two non-optional dependencies ask for stable `datarobot` on their own:

- `datarobot-predict` requires `datarobot>=2.17`, unconditionally
- `datarobot-moderations[all]` requires `datarobot>=3.6.0`

So the swap needs stable `datarobot` added to `[tool.uv].exclude-dependencies`, in the root project and again in `e2e-tests` because it carries its own lockfile. With that in place, uv resolves to exactly one distribution.

## What this PR changes

- `setup.py`: the three `datarobot` pins (`[core]`, `[auth]`, `[fs]`) become `datarobot-early-access` at `>=3.19.0,<4.0.0`
- `pyproject.toml` and `e2e-tests/pyproject.toml`: exclude stable `datarobot`
- Relocked `uv.lock`, `e2e-tests/uv.lock`, `docs/uv.lock`
- Version bump to 0.26.20 plus CHANGELOG entry

## What already passes locally

| Check | Result |
| --- | --- |
| Unit suite (`tests`, CI's ignore list) | 4000 passed, 0 failed |
| `task mypy` (`--no-site-packages`) | clean, 327 files |
| `ruff check` / `ruff format --check` | clean, 667 files |
| Root lock resolves | one distribution, stable `datarobot` absent |
| `e2e-tests` venv (`uv sync --group dragent-langgraph`) | one distribution, imports fine |
| Wheel build | metadata correctly declares `datarobot-early-access` |

The two `test_config.py` tests that fail on stable 3.18.0 pass here, which is the whole reason the probe is interesting.

## Findings so far

**1. Early-access prints a banner on every `import datarobot`.** Its `__init__.py` unconditionally imports `datarobot._experimental.pipelines`, which emits three lines:

```
You have imported from the _experimental directory.
This directory is used for unreleased datarobot features.
Unless you specifically know better, you don't have the access to use this functionality in the app, so this code will not work.
```

This goes to **stderr**, not stdout, so MCP stdio framing is safe. It will still show up in every CI log and every agent container's logs. Stable `datarobot` does not ship `_experimental` at all, so this is early-access-only noise.

**2. The exclusion does not protect downstream consumers.** `exclude-dependencies` is a uv-only mechanism. It never reaches wheel metadata, so anyone doing a plain `pip install datarobot-genai[core]` from the built wheel gets both:

```
datarobot==3.18.0
datarobot-early-access==3.19.0.2026.8.3.173957
```

Installing both in one env produces a genuinely misleading state. The metadata and the code disagree:

```
importlib.metadata says datarobot           == 3.18.0
importlib.metadata says datarobot-early-access == 3.19.0.2026.8.3.173957
code actually loaded                        == 3.19.0b0
```

Whichever wheel unpacks last owns the files, while both dist-infos stay on disk. Anything that trusts installed metadata (resolvers, `pip check`, SBOM and vulnerability scanners, our own version gates) reads a version that is not the code running. That is the failure mode we should assume we cannot fix from inside this repo, and it is the strongest argument against doing this swap for real in a published library.

## What we want CI to answer

- Do the e2e agent matrices (nat / langgraph / crewai / llamaindex) resolve and run
- Do the integration and acceptance jobs behave, particularly anything asserting on `datarobot` version or metadata
- Whether the `_experimental` banner breaks any log-scraping or output-matching assertions
- Whether the publish-testpypi path is happy with the swapped metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)
