### PR TITLE
[MODEL-24552] Fix Datastore Return Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.27.14
+- `drtools/predictive`: `catalog_list_datastores` now requests `type=all` from `GET externalDataStores/` (the API defaults to JDBC-only and returns `[]` when the user only has native-database or connector stores). Agents listing connections no longer report none connected. Optional `datastore_type` still filters (`jdbc`, `dr-database-v1`, `dr-connector-v1`, `databases`); each row includes `type`.
+
 ## 0.27.13
 - `drmcp/core/telemetry`: MCP server startup no longer blocks on unreachable OTLP endpoints — span export uses ``BatchSpanProcessor`` (background thread) instead of ``SimpleSpanProcessor`` (synchronous export on every span end).
 

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -949,7 +949,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.13"
+version = "0.27.14"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.27.13"
+version = "0.27.14"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -583,6 +583,7 @@ def test_create_dr_client() -> StubDRClient:
                         {
                             "id": stub_datastore.id,
                             "canonicalName": stub_datastore.canonical_name,
+                            "type": "jdbc",
                             "creatorId": stub_datastore.creator_id,
                             "params": dict(stub_datastore.params),
                         }

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -40,6 +40,19 @@ logger = logging.getLogger(__name__)
 # we stay just under it.
 _PREVIEW_QUERY_MAX_ROWS = 9999
 
+# GET externalDataStores/ with no `type` defaults to JDBC-only and returns [] when
+# the user only has native-database or connector stores. `all` returns every kind.
+_DATASTORE_LIST_TYPE_ALL = "all"
+_DATASTORE_LIST_TYPES = frozenset(
+    {
+        "all",
+        "databases",
+        "dr-connector-v1",
+        "dr-database-v1",
+        "jdbc",
+    }
+)
+
 
 def _serialize_datastore_params(params: Any) -> dict[str, Any]:
     """Return JSON-serializable params; DataRobot SDK uses DataStoreParameters, not a dict."""
@@ -258,7 +271,8 @@ async def catalog_get_preview(
     tags={"predictive", "data", "read", "datastore", "list", "daria"},
     description=(
         "[Datastore—list connections] Use when the user works with saved external connections "
-        "(DB, warehouse, bucket, etc.) and needs datastore IDs. Read-only. Not AI Catalog "
+        "(DB, warehouse, bucket, etc.) and needs datastore IDs. Returns JDBC, native-database, "
+        "and connector stores together. Read-only. Not AI Catalog "
         "datasets (catalog_list_datasets), not modeling projects. "
         "Next step: catalog_browse_datastore "
         "or catalog_query_datastore."
@@ -278,16 +292,29 @@ async def catalog_list_datastores(
             "use offset to page."
         ),
     ] = PAGINATION_MAX,
+    datastore_type: Annotated[
+        str,
+        (
+            "Connection kind to list. Default 'all' (JDBC, native database, and connectors). "
+            "Also: 'jdbc', 'dr-database-v1', 'dr-connector-v1', 'databases'."
+        ),
+    ] = _DATASTORE_LIST_TYPE_ALL,
 ) -> dict[str, Any]:
     if offset is not None and offset < 0:
         raise ToolError("offset must be non-negative", kind=ToolErrorKind.VALIDATION)
+    if datastore_type not in _DATASTORE_LIST_TYPES:
+        allowed = ", ".join(sorted(_DATASTORE_LIST_TYPES))
+        raise ToolError(
+            f"datastore_type must be one of: {allowed}",
+            kind=ToolErrorKind.VALIDATION,
+        )
 
     limit, message = clamp_limit(limit)
 
     with ThreadSafeDataRobotClient().request_user_client():
         rest_client = dr.client.get_client()
 
-        params: dict[str, Any] = {"limit": limit}
+        params: dict[str, Any] = {"limit": limit, "type": datastore_type}
         if offset is not None:
             params["offset"] = offset
         try:
