### PR TITLE
[BUZZOK-32053] Add cve-sync CI automation to auto-fix CVEs in datarobot-genai

### DIFF
--- a/.github/workflows/cve-sync.yml
+++ b/.github/workflows/cve-sync.yml
@@ -9,10 +9,9 @@
 #
 # On a schedule or a dispatch: resync every resolution root against current
 # policy, re-lock, bump the version, and push a branch. It stops at the branch on
-# purpose. A Harness watcher turns that branch into a pull request, and that
-# indirection is load-bearing rather than convenient: a branch pushed with
-# GITHUB_TOKEN does not trigger workflows, so without the watcher the branch would
-# arrive with none of this repo's checks having run on it.
+# purpose so a separate process can open the pull request: a branch pushed with
+# GITHUB_TOKEN does not trigger workflows, so without that follow-up the branch
+# would arrive with none of this repo's checks having run on it.
 #
 # This is the shape of examples/3-resync-branch.yml in datarobot-oss/cve-sync,
 # which was written for this repo. That file carries the reasoning these comments
@@ -67,12 +66,12 @@ jobs:
         uses: datarobot-oss/cve-sync/actions/gate@main
 
   resync:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     # Declared explicitly rather than inherited. `contents: write` is all a branch
-    # push needs, and it is NOT affected by the org's restriction on Actions
-    # opening pull requests, which is why the Harness watcher exists.
+    # push needs; opening the pull request itself is left to a separate,
+    # downstream process.
     permissions:
       contents: write
 
@@ -139,9 +138,8 @@ jobs:
       # reads `[project].version` out of pyproject.toml and tags exactly that, so an
       # unbumped resync merges and publishes nothing and the fix never reaches
       # anyone pinned to a tag. It also satisfies changelog-check, which does not
-      # exempt this pipeline the way it exempts a bot: the service account opening
-      # the pull request is a normal login, and unlike Dependabot this automation can
-      # write the entry itself.
+      # exempt this automation the way it exempts some bots, so this pipeline
+      # writes the entry itself.
       #
       # This step re-locks all three roots, not just the one it stamped, and that
       # matters in this repo specifically. `docs` and `e2e-tests` depend on this

