### PR TITLE
[BUZZOK-31902] Make unauthenticated agent card access opt in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.32
+- `dragent`: added `enable_unauthenticated_well_known_route` to `DRAgentA2AConfig` so agent developers can opt in per agent to serving `GET /.well-known/agent-card.json` without authentication. When disabled (default), unauthenticated requests receive 404. When enabled, anonymous callers receive a redacted agent card; authenticated callers always receive the full card.
+
 ## 0.26.31
 - `dragent`: A2A agent cards always include `securitySchemes`. Agents without `server_auth` or `cross_application_access` advertise HTTP Bearer auth (`bearerAuth`) for DataRobot API tokens; OAuth-configured agents continue to publish `oauth2` schemes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.26.32
+## 0.27.0
 - `dragent`: added `enable_unauthenticated_well_known_route` to `DRAgentA2AConfig` as the per-agent developer opt-in for unauthenticated `GET /.well-known/agent-card.json`. Unauthenticated access also requires platform-level opt-in per cluster (routing is configured outside this library). Both must be enabled: when the agent flag is disabled (default), unauthenticated requests receive 401 regardless of platform settings; when enabled, anonymous callers receive a redacted agent card. Authenticated callers always receive the full card.
 
 ## 0.26.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.26.32
-- `dragent`: added `enable_unauthenticated_well_known_route` to `DRAgentA2AConfig` so agent developers can opt in per agent to serving `GET /.well-known/agent-card.json` without authentication. When disabled (default), unauthenticated requests receive 404. When enabled, anonymous callers receive a redacted agent card; authenticated callers always receive the full card.
+- `dragent`: added `enable_unauthenticated_well_known_route` to `DRAgentA2AConfig` so agent developers can opt in per agent to serving `GET /.well-known/agent-card.json` without authentication. When disabled (default), unauthenticated requests receive 401. When enabled, anonymous callers receive a redacted agent card; authenticated callers always receive the full card.
 
 ## 0.26.31
 - `dragent`: A2A agent cards always include `securitySchemes`. Agents without `server_auth` or `cross_application_access` advertise HTTP Bearer auth (`bearerAuth`) for DataRobot API tokens; OAuth-configured agents continue to publish `oauth2` schemes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.26.32
-- `dragent`: added `enable_unauthenticated_well_known_route` to `DRAgentA2AConfig` so agent developers can opt in per agent to serving `GET /.well-known/agent-card.json` without authentication. When disabled (default), unauthenticated requests receive 401. When enabled, anonymous callers receive a redacted agent card; authenticated callers always receive the full card.
+- `dragent`: added `enable_unauthenticated_well_known_route` to `DRAgentA2AConfig` as the per-agent developer opt-in for unauthenticated `GET /.well-known/agent-card.json`. Unauthenticated access also requires platform-level opt-in per cluster (routing is configured outside this library). Both must be enabled: when the agent flag is disabled (default), unauthenticated requests receive 401 regardless of platform settings; when enabled, anonymous callers receive a redacted agent card. Authenticated callers always receive the full card.
 
 ## 0.26.31
 - `dragent`: A2A agent cards always include `securitySchemes`. Agents without `server_auth` or `cross_application_access` advertise HTTP Bearer auth (`bearerAuth`) for DataRobot API tokens; OAuth-configured agents continue to publish `oauth2` schemes.

--- a/docs/src/nat/a2a-auth.md
+++ b/docs/src/nat/a2a-auth.md
@@ -239,12 +239,12 @@ identity metadata and the agent card URL.
 
 ### Server-side configuration reference: `enable_unauthenticated_well_known_route`
 
-Unauthenticated access to `GET /.well-known/agent-card.json` requires **two**
+Unauthenticated access to `GET /.well-known/agent-card.json` requires two
 independent opt-ins:
 
-1. **Platform (per cluster)** — cluster administrators enable routing of
+1. Platform (per cluster) — cluster administrators enable routing of
    unauthenticated traffic to agents. This is configured outside `workflow.yaml`.
