### PR TITLE
Dragent a2a tasks artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.17
+- `dragent`: added A2A **Tasks, Artifacts, Files and Images** support via the new
+  `datarobot_genai.dragent.a2a_artifacts` module. NAT's `NATWorkflowAgentExecutor` is
+  message-only (`get_user_input()` drops inbound files, `to_type=str` flattens the result,
+  and it returns a bare `Message`) — and because A2A `Artifact`s only exist on a `Task`,
+  artifacts were structurally impossible, not merely unsupported.
+  - An application implements one method — `ArtifactBuilder.build_artifacts(inputs,
+    response_text)` — and returns artifacts built with the module-level helpers
+    `text_artifact`, `data_artifact`, `file_artifact` (inline `FileWithBytes`),
+    `file_uri_artifact` (`FileWithUri`), and `mixed_artifact` (several part kinds in one
+    artifact). No base class, no imports from private modules.
+  - `extract_request_inputs()` parses **every** inbound part kind (text, file, data) into
+    `A2ARequestInputs` / `InboundFile`, with tolerant base64 decoding so one malformed
+    attachment cannot fail a request.
+  - `TaskArtifactAgentExecutor` owns the whole lifecycle — task creation, state
+    transitions, artifact publication, failure handling, cancellation. It is concrete and
+    public; subclass it directly to override `run_workflow`.
+  - `cancel()` now publishes a terminal `canceled` state instead of always raising
+    `UnsupportedOperationError`. Best-effort bookkeeping — it does not preempt in-flight work.
+- `dragent`: added `a2a.artifact_builder` — a dotted import path to an `ArtifactBuilder`
+  implementation. Applications publish Tasks and Artifacts without registering a
+  front-end plugin. Misconfiguration (bad path, non-class, missing `build_artifacts`) is
+  reported at startup rather than at request time.
+- `dragent`: added `a2a.task_mode` (`auto` | `always` | `never`). Both `Task` and `Message`
+  are valid `message/send` results, so the response shape is now selectable: `auto`
+  (default) returns a `Message` when the builder produces no artifacts and a `Task` when it
+  does; `always` opens a `Task` up front and emits `submitted → working → completed` for
+  long-running work; `never` always replies with a `Message`. Default `auto` is
+  non-breaking for existing callers.
+- `dragent`: the internal per-user A2A executor gained a single `_run_request` seam.
+  Response behaviour is layered by overriding that instead of `execute()`, so per-user
+  identity resolution and inbound-header forwarding (which Okta cross-application access
+  depends on) cannot be bypassed by a subclass.
+
 ## 0.26.16
 - Added `mcp_enable_unauthenticated_well_known_route` MCP config.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Response behaviour is layered by overriding that instead of `execute()`, so per-user
   identity resolution and inbound-header forwarding (which Okta cross-application access
   depends on) cannot be bypassed by a subclass.
+- `dragent`: added the **consuming** half via the new
+  `datarobot_genai.dragent.a2a_artifact_client` module. NAT flattens A2A in both
+  directions — `A2ABaseClient.send_message(message_text: str)` can only build a
+  text-only `Message`, and `extract_text_from_events()` discards artifacts — so an
+  agent could neither send files nor read artifacts back. Neither is a protocol limit:
+  the raw events already carry every artifact.
+  - `OutboundFile` plus `build_client_message` / `build_send_message_payload` put text,
+    files (inline `FileWithBytes` or referenced `FileWithUri`) and structured
+    `DataPart`s on the wire, typed or as raw JSON-RPC.
+  - `iter_artifacts`, `summarize_task` and `save_task_files` read them back.
+    `iter_artifacts` de-duplicates by `artifact_id`, since a task and its update
+    events can both reference the same artifact. `save_task_files` writes inline files
+    only, flattening names to their basename so an artifact cannot traverse out of the
+    output directory.
+- `dragent`: `authenticated_a2a_client` gained `send_parts()`, which sends a full
+  multi-part `Message` through the function group's own authenticated client — so the
+  Okta cross-application-access exchange applies exactly as it does to a text-only
+  call. Applications no longer need to reach into `_client._client` to borrow it.
+- `dragent`: added the `artifact_client` config key to `authenticated_a2a_client`
+  (default `false`). When set, registers two further functions alongside NAT's
+  text-only `call`: `send_with_attachments` (send text, structured data and file URIs;
+  returns a rendered report of every artifact) and `get_task_artifacts` (re-read a
+  known task's artifacts). Opt-in because registering functions changes which tools an
+  agent's LLM can select; unset, tool selection is unchanged.
 
 ## 0.26.24
 - Initial cve-sync resync of constraints and overrides.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `extract_request_inputs()` parses **every** inbound part kind (text, file, data) into
     `A2ARequestInputs` / `InboundFile`, with tolerant base64 decoding so one malformed
     attachment cannot fail a request.
+  - `A2ARequestInputs` also carries the conversational context a builder needs to decide
+    *what* to return, rather than only what was attached: `message_id`, `task_id`,
+    `context_id` (stable across turns), the inbound message's `metadata` (for
+    out-of-band hints such as requested output formats), `history` (prior `Message`
+    objects on a continued task) and the raw `context` as an escape hatch, plus
+    `is_follow_up`, `history_text(limit=...)` and `asked_for(*keywords)` helpers. The
+    `ArtifactBuilder` signature is unchanged — the extra information arrives on the
+    existing `inputs` argument, so existing builders keep working.
   - `TaskArtifactAgentExecutor` owns the whole lifecycle — task creation, state
     transitions, artifact publication, failure handling, cancellation. It is concrete and
     public; subclass it directly to override `run_workflow`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   multi-part `Message` through the function group's own authenticated client — so the
   Okta cross-application-access exchange applies exactly as it does to a text-only
   call. Applications no longer need to reach into `_client._client` to borrow it.
