### PR TITLE
[MODEL-24540] Fix blocking MCP server startup caused by synchronous OpenTelemetry span processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.27.13
+- `drmcp/core/telemetry`: MCP server startup no longer blocks on unreachable OTLP endpoints — span export uses ``BatchSpanProcessor`` (background thread) instead of ``SimpleSpanProcessor`` (synchronous export on every span end).
+
 ## 0.27.12
 - `drtools/core/sandbox`: workload scheduling and image-pull time no longer consume the caller's `timeout_s` (which bounds user code, enforced in-container). A separate `provisioning_timeout_s` allowance (default 300s, constructor-tunable) bounds the infra wait — a cold node's first pull of the sandbox image (60-90s) used to surface as `SandboxTimeout` before user code ever ran.
 - `drtools/core/sandbox`: a workload marked terminal-failure by a transient `ErrImagePull` (k8s retries the pull and the container then runs) no longer fails with "no result marker in logs"; on failure statuses the marker wait extends to the remaining overall budget instead of the fixed 30s flush budget.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -949,7 +949,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.12"
+version = "0.27.13"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.27.12"
+version = "0.27.13"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/telemetry.py
+++ b/src/datarobot_genai/drmcp/core/telemetry.py
@@ -45,7 +45,7 @@ from opentelemetry.sdk._logs import LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import Span
 from opentelemetry.trace import SpanContext
 from opentelemetry.trace import SpanKind
@@ -191,9 +191,9 @@ def _setup_otel_env_variables() -> None:
 
 
 def _setup_otel_exporter() -> None:
-    """Set up OpenTelemetry exporter with SimpleSpanProcessor."""
+    """Set up OpenTelemetry exporter with BatchSpanProcessor."""
     otlp_exporter = OTLPSpanExporter()
-    span_processor = SimpleSpanProcessor(otlp_exporter)
+    span_processor = BatchSpanProcessor(otlp_exporter)
     provider = trace.get_tracer_provider()
     # mypy: TracerProvider has add_span_processor at runtime; typing may lag
     if hasattr(provider, "add_span_processor"):

--- a/tests/drmcp/unit/test_telemetry.py
+++ b/tests/drmcp/unit/test_telemetry.py
@@ -180,6 +180,30 @@ def test_setup_otel_env_variables_deployment_shape_runtime_params() -> None:
         assert exporter._endpoint == collector_base + "/v1/metrics"
 
 
+def test_setup_otel_exporter_uses_batch_span_processor() -> None:
+    """Span export must be async so startup is not blocked by OTLP timeouts."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    provider = TracerProvider()
+
+    with (
+        patch(
+            "datarobot_genai.drmcp.core.telemetry.trace.get_tracer_provider",
+            return_value=provider,
+        ),
+        patch(
+            "datarobot_genai.drmcp.core.telemetry.OTLPSpanExporter",
+            return_value=MagicMock(),
+        ),
+    ):
+        telemetry._setup_otel_exporter()
+
+    active = provider._active_span_processor
+    registered = getattr(active, "_span_processors", (active,))
+    assert any(isinstance(p, BatchSpanProcessor) for p in registered)
+
+
 def test_initialize_telemetry_proceeds_with_config_headers() -> None:
     """initialize_telemetry should NOT skip when otel_exporter_otlp_headers is set
     in Config, even if otel_entity_id is empty.

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.12"
+version = "0.27.13"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

The MCP server startup is being blocked by OpenTelemetry (OTEL) because SimpleSpanProcessor is being used instead of BatchSpanProcessor. This causes every span to be exported synchronously in the calling thread. When the OTEL endpoint is unreachable (e.g., in Codespaces), each export stalls for ~20 seconds, leading to a total startup delay that exceeds the 120-second watchdog timeout. The initialize_telemetry() function in datarobot_genai/drmcp/core/telemetry.py should be updated to use BatchSpanProcessor to ensure exports occur on a background thread.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow telemetry wiring change with standard OpenTelemetry batching; improves startup reliability without altering auth or business logic.
> 
> **Overview**
> Fixes **blocking MCP server startup** when OpenTelemetry is enabled but the OTLP collector is unreachable (e.g. Codespaces): span export no longer runs synchronously on every span end.
> 
> In `drmcp/core/telemetry.py`, **`_setup_otel_exporter`** registers **`BatchSpanProcessor`** instead of **`SimpleSpanProcessor`**, matching how log export already uses **`BatchLogRecordProcessor`** and aligning with the **`core`** OTel bootstrap default. Exports move to a background worker so startup spans do not stall on ~20s HTTP timeouts and trip the startup watchdog.
> 
> Release **0.27.13** (version bumps and changelog). A unit test asserts the registered span processor is **`BatchSpanProcessor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29ed9bbf877b408a27f443fff369d5c6e31c187e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->