### PR TITLE
BUZZOK-31333 Unify LiteLLM logs with the rest of the dragent logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.26.25
+- Unify LiteLLM logs with the rest of the dragent logs
+
 ## 0.26.24
 - Initial cve-sync resync of constraints and overrides.
 - Address CVEs for a large number of packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.26.24"
+version = "0.26.25"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/utils/logging.py
+++ b/src/datarobot_genai/core/utils/logging.py
@@ -20,17 +20,17 @@ _LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
 
 
 def _configure_litellm_loggers() -> None:
-    """Keep LiteLLM's native handler/formatter and suppress duplicate root propagation.
+    """Route LiteLLM log records through the application root logger only.
 
-    LiteLLM attaches its own ``StreamHandler`` (``HH:MM:SS - LiteLLM:LEVEL: file:line``)
-    when ``litellm._logging`` is imported. With ``propagate=True`` (the prior default here),
-    the same record also reaches the application root logger and prints twice in different
-    formats. We keep LiteLLM's handler and set ``propagate=False`` so only the native
-    LiteLLM line is emitted.
+    LiteLLM attaches its own ``StreamHandler`` (with a distinct ANSI formatter) when
+    ``litellm._logging`` is imported. If that happens after ``setup_logging()`` has
+    already run, or if handlers are left attached while ``propagate`` is true, each
+    log line is emitted twice (LiteLLM formatter + app formatter).
     """
     for name in _LITELLM_LOGGER_NAMES:
         lg = logging.getLogger(name)
-        lg.propagate = False
+        lg.handlers.clear()
+        lg.propagate = True
 
 
 def setup_logging() -> None:
@@ -38,7 +38,7 @@ def setup_logging() -> None:
     current_log_level = logging.getLogger().getEffectiveLevel()
     logger.info(f"Setting up logging, log level: {logging._levelToName[current_log_level]}")
 
-    # Import litellm so its module-level handler registration runs before we configure it.
+    # Import litellm so its module-level handler registration runs before we strip it.
     try:
         import litellm  # noqa: F401, PLC0415
     except ImportError:

--- a/src/datarobot_genai/core/utils/logging.py
+++ b/src/datarobot_genai/core/utils/logging.py
@@ -20,17 +20,17 @@ _LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
 
 
 def _configure_litellm_loggers() -> None:
-    """Route LiteLLM log records through the application root logger only.
+    """Keep LiteLLM's native handler/formatter and suppress duplicate root propagation.
 
-    LiteLLM attaches its own ``StreamHandler`` (with a distinct ANSI formatter) when
-    ``litellm._logging`` is imported. If that happens after ``setup_logging()`` has
-    already run, or if handlers are left attached while ``propagate`` is true, each
-    log line is emitted twice (LiteLLM formatter + app formatter).
+    LiteLLM attaches its own ``StreamHandler`` (``HH:MM:SS - LiteLLM:LEVEL: file:line``)
+    when ``litellm._logging`` is imported. With ``propagate=True`` (the prior default here),
+    the same record also reaches the application root logger and prints twice in different
+    formats. We keep LiteLLM's handler and set ``propagate=False`` so only the native
+    LiteLLM line is emitted.
     """
     for name in _LITELLM_LOGGER_NAMES:
         lg = logging.getLogger(name)
-        lg.handlers.clear()
-        lg.propagate = True
+        lg.propagate = False
 
 
 def setup_logging() -> None:
@@ -38,7 +38,7 @@ def setup_logging() -> None:
     current_log_level = logging.getLogger().getEffectiveLevel()
     logger.info(f"Setting up logging, log level: {logging._levelToName[current_log_level]}")
 
-    # Import litellm so its module-level handler registration runs before we strip it.
+    # Import litellm so its module-level handler registration runs before we configure it.
     try:
         import litellm  # noqa: F401, PLC0415
     except ImportError:

--- a/src/datarobot_genai/core/utils/logging.py
+++ b/src/datarobot_genai/core/utils/logging.py
@@ -16,15 +16,32 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
+
+
+def _configure_litellm_loggers() -> None:
+    """Route LiteLLM log records through the application root logger only.
+
+    LiteLLM attaches its own ``StreamHandler`` (with a distinct ANSI formatter) when
+    ``litellm._logging`` is imported. If that happens after ``setup_logging()`` has
+    already run, or if handlers are left attached while ``propagate`` is true, each
+    log line is emitted twice (LiteLLM formatter + app formatter).
+    """
+    for name in _LITELLM_LOGGER_NAMES:
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.propagate = True
+
 
 def setup_logging() -> None:
     """Setup uniform logging for the application."""  # noqa: D401
     current_log_level = logging.getLogger().getEffectiveLevel()
     logger.info(f"Setting up logging, log level: {logging._levelToName[current_log_level]}")
 
-    for name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"):
-        lg = logging.getLogger(name)
-        if lg:
-            logger.debug(f"Resetting logger {name}")
-            lg.handlers.clear()
-            lg.propagate = True
+    # Import litellm so its module-level handler registration runs before we strip it.
+    try:
+        import litellm  # noqa: F401, PLC0415
+    except ImportError:
+        pass
+
+    _configure_litellm_loggers()

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.26.24"
+version = "0.26.25"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Minor change for LiteLLM logs (without duplication, unified format)
<img width="812" height="131" alt="Screenshot 2026-08-06 at 16 45 09" src="https://github.com/user-attachments/assets/9d6451c6-42cc-43c1-a4d1-8ca35aa4dde2" />


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no auth, data, or API behavior impact; main risk is missing LiteLLM logs if import order or handler setup differs in some entrypoints.
> 
> **Overview**
> **LiteLLM logging** is refactored so messages use the same handlers and format as the rest of dragent, without duplicate lines.
> 
> `setup_logging()` now **imports `litellm` first** (when installed) so LiteLLM can register its default handlers, then **`_configure_litellm_loggers()`** clears handlers on the `LiteLLM`, `LiteLLM Router`, and `LiteLLM Proxy` loggers and sets **`propagate = True`** so records flow through the app root logger. The previous inline loop and per-logger debug reset are replaced by this helper and a short docstring explaining the double-emission issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8b396dc453116dee86748eaf1ae5fb1be811eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->