--- a/.github/workflows/cve-sync.yml
+++ b/.github/workflows/cve-sync.yml
@@ -1,0 +1,194 @@
+---
+# Automated CVE policy sync, against the shared floors in datarobot-oss/cve-sync.
+#
+# Two halves that never run together.
+#
+# On a pull request: a regression gate. It fails only on a floor violation this
+# branch introduces, so a floor landing upstream never reds a pull request that
+# did not touch dependencies.
+#
+# On a schedule or a dispatch: resync every resolution root against current
+# policy, re-lock, bump the version, and push a branch. It stops at the branch on
+# purpose. A Harness watcher turns that branch into a pull request, and that
+# indirection is load-bearing rather than convenient: a branch pushed with
+# GITHUB_TOKEN does not trigger workflows, so without the watcher the branch would
+# arrive with none of this repo's checks having run on it.
+#
+# This is the shape of examples/3-resync-branch.yml in datarobot-oss/cve-sync,
+# which was written for this repo. That file carries the reasoning these comments
+# do not repeat.
+#
+# WHY THIS REPO IS THE HARD CASE. It has three resolution roots: the package
+# itself, `docs`, and `e2e-tests`, each with its own pyproject and its own
+# uv.lock, and the last two depend on the first by path. Every one of them
+# resolves independently, so every one of them needs its own copy of the cve-sync
+# residue, and a gate watching one of them reports green while the other two drift
+# below policy. Both jobs below cover all three.
+#
+# The actions track `@main` rather than a tag, matching the shipped examples. The
+# tradeoff is real and worth knowing: cve-sync can change what runs here without a
+# review in this repo. They are first-party actions in a repo we own, and cve-sync
+# cuts a patch tag on every merge, so pinning is available the day that tradeoff
+# stops being acceptable.
+name: cve-sync
+
+on:
+  pull_request:
+  schedule:
+    # Monday 06:00 UTC, an hour after cve-sync's own policy-currency cron, so a
+    # floor raised there has a chance to be current by the time this reads it.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # The gate reads each baseline lock out of the base ref, so it needs
+          # history and not just the tip.
+          fetch-depth: 0
+
+      # No inputs. It covers all three roots' locks, which is the whole reason this
+      # repo needed the gate to grow past a single lock path: pointed at the root
+      # uv.lock it would watch one of three, and the scoped overrides in
+      # cve-sync's policy/overrides/datarobot-genai-e2e-tests.toml exist precisely
+      # because that root resolves differently from this one.
+      #
+      # Regression mode, which is the only thing that makes this safe to require:
+      # it fails on a violation THIS branch introduces, so a floor landing upstream
+      # never reds a pull request that did not touch dependencies.
+      - name: cve-sync gate
+        uses: datarobot-oss/cve-sync/actions/gate@main
+
+  resync:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    # Declared explicitly rather than inherited. `contents: write` is all a branch
+    # push needs, and it is NOT affected by the org's restriction on Actions
+    # opening pull requests, which is why the Harness watcher exists.
+    permissions:
+      contents: write
+
+    # A dispatch fired during the weekly run would otherwise race the push.
+    # branch-and-link force-pushes a same-day branch by design, so without this the
+    # loser of that race overwrites the winner quietly instead of failing.
+    concurrency:
+      group: cve-sync-resync
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      # Splices into all three roots and re-locks each. A conflict fails the job
+      # and pushes nothing, because nothing usable was produced; a floor still
+      # unmet after locking reports and lets the branch through, because partial
+      # progress is worth a reviewer's eyes.
+      - name: Splice residue and re-lock
+        id: resync
+        uses: datarobot-oss/cve-sync/actions/resync@main
+
+      # One bullet per package that moved, from the report resync already wrote.
+      # The generic alternative, "floors were raised, see the diff", is only useful
+      # while the diff is still in front of the reader.
+      #
+      # Deduped on (package, before, after) because the global floors are carried
+      # in all three roots, so one floor move appears three times.
+      #
+      # The no-packages bullet is load-bearing rather than defensive. `changed` is a
+      # whole-file comparison while `packages_changed` compares only version
+      # specifiers, so the two disagree on any run that rewrites the block without
+      # moving a floor: a marker that shifted, a package respelled in policy, an
+      # edited waiver notice. That run has something real to commit and nothing to
+      # name, and stamp-release rejects an empty entry, so with no bullet here the
+      # job fails and the branch is never pushed.
+      - name: Describe what moved
+        id: entry
+        if: steps.resync.outputs.changed == 'true'
+        env:
+          JSON_PATH: ${{ steps.resync.outputs.json-path }}
+        run: |
+          set -euo pipefail
+          {
+            echo "text<<CVE_SYNC_ENTRY"
+            jq -r '
+              [ .results[].packages_changed[] ]
+              | unique_by([.package, .before, .after]) as $moved
+              | if ($moved | length) == 0 then
+                  "Re-emit the cve-sync residue block. No dependency floor moved."
+                else
+                  $moved[]
+                  | if .before == null then
+                      "Add a `\(.package)` floor at `\(.after)`."
+                    elif .after == null then
+                      "Drop the `\(.package)` floor, which policy no longer carries."
+                    else
+                      "Raise the `\(.package)` floor from `\(.before)` to `\(.after)`."
+                    end
+                end' "$JSON_PATH"
+            echo "CVE_SYNC_ENTRY"
+          } >> "$GITHUB_OUTPUT"
+
+      # The release decision, and here the version really is it: release-on-merge
+      # reads `[project].version` out of pyproject.toml and tags exactly that, so an
+      # unbumped resync merges and publishes nothing and the fix never reaches
+      # anyone pinned to a tag. It also satisfies changelog-check, which does not
+      # exempt this pipeline the way it exempts a bot: the service account opening
+      # the pull request is a normal login, and unlike Dependabot this automation can
+      # write the entry itself.
+      #
+      # This step re-locks all three roots, not just the one it stamped, and that
+      # matters in this repo specifically. `docs` and `e2e-tests` depend on this
+      # package by path, so their locks record its version too. Bumping the root and
+      # re-locking only the root leaves them behind, which is how docs/uv.lock came
+      # to record 0.28.0 against a 0.28.3 pyproject.
+      #
+      # Keep the `if`: stamping on a run where nothing moved dirties the tree, which
+      # makes the push below fire, which turns a no-op into a pull request releasing
+      # a version that contains nothing.
+      - name: Stamp the release
+        if: steps.resync.outputs.changed == 'true'
+        uses: datarobot-oss/cve-sync/actions/stamp-release@main
+        with:
+          entry: ${{ steps.entry.outputs.text }}
+
+      # `paths` is narrowed rather than left at the default `-A`, so a stray build
+      # artifact cannot ride along inside a commit whose message says it is a policy
+      # resync. Every root's manifest and lock has to be named, not just the stamped
+      # one, because the stamp re-locks all three.
+      #
+      # branch-and-link also refuses outright to commit an untracked file that no
+      # declared path matches, unless `allow-untracked` is set, so a new file
+      # appearing here fails the run rather than arriving unnoticed.
+      - name: Push a branch
+        if: steps.resync.outputs.changed == 'true'
+        uses: datarobot-oss/cve-sync/actions/branch-and-link@main
+        with:
+          paths: >-
+            pyproject.toml
+            uv.lock
+            docs/pyproject.toml
+            docs/uv.lock
+            e2e-tests/pyproject.toml
+            e2e-tests/uv.lock
+            CHANGELOG.md
+          # Name the packages in the subject line, so a reviewer scanning a pull
+          # request list can tell a routine patch bump from something bigger. The
+          # fallback covers the run where residue moved but no version specifier
+          # did.
+          commit-message: "Sync cve-sync policy residue: ${{ steps.resync.outputs.packages-changed || 'block re-emitted' }}"
+          pr-body: >
+            Automated resync against current cve-sync policy across all three
+            resolution roots. Review the dependency changes in the three lockfiles
+            before merging.
+
+
+            The version bump and changelog entry are already in this branch, so
+            merging cuts a real release. Check that the new minimums are what you
+            want before they reach anyone pinned to a tag.