-2. **Agent (per deployment)** — set `enable_unauthenticated_well_known_route:
+2. Agent (per deployment) — set `enable_unauthenticated_well_known_route:
    true` under `general.front_end.a2a` in the agent's `workflow.yaml`.
 
 Both must be enabled for anonymous callers to reach the agent card endpoint.

--- a/docs/src/nat/a2a-auth.md
+++ b/docs/src/nat/a2a-auth.md
@@ -164,6 +164,9 @@ general:
         id: "my-agent-id"       # Emitted as urn:datarobot:agent:identity:external
         url: "https://my-agent-id.example.com/a2a/"  # Overrides the auto-generated card URL
 
+      # Optional: opt in to serving the agent card without authentication
+      enable_unauthenticated_well_known_route: true
+
 # Client-side: call a remote XAA-protected agent
 function_groups:
   remote_agent:
@@ -232,6 +235,7 @@ identity metadata and the agent card URL.
 |-------|---------|
 | `external.id` | Catalog discovery identifier. Emitted as the `urn:datarobot:agent:identity:external` extension on the agent card. |
 | `external.url` | Overrides the auto-generated agent card endpoint URL. Used as-is — no normalization is applied. |
+| `enable_unauthenticated_well_known_route` | When `true`, unauthenticated `GET /.well-known/agent-card.json` requests receive a redacted agent card. When `false` (default), unauthenticated requests receive 404. Authenticated callers always receive the full card. |
 
 ### Client-side configuration reference: `okta_cross_app_access`
 

--- a/docs/src/nat/a2a-auth.md
+++ b/docs/src/nat/a2a-auth.md
@@ -235,7 +235,7 @@ identity metadata and the agent card URL.
 |-------|---------|
 | `external.id` | Catalog discovery identifier. Emitted as the `urn:datarobot:agent:identity:external` extension on the agent card. |
 | `external.url` | Overrides the auto-generated agent card endpoint URL. Used as-is — no normalization is applied. |
-| `enable_unauthenticated_well_known_route` | When `true`, unauthenticated `GET /.well-known/agent-card.json` requests receive a redacted agent card. When `false` (default), unauthenticated requests receive 404. Authenticated callers always receive the full card. |
+| `enable_unauthenticated_well_known_route` | When `true`, unauthenticated `GET /.well-known/agent-card.json` requests receive a redacted agent card. When `false` (default), unauthenticated requests receive 401. Authenticated callers always receive the full card. |
 
 ### Client-side configuration reference: `okta_cross_app_access`
 

--- a/docs/src/nat/a2a-auth.md
+++ b/docs/src/nat/a2a-auth.md
@@ -164,7 +164,8 @@ general:
         id: "my-agent-id"       # Emitted as urn:datarobot:agent:identity:external
         url: "https://my-agent-id.example.com/a2a/"  # Overrides the auto-generated card URL
 
-      # Optional: opt in to serving the agent card without authentication
+      # Optional: per-agent opt-in for unauthenticated agent-card access
+      # (also requires platform-level opt-in per cluster)
       enable_unauthenticated_well_known_route: true
 
 # Client-side: call a remote XAA-protected agent
@@ -235,7 +236,24 @@ identity metadata and the agent card URL.
 |-------|---------|
 | `external.id` | Catalog discovery identifier. Emitted as the `urn:datarobot:agent:identity:external` extension on the agent card. |
 | `external.url` | Overrides the auto-generated agent card endpoint URL. Used as-is — no normalization is applied. |
-| `enable_unauthenticated_well_known_route` | When `true`, unauthenticated `GET /.well-known/agent-card.json` requests receive a redacted agent card. When `false` (default), unauthenticated requests receive 401. Authenticated callers always receive the full card. |
+
+### Server-side configuration reference: `enable_unauthenticated_well_known_route`
+
+Unauthenticated access to `GET /.well-known/agent-card.json` requires **two**
+independent opt-ins:
+
+1. **Platform (per cluster)** — cluster administrators enable routing of
+   unauthenticated traffic to agents. This is configured outside `workflow.yaml`.
+2. **Agent (per deployment)** — set `enable_unauthenticated_well_known_route:
+   true` under `general.front_end.a2a` in the agent's `workflow.yaml`.
+
+Both must be enabled for anonymous callers to reach the agent card endpoint.
+The agent-side flag is enforced by the A2A server in this library; platform
+routing is enforced before the request reaches the agent process.
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `enable_unauthenticated_well_known_route` | `false` | Per-agent developer opt-in. When `true`, unauthenticated requests that reach the agent receive a redacted agent card. When `false`, they receive 401. Authenticated callers always receive the full card regardless of this setting. |
 
 ### Client-side configuration reference: `okta_cross_app_access`
 

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -187,7 +187,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.32"
+version = "0.27.0"
 source = { editable = "../" }
 
 [package.metadata]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -187,7 +187,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.31"
+version = "0.26.32"
 source = { editable = "../" }
 
 [package.metadata]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.31"
+version = "0.27.0"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.31"
+version = "0.27.0"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -45,7 +45,7 @@ from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2Resour
 from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
-from starlette.responses import Response
+from starlette.responses import JSONResponse
 
 from datarobot_genai.core.runtime import get_deployment_id
 from datarobot_genai.core.runtime import get_workload_id
@@ -486,7 +486,17 @@ class DRAgentA2AStarletteApplication(A2AStarletteApplication):
                 resolve_identity_from_headers(headers, on_invalid_auth_context="none") is None
                 and not self._enable_unauthenticated_well_known_route
             ):
-                return Response(status_code=401)
+                return JSONResponse(
+                    status_code=401,
+                    content={
+                        "error": (
+                            "Unauthenticated access to /.well-known/agent-card.json is "
+                            "disabled. Set enable_unauthenticated_well_known_route: true in "
+                            "workflow.yaml to allow anonymous access (also requires "
+                            "platform-level opt-in per cluster)."
+                        ),
+                    },
+                )
             return await super()._handle_get_agent_card(request)
         finally:
             _a2a_headers.reset(token)

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -481,7 +481,7 @@ class DRAgentA2AStarletteApplication(A2AStarletteApplication):
                 resolve_identity_from_headers(headers, on_invalid_auth_context="none") is None
                 and not self._enable_unauthenticated_well_known_route
             ):
-                return Response(status_code=404)
+                return Response(status_code=401)
             return await super()._handle_get_agent_card(request)
         finally:
             _a2a_headers.reset(token)
@@ -499,7 +499,7 @@ class DRAgentA2AFrontEndPluginWorker(A2AFrontEndPluginWorker):
     ) -> DRAgentA2AStarletteApplication:
         """Create an A2A server with identity-keyed public and extended agent cards.
 
-        The public ``GET /.well-known/agent-card.json`` route returns 404 for
+        The public ``GET /.well-known/agent-card.json`` route returns 401 for
         unauthenticated callers unless ``enable_unauthenticated_well_known_route``
         is enabled, in which case a redacted card is served. Authenticated callers
         always receive the full card. ``extended_agent_card`` is also wired for

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -445,7 +445,12 @@ def _extended_card_modifier(card: AgentCard, context: ServerCallContext) -> Agen
 
 
 class DRAgentA2AStarletteApplication(A2AStarletteApplication):
-    """A2A server that gates public agent-card access on developer opt-in."""
+    """A2A server that gates public agent-card access on per-agent developer opt-in.
+
+    Unauthenticated access also depends on platform-level opt-in per cluster to
+    route anonymous traffic to the agent; this class enforces only the agent-side
+    policy once a request reaches the process.
+    """
 
     def __init__(
         self,
@@ -499,9 +504,14 @@ class DRAgentA2AFrontEndPluginWorker(A2AFrontEndPluginWorker):
     ) -> DRAgentA2AStarletteApplication:
         """Create an A2A server with identity-keyed public and extended agent cards.
 
-        The public ``GET /.well-known/agent-card.json`` route returns 401 for
-        unauthenticated callers unless ``enable_unauthenticated_well_known_route``
-        is enabled, in which case a redacted card is served. Authenticated callers
+        Unauthenticated ``GET /.well-known/agent-card.json`` access requires opt-in
+        at two levels: platform administrators must enable unauthenticated routing
+        per cluster, and ``enable_unauthenticated_well_known_route`` must be set
+        in the agent's ``workflow.yaml``. This method enforces the agent-side
+        flag only.
+
+        When the agent flag is disabled (default), unauthenticated callers receive
+        401. When enabled, they receive a redacted card. Authenticated callers
         always receive the full card. ``extended_agent_card`` is also wired for
         ``agent/getAuthenticatedExtendedCard`` clients.
         """

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -21,10 +21,14 @@ and endpoint URL resolution.  The FastAPI framework glue lives in
 """
 
 import logging
+from collections.abc import Awaitable
+from collections.abc import Callable
 
 import httpx
 from a2a.server.apps import A2AStarletteApplication
+from a2a.server.apps.jsonrpc.jsonrpc_app import CallContextBuilder
 from a2a.server.context import ServerCallContext
+from a2a.server.request_handlers.request_handler import RequestHandler
 from a2a.types import AgentCapabilities
 from a2a.types import AgentCard
 from a2a.types import AgentExtension
@@ -41,6 +45,7 @@ from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2Resour
 from nat.plugins.a2a.server.agent_executor_adapter import NATWorkflowAgentExecutor
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
+from starlette.responses import Response
 
 from datarobot_genai.core.runtime import get_deployment_id
 from datarobot_genai.core.runtime import get_workload_id
@@ -440,12 +445,43 @@ def _extended_card_modifier(card: AgentCard, context: ServerCallContext) -> Agen
 
 
 class DRAgentA2AStarletteApplication(A2AStarletteApplication):
-    """A2A server that selects redacted vs extended cards on the public GET route."""
+    """A2A server that gates public agent-card access on developer opt-in."""
+
+    def __init__(
+        self,
+        agent_card: AgentCard,
+        http_handler: RequestHandler,
+        extended_agent_card: AgentCard | None = None,
+        context_builder: CallContextBuilder | None = None,
+        card_modifier: Callable[[AgentCard], Awaitable[AgentCard] | AgentCard] | None = None,
+        extended_card_modifier: Callable[
+            [AgentCard, ServerCallContext], Awaitable[AgentCard] | AgentCard
+        ]
+        | None = None,
+        max_content_length: int | None = 10 * 1024 * 1024,
+        *,
+        enable_unauthenticated_well_known_route: bool = False,
+    ) -> None:
+        self._enable_unauthenticated_well_known_route = enable_unauthenticated_well_known_route
+        super().__init__(
+            agent_card=agent_card,
+            http_handler=http_handler,
+            extended_agent_card=extended_agent_card,
+            context_builder=context_builder,
+            card_modifier=card_modifier,
+            extended_card_modifier=extended_card_modifier,
+            max_content_length=max_content_length,
+        )
 
     async def _handle_get_agent_card(self, request):  # type: ignore[no-untyped-def]
         headers = normalise_headers(dict(request.headers))
         token = _a2a_headers.set(headers)
         try:
+            if (
+                resolve_identity_from_headers(headers, on_invalid_auth_context="none") is None
+                and not self._enable_unauthenticated_well_known_route
+            ):
+                return Response(status_code=404)
             return await super()._handle_get_agent_card(request)
         finally:
             _a2a_headers.reset(token)
@@ -458,12 +494,15 @@ class DRAgentA2AFrontEndPluginWorker(A2AFrontEndPluginWorker):
         self,
         agent_card: AgentCard,
         agent_executor: NATWorkflowAgentExecutor,
+        *,
+        enable_unauthenticated_well_known_route: bool = False,
     ) -> DRAgentA2AStarletteApplication:
         """Create an A2A server with identity-keyed public and extended agent cards.
 
-        The public ``GET /.well-known/agent-card.json`` route serves a redacted card
-        to anonymous callers and the full card when gateway identity headers are
-        present.  ``extended_agent_card`` is also wired for
+        The public ``GET /.well-known/agent-card.json`` route returns 404 for
+        unauthenticated callers unless ``enable_unauthenticated_well_known_route``
+        is enabled, in which case a redacted card is served. Authenticated callers
+        always receive the full card. ``extended_agent_card`` is also wired for
         ``agent/getAuthenticatedExtendedCard`` clients.
         """
         base_server = super().create_a2a_server(agent_card, agent_executor)
@@ -473,6 +512,7 @@ class DRAgentA2AFrontEndPluginWorker(A2AFrontEndPluginWorker):
             extended_agent_card=agent_card,
             card_modifier=_public_card_modifier,
             extended_card_modifier=_extended_card_modifier,
+            enable_unauthenticated_well_known_route=enable_unauthenticated_well_known_route,
         )
         logger.info("Created A2A server with identity-keyed public agent card")
         return server

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -187,6 +187,11 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         )
         skills = self.front_end_config.a2a.skills if self.front_end_config.a2a else []
         external = self.front_end_config.a2a.external if self.front_end_config.a2a else None
+        enable_unauthenticated_well_known_route = (
+            self.front_end_config.a2a.enable_unauthenticated_well_known_route
+            if self.front_end_config.a2a
+            else False
+        )
 
         agent_card = await create_agent_card(
             frontend_config=self._a2a_worker.front_end_config,
@@ -202,7 +207,11 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         self._session_managers.append(session_manager)
         agent_executor = _PerUserCompatibleAgentExecutor(session_manager)
 
-        a2a_server = self._a2a_worker.create_a2a_server(agent_card, agent_executor)
+        a2a_server = self._a2a_worker.create_a2a_server(
+            agent_card,
+            agent_executor,
+            enable_unauthenticated_well_known_route=enable_unauthenticated_well_known_route,
+        )
         a2a_app = a2a_server.build()
 
         app.mount(f"/{A2A_MOUNT_PATH}", a2a_app)

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -81,7 +81,7 @@ class DRAgentA2AConfig(BaseModel):
         default=False,
         description=(
             "Opt in to serving GET /.well-known/agent-card.json to unauthenticated "
-            "callers. When disabled (default), unauthenticated requests receive 404. "
+            "callers. When disabled (default), unauthenticated requests receive 401. "
             "When enabled, anonymous callers receive a redacted agent card."
         ),
     )

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -77,6 +77,14 @@ class DRAgentA2AConfig(BaseModel):
         default=None,
         description="External identity and URL override for the agent card.",
     )
+    enable_unauthenticated_well_known_route: bool = Field(
+        default=False,
+        description=(
+            "Opt in to serving GET /.well-known/agent-card.json to unauthenticated "
+            "callers. When disabled (default), unauthenticated requests receive 404. "
+            "When enabled, anonymous callers receive a redacted agent card."
+        ),
+    )
 
 
 # Register frontend

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -80,8 +80,10 @@ class DRAgentA2AConfig(BaseModel):
     enable_unauthenticated_well_known_route: bool = Field(
         default=False,
         description=(
-            "Opt in to serving GET /.well-known/agent-card.json to unauthenticated "
-            "callers. When disabled (default), unauthenticated requests receive 401. "
+            "Per-agent developer opt-in for unauthenticated "
+            "GET /.well-known/agent-card.json. Also requires platform-level "
+            "opt-in per cluster to route unauthenticated traffic to the agent. "
+            "When disabled (default), unauthenticated requests receive 401. "
             "When enabled, anonymous callers receive a redacted agent card."
         ),
     )

--- a/tests/dragent/frontends/test_a2a.py
+++ b/tests/dragent/frontends/test_a2a.py
@@ -490,6 +490,9 @@ class TestUnauthenticatedWellKnownRoute:
         server = await self._make_server(a2a_frontend_config)
         response = await server._handle_get_agent_card(self._make_request())
         assert response.status_code == 401
+        body = json.loads(response.body)
+        assert "error" in body
+        assert "enable_unauthenticated_well_known_route" in body["error"]
 
     async def test_unauthenticated_with_opt_in_returns_redacted_card(self, a2a_frontend_config):
         server = await self._make_server(

--- a/tests/dragent/frontends/test_a2a.py
+++ b/tests/dragent/frontends/test_a2a.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -34,6 +35,7 @@ from datarobot_genai.dragent.frontends.a2a import JWT_BEARER_GRANT_TYPE_URI
 from datarobot_genai.dragent.frontends.a2a import OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE
 from datarobot_genai.dragent.frontends.a2a import TOKEN_EXCHANGE_GRANT_TYPE_URI
 from datarobot_genai.dragent.frontends.a2a import TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE
+from datarobot_genai.dragent.frontends.a2a import DRAgentA2AStarletteApplication
 from datarobot_genai.dragent.frontends.a2a import _public_card_modifier
 from datarobot_genai.dragent.frontends.a2a import create_agent_card
 from datarobot_genai.dragent.frontends.a2a import get_a2a_endpoint_url
@@ -451,6 +453,61 @@ class TestCreateAgentCard:
         assert JWT_BEARER_GRANT_TYPE_URI in uris
         assert INTERNAL_IDENTITY_URI in uris
         assert EXTERNAL_IDENTITY_URI in uris
+
+
+class TestUnauthenticatedWellKnownRoute:
+    @staticmethod
+    def _make_request(headers: dict[str, str] | None = None):
+        from starlette.requests import Request
+
+        raw_headers = [
+            (key.lower().encode(), value.encode()) for key, value in (headers or {}).items()
+        ]
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/.well-known/agent-card.json",
+            "headers": raw_headers,
+        }
+        return Request(scope)
+
+    @staticmethod
+    async def _make_server(
+        a2a_frontend_config,
+        *,
+        enable_unauthenticated_well_known_route: bool = False,
+    ) -> DRAgentA2AStarletteApplication:
+        card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
+        return DRAgentA2AStarletteApplication(
+            agent_card=card,
+            http_handler=MagicMock(),
+            extended_agent_card=card,
+            card_modifier=_public_card_modifier,
+            enable_unauthenticated_well_known_route=enable_unauthenticated_well_known_route,
+        )
+
+    async def test_unauthenticated_without_opt_in_returns_404(self, a2a_frontend_config):
+        server = await self._make_server(a2a_frontend_config)
+        response = await server._handle_get_agent_card(self._make_request())
+        assert response.status_code == 404
+
+    async def test_unauthenticated_with_opt_in_returns_redacted_card(self, a2a_frontend_config):
+        server = await self._make_server(
+            a2a_frontend_config, enable_unauthenticated_well_known_route=True
+        )
+        response = await server._handle_get_agent_card(self._make_request())
+        assert response.status_code == 200
+        card = json.loads(response.body)
+        assert card.get("skills") == []
+
+    async def test_authenticated_without_opt_in_returns_full_card(self, a2a_frontend_config):
+        server = await self._make_server(a2a_frontend_config)
+        response = await server._handle_get_agent_card(
+            self._make_request({"x-datarobot-user-id": "64baa56996fb36e3eeeefc44"})
+        )
+        assert response.status_code == 200
+        card = json.loads(response.body)
+        assert card.get("skills")
 
 
 class TestGetA2aEndpointUrl:

--- a/tests/dragent/frontends/test_a2a.py
+++ b/tests/dragent/frontends/test_a2a.py
@@ -486,10 +486,10 @@ class TestUnauthenticatedWellKnownRoute:
             enable_unauthenticated_well_known_route=enable_unauthenticated_well_known_route,
         )
 
-    async def test_unauthenticated_without_opt_in_returns_404(self, a2a_frontend_config):
+    async def test_unauthenticated_without_opt_in_returns_401(self, a2a_frontend_config):
         server = await self._make_server(a2a_frontend_config)
         response = await server._handle_get_agent_card(self._make_request())
-        assert response.status_code == 404
+        assert response.status_code == 401
 
     async def test_unauthenticated_with_opt_in_returns_redacted_card(self, a2a_frontend_config):
         server = await self._make_server(

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -556,6 +556,19 @@ class TestDRAgentFastApiFrontEndConfig:
         assert config.a2a.external.id == "ext-id-123"
         assert config.a2a.external.url == "https://external.example.com/"
 
+    def test_a2a_enable_unauthenticated_well_known_route_defaults_false(self):
+        config = DRAgentFastApiFrontEndConfig(a2a=DRAgentA2AConfig(server=A2AFrontEndConfig()))
+        assert config.a2a.enable_unauthenticated_well_known_route is False
+
+    def test_a2a_enable_unauthenticated_well_known_route_can_be_enabled(self):
+        config = DRAgentFastApiFrontEndConfig(
+            a2a=DRAgentA2AConfig(
+                server=A2AFrontEndConfig(),
+                enable_unauthenticated_well_known_route=True,
+            )
+        )
+        assert config.a2a.enable_unauthenticated_well_known_route is True
+
 
 class TestDRAgentFastApiFrontEndPluginWorkerCleanup:
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.31"
+version = "0.27.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
For workloads the unauthenticated access to the agent card is controlled per deployment by adding `routes` to the artifact spec. There is also a cluster-wide toggle. For custom model deployments there is only a cluster wide toggle so we need to handle the opt-in in the agent card endpoint.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Add `enable_unauthenticated_well_known_route`, default `False`, configurable in `workflow.yaml` to opt into unauthenticated agent card access. It would also need to be enabled at the cluster level.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can reach the public agent-card endpoint (401 by default vs redacted card), which is auth-adjacent; behavior is conservative by default and covered by new tests.
> 
> **Overview**
> **Makes unauthenticated agent-card discovery opt-in** instead of always serving a redacted card to anonymous callers on `GET /.well-known/agent-card.json`.
> 
> Adds `enable_unauthenticated_well_known_route` on `DRAgentA2AConfig` (default `false`). The A2A Starlette handler returns **401** when the caller has no gateway identity and the flag is off; when `true`, anonymous requests proceed to the existing redacted public card. **Authenticated callers always receive the full card** regardless of the flag. The FastAPI frontend passes the setting from `workflow.yaml` into `create_a2a_server`.
> 
> Docs and changelog describe **dual opt-in**: cluster/platform routing for anonymous traffic (outside this repo) plus this per-deployment flag. Version bumped to **0.26.25**; unit tests cover 401, redacted-with-opt-in, and authenticated-without-opt-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1eeb49b4c48ce48265e6dabda02c3cde850018f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->