### PR TITLE
[BUZZOK-31905] Always include securitySchemes in agent card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.31
+- `dragent`: A2A agent cards always include `securitySchemes`. Agents without `server_auth` or `cross_application_access` advertise HTTP Bearer auth (`bearerAuth`) for DataRobot API tokens; OAuth-configured agents continue to publish `oauth2` schemes.
+
 ## 0.26.30
 - `drmcputils/categories` + `drmcpbase/fastmcp_transforms`: **`x-datarobot-mcp-tools: dr_user_tools` now selects the user's tools instead of hiding every tool.** The marker-resolved buckets (`dr_user_tools`, `dr_dynamic_tools`) name no static tools — membership comes from each tool's `meta.tool_category` marker at request time — so `resolve_to_tool_names`, a pure function over the taxonomy with no view of the catalog, expanded them to the empty set. A present-but-empty allowlist is a hard deny (deliberately, since 0.26.30's Tool Sets change), so picking "Your own tools" in a category picker returned nothing at all. The header now parses into a **`ToolAllowlist`** that records *how* each name arrived, because "the client named this tool" and "this name fell out of expanding a category" are different permissions that a flat `frozenset[str]` could not tell apart:
   - `explicit` — names the client wrote (and unknown tokens, which simply match nothing). Admits any tool with that name.

--- a/docs/src/nat/a2a-auth.md
+++ b/docs/src/nat/a2a-auth.md
@@ -95,10 +95,12 @@ This is the simplest setup — no agent card extensions or multi-step flows
 involved.
 
 > **Important:** `datarobot_api_key` is the default authentication mechanism
-> for DataRobot-hosted agents. However, when the remote agent card declares a 
-> specific mechanism (e.g. OAuth2 via `cross_application_access`), security-scheme 
-> negotiation validates and requires a matching auth provider on the client side. 
-> Use `okta_cross_app_access` (Option 2) for OAuth2-protected agents. 
+> for DataRobot-hosted agents. Every agent card includes `securitySchemes`; agents
+> without explicit OAuth configuration advertise HTTP Bearer auth (`bearerAuth`)
+> for DataRobot API tokens. When the remote agent card declares OAuth2 via
+> `cross_application_access`, security-scheme negotiation validates and requires a
+> matching auth provider on the client side. Use `okta_cross_app_access` (Option 2)
+> for OAuth2-protected agents.
 
 ## Option 2: Okta cross-application access (XAA)
 

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -187,7 +187,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.24"
+version = "0.26.25"
 source = { editable = "../" }
 
 [package.metadata]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -187,7 +187,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.25"
+version = "0.26.31"
 source = { editable = "../" }
 
 [package.metadata]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -2415,17 +2415,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -2441,16 +2441,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -3728,10 +3728,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3747,10 +3747,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.30"
+version = "0.26.31"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.30"
+version = "0.26.31"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -31,6 +31,7 @@ from a2a.types import AgentExtension
 from a2a.types import AgentSkill
 from a2a.types import AuthorizationCodeOAuthFlow
 from a2a.types import ClientCredentialsOAuthFlow
+from a2a.types import HTTPAuthSecurityScheme
 from a2a.types import InvalidParamsError
 from a2a.types import OAuth2SecurityScheme
 from a2a.types import OAuthFlows
@@ -67,6 +68,10 @@ OAUTH2_SECURITY_DESCRIPTION_WITH_TOKEN_EXCHANGE = (
     "identity assertion via RFC 8693 Token Exchange. Refer to the capabilities.extensions "
     "block for strict execution parameters and routing."
 )
+
+BEARER_SECURITY_SCHEME_NAME = "bearerAuth"
+
+BEARER_SECURITY_DESCRIPTION = "DataRobot API token supplied as an Authorization Bearer header."
 
 # Extension URI for the RFC 7523 JWT Bearer Grant (outer grant type for the hybrid flow).
 JWT_BEARER_GRANT_TYPE_URI = "urn:ietf:params:oauth:grant-type:jwt-bearer"
@@ -280,25 +285,38 @@ def _resolve_url(
     return get_a2a_endpoint_url(frontend_config.host, frontend_config.port)
 
 
+def build_default_bearer_security_schemes() -> tuple[
+    dict[str, SecurityScheme], list[dict[str, list[str]]]
+]:
+    """Return the default HTTP Bearer scheme for agents without explicit OAuth config."""
+    security_schemes = {
+        BEARER_SECURITY_SCHEME_NAME: SecurityScheme(
+            root=HTTPAuthSecurityScheme(
+                type="http",
+                scheme="bearer",
+                description=BEARER_SECURITY_DESCRIPTION,
+            )
+        )
+    }
+    return security_schemes, [{BEARER_SECURITY_SCHEME_NAME: []}]
+
+
 async def build_security_schemes(
     frontend_config: A2AFrontEndConfig,
     cross_app_access: CrossApplicationAccessConfig | None,
-) -> tuple[
-    dict[str, SecurityScheme] | None,
-    list[dict[str, list[str]]] | None,
-]:
+) -> tuple[dict[str, SecurityScheme], list[dict[str, list[str]]]]:
     """Assemble A2A security schemes, merging up to two auth sources.
 
     * ``server_auth`` → authorization_code flow.
     * ``cross_app_access`` → client_credentials flow.
+    * Neither configured → HTTP Bearer scheme for DataRobot API tokens.
 
-    Returns ``(security_schemes, security_requirements)``, both ``None``
-    when neither source is configured.
+    Always returns a populated ``securitySchemes`` map.
     """
     server_auth = frontend_config.server_auth
 
     if not server_auth and not cross_app_access:
-        return None, None
+        return build_default_bearer_security_schemes()
 
     auth_code_flow, server_auth_scopes = (
         await build_oauth_flow_from_server_auth(server_auth) if server_auth else (None, [])
@@ -367,8 +385,8 @@ async def create_agent_card(
             extensions=extensions,
         ),
         skills=resolved_skills,
-        security_schemes=security_schemes or None,
-        security=security or None,
+        security_schemes=security_schemes,
+        security=security,
         supports_authenticated_extended_card=True,
     )
 

--- a/tests/dragent/frontends/test_a2a.py
+++ b/tests/dragent/frontends/test_a2a.py
@@ -23,6 +23,8 @@ from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from datarobot_genai.dragent.cross_app_access_config import CrossApplicationAccessConfig
 from datarobot_genai.dragent.cross_app_access_config import CrossAppTokenExchange
 from datarobot_genai.dragent.cross_app_access_config import CrossAppTokenRequest
+from datarobot_genai.dragent.frontends.a2a import BEARER_SECURITY_DESCRIPTION
+from datarobot_genai.dragent.frontends.a2a import BEARER_SECURITY_SCHEME_NAME
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_EXTENSION_DESCRIPTION
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_FLOW_REF
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_SECURITY_SCHEME_REF
@@ -67,6 +69,8 @@ class TestRedactAgentCard:
 
         assert redacted.skills == []
         assert redacted.supports_authenticated_extended_card is True
+        assert redacted.security_schemes is not None
+        assert BEARER_SECURITY_SCHEME_NAME in redacted.security_schemes
         assert card.capabilities.extensions is not None
         uris = [ext.uri for ext in card.capabilities.extensions]
         assert INTERNAL_IDENTITY_URI in uris
@@ -95,6 +99,8 @@ class TestRedactAgentCard:
 
         assert redacted.capabilities.extensions is not None
         assert any(ext.uri == JWT_BEARER_GRANT_TYPE_URI for ext in redacted.capabilities.extensions)
+        assert redacted.security_schemes is not None
+        assert "oauth2" in redacted.security_schemes
 
 
 class TestAgentCardIdentitySelection:
@@ -305,10 +311,17 @@ class TestCreateAgentCard:
         assert "token_url" not in ext.params
         assert "scopes" not in ext.params
 
-    async def test_no_security_when_server_auth_absent(self, a2a_frontend_config):
+    async def test_default_bearer_security_schemes_when_no_auth_configured(
+        self, a2a_frontend_config
+    ):
         card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
-        assert card.security_schemes is None
-        assert card.security is None
+
+        assert BEARER_SECURITY_SCHEME_NAME in card.security_schemes
+        bearer_scheme = card.security_schemes[BEARER_SECURITY_SCHEME_NAME].root
+        assert bearer_scheme.type == "http"
+        assert bearer_scheme.scheme == "bearer"
+        assert bearer_scheme.description == BEARER_SECURITY_DESCRIPTION
+        assert card.security == [{BEARER_SECURITY_SCHEME_NAME: []}]
 
     async def test_internal_identity_extension_when_deployment_id_set(self, a2a_frontend_config):
         """GIVEN MLOPS_DEPLOYMENT_ID is set WHEN create_agent_card is called THEN the internal

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.30"
+version = "0.26.31"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2745,17 +2745,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -2771,16 +2771,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -3962,10 +3962,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3981,10 +3981,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
With unauthenticated redacted agent card access enabled, the agent card should always advertise the `securitySchemes` to access the full card.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Include HTTP Bearer using DR API token in the `securitySchemes` when other access is not configured.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the published A2A agent card contract for agents that previously omitted `securitySchemes`, which can affect client security-scheme negotiation; behavior is intentional for auth discovery but should be validated against existing A2A callers.
> 
> **Overview**
> **A2A agent cards always advertise how to authenticate**, including on redacted public cards, by never leaving `securitySchemes` / `security` unset.
> 
> When neither `server_auth` nor `cross_application_access` is configured, `build_security_schemes` now returns a default **`bearerAuth`** HTTP Bearer scheme (DataRobot API token) via new `build_default_bearer_security_schemes()`. OAuth-configured agents still publish the existing **`oauth2`** scheme. `create_agent_card` always attaches the returned schemes (no `None` fallback).
> 
> Docs in `a2a-auth.md` and **0.26.25** changelog describe the new default. Unit tests expect bearer on minimal cards and OAuth when XAA is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d33d961a9920e403dbbcd01aaa2f9564e21b8267. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->