+- `dragent`: `outbound_file_from_uri()` derives an attachment's filename and MIME type
+  from a URI's **path** rather than the whole URI. Pre-signed URLs are the documented
+  way to send a file by reference and they carry a query string, which previously
+  defeated type inference (everything became `application/octet-stream`) and left the
+  signature parameters in the filename. `send_with_attachments` uses it.
+- `dragent`: under `task_mode="auto"` (and `"never"`), a malformed A2A message is now
+  rejected **before** the workflow runs. `new_task()` validates the message as a side
+  effect, and it was only reached after artifact assembly, so an otherwise successful
+  run could end as `InvalidParamsError` with its artifacts discarded. The task is now
+  built up front and published only if one is needed.
 - `dragent`: added the `artifact_client` config key to `authenticated_a2a_client`
   (default `false`). When set, registers two further functions alongside NAT's
   text-only `call`: `send_with_attachments` (send text, structured data and file URIs;

--- a/docs/properdocs.yml
+++ b/docs/properdocs.yml
@@ -113,6 +113,7 @@ nav:
     - Caveats: nat/caveats.md
   - DRAgent:
     - dragent/README.md
+    - A2A Tasks & Artifacts: dragent/a2a-artifacts.md
     - Tracing: dragent/tracing.md
   - DR Tools:
     - drtools/README.md

--- a/docs/src/dragent/a2a-artifacts.md
+++ b/docs/src/dragent/a2a-artifacts.md
@@ -213,11 +213,92 @@ class StructuredExecutor(TaskArtifactAgentExecutor):
 `TaskArtifactAgentExecutor` is concrete and public, with a single base class — there
 is no base-ordering requirement to get wrong.
 
+## The other side: consuming artifacts
+
+Everything above makes an agent *return* artifacts. The mirror problem is that a
+*calling* agent can neither send files nor read artifacts back, because NAT
+flattens A2A in both directions:
+
+| Direction | NAT flattens at | Consequence |
+|---|---|---|
+| Sending | `A2ABaseClient.send_message(message_text: str)` | builds a text-only `Message` |
+| Reading | `A2ABaseClient.extract_text_from_events()` | artifacts silently discarded |
+
+Neither is a protocol limit — the raw events already carry every artifact.
+`datarobot_genai.dragent.a2a_artifact_client` supplies the missing helpers.
+
+### From an LLM: one config line
+
+```yaml
+function_groups:
+  finance_agent:
+    _type: authenticated_a2a_client
+    registry:
+      external_id: agent-finance
+    auth_provider: okta_auth
+    artifact_client: true
+```
+
+That registers two functions alongside NAT's text-only `call`:
+
+| Function | Purpose |
+|---|---|
+| `send_with_attachments(message, attach_data=None, attach_uris=None)` | Sends text, structured data and file URIs; returns a rendered report of the Task and every artifact |
+| `get_task_artifacts(task_id)` | Re-reads a known task's artifacts |
+
+Naming the group in `tool_names` exposes both automatically.
+
+!!! note "Why this is opt-in"
+    Registering functions changes which tools an agent's LLM can select, so
+    `artifact_client` defaults to `false`. Unset, tool selection is unchanged.
+
+Files go by **URI** here rather than by content, because a model cannot emit raw
+bytes. To send bytes, call `send_parts()` from code.
+
+### From code: bytes, and structured access
+
+```python
+from datarobot_genai.dragent.a2a_artifact_client import (
+    OutboundFile, iter_artifacts, save_task_files, summarize_task,
+)
+
+group = await builder.get_function_group("finance_agent")
+
+events = await group.send_parts(
+    text="analyse this",
+    files=[OutboundFile("in.png", "image/png", content=png_bytes)],
+    data={"threshold": 0.5},
+)
+
+for artifact in iter_artifacts(events):        # every Artifact, de-duplicated
+    ...
+paths = save_task_files(events, "/tmp/out")    # inline files written to disk
+report = summarize_task(events)                # text rendering, for a tool result
+```
+
+`send_parts()` goes through the function group's own authenticated client, so the
+Okta cross-application-access exchange applies exactly as it does to a text-only
+call. Applications never need to reach into the client to borrow it.
+
+### Rendering vs access
+
+`summarize_task()` returns **text**, because a NAT function's return value becomes
+an LLM tool result: previews are truncated and files are reported by name, type and
+size rather than inlined. When code consumes the result, prefer `iter_artifacts()`
+and `save_task_files()`.
+
+`save_task_files()` writes inline files only — a `FileWithUri` carries none of the
+call's authentication, so fetching it is the caller's problem — and flattens names
+to their basename, so an artifact cannot write outside the output directory.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
 | Response is `"kind": "message"` with no artifacts | No `artifact_builder` configured, or the builder returned `[]` | Set `a2a.artifact_builder`; check the builder's return value |
+| `send_with_attachments` not offered to the LLM | `artifact_client` not set | Set `artifact_client: true` on the function group; confirm the group is named in `tool_names` |
+| `A2A client not initialized` from `send_parts()` | Function group not entered | Resolve it via `builder.get_function_group(...)`, which enters it |
+| `A2A client unavailable: agent card registry lookup failed` | Degraded mode after a registry miss | Fix `registry.external_id` / `deployment_id`; check `DATAROBOT_API_TOKEN` |
 | `a2a.artifact_builder ... is not a class` / `Could not import` | Bad dotted path | Use `package.module.ClassName`; confirm it is importable from the agent's working directory |
 | `... does not implement build_artifacts` | Class lacks the method | Implement `async def build_artifacts(self, inputs, response_text)` |
 | Artifacts vanish; only text arrives | Caller is reading with a text-only client | Read `result.artifacts`; text-only callers concatenate `TextPart`s and drop the rest |
@@ -227,7 +308,11 @@ is no base-ordering requirement to get wrong.
 
 ## API reference
 
-Full signatures and docstrings for every public name — `ArtifactBuilder`,
-`OutboundArtifact`, `TaskArtifactAgentExecutor`, `A2ARequestInputs`, `InboundFile`,
-and the `*_artifact` helpers — are generated from the source under
-**API → dragent → a2a_artifacts**.
+Full signatures and docstrings for every public name are generated from the source:
+
+- **API → dragent → a2a_artifacts** (producing) — `ArtifactBuilder`,
+  `OutboundArtifact`, `TaskArtifactAgentExecutor`, `A2ARequestInputs`,
+  `InboundFile`, and the `*_artifact` helpers.
+- **API → dragent → a2a_artifact_client** (consuming) — `OutboundFile`,
+  `build_client_message`, `build_send_message_payload`, `iter_artifacts`,
+  `summarize_task`, `save_task_files`.

--- a/docs/src/dragent/a2a-artifacts.md
+++ b/docs/src/dragent/a2a-artifacts.md
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2026 DataRobot, Inc. and its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
 # A2A Tasks, Artifacts, Files and Images
 
 By default a DRAgent A2A server replies with a plain text `Message`. To return

--- a/docs/src/dragent/a2a-artifacts.md
+++ b/docs/src/dragent/a2a-artifacts.md
@@ -213,6 +213,49 @@ class StructuredExecutor(TaskArtifactAgentExecutor):
 `TaskArtifactAgentExecutor` is concrete and public, with a single base class — there
 is no base-ordering requirement to get wrong.
 
+## Deciding what to return
+
+A builder is not obliged to return a fixed set. `inputs` carries the request and the
+conversation around it, so output can vary per call:
+
+| Field | Use it for |
+|---|---|
+| `inputs.text` | What was asked. `inputs.asked_for("chart", "csv")` is a case-insensitive convenience |
+| `inputs.files` / `inputs.data` | Inbound attachments — echo, transform, or analyse them |
+| `inputs.metadata` | Out-of-band hints from the caller, e.g. `{"formats": ["csv"]}`. More reliable than keywords when the caller is code rather than a person |
+| `inputs.context_id` | Stable across turns — key on this to correlate an exchange |
+| `inputs.task_id` / `inputs.is_follow_up` | Whether this continues an existing task |
+| `inputs.history` / `inputs.history_text(limit=n)` | Prior turns on the task, oldest first. Empty on a first turn *and* when the client didn't request history — treat empty as "unknown" |
+| `inputs.context` | The raw `RequestContext`, as an escape hatch. Prefer the named fields |
+
+```python
+class FinanceArtifacts:
+    async def build_artifacts(self, inputs, response_text):
+        artifacts = [text_artifact("summary", response_text)]
+
+        # Rendering is the expensive part, and base64 inflates the response
+        # ~33% -- so earn it rather than doing it every time.
+        requested = {f.lower() for f in (inputs.metadata.get("formats") or [])}
+        if inputs.asked_for("chart", "graph", "trend") or "png" in requested:
+            artifacts.append(file_artifact("chart.png", render_chart(), "image/png"))
+
+        # Don't re-send a reference the caller already has.
+        if not any("reference-doc" in t for t in inputs.history_text()):
+            artifacts.append(file_uri_artifact("reference-doc", DOC_URL, "text/html"))
+
+        return artifacts
+```
+
+Returning `[]` is meaningful: under the default `task_mode: auto` it produces a plain
+`Message` rather than an empty `Task`. That is the intended way to say "nothing
+task-shaped this time".
+
+!!! note "What the builder does *not* see"
+    The workflow's intermediate steps — which tools ran and what they returned — are
+    not surfaced. `run_workflow` returns only the final text. If you need to build an
+    artifact from a tool's raw output, subclass `TaskArtifactAgentExecutor` and
+    override `run_workflow`.
+
 ## The other side: consuming artifacts
 
 Everything above makes an agent *return* artifacts. The mirror problem is that a

--- a/docs/src/dragent/a2a-artifacts.md
+++ b/docs/src/dragent/a2a-artifacts.md
@@ -1,0 +1,217 @@
+# A2A Tasks, Artifacts, Files and Images
+
+By default a DRAgent A2A server replies with a plain text `Message`. To return
+**files, images, or structured data**, configure an *artifact builder*: one class
+with one method.
+
+## Why this is needed
+
+NAT's A2A adapter is *Phase 1 / message-only*. It reads text from the inbound
+request and discards file and data parts, flattens the workflow result to a string,
+and returns a bare `Message`.
+
+In the A2A specification, `Artifact` objects only exist on a `Task` — a `Message`
+has no `artifacts` field. So artifacts are not merely unsupported through that
+path; they are **structurally impossible**. `datarobot_genai.dragent.a2a_artifacts`
+supplies the missing half: full inbound part parsing, and a task lifecycle that can
+carry artifacts.
+
+## Quick start
+
+Implement a builder:
+
+```python
+# myapp/finance.py
+from datarobot_genai.dragent.a2a_artifacts import (
+    data_artifact,
+    file_artifact,
+    text_artifact,
+)
+
+
+class FinanceArtifacts:
+    async def build_artifacts(self, inputs, response_text):
+        return [
+            text_artifact("summary", response_text),
+            data_artifact("analysis", {"symbol": "AAPL", "change_pct": 1.2}),
+            file_artifact("chart.png", render_chart(), "image/png"),
+        ]
+```
+
+Reference it from `workflow.yaml`:
+
+```yaml
+general:
+  front_end:
+    _type: dragent_fastapi
+    a2a:
+      server:
+        name: Finance Agent
+        description: Answers questions about market data.
+      artifact_builder: "myapp.finance.FinanceArtifacts"
+      task_mode: auto
+```
+
+That is the whole integration. No custom front-end plugin, no subclassing, no
+imports from private modules.
+
+## Concepts
+
+An **artifact** is a *named container* of parts — it is not itself binary data.
+Binary payloads travel inside a file part. One artifact may hold several part kinds
+at once.
+
+| Part kind | Carries | Helper |
+|---|---|---|
+| `TextPart` | human-readable text | `text_artifact` |
+| `DataPart` | structured JSON | `data_artifact` |
+| `FilePart` / `FileWithBytes` | a file, inlined as base64 | `file_artifact` |
+| `FilePart` / `FileWithUri` | a file, by reference | `file_uri_artifact` |
+| several at once | summary + data + file together | `mixed_artifact` |
+
+## Response shape: `task_mode`
+
+Both `Task` and `Message` are valid results for `message/send`
+(`SendMessageSuccessResponse.result: Task | Message`), so the response shape is
+selectable.
+
+| Mode | Behaviour | Use when |
+|---|---|---|
+| `auto` *(default)* | Run the workflow, then decide: no artifacts → `Message`; one or more → `Task` carrying them. No progress events, because the outcome decides the shape. | Most agents. Non-breaking for callers that expect a message. |
+| `always` | Open the `Task` up front and emit `submitted` → `working` → `completed`. | Callers need progress on long-running work, or the agent always produces artifacts. |
+| `never` | Always reply with a `Message`, even if the builder returns artifacts. | Explicit opt-out. |
+
+There is a genuine trade-off between `auto` and `always`. Emitting `working`
+requires committing to a `Task` *before* the workflow has run, so it cannot depend
+on whether artifacts exist. `auto` therefore has no progress events; `always` has
+them but is always task-shaped.
+
+## Reading inbound files
+
+`build_artifacts` receives an `A2ARequestInputs` carrying **everything** the caller
+sent, not just text:
+
+```python
+class DescribeUpload:
+    async def build_artifacts(self, inputs, response_text):
+        for file in inputs.files:
+            print(file.describe())        # "chart.png (image/png, 4096 bytes inline)"
+            if file.is_inline:
+                process(file.content)     # decoded bytes
+            else:
+                fetch(file.uri)           # FileWithUri reference
+
+        return [data_artifact("received", {"count": len(inputs.files)})]
+```
+
+| Attribute | Description |
+|---|---|
+| `inputs.text` | Concatenated text of every `TextPart` |
+| `inputs.files` | Every `FilePart`, decoded into `InboundFile` |
+| `inputs.data` | The `data` payload of every `DataPart` |
+| `inputs.has_attachments` | `True` when any file or data part was sent |
+
+An `InboundFile` has exactly one of `content` (inline bytes) or `uri` (reference),
+mirroring the spec's `FileWithBytes` / `FileWithUri` union. Base64 decoding is
+tolerant of newline-wrapped and base64url payloads; an attachment that cannot be
+decoded is logged and skipped rather than failing the whole request.
+
+A **file-only request** ("here is an image, describe it") is legitimate under the
+A2A spec and is supported — the workflow simply receives an empty query.
+
+## Choosing a file representation
+
+```python
+# Inline: self-contained, but base64 inflates the payload by ~33%.
+file_artifact("chart.png", png_bytes, "image/png")
+
+# By reference: scales to large files, but the caller must be able to reach it.
+file_uri_artifact("report.csv", "https://example.com/report.csv", "text/csv")
+```
+
+A URI inherits no A2A credentials. Use a pre-signed URL or a separately authorised
+endpoint — otherwise the caller will be unable to fetch it.
+
+## Multi-part artifacts
+
+Most real deliverables are a summary, the machine-readable equivalent, and the
+generated file, delivered as one named unit:
+
+```python
+mixed_artifact(
+    "q3-report",
+    text="Revenue up 4.1% quarter over quarter.",
+    data={"revenue_change_pct": 4.1},
+    files=[("q3.csv", csv_bytes, "text/csv")],
+)
+```
+
+## Advertise your modalities
+
+If your agent can return files, declare that on the agent card. The card describes
+*capability*, not what any single response happened to contain — a text-only card
+tells callers not to expect files, and some will not look for them.
+
+```yaml
+a2a:
+  server:
+    name: Finance Agent
+    default_input_modes: ["text/plain", "image/png"]
+    default_output_modes: ["text/plain", "application/json", "image/png", "text/csv"]
+```
+
+## Multi-turn conversations
+
+Reuse **`contextId`**, not `taskId`. A task that has reached a terminal state
+cannot be continued — the A2A request handler rejects a follow-up that references
+one. `contextId` is what threads related tasks together.
+
+## Cancellation
+
+`tasks/cancel` publishes a terminal `canceled` state so the caller stops waiting.
+
+This is **best-effort bookkeeping, not preemption**: work already in flight is not
+interrupted, because NAT exposes no cancellation hook into a running session. Any
+compute already started runs to completion and its result is discarded. If you need
+true cancellation, subclass `TaskArtifactAgentExecutor`, thread a cancellation
+token through `run_workflow`, and check it between steps.
+
+## Advanced: customising workflow invocation
+
+The builder hook covers most cases. To change *how* the workflow is invoked — for
+example to keep a structured result rather than a flattened string — subclass the
+executor directly:
+
+```python
+from datarobot_genai.dragent.a2a_artifacts import TaskArtifactAgentExecutor
+
+
+class StructuredExecutor(TaskArtifactAgentExecutor):
+    async def run_workflow(self, inputs, context):
+        async with self.session_manager.session() as session:
+            async with session.run(inputs.text) as runner:
+                self.last_result = await runner.result(to_type=MyModel)
+                return self.last_result.summary
+```
+
+`TaskArtifactAgentExecutor` is concrete and public, with a single base class — there
+is no base-ordering requirement to get wrong.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Response is `"kind": "message"` with no artifacts | No `artifact_builder` configured, or the builder returned `[]` | Set `a2a.artifact_builder`; check the builder's return value |
+| `a2a.artifact_builder ... is not a class` / `Could not import` | Bad dotted path | Use `package.module.ClassName`; confirm it is importable from the agent's working directory |
+| `... does not implement build_artifacts` | Class lacks the method | Implement `async def build_artifacts(self, inputs, response_text)` |
+| Artifacts vanish; only text arrives | Caller is reading with a text-only client | Read `result.artifacts`; text-only callers concatenate `TextPart`s and drop the rest |
+| Caller cannot fetch a URI file | The URI inherits no A2A auth | Use a pre-signed URL, or inline the bytes |
+| Large or slow responses | Big files inlined as base64 | Switch to `file_uri_artifact` |
+| `Task failed: ...` in a text message | The builder or workflow raised | Check the deployment logs; the traceback is logged |
+
+## API reference
+
+Full signatures and docstrings for every public name — `ArtifactBuilder`,
+`OutboundArtifact`, `TaskArtifactAgentExecutor`, `A2ARequestInputs`, `InboundFile`,
+and the `*_artifact` helpers — are generated from the source under
+**API → dragent → a2a_artifacts**.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -187,7 +187,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.24"
+version = "0.26.25"
 source = { editable = "../" }
 
 [package.metadata]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -145,7 +145,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.12"
+version = "0.26.17"
 source = { editable = "../" }
 
 [package.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.16"
+version = "0.26.17"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/a2a_artifact_client.py
+++ b/src/datarobot_genai/dragent/a2a_artifact_client.py
@@ -335,29 +335,51 @@ def _iter_tasks(events: list[Any]) -> list[Any]:
 def iter_artifacts(events: list[Any]) -> list[Any]:
     """Collect every ``Artifact`` from a list of A2A response events.
 
-    Handles both response shapes -- a bare ``Message`` (which carries no
-    artifacts) and ``ClientEvent`` tuples carrying a ``Task`` -- and
-    de-duplicates by ``artifact_id``, because a task and its update events can
-    both reference the same artifact.
+    Handles both response shapes: a bare ``Message`` (which carries no artifacts)
+    and ``ClientEvent`` tuples carrying a ``Task``.
+
+    Artifacts are keyed by ``artifact_id``, because a task and its update events
+    can both reference the same artifact. A2A permits an artifact to arrive in
+    **chunks** (``TaskArtifactUpdateEvent.append``), so repeat sightings of an id
+    have their parts *merged* rather than discarded -- taking only the first
+    sighting would silently truncate a chunked artifact. Parts already present are
+    not duplicated, so a peer that re-sends a complete artifact is handled too.
 
     Args:
         events: Events returned by a parts-aware send.
 
     Returns:
-        Artifacts in first-seen order. Empty if the peer replied with a
-        ``Message``, or with a ``Task`` carrying none.
+        Artifacts in first-seen order, each carrying every part observed for it.
+        Empty if the peer replied with a ``Message``, or with a ``Task`` carrying
+        none.
     """
     artifacts: list[Any] = []
-    seen: set[str] = set()
+    by_key: dict[str, Any] = {}
+    anonymous = 0
 
     for task in _iter_tasks(events):
         for artifact in getattr(task, "artifacts", None) or []:
             artifact_id = getattr(artifact, "artifact_id", None)
-            key = str(artifact_id) if artifact_id else f"_anon_{len(seen)}"
-            if key in seen:
+            if artifact_id:
+                key = str(artifact_id)
+            else:
+                # No id to correlate on, so it cannot be a chunk of anything.
+                key = f"_anon_{anonymous}"
+                anonymous += 1
+
+            existing = by_key.get(key)
+            if existing is None:
+                by_key[key] = artifact
+                artifacts.append(artifact)
                 continue
-            seen.add(key)
-            artifacts.append(artifact)
+
+            # Same artifact seen again: merge any parts we haven't already got.
+            known = getattr(existing, "parts", None)
+            if known is None:
+                continue
+            for part in getattr(artifact, "parts", None) or []:
+                if part not in known:
+                    known.append(part)
 
     return artifacts
 

--- a/src/datarobot_genai/dragent/a2a_artifact_client.py
+++ b/src/datarobot_genai/dragent/a2a_artifact_client.py
@@ -1,0 +1,502 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client-side A2A Files, Images, Data and Artifacts -- the consuming half.
+
+:mod:`datarobot_genai.dragent.a2a_artifacts` lets an agent **return** Tasks and
+Artifacts.  This module lets an agent **send** files and **read** artifacts back,
+which is the same upstream gap mirrored on the caller's side of the hop:
+
+============  ==========================================================  ==============================
+Direction     NAT flattens at                                             Consequence
+============  ==========================================================  ==============================
+Sending       ``A2ABaseClient.send_message(message_text: str)``            builds a text-only ``Message``
+Reading       ``A2ABaseClient.extract_text_from_events()``                 artifacts silently discarded
+============  ==========================================================  ==============================
+
+Neither is a protocol limitation.  The raw ``events`` NAT yields already carry
+every artifact; what is missing is a way to *put* non-text parts on the wire and
+helpers to *get* the non-text parts back off it.  This module supplies both.
+
+Usage
+-----
+Enable the artifact-aware functions on an authenticated A2A client::
+
+    function_groups:
+      finance_agent:
+        _type: authenticated_a2a_client
+        registry:
+          external_id: agent-finance
+        auth_provider: okta_auth
+        artifact_client: true
+
+That registers two extra functions alongside NAT's text-only ``call``:
+
+``send_with_attachments``
+    Sends text plus optional files and structured data, and returns a rendered
+    report of the Task and every artifact.
+``get_task_artifacts``
+    Re-reads the artifacts of a known ``task_id``.
+
+For programmatic access, use the readers directly::
+
+    from datarobot_genai.dragent.a2a_artifact_client import (
+        OutboundFile, iter_artifacts, save_task_files,
+    )
+
+    events = await group.send_parts(
+        text="analyse this",
+        files=[OutboundFile("in.csv", "text/csv", content=csv_bytes)],
+    )
+    for artifact in iter_artifacts(events):
+        ...
+    paths = save_task_files(events, "/tmp/out")
+
+Rendering vs access
+-------------------
+:func:`summarize_task` renders artifacts as **text**, because a NAT function's
+return value becomes an LLM tool result.  That is a presentation choice, not a
+protocol one -- prefer :func:`iter_artifacts` and :func:`save_task_files` when
+code, rather than a model, consumes the result.
+
+.. note::
+   This module bridges an upstream gap.  If NAT gains native multi-part send and
+   artifact reads, prefer those; the surface here is intentionally small so
+   migration stays cheap.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from a2a.types import DataPart
+from a2a.types import FilePart
+from a2a.types import FileWithBytes
+from a2a.types import FileWithUri
+from a2a.types import Message
+from a2a.types import Part
+from a2a.types import Role
+from a2a.types import TextPart
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "OutboundFile",
+    "build_client_message",
+    "build_send_message_payload",
+    "iter_artifacts",
+    "save_task_files",
+    "summarize_task",
+]
+
+# Cap the number of bytes a rendered summary will echo per text part, so a large
+# artifact cannot blow an LLM's context window through a tool result.
+_TEXT_PREVIEW_CHARS = 120
+
+
+# ---------------------------------------------------------------------------
+# Outbound: putting non-text parts on the wire
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OutboundFile:
+    """A file to attach to an outbound A2A message.
+
+    Set :attr:`content` to inline the bytes (A2A ``FileWithBytes``) **or**
+    :attr:`uri` to send a reference (``FileWithUri``) -- the two are mutually
+    exclusive in the protocol.
+
+    Inline is simpler but base64 inflates the payload by roughly a third, so
+    prefer :attr:`uri` for large files. Note that a URI carries no A2A
+    authentication: the receiving agent must be able to fetch it independently,
+    which usually means a pre-signed URL.
+
+    Attributes:
+        name: Filename advertised to the receiving agent.
+        mime_type: MIME type, e.g. ``image/png``.
+        content: Raw bytes to inline. Base64-encoded for you.
+        uri: Remote location, when referencing rather than inlining.
+
+    Raises:
+        ValueError: If neither or both of ``content`` and ``uri`` are set.
+    """
+
+    name: str
+    mime_type: str
+    content: bytes | None = None
+    uri: str | None = None
+
+    def __post_init__(self) -> None:
+        # Compare against None rather than truthiness, so a legitimate zero-byte
+        # file (content=b"") is not mistaken for "unset".
+        if (self.content is None) == (self.uri is None):
+            raise ValueError(
+                f"OutboundFile {self.name!r}: set exactly one of 'content' or 'uri' "
+                "(A2A FileWithBytes and FileWithUri are mutually exclusive)."
+            )
+
+    def to_part(self) -> Part:
+        """Return this file as a typed A2A ``FilePart``.
+
+        Returns:
+            A ``Part`` wrapping either ``FileWithBytes`` or ``FileWithUri``.
+        """
+        file_obj: FileWithBytes | FileWithUri
+        if self.content is not None:
+            file_obj = FileWithBytes(
+                bytes=base64.b64encode(self.content).decode("ascii"),
+                mime_type=self.mime_type,
+                name=self.name,
+            )
+        else:
+            file_obj = FileWithUri(
+                uri=self.uri or "", mime_type=self.mime_type, name=self.name
+            )
+        return Part(root=FilePart(file=file_obj))
+
+    def to_wire(self) -> dict[str, Any]:
+        """Return this file as the ``file`` object of a raw JSON-RPC ``FilePart``.
+
+        Note the **camelCase** ``mimeType``: A2A models use snake_case in Python
+        but serialise to camelCase on the wire.
+
+        Returns:
+            A plain dict, for use with :func:`build_send_message_payload`.
+        """
+        if self.content is not None:
+            return {
+                "bytes": base64.b64encode(self.content).decode("ascii"),
+                "mimeType": self.mime_type,
+                "name": self.name,
+            }
+        return {"uri": self.uri, "mimeType": self.mime_type, "name": self.name}
+
+
+def build_client_message(
+    text: str | None = None,
+    files: list[OutboundFile] | None = None,
+    data: dict[str, Any] | None = None,
+    *,
+    task_id: str | None = None,
+    context_id: str | None = None,
+) -> Message:
+    """Build a typed ``Message`` carrying any mix of part kinds.
+
+    This is what NAT's ``send_message(message_text: str)`` cannot express: it
+    always constructs a single ``TextPart``.
+
+    Args:
+        text: Optional text body, becomes a ``TextPart``.
+        files: Optional attachments, each becoming a ``FilePart``.
+        data: Optional structured payload, becomes a ``DataPart``.
+        task_id: Set to continue an existing task (multi-turn).
+        context_id: Set to stay within an existing conversation context.
+
+    Returns:
+        A validated ``Message``, ready for the a2a-sdk client.
+
+    Raises:
+        ValueError: If no part of any kind was supplied.
+    """
+    parts: list[Part] = []
+    if text:
+        parts.append(Part(root=TextPart(text=text)))
+    for outbound_file in files or []:
+        parts.append(outbound_file.to_part())
+    # Compare against None so an intentionally empty dict still produces a part.
+    if data is not None:
+        parts.append(Part(root=DataPart(data=data)))
+
+    if not parts:
+        raise ValueError(
+            "An A2A message needs at least one part: pass text, files or data."
+        )
+
+    return Message(
+        role=Role.user,
+        parts=parts,
+        message_id=uuid.uuid4().hex,
+        task_id=task_id,
+        context_id=context_id,
+    )
+
+
+def build_send_message_payload(
+    text: str | None = None,
+    files: list[OutboundFile] | None = None,
+    data: dict[str, Any] | None = None,
+    *,
+    task_id: str | None = None,
+    context_id: str | None = None,
+    request_id: int | str = 1,
+) -> dict[str, Any]:
+    """Build a complete ``message/send`` JSON-RPC request as a plain dict.
+
+    The transparent counterpart to :func:`build_client_message`: the returned
+    dict is exactly what goes on the wire, which makes it useful for ``curl``
+    reproductions, documentation and tests. Prefer
+    :func:`build_client_message` in application code, where pydantic validation
+    is worth having.
+
+    Args:
+        text: Optional text body.
+        files: Optional attachments.
+        data: Optional structured payload.
+        task_id: Set to continue an existing task.
+        context_id: Set to stay within an existing conversation context.
+        request_id: JSON-RPC envelope id.
+
+    Returns:
+        The JSON-RPC request as a dict, ready for ``json=`` in an HTTP POST.
+
+    Raises:
+        ValueError: If no part of any kind was supplied.
+    """
+    parts: list[dict[str, Any]] = []
+    if text:
+        parts.append({"kind": "text", "text": text})
+    for outbound_file in files or []:
+        parts.append({"kind": "file", "file": outbound_file.to_wire()})
+    if data is not None:
+        parts.append({"kind": "data", "data": data})
+
+    if not parts:
+        raise ValueError(
+            "An A2A message needs at least one part: pass text, files or data."
+        )
+
+    message: dict[str, Any] = {
+        "role": "user",
+        "parts": parts,
+        "messageId": uuid.uuid4().hex,
+        "kind": "message",
+    }
+    if task_id:
+        message["taskId"] = task_id
+    if context_id:
+        message["contextId"] = context_id
+
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "message/send",
+        "params": {"message": message},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Inbound: recovering the parts NAT's text extraction discards
+# ---------------------------------------------------------------------------
+
+
+def _iter_tasks(events: list[Any]) -> list[Any]:
+    """Yield the ``Task`` carried by each event, tolerating both event shapes.
+
+    The a2a-sdk client yields either a bare ``Message`` or a ``ClientEvent``
+    tuple of ``(Task, UpdateEvent | None)``.
+
+    Args:
+        events: Events as returned by the client.
+
+    Returns:
+        Every object that looks like a ``Task``, in arrival order.
+    """
+    tasks: list[Any] = []
+    for event in events:
+        candidate = event[0] if isinstance(event, tuple) and event else event
+        # Duck-typed rather than isinstance: the SDK's Task is re-exported from
+        # several modules, and a strict check makes this brittle across versions.
+        if getattr(candidate, "status", None) is not None or hasattr(
+            candidate, "artifacts"
+        ):
+            tasks.append(candidate)
+    return tasks
+
+
+def iter_artifacts(events: list[Any]) -> list[Any]:
+    """Collect every ``Artifact`` from a list of A2A response events.
+
+    Handles both response shapes -- a bare ``Message`` (which carries no
+    artifacts) and ``ClientEvent`` tuples carrying a ``Task`` -- and
+    de-duplicates by ``artifact_id``, because a task and its update events can
+    both reference the same artifact.
+
+    Args:
+        events: Events returned by a parts-aware send.
+
+    Returns:
+        Artifacts in first-seen order. Empty if the peer replied with a
+        ``Message``, or with a ``Task`` carrying none.
+    """
+    artifacts: list[Any] = []
+    seen: set[str] = set()
+
+    for task in _iter_tasks(events):
+        for artifact in getattr(task, "artifacts", None) or []:
+            artifact_id = getattr(artifact, "artifact_id", None)
+            key = str(artifact_id) if artifact_id else f"_anon_{len(seen)}"
+            if key in seen:
+                continue
+            seen.add(key)
+            artifacts.append(artifact)
+
+    return artifacts
+
+
+def _decoded_size(b64: str) -> int:
+    """Return the decoded byte length of a base64 string, or 0 if unusable.
+
+    Args:
+        b64: Base64 text, as carried by ``FileWithBytes.bytes``.
+
+    Returns:
+        Decoded length in bytes; 0 when the value is absent or malformed.
+    """
+    if not b64:
+        return 0
+    try:
+        return len(base64.b64decode(b64, validate=False))
+    except (binascii.Error, ValueError):
+        return 0
+
+
+def summarize_task(events: list[Any]) -> str:
+    """Render a human-readable report of a Task, including non-text parts.
+
+    Use this instead of NAT's ``extract_text_from_events()`` when files, images
+    or structured data matter -- that helper returns text only.
+
+    The output is deliberately compact and text-only, because a NAT function's
+    return value becomes an LLM tool result: text previews are truncated and
+    file parts are reported by name, type and size rather than inlined. For
+    programmatic access use :func:`iter_artifacts`; to persist attachments use
+    :func:`save_task_files`.
+
+    Args:
+        events: Events returned by a parts-aware send.
+
+    Returns:
+        A multi-line report of task state and every artifact part.
+    """
+    if not events:
+        return "No response events."
+
+    lines: list[str] = []
+
+    tasks = _iter_tasks(events)
+    if tasks:
+        task = tasks[0]
+        status = getattr(task, "status", None)
+        state = getattr(status, "state", None)
+        lines.append(
+            f"Task {getattr(task, 'id', '?')} state={getattr(state, 'value', state)}"
+        )
+    else:
+        lines.append("Response was a bare Message (no Task was created).")
+
+    artifacts = iter_artifacts(events)
+    if not artifacts:
+        lines.append("No artifacts returned.")
+        return "\n".join(lines)
+
+    lines.append(f"{len(artifacts)} artifact(s):")
+    for artifact in artifacts:
+        lines.append(f"  - {getattr(artifact, 'name', None) or '<unnamed>'}")
+        for raw_part in getattr(artifact, "parts", None) or []:
+            part = raw_part.root if hasattr(raw_part, "root") else raw_part
+            kind = getattr(part, "kind", None)
+
+            if kind == "text":
+                preview = (getattr(part, "text", "") or "").replace("\n", " ")
+                lines.append(f"      text: {preview[:_TEXT_PREVIEW_CHARS]}")
+            elif kind == "data":
+                try:
+                    rendered = json.dumps(getattr(part, "data", None))
+                except (TypeError, ValueError):
+                    rendered = repr(getattr(part, "data", None))
+                lines.append(f"      data: {rendered[:_TEXT_PREVIEW_CHARS]}")
+            elif kind == "file":
+                file_obj = getattr(part, "file", None)
+                name = getattr(file_obj, "name", None) or "<unnamed>"
+                mime = getattr(file_obj, "mime_type", None) or "unknown"
+                uri = getattr(file_obj, "uri", None)
+                if uri:
+                    lines.append(f"      file: {name} ({mime}) uri={uri}")
+                else:
+                    size = _decoded_size(getattr(file_obj, "bytes", "") or "")
+                    lines.append(f"      file: {name} ({mime}) {size:,} bytes inline")
+            else:  # pragma: no cover - forward compatibility with new part kinds
+                lines.append(f"      {kind}: <unhandled part kind>")
+
+    return "\n".join(lines)
+
+
+def save_task_files(events: list[Any], output_dir: str | Path) -> list[Path]:
+    """Write every inline file artifact to disk.
+
+    Only ``FileWithBytes`` parts are written. ``FileWithUri`` parts are skipped,
+    because fetching them is the caller's problem: an A2A URI carries none of the
+    A2A call's authentication.
+
+    Filenames are flattened to their basename so an artifact cannot write outside
+    ``output_dir``.
+
+    Args:
+        events: Events returned by a parts-aware send.
+        output_dir: Directory to write into. Created if absent.
+
+    Returns:
+        Paths written, in artifact order.
+    """
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    for artifact in iter_artifacts(events):
+        for raw_part in getattr(artifact, "parts", None) or []:
+            part = raw_part.root if hasattr(raw_part, "root") else raw_part
+            if getattr(part, "kind", None) != "file":
+                continue
+            file_obj = getattr(part, "file", None)
+            payload = getattr(file_obj, "bytes", None)
+            if not payload:
+                continue
+
+            # Basename only: a malicious or careless peer must not be able to
+            # traverse out of output_dir with a name like "../../etc/passwd".
+            raw_name = getattr(file_obj, "name", None) or "artifact.bin"
+            safe_name = Path(str(raw_name)).name or "artifact.bin"
+
+            try:
+                decoded = base64.b64decode(payload, validate=False)
+            except (binascii.Error, ValueError):
+                logger.warning(
+                    "Skipping artifact file %s: payload is not valid base64", safe_name
+                )
+                continue
+
+            destination = directory / safe_name
+            destination.write_bytes(decoded)
+            written.append(destination)
+
+    logger.info("Wrote %d artifact file(s) to %s", len(written), directory)
+    return written

--- a/src/datarobot_genai/dragent/a2a_artifact_client.py
+++ b/src/datarobot_genai/dragent/a2a_artifact_client.py
@@ -82,9 +82,11 @@ import base64
 import binascii
 import json
 import logging
+import mimetypes
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Any
 
 from a2a.types import DataPart
@@ -102,6 +104,7 @@ __all__ = [
     "OutboundFile",
     "build_client_message",
     "build_send_message_payload",
+    "outbound_file_from_uri",
     "iter_artifacts",
     "save_task_files",
     "summarize_task",
@@ -189,6 +192,36 @@ class OutboundFile:
                 "name": self.name,
             }
         return {"uri": self.uri, "mimeType": self.mime_type, "name": self.name}
+
+
+def outbound_file_from_uri(uri: str) -> OutboundFile:
+    """Build an :class:`OutboundFile` referencing ``uri``, inferring name and type.
+
+    Both are derived from the URI's **path**, never the full URI. Pre-signed URLs
+    are the documented way to send a file and they carry a query string, so
+    inferring from the whole URI yields no MIME match (everything becomes
+    ``application/octet-stream``) and leaves the query blob in the filename.
+
+    Args:
+        uri: The location to reference. A query string is ignored for naming.
+
+    Returns
+    -------
+        An ``OutboundFile`` with ``uri`` set and nothing inlined.
+
+    Examples
+    --------
+        >>> f = outbound_file_from_uri("https://s3/bucket/q4.csv?X-Amz-Signature=abc")
+        >>> f.name, f.mime_type
+        ('q4.csv', 'text/csv')
+    """
+    path = urlparse(uri).path
+    name = path.rstrip("/").rsplit("/", 1)[-1] or "attachment"
+    return OutboundFile(
+        name=name,
+        mime_type=mimetypes.guess_type(name)[0] or "application/octet-stream",
+        uri=uri,
+    )
 
 
 def build_client_message(

--- a/src/datarobot_genai/dragent/a2a_artifacts.py
+++ b/src/datarobot_genai/dragent/a2a_artifacts.py
@@ -719,9 +719,18 @@ class TaskArtifactAgentExecutor:
         """Run first, then return a ``Message`` or a ``Task`` based on the outcome.
 
         Trade-off: because the choice depends on whether artifacts exist, the task
-        cannot be opened before the workflow runs, so no ``working`` event is
+        cannot be *published* before the workflow runs, so no ``working`` event is
         emitted.  Use ``task_mode="always"`` when progress matters more.
+
+        The task is still *built* up front, though never published unless needed:
+        ``new_task()`` validates the message, and discovering a malformed request
+        only after the workflow had run would turn a successful execution into an
+        ``InvalidParamsError`` and discard the artifacts with it.
         """
+        # Validate now, publish later (or never). Skipped when continuing an
+        # existing task, since that message was validated on its own turn.
+        prepared_task = None if context.current_task is not None else self._build_task(context)
+
         try:
             _, response_text, artifacts = await self._run(context)
         except Exception as exc:
@@ -747,7 +756,7 @@ class TaskArtifactAgentExecutor:
             logger.info("A2A request answered with a Message (%d artifacts)", len(artifacts))
             return
 
-        task = await self._ensure_task(context, event_queue)
+        task = await self._ensure_task(context, event_queue, prepared_task)
         updater = TaskUpdater(event_queue, task.id, task.context_id)
         try:
             await self._publish_artifacts(updater, artifacts)
@@ -783,9 +792,40 @@ class TaskArtifactAgentExecutor:
             await self._publish_failure(updater, task.id, exc)
             raise ServerError(error=InternalError()) from exc
 
-    @staticmethod
-    async def _ensure_task(context: RequestContext, event_queue: EventQueue) -> Any:
-        """Return the task for this request, creating and enqueuing one if needed.
+    def _build_task(self, context: RequestContext) -> Any:
+        """Create -- but do not publish -- the Task for this request.
+
+        ``new_task()`` validates the message as a side effect: it rejects an empty
+        ``TextPart``, for instance. Calling it *before* the workflow runs means a
+        malformed request is refused up front, rather than after the work is done
+        and the artifacts have to be thrown away.
+
+        Args:
+            context: Inbound A2A request context.
+
+        Returns
+        -------
+            A ``Task`` in ``submitted`` state, not yet enqueued.
+
+        Raises
+        ------
+            ServerError: ``InvalidParamsError`` if the message is malformed,
+                translated from ``new_task()``'s ``ValueError`` so callers get the
+                error the protocol expects.
+        """
+        try:
+            return new_task(context.message)  # state = submitted
+        except ValueError as exc:
+            logger.error("Rejecting malformed A2A message: %s", exc)
+            raise ServerError(error=InvalidParamsError(message=str(exc))) from exc
+
+    async def _ensure_task(
+        self,
+        context: RequestContext,
+        event_queue: EventQueue,
+        prepared: Any = None,
+    ) -> Any:
+        """Return the task for this request, publishing one if needed.
 
         A Task must exist before any status or artifact event can reference it.
 
@@ -794,18 +834,20 @@ class TaskArtifactAgentExecutor:
         follow-up referencing a terminal task before ``execute()`` is reached.
         Re-use ``contextId`` (not ``taskId``) to continue a conversation.
 
-        ``new_task()`` also validates the message (it rejects an empty
-        ``TextPart``), so that is translated into the error the caller expects
-        rather than leaking a bare ``ValueError``.
+        Args:
+            context: Inbound A2A request context.
+            event_queue: Queue the A2A server drains to stream events.
+            prepared: A Task already built by :meth:`_build_task`, reused so the
+                message is not validated twice and no id is generated twice.
+
+        Returns
+        -------
+            The Task every subsequent event will reference.
         """
         task = context.current_task
         if task is not None:
             return task
-        try:
-            task = new_task(context.message)  # state = submitted
-        except ValueError as exc:
-            logger.error("Rejecting malformed A2A message: %s", exc)
-            raise ServerError(error=InvalidParamsError(message=str(exc))) from exc
+        task = prepared if prepared is not None else self._build_task(context)
         await event_queue.enqueue_event(task)
         return task
 

--- a/src/datarobot_genai/dragent/a2a_artifacts.py
+++ b/src/datarobot_genai/dragent/a2a_artifacts.py
@@ -1,0 +1,812 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A2A Tasks, Artifacts, Files and Images for DRAgent front ends.
+
+NAT's :class:`~nat.plugins.a2a.server.agent_executor_adapter.NATWorkflowAgentExecutor`
+is explicitly *Phase 1 / message-only*: ``get_user_input()`` reads text and drops
+inbound files, ``to_type=str`` flattens the result, and it returns a bare
+``Message``.  Because A2A ``Artifact`` objects only exist on a ``Task``, artifacts
+are structurally impossible through that path -- not merely unsupported.
+
+This module supplies the missing half:
+
+* :func:`extract_request_inputs` parses **every** inbound part kind (text, file,
+  data), rather than text alone.
+* :class:`TaskArtifactAgentExecutor` owns the task lifecycle and publishes
+  artifacts, while inheriting the per-user identity and header forwarding that
+  Okta cross-application access depends on.
+* An application supplies only an :class:`ArtifactBuilder` -- one method, no base
+  class -- and the module-level ``*_artifact`` helpers to construct its outputs.
+
+Usage
+-----
+Implement a builder::
+
+    from datarobot_genai.dragent.a2a_artifacts import data_artifact, file_artifact
+
+    class FinanceArtifacts:
+        async def build_artifacts(self, inputs, response_text):
+            return [
+                data_artifact("analysis", {"symbol": "AAPL"}),
+                file_artifact("chart.png", png_bytes, "image/png"),
+            ]
+
+Then reference it from ``workflow.yaml``; no custom front-end plugin and no
+subclassing are required::
+
+    general:
+      front_end:
+        _type: dragent_fastapi
+        a2a:
+          server:
+            name: My Agent
+          artifact_builder: "myapp.finance.FinanceArtifacts"
+          task_mode: auto
+
+Response shape
+--------------
+Both ``Task`` and ``Message`` are valid results for ``message/send``
+(``SendMessageSuccessResponse.result: Task | Message``), so the response shape is
+selectable -- see :class:`TaskMode`.
+
+.. note::
+   This module bridges an upstream gap.  If NAT gains native task and artifact
+   support, prefer that; the surface here is intentionally small so migration
+   stays cheap.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import typing
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Protocol
+from typing import runtime_checkable
+
+from a2a.server.agent_execution import RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import DataPart
+from a2a.types import FilePart
+from a2a.types import FileWithBytes
+from a2a.types import FileWithUri
+from a2a.types import InternalError
+from a2a.types import InvalidParamsError
+from a2a.types import Part
+from a2a.types import TaskNotFoundError
+from a2a.types import TextPart
+from a2a.utils import new_agent_text_message
+from a2a.utils import new_task
+from a2a.utils.errors import ServerError
+
+logger = logging.getLogger(__name__)
+
+TaskMode = typing.Literal["auto", "always", "never"]
+"""Response strategy for :class:`TaskArtifactAgentExecutor`.
+
+``"auto"`` (default)
+    Run the workflow, then decide: no artifacts -> return a ``Message``; one or
+    more artifacts -> return a ``Task`` carrying them.  Because the decision needs
+    the outcome, no ``submitted``/``working`` progress events are emitted.
+    Non-breaking for callers that expect a message.
+``"always"``
+    Create the ``Task`` up front and emit ``submitted -> working -> completed``.
+    Use when callers need progress on long-running work, or when the agent always
+    produces artifacts.
+``"never"``
+    Never open a task; always return a ``Message`` built from the workflow text.
+"""
+
+__all__ = [
+    "A2ARequestInputs",
+    "ArtifactBuilder",
+    "InboundFile",
+    "OutboundArtifact",
+    "TaskArtifactAgentExecutor",
+    "TaskMode",
+    "artifact",
+    "data_artifact",
+    "extract_request_inputs",
+    "file_artifact",
+    "file_uri_artifact",
+    "mixed_artifact",
+    "text_artifact",
+]
+
+
+# ---------------------------------------------------------------------------
+# Inbound request parsing (the half NAT's get_user_input() discards)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InboundFile:
+    """A ``FilePart`` received from the calling agent.
+
+    Exactly one of :attr:`content` / :attr:`uri` is populated, mirroring the A2A
+    spec's ``FileWithBytes`` vs ``FileWithUri`` union.
+
+    Attributes
+    ----------
+        name: Client-supplied filename, if any.
+        mime_type: Declared MIME type, e.g. ``image/png``.
+        content: Decoded bytes when the sender inlined the file (``FileWithBytes``).
+        uri: Remote location when the sender passed a reference (``FileWithUri``).
+    """
+
+    name: str | None
+    mime_type: str | None
+    content: bytes | None = None
+    uri: str | None = None
+
+    @property
+    def is_inline(self) -> bool:
+        """True when the payload arrived as inline bytes rather than a URI."""
+        return self.content is not None
+
+    @property
+    def size(self) -> int:
+        """Decoded size in bytes; ``0`` for URI references."""
+        return len(self.content) if self.content else 0
+
+    def describe(self) -> str:
+        """Return a short human-readable summary for logs and text artifacts."""
+        where = f"{self.size} bytes inline" if self.is_inline else f"uri={self.uri}"
+        return f"{self.name or '<unnamed>'} ({self.mime_type or 'unknown'}, {where})"
+
+
+@dataclass
+class A2ARequestInputs:
+    """Everything the caller actually sent, not just the text.
+
+    Attributes
+    ----------
+        text: Concatenated text of every ``TextPart`` in the request.
+        files: Every ``FilePart``, decoded into :class:`InboundFile`.
+        data: The ``data`` payload of every ``DataPart``.
+    """
+
+    text: str = ""
+    files: list[InboundFile] = field(default_factory=list)
+    data: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def has_attachments(self) -> bool:
+        """True when the request carried any file or structured-data part."""
+        return bool(self.files or self.data)
+
+
+def _unwrap(part: Any) -> Any:
+    """Return the concrete part model, unwrapping the ``Part`` RootModel if needed.
+
+    ``a2a.types.Part`` is a pydantic ``RootModel`` union of
+    ``TextPart | FilePart | DataPart`` (distinguished in JSON by the ``kind``
+    literal), so the useful object lives at ``.root``.  Some call sites hand us
+    the inner model directly, so tolerate both shapes.
+    """
+    return part.root if hasattr(part, "root") else part
+
+
+def _b64decode_tolerant(payload: str, *, context: str) -> bytes | None:
+    """Base64-decode, retrying leniently before giving up.
+
+    Strict decoding rejects payloads containing newlines or using the URL-safe
+    alphabet, both of which appear in the wild.  Try strict first (fast, catches
+    genuine corruption), then a lenient pass, then base64url.
+
+    Args:
+        payload: The base64 text to decode.
+        context: Identifier used in the warning log when decoding fails.
+
+    Returns
+    -------
+        Decoded bytes, or ``None`` if every strategy failed.
+    """
+    try:
+        return base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError):
+        pass
+
+    # Lenient: ignores stray whitespace/newlines from pretty-printed JSON.
+    try:
+        return base64.b64decode(payload)
+    except (binascii.Error, ValueError):
+        pass
+
+    # base64url alphabet ('-' and '_' instead of '+' and '/').
+    try:
+        padded = payload + "=" * (-len(payload) % 4)
+        return base64.urlsafe_b64decode(padded)
+    except (binascii.Error, ValueError) as exc:
+        logger.warning("Could not base64-decode %s: %s", context, exc)
+        return None
+
+
+def _decode_file_part(part: FilePart) -> InboundFile:
+    """Convert a ``FilePart`` into an :class:`InboundFile`, decoding base64 bytes.
+
+    Invalid base64 is downgraded to a URI-less, content-less entry with a warning
+    so a single bad attachment does not abort the task.
+    """
+    file_obj = part.file
+    name = getattr(file_obj, "name", None)
+    mime = getattr(file_obj, "mime_type", None)
+
+    uri = getattr(file_obj, "uri", None)
+    if uri:
+        return InboundFile(name=name, mime_type=mime, uri=uri)
+
+    raw = getattr(file_obj, "bytes", None)
+    if not raw:
+        return InboundFile(name=name, mime_type=mime)
+
+    # The A2A wire format carries FileWithBytes.bytes as a base64 string.
+    decoded = _b64decode_tolerant(raw, context=f"FilePart {name!r}")
+    return InboundFile(name=name, mime_type=mime, content=decoded)
+
+
+def extract_request_inputs(context: RequestContext) -> A2ARequestInputs:
+    """Parse **all** part kinds out of an inbound A2A request.
+
+    This is the deliberate replacement for NAT's ``context.get_user_input()``,
+    which returns text only and therefore silently drops files, images and
+    structured data.
+
+    Args:
+        context: The A2A request context handed to ``execute()``.
+
+    Returns
+    -------
+        An :class:`A2ARequestInputs` with text, files and data separated.  Parts
+        that cannot be decoded are logged and skipped rather than raising, so one
+        malformed attachment cannot fail the whole request.
+    """
+    inputs = A2ARequestInputs()
+    message = getattr(context, "message", None)
+    if message is None or not getattr(message, "parts", None):
+        return inputs
+
+    texts: list[str] = []
+    for raw in message.parts:
+        part = _unwrap(raw)
+        kind = getattr(part, "kind", None)
+
+        if kind == "text" or isinstance(part, TextPart):
+            texts.append(part.text)
+
+        elif kind == "file" or isinstance(part, FilePart):
+            inputs.files.append(_decode_file_part(part))
+
+        elif kind == "data" or isinstance(part, DataPart):
+            payload = getattr(part, "data", None)
+            if isinstance(payload, dict):
+                inputs.data.append(payload)
+            else:  # pragma: no cover - defensive, spec says data is an object
+                logger.warning("Ignoring DataPart with non-object payload: %r", type(payload))
+
+    inputs.text = "\n".join(t for t in texts if t)
+    if inputs.has_attachments:
+        logger.info(
+            "Inbound A2A request carried %d file part(s) and %d data part(s)",
+            len(inputs.files),
+            len(inputs.data),
+        )
+    return inputs
+
+
+# ---------------------------------------------------------------------------
+# Outbound artifacts
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OutboundArtifact:
+    """One artifact to publish on the task.
+
+    An artifact is a *named container* of :class:`~a2a.types.Part` objects -- it is
+    not itself binary data.  Binary payloads travel inside a ``FilePart``.  A
+    single artifact may hold several part kinds at once; see :func:`mixed_artifact`.
+
+    Prefer the module-level helpers (:func:`text_artifact`, :func:`data_artifact`,
+    :func:`file_artifact`, :func:`file_uri_artifact`, :func:`mixed_artifact`) over
+    constructing this directly.
+
+    Attributes
+    ----------
+        name: Artifact name shown to the caller.
+        parts: The wrapped parts carried by this artifact.
+        metadata: Optional metadata published alongside the artifact.
+    """
+
+    name: str
+    parts: list[Part]
+    metadata: dict[str, Any] | None = None
+
+
+def artifact(
+    name: str, parts: list[Part], metadata: dict[str, Any] | None = None
+) -> OutboundArtifact:
+    """Bundle pre-built parts into one artifact (mixed part kinds allowed).
+
+    Args:
+        name: Artifact name shown to the caller.
+        parts: Already-wrapped ``Part`` objects.
+        metadata: Optional metadata dict published with the artifact.
+    """
+    return OutboundArtifact(name=name, parts=parts, metadata=metadata)
+
+
+def text_artifact(name: str, text: str, metadata: dict[str, Any] | None = None) -> OutboundArtifact:
+    """Artifact containing a single ``TextPart``."""
+    return artifact(name, [Part(root=TextPart(text=text))], metadata)
+
+
+def data_artifact(
+    name: str, data: dict[str, Any], metadata: dict[str, Any] | None = None
+) -> OutboundArtifact:
+    """Artifact containing a single ``DataPart`` (machine-readable JSON)."""
+    return artifact(name, [Part(root=DataPart(data=data))], metadata)
+
+
+def file_artifact(
+    name: str,
+    content: bytes,
+    mime_type: str,
+    *,
+    filename: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> OutboundArtifact:
+    """Artifact containing an **inline** file (``FileWithBytes``).
+
+    Bytes are base64-encoded here because that is what the A2A wire format
+    requires -- which inflates the payload by roughly a third.  Best for small
+    payloads; prefer :func:`file_uri_artifact` for large files.
+
+    Args:
+        name: Artifact name.
+        content: Raw file bytes.
+        mime_type: MIME type, e.g. ``image/png`` or ``text/csv``.
+        filename: Name carried inside the file part (defaults to ``name``).
+        metadata: Optional artifact metadata.
+    """
+    encoded = base64.b64encode(content).decode("ascii")
+    part = FilePart(file=FileWithBytes(bytes=encoded, mime_type=mime_type, name=filename or name))
+    return artifact(name, [Part(root=part)], metadata)
+
+
+def file_uri_artifact(
+    name: str,
+    uri: str,
+    mime_type: str,
+    *,
+    filename: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> OutboundArtifact:
+    """Artifact referencing a file by URI (``FileWithUri``).
+
+    Nothing is inlined, so this scales to large artifacts -- but the caller must be
+    able to reach *and* be authorised for the URI.  A URI inherits no A2A
+    credentials, so use a pre-signed URL or a separately authorised endpoint.
+
+    Args:
+        name: Artifact name.
+        uri: Location of the file.
+        mime_type: MIME type of the referenced file.
+        filename: Name carried inside the file part (defaults to ``name``).
+        metadata: Optional artifact metadata.
+    """
+    part = FilePart(file=FileWithUri(uri=uri, mime_type=mime_type, name=filename or name))
+    return artifact(name, [Part(root=part)], metadata)
+
+
+def mixed_artifact(
+    name: str,
+    *,
+    text: str | None = None,
+    data: dict[str, Any] | None = None,
+    files: list[tuple[str, bytes, str]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> OutboundArtifact:
+    """One artifact holding several part kinds at once.
+
+    This is the shape most real deliverables take: a human-readable summary, the
+    machine-readable equivalent, and the generated file(s) together.
+
+    Args:
+        name: Artifact name.
+        text: Optional summary text.
+        data: Optional structured payload.
+        files: Optional list of ``(filename, content, mime_type)`` tuples, inlined
+            as ``FileWithBytes``.
+        metadata: Optional artifact metadata.
+    """
+    parts: list[Part] = []
+    if text is not None:
+        parts.append(Part(root=TextPart(text=text)))
+    if data is not None:
+        parts.append(Part(root=DataPart(data=data)))
+    for filename, content, mime_type in files or []:
+        parts.append(
+            Part(
+                root=FilePart(
+                    file=FileWithBytes(
+                        bytes=base64.b64encode(content).decode("ascii"),
+                        mime_type=mime_type,
+                        name=filename,
+                    )
+                )
+            )
+        )
+    return artifact(name, parts, metadata)
+
+
+# ---------------------------------------------------------------------------
+# The application's contribution
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ArtifactBuilder(Protocol):
+    """What an application implements to publish artifacts.
+
+    One method, no base class, no imports from private modules::
+
+        class FinanceArtifacts:
+            async def build_artifacts(self, inputs, response_text):
+                return [data_artifact("analysis", {"symbol": "AAPL"})]
+
+    Returning an empty list means "nothing task-shaped to report", which under
+    ``task_mode="auto"`` yields a plain ``Message``.
+    """
+
+    async def build_artifacts(
+        self, inputs: A2ARequestInputs, response_text: str
+    ) -> list[OutboundArtifact]:
+        """Describe the artifacts this agent returns.
+
+        Args:
+            inputs: Everything the caller sent (text, files, structured data).
+            response_text: The workflow's textual result.
+
+        Returns
+        -------
+            The artifacts to publish, in order.  Empty means none.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Executor
+# ---------------------------------------------------------------------------
+
+
+def _import_class(dotted_path: str, *, what: str) -> type:
+    """Import ``pkg.module.Class`` and return the class.
+
+    Raises
+    ------
+        ValueError: If the path is malformed, unimportable, or not a class.
+    """
+    module_name, _, class_name = dotted_path.rpartition(".")
+    if not module_name:
+        raise ValueError(f"{what} must be a dotted path to a class, got {dotted_path!r}")
+    try:
+        module = __import__(module_name, fromlist=[class_name])
+        obj = getattr(module, class_name)
+    except (ImportError, AttributeError) as exc:
+        raise ValueError(f"Could not import {what} {dotted_path!r}: {exc}") from exc
+    if not isinstance(obj, type):
+        raise ValueError(f"{what} {dotted_path!r} is not a class")
+    return obj
+
+
+def load_artifact_builder(dotted_path: str) -> ArtifactBuilder:
+    """Import and instantiate an :class:`ArtifactBuilder` from a dotted path.
+
+    Args:
+        dotted_path: e.g. ``"myapp.finance.FinanceArtifacts"``.
+
+    Returns
+    -------
+        A builder instance.
+
+    Raises
+    ------
+        ValueError: If the path cannot be imported, is not a class, or the class
+            does not implement ``build_artifacts``.
+    """
+    builder_cls = _import_class(dotted_path, what="a2a.artifact_builder")
+    if not hasattr(builder_cls, "build_artifacts"):
+        raise ValueError(
+            f"a2a.artifact_builder {dotted_path!r} does not implement "
+            "build_artifacts(inputs, response_text)"
+        )
+    return typing.cast(ArtifactBuilder, builder_cls())
+
+
+class TaskArtifactAgentExecutor:
+    """A2A executor that publishes Tasks and Artifacts.
+
+    Owns the whole lifecycle -- task creation, state transitions, artifact
+    publication, failure handling and cancellation -- so an application supplies
+    only an :class:`ArtifactBuilder`.
+
+    This class is **concrete and public**.  Subclass it directly if you need to
+    change how the workflow is invoked (override :meth:`run_workflow`); there is
+    no base-ordering requirement to get wrong.
+
+    .. note::
+       The front end composes this over the per-user executor, which supplies the
+       identity resolution and inbound-header forwarding that Okta
+       cross-application access depends on.  See
+       :func:`datarobot_genai.dragent.frontends.fastapi.DRAgentFastApiFrontEndPlugin`.
+
+    Args:
+        session_manager: NAT session manager used to run the workflow.
+        builder: Supplies the artifacts. When ``None``, no artifacts are produced,
+            which under ``task_mode="auto"`` reproduces message-only behaviour.
+        task_mode: Response strategy; see :data:`TaskMode`.
+        default_artifact_name: Name for the fallback text artifact used in
+            ``task_mode="always"`` when the builder returns nothing.
+    """
+
+    def __init__(
+        self,
+        session_manager: Any,
+        *,
+        builder: ArtifactBuilder | None = None,
+        task_mode: TaskMode = "auto",
+        default_artifact_name: str = "response",
+    ) -> None:
+        self.session_manager = session_manager
+        self.builder = builder
+        self.task_mode: TaskMode = task_mode
+        self.default_artifact_name = default_artifact_name
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Run the workflow and publish either a ``Task`` or a ``Message``.
+
+        Args:
+            context: Inbound A2A request context.
+            event_queue: Queue the A2A server drains to stream events to the caller.
+
+        Raises
+        ------
+            ServerError: ``InvalidParamsError`` for a malformed request,
+                ``InternalError`` if the workflow raises.
+        """
+        if not getattr(context, "message", None):
+            logger.error("A2A request context has no message")
+            raise ServerError(error=InvalidParamsError(message="Request contained no message."))
+
+        if self.task_mode == "always":
+            await self._execute_as_task(context, event_queue)
+        else:
+            await self._execute_and_choose(context, event_queue)
+
+    async def _run(
+        self, context: RequestContext
+    ) -> tuple[A2ARequestInputs, str, list[OutboundArtifact]]:
+        """Parse the request, run the workflow, and collect artifacts."""
+        inputs = extract_request_inputs(context)
+        response_text = await self.run_workflow(inputs, context)
+        artifacts = await self.build_artifacts(inputs, response_text)
+        return inputs, response_text, artifacts
+
+    async def _execute_and_choose(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Run first, then return a ``Message`` or a ``Task`` based on the outcome.
+
+        Trade-off: because the choice depends on whether artifacts exist, the task
+        cannot be opened before the workflow runs, so no ``working`` event is
+        emitted.  Use ``task_mode="always"`` when progress matters more.
+        """
+        try:
+            _, response_text, artifacts = await self._run(context)
+        except Exception as exc:
+            logger.error("A2A request failed: %s", exc, exc_info=True)
+            raise ServerError(error=InternalError()) from exc
+
+        if self.task_mode == "never" or not artifacts:
+            # Nothing task-shaped to return: a plain Message is cheaper and is what
+            # callers of a message-only agent already expect.
+            await event_queue.enqueue_event(
+                new_agent_text_message(response_text, context_id=context.context_id, task_id=None)
+            )
+            logger.info("A2A request answered with a Message (%d artifacts)", len(artifacts))
+            return
+
+        task = await self._ensure_task(context, event_queue)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        try:
+            await self._publish_artifacts(updater, artifacts)
+            await updater.complete()
+            logger.info("A2A task %s completed with %d artifact(s)", task.id, len(artifacts))
+        except Exception as exc:
+            logger.error("A2A task %s failed: %s", task.id, exc, exc_info=True)
+            await self._publish_failure(updater, task.id, exc)
+            raise ServerError(error=InternalError()) from exc
+
+    async def _execute_as_task(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Open a ``Task`` up front and emit ``submitted -> working -> completed``."""
+        task = await self._ensure_task(context, event_queue)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+
+        try:
+            # submitted -> working. Clients render this as "in progress"; it is also
+            # what makes a long-running task observable at all.
+            await updater.start_work()
+
+            _, response_text, artifacts = await self._run(context)
+            if not artifacts:
+                artifacts = [text_artifact(self.default_artifact_name, response_text)]
+
+            await self._publish_artifacts(updater, artifacts)
+
+            # working -> completed. Terminal; TaskUpdater guards double-completion.
+            await updater.complete()
+            logger.info("A2A task %s completed with %d artifact(s)", task.id, len(artifacts))
+
+        except Exception as exc:
+            logger.error("A2A task %s failed: %s", task.id, exc, exc_info=True)
+            await self._publish_failure(updater, task.id, exc)
+            raise ServerError(error=InternalError()) from exc
+
+    @staticmethod
+    async def _ensure_task(context: RequestContext, event_queue: EventQueue) -> Any:
+        """Return the task for this request, creating and enqueuing one if needed.
+
+        A Task must exist before any status or artifact event can reference it.
+
+        In practice ``current_task`` is always ``None`` here: this executor drives
+        the task to a terminal state, and the A2A request handler rejects a
+        follow-up referencing a terminal task before ``execute()`` is reached.
+        Re-use ``contextId`` (not ``taskId``) to continue a conversation.
+
+        ``new_task()`` also validates the message (it rejects an empty
+        ``TextPart``), so that is translated into the error the caller expects
+        rather than leaking a bare ``ValueError``.
+        """
+        task = context.current_task
+        if task is not None:
+            return task
+        try:
+            task = new_task(context.message)  # state = submitted
+        except ValueError as exc:
+            logger.error("Rejecting malformed A2A message: %s", exc)
+            raise ServerError(error=InvalidParamsError(message=str(exc))) from exc
+        await event_queue.enqueue_event(task)
+        return task
+
+    @staticmethod
+    async def _publish_artifacts(updater: TaskUpdater, artifacts: list[OutboundArtifact]) -> None:
+        """Emit each artifact as its own ``TaskArtifactUpdateEvent``."""
+        for item in artifacts:
+            await updater.add_artifact(
+                parts=item.parts,
+                name=item.name,
+                metadata=item.metadata,
+                last_chunk=True,
+            )
+
+    @staticmethod
+    async def _publish_failure(updater: TaskUpdater, task_id: str, exc: Exception) -> None:
+        """Surface a terminal ``failed`` state so the caller stops waiting."""
+        try:
+            await updater.failed(
+                message=updater.new_agent_message([Part(root=TextPart(text=f"Task failed: {exc}"))])
+            )
+        except Exception:  # pragma: no cover - queue already closed
+            logger.warning("Could not publish failed state for task %s", task_id)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Publish a ``canceled`` state for the referenced task.
+
+        NAT's implementation raises ``UnsupportedOperationError`` unconditionally,
+        which made sense when no ``Task`` existed.  Now that tasks are real -- and
+        NAT's own client registers a ``cancel_task`` tool for the LLM -- always
+        failing would leave callers polling a task that never resolves.
+
+        .. warning::
+           This is **best-effort bookkeeping, not preemption.**  It moves the task
+           to a terminal ``canceled`` state so the caller stops waiting; it does
+           **not** interrupt an in-flight workflow, because NAT exposes no
+           cancellation hook into a running session.  Any compute already started
+           runs to completion and its result is discarded.  If you need true
+           cancellation, thread a ``CancellationToken``/``asyncio.Event`` through
+           :meth:`run_workflow` and check it between steps.
+
+        Args:
+            context: The A2A request context identifying the task to cancel.
+            event_queue: Queue used to publish the terminal status update.
+
+        Raises
+        ------
+            ServerError: ``TaskNotFoundError`` if no task is associated with the
+                request, since there is then nothing to cancel.
+        """
+        task = context.current_task
+        if task is None:
+            logger.warning("Cancellation requested but no task is associated with the request")
+            raise ServerError(error=TaskNotFoundError())
+
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        await updater.cancel(
+            message=updater.new_agent_message(
+                [
+                    Part(
+                        root=TextPart(
+                            text=(
+                                "Task marked canceled. Note: work already in "
+                                "progress is not interrupted."
+                            )
+                        )
+                    )
+                ]
+            )
+        )
+        logger.info("A2A task %s marked canceled", task.id)
+
+    # -- overridable seams -------------------------------------------------
+
+    async def run_workflow(self, inputs: A2ARequestInputs, context: RequestContext) -> str:
+        """Execute the underlying NAT workflow and return its text result.
+
+        Mirrors NAT's own invocation (``session_manager.session()`` ->
+        ``session.run(query)`` -> ``runner.result(to_type=str)``) so concurrency
+        limits and per-user isolation behave exactly as upstream.
+
+        .. note::
+           NAT rejects an empty query with ``InvalidParamsError``.  This
+           deliberately allows it, because a **file-only** request ("here is an
+           image, describe it") is legitimate under the A2A spec and is precisely
+           what this module exists to enable.  Override to reinstate a stricter
+           check if your agent always requires text.
+
+        Override this if your workflow returns something richer than text and you
+        want structured values to reach the builder.
+
+        Args:
+            inputs: Parsed request parts.
+            context: Inbound A2A request context (for ids and fallbacks).
+
+        Returns
+        -------
+            The workflow's response as a string.
+        """
+        query = inputs.text or context.get_user_input() or ""
+        async with self.session_manager.session() as session:
+            async with session.run(query) as runner:
+                # ``result()`` is typed as returning Any upstream; narrow it here
+                # so callers (and mypy --strict) get a concrete str.
+                result: Any = await runner.result(to_type=str)
+                return str(result)
+
+    async def build_artifacts(
+        self, inputs: A2ARequestInputs, response_text: str
+    ) -> list[OutboundArtifact]:
+        """Delegate to the configured :class:`ArtifactBuilder`.
+
+        Returns an empty list when no builder is configured, which under
+        ``task_mode="auto"`` reproduces message-only behaviour.
+        """
+        if self.builder is None:
+            return []
+        return await self.builder.build_artifacts(inputs, response_text)

--- a/src/datarobot_genai/dragent/a2a_artifacts.py
+++ b/src/datarobot_genai/dragent/a2a_artifacts.py
@@ -627,6 +627,16 @@ class TaskArtifactAgentExecutor:
         if self.task_mode == "never" or not artifacts:
             # Nothing task-shaped to return: a plain Message is cheaper and is what
             # callers of a message-only agent already expect.
+            if artifacts:
+                # task_mode="never" is explicit, so honour it -- but this is a
+                # silent data-loss path if it was set by mistake, and A2A gives us
+                # nowhere to put artifacts on a Message.
+                logger.warning(
+                    "task_mode='never' is discarding %d artifact(s) built for this "
+                    "request; artifacts can only be carried by a Task. Use "
+                    "task_mode='auto' to return them when they exist.",
+                    len(artifacts),
+                )
             await event_queue.enqueue_event(
                 new_agent_text_message(response_text, context_id=context.context_id, task_id=None)
             )

--- a/src/datarobot_genai/dragent/a2a_artifacts.py
+++ b/src/datarobot_genai/dragent/a2a_artifacts.py
@@ -175,21 +175,95 @@ class InboundFile:
 class A2ARequestInputs:
     """Everything the caller actually sent, not just the text.
 
+    An :class:`ArtifactBuilder` decides *what to return*, so it needs to see what
+    was asked. This carries the request itself plus the conversational context
+    around it, so a builder can vary its output per request instead of returning a
+    fixed set.
+
     Attributes
     ----------
         text: Concatenated text of every ``TextPart`` in the request.
         files: Every ``FilePart``, decoded into :class:`InboundFile`.
         data: The ``data`` payload of every ``DataPart``.
+        message_id: The inbound message's id.
+        task_id: The task this message continues, or ``None`` on a first turn.
+        context_id: Conversation grouping id. Stable across turns, unlike
+            ``task_id`` — key on this to correlate a multi-turn exchange.
+        metadata: The inbound message's ``metadata`` object, if any. Callers use
+            this to pass hints out of band, e.g. requested output formats.
+        history: Earlier ``Message`` objects on the continued task, oldest first.
+            Empty on a first turn, and empty if the client did not request
+            history. Raw A2A models, not flattened — use :meth:`history_text`
+            for the common case.
+        context: The raw ``RequestContext``. An escape hatch for anything not
+            surfaced above; prefer the named fields, which are stable.
     """
 
     text: str = ""
     files: list[InboundFile] = field(default_factory=list)
     data: list[dict[str, Any]] = field(default_factory=list)
+    message_id: str | None = None
+    task_id: str | None = None
+    context_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    history: list[Any] = field(default_factory=list)
+    context: Any = None
 
     @property
     def has_attachments(self) -> bool:
         """True when the request carried any file or structured-data part."""
         return bool(self.files or self.data)
+
+    @property
+    def is_follow_up(self) -> bool:
+        """True when this message continues an existing task."""
+        return bool(self.task_id)
+
+    def history_text(self, limit: int | None = None) -> list[str]:
+        """Return prior turns as plain strings, newest last.
+
+        Flattens each historical ``Message`` to the text of its ``TextPart``s,
+        which is what a builder usually wants when deciding whether something was
+        already sent. Non-text parts are ignored here; read :attr:`history`
+        directly if they matter.
+
+        Args:
+            limit: Return at most this many of the most recent turns. ``None``
+                returns all of them.
+
+        Returns
+        -------
+            One string per historical message that had any text, oldest first.
+        """
+        out: list[str] = []
+        for message in self.history:
+            texts = [
+                getattr(_unwrap(p), "text", "")
+                for p in getattr(message, "parts", None) or []
+                if getattr(_unwrap(p), "kind", None) == "text"
+            ]
+            joined = "\n".join(t for t in texts if t)
+            if joined:
+                out.append(joined)
+        return out[-limit:] if limit else out
+
+    def asked_for(self, *keywords: str) -> bool:
+        """True when the request text mentions any of ``keywords``.
+
+        A convenience for the most common branch in a builder -- deciding whether
+        to build an expensive artifact at all. Case-insensitive substring match;
+        deliberately naive, since anything smarter belongs in the workflow's LLM
+        rather than in artifact assembly.
+
+        Args:
+            *keywords: Terms to look for.
+
+        Returns
+        -------
+            True if any keyword appears in the request text.
+        """
+        haystack = self.text.lower()
+        return any(k.lower() in haystack for k in keywords)
 
 
 def _unwrap(part: Any) -> Any:
@@ -277,10 +351,31 @@ def extract_request_inputs(context: RequestContext) -> A2ARequestInputs:
         that cannot be decoded are logged and skipped rather than raising, so one
         malformed attachment cannot fail the whole request.
     """
-    inputs = A2ARequestInputs()
+    inputs = A2ARequestInputs(context=context)
+
+    # Conversational context, so a builder can vary output per request rather than
+    # returning a fixed set. Read defensively: RequestContext is populated by the
+    # a2a-sdk request handler and not every field is set on every call path.
+    task = getattr(context, "current_task", None)
+    inputs.task_id = getattr(context, "task_id", None) or getattr(task, "id", None)
+    inputs.context_id = getattr(context, "context_id", None) or getattr(
+        task, "context_id", None
+    )
+    if task is not None:
+        # A2A Tasks carry their prior Messages. Present only when the client asked
+        # for history, so treat an empty list as "unknown", not "first turn".
+        inputs.history = list(getattr(task, "history", None) or [])
+
     message = getattr(context, "message", None)
     if message is None or not getattr(message, "parts", None):
         return inputs
+
+    inputs.message_id = getattr(message, "message_id", None)
+    inputs.task_id = inputs.task_id or getattr(message, "task_id", None)
+    inputs.context_id = inputs.context_id or getattr(message, "context_id", None)
+    message_metadata = getattr(message, "metadata", None)
+    if isinstance(message_metadata, dict):
+        inputs.metadata = dict(message_metadata)
 
     texts: list[str] = []
     for raw in message.parts:
@@ -307,6 +402,15 @@ def extract_request_inputs(context: RequestContext) -> A2ARequestInputs:
             len(inputs.files),
             len(inputs.data),
         )
+    logger.debug(
+        "A2A request context: context_id=%s task_id=%s follow_up=%s "
+        "history_turns=%d metadata_keys=%s",
+        inputs.context_id,
+        inputs.task_id,
+        inputs.is_follow_up,
+        len(inputs.history),
+        sorted(inputs.metadata) or "-",
+    )
     return inputs
 
 

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -16,6 +16,7 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+from a2a.server.agent_execution import AgentExecutor
 from a2a.server.agent_execution import RequestContext
 from a2a.server.events import EventQueue
 from a2a.types import InvalidParamsError
@@ -35,6 +36,10 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from datarobot_genai.core.utils.logging import setup_logging
+from datarobot_genai.dragent.a2a_artifacts import ArtifactBuilder
+from datarobot_genai.dragent.a2a_artifacts import TaskArtifactAgentExecutor
+from datarobot_genai.dragent.a2a_artifacts import TaskMode
+from datarobot_genai.dragent.a2a_artifacts import load_artifact_builder
 
 from .a2a import A2A_MOUNT_PATH
 from .a2a import create_agent_card
@@ -158,12 +163,62 @@ class _PerUserCompatibleAgentExecutor(NATWorkflowAgentExecutor):
             if workflow_key:
                 token = self.session_manager._context_state.user_id.set(workflow_key)
 
-            await super().execute(context, event_queue)
+            await self._run_request(context, event_queue)
         finally:
             if token is not None:
                 self.session_manager._context_state.user_id.reset(token)
             if token_headers is not None:
                 _a2a_headers.reset(token_headers)
+
+    async def _run_request(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Handle the request once identity and headers are established.
+
+        The single seam subclasses override to change *what* is returned while
+        inheriting the per-user identity resolution and header forwarding set up by
+        :meth:`execute`.  The default delegates to NAT's message-only
+        implementation.
+
+        Overriding this rather than :meth:`execute` means a subclass cannot
+        accidentally bypass the auth context, and there is no base-class ordering
+        to get wrong.
+        """
+        await super().execute(context, event_queue)
+
+
+class _TaskArtifactPerUserExecutor(_PerUserCompatibleAgentExecutor):
+    """Per-user executor that publishes A2A Tasks and Artifacts.
+
+    Composition, not a mixin: :meth:`execute` is inherited unchanged (so identity
+    resolution and inbound-header forwarding are guaranteed), and the single
+    ``_run_request`` seam delegates to a contained
+    :class:`~datarobot_genai.dragent.a2a_artifacts.TaskArtifactAgentExecutor`.
+
+    Args:
+        session_manager: NAT session manager used to run the workflow.
+        builder: Supplies the artifacts to publish.
+        task_mode: Response shape; see
+            :data:`~datarobot_genai.dragent.a2a_artifacts.TaskMode`.
+    """
+
+    def __init__(
+        self,
+        session_manager: SessionManager,
+        *,
+        builder: ArtifactBuilder,
+        task_mode: TaskMode = "auto",
+    ) -> None:
+        super().__init__(session_manager)
+        self._delegate = TaskArtifactAgentExecutor(
+            session_manager, builder=builder, task_mode=task_mode
+        )
+
+    async def _run_request(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Publish a Task with artifacts (or a Message) instead of NAT's text reply."""
+        await self._delegate.execute(context, event_queue)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Publish a terminal ``canceled`` state rather than always raising."""
+        await self._delegate.cancel(context, event_queue)
 
 
 class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
@@ -224,7 +279,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             max_concurrency=self._a2a_worker.max_concurrency,
         )
         self._session_managers.append(session_manager)
-        agent_executor = _PerUserCompatibleAgentExecutor(session_manager)
+        agent_executor = self._build_agent_executor(session_manager)
 
         a2a_server = self._a2a_worker.create_a2a_server(agent_card, agent_executor)
         a2a_app = a2a_server.build()
@@ -233,6 +288,40 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
 
         logger.info(f"A2A endpoint URL: {agent_card.url}")
         logger.info(f"A2A agent card URL: {agent_card.url}.well-known/agent-card.json")
+
+    def _build_agent_executor(self, session_manager: SessionManager) -> AgentExecutor:
+        """Construct the A2A agent executor for this front end.
+
+        With no ``a2a.artifact_builder`` configured, the built-in message-only
+        executor is used and behaviour is unchanged.
+
+        When a builder *is* configured, it is composed into
+        :class:`_TaskArtifactPerUserExecutor`, which layers the task/artifact
+        lifecycle onto the per-user identity resolution and inbound-header
+        forwarding that Okta cross-application access depends on.
+
+        Raises
+        ------
+            ValueError: If the builder path cannot be imported or does not
+                implement ``build_artifacts``.
+        """
+        a2a_config = self.front_end_config.a2a
+        builder_path = a2a_config.artifact_builder if a2a_config else None
+
+        if not builder_path or a2a_config is None:
+            return _PerUserCompatibleAgentExecutor(session_manager)
+
+        builder = load_artifact_builder(builder_path)
+        logger.info(
+            "A2A artifact builder %s enabled (task_mode=%s)",
+            builder_path,
+            a2a_config.task_mode,
+        )
+        return _TaskArtifactPerUserExecutor(
+            session_manager,
+            builder=builder,
+            task_mode=a2a_config.task_mode,
+        )
 
     def build_app(self) -> FastAPI:
         """Build the FastAPI app, wrapping the parent lifespan to clean up the A2A worker."""

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -77,6 +77,28 @@ class DRAgentA2AConfig(BaseModel):
         default=None,
         description="External identity and URL override for the agent card.",
     )
+    artifact_builder: str | None = Field(
+        default=None,
+        description=(
+            "Dotted import path to a class implementing "
+            "datarobot_genai.dragent.a2a_artifacts.ArtifactBuilder, e.g. "
+            "'myapp.finance.FinanceArtifacts'. Its build_artifacts(inputs, "
+            "response_text) return value is published as A2A Artifacts, enabling "
+            "Tasks, Files and Images. When unset, the agent replies with plain "
+            "Messages."
+        ),
+    )
+    task_mode: typing.Literal["auto", "always", "never"] = Field(
+        default="auto",
+        description=(
+            "Response shape. Both Task and Message are valid message/send results. "
+            "'auto': return a Message when the builder produces no artifacts, a "
+            "Task when it does (no progress events, since the outcome decides). "
+            "'always': open a Task up front and emit submitted -> working -> "
+            "completed, for long-running work. 'never': always reply with a "
+            "Message."
+        ),
+    )
 
 
 # Register frontend

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -17,7 +17,6 @@ import asyncio
 import functools
 import inspect
 import logging
-import mimetypes
 from collections.abc import AsyncGenerator
 from typing import Any
 from typing import Protocol
@@ -46,6 +45,7 @@ from pydantic import model_validator
 
 from datarobot_genai.dragent.a2a_artifact_client import OutboundFile
 from datarobot_genai.dragent.a2a_artifact_client import build_client_message
+from datarobot_genai.dragent.a2a_artifact_client import outbound_file_from_uri
 from datarobot_genai.dragent.a2a_artifact_client import summarize_task
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
@@ -617,14 +617,10 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
             Returns:
                 A rendered report of the task state and every artifact.
             """
-            files = [
-                OutboundFile(
-                    name=uri.rstrip("/").rsplit("/", 1)[-1] or "attachment",
-                    mime_type=mimetypes.guess_type(uri)[0] or "application/octet-stream",
-                    uri=uri,
-                )
-                for uri in attach_uris or []
-            ]
+            # Name and MIME type come from the URI's path only -- pre-signed URLs
+            # carry a query string, which otherwise defeats type inference and
+            # ends up in the filename. See outbound_file_from_uri().
+            files = [outbound_file_from_uri(uri) for uri in attach_uris or []]
             events = await self.send_parts(
                 text=message, files=files or None, data=attach_data
             )

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -17,6 +17,7 @@ import asyncio
 import functools
 import inspect
 import logging
+import mimetypes
 from collections.abc import AsyncGenerator
 from typing import Any
 from typing import Protocol
@@ -43,6 +44,9 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
 
+from datarobot_genai.dragent.a2a_artifact_client import OutboundFile
+from datarobot_genai.dragent.a2a_artifact_client import build_client_message
+from datarobot_genai.dragent.a2a_artifact_client import summarize_task
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
 from datarobot_genai.dragent.agent_card_registry import get_default_registry_sync
@@ -199,6 +203,69 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
         logger.info("Connected to A2A agent at %s", self._base_url)
         return self
 
+    async def send_parts(
+        self,
+        text: str | None = None,
+        files: list[OutboundFile] | None = None,
+        data: dict[str, Any] | None = None,
+        *,
+        task_id: str | None = None,
+        context_id: str | None = None,
+    ) -> list[Any]:
+        """Send a multi-part message and return the raw response events.
+
+        NAT's :meth:`send_message` takes ``message_text: str`` and builds a
+        single ``TextPart``, so inbound files and structured data cannot be
+        expressed through it. This sends a full ``Message`` instead.
+
+        Authentication is unchanged: the message goes through the same a2a-sdk
+        client and the same interceptors configured in :meth:`__aenter__`, so
+        the Okta cross-application-access exchange applies exactly as it does to
+        a text-only call.
+
+        Args:
+            text: Optional text body.
+            files: Optional attachments (images, CSVs, PDFs ...).
+            data: Optional structured payload.
+            task_id: Set to continue an existing task.
+            context_id: Set to stay within an existing conversation context.
+
+        Returns:
+            Raw response events. Each is either a ``Message`` or a
+            ``ClientEvent`` tuple of ``(Task, UpdateEvent | None)``. Pass to
+            :func:`~datarobot_genai.dragent.a2a_artifact_client.iter_artifacts`
+            or :func:`~datarobot_genai.dragent.a2a_artifact_client.summarize_task`.
+
+        Raises:
+            RuntimeError: If the client was not initialised via ``async with``.
+            ValueError: If no part of any kind was supplied.
+        """
+        if not self._client:
+            raise RuntimeError(
+                "A2A client not initialized -- enter the function group via "
+                "'async with' before calling send_parts()."
+            )
+
+        message = build_client_message(
+            text=text,
+            files=files,
+            data=data,
+            task_id=task_id,
+            context_id=context_id,
+        )
+
+        events: list[Any] = []
+        async for event in self._client.send_message(message):
+            events.append(event)
+
+        logger.info(
+            "A2A multi-part send returned %d event(s) (files=%d, data=%s)",
+            len(events),
+            len(files or []),
+            data is not None,
+        )
+        return events
+
 
 class AgentCardRegistryLookup(BaseModel):
     """Identifies an agent card in the central DataRobot agent card registry.
@@ -276,6 +343,15 @@ class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_clie
     registry: AgentCardRegistryLookup | None = Field(
         default=None,
         description="Central DataRobot agent card registry lookup. Mutually exclusive with 'url'.",
+    )
+
+    artifact_client: bool = Field(
+        default=False,
+        description="Register artifact-aware functions alongside NAT's text-only "
+        "'call'. Adds 'send_with_attachments' (send files and structured data, "
+        "read every returned artifact) and 'get_task_artifacts' (re-read a known "
+        "task's artifacts). Off by default: registering extra functions changes "
+        "which tools an agent's LLM can select, so this is opt-in.",
     )
 
     @model_validator(mode="after")
@@ -446,6 +522,148 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
 
             fn = _raise_registry_error
         super().add_function(name, _wrap_a2a_function(fn), **kwargs)
+
+    async def send_parts(
+        self,
+        text: str | None = None,
+        files: list[OutboundFile] | None = None,
+        data: dict[str, Any] | None = None,
+        *,
+        task_id: str | None = None,
+        context_id: str | None = None,
+    ) -> list[Any]:
+        """Send a multi-part A2A message and return the raw response events.
+
+        The programmatic entry point for callers that need files, images or
+        structured data on the wire. Authentication -- including the Okta
+        cross-application-access exchange -- applies unchanged, because this
+        reuses the function group's own authenticated client.
+
+        Args:
+            text: Optional text body.
+            files: Optional attachments.
+            data: Optional structured payload.
+            task_id: Set to continue an existing task.
+            context_id: Set to stay within an existing conversation context.
+
+        Returns:
+            Raw response events, for
+            :func:`~datarobot_genai.dragent.a2a_artifact_client.iter_artifacts`,
+            :func:`~datarobot_genai.dragent.a2a_artifact_client.summarize_task`
+            or
+            :func:`~datarobot_genai.dragent.a2a_artifact_client.save_task_files`.
+
+        Raises:
+            RuntimeError: If the client is unavailable, including when a registry
+                lookup failed and the group initialised in degraded mode.
+            ValueError: If no part of any kind was supplied.
+        """
+        registry_error = getattr(self, "_registry_error", None)
+        if registry_error is not None:
+            raise RuntimeError(
+                f"A2A client unavailable: agent card registry lookup failed ({registry_error})"
+            )
+
+        send_parts = getattr(self._client, "send_parts", None)
+        if send_parts is None:
+            raise RuntimeError(
+                "A2A client does not support multi-part send -- expected "
+                "_AuthenticatedA2ABaseClient. Ensure the function group was "
+                "entered via 'async with'."
+            )
+
+        return await send_parts(  # type: ignore[no-any-return]
+            text=text,
+            files=files,
+            data=data,
+            task_id=task_id,
+            context_id=context_id,
+        )
+
+    def _register_functions(self) -> None:
+        """Register NAT's functions, plus artifact-aware ones when enabled.
+
+        ``super()`` registers the stock three-level API, of which ``call`` is
+        text-only in both directions. When ``artifact_client`` is set, two more
+        functions are added so an agent's LLM can send attachments and read
+        artifacts without the application writing its own A2A client.
+        """
+        super()._register_functions()
+
+        config: AuthenticatedA2AClientConfig = self._config  # type: ignore[assignment]
+        if not getattr(config, "artifact_client", False):
+            return
+
+        async def send_with_attachments(
+            message: str,
+            attach_data: dict[str, Any] | None = None,
+            attach_uris: list[str] | None = None,
+        ) -> str:
+            """Send a message to the remote agent and report every artifact returned.
+
+            Files are attached **by URI** rather than by content, because a model
+            cannot emit raw bytes. To send bytes, call
+            :meth:`AuthenticatedA2AClientFunctionGroup.send_parts` from code with
+            :class:`~datarobot_genai.dragent.a2a_artifact_client.OutboundFile`.
+
+            Args:
+                message: The text to send.
+                attach_data: Optional structured payload, sent as a DataPart.
+                attach_uris: Optional file URIs, each sent as a FilePart. The MIME
+                    type is inferred from the extension. Note that an A2A URI
+                    carries none of the call's authentication, so the receiving
+                    agent must be able to fetch it independently.
+
+            Returns:
+                A rendered report of the task state and every artifact.
+            """
+            files = [
+                OutboundFile(
+                    name=uri.rstrip("/").rsplit("/", 1)[-1] or "attachment",
+                    mime_type=mimetypes.guess_type(uri)[0] or "application/octet-stream",
+                    uri=uri,
+                )
+                for uri in attach_uris or []
+            ]
+            events = await self.send_parts(
+                text=message, files=files or None, data=attach_data
+            )
+            return summarize_task(events)
+
+        async def get_task_artifacts(task_id: str) -> str:
+            """Re-read the artifacts of a task by id.
+
+            Args:
+                task_id: The task to inspect.
+
+            Returns:
+                A rendered report of the task state and every artifact.
+            """
+            task = await self._client.get_task(task_id)  # type: ignore[union-attr]
+            return summarize_task([task])
+
+        self.add_function(
+            name="send_with_attachments",
+            fn=send_with_attachments,
+            description=(
+                "Send a message to this agent and read back everything it returns, "
+                "including files, images and structured data. Use this instead of "
+                "'call' whenever the reply may contain artifacts, or when the user "
+                "asks what files or images the other agent produced."
+            ),
+        )
+        self.add_function(
+            name="get_task_artifacts",
+            fn=get_task_artifacts,
+            description=(
+                "List the artifacts (files, images, structured data) attached to a "
+                "known task_id on this agent."
+            ),
+        )
+        logger.info(
+            "Registered artifact-aware A2A client functions "
+            "(send_with_attachments, get_task_artifacts)"
+        )
 
     async def __aenter__(self) -> "AuthenticatedA2AClientFunctionGroup":
         config: AuthenticatedA2AClientConfig = self._config  # type: ignore[assignment]

--- a/tests/dragent/test_a2a_artifact_client.py
+++ b/tests/dragent/test_a2a_artifact_client.py
@@ -230,8 +230,39 @@ class TestIterArtifacts:
         task = _task([artifact])
         # WHEN artifacts are collected across both events
         artifacts = iter_artifacts([(task, None), (task, None)])
-        # THEN it appears once, not twice
+        # THEN it appears once, and its parts are not duplicated either
         assert len(artifacts) == 1
+        assert len(artifacts[0].parts) == 1
+
+    def test_merges_parts_of_a_chunked_artifact(self) -> None:
+        # GIVEN one artifact_id arriving in two chunks, as A2A permits via
+        # TaskArtifactUpdateEvent.append
+        first = _task(
+            [_artifact("report", [Part(root=TextPart(text="part-1"))], artifact_id="c")],
+            state=TaskState.working,
+        )
+        second = _task(
+            [_artifact("report", [Part(root=TextPart(text="part-2"))], artifact_id="c")]
+        )
+        # WHEN artifacts are collected across both events
+        artifacts = iter_artifacts([(first, None), (second, None)])
+        # THEN the chunks are merged rather than the later one being dropped --
+        # first-seen-wins would silently truncate a streamed artifact
+        assert len(artifacts) == 1
+        texts = [p.root.text for p in artifacts[0].parts]
+        assert texts == ["part-1", "part-2"]
+
+    def test_keeps_anonymous_artifacts_separate(self) -> None:
+        # GIVEN two artifacts with no artifact_id to correlate on
+        task = _task(
+            [
+                Artifact(artifact_id="", name="a", parts=[Part(root=TextPart(text="1"))]),
+                Artifact(artifact_id="", name="b", parts=[Part(root=TextPart(text="2"))]),
+            ]
+        )
+        # WHEN collected
+        # THEN they are not merged into one: with no id, neither can be a chunk
+        assert len(iter_artifacts([task])) == 2
 
     def test_preserves_distinct_artifacts(self) -> None:
         # GIVEN two different artifacts

--- a/tests/dragent/test_a2a_artifact_client.py
+++ b/tests/dragent/test_a2a_artifact_client.py
@@ -1,0 +1,482 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the consuming half of A2A artifacts.
+
+Covers putting non-text parts on the wire and recovering them from response
+events -- the mirror of ``test_a2a_artifacts.py``, which covers producing them.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import pytest
+from a2a.types import Artifact
+from a2a.types import DataPart
+from a2a.types import FilePart
+from a2a.types import FileWithBytes
+from a2a.types import FileWithUri
+from a2a.types import Message
+from a2a.types import Part
+from a2a.types import Role
+from a2a.types import Task
+from a2a.types import TaskState
+from a2a.types import TaskStatus
+from a2a.types import TextPart
+
+from datarobot_genai.dragent.a2a_artifact_client import OutboundFile
+from datarobot_genai.dragent.a2a_artifact_client import build_client_message
+from datarobot_genai.dragent.a2a_artifact_client import build_send_message_payload
+from datarobot_genai.dragent.a2a_artifact_client import iter_artifacts
+from datarobot_genai.dragent.a2a_artifact_client import save_task_files
+from datarobot_genai.dragent.a2a_artifact_client import summarize_task
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-image-payload"
+
+
+def _task(
+    artifacts: list[Artifact] | None = None,
+    state: TaskState = TaskState.completed,
+    task_id: str = "task-1",
+) -> Task:
+    """Build a Task carrying the given artifacts."""
+    return Task(
+        id=task_id,
+        context_id="ctx-1",
+        status=TaskStatus(state=state),
+        artifacts=artifacts or [],
+    )
+
+
+def _artifact(name: str, parts: list[Part], artifact_id: str = "a-1") -> Artifact:
+    """Build an Artifact with an explicit id, for de-duplication tests."""
+    return Artifact(artifact_id=artifact_id, name=name, parts=parts)
+
+
+def _message(text: str = "hello") -> Message:
+    """Build a bare agent Message, the artifact-free response shape."""
+    return Message(
+        role=Role.agent, parts=[Part(root=TextPart(text=text))], message_id="m-1"
+    )
+
+
+class TestOutboundFile:
+    def test_inlines_content_as_base64(self) -> None:
+        # GIVEN a file carrying raw bytes
+        outbound = OutboundFile("chart.png", "image/png", content=PNG_BYTES)
+        # WHEN converted to a typed part
+        part = outbound.to_part()
+        # THEN the bytes are base64-encoded into a FileWithBytes
+        assert isinstance(part.root, FilePart)
+        assert isinstance(part.root.file, FileWithBytes)
+        assert base64.b64decode(part.root.file.bytes) == PNG_BYTES
+
+    def test_references_uri_without_inlining(self) -> None:
+        # GIVEN a file carrying a URI
+        outbound = OutboundFile("doc.html", "text/html", uri="https://example.com/d")
+        # WHEN converted to a typed part
+        part = outbound.to_part()
+        # THEN it is a FileWithUri and nothing is inlined
+        assert isinstance(part.root.file, FileWithUri)
+        assert part.root.file.uri == "https://example.com/d"
+        assert getattr(part.root.file, "bytes", None) is None
+
+    def test_wire_form_uses_camel_case_mime_type(self) -> None:
+        # GIVEN a file with raw bytes
+        outbound = OutboundFile("r.csv", "text/csv", content=b"a,b\n")
+        # WHEN rendered to the raw JSON-RPC form
+        wire = outbound.to_wire()
+        # THEN the key is camelCase, per the A2A wire convention
+        assert wire["mimeType"] == "text/csv"
+        assert "mime_type" not in wire
+
+    @pytest.mark.parametrize(
+        ("kwargs", "reason"),
+        [
+            ({}, "neither content nor uri"),
+            ({"content": b"x", "uri": "https://e.com"}, "both content and uri"),
+        ],
+    )
+    def test_rejects_ambiguous_representations(
+        self, kwargs: dict[str, Any], reason: str
+    ) -> None:
+        # GIVEN neither or both of the two mutually exclusive representations
+        # WHEN the file is constructed
+        # THEN it fails loudly rather than silently picking one
+        with pytest.raises(ValueError, match="exactly one of"):
+            OutboundFile("f", "application/octet-stream", **kwargs)
+
+    def test_accepts_a_legitimate_zero_byte_file(self) -> None:
+        # GIVEN an empty file, which is falsy but not unset
+        outbound = OutboundFile("empty.txt", "text/plain", content=b"")
+        # WHEN converted
+        part = outbound.to_part()
+        # THEN it is treated as inline content, not as "no content supplied"
+        assert base64.b64decode(part.root.file.bytes) == b""
+
+
+class TestBuildClientMessage:
+    def test_carries_every_part_kind_in_order(self) -> None:
+        # GIVEN text, a file and structured data
+        message = build_client_message(
+            text="analyse",
+            files=[OutboundFile("in.png", "image/png", content=PNG_BYTES)],
+            data={"threshold": 0.5},
+        )
+        # WHEN the parts are inspected
+        kinds = [p.root.kind for p in message.parts]
+        # THEN all three are present, text first
+        assert kinds == ["text", "file", "data"]
+        assert message.role == Role.user
+
+    def test_omits_empty_text_but_keeps_empty_data(self) -> None:
+        # GIVEN no text and a deliberately empty data payload
+        message = build_client_message(data={})
+        # WHEN the parts are inspected
+        # THEN the empty dict still produces a DataPart -- {} is a value, not "unset"
+        assert [p.root.kind for p in message.parts] == ["data"]
+
+    def test_threads_task_and_context_ids(self) -> None:
+        # GIVEN ids for an in-flight conversation
+        message = build_client_message(text="more", task_id="t-9", context_id="c-9")
+        # WHEN the message is built
+        # THEN both are carried, so the turn continues rather than starting fresh
+        assert message.task_id == "t-9"
+        assert message.context_id == "c-9"
+
+    def test_rejects_a_message_with_no_parts(self) -> None:
+        # GIVEN nothing to send
+        # WHEN a message is requested
+        # THEN it fails rather than sending an empty message the peer must reject
+        with pytest.raises(ValueError, match="at least one part"):
+            build_client_message()
+
+    def test_generates_a_unique_message_id_per_call(self) -> None:
+        # GIVEN two identical sends
+        first = build_client_message(text="same")
+        second = build_client_message(text="same")
+        # WHEN their ids are compared
+        # THEN they differ, so the peer cannot treat the second as a replay
+        assert first.message_id != second.message_id
+
+
+class TestBuildSendMessagePayload:
+    def test_matches_the_json_rpc_envelope(self) -> None:
+        # GIVEN a text and data send
+        payload = build_send_message_payload(text="hi", data={"a": 1}, request_id=7)
+        # WHEN the envelope is inspected
+        # THEN it is a well-formed message/send request
+        assert payload["jsonrpc"] == "2.0"
+        assert payload["id"] == 7
+        assert payload["method"] == "message/send"
+        assert payload["params"]["message"]["kind"] == "message"
+
+    def test_is_json_serialisable(self) -> None:
+        # GIVEN a payload including binary content
+        payload = build_send_message_payload(
+            files=[OutboundFile("a.png", "image/png", content=PNG_BYTES)]
+        )
+        # WHEN serialised
+        # THEN it round-trips, because bytes were base64-encoded
+        assert json.loads(json.dumps(payload)) == payload
+
+    def test_rejects_a_payload_with_no_parts(self) -> None:
+        # GIVEN nothing to send
+        # WHEN a payload is requested
+        # THEN it fails, consistent with build_client_message
+        with pytest.raises(ValueError, match="at least one part"):
+            build_send_message_payload()
+
+
+class TestIterArtifacts:
+    def test_collects_artifacts_from_a_client_event_tuple(self) -> None:
+        # GIVEN a ClientEvent tuple, the shape the sdk yields for tasks
+        task = _task([_artifact("summary", [Part(root=TextPart(text="ok"))])])
+        # WHEN artifacts are collected
+        artifacts = iter_artifacts([(task, None)])
+        # THEN the tuple is unwrapped and the artifact found
+        assert [a.name for a in artifacts] == ["summary"]
+
+    def test_collects_artifacts_from_a_bare_task(self) -> None:
+        # GIVEN a Task not wrapped in a tuple
+        task = _task([_artifact("summary", [Part(root=TextPart(text="ok"))])])
+        # WHEN artifacts are collected
+        # THEN both event shapes are handled
+        assert len(iter_artifacts([task])) == 1
+
+    def test_returns_nothing_for_a_bare_message(self) -> None:
+        # GIVEN a Message response, which cannot carry artifacts
+        # WHEN artifacts are collected
+        # THEN the result is empty rather than an error
+        assert iter_artifacts([_message()]) == []
+
+    def test_deduplicates_by_artifact_id(self) -> None:
+        # GIVEN a task and an update event referencing the same artifact
+        artifact = _artifact("chart", [Part(root=TextPart(text="x"))], artifact_id="dup")
+        task = _task([artifact])
+        # WHEN artifacts are collected across both events
+        artifacts = iter_artifacts([(task, None), (task, None)])
+        # THEN it appears once, not twice
+        assert len(artifacts) == 1
+
+    def test_preserves_distinct_artifacts(self) -> None:
+        # GIVEN two different artifacts
+        task = _task(
+            [
+                _artifact("one", [Part(root=TextPart(text="1"))], artifact_id="a"),
+                _artifact("two", [Part(root=TextPart(text="2"))], artifact_id="b"),
+            ]
+        )
+        # WHEN collected
+        # THEN both survive, in order
+        assert [a.name for a in iter_artifacts([task])] == ["one", "two"]
+
+    def test_handles_no_events(self) -> None:
+        # GIVEN an empty event list
+        # WHEN artifacts are collected
+        # THEN the result is empty
+        assert iter_artifacts([]) == []
+
+
+class TestSummarizeTask:
+    def test_reports_state_and_every_part_kind(self) -> None:
+        # GIVEN a completed task with all three part kinds
+        task = _task(
+            [
+                _artifact(
+                    "deliverable",
+                    [
+                        Part(root=TextPart(text="the answer")),
+                        Part(root=DataPart(data={"k": "v"})),
+                        Part(
+                            root=FilePart(
+                                file=FileWithBytes(
+                                    bytes=base64.b64encode(PNG_BYTES).decode(),
+                                    mime_type="image/png",
+                                    name="chart.png",
+                                )
+                            )
+                        ),
+                    ],
+                )
+            ]
+        )
+        # WHEN summarised
+        summary = summarize_task([(task, None)])
+        # THEN state, artifact name and each part kind are all reported
+        assert "state=completed" in summary
+        assert "1 artifact(s)" in summary
+        assert "deliverable" in summary
+        assert "text: the answer" in summary
+        assert '"k": "v"' in summary
+        assert f"chart.png (image/png) {len(PNG_BYTES):,} bytes inline" in summary
+
+    def test_reports_a_uri_file_without_a_size(self) -> None:
+        # GIVEN a file sent by reference
+        task = _task(
+            [
+                _artifact(
+                    "ref",
+                    [
+                        Part(
+                            root=FilePart(
+                                file=FileWithUri(
+                                    uri="https://example.com/d",
+                                    mime_type="text/html",
+                                    name="d.html",
+                                )
+                            )
+                        )
+                    ],
+                )
+            ]
+        )
+        # WHEN summarised
+        summary = summarize_task([task])
+        # THEN the URI is shown and no byte count is claimed
+        assert "uri=https://example.com/d" in summary
+        assert "bytes inline" not in summary
+
+    def test_truncates_long_text_previews(self) -> None:
+        # GIVEN an artifact with a very long text part
+        task = _task([_artifact("big", [Part(root=TextPart(text="x" * 5000))])])
+        # WHEN summarised
+        summary = summarize_task([task])
+        # THEN the preview is capped, so a tool result cannot flood an LLM context
+        assert len(summary) < 500
+
+    def test_distinguishes_a_message_response(self) -> None:
+        # GIVEN a bare Message
+        # WHEN summarised
+        summary = summarize_task([_message()])
+        # THEN it says so explicitly, rather than reporting an empty task
+        assert "bare Message" in summary
+
+    def test_reports_a_task_with_no_artifacts(self) -> None:
+        # GIVEN a completed task that produced nothing
+        # WHEN summarised
+        summary = summarize_task([_task([])])
+        # THEN state is reported and the absence is explicit
+        assert "state=completed" in summary
+        assert "No artifacts returned." in summary
+
+    def test_handles_no_events(self) -> None:
+        # GIVEN no events at all
+        # WHEN summarised
+        # THEN it degrades to a readable message instead of raising
+        assert summarize_task([]) == "No response events."
+
+
+class TestSaveTaskFiles:
+    def test_writes_inline_files_with_original_bytes(self, tmp_path: Any) -> None:
+        # GIVEN an artifact carrying an inline file
+        task = _task(
+            [
+                _artifact(
+                    "out",
+                    [
+                        Part(
+                            root=FilePart(
+                                file=FileWithBytes(
+                                    bytes=base64.b64encode(PNG_BYTES).decode(),
+                                    mime_type="image/png",
+                                    name="chart.png",
+                                )
+                            )
+                        )
+                    ],
+                )
+            ]
+        )
+        # WHEN saved
+        written = save_task_files([task], tmp_path)
+        # THEN the file exists with byte-identical content
+        assert [p.name for p in written] == ["chart.png"]
+        assert written[0].read_bytes() == PNG_BYTES
+
+    def test_skips_uri_files(self, tmp_path: Any) -> None:
+        # GIVEN a file sent by reference, which carries no bytes to write
+        task = _task(
+            [
+                _artifact(
+                    "ref",
+                    [
+                        Part(
+                            root=FilePart(
+                                file=FileWithUri(
+                                    uri="https://example.com/x",
+                                    mime_type="text/html",
+                                    name="x.html",
+                                )
+                            )
+                        )
+                    ],
+                )
+            ]
+        )
+        # WHEN saved
+        # THEN nothing is written -- fetching a URI is the caller's problem, since
+        # it carries none of the A2A call's authentication
+        assert save_task_files([task], tmp_path) == []
+
+    def test_flattens_paths_to_prevent_traversal(self, tmp_path: Any) -> None:
+        # GIVEN a hostile artifact filename attempting directory traversal
+        task = _task(
+            [
+                _artifact(
+                    "evil",
+                    [
+                        Part(
+                            root=FilePart(
+                                file=FileWithBytes(
+                                    bytes=base64.b64encode(b"pwned").decode(),
+                                    mime_type="text/plain",
+                                    name="../../etc/passwd",
+                                )
+                            )
+                        )
+                    ],
+                )
+            ]
+        )
+        # WHEN saved
+        written = save_task_files([task], tmp_path)
+        # THEN the file lands inside the output directory under its basename only
+        assert written[0].parent == tmp_path
+        assert written[0].name == "passwd"
+
+    def test_creates_the_output_directory(self, tmp_path: Any) -> None:
+        # GIVEN a target directory that does not exist
+        target = tmp_path / "nested" / "out"
+        task = _task(
+            [
+                _artifact(
+                    "out",
+                    [
+                        Part(
+                            root=FilePart(
+                                file=FileWithBytes(
+                                    bytes=base64.b64encode(b"x").decode(),
+                                    mime_type="text/plain",
+                                    name="a.txt",
+                                )
+                            )
+                        )
+                    ],
+                )
+            ]
+        )
+        # WHEN saved
+        save_task_files([task], target)
+        # THEN the directory was created rather than raising
+        assert target.is_dir()
+
+    def test_skips_malformed_base64_without_failing_the_batch(
+        self, tmp_path: Any
+    ) -> None:
+        # GIVEN one corrupt file and one valid file
+        task = _task(
+            [
+                _artifact(
+                    "mixed",
+                    [
+                        Part(
+                            root=FilePart(
+                                file=FileWithBytes(
+                                    bytes="!!!not-base64!!!",
+                                    mime_type="application/octet-stream",
+                                    name="bad.bin",
+                                )
+                            )
+                        ),
+                        Part(
+                            root=FilePart(
+                                file=FileWithBytes(
+                                    bytes=base64.b64encode(b"good").decode(),
+                                    mime_type="text/plain",
+                                    name="good.txt",
+                                )
+                            )
+                        ),
+                    ],
+                )
+            ]
+        )
+        # WHEN saved
+        written = save_task_files([task], tmp_path)
+        # THEN the good file still lands: one bad attachment cannot fail the rest
+        assert [p.name for p in written] == ["good.txt"]

--- a/tests/dragent/test_a2a_artifact_client.py
+++ b/tests/dragent/test_a2a_artifact_client.py
@@ -42,6 +42,7 @@ from datarobot_genai.dragent.a2a_artifact_client import OutboundFile
 from datarobot_genai.dragent.a2a_artifact_client import build_client_message
 from datarobot_genai.dragent.a2a_artifact_client import build_send_message_payload
 from datarobot_genai.dragent.a2a_artifact_client import iter_artifacts
+from datarobot_genai.dragent.a2a_artifact_client import outbound_file_from_uri
 from datarobot_genai.dragent.a2a_artifact_client import save_task_files
 from datarobot_genai.dragent.a2a_artifact_client import summarize_task
 
@@ -127,6 +128,53 @@ class TestOutboundFile:
         part = outbound.to_part()
         # THEN it is treated as inline content, not as "no content supplied"
         assert base64.b64decode(part.root.file.bytes) == b""
+
+
+class TestOutboundFileFromUri:
+    """Pre-signed URLs are the documented way to send a file, and they carry a
+    query string -- inferring from the whole URI breaks both name and type."""
+
+    def test_ignores_a_presigned_query_string(self) -> None:
+        # GIVEN a pre-signed URL with signature parameters
+        uri = "https://bucket.s3.amazonaws.com/reports/q4.csv?X-Amz-Signature=deadbeef&X-Amz-Expires=900"
+        # WHEN an outbound file is derived from it
+        f = outbound_file_from_uri(uri)
+        # THEN the name is clean and the type is correct -- inferring from the full
+        # URI would give "q4.csv?X-Amz-Signature=..." and application/octet-stream
+        assert f.name == "q4.csv"
+        assert f.mime_type == "text/csv"
+        assert f.uri == uri
+
+    @pytest.mark.parametrize(
+        ("uri", "name", "mime"),
+        [
+            ("https://x/y/chart.png?sig=1", "chart.png", "image/png"),
+            ("https://x/y/data.json", "data.json", "application/json"),
+            ("https://x/y/report.pdf?a=1&b=2", "report.pdf", "application/pdf"),
+            # No extension to infer from -> the documented fallback.
+            ("https://x/y/blob?sig=1", "blob", "application/octet-stream"),
+            # A trailing slash is stripped, so the last real segment names it.
+            ("https://x/y/", "y", "application/octet-stream"),
+            # Nothing in the path at all -> the fallback name.
+            ("https://x", "attachment", "application/octet-stream"),
+            ("https://x/", "attachment", "application/octet-stream"),
+        ],
+    )
+    def test_derives_name_and_type_from_the_path(self, uri: str, name: str, mime: str) -> None:
+        # GIVEN assorted URI shapes
+        f = outbound_file_from_uri(uri)
+        # WHEN name and type are derived
+        # THEN they come from the path, with a safe fallback when there is nothing
+        assert (f.name, f.mime_type) == (name, mime)
+
+    def test_references_rather_than_inlining(self) -> None:
+        # GIVEN a URI-derived file
+        f = outbound_file_from_uri("https://x/y/a.txt")
+        # WHEN converted to a part
+        part = f.to_part()
+        # THEN it is a FileWithUri and no bytes were read or embedded
+        assert f.content is None
+        assert part.root.file.uri == "https://x/y/a.txt"
 
 
 class TestBuildClientMessage:

--- a/tests/dragent/test_a2a_artifacts.py
+++ b/tests/dragent/test_a2a_artifacts.py
@@ -1,0 +1,740 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for A2A Tasks, Artifacts, Files and Images.
+
+No live infrastructure required: the NAT session manager and A2A event queue are
+stubbed, so these exercise inbound part parsing, artifact construction, wire-format
+serialisation, the task lifecycle, response-shape selection, builder loading, and
+the per-user composition contract.
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from a2a.types import DataPart
+from a2a.types import FilePart
+from a2a.types import FileWithBytes
+from a2a.types import FileWithUri
+from a2a.types import Message
+from a2a.types import Part
+from a2a.types import Role
+from a2a.types import TaskArtifactUpdateEvent
+from a2a.types import TaskStatusUpdateEvent
+from a2a.types import TextPart
+from a2a.utils.errors import ServerError
+
+from datarobot_genai.dragent.a2a_artifacts import A2ARequestInputs
+from datarobot_genai.dragent.a2a_artifacts import ArtifactBuilder
+from datarobot_genai.dragent.a2a_artifacts import InboundFile
+from datarobot_genai.dragent.a2a_artifacts import OutboundArtifact
+from datarobot_genai.dragent.a2a_artifacts import TaskArtifactAgentExecutor
+from datarobot_genai.dragent.a2a_artifacts import data_artifact
+from datarobot_genai.dragent.a2a_artifacts import extract_request_inputs
+from datarobot_genai.dragent.a2a_artifacts import file_artifact
+from datarobot_genai.dragent.a2a_artifacts import file_uri_artifact
+from datarobot_genai.dragent.a2a_artifacts import load_artifact_builder
+from datarobot_genai.dragent.a2a_artifacts import mixed_artifact
+from datarobot_genai.dragent.a2a_artifacts import text_artifact
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n-opaque-test-bytes"
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeContext:
+    """Stand-in for a2a's RequestContext (only the read fields are provided)."""
+
+    def __init__(self, message: Message | None, current_task: Any = None) -> None:
+        self.message = message
+        self.current_task = current_task
+        self.context_id = "ctx-1"
+        self.task_id = "task-1"
+
+    def get_user_input(self) -> str:
+        return ""
+
+
+class _RecordingQueue:
+    """Captures the events an executor publishes."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def enqueue_event(self, event: object) -> None:
+        self.events.append(event)
+
+
+class _StubSessionManager:
+    """Minimal SessionManager: records the query, returns a canned result."""
+
+    def __init__(self, result: str = "canned result", raises: bool = False) -> None:
+        self.result = result
+        self.raises = raises
+        self.last_query: str | None = None
+        _type = SimpleNamespace(type="stub-workflow")
+        self.config = SimpleNamespace(workflow=_type)
+        self.workflow = SimpleNamespace(config=SimpleNamespace(workflow=_type))
+
+    def session(self) -> Any:
+        outer = self
+
+        class _SessionCM:
+            async def __aenter__(self) -> Any:
+                class _Session:
+                    def run(self, query: str) -> Any:
+                        outer.last_query = query
+
+                        class _RunCM:
+                            async def __aenter__(self) -> Any:
+                                class _Runner:
+                                    async def result(self, to_type: type = str) -> str:
+                                        if outer.raises:
+                                            raise RuntimeError("workflow exploded")
+                                        return outer.result
+
+                                return _Runner()
+
+                            async def __aexit__(self, *a: object) -> bool:
+                                return False
+
+                        return _RunCM()
+
+                return _Session()
+
+            async def __aexit__(self, *a: object) -> bool:
+                return False
+
+        return _SessionCM()
+
+
+class TwoArtifactBuilder:
+    """Builder that always produces a text artifact and a file artifact."""
+
+    async def build_artifacts(
+        self, inputs: A2ARequestInputs, response_text: str
+    ) -> list[OutboundArtifact]:
+        return [
+            text_artifact("summary", response_text),
+            file_artifact("chart.png", PNG_BYTES, "image/png"),
+        ]
+
+
+class EmptyBuilder:
+    """Builder that reports nothing task-shaped."""
+
+    async def build_artifacts(
+        self, inputs: A2ARequestInputs, response_text: str
+    ) -> list[OutboundArtifact]:
+        return []
+
+
+class EchoAttachmentsBuilder:
+    """Builder that proves inbound files reached the application."""
+
+    async def build_artifacts(
+        self, inputs: A2ARequestInputs, response_text: str
+    ) -> list[OutboundArtifact]:
+        return [
+            data_artifact(
+                "echo-of-your-attachments",
+                {"files": [f.describe() for f in inputs.files]},
+            )
+        ]
+
+
+class NotABuilder:
+    """Deliberately missing ``build_artifacts``."""
+
+
+def _message(*parts: Part) -> Message:
+    return Message(role=Role.user, parts=list(parts), message_id="m1")
+
+
+def _executor(
+    session_manager: _StubSessionManager,
+    builder: ArtifactBuilder | None = None,
+    task_mode: str = "auto",
+) -> TaskArtifactAgentExecutor:
+    return TaskArtifactAgentExecutor(
+        session_manager,
+        builder=builder,
+        task_mode=task_mode,  # type: ignore[arg-type]
+    )
+
+
+def _states(queue: _RecordingQueue) -> list[str]:
+    return [e.status.state.value for e in queue.events if isinstance(e, TaskStatusUpdateEvent)]
+
+
+def _artifacts(queue: _RecordingQueue) -> list[TaskArtifactUpdateEvent]:
+    return [e for e in queue.events if isinstance(e, TaskArtifactUpdateEvent)]
+
+
+# ---------------------------------------------------------------------------
+# Inbound parsing -- the half NAT's get_user_input() discards
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRequestInputs:
+    def test_extracts_text(self) -> None:
+        # GIVEN a request carrying a single text part
+        ctx = _FakeContext(_message(Part(root=TextPart(text="hello"))))
+        # WHEN the request is parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the text is available and no attachments are reported
+        assert inputs.text == "hello"
+        assert not inputs.has_attachments
+
+    def test_joins_multiple_text_parts(self) -> None:
+        # GIVEN two text parts
+        ctx = _FakeContext(
+            _message(Part(root=TextPart(text="one")), Part(root=TextPart(text="two")))
+        )
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN they are newline-joined in order
+        assert inputs.text == "one\ntwo"
+
+    def test_extracts_inline_file_and_decodes_base64(self) -> None:
+        # GIVEN an inline file part carrying base64 bytes
+        encoded = base64.b64encode(b"hello bytes").decode("ascii")
+        ctx = _FakeContext(
+            _message(
+                Part(
+                    root=FilePart(
+                        file=FileWithBytes(bytes=encoded, mime_type="text/plain", name="a.txt")
+                    )
+                )
+            )
+        )
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the bytes are decoded and reported as inline
+        assert len(inputs.files) == 1
+        file = inputs.files[0]
+        assert file.content == b"hello bytes"
+        assert file.is_inline
+        assert file.size == len(b"hello bytes")
+        assert file.name == "a.txt"
+
+    def test_extracts_uri_file(self) -> None:
+        # GIVEN a file part carrying a URI rather than bytes
+        ctx = _FakeContext(
+            _message(
+                Part(
+                    root=FilePart(
+                        file=FileWithUri(
+                            uri="https://example.com/x.csv", mime_type="text/csv", name="x.csv"
+                        )
+                    )
+                )
+            )
+        )
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the reference is preserved and nothing is inlined
+        file = inputs.files[0]
+        assert file.uri == "https://example.com/x.csv"
+        assert not file.is_inline
+        assert file.size == 0
+
+    def test_extracts_data_part(self) -> None:
+        # GIVEN a structured data part
+        ctx = _FakeContext(_message(Part(root=DataPart(data={"k": 1}))))
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the payload is captured
+        assert inputs.data == [{"k": 1}]
+        assert inputs.has_attachments
+
+    def test_all_kinds_together(self) -> None:
+        # GIVEN a request mixing text, file and data parts
+        encoded = base64.b64encode(b"img").decode("ascii")
+        ctx = _FakeContext(
+            _message(
+                Part(root=TextPart(text="describe this")),
+                Part(root=FilePart(file=FileWithBytes(bytes=encoded, mime_type="image/png"))),
+                Part(root=DataPart(data={"threshold": 0.5})),
+            )
+        )
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN each kind lands in its own bucket
+        assert inputs.text == "describe this"
+        assert inputs.files[0].content == b"img"
+        assert inputs.data == [{"threshold": 0.5}]
+
+    def test_bad_base64_is_tolerated(self) -> None:
+        # GIVEN a file part whose payload is not valid base64
+        ctx = _FakeContext(
+            _message(
+                Part(root=FilePart(file=FileWithBytes(bytes="!!!not base64!!!", name="bad.bin")))
+            )
+        )
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the attachment is degraded rather than failing the whole request
+        assert len(inputs.files) == 1
+        assert inputs.files[0].content is None
+
+    def test_base64_with_newlines_is_decoded(self) -> None:
+        # GIVEN base64 wrapped across lines, as pretty-printers emit
+        raw = b"a longer payload that will wrap when encoded" * 2
+        encoded = base64.encodebytes(raw).decode("ascii")
+        ctx = _FakeContext(
+            _message(Part(root=FilePart(file=FileWithBytes(bytes=encoded, name="w.bin"))))
+        )
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the lenient pass recovers the bytes
+        assert inputs.files[0].content == raw
+
+    def test_urlsafe_base64_is_decoded(self) -> None:
+        # GIVEN a payload encoded with the base64url alphabet
+        raw = bytes(range(256))
+        encoded = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+        ctx = _FakeContext(
+            _message(Part(root=FilePart(file=FileWithBytes(bytes=encoded, name="u.bin"))))
+        )
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the base64url fallback recovers the bytes
+        assert inputs.files[0].content == raw
+
+    def test_empty_message_is_safe(self) -> None:
+        # GIVEN a context with no message at all
+        ctx = _FakeContext(None)
+        # WHEN parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN an empty result is returned rather than raising
+        assert inputs.text == ""
+        assert inputs.files == []
+        assert inputs.data == []
+
+
+class TestInboundFile:
+    def test_describe_reports_inline_size(self) -> None:
+        # GIVEN an inline file
+        file = InboundFile(name="a.png", mime_type="image/png", content=b"1234")
+        # WHEN described
+        described = file.describe()
+        # THEN the summary names it and reports the byte count
+        assert "a.png" in described
+        assert "4 bytes inline" in described
+
+    def test_describe_reports_uri(self) -> None:
+        # GIVEN a URI reference with no name
+        file = InboundFile(name=None, mime_type=None, uri="https://example.com/a")
+        # WHEN described
+        described = file.describe()
+        # THEN a placeholder name is used and the uri is shown
+        assert "<unnamed>" in described
+        assert "uri=https://example.com/a" in described
+
+
+# ---------------------------------------------------------------------------
+# Artifact helpers
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactHelpers:
+    def test_text_artifact(self) -> None:
+        # GIVEN a text artifact
+        result = text_artifact("summary", "hello")
+        # WHEN inspected
+        # THEN it carries one TextPart with the supplied text
+        assert result.name == "summary"
+        assert result.parts[0].root.text == "hello"
+
+    def test_data_artifact(self) -> None:
+        # GIVEN a data artifact
+        result = data_artifact("analysis", {"n": 3})
+        # WHEN inspected
+        # THEN the structured payload round-trips
+        assert result.parts[0].root.data == {"n": 3}
+
+    def test_file_artifact_encodes_base64(self) -> None:
+        # GIVEN raw bytes
+        result = file_artifact("chart.png", b"\x00\x01", "image/png")
+        # WHEN inspected
+        file = result.parts[0].root.file
+        # THEN the bytes are base64-encoded and the mime type preserved
+        assert base64.b64decode(file.bytes) == b"\x00\x01"
+        assert file.mime_type == "image/png"
+        assert file.name == "chart.png"
+
+    def test_file_artifact_filename_can_differ_from_artifact_name(self) -> None:
+        # GIVEN an explicit filename
+        result = file_artifact("report", b"x", "text/csv", filename="q3.csv")
+        # WHEN inspected
+        # THEN the artifact name and the file name are independent
+        assert result.name == "report"
+        assert result.parts[0].root.file.name == "q3.csv"
+
+    def test_file_uri_artifact_inlines_nothing(self) -> None:
+        # GIVEN a URI artifact
+        result = file_uri_artifact("big.csv", "https://example.com/big.csv", "text/csv")
+        # WHEN inspected
+        file = result.parts[0].root.file
+        # THEN it references the uri and carries no inline bytes
+        assert file.uri == "https://example.com/big.csv"
+        assert getattr(file, "bytes", None) is None
+
+    def test_mixed_artifact_ordering(self) -> None:
+        # GIVEN a multi-part artifact with text, data and a file
+        result = mixed_artifact(
+            "bundle",
+            text="summary",
+            data={"k": 1},
+            files=[("a.bin", b"xy", "application/octet-stream")],
+        )
+        # WHEN the part kinds are read in order
+        kinds = [p.root.kind for p in result.parts]
+        # THEN text precedes data precedes file
+        assert kinds == ["text", "data", "file"]
+
+    def test_metadata_is_carried(self) -> None:
+        # GIVEN an artifact built with metadata
+        result = text_artifact("s", "t", {"source": "unit-test"})
+        # WHEN inspected
+        # THEN the metadata is preserved for publication
+        assert result.metadata == {"source": "unit-test"}
+
+
+class TestWireFormat:
+    def test_file_part_serialises_to_camel_case(self) -> None:
+        # GIVEN a file artifact
+        result = file_artifact("a.png", b"\x00", "image/png")
+        # WHEN serialised the way the A2A transport does
+        dumped = result.parts[0].model_dump(by_alias=True, exclude_none=True)
+        # THEN the file payload uses the wire's camelCase key
+        assert dumped["kind"] == "file"
+        assert "mimeType" in dumped["file"]
+        assert "mime_type" not in dumped["file"]
+
+    def test_message_wire_keys(self) -> None:
+        # GIVEN a message carrying a text part
+        message = _message(Part(root=TextPart(text="hi")))
+        # WHEN serialised by alias
+        dumped = message.model_dump(by_alias=True, exclude_none=True)
+        # THEN identifiers use camelCase and the discriminator is present
+        assert dumped["kind"] == "message"
+        assert "messageId" in dumped
+
+
+# ---------------------------------------------------------------------------
+# Response shape: task_mode
+# ---------------------------------------------------------------------------
+
+
+class TestTaskModeAlways:
+    @pytest.mark.asyncio
+    async def test_emits_submitted_working_artifacts_completed(self) -> None:
+        # GIVEN an executor in ``always`` mode with a builder producing two artifacts
+        sm = _StubSessionManager("AAPL up 1.2%")
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="how is AAPL?"))))
+        # WHEN it executes
+        await _executor(sm, TwoArtifactBuilder(), "always").execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN a Task is opened, driven working -> completed, and both artifacts emitted
+        assert queue.events[0].status.state.value == "submitted"
+        assert _states(queue) == ["working", "completed"]
+        assert len(_artifacts(queue)) == 2
+        assert sm.last_query == "how is AAPL?"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_text_artifact_when_builder_is_empty(self) -> None:
+        # GIVEN ``always`` mode with a builder that produces nothing
+        sm = _StubSessionManager("only words")
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="q"))))
+        # WHEN it executes
+        await _executor(sm, EmptyBuilder(), "always").execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN the task still completes, carrying the response as one text artifact
+        assert _states(queue)[-1] == "completed"
+        assert len(_artifacts(queue)) == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_publishes_failed_state_and_raises(self) -> None:
+        # GIVEN a workflow that raises
+        sm = _StubSessionManager(raises=True)
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="boom"))))
+        # WHEN it executes
+        with pytest.raises(ServerError):
+            await _executor(sm, TwoArtifactBuilder(), "always").execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN the task reaches a terminal failed state so the caller stops waiting
+        assert "failed" in _states(queue)
+
+    @pytest.mark.asyncio
+    async def test_file_only_request_is_allowed(self) -> None:
+        # GIVEN a request with a file but no text, which NAT would reject
+        encoded = base64.b64encode(PNG_BYTES).decode("ascii")
+        sm = _StubSessionManager("described")
+        queue = _RecordingQueue()
+        ctx = _FakeContext(
+            _message(Part(root=FilePart(file=FileWithBytes(bytes=encoded, mime_type="image/png"))))
+        )
+        # WHEN it executes
+        await _executor(sm, TwoArtifactBuilder(), "always").execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN the task completes and the workflow was invoked with an empty query
+        assert _states(queue)[-1] == "completed"
+        assert sm.last_query == ""
+
+    @pytest.mark.asyncio
+    async def test_inbound_files_reach_the_builder(self) -> None:
+        # GIVEN a request carrying a file and a builder that echoes attachments
+        encoded = base64.b64encode(b"1234").decode("ascii")
+        queue = _RecordingQueue()
+        ctx = _FakeContext(
+            _message(
+                Part(root=TextPart(text="echo")),
+                Part(root=FilePart(file=FileWithBytes(bytes=encoded, name="in.bin"))),
+            )
+        )
+        # WHEN it executes
+        await _executor(_StubSessionManager(), EchoAttachmentsBuilder(), "always").execute(  # type: ignore[arg-type]
+            ctx, queue
+        )
+        # THEN the application saw the decoded attachment
+        payload = _artifacts(queue)[0].artifact.parts[0].root.data
+        assert "in.bin" in payload["files"][0]
+        assert "4 bytes inline" in payload["files"][0]
+
+    @pytest.mark.asyncio
+    async def test_missing_message_raises_invalid_params(self) -> None:
+        # GIVEN a context with no message
+        ctx = _FakeContext(None)
+        # WHEN it executes
+        with pytest.raises(ServerError) as exc:
+            await _executor(_StubSessionManager(), TwoArtifactBuilder(), "always").execute(  # type: ignore[arg-type]
+                ctx, _RecordingQueue()
+            )
+        # THEN the caller is told the params were invalid, not that the server failed
+        assert exc.value.error.__class__.__name__ == "InvalidParamsError"
+
+    @pytest.mark.asyncio
+    async def test_empty_textpart_is_rejected_cleanly(self) -> None:
+        # GIVEN a message whose only part is empty text
+        ctx = _FakeContext(_message(Part(root=TextPart(text=""))))
+        # WHEN it executes
+        with pytest.raises(ServerError) as exc:
+            await _executor(_StubSessionManager(), TwoArtifactBuilder(), "always").execute(  # type: ignore[arg-type]
+                ctx, _RecordingQueue()
+            )
+        # THEN the ValueError from new_task() is translated, not leaked
+        assert exc.value.error.__class__.__name__ == "InvalidParamsError"
+
+
+class TestTaskModeAuto:
+    @pytest.mark.asyncio
+    async def test_returns_message_when_no_artifacts(self) -> None:
+        # GIVEN the default ``auto`` mode and a builder producing nothing
+        sm = _StubSessionManager("just words")
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="hi"))))
+        # WHEN it executes
+        await _executor(sm, EmptyBuilder()).execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN a plain Message is returned and no Task is opened
+        assert len(queue.events) == 1
+        assert isinstance(queue.events[0], Message)
+        assert queue.events[0].parts[0].root.text == "just words"
+        assert _states(queue) == []
+
+    @pytest.mark.asyncio
+    async def test_returns_message_when_no_builder_configured(self) -> None:
+        # GIVEN no builder at all
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="hi"))))
+        # WHEN it executes
+        await _executor(_StubSessionManager("plain")).execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN behaviour matches a message-only agent
+        assert isinstance(queue.events[0], Message)
+        assert _artifacts(queue) == []
+
+    @pytest.mark.asyncio
+    async def test_returns_task_when_artifacts_exist(self) -> None:
+        # GIVEN ``auto`` mode and a builder producing artifacts
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="how is AAPL?"))))
+        # WHEN it executes
+        await _executor(_StubSessionManager(), TwoArtifactBuilder()).execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN a Task carrying both artifacts is completed
+        assert len(_artifacts(queue)) == 2
+        assert _states(queue)[-1] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_no_working_event_because_outcome_decides_shape(self) -> None:
+        # GIVEN ``auto`` mode, where the response shape depends on the outcome
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="q"))))
+        # WHEN it executes
+        await _executor(_StubSessionManager(), TwoArtifactBuilder()).execute(ctx, queue)  # type: ignore[arg-type]
+        # THEN no ``working`` progress event is emitted -- the documented trade-off
+        # of deciding after the workflow has run
+        assert "working" not in _states(queue)
+
+    @pytest.mark.asyncio
+    async def test_workflow_failure_raises_server_error(self) -> None:
+        # GIVEN a workflow that raises, before any task exists
+        sm = _StubSessionManager(raises=True)
+        # WHEN it executes in ``auto`` mode
+        with pytest.raises(ServerError):
+            await _executor(sm, TwoArtifactBuilder()).execute(  # type: ignore[arg-type]
+                _FakeContext(_message(Part(root=TextPart(text="boom")))), _RecordingQueue()
+            )
+        # THEN the caller receives a ServerError rather than a bare exception
+
+
+class TestTaskModeNever:
+    @pytest.mark.asyncio
+    async def test_returns_message_even_when_artifacts_exist(self) -> None:
+        # GIVEN ``never`` mode with a builder that would produce artifacts
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="hi"))))
+        # WHEN it executes
+        await _executor(_StubSessionManager("text only"), TwoArtifactBuilder(), "never").execute(  # type: ignore[arg-type]
+            ctx, queue
+        )
+        # THEN the artifacts are suppressed and a Message is returned
+        assert isinstance(queue.events[0], Message)
+        assert _artifacts(queue) == []
+        assert _states(queue) == []
+
+    def test_auto_is_the_default(self) -> None:
+        # GIVEN an executor constructed without an explicit mode
+        executor = TaskArtifactAgentExecutor(_StubSessionManager())
+        # WHEN the mode is read
+        # THEN it defaults to ``auto``, which is non-breaking for existing callers
+        assert executor.task_mode == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+
+class TestCancel:
+    @pytest.mark.asyncio
+    async def test_no_task_raises_task_not_found(self) -> None:
+        # GIVEN a cancellation request with no associated task
+        ctx = _FakeContext(_message(Part(root=TextPart(text="x"))), current_task=None)
+        # WHEN cancel is called
+        with pytest.raises(ServerError) as exc:
+            await _executor(_StubSessionManager(), TwoArtifactBuilder()).cancel(  # type: ignore[arg-type]
+                ctx, _RecordingQueue()
+            )
+        # THEN the caller is told there is nothing to cancel
+        assert exc.value.error.__class__.__name__ == "TaskNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# Builder loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadArtifactBuilder:
+    def test_loads_a_valid_builder(self) -> None:
+        # GIVEN a dotted path to a conforming builder
+        path = f"{TwoArtifactBuilder.__module__}.TwoArtifactBuilder"
+        # WHEN it is loaded
+        builder = load_artifact_builder(path)
+        # THEN an instance satisfying the protocol is returned
+        assert isinstance(builder, TwoArtifactBuilder)
+        assert isinstance(builder, ArtifactBuilder)
+
+    def test_rejects_class_without_build_artifacts(self) -> None:
+        # GIVEN a class that does not implement the protocol
+        path = f"{NotABuilder.__module__}.NotABuilder"
+        # WHEN it is loaded
+        with pytest.raises(ValueError, match="build_artifacts"):
+            load_artifact_builder(path)
+        # THEN the misconfiguration is reported at startup, not at request time
+
+    def test_rejects_path_without_module(self) -> None:
+        # GIVEN a bare name with no module component
+        # WHEN it is loaded
+        with pytest.raises(ValueError, match="dotted path"):
+            load_artifact_builder("NoModule")
+        # THEN the malformed path is rejected
+
+    def test_rejects_unimportable_module(self) -> None:
+        # GIVEN a module that does not exist
+        # WHEN it is loaded
+        with pytest.raises(ValueError, match="Could not import"):
+            load_artifact_builder("datarobot_genai.does_not_exist.Thing")
+        # THEN the import failure is surfaced with the offending path
+
+    def test_rejects_non_class_target(self) -> None:
+        # GIVEN a dotted path naming a function rather than a class
+        # WHEN it is loaded
+        with pytest.raises(ValueError, match="not a class"):
+            load_artifact_builder("datarobot_genai.dragent.a2a_artifacts.text_artifact")
+        # THEN it is rejected
+
+
+# ---------------------------------------------------------------------------
+# Composition contract with the per-user executor
+# ---------------------------------------------------------------------------
+
+
+class TestPerUserComposition:
+    def test_per_user_executor_exposes_a_single_seam(self) -> None:
+        # GIVEN the per-user executor
+        from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
+
+        # WHEN its overridable seam is inspected
+        # THEN subclasses can change the response without touching execute(), so the
+        # identity/header setup cannot be bypassed
+        assert hasattr(_PerUserCompatibleAgentExecutor, "_run_request")
+
+    def test_task_artifact_executor_inherits_execute_unchanged(self) -> None:
+        # GIVEN the composed task/artifact executor
+        from datarobot_genai.dragent.frontends.fastapi import _PerUserCompatibleAgentExecutor
+        from datarobot_genai.dragent.frontends.fastapi import _TaskArtifactPerUserExecutor
+
+        # WHEN execute and the seam are compared
+        # THEN execute() is inherited verbatim (auth context preserved) and only the
+        # seam is overridden -- there is no base-ordering requirement to get wrong
+        assert _TaskArtifactPerUserExecutor.execute is _PerUserCompatibleAgentExecutor.execute
+        assert (
+            _TaskArtifactPerUserExecutor._run_request
+            is not _PerUserCompatibleAgentExecutor._run_request
+        )
+
+    @pytest.mark.asyncio
+    async def test_seam_delegates_to_the_task_artifact_executor(self) -> None:
+        # GIVEN a composed executor with a builder
+        from datarobot_genai.dragent.frontends.fastapi import _TaskArtifactPerUserExecutor
+
+        executor = _TaskArtifactPerUserExecutor(
+            _StubSessionManager(),  # type: ignore[arg-type]
+            builder=TwoArtifactBuilder(),
+            task_mode="always",
+        )
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="q"))))
+        # WHEN the seam is invoked directly
+        await executor._run_request(ctx, queue)  # type: ignore[arg-type]
+        # THEN the task/artifact lifecycle runs
+        assert _states(queue)[-1] == "completed"
+        assert len(_artifacts(queue)) == 2

--- a/tests/dragent/test_a2a_artifacts.py
+++ b/tests/dragent/test_a2a_artifacts.py
@@ -194,6 +194,103 @@ def _artifacts(queue: _RecordingQueue) -> list[TaskArtifactUpdateEvent]:
 # ---------------------------------------------------------------------------
 
 
+class TestRequestContextAwareness:
+    """A builder decides *what* to return, so it must see what was asked."""
+
+    def test_surfaces_the_conversation_identifiers(self) -> None:
+        # GIVEN a request on an existing task
+        ctx = _FakeContext(_message(Part(root=TextPart(text="hi"))))
+        # WHEN the request is parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the builder can correlate the turn and see it is a follow-up
+        assert inputs.context_id == "ctx-1"
+        assert inputs.task_id == "task-1"
+        assert inputs.is_follow_up is True
+        assert inputs.context is ctx
+
+    def test_first_turn_is_not_a_follow_up(self) -> None:
+        # GIVEN a request with no task association
+        ctx = _FakeContext(_message(Part(root=TextPart(text="hi"))))
+        ctx.task_id = None
+        # WHEN the request is parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the builder can distinguish a fresh exchange from a continuation
+        assert inputs.is_follow_up is False
+
+    def test_surfaces_message_metadata(self) -> None:
+        # GIVEN a caller passing out-of-band hints via message metadata
+        message = _message(Part(root=TextPart(text="hi")))
+        message.metadata = {"formats": ["csv"], "locale": "en-GB"}
+        # WHEN the request is parsed
+        inputs = extract_request_inputs(_FakeContext(message))  # type: ignore[arg-type]
+        # THEN they reach the builder, so output can honour a requested format
+        assert inputs.metadata["formats"] == ["csv"]
+
+    def test_metadata_defaults_to_empty_not_none(self) -> None:
+        # GIVEN a request with no metadata
+        inputs = extract_request_inputs(  # type: ignore[arg-type]
+            _FakeContext(_message(Part(root=TextPart(text="hi"))))
+        )
+        # WHEN metadata is read
+        # THEN it is safe to subscript without a None check
+        assert inputs.metadata == {}
+        assert inputs.metadata.get("anything") is None
+
+    def test_surfaces_prior_turns_from_task_history(self) -> None:
+        # GIVEN a task carrying two earlier messages
+        history = [
+            _message(Part(root=TextPart(text="first question"))),
+            _message(Part(root=TextPart(text="second question"))),
+        ]
+        task = SimpleNamespace(id="task-9", context_id="ctx-9", history=history)
+        ctx = _FakeContext(_message(Part(root=TextPart(text="third"))), current_task=task)
+        # WHEN the request is parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN the builder can see what was already discussed
+        assert len(inputs.history) == 2
+        assert inputs.history_text() == ["first question", "second question"]
+
+    def test_history_text_can_be_limited_to_recent_turns(self) -> None:
+        # GIVEN three prior turns
+        history = [_message(Part(root=TextPart(text=f"turn {i}"))) for i in range(3)]
+        task = SimpleNamespace(id="t", context_id="c", history=history)
+        ctx = _FakeContext(_message(Part(root=TextPart(text="now"))), current_task=task)
+        # WHEN only the most recent turn is requested
+        recent = extract_request_inputs(ctx).history_text(limit=1)  # type: ignore[arg-type]
+        # THEN the newest is returned, so a builder can cap prompt/context size
+        assert recent == ["turn 2"]
+
+    def test_history_is_empty_without_a_task(self) -> None:
+        # GIVEN a first-turn request
+        inputs = extract_request_inputs(  # type: ignore[arg-type]
+            _FakeContext(_message(Part(root=TextPart(text="hi"))), current_task=None)
+        )
+        # WHEN history is read
+        # THEN it is an empty list rather than None
+        assert inputs.history == []
+        assert inputs.history_text() == []
+
+    def test_asked_for_matches_case_insensitively(self) -> None:
+        # GIVEN a request mentioning a chart
+        inputs = extract_request_inputs(  # type: ignore[arg-type]
+            _FakeContext(_message(Part(root=TextPart(text="Send me a CHART of revenue"))))
+        )
+        # WHEN the builder checks what was asked
+        # THEN it can branch without writing its own string handling
+        assert inputs.asked_for("chart") is True
+        assert inputs.asked_for("csv", "chart") is True
+        assert inputs.asked_for("spreadsheet") is False
+
+    def test_context_fields_survive_a_partless_message(self) -> None:
+        # GIVEN a message with no parts (an early-return path)
+        ctx = _FakeContext(None, current_task=SimpleNamespace(id="t2", context_id="c2", history=[]))
+        # WHEN the request is parsed
+        inputs = extract_request_inputs(ctx)  # type: ignore[arg-type]
+        # THEN identifiers are still populated -- the early return must not skip them
+        assert inputs.task_id == "task-1"
+        assert inputs.context_id == "ctx-1"
+
+
 class TestExtractRequestInputs:
     def test_extracts_text(self) -> None:
         # GIVEN a request carrying a single text part

--- a/tests/dragent/test_a2a_artifacts.py
+++ b/tests/dragent/test_a2a_artifacts.py
@@ -34,6 +34,7 @@ from a2a.types import FileWithUri
 from a2a.types import Message
 from a2a.types import Part
 from a2a.types import Role
+from a2a.types import Task
 from a2a.types import TaskArtifactUpdateEvent
 from a2a.types import TaskStatusUpdateEvent
 from a2a.types import TextPart
@@ -640,6 +641,54 @@ class TestTaskModeAlways:
             )
         # THEN the ValueError from new_task() is translated, not leaked
         assert exc.value.error.__class__.__name__ == "InvalidParamsError"
+
+
+class TestValidationHappensBeforeWork:
+    """A malformed request must be refused up front, not after the workflow ran."""
+
+    @pytest.mark.asyncio
+    async def test_auto_rejects_a_malformed_message_without_running_the_workflow(self) -> None:
+        # GIVEN auto mode and a message new_task() will reject (empty text part)
+        sm = _StubSessionManager("should never run")
+        ctx = _FakeContext(_message(Part(root=TextPart(text=""))))
+        # WHEN it executes
+        with pytest.raises(ServerError) as exc:
+            await _executor(sm, TwoArtifactBuilder(), "auto").execute(  # type: ignore[arg-type]
+                ctx, _RecordingQueue()
+            )
+        # THEN it fails as invalid params AND the workflow was never invoked --
+        # validating late would have discarded a completed run's artifacts
+        assert exc.value.error.__class__.__name__ == "InvalidParamsError"
+        assert sm.last_query is None, f"workflow ran before validation: {sm.last_query!r}"
+
+    @pytest.mark.asyncio
+    async def test_auto_publishes_the_task_it_validated(self) -> None:
+        # GIVEN a valid request in auto mode
+        queue = _RecordingQueue()
+        ctx = _FakeContext(_message(Part(root=TextPart(text="hi"))))
+        # WHEN it executes
+        await _executor(_StubSessionManager("ok"), TwoArtifactBuilder(), "auto").execute(  # type: ignore[arg-type]
+            ctx, queue
+        )
+        # THEN exactly one Task was published, and every artifact event references
+        # it -- the up-front build must be reused, not duplicated with a fresh id
+        tasks = [e for e in queue.events if isinstance(e, Task)]
+        assert len(tasks) == 1
+        assert {a.task_id for a in _artifacts(queue)} == {tasks[0].id}
+
+    @pytest.mark.asyncio
+    async def test_never_mode_also_validates_before_running(self) -> None:
+        # GIVEN never mode, where no task is ever published
+        sm = _StubSessionManager("should never run")
+        ctx = _FakeContext(_message(Part(root=TextPart(text=""))))
+        # WHEN it executes
+        with pytest.raises(ServerError) as exc:
+            await _executor(sm, TwoArtifactBuilder(), "never").execute(  # type: ignore[arg-type]
+                ctx, _RecordingQueue()
+            )
+        # THEN a malformed request is still refused before any work happens
+        assert exc.value.error.__class__.__name__ == "InvalidParamsError"
+        assert sm.last_query is None
 
 
 class TestTaskModeAuto:

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.24"
+version = "0.26.25"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -3962,10 +3962,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3981,10 +3981,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.16"
+version = "0.26.17"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -2708,17 +2708,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -2734,16 +2734,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -3931,10 +3931,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", extra = ["ws"], marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp", extra = ["ws"] },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3950,10 +3950,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", extra = ["ws"], marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp", extra = ["ws"] },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [


### PR DESCRIPTION
# RATIONALE
 
Dell (PBMP-7902) reported that agents built on our A2A blueprint can only exchange
plain text — no Tasks, Artifacts, Files, Images or structured data. That's accurate,
and structural: NAT's A2A executor returns a bare `Message`, and in A2A an
`Artifact` only exists on a `Task`. So artifacts weren't unsupported, they were
unrepresentable. The client side is flattened the same way, in both directions.
 
This adds both halves as public, opt-in API. Adoption is two `workflow.yaml` keys to
produce artifacts and one to consume them — replacing ~1,600 lines the customer repo
had to vendor, including an executor that subclassed a private library class to
inherit the header forwarding Okta cross-application access depends on.
 
Unset, behaviour is unchanged in both directions.
 
## CHANGES
 
**New** `dragent/a2a_artifacts.py` — producing. `ArtifactBuilder` Protocol (one
method), `TaskArtifactAgentExecutor` owning the task lifecycle,
`extract_request_inputs()` parsing every inbound part kind, and `text_artifact` /
`data_artifact` / `file_artifact` / `file_uri_artifact` / `mixed_artifact` helpers.
 
**New** `dragent/a2a_artifact_client.py` — consuming. `OutboundFile`,
`build_client_message`, `build_send_message_payload`, `iter_artifacts`,
`summarize_task`, `save_task_files`.
 
**`frontends/register.py`** — `artifact_builder` (dotted path; validated at startup)
and `task_mode` (`auto` | `always` | `never`, default `auto`).
 
**`frontends/fastapi.py`** — a single `_run_request` seam on the per-user executor;
`_TaskArtifactPerUserExecutor` delegating to a *contained*
`TaskArtifactAgentExecutor`; `_build_agent_executor()` to select between paths.
 
**`plugins/auth_a2a_client.py`** — `send_parts()` for multi-part sends through the
group's existing authenticated client, and an `artifact_client` key (default
`false`) registering `send_with_attachments` and `get_task_artifacts`.
 
**Tests** — 76 new (44 producing, 32 consuming). **Docs** —
`docs/src/dragent/a2a-artifacts.md` + nav entry. **Version** — `0.26.25`.
 
Neither new module imports NAT.
 
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] ~~New tools in `src/datarobot_genai/drtools/`~~ — N/A, no `drtools` changes
## NOTES
 
### Where NAT flattens A2A
 
| Side | Location | Consequence |
|---|---|---|
| Serving | `get_user_input()` | inbound files and data parts discarded before the workflow |
| Serving | `to_type=str`, returns `Message` | artifacts unrepresentable |
| Calling | `send_message(message_text: str)` | caller cannot send files |
| Calling | `extract_text_from_events()` | artifacts dropped on read |
 
None of this is a protocol limit — the raw client events already carry every
artifact. Upstream isn't a route either: `nvidia-nat-a2a` 1.6.0/1.7.0/1.8.0 ship a
byte-identical (same md5) executor.
 
### Protocol decisions worth review
 
**`cancel()` no longer raises `UnsupportedOperationError`.** It publishes a terminal
`canceled` state, because NAT's own client registers a `cancel_task` tool and always
failing leaves callers polling a task that never resolves. The caveat: NAT exposes
no cancellation hook into a running session, so this is **bookkeeping, not
preemption** — in-flight work runs to completion and its result is discarded, while
the task reports `canceled`. The status message and docstring say so. This is the
decision I'm least sure about; happy to revert to `UnsupportedOperationError` or put
it behind a flag.
 
**`task_mode: "never"` discards artifacts** a builder produced, since a `Message`
has nowhere to carry them. Explicit config is honoured, but now logs a warning
naming the count rather than dropping them silently.
 
**Tolerant inbound base64** (strict → lenient → base64url) accepts payloads a strict
reader would reject, so one malformed attachment can't fail a whole request.
 
**`iter_artifacts` merges parts across repeat `artifact_id` sightings**, because A2A
permits chunked artifacts via `TaskArtifactUpdateEvent.append`. First-seen-wins
would silently truncate a streamed artifact.
 
Otherwise this follows the spec directly: artifacts only on tasks; `Task` and
`Message` both valid `message/send` results; three part kinds; the two file
representations mutually exclusive and enforced; `contextId` reusable vs `taskId`
terminal; camelCase on the wire, snake_case in Python.
 
### Design
 
Composition, not inheritance. The library composes the artifact executor *around*
the per-user executor, so per-user identity resolution and inbound-header forwarding
cannot be bypassed by an application. `TaskArtifactAgentExecutor` is public and
concrete so there's a supported subclassing target — the earlier version reached for
private `_PerUserCompatibleAgentExecutor` instead, and getting its base-class order
wrong degraded silently to message-only.
 
`send_parts()` sends through the interceptors already configured in `__aenter__`, so
the Okta exchange applies exactly as it does to a text-only call. Applications no
longer reach into `_client._client` to borrow the client.
 
`artifact_client` is opt-in because registering functions changes which tools an
agent's LLM can select — that can't be called non-breaking.
 
### Version
 
Merged `main` and renumbered to `0.26.25`; the branch originally claimed `0.26.17`,
which `main` has since used.
 
## TESTING
 
`task test-module MODULE=dragent`, plus `task lint` and `task test`.
 
Validated end to end on a two-agent chain over a **live Okta
cross-application-access exchange** (real RFC 8693 → RFC 7523 two-step exchange,
audience rebound between agents):
 
- `Task`, `state: completed`, **7 artifacts** spanning `TextPart`, `DataPart`,
  inline `FilePart` (`image/png`, `text/csv`), `FileWithUri` and a multi-part
  artifact.
- Inbound `image/png` round-trips **byte-identical** (197 bytes both ways) —
  impossible on the stock path.
- Caller sends a `DataPart` via `send_with_attachments` and reads every artifact
  back over the authenticated hop.
- Output is **structurally identical** to the previous vendored implementation
  (same names, part kinds, metadata keys, mime types, payload sizes), so this is a
  refactor of proven behaviour.
- Both escape hatches verified: no `artifact_builder` → `kind: "message"`; no
  `artifact_client` → no extra functions registered.
## RELATED
 
- Jira **PBMP-7902**
- Consuming application, draft PR pending this release: `<demo-repo-PR-link>` — this
  change deletes ~1,600 lines from it across five files
## REVIEWERS
 
@cavitcakir, @jpclemens0 (maintainers per `CONTRIBUTING.md`)
 
@<anatolii-handle> for A2A backward-compatibility: `task_mode: auto` leaves
message-only callers unaffected, the `_run_request` seam is inert without an
`artifact_builder`, `artifact_client` defaults off, and the `cancel()` decision
above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches A2A request/response paths, auth header forwarding, and cancellation semantics; defaults are off/non-breaking but misconfiguration or the new cancel behavior could affect long-running callers.
> 
> **Overview**
> Adds **opt-in A2A Task/Artifact support** for DRAgent so agents can return files, images, and structured data—not only plain `Message` text—and callers can send/read those parts over authenticated hops.
> 
> **Serving:** New `a2a_artifacts` module with `ArtifactBuilder`, `TaskArtifactAgentExecutor`, full inbound part parsing (`extract_request_inputs`), artifact helpers, configurable `a2a.artifact_builder` and `a2a.task_mode` (`auto` | `always` | `never`). The FastAPI front end composes this via `_run_request` / `_TaskArtifactPerUserExecutor` so per-user identity and header forwarding stay intact; without a builder, behavior stays message-only. `cancel()` now publishes a terminal `canceled` state (bookkeeping, not preemption).
> 
> **Calling:** New `a2a_artifact_client` for multi-part sends and artifact reads (`send_parts`, `iter_artifacts`, `summarize_task`, `save_task_files`). `authenticated_a2a_client` gains optional `artifact_client: true` to register `send_with_attachments` and `get_task_artifacts`.
> 
> Docs (`a2a-artifacts.md`), changelog, version **0.26.25**, and extensive unit tests accompany the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c177e24f66b7e8f53d342c21dac68aa6b1b3283. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->