@@ -304,6 +331,7 @@ async def catalog_list_datastores(
                 {
                     "id": ds.get("id", ""),
                     "canonical_name": ds.get("canonicalName", ""),
+                    "type": ds.get("type", ""),
                     "creator_id": ds.get("creatorId", ""),
                     "params": _serialize_datastore_params(ds.get("params", {})),
                 }

--- a/tests/drmcp/unit/predictive_tools/test_data.py
+++ b/tests/drmcp/unit/predictive_tools/test_data.py
@@ -426,7 +426,7 @@ async def test_catalog_list_datastores_success() -> None:
         assert result["limit"] == 10
         assert "next" in result
         mock_rest.get.assert_called_once_with(
-            "externalDataStores/", params={"offset": 0, "limit": 10}
+            "externalDataStores/", params={"offset": 0, "limit": 10, "type": "all"}
         )
 
 
@@ -463,7 +463,9 @@ async def test_catalog_list_datastores_serializes_params_from_response() -> None
         assert result["datastores"][0]["params"] == expected
         assert "offset" not in result
         assert result["limit"] == 100
-        mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 100})
+        mock_rest.get.assert_called_once_with(
+            "externalDataStores/", params={"limit": 100, "type": "all"}
+        )
 
 
 @pytest.mark.asyncio
@@ -493,7 +495,7 @@ async def test_catalog_list_datastores_pagination_total_count_from_api() -> None
         assert result["total_count"] == 42
         assert result["previous"] == "https://api/prev"
         mock_rest.get.assert_called_once_with(
-            "externalDataStores/", params={"offset": 5, "limit": 1}
+            "externalDataStores/", params={"offset": 5, "limit": 1, "type": "all"}
         )
 
 
@@ -508,7 +510,44 @@ async def test_catalog_list_datastores_clamps_limit_above_max() -> None:
         result = await data.catalog_list_datastores(limit=1001)
         assert result["limit"] == 100
         assert "Limit cannot exceed 100" in (result.get("note") or "")
-        mock_rest.get.assert_called_once_with("externalDataStores/", params={"limit": 100})
+        mock_rest.get.assert_called_once_with(
+            "externalDataStores/", params={"limit": 100, "type": "all"}
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_get_client_context_with_token_from_request_header")
+async def test_catalog_list_datastores_passes_datastore_type() -> None:
+    """GIVEN a datastore_type filter WHEN listing THEN the API type query param is set."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {
+                "id": "conn1",
+                "canonicalName": "Jira",
+                "type": "dr-connector-v1",
+                "creatorId": "user1",
+                "params": {},
+            }
+        ],
+    }
+    mock_rest = MagicMock()
+    mock_rest.get.return_value = mock_response
+    with patch.object(dr.client, "get_client", return_value=mock_rest):
+        result = await data.catalog_list_datastores(datastore_type="dr-connector-v1")
+        assert result["count"] == 1
+        assert result["datastores"][0]["type"] == "dr-connector-v1"
+        mock_rest.get.assert_called_once_with(
+            "externalDataStores/", params={"limit": 100, "type": "dr-connector-v1"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_catalog_list_datastores_rejects_unknown_datastore_type() -> None:
+    """GIVEN an invalid datastore_type WHEN listing THEN a validation error is raised."""
+    with pytest.raises(ToolError, match="datastore_type must be one of") as exc_info:
+        await data.catalog_list_datastores(datastore_type="not-a-type")
+    assert exc_info.value.kind == ToolErrorKind.VALIDATION
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.27.13"
+version = "0.27.14"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Fixes `catalog_list_datastores` so agents see every configured external connection, not an empty list when the tenant only has native-database or connector stores.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only predictive MCP tool change with a safer default and an optional filter; no auth or data-mutation paths touched.
> 
> **Overview**
> Fixes **`catalog_list_datastores`** so agents see every configured external connection, not an empty list when the tenant only has native-database or connector stores.
> 
> **`GET externalDataStores/`** is now called with **`type=all`** by default (omitting `type` made the API JDBC-only). Each listed row includes a **`type`** field. Callers can narrow results with optional **`datastore_type`** (`jdbc`, `dr-database-v1`, `dr-connector-v1`, `databases`, or `all`); invalid values raise a validation **`ToolError`**.
> 
> Release **0.27.14**; unit tests and MCP client stubs updated for the new query param and response shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e436bd0d4894dbd8f82d348e9960b4bcf26c0b1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->