### PR TITLE
[MMM-24583] Add target support to moderation integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.28
+- `dragent`: `datarobot_moderation` middleware now honors `target` on `DataRobotModerationConfig`. A `moderation` block with multiple `targets` (e.g. `workflow_overall`, `devex-agent`) previously had every target's guards merged into one pipeline regardless of which target a middleware instance was attached to; setting `target` scopes it to a single named `TargetBlock`, so different `workflow.yaml` functions (the overall workflow vs. an individual agent) can each apply a different guard set from one shared config. Omitting `target` preserves the existing whole-workflow behavior. A `target` with no matching block is a no-op rather than silently applying every guard.
+
 ## 0.26.27
 - `drtools/panels`: new `get_time_series_scoring_dataset_panel` tool — ported from wren-mcp's time-series scoring facade. Introspects a time-series deployment's datetime partitioning + forecast settings via the DataRobot SDK (target, datetime partition column, multiseries id column, feature derivation window, forecast distance/basis unit, known-in-advance features, date format), infers the forecast point from the latest timestamp when not supplied, builds a forward-looking scoring frame (recent history + future forecast window with known-in-advance values carried forward) in polars, and stores it as a derived Dataset panel (Parquet payload) with lineage to the source panel. Like the other wren-ported panel builders (`create_chart_panel`, the composition tools), the default `source` stays wren's session-scoped `staging` (not `main`) for BPA facade-delegation parity; promote via `move_panel`. Prerequisite for the upcoming TS predict / what-if panel flows.
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.27"
+version = "0.26.28"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.27"
+version = "0.26.28"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_moderation_middleware.py
@@ -33,6 +33,11 @@ Guard configuration (``_type: datarobot_moderation``):
   from ``model_dir`` (defaults to the directory containing ``workflow.yaml``, resolved from
   ``DRAGENT_CONFIG_FILE`` when set, otherwise the process working directory).
 * If neither source is present or both are empty, the middleware is a no-op.
+* **Per-agent targeting** — a ``moderation`` block may declare multiple ``targets`` (e.g.
+  ``workflow_overall``, ``devex-agent``). Set ``target`` on this middleware's config to apply
+  only that entry's guards; declare one middleware instance per ``target`` and attach each to a
+  different ``functions:``/``workflow:`` entry so individual agents get their own guard set from
+  one shared config. Omitting ``target`` merges every target's guards (whole-workflow behavior).
 
 ``ModerationPipeline.stream_response_async`` only accepts OpenAI ``ChatCompletionChunk``; DRAgent
 streaming uses ``convert_dragent_event_response_to_openai_chat_completion_chunk`` at that
@@ -200,11 +205,42 @@ class DataRobotModerationConfig(
             "takes priority over ``moderation_config.yaml``."
         ),
     )
+    target: str | None = Field(
+        default=None,
+        description=(
+            "Name of the single ``ModerationConfig.targets[].target`` entry this middleware "
+            "instance applies. Lets one shared moderation config attach different guard sets "
+            "to different ``workflow.yaml`` functions (e.g. ``workflow_overall`` vs. an "
+            "individual agent) by declaring a separate middleware instance per target. When "
+            "omitted (default), every target's guards are merged, preserving whole-workflow "
+            "behavior."
+        ),
+    )
 
 
 def moderation_config_has_guards(moderation: ModerationConfig) -> bool:
     """Return whether ``moderation`` defines at least one guard across all targets."""
     return any(target.guards for target in moderation.targets)
+
+
+def select_moderation_target(moderation: ModerationConfig, target: str | None) -> ModerationConfig:
+    """Restrict ``moderation`` to the single ``TargetBlock`` named ``target``.
+
+    Returns ``moderation`` unchanged when ``target`` is ``None`` (today's whole-workflow
+    behavior: every target's guards apply). When ``target`` is set but no ``TargetBlock``
+    matches, the result has no targets, so the middleware becomes a no-op rather than
+    silently falling back to every guard.
+    """
+    if target is None:
+        return moderation
+    matching = [block for block in moderation.targets if block.target == target]
+    if not matching:
+        _logger.debug(
+            "Moderation target %r not found among configured targets (%s); no guards apply",
+            target,
+            [block.target for block in moderation.targets],
+        )
+    return moderation.model_copy(update={"targets": matching})
 
 
 def _default_moderation_model_dir() -> str:
