### PR TITLE
[-] Fix DR logo image path for README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.27.8
+- Fixed DataRobot logo image path for `README.md`.
+
 ## 0.27.7
 - `drtools/workload`: synced the workload tools with the Workload API MCP server's `datarobot-workload-api` skill alignment:
   - `artifact_get_build` now normalizes build-status variants (`completed`, `in-progress`, …) and annotates single-build responses with `deployable` and `status_guidance` — `BUILT` means built but **not yet pushed** to the registry and is not deployable; only `COMPLETED` is. `artifact_build_run_action(action='trigger')` responses now tell callers to wait for `COMPLETED`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/datarobot-oss/datarobot-genai">
-    <img src="docs/img/datarobot_logo.avif" width="600px" alt="DataRobot Logo"/>
+    <img src="docs/src/img/datarobot_logo.avif" width="600px" alt="DataRobot Logo"/>
   </a>
 </p>
 <h3 align="center">DataRobot GenAI Library</h3>

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -947,7 +947,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.7"
+version = "0.27.8"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.27.7"
+version = "0.27.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1134,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.7"
+version = "0.27.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

Fix broken docs src image reference in README.

## CHANGES

## Checklist
- [x] Updated version in pyproject.toml
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (N/A - no new tools)

## TESTING

No testing needed - this is a documentation path fix and version bump.

https://claude.ai/code/session_01EdUpr3ymhLnccjqYNYJK2z

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 807755765edef56afbe7be4ecdc07081f5cd868f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->