--- a/.taskfiles/cve-sync.yml
+++ b/.taskfiles/cve-sync.yml
@@ -78,50 +78,126 @@ tasks:
     cmds:
       - "{{.CVE_SYNC}} audit --target {{.CVE_SYNC_TARGET}}"
 
-  # check and gate loop over the roots in shell rather than using Task's `dir:`,
-  # which joins an absolute path onto the Taskfile's own directory and would
-  # produce a doubled path. `cd` here is unambiguous, and it also puts `git show`
-  # in the right repo.
-  check:
-    desc: Strict floor gate over every root's lock. Every violation counts.
+  # Signposts, not features. `fix` and `fix-cve` write policy, so they only exist
+  # in a cve-sync clone and are deliberately not shipped here. Without these two
+  # tasks the mistake is silent: `task cve-sync:fix` in a downstream repo just
+  # reports an unknown task, which reads as "wrong name" rather than "wrong repo",
+  # and the muscle memory survives to be repeated. Naming them and having them say
+  # where to go is cheaper than remembering.
+  fix:
+    desc: "(not here) Fixing a CVE writes policy, which only happens in a cve-sync clone."
     silent: true
     cmds:
       - |
-        set -uo pipefail
-        cd "{{.CVE_SYNC_TARGET}}"
-        roots="$({{.CVE_SYNC}} roots --target .)" || exit 1
-        failed=0
-        for root in $roots; do
-          lock="uv.lock"
-          [ "$root" = "." ] || lock="$root/uv.lock"
-          echo "== $lock"
-          # Keep going after a failure: a gate that stops at the first bad root
-          # hides how much there is left to fix.
-          {{.CVE_SYNC}} check --lock "$lock" || failed=1
-        done
-        exit $failed
+        cat >&2 <<'EOF'
+        cve-sync: `fix` is not available in this repo.
 