@@ -253,11 +289,12 @@ def _load_llm_moderation_pipeline_from_inline(
 ) -> ModerationPipeline | None:
     """Load guards from the inline ``moderation`` block."""
     assert config.moderation is not None
-    if not moderation_config_has_guards(config.moderation):
+    moderation = select_moderation_target(config.moderation, config.target)
+    if not moderation_config_has_guards(moderation):
         _logger.debug("Inline ``moderation`` has no guards; moderation middleware is a no-op")
         return None
     resolved_model_dir = resolve_moderation_model_dir(config.model_dir)
-    return ModerationPipeline.from_config(config.moderation, model_dir=resolved_model_dir)
+    return ModerationPipeline.from_config(moderation, model_dir=resolved_model_dir)
 
 
 def _load_llm_moderation_pipeline_from_config_file(
@@ -281,6 +318,7 @@ def _load_llm_moderation_pipeline_from_config_file(
             config_path,
         )
         return None
+    moderation = select_moderation_target(moderation, config.target)
     if not moderation_config_has_guards(moderation):
         _logger.debug(
             "No inline ``moderation`` block and %s has no guards; moderation middleware is a no-op",
@@ -288,7 +326,9 @@ def _load_llm_moderation_pipeline_from_config_file(
         )
         return None
 
-    return ModerationPipeline.from_yaml(str(config_path))
+    return ModerationPipeline.from_config(
+        moderation, model_dir=resolve_moderation_model_dir(config.model_dir)
+    )
 
 
 def load_llm_moderation_pipeline(config: DataRobotModerationConfig) -> ModerationPipeline | None:

--- a/tests/dragent/plugins/fixtures/moderation_multi_target/moderation_config.yaml
+++ b/tests/dragent/plugins/fixtures/moderation_multi_target/moderation_config.yaml
@@ -1,0 +1,17 @@
+---
+targets:
+  - target: workflow_overall
+    guards:
+      - name: Workflow Tokens
+        description: Track prompt tokens for the whole workflow.
+        ootb_type: token_count
+        stage: prompt
+        type: ootb
+  - target: devex-agent
+    guards:
+      - name: DevEx Agent Tokens
+        description: Track prompt tokens for the devex-agent function only.
+        ootb_type: token_count
+        stage: prompt
+        type: ootb
+timeout_sec: 60

--- a/tests/dragent/plugins/test_datarobot_moderation_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_moderation_middleware.py
@@ -131,6 +131,7 @@ from datarobot_genai.dragent.plugins.datarobot_moderation_middleware import (
 from datarobot_genai.dragent.plugins.datarobot_moderation_middleware import (
     resolve_moderation_model_dir,
 )
+from datarobot_genai.dragent.plugins.datarobot_moderation_middleware import select_moderation_target
 from datarobot_genai.dragent.plugins.datarobot_moderation_middleware import (
     workflow_input_to_completion_dict,
 )
@@ -833,6 +834,73 @@ def test_load_llm_moderation_pipeline_from_config_moderation_field() -> None:
         pipeline = load_llm_moderation_pipeline(cfg)
     assert pipeline is not None
     assert pipeline._pipeline.get_prescore_guards()
+
+
+INTEGRATION_MODERATION_MULTI_TARGET_DIR = (
+    Path(__file__).parent / "fixtures" / "moderation_multi_target"
+)
+
+
+def _multi_target_moderation_config() -> ModerationConfig:
+    return _moderation_config_from_fixture_dir(INTEGRATION_MODERATION_MULTI_TARGET_DIR)
+
+
+def _prescore_guard_names(pipeline: Any) -> list[str]:
+    return [guard.name for guard in pipeline._pipeline.get_prescore_guards()]
+
+
+def test_select_moderation_target_no_target_returns_same_object() -> None:
+    # ``target=None`` must be a true no-op (identity), not just an equal copy, so that
+    # callers relying on the whole-workflow default never pay a validation/copy cost.
+    moderation = _multi_target_moderation_config()
+    assert select_moderation_target(moderation, None) is moderation
+
+
+@pytest.mark.parametrize(
+    ("target", "expected_guard_names"),
+    [
+        pytest.param("devex-agent", ["DevEx Agent Tokens"], id="matching-target"),
+        pytest.param("workload-agent", [], id="unknown-target-drops-all-targets"),
+    ],
+)
+def test_select_moderation_target_filters_by_name(
+    target: str, expected_guard_names: list[str]
+) -> None:
+    moderation = _multi_target_moderation_config()
+    selected = select_moderation_target(moderation, target)
+    guard_names = [guard.name for block in selected.targets for guard in block.guards]
+    assert guard_names == expected_guard_names
+
+
+@pytest.mark.parametrize("config_mode", ["inline", "config_file"])
+@pytest.mark.parametrize(
+    ("target", "expected_guard_names"),
+    [
+        pytest.param("devex-agent", ["DevEx Agent Tokens"], id="matching-target"),
+        pytest.param(None, ["DevEx Agent Tokens", "Workflow Tokens"], id="no-target-merges-all"),
+        pytest.param("workload-agent", None, id="unknown-target-is-noop"),
+    ],
+)
+def test_load_llm_moderation_pipeline_respects_target(
+    config_mode: str, target: str | None, expected_guard_names: list[str] | None
+) -> None:
+    # GIVEN a moderation config with distinct guards for "workflow_overall" and "devex-agent"
+    # WHEN a middleware config is built with the given ``target`` (inline or config-file source)
+    # THEN the pipeline runs exactly that target's guards, all targets' guards when unset, or is
+    # a no-op (``None``) when ``target`` names no configured ``TargetBlock``
+    if config_mode == "inline":
+        cfg = DataRobotModerationConfig(moderation=_multi_target_moderation_config(), target=target)
+    else:
+        cfg = DataRobotModerationConfig(
+            model_dir=str(INTEGRATION_MODERATION_MULTI_TARGET_DIR), target=target
+        )
+    with patch.dict(os.environ, _CREDENTIAL_ENV):
+        pipeline = load_llm_moderation_pipeline(cfg)
+    if expected_guard_names is None:
+        assert pipeline is None
+    else:
+        assert pipeline is not None
+        assert sorted(_prescore_guard_names(pipeline)) == sorted(expected_guard_names)
 
 
 def test_load_llm_moderation_pipeline_from_config_file_model_dir() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.27"
+version = "0.26.28"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which guards run per workflow function and can turn moderation into a no-op on typos; behavior is intentional but affects production guardrail coverage for multi-target configs.
> 
> **Overview**
> **`datarobot_moderation` middleware** now respects an optional **`target`** on `DataRobotModerationConfig`, aligning with multi-`targets` moderation YAML (e.g. `workflow_overall` vs a named agent).
> 
> Previously, every `TargetBlock` in a shared config was merged into one pipeline for every middleware instance. With **`target` set**, pipeline loading (`select_moderation_target`) keeps only the matching block so you can attach **separate middleware instances** to different `workflow.yaml` functions and apply **different guard sets** from one file. **Omitting `target`** keeps the old behavior (all targets merged). A **unknown `target`** yields **no guards** (no-op), not a silent merge of everything.
> 
> File-based loading now builds the pipeline via **`ModerationPipeline.from_config`** on the filtered config (not raw `from_yaml` on the full file). Release **0.26.25** and tests cover inline vs config-file paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6d37d392cabc5d673ed4f01b3783d9dec6dfdc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->