### PR TITLE
Update memory configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.27.13
+- `core/config` and `dragent/plugins/datarobot_mem0_memory`: moved the fixed `MEM0_API_KEY`, `AGENT_MEMORY_SPACE_ID`, and `AGENT_MEMORY_TTL_DAYS` settings into the shared application config. Memory provider selection and provisioning remain owned by `af-component-memory`; the runtime plugin consumes the resulting parameters without requiring agent templates to declare memory fields.
+
 ## 0.27.12
 - `drtools/core/sandbox`: workload scheduling and image-pull time no longer consume the caller's `timeout_s` (which bounds user code, enforced in-container). A separate `provisioning_timeout_s` allowance (default 300s, constructor-tunable) bounds the infra wait — a cold node's first pull of the sandbox image (60-90s) used to surface as `SandboxTimeout` before user code ever ran.
 - `drtools/core/sandbox`: a workload marked terminal-failure by a transient `ErrImagePull` (k8s retries the pull and the container then runs) no longer fails with "no result marker in logs"; on failure statuses the marker wait extends to the remaining overall budget instead of the fixed 30s flush budget.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -949,7 +949,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.12"
+version = "0.27.13"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.27.12"
+version = "0.27.13"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/config.py
+++ b/src/datarobot_genai/core/config.py
@@ -128,6 +128,11 @@ class Config(LLMConfig, DataRobotAppFrameworkBaseSettings):
 
     datarobot_endpoint: str = "https://app.datarobot.com/api/v2"
 
+    # Fixed runtime parameter names supplied by af-component-memory.
+    mem0_api_key: str | None = None
+    agent_memory_space_id: str | None = None
+    agent_memory_ttl_days: int | None = None
+
     max_history_messages: int = Field(
         default=DEFAULT_MAX_HISTORY_MESSAGES, ge=0, alias="datarobot_genai_max_history_messages"
     )

--- a/src/datarobot_genai/dragent/plugins/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_mem0_memory.py
@@ -44,7 +44,6 @@ from datetime import datetime
 from datetime import timedelta
 from typing import Any
 
-from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from nat.builder.builder import Builder
 from nat.builder.context import Context
 from nat.cli.register_workflow import register_memory
@@ -55,22 +54,11 @@ from nat.memory.models import MemoryItem
 from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 from pydantic import Field
 
+from datarobot_genai.core.config import Config
 from datarobot_genai.core.telemetry.memory import trace_memory_operation
 from datarobot_genai.core.telemetry.memory import truncate_memory_text
 
 logger = logging.getLogger(__name__)
-
-
-class Config(DataRobotAppFrameworkBaseSettings):
-    """
-    Finds variables in the priority order of: env
-    variables (including Runtime Parameters), .env, file_secrets, then
-    Pulumi output variables.
-    """
-
-    mem0_api_key: str | None = None
-    agent_memory_space_id: str | None = None
-    agent_memory_ttl_days: int | None = None
 
 
 def _get_default_memory_backend_config() -> Config:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -49,6 +49,23 @@ def _make_config(**overrides: object) -> Config:
     return Config.model_construct(**defaults)
 
 
+def test_config_reads_memory_component_runtime_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # GIVEN the fixed runtime parameters exported by af-component-memory.
+    monkeypatch.setenv("MEM0_API_KEY", "mem0-key")
+    monkeypatch.setenv("AGENT_MEMORY_SPACE_ID", "memory-space-id")
+    monkeypatch.setenv("AGENT_MEMORY_TTL_DAYS", "30")
+
+    # WHEN the shared application config is loaded.
+    config = Config()
+
+    # THEN all memory settings are available to runtime integrations.
+    assert config.mem0_api_key == "mem0-key"
+    assert config.agent_memory_space_id == "memory-space-id"
+    assert config.agent_memory_ttl_days == 30
+
+
 # --- get_max_history_messages_default (existing tests, preserved) ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.12"
+version = "0.27.13"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config consolidation with unchanged env names and existing plugin default factories; no auth or data-path behavior change beyond reading the same values from a single source.
> 
> **Overview**
> **Centralizes memory runtime settings** so `af-component-memory` can inject `MEM0_API_KEY`, `AGENT_MEMORY_SPACE_ID`, and `AGENT_MEMORY_TTL_DAYS` once via the shared app `Config`, without duplicating fields on agent templates.
> 
> Adds `mem0_api_key`, `agent_memory_space_id`, and `agent_memory_ttl_days` to `datarobot_genai.core.config.Config` (same env/runtime-parameter resolution as other settings). The `dr_mem0_memory` NAT plugin drops its local `Config` subclass and reads defaults through that shared `Config`; provider selection and provisioning stay with `af-component-memory`.
> 
> Release **0.27.13** plus a unit test that env vars map into `Config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b98f1581aa883aebf408334756f544d94de0cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->