+        Fixing a CVE writes to cve-sync's policy/, so it runs from a cve-sync
+        checkout and edits both repos at once:
+
+            cd /path/to/cve-sync
+            task fix -- --target {{.CVE_SYNC_TARGET}}
+
+        If you only need to pull already-merged policy into this repo, that is a
+        different and much smaller thing, and it does belong here:
+
+            task cve-sync:sync      # splice the residue and re-lock
+            task cve-sync:status    # or just ask whether you are behind
+
+        EOF
+        exit 1
+
+  fix-cve:
+    desc: "(not here) Same as cve-sync:fix, for a single CVE."
+    silent: true
+    cmds:
+      - |
+        cat >&2 <<'EOF'
+        cve-sync: `fix-cve` is not available in this repo.
+
+        It writes cve-sync policy, so run it from a cve-sync checkout:
+
+            cd /path/to/cve-sync
+            task fix-cve -- --target {{.CVE_SYNC_TARGET}}
+
+        To pull already-merged policy into this repo instead:
+
+            task cve-sync:sync
+
+        EOF
+        exit 1
+
+  # These four were a shell loop each until the CLI grew `--target`. What the
+  # loops had to get right, and did not always: discovering every resolution
+  # root, not word-splitting a root path that holds spaces (a copier template
+  # repo names its directory after a template variable, so
+  # af-component-evaluation's root is `template/[[ evaluation_app_name ]]`),
+  # reading each baseline with `git cat-file blob` rather than `git show`,
+  # guarding against the empty file that produces, carrying a failure flag out of
+  # a `while` that must not run in a subshell, and continuing past the first bad
+  # root so the reader sees everything left to fix rather than one item per CI
+  # run. All of that now lives in one place, with tests.
+  check:
+    desc: Strict floor gate over every lock in the repo. Every violation counts.
+    silent: true
+    cmds:
+      - "{{.CVE_SYNC}} check --target {{.CVE_SYNC_TARGET}}"
+
+  # A copier template repo ships pre-baked lock artifacts generated from its
+  # pyproject.toml.jinja, and those are what reach a customer. They are not any
+  # root's uv.lock, and the project name recorded inside one is a jinja
+  # placeholder rather than a real project, so their identity comes from
+  # policy/copier.yaml instead of from the lock.
+  #
+  # `check` above already covers them. This narrows to just them, for a repo that
+  # wants the two answers on separate jobs.
+  #
+  # Worth running even when `sync` reports clean. Splicing the residue into a
+  # template proves the residue is current; it says nothing about whether these
+  # committed locks were regenerated afterwards.
+  check-templates:
+    desc: Floor gate over the lock artifacts a copier template ships.
+    silent: true
+    cmds:
+      - "{{.CVE_SYNC}} check --target {{.CVE_SYNC_TARGET}} --scope templates"
+
+  # What CI runs on a PR. The difference from `check` is the only thing that
+  # makes it safe to require: a strict check on a required job reds every open
+  # pull request in the repo the moment a floor lands upstream, including the
+  # ones that never touched a dependency. That is the failure mode cve-sync
+  # exists to prevent.
+  #
+  # --baseline-ref replaces what used to be a `git cat-file blob` per root into a
+  # temp file, plus a `-s` guard on each, plus a `rm -f`. The CLI reads each
+  # lock's baseline out of git itself now, so a lock this branch ADDS simply has
+  # no baseline and degrades to reporting rather than failing, and there is no
+  # empty file left anywhere to be mistaken for a compliant one.
   gate:
     desc: >
       What CI runs on a PR: fail only on violations this branch introduces
       relative to CVE_SYNC_BASE_REF. A floor landing upstream never fails it.
     silent: true
     cmds:
-      - |
-        set -uo pipefail
-        cd "{{.CVE_SYNC_TARGET}}"
-        roots="$({{.CVE_SYNC}} roots --target .)" || exit 1
-        failed=0
-        for root in $roots; do
-          lock="uv.lock"
-          [ "$root" = "." ] || lock="$root/uv.lock"
-          echo "== $lock"
-          baseline="$(mktemp)"
-          if ! git show "{{.CVE_SYNC_BASE_REF}}:$lock" > "$baseline" 2>/dev/null; then
-            echo "cve-sync: no $lock at {{.CVE_SYNC_BASE_REF}}; reporting without failing"
-            rm -f "$baseline"
-          fi
-          {{.CVE_SYNC}} check --lock "$lock" --baseline "$baseline" || failed=1
-          rm -f "$baseline"
-        done
-        exit $failed
+      - "{{.CVE_SYNC}} check --target {{.CVE_SYNC_TARGET}} --baseline-ref {{.CVE_SYNC_BASE_REF}}"
+
+  # The PR-job counterpart to check-templates, for a repo running the two on
+  # separate jobs. `gate` above already covers these.
+  #
+  # Worth stating what this gates, because nothing else does: in a copier template
+  # repo the template IS the product, and a human editing the template's
+  # dependencies is otherwise unchecked until the next scheduled run.
+  #
+  # Keep running the strict check-templates on the scheduled job as well. The two
+  # answer different questions. Regression mode asks "did this branch introduce
+  # it"; strict asks "are the shipped locks compliant at all", and the second is
+  # still worth asking weekly, because a fresh resolution picks latest-available
+  # and can look compliant while a committed artifact sits patch releases behind.
+  gate-templates:
+    desc: >
+      What CI runs on a PR for a copier template's shipped locks: fail only on
+      violations this branch introduces relative to CVE_SYNC_BASE_REF.
+    silent: true
+    cmds:
+      - >-
+        {{.CVE_SYNC}} check --target {{.CVE_SYNC_TARGET}}
+        --scope templates --baseline-ref {{.CVE_SYNC_BASE_REF}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.4
+- Enable `cve-sync` automation in the repo
+
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.
 - A group that resolves an `AgentCardAware` auth provider now takes its own copy of it, so the card it fetched stays with the agent it fetched it from. Configuration and credentials are unchanged and still shared.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -189,7 +189,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.1"
+version = "0.29.2"
 source = { editable = "../" }
 
 [package.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.4"
+version = "0.29.5"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.3"
+version = "0.29.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.3"
+version = "0.29.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

Add cve-sync CI automation

This repo has carried marker-managed cve-sync residue in all three of its resolution roots since the adoption PR, but nothing has ever kept it current or checked it on a pull request. Both halves were run by hand.

The problem this closes. `.`, `docs`, and `e2e-tests` each have their own pyproject and their own uv.lock, and each resolves independently. uv reads `[tool.uv]` only from the root of what it resolves, so a CVE floor that cannot travel through package metadata has to be written into all three or it is silently dropped from the ones that miss it. Nothing checked that, and nothing kept them current, so a floor raised upstream in cve-sync would sit unapplied here indefinitely and a pull request could drop one below policy with every check green.

The new `gate` takes no inputs, and for this repo that is the point. Until cve-sync 0.0.30 it could only be pointed at a single lock, which would have meant watching one root of three while the other two drifted.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- `.github/workflows/cve-sync.yml`. On a pull request, a regression gate over all three locks that fails only on a violation the branch introduces, so a floor landing upstream cannot red an unrelated pull request. On a Monday cron or a dispatch, a resync that splices current policy into all three roots, re-locks, bumps the version with a changelog entry naming the packages that moved, and pushes a branch for the Harness watcher to turn into a pull request.
- The vendored `.taskfiles/cve-sync.yml` re-synced from cve-sync 0.0.31. The copy here was several releases behind, from before root discovery, space-safe path handling, and the baseline reads moved out of shell loops and into the CLI.

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated resync can open PRs that bump version and dependency floors across three lockfiles; merging publishes a release, so review of auto-generated dependency changes matters.
> 
> **Overview**
> Adds a **`cve-sync` GitHub Actions workflow** with two paths: on pull requests, a **regression gate** (via `datarobot-oss/cve-sync` actions) that fails only when this branch worsens CVE floors across all three resolution roots—root package, `docs`, and `e2e-tests`; on schedule (Mondays 06:00 UTC) or manual dispatch, a **resync** job that splices policy, re-locks all three trees, builds a changelog entry, **stamps a release**, and pushes a branch (Harness opens the PR) with only the named manifest/lock/changelog paths.
> 
> Updates **`.taskfiles/cve-sync.yml`** to delegate multi-root **`check`** / **`gate`** to the CLI (`--target`, `--baseline-ref`), adds **`check-templates`** / **`gate-templates`**, and replaces real **`fix`** / **`fix-cve`** with signpost tasks that explain those belong in a `cve-sync` clone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608f477c37d2e1878f9d1f76141df750c4ecd533. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->