### PR TITLE
[BUZZOK-32130] Improve in-memory cache for remote agent cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.2
-- `dragent`: prefetch central agent card registry lookups at FastAPI startup for all `authenticated_a2a_client` function groups with a `registry` block (`AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP`, default `true`).
-- `dragent`: agent card registry stale-if-error for in-memory cache — serve last-known-good cards when registry fetch fails, within `AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS` (`AGENT_CARD_REGISTRY_STALE_IF_ERROR`, default `true`).
-- `dragent`: background agent card registry refresh loop for registered IDs past the soft cache TTL (`AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS`, default `1800`; set `0` to disable).
+- `dragent`: prefetch central agent card registry lookups at FastAPI startup for all `authenticated_a2a_client` function groups with a `registry` block.
+- `dragent`: agent card registry stale-if-error for in-memory cache — serve last-known-good cards when a registry fetch fails.
+- `dragent`: background agent card registry refresh loop for registered IDs past the soft cache TTL (every 30 minutes).
 
 ## 0.29.1
 - `docs/` and `e2e-tests/`: **re-locked to match the root.** Both are separate resolution roots with their own `uv.lock`, and nothing re-locks them when the root's dependencies change, so they had been drifting since 0.28.0. `docs/uv.lock` still carried the `datarobot-early-access` pin that 0.28.3 gave up, and `e2e-tests/uv.lock` still resolved `datarobot` 3.17.0; both now take stable `datarobot>=3.18.0,<4.0.0` with the matching extra specifiers, and both pick up `pydantic-settings` for the `auth`, `drmcpbase`, `drmcputils`, and `drtools` extras. Neither lock ships in the wheel, so this changes no published dependency; it stops the docs build and the e2e suite from installing a resolution the package itself no longer describes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.2
+- `dragent`: prefetch central agent card registry lookups at FastAPI startup for all `authenticated_a2a_client` function groups with a `registry` block (`AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP`, default `true`).
+- `dragent`: agent card registry stale-if-error for in-memory cache — serve last-known-good cards when registry fetch fails, within `AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS` (`AGENT_CARD_REGISTRY_STALE_IF_ERROR`, default `true`).
+- `dragent`: background agent card registry refresh loop for registered IDs past the soft cache TTL (`AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS`, default `1800`; set `0` to disable).
+
 ## 0.29.1
 - `docs/` and `e2e-tests/`: **re-locked to match the root.** Both are separate resolution roots with their own `uv.lock`, and nothing re-locks them when the root's dependencies change, so they had been drifting since 0.28.0. `docs/uv.lock` still carried the `datarobot-early-access` pin that 0.28.3 gave up, and `e2e-tests/uv.lock` still resolved `datarobot` 3.17.0; both now take stable `datarobot>=3.18.0,<4.0.0` with the matching extra specifiers, and both pick up `pydantic-settings` for the `auth`, `drmcpbase`, `drmcputils`, and `drtools` extras. Neither lock ships in the wheel, so this changes no published dependency; it stops the docs build and the e2e suite from installing a resolution the package itself no longer describes.
 - Every root's lock now stamps the same `datarobot-genai` version. The satellites install the root as an editable path dependency and record its version, which the release bump does not update on its own, so `docs/` sat at 0.28.3 and `e2e-tests/` at 0.28.5 against a 0.29.0 root. Left alone this is the same drift the rest of this entry removes.

--- a/docs/src/nat/a2a-client.md
+++ b/docs/src/nat/a2a-client.md
@@ -104,9 +104,9 @@ function_groups:
 When a workflow has many registry-backed function groups, all cards are resolved in a maximum of two HTTP calls: one for deployment IDs, one for external IDs. Results are cached in-memory and
 reused until the TTL expires.
 
-On dragent startup, all registry IDs from `workflow.yaml` are **prefetched** in the same batch (enabled by default via `AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP`). Disable with `AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP=false` if you need to defer registry access until the first tool call.
+On dragent startup, all registry IDs from `workflow.yaml` are **prefetched** in the same batch before the server accepts traffic.
 
-While the server is running, registered cards are **refreshed in the background** on a fixed interval (default 30 min via `AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS`). Only entries past the soft cache TTL are re-fetched; failures are logged and existing cache entries are retained.
+While the server is running, registered cards are **refreshed in the background** every 30 minutes. Only entries past the soft cache TTL are re-fetched; failures are logged and existing cache entries are retained. If a registry fetch fails, the last-known-good cached card is served.
 
 #### Registry environment variables
 
@@ -116,10 +116,6 @@ While the server is running, registered cards are **refreshed in the background*
 | `DATAROBOT_ENDPOINT` | Yes | DataRobot API base URL, e.g. `https://app.datarobot.com/api/v2`. |
 | `AGENT_CARD_REGISTRY_CACHE_TTL` | No | Cache TTL in seconds. Default `86400` (24 h). Set to `0` to disable caching. |
 | `AGENT_CARD_REGISTRY_TIMEOUT` | No | HTTP timeout in seconds for registry requests. Default `30`. |
-| `AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP` | No | When `true` (default), batch-fetch all registry-backed agent cards during dragent startup before accepting traffic. Set to `false` to disable. |
-| `AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS` | No | Maximum age in seconds for serving a cached card when the registry is unreachable (stale-if-error). Default `86400` (24 h). |
-| `AGENT_CARD_REGISTRY_STALE_IF_ERROR` | No | When `true` (default), return the last-known-good cached card if a registry fetch fails and the entry is within `AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS`. |
-| `AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS` | No | Background refresh period in seconds for registered cards past the soft cache TTL. Default `1800` (30 min). Set to `0` to disable. |
 | `AGENT_CARD_REGISTRY_ON_DUPLICATE` | No | Strategy when multiple cards share the same external ID: `first` keeps the earliest registered card, `last` keeps the most recently registered card, `error` raises an exception. Default: `first`. |
 
 Variables are loaded via `DataRobotAppFrameworkBaseSettings`, which supports env vars, `.env`

--- a/docs/src/nat/a2a-client.md
+++ b/docs/src/nat/a2a-client.md
@@ -104,6 +104,10 @@ function_groups:
 When a workflow has many registry-backed function groups, all cards are resolved in a maximum of two HTTP calls: one for deployment IDs, one for external IDs. Results are cached in-memory and
 reused until the TTL expires.
 
+On dragent startup, all registry IDs from `workflow.yaml` are **prefetched** in the same batch (enabled by default via `AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP`). Disable with `AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP=false` if you need to defer registry access until the first tool call.
+
+While the server is running, registered cards are **refreshed in the background** on a fixed interval (default 30 min via `AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS`). Only entries past the soft cache TTL are re-fetched; failures are logged and existing cache entries are retained.
+
 #### Registry environment variables
 
 | Variable | Required | Description |
@@ -112,6 +116,10 @@ reused until the TTL expires.
 | `DATAROBOT_ENDPOINT` | Yes | DataRobot API base URL, e.g. `https://app.datarobot.com/api/v2`. |
 | `AGENT_CARD_REGISTRY_CACHE_TTL` | No | Cache TTL in seconds. Default `86400` (24 h). Set to `0` to disable caching. |
 | `AGENT_CARD_REGISTRY_TIMEOUT` | No | HTTP timeout in seconds for registry requests. Default `30`. |
+| `AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP` | No | When `true` (default), batch-fetch all registry-backed agent cards during dragent startup before accepting traffic. Set to `false` to disable. |
+| `AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS` | No | Maximum age in seconds for serving a cached card when the registry is unreachable (stale-if-error). Default `86400` (24 h). |
+| `AGENT_CARD_REGISTRY_STALE_IF_ERROR` | No | When `true` (default), return the last-known-good cached card if a registry fetch fails and the entry is within `AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS`. |
+| `AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS` | No | Background refresh period in seconds for registered cards past the soft cache TTL. Default `1800` (30 min). Set to `0` to disable. |
 | `AGENT_CARD_REGISTRY_ON_DUPLICATE` | No | Strategy when multiple cards share the same external ID: `first` keeps the earliest registered card, `last` keeps the most recently registered card, `error` raises an exception. Default: `first`. |
 
 Variables are loaded via `DataRobotAppFrameworkBaseSettings`, which supports env vars, `.env`

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -949,7 +949,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.1"
+version = "0.29.2"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -2421,17 +2421,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -2447,16 +2447,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -3734,10 +3734,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3753,10 +3753,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.1"
+version = "0.29.2"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -542,8 +542,12 @@ class AgentCardRegistry:
                 cards = await self._fetch(params)
                 self._store_cards(cards)
 
-                if lookup_key in self._cache:
-                    return self._cache[lookup_key].card
+                if lookup_key in cards:
+                    return cards[lookup_key]
+
+                # Successful miss — evict stale entry so stale-if-error cannot
+                # resurrect a deregistered agent on a later fetch failure.
+                self._cache.pop(lookup_key, None)
             except AgentCardRegistryError:
                 if stale_card := self._try_get_stale(lookup_key):
                     return stale_card

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -55,6 +55,12 @@ logger = logging.getLogger(__name__)
 # Default cache TTL: 24 hours (in seconds).
 _DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
 
+# Default hard staleness bound for stale-if-error (in seconds).
+_DEFAULT_MAX_STALENESS_SECONDS = 24 * 3600
+
+# Default background refresh interval (in seconds). 0 disables the refresh loop.
+_DEFAULT_REFRESH_INTERVAL_SECONDS = 30 * 60
+
 # Default HTTP timeout for registry requests (in seconds).
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -119,6 +125,43 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
             "creation time (ascending), so 'first' keeps the earliest "
             "registered card, 'last' keeps the most recently registered card, "
             "and 'error' raises AgentCardRegistryError.  Default: 'first'."
+        ),
+    )
+
+    agent_card_registry_prefetch_on_startup: bool = Field(
+        default=True,
+        description=(
+            "When true, batch-fetch all registry-backed agent cards during "
+            "dragent FastAPI startup (before accepting traffic). "
+            "Set AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP=false to disable."
+        ),
+    )
+
+    agent_card_registry_max_staleness_seconds: int = Field(
+        default=_DEFAULT_MAX_STALENESS_SECONDS,
+        ge=0,
+        description=(
+            "Maximum age in seconds for serving a cached agent card when the "
+            "registry is unreachable (stale-if-error). Default: 86400 (24 hours)."
+        ),
+    )
+
+    agent_card_registry_stale_if_error: bool = Field(
+        default=True,
+        description=(
+            "When true, return the last-known-good cached agent card if a "
+            "registry fetch fails and the entry is within "
+            "agent_card_registry_max_staleness_seconds. "
+            "Set AGENT_CARD_REGISTRY_STALE_IF_ERROR=false to disable."
+        ),
+    )
+
+    agent_card_registry_refresh_interval_seconds: int = Field(
+        default=_DEFAULT_REFRESH_INTERVAL_SECONDS,
+        ge=0,
+        description=(
+            "Background refresh period in seconds for registered agent cards "
+            "past the soft cache TTL. Set to 0 to disable. Default: 1800 (30 min)."
         ),
     )
 
@@ -219,14 +262,36 @@ class _CacheEntry:
         self.card = card
         self.fetched_at = time.monotonic()
 
+    def age_seconds(self) -> float:
+        """Return the entry age in seconds."""
+        return time.monotonic() - self.fetched_at
+
+    def is_fresh(self, cache_ttl: int) -> bool:
+        """Return *True* if this entry is within the soft TTL (*cache_ttl*).
+
+        A TTL of 0 means "never fresh" (always attempt refresh).
+        """
+        if cache_ttl == 0:
+            return False
+        return self.age_seconds() < cache_ttl
+
     def is_expired(self, ttl: int) -> bool:
         """Return *True* if this entry is older than *ttl* seconds.
 
         A TTL of 0 means "always expired" (no caching).
+
+        .. deprecated::
+            Prefer :meth:`is_fresh` with the soft cache TTL.
         """
         if ttl == 0:
             return True
-        return (time.monotonic() - self.fetched_at) >= ttl
+        return self.age_seconds() >= ttl
+
+    def is_within_staleness(self, max_staleness_seconds: int) -> bool:
+        """Return *True* if this entry may be served under stale-if-error."""
+        if max_staleness_seconds == 0:
+            return False
+        return self.age_seconds() <= max_staleness_seconds
 
 
 class AgentCardRegistry:
@@ -235,9 +300,10 @@ class AgentCardRegistry:
     IDs are ``register()``-ed synchronously at config-parse time (no I/O).
     The first ``get()`` flushes all pending IDs in ≤2 HTTP calls
     (one per ID type — API uses AND when both are mixed).
-    Subsequent ``get()`` calls hit the in-memory cache until TTL expires.
-    Cache TTL is controlled via ``AGENT_CARD_REGISTRY_CACHE_TTL`` env var
-    (default 86400s / 24h, set to 0 to disable caching).
+    Subsequent ``get()`` calls hit the in-memory cache until the soft TTL
+    (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails and
+    ``AGENT_CARD_REGISTRY_STALE_IF_ERROR`` is enabled, a cached card may still
+    be returned up to ``AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS``.
     """
 
     def __init__(
@@ -246,6 +312,8 @@ class AgentCardRegistry:
         endpoint: str | None = None,
         timeout: float | None = None,
         cache_ttl: int | None = None,
+        max_staleness_seconds: int | None = None,
+        stale_if_error: bool | None = None,
         on_duplicate: DuplicateStrategy | None = None,
     ) -> None:
         self._api_token = api_token
@@ -257,16 +325,35 @@ class AgentCardRegistry:
         self._pending_deployment_ids: set[str] = set()
         self._pending_external_ids: set[str] = set()
 
+        # All IDs registered at config-parse time (used for background refresh)
+        self._registered_deployment_ids: set[str] = set()
+        self._registered_external_ids: set[str] = set()
+
         config = AgentCardRegistryConfig()
         self._timeout = timeout if timeout is not None else config.agent_card_registry_timeout
         self._cache_ttl = (
             cache_ttl if cache_ttl is not None else config.agent_card_registry_cache_ttl
         )
+        self._max_staleness_seconds = (
+            max_staleness_seconds
+            if max_staleness_seconds is not None
+            else config.agent_card_registry_max_staleness_seconds
+        )
+        self._stale_if_error = (
+            stale_if_error
+            if stale_if_error is not None
+            else config.agent_card_registry_stale_if_error
+        )
         self._on_duplicate: DuplicateStrategy = (
             on_duplicate if on_duplicate is not None else config.agent_card_registry_on_duplicate
         )
 
-        logger.debug("AgentCardRegistry created (cache_ttl=%ds)", self._cache_ttl)
+        logger.debug(
+            "AgentCardRegistry created (cache_ttl=%ds, max_staleness=%ds, stale_if_error=%s)",
+            self._cache_ttl,
+            self._max_staleness_seconds,
+            self._stale_if_error,
+        )
 
     # ------------------------------------------------------------------
     # Registration (synchronous — called at config-parse time)
@@ -287,8 +374,14 @@ class AgentCardRegistry:
         """
         if deployment_id:
             self._pending_deployment_ids.add(deployment_id)
+            self._registered_deployment_ids.add(deployment_id)
         elif external_id:
             self._pending_external_ids.add(external_id)
+            self._registered_external_ids.add(external_id)
+
+    def has_registered_lookups(self) -> bool:
+        """Return whether any registry lookup IDs were registered."""
+        return bool(self._registered_deployment_ids or self._registered_external_ids)
 
     # ------------------------------------------------------------------
     # Internal HTTP
@@ -353,10 +446,32 @@ class AgentCardRegistry:
         logger.info("Fetched %d agent card(s) from registry (%d pages).", len(cards), pages_fetched)
         return cards
 
-    def _is_cached(self, key: str) -> bool:
-        """Return True if *key* is cached and not expired."""
+    def _is_fresh(self, key: str) -> bool:
+        """Return True if *key* is cached and within the soft TTL."""
         entry = self._cache.get(key)
-        return entry is not None and not entry.is_expired(self._cache_ttl)
+        return entry is not None and entry.is_fresh(self._cache_ttl)
+
+    def _is_cached(self, key: str) -> bool:
+        """Return True if *key* is cached and within the soft TTL."""
+        return self._is_fresh(key)
+
+    def _try_get_stale(self, key: str) -> AgentCard | None:
+        """Return a stale cached card when refresh failed and policy allows it."""
+        if not self._stale_if_error:
+            return None
+        entry = self._cache.get(key)
+        if entry is None or not entry.is_within_staleness(self._max_staleness_seconds):
+            return None
+        logger.warning(
+            "Registry unreachable; serving stale agent card for %s (age=%.0fs)",
+            key,
+            entry.age_seconds(),
+        )
+        return entry.card
+
+    def _store_cards(self, cards: dict[str, AgentCard]) -> None:
+        for key, card in cards.items():
+            self._cache[key] = _CacheEntry(card)
 
     async def _flush_pending(self) -> None:
         """Batch-fetch all registered-but-uncached IDs.  Must be called under ``_lock``."""
@@ -372,13 +487,11 @@ class AgentCardRegistry:
 
         if missing_dep:
             cards = await self._fetch({"deploymentIds": ",".join(missing_dep)})
-            for k, card in cards.items():
-                self._cache[k] = _CacheEntry(card)
+            self._store_cards(cards)
 
         if missing_ext:
             cards = await self._fetch({"externalIds": ",".join(missing_ext)})
-            for k, card in cards.items():
-                self._cache[k] = _CacheEntry(card)
+            self._store_cards(cards)
 
     # ------------------------------------------------------------------
     # Public API
@@ -415,13 +528,39 @@ class AgentCardRegistry:
 
             if missing_dep:
                 cards = await self._fetch({"deploymentIds": ",".join(missing_dep)})
-                for k, card in cards.items():
-                    self._cache[k] = _CacheEntry(card)
+                self._store_cards(cards)
 
             if missing_ext:
                 cards = await self._fetch({"externalIds": ",".join(missing_ext)})
-                for k, card in cards.items():
-                    self._cache[k] = _CacheEntry(card)
+                self._store_cards(cards)
+
+    async def refresh_all_registered(self) -> None:
+        """Re-fetch registered IDs whose cache entries are past the soft TTL.
+
+        Failures are logged and existing cache entries are left in place so
+        stale-if-error can continue serving them during registry outages.
+        """
+        if not self._registered_deployment_ids and not self._registered_external_ids:
+            logger.debug("No registered agent card IDs; skipping background refresh.")
+            return
+
+        deployment_ids = sorted(self._registered_deployment_ids)
+        external_ids = sorted(self._registered_external_ids)
+        logger.debug(
+            "Refreshing registered agent cards (deployment_ids=%s, external_ids=%s)",
+            deployment_ids,
+            external_ids,
+        )
+        try:
+            await self.prefetch(
+                deployment_ids=deployment_ids or None,
+                external_ids=external_ids or None,
+            )
+        except AgentCardRegistryError:
+            logger.warning(
+                "Background agent card registry refresh failed; keeping cached entries.",
+                exc_info=True,
+            )
 
     async def get(
         self,
@@ -447,33 +586,39 @@ class AgentCardRegistry:
 
         lookup_key: str = deployment_id or external_id  # type: ignore[assignment]
 
-        # Fast path — cached and not expired
-        if self._is_cached(lookup_key):
+        # Fast path — fresh cache hit
+        if self._is_fresh(lookup_key):
             return self._cache[lookup_key].card
 
         async with self._lock:
             # Double-check after acquiring lock
-            if self._is_cached(lookup_key):
+            if self._is_fresh(lookup_key):
                 return self._cache[lookup_key].card
 
-            # Flush all pending registrations in a batch
-            if self._pending_deployment_ids or self._pending_external_ids:
-                await self._flush_pending()
-                if self._is_cached(lookup_key):
+            try:
+                # Flush all pending registrations in a batch
+                if self._pending_deployment_ids or self._pending_external_ids:
+                    await self._flush_pending()
+                    if self._is_fresh(lookup_key):
+                        return self._cache[lookup_key].card
+
+                # Still not fresh — fetch individually
+                params: dict[str, str] = (
+                    {"deploymentIds": deployment_id}
+                    if deployment_id
+                    else {"externalIds": external_id}  # type: ignore[dict-item]
+                )
+                cards = await self._fetch(params)
+                self._store_cards(cards)
+
+                if lookup_key in self._cache:
                     return self._cache[lookup_key].card
+            except AgentCardRegistryError:
+                if stale_card := self._try_get_stale(lookup_key):
+                    return stale_card
+                raise
 
-            # Still not found — fetch individually
-            params: dict[str, str] = (
-                {"deploymentIds": deployment_id} if deployment_id else {"externalIds": external_id}  # type: ignore[dict-item]
-            )
-            cards = await self._fetch(params)
-            for k, card in cards.items():
-                self._cache[k] = _CacheEntry(card)
-
-            if lookup_key in self._cache:
-                return self._cache[lookup_key].card
-
-        # If we got here, the key was not found despite fetching
+        # Fetch succeeded but the requested key was absent from the response.
         id_label = (
             f"deployment_id='{deployment_id}'" if deployment_id else f"external_id='{external_id}'"
         )

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -55,12 +55,6 @@ logger = logging.getLogger(__name__)
 # Default cache TTL: 24 hours (in seconds).
 _DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
 
-# Default hard staleness bound for stale-if-error (in seconds).
-_DEFAULT_MAX_STALENESS_SECONDS = 24 * 3600
-
-# Default background refresh interval (in seconds). 0 disables the refresh loop.
-_DEFAULT_REFRESH_INTERVAL_SECONDS = 30 * 60
-
 # Default HTTP timeout for registry requests (in seconds).
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -125,43 +119,6 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
             "creation time (ascending), so 'first' keeps the earliest "
             "registered card, 'last' keeps the most recently registered card, "
             "and 'error' raises AgentCardRegistryError.  Default: 'first'."
-        ),
-    )
-
-    agent_card_registry_prefetch_on_startup: bool = Field(
-        default=True,
-        description=(
-            "When true, batch-fetch all registry-backed agent cards during "
-            "dragent FastAPI startup (before accepting traffic). "
-            "Set AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP=false to disable."
-        ),
-    )
-
-    agent_card_registry_max_staleness_seconds: int = Field(
-        default=_DEFAULT_MAX_STALENESS_SECONDS,
-        ge=0,
-        description=(
-            "Maximum age in seconds for serving a cached agent card when the "
-            "registry is unreachable (stale-if-error). Default: 86400 (24 hours)."
-        ),
-    )
-
-    agent_card_registry_stale_if_error: bool = Field(
-        default=True,
-        description=(
-            "When true, return the last-known-good cached agent card if a "
-            "registry fetch fails and the entry is within "
-            "agent_card_registry_max_staleness_seconds. "
-            "Set AGENT_CARD_REGISTRY_STALE_IF_ERROR=false to disable."
-        ),
-    )
-
-    agent_card_registry_refresh_interval_seconds: int = Field(
-        default=_DEFAULT_REFRESH_INTERVAL_SECONDS,
-        ge=0,
-        description=(
-            "Background refresh period in seconds for registered agent cards "
-            "past the soft cache TTL. Set to 0 to disable. Default: 1800 (30 min)."
         ),
     )
 
@@ -287,12 +244,6 @@ class _CacheEntry:
             return True
         return self.age_seconds() >= ttl
 
-    def is_within_staleness(self, max_staleness_seconds: int) -> bool:
-        """Return *True* if this entry may be served under stale-if-error."""
-        if max_staleness_seconds == 0:
-            return False
-        return self.age_seconds() <= max_staleness_seconds
-
 
 class AgentCardRegistry:
     """Batch-capable, TTL-cached client for the central agent card registry.
@@ -301,9 +252,8 @@ class AgentCardRegistry:
     The first ``get()`` flushes all pending IDs in ≤2 HTTP calls
     (one per ID type — API uses AND when both are mixed).
     Subsequent ``get()`` calls hit the in-memory cache until the soft TTL
-    (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails and
-    ``AGENT_CARD_REGISTRY_STALE_IF_ERROR`` is enabled, a cached card may still
-    be returned up to ``AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS``.
+    (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails, the
+    last-known-good cached card is returned if one is present.
     """
 
     def __init__(
@@ -312,8 +262,6 @@ class AgentCardRegistry:
         endpoint: str | None = None,
         timeout: float | None = None,
         cache_ttl: int | None = None,
-        max_staleness_seconds: int | None = None,
-        stale_if_error: bool | None = None,
         on_duplicate: DuplicateStrategy | None = None,
     ) -> None:
         self._api_token = api_token
@@ -334,26 +282,11 @@ class AgentCardRegistry:
         self._cache_ttl = (
             cache_ttl if cache_ttl is not None else config.agent_card_registry_cache_ttl
         )
-        self._max_staleness_seconds = (
-            max_staleness_seconds
-            if max_staleness_seconds is not None
-            else config.agent_card_registry_max_staleness_seconds
-        )
-        self._stale_if_error = (
-            stale_if_error
-            if stale_if_error is not None
-            else config.agent_card_registry_stale_if_error
-        )
         self._on_duplicate: DuplicateStrategy = (
             on_duplicate if on_duplicate is not None else config.agent_card_registry_on_duplicate
         )
 
-        logger.debug(
-            "AgentCardRegistry created (cache_ttl=%ds, max_staleness=%ds, stale_if_error=%s)",
-            self._cache_ttl,
-            self._max_staleness_seconds,
-            self._stale_if_error,
-        )
+        logger.debug("AgentCardRegistry created (cache_ttl=%ds)", self._cache_ttl)
 
     # ------------------------------------------------------------------
     # Registration (synchronous — called at config-parse time)
@@ -456,11 +389,9 @@ class AgentCardRegistry:
         return self._is_fresh(key)
 
     def _try_get_stale(self, key: str) -> AgentCard | None:
-        """Return a stale cached card when refresh failed and policy allows it."""
-        if not self._stale_if_error:
-            return None
+        """Return the last-known-good cached card when a registry refresh failed."""
         entry = self._cache.get(key)
-        if entry is None or not entry.is_within_staleness(self._max_staleness_seconds):
+        if entry is None:
             return None
         logger.warning(
             "Registry unreachable; serving stale agent card for %s (age=%.0fs)",

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -31,6 +31,8 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from datarobot_genai.core.utils.logging import setup_logging
+from datarobot_genai.dragent.registry_refresh import registry_refresh_lifespan
+from datarobot_genai.dragent.registry_warmup import warmup_registry_from_config
 
 from .a2a import A2A_MOUNT_PATH
 from .a2a import DRAgentA2AFrontEndPluginWorker
@@ -276,7 +278,9 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         @asynccontextmanager
         async def lifespan(lifespan_app: FastAPI) -> AsyncIterator[None]:
             async with parent_lifespan(lifespan_app):
-                yield
+                await warmup_registry_from_config(self._config)
+                async with registry_refresh_lifespan(self._config):
+                    yield
             if self._a2a_worker is not None:
                 await self._a2a_worker.cleanup()
                 logger.info("A2A worker resources cleaned up")

--- a/src/datarobot_genai/dragent/registry_refresh.py
+++ b/src/datarobot_genai/dragent/registry_refresh.py
@@ -1,0 +1,89 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background refresh loop for the central agent card registry cache."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
+from datarobot_genai.dragent.agent_card_registry import get_default_registry
+
+if TYPE_CHECKING:
+    from nat.data_models.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+def is_registry_refresh_enabled() -> bool:
+    """Return whether the background registry refresh loop is enabled."""
+    return AgentCardRegistryConfig().agent_card_registry_refresh_interval_seconds > 0
+
+
+def get_registry_refresh_interval_seconds() -> int:
+    """Return the configured background refresh interval in seconds."""
+    return AgentCardRegistryConfig().agent_card_registry_refresh_interval_seconds
+
+
+async def registry_refresh_loop(
+    registry: AgentCardRegistry,
+    interval_seconds: int,
+) -> None:
+    """Periodically refresh soft-expired registered agent cards."""
+    while True:
+        await asyncio.sleep(interval_seconds)
+        try:
+            await registry.refresh_all_registered()
+        except Exception:
+            logger.exception("Background agent card registry refresh failed")
+
+
+@asynccontextmanager
+async def registry_refresh_lifespan(_config: Config) -> AsyncIterator[None]:
+    """Start the background refresh task for the registry singleton.
+
+    No-op when ``AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS`` is ``0`` or when
+    no registry-backed IDs were registered at config-parse time.
+    """
+    interval = get_registry_refresh_interval_seconds()
+    if interval <= 0:
+        logger.debug("Agent card registry background refresh is disabled.")
+        yield
+        return
+
+    registry = await get_default_registry()
+    if not registry.has_registered_lookups():
+        logger.debug("No registered agent card IDs; skipping background refresh task.")
+        yield
+        return
+
+    logger.info(
+        "Starting agent card registry background refresh (interval=%ds)",
+        interval,
+    )
+    task = asyncio.create_task(registry_refresh_loop(registry, interval))
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        logger.debug("Agent card registry background refresh task stopped.")

--- a/src/datarobot_genai/dragent/registry_refresh.py
+++ b/src/datarobot_genai/dragent/registry_refresh.py
@@ -24,7 +24,6 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
-from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
 
 if TYPE_CHECKING:
@@ -32,20 +31,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-def is_registry_refresh_enabled() -> bool:
-    """Return whether the background registry refresh loop is enabled."""
-    return AgentCardRegistryConfig().agent_card_registry_refresh_interval_seconds > 0
-
-
-def get_registry_refresh_interval_seconds() -> int:
-    """Return the configured background refresh interval in seconds."""
-    return AgentCardRegistryConfig().agent_card_registry_refresh_interval_seconds
+# Refresh registered cards that are past the soft TTL this often.
+_REFRESH_INTERVAL_SECONDS = 30 * 60
 
 
 async def registry_refresh_loop(
     registry: AgentCardRegistry,
-    interval_seconds: int,
+    interval_seconds: int = _REFRESH_INTERVAL_SECONDS,
 ) -> None:
     """Periodically refresh soft-expired registered agent cards."""
     while True:
@@ -60,15 +52,8 @@ async def registry_refresh_loop(
 async def registry_refresh_lifespan(_config: Config) -> AsyncIterator[None]:
     """Start the background refresh task for the registry singleton.
 
-    No-op when ``AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS`` is ``0`` or when
-    no registry-backed IDs were registered at config-parse time.
+    No-op when no registry-backed IDs were registered at config-parse time.
     """
-    interval = get_registry_refresh_interval_seconds()
-    if interval <= 0:
-        logger.debug("Agent card registry background refresh is disabled.")
-        yield
-        return
-
     registry = await get_default_registry()
     if not registry.has_registered_lookups():
         logger.debug("No registered agent card IDs; skipping background refresh task.")
@@ -77,9 +62,9 @@ async def registry_refresh_lifespan(_config: Config) -> AsyncIterator[None]:
 
     logger.info(
         "Starting agent card registry background refresh (interval=%ds)",
-        interval,
+        _REFRESH_INTERVAL_SECONDS,
     )
-    task = asyncio.create_task(registry_refresh_loop(registry, interval))
+    task = asyncio.create_task(registry_refresh_loop(registry, _REFRESH_INTERVAL_SECONDS))
     try:
         yield
     finally:

--- a/src/datarobot_genai/dragent/registry_warmup.py
+++ b/src/datarobot_genai/dragent/registry_warmup.py
@@ -1,0 +1,135 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Startup prefetch for central agent card registry lookups.
+
+Collects ``registry`` blocks from ``authenticated_a2a_client`` function groups
+in the loaded NAT config and batch-fetches all agent cards before the server
+accepts traffic (when enabled via ``AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
+from datarobot_genai.dragent.agent_card_registry import get_default_registry
+from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientConfig
+
+if TYPE_CHECKING:
+    from nat.data_models.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class _WarmState:
+    """Mutable container for registry prefetch warm state."""
+
+    warm: bool = False
+
+
+def is_registry_warm() -> bool:
+    """Return whether the latest startup prefetch completed successfully.
+
+    When prefetch is disabled or there are no registry-backed function groups,
+    this returns ``True`` (nothing to warm).
+    """
+    return _WarmState.warm
+
+
+def reset_registry_warm_state() -> None:
+    """Reset warm state (for tests)."""
+    _WarmState.warm = False
+
+
+def is_prefetch_on_startup_enabled() -> bool:
+    """Return whether startup registry prefetch is enabled."""
+    return AgentCardRegistryConfig().agent_card_registry_prefetch_on_startup
+
+
+def collect_registry_lookup_ids(
+    config: Config,
+) -> tuple[list[str], list[str]]:
+    """Return deduplicated ``(deployment_ids, external_ids)`` from *config*.
+
+    Only ``authenticated_a2a_client`` function groups with a ``registry`` block
+    contribute IDs. Order is preserved (first-seen).
+    """
+    deployment_ids: list[str] = []
+    external_ids: list[str] = []
+    seen_dep: set[str] = set()
+    seen_ext: set[str] = set()
+
+    function_groups = getattr(config, "function_groups", None) or {}
+    for fg_config in function_groups.values():
+        if not isinstance(fg_config, AuthenticatedA2AClientConfig):
+            continue
+        if fg_config.registry is None:
+            continue
+        if dep_id := fg_config.registry.deployment_id:
+            if dep_id not in seen_dep:
+                seen_dep.add(dep_id)
+                deployment_ids.append(dep_id)
+        if ext_id := fg_config.registry.external_id:
+            if ext_id not in seen_ext:
+                seen_ext.add(ext_id)
+                external_ids.append(ext_id)
+
+    return deployment_ids, external_ids
+
+
+async def warmup_registry_from_config(config: Config) -> None:
+    """Batch-prefetch agent cards for all registry-backed A2A clients in *config*.
+
+    No-op when prefetch is disabled or when no registry lookups are configured.
+    On failure, logs an error and leaves :func:`is_registry_warm` as ``False``.
+    """
+    if not is_prefetch_on_startup_enabled():
+        logger.debug("Agent card registry prefetch on startup is disabled.")
+        _WarmState.warm = True
+        return
+
+    deployment_ids, external_ids = collect_registry_lookup_ids(config)
+    if not deployment_ids and not external_ids:
+        logger.debug("No registry-backed A2A function groups; skipping agent card prefetch.")
+        _WarmState.warm = True
+        return
+
+    _WarmState.warm = False
+    logger.info(
+        "Prefetching agent cards from central registry (deployment_ids=%s, external_ids=%s)",
+        deployment_ids,
+        external_ids,
+    )
+
+    try:
+        registry = await get_default_registry()
+        await registry.prefetch(
+            deployment_ids=deployment_ids or None,
+            external_ids=external_ids or None,
+        )
+    except Exception:
+        logger.exception(
+            "Agent card registry prefetch failed; registry-backed A2A tools may "
+            "degrade until the central registry is reachable."
+        )
+        return
+
+    _WarmState.warm = True
+    logger.info(
+        "Agent card registry prefetch complete (%d deployment ID(s), %d external ID(s)).",
+        len(deployment_ids),
+        len(external_ids),
+    )

--- a/src/datarobot_genai/dragent/registry_warmup.py
+++ b/src/datarobot_genai/dragent/registry_warmup.py
@@ -16,7 +16,7 @@
 
 Collects ``registry`` blocks from ``authenticated_a2a_client`` function groups
 in the loaded NAT config and batch-fetches all agent cards before the server
-accepts traffic (when enabled via ``AGENT_CARD_REGISTRY_PREFETCH_ON_STARTUP``).
+accepts traffic.
 """
 
 from __future__ import annotations
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientConfig
 
@@ -43,8 +42,8 @@ class _WarmState:
 def is_registry_warm() -> bool:
     """Return whether the latest startup prefetch completed successfully.
 
-    When prefetch is disabled or there are no registry-backed function groups,
-    this returns ``True`` (nothing to warm).
+    When there are no registry-backed function groups, this returns ``True``
+    (nothing to warm).
     """
     return _WarmState.warm
 
@@ -52,11 +51,6 @@ def is_registry_warm() -> bool:
 def reset_registry_warm_state() -> None:
     """Reset warm state (for tests)."""
     _WarmState.warm = False
-
-
-def is_prefetch_on_startup_enabled() -> bool:
-    """Return whether startup registry prefetch is enabled."""
-    return AgentCardRegistryConfig().agent_card_registry_prefetch_on_startup
 
 
 def collect_registry_lookup_ids(
@@ -93,14 +87,9 @@ def collect_registry_lookup_ids(
 async def warmup_registry_from_config(config: Config) -> None:
     """Batch-prefetch agent cards for all registry-backed A2A clients in *config*.
 
-    No-op when prefetch is disabled or when no registry lookups are configured.
-    On failure, logs an error and leaves :func:`is_registry_warm` as ``False``.
+    No-op when no registry lookups are configured. On failure, logs an error and
+    leaves :func:`is_registry_warm` as ``False``.
     """
-    if not is_prefetch_on_startup_enabled():
-        logger.debug("Agent card registry prefetch on startup is disabled.")
-        _WarmState.warm = True
-        return
-
     deployment_ids, external_ids = collect_registry_lookup_ids(config)
     if not deployment_ids and not external_ids:
         logger.debug("No registry-backed A2A function groups; skipping agent card prefetch.")

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -420,6 +420,46 @@ class TestAgentCardRegistryStaleIfError:
 
         assert card is stale_card
 
+    async def test_raises_when_deregistered_after_soft_ttl(self, mock_fetch):
+        stale_card = MagicMock(name="stale-card")
+        mock_fetch.side_effect = [
+            {"dep-1": stale_card},
+            {},
+        ]
+        registry = AgentCardRegistry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+        )
+        await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120
+
+        with pytest.raises(AgentCardRegistryError, match="No agent card found"):
+            await registry.get(deployment_id="dep-1")
+
+        assert "dep-1" not in registry._cache
+
+    async def test_deregistered_not_resurrected_by_stale_if_error(self, mock_fetch):
+        stale_card = MagicMock(name="stale-card")
+        mock_fetch.side_effect = [
+            {"dep-1": stale_card},
+            {},
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = AgentCardRegistry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+        )
+        await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120
+
+        with pytest.raises(AgentCardRegistryError, match="No agent card found"):
+            await registry.get(deployment_id="dep-1")
+
+        with pytest.raises(AgentCardRegistryError, match="registry down"):
+            await registry.get(deployment_id="dep-1")
+
 
 # ---------------------------------------------------------------------------
 # Tests: AgentCardRegistry — register + batch flush

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -102,6 +102,19 @@ class TestAgentCardRegistryConfig:
         config = AgentCardRegistryConfig(agent_card_registry_on_duplicate="last")
         assert config.agent_card_registry_on_duplicate == "last"
 
+    def test_stale_if_error_default(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_stale_if_error is True
+
+    def test_max_staleness_default(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_max_staleness_seconds == 24 * 3600
+
+    def test_stale_if_error_from_env(self):
+        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_STALE_IF_ERROR": "false"}):
+            config = AgentCardRegistryConfig()
+            assert config.agent_card_registry_stale_if_error is False
+
 
 # ---------------------------------------------------------------------------
 # Tests: _CacheEntry
@@ -111,16 +124,29 @@ class TestAgentCardRegistryConfig:
 class TestCacheEntry:
     def test_not_expired_within_ttl(self):
         entry = _CacheEntry(MagicMock())
+        assert entry.is_fresh(3600)
         assert not entry.is_expired(3600)
 
     def test_expired_with_zero_ttl(self):
         entry = _CacheEntry(MagicMock())
+        assert not entry.is_fresh(0)
         assert entry.is_expired(0)
 
     def test_expired_after_ttl(self):
         entry = _CacheEntry(MagicMock())
         entry.fetched_at -= 100  # Simulate 100s ago
+        assert not entry.is_fresh(50)
         assert entry.is_expired(50)
+
+    def test_within_staleness(self):
+        entry = _CacheEntry(MagicMock())
+        entry.fetched_at -= 100
+        assert entry.is_within_staleness(3600)
+        assert not entry.is_within_staleness(50)
+
+    def test_zero_max_staleness_never_servable(self):
+        entry = _CacheEntry(MagicMock())
+        assert not entry.is_within_staleness(0)
 
 
 # ---------------------------------------------------------------------------
@@ -360,6 +386,102 @@ class TestAgentCardRegistry:
 
 
 # ---------------------------------------------------------------------------
+# Tests: AgentCardRegistry — stale-if-error
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRegistryStaleIfError:
+    @pytest.fixture
+    def mock_fetch(self):
+        with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
+            yield m
+
+    async def test_serves_stale_when_refresh_fails(self, mock_fetch):
+        stale_card = MagicMock(name="stale-card")
+        mock_fetch.side_effect = [
+            {"dep-1": stale_card},
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = AgentCardRegistry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            max_staleness_seconds=3600,
+            stale_if_error=True,
+        )
+
+        card1 = await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120  # past soft TTL, within staleness
+
+        card2 = await registry.get(deployment_id="dep-1")
+
+        assert card1 is stale_card
+        assert card2 is stale_card
+        assert mock_fetch.await_count == 2
+
+    async def test_raises_when_stale_if_error_disabled(self, mock_fetch):
+        stale_card = MagicMock(name="stale-card")
+        mock_fetch.side_effect = [
+            {"dep-1": stale_card},
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = AgentCardRegistry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            max_staleness_seconds=3600,
+            stale_if_error=False,
+        )
+
+        await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120
+
+        with pytest.raises(AgentCardRegistryError, match="registry down"):
+            await registry.get(deployment_id="dep-1")
+
+    async def test_raises_when_beyond_max_staleness(self, mock_fetch):
+        stale_card = MagicMock(name="stale-card")
+        mock_fetch.side_effect = [
+            {"dep-1": stale_card},
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = AgentCardRegistry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            max_staleness_seconds=30,
+            stale_if_error=True,
+        )
+
+        await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120  # beyond max_staleness
+
+        with pytest.raises(AgentCardRegistryError, match="registry down"):
+            await registry.get(deployment_id="dep-1")
+
+    async def test_stale_if_error_on_flush_pending_failure(self, mock_fetch):
+        stale_card = MagicMock(name="stale-card")
+        mock_fetch.side_effect = [
+            {"dep-1": stale_card},
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = AgentCardRegistry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            max_staleness_seconds=3600,
+            stale_if_error=True,
+        )
+        await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120
+
+        registry.register(deployment_id="dep-2")
+        card = await registry.get(deployment_id="dep-1")
+
+        assert card is stale_card
+
+
+# ---------------------------------------------------------------------------
 # Tests: AgentCardRegistry — register + batch flush
 # ---------------------------------------------------------------------------
 
@@ -415,6 +537,7 @@ class TestAgentCardRegistryRegisterFlush:
         await registry.get(deployment_id="dep-1")
         assert len(registry._pending_deployment_ids) == 0
         assert len(registry._pending_external_ids) == 0
+        assert registry.has_registered_lookups() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -102,19 +102,6 @@ class TestAgentCardRegistryConfig:
         config = AgentCardRegistryConfig(agent_card_registry_on_duplicate="last")
         assert config.agent_card_registry_on_duplicate == "last"
 
-    def test_stale_if_error_default(self):
-        config = AgentCardRegistryConfig()
-        assert config.agent_card_registry_stale_if_error is True
-
-    def test_max_staleness_default(self):
-        config = AgentCardRegistryConfig()
-        assert config.agent_card_registry_max_staleness_seconds == 24 * 3600
-
-    def test_stale_if_error_from_env(self):
-        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_STALE_IF_ERROR": "false"}):
-            config = AgentCardRegistryConfig()
-            assert config.agent_card_registry_stale_if_error is False
-
 
 # ---------------------------------------------------------------------------
 # Tests: _CacheEntry
@@ -137,16 +124,6 @@ class TestCacheEntry:
         entry.fetched_at -= 100  # Simulate 100s ago
         assert not entry.is_fresh(50)
         assert entry.is_expired(50)
-
-    def test_within_staleness(self):
-        entry = _CacheEntry(MagicMock())
-        entry.fetched_at -= 100
-        assert entry.is_within_staleness(3600)
-        assert not entry.is_within_staleness(50)
-
-    def test_zero_max_staleness_never_servable(self):
-        entry = _CacheEntry(MagicMock())
-        assert not entry.is_within_staleness(0)
 
 
 # ---------------------------------------------------------------------------
@@ -406,12 +383,10 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=3600,
-            stale_if_error=True,
         )
 
         card1 = await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120  # past soft TTL, within staleness
+        registry._cache["dep-1"].fetched_at -= 120  # past soft TTL
 
         card2 = await registry.get(deployment_id="dep-1")
 
@@ -419,42 +394,9 @@ class TestAgentCardRegistryStaleIfError:
         assert card2 is stale_card
         assert mock_fetch.await_count == 2
 
-    async def test_raises_when_stale_if_error_disabled(self, mock_fetch):
-        stale_card = MagicMock(name="stale-card")
-        mock_fetch.side_effect = [
-            {"dep-1": stale_card},
-            AgentCardRegistryError("registry down"),
-        ]
-        registry = AgentCardRegistry(
-            api_token="tok",
-            endpoint="https://ep",
-            cache_ttl=60,
-            max_staleness_seconds=3600,
-            stale_if_error=False,
-        )
-
-        await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120
-
-        with pytest.raises(AgentCardRegistryError, match="registry down"):
-            await registry.get(deployment_id="dep-1")
-
-    async def test_raises_when_beyond_max_staleness(self, mock_fetch):
-        stale_card = MagicMock(name="stale-card")
-        mock_fetch.side_effect = [
-            {"dep-1": stale_card},
-            AgentCardRegistryError("registry down"),
-        ]
-        registry = AgentCardRegistry(
-            api_token="tok",
-            endpoint="https://ep",
-            cache_ttl=60,
-            max_staleness_seconds=30,
-            stale_if_error=True,
-        )
-
-        await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120  # beyond max_staleness
+    async def test_raises_when_no_cached_card(self, mock_fetch):
+        mock_fetch.side_effect = AgentCardRegistryError("registry down")
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
 
         with pytest.raises(AgentCardRegistryError, match="registry down"):
             await registry.get(deployment_id="dep-1")
@@ -469,8 +411,6 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=3600,
-            stale_if_error=True,
         )
         await registry.get(deployment_id="dep-1")
         registry._cache["dep-1"].fetched_at -= 120

--- a/tests/dragent/test_registry_refresh.py
+++ b/tests/dragent/test_registry_refresh.py
@@ -20,10 +20,7 @@ from unittest.mock import patch
 import pytest
 
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
-from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
-from datarobot_genai.dragent.registry_refresh import get_registry_refresh_interval_seconds
-from datarobot_genai.dragent.registry_refresh import is_registry_refresh_enabled
 from datarobot_genai.dragent.registry_refresh import registry_refresh_lifespan
 from datarobot_genai.dragent.registry_refresh import registry_refresh_loop
 
@@ -77,23 +74,6 @@ class TestAgentCardRegistryRefresh:
         mock_fetch.assert_not_awaited()
 
 
-class TestRegistryRefreshConfig:
-    def test_refresh_enabled_by_default(self):
-        config = AgentCardRegistryConfig()
-        assert config.agent_card_registry_refresh_interval_seconds == 30 * 60
-        assert is_registry_refresh_enabled() is True
-
-    def test_refresh_disabled_when_zero(self):
-        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS": "0"}):
-            config = AgentCardRegistryConfig()
-            assert config.agent_card_registry_refresh_interval_seconds == 0
-            assert is_registry_refresh_enabled() is False
-
-    def test_refresh_interval_from_env(self):
-        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS": "900"}):
-            assert get_registry_refresh_interval_seconds() == 900
-
-
 class TestRegistryRefreshLoop:
     async def test_loop_calls_refresh_after_interval(self):
         registry = AsyncMock()
@@ -140,7 +120,6 @@ class TestRegistryRefreshLifespan:
             return fake_task
 
         with (
-            patch(f"{_MODULE}.get_registry_refresh_interval_seconds", return_value=60),
             patch(
                 f"{_MODULE}.get_default_registry",
                 AsyncMock(return_value=mock_registry),
@@ -152,24 +131,12 @@ class TestRegistryRefreshLifespan:
 
             fake_task.cancel.assert_called_once()
 
-    async def test_lifespan_no_op_when_disabled(self):
-        config = MagicMock()
-        with (
-            patch(f"{_MODULE}.get_registry_refresh_interval_seconds", return_value=0),
-            patch(f"{_MODULE}.asyncio.create_task") as mock_create_task,
-        ):
-            async with registry_refresh_lifespan(config):
-                pass
-
-            mock_create_task.assert_not_called()
-
     async def test_lifespan_no_op_without_registered_ids(self):
         mock_registry = MagicMock()
         mock_registry.has_registered_lookups.return_value = False
         config = MagicMock()
 
         with (
-            patch(f"{_MODULE}.get_registry_refresh_interval_seconds", return_value=60),
             patch(
                 f"{_MODULE}.get_default_registry",
                 AsyncMock(return_value=mock_registry),

--- a/tests/dragent/test_registry_refresh.py
+++ b/tests/dragent/test_registry_refresh.py
@@ -1,0 +1,182 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
+from datarobot_genai.dragent.registry_refresh import get_registry_refresh_interval_seconds
+from datarobot_genai.dragent.registry_refresh import is_registry_refresh_enabled
+from datarobot_genai.dragent.registry_refresh import registry_refresh_lifespan
+from datarobot_genai.dragent.registry_refresh import registry_refresh_loop
+
+_MODULE = "datarobot_genai.dragent.registry_refresh"
+
+
+class TestAgentCardRegistryRefresh:
+    @pytest.fixture
+    def mock_fetch(self):
+        with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
+            yield m
+
+    async def test_refresh_skips_fresh_entries(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="card")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry.register(deployment_id="dep-1")
+        await registry.get(deployment_id="dep-1")
+
+        mock_fetch.reset_mock()
+        await registry.refresh_all_registered()
+        mock_fetch.assert_not_awaited()
+
+    async def test_refresh_refetches_soft_expired_entries(self, mock_fetch):
+        mock_fetch.return_value = {"dep-1": MagicMock(name="card")}
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
+        registry.register(deployment_id="dep-1")
+        await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120
+
+        mock_fetch.reset_mock()
+        mock_fetch.return_value = {"dep-1": MagicMock(name="refreshed")}
+        await registry.refresh_all_registered()
+
+        mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1"})
+
+    async def test_refresh_logs_on_failure_without_raising(self, mock_fetch):
+        mock_fetch.side_effect = [
+            {"dep-1": MagicMock(name="card")},
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
+        registry.register(deployment_id="dep-1")
+        await registry.get(deployment_id="dep-1")
+        registry._cache["dep-1"].fetched_at -= 120
+
+        await registry.refresh_all_registered()
+
+    async def test_refresh_no_op_without_registered_ids(self, mock_fetch):
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        await registry.refresh_all_registered()
+        mock_fetch.assert_not_awaited()
+
+
+class TestRegistryRefreshConfig:
+    def test_refresh_enabled_by_default(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_refresh_interval_seconds == 30 * 60
+        assert is_registry_refresh_enabled() is True
+
+    def test_refresh_disabled_when_zero(self):
+        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS": "0"}):
+            config = AgentCardRegistryConfig()
+            assert config.agent_card_registry_refresh_interval_seconds == 0
+            assert is_registry_refresh_enabled() is False
+
+    def test_refresh_interval_from_env(self):
+        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_REFRESH_INTERVAL_SECONDS": "900"}):
+            assert get_registry_refresh_interval_seconds() == 900
+
+
+class TestRegistryRefreshLoop:
+    async def test_loop_calls_refresh_after_interval(self):
+        registry = AsyncMock()
+        with patch(f"{_MODULE}.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = [None, asyncio.CancelledError()]
+
+            with pytest.raises(asyncio.CancelledError):
+                await registry_refresh_loop(registry, interval_seconds=60)
+
+        registry.refresh_all_registered.assert_awaited_once()
+
+    async def test_loop_continues_after_refresh_error(self):
+        registry = AsyncMock()
+        registry.refresh_all_registered.side_effect = [RuntimeError("boom"), None]
+        with patch(f"{_MODULE}.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = [None, None, asyncio.CancelledError()]
+
+            with pytest.raises(asyncio.CancelledError):
+                await registry_refresh_loop(registry, interval_seconds=60)
+
+        assert registry.refresh_all_registered.await_count == 2
+
+
+class TestRegistryRefreshLifespan:
+    async def test_lifespan_starts_and_stops_task(self):
+        mock_registry = MagicMock()
+        mock_registry.has_registered_lookups.return_value = True
+        config = MagicMock()
+
+        class _FakeTask:
+            def __init__(self) -> None:
+                self.cancel = MagicMock()
+
+            def __await__(self):
+                async def _noop() -> None:
+                    return None
+
+                return _noop().__await__()
+
+        fake_task = _FakeTask()
+
+        def _create_task(coro):
+            coro.close()
+            return fake_task
+
+        with (
+            patch(f"{_MODULE}.get_registry_refresh_interval_seconds", return_value=60),
+            patch(
+                f"{_MODULE}.get_default_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch(f"{_MODULE}.asyncio.create_task", side_effect=_create_task) as mock_create_task,
+        ):
+            async with registry_refresh_lifespan(config):
+                mock_create_task.assert_called_once()
+
+            fake_task.cancel.assert_called_once()
+
+    async def test_lifespan_no_op_when_disabled(self):
+        config = MagicMock()
+        with (
+            patch(f"{_MODULE}.get_registry_refresh_interval_seconds", return_value=0),
+            patch(f"{_MODULE}.asyncio.create_task") as mock_create_task,
+        ):
+            async with registry_refresh_lifespan(config):
+                pass
+
+            mock_create_task.assert_not_called()
+
+    async def test_lifespan_no_op_without_registered_ids(self):
+        mock_registry = MagicMock()
+        mock_registry.has_registered_lookups.return_value = False
+        config = MagicMock()
+
+        with (
+            patch(f"{_MODULE}.get_registry_refresh_interval_seconds", return_value=60),
+            patch(
+                f"{_MODULE}.get_default_registry",
+                AsyncMock(return_value=mock_registry),
+            ),
+            patch(f"{_MODULE}.asyncio.create_task") as mock_create_task,
+        ):
+            async with registry_refresh_lifespan(config):
+                pass
+
+            mock_create_task.assert_not_called()

--- a/tests/dragent/test_registry_warmup.py
+++ b/tests/dragent/test_registry_warmup.py
@@ -1,0 +1,145 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from nat.runtime.loader import load_config
+
+import datarobot_genai.dragent.plugins.auth_a2a_client  # noqa: F401
+from datarobot_genai.dragent.agent_card_registry import reset_default_registry
+from datarobot_genai.dragent.plugins.auth_a2a_client import AgentCardRegistryLookup
+from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientConfig
+from datarobot_genai.dragent.registry_warmup import collect_registry_lookup_ids
+from datarobot_genai.dragent.registry_warmup import is_registry_warm
+from datarobot_genai.dragent.registry_warmup import reset_registry_warm_state
+from datarobot_genai.dragent.registry_warmup import warmup_registry_from_config
+
+_MODULE = "datarobot_genai.dragent.registry_warmup"
+
+
+@pytest.fixture(autouse=True)
+def _reset_warm_state():
+    reset_registry_warm_state()
+    reset_default_registry()
+    yield
+    reset_registry_warm_state()
+    reset_default_registry()
+
+
+@pytest.fixture
+def workflow_path() -> Path:
+    return Path(__file__).parent / "plugins" / "fixtures" / "workflow_with_a2a.yaml"
+
+
+@pytest.fixture
+def nat_config(workflow_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("DATAROBOT_API_TOKEN", "test-token")
+    return load_config(workflow_path)
+
+
+class TestCollectRegistryLookupIds:
+    def test_collects_ids_from_yaml_config(self, nat_config):
+        dep_ids, ext_ids = collect_registry_lookup_ids(nat_config)
+        assert dep_ids == ["1234"]
+        assert ext_ids == ["abcd"]
+
+    def test_deduplicates_ids(self):
+        config = MagicMock()
+        shared_registry = AgentCardRegistryLookup(deployment_id="dep-1")
+        config.function_groups = {
+            "a": AuthenticatedA2AClientConfig(registry=shared_registry, auth_provider="x"),
+            "b": AuthenticatedA2AClientConfig(registry=shared_registry, auth_provider="x"),
+        }
+        dep_ids, ext_ids = collect_registry_lookup_ids(config)
+        assert dep_ids == ["dep-1"]
+        assert ext_ids == []
+
+    def test_skips_url_only_a2a_clients(self, nat_config):
+        dep_ids, ext_ids = collect_registry_lookup_ids(nat_config)
+        # workflow also has a2a_agent with url only — must not appear
+        assert "http://agent.example.com:8080" not in dep_ids
+        assert len(dep_ids) == 1
+
+    def test_empty_when_no_registry_groups(self):
+        config = MagicMock()
+        config.function_groups = {
+            "mcp": MagicMock(),
+            "a2a": AuthenticatedA2AClientConfig(
+                url="http://agent.example.com:8080",
+                auth_provider="auth",
+            ),
+        }
+        dep_ids, ext_ids = collect_registry_lookup_ids(config)
+        assert dep_ids == []
+        assert ext_ids == []
+
+
+class TestWarmupRegistryFromConfig:
+    async def test_prefetch_called_for_registry_ids(self, nat_config):
+        mock_registry = AsyncMock()
+        with (
+            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=True),
+            patch(f"{_MODULE}.get_default_registry", AsyncMock(return_value=mock_registry)),
+        ):
+            await warmup_registry_from_config(nat_config)
+
+        mock_registry.prefetch.assert_awaited_once_with(
+            deployment_ids=["1234"],
+            external_ids=["abcd"],
+        )
+        assert is_registry_warm() is True
+
+    async def test_skips_when_disabled(self, nat_config):
+        mock_get = AsyncMock()
+        with (
+            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=False),
+            patch(f"{_MODULE}.get_default_registry", mock_get),
+        ):
+            await warmup_registry_from_config(nat_config)
+
+        mock_get.assert_not_awaited()
+        assert is_registry_warm() is True
+
+    async def test_no_op_when_no_registry_groups(self):
+        config = MagicMock()
+        config.function_groups = {
+            "a2a": AuthenticatedA2AClientConfig(
+                url="http://agent.example.com:8080",
+                auth_provider="auth",
+            ),
+        }
+        mock_get = AsyncMock()
+        with (
+            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=True),
+            patch(f"{_MODULE}.get_default_registry", mock_get),
+        ):
+            await warmup_registry_from_config(config)
+
+        mock_get.assert_not_awaited()
+        assert is_registry_warm() is True
+
+    async def test_warm_false_on_prefetch_failure(self, nat_config):
+        mock_registry = AsyncMock()
+        mock_registry.prefetch.side_effect = RuntimeError("registry down")
+        with (
+            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=True),
+            patch(f"{_MODULE}.get_default_registry", AsyncMock(return_value=mock_registry)),
+        ):
+            await warmup_registry_from_config(nat_config)
+
+        assert is_registry_warm() is False

--- a/tests/dragent/test_registry_warmup.py
+++ b/tests/dragent/test_registry_warmup.py
@@ -92,27 +92,13 @@ class TestCollectRegistryLookupIds:
 class TestWarmupRegistryFromConfig:
     async def test_prefetch_called_for_registry_ids(self, nat_config):
         mock_registry = AsyncMock()
-        with (
-            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=True),
-            patch(f"{_MODULE}.get_default_registry", AsyncMock(return_value=mock_registry)),
-        ):
+        with patch(f"{_MODULE}.get_default_registry", AsyncMock(return_value=mock_registry)):
             await warmup_registry_from_config(nat_config)
 
         mock_registry.prefetch.assert_awaited_once_with(
             deployment_ids=["1234"],
             external_ids=["abcd"],
         )
-        assert is_registry_warm() is True
-
-    async def test_skips_when_disabled(self, nat_config):
-        mock_get = AsyncMock()
-        with (
-            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=False),
-            patch(f"{_MODULE}.get_default_registry", mock_get),
-        ):
-            await warmup_registry_from_config(nat_config)
-
-        mock_get.assert_not_awaited()
         assert is_registry_warm() is True
 
     async def test_no_op_when_no_registry_groups(self):
@@ -124,10 +110,7 @@ class TestWarmupRegistryFromConfig:
             ),
         }
         mock_get = AsyncMock()
-        with (
-            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=True),
-            patch(f"{_MODULE}.get_default_registry", mock_get),
-        ):
+        with patch(f"{_MODULE}.get_default_registry", mock_get):
             await warmup_registry_from_config(config)
 
         mock_get.assert_not_awaited()
@@ -136,10 +119,7 @@ class TestWarmupRegistryFromConfig:
     async def test_warm_false_on_prefetch_failure(self, nat_config):
         mock_registry = AsyncMock()
         mock_registry.prefetch.side_effect = RuntimeError("registry down")
-        with (
-            patch(f"{_MODULE}.is_prefetch_on_startup_enabled", return_value=True),
-            patch(f"{_MODULE}.get_default_registry", AsyncMock(return_value=mock_registry)),
-        ):
+        with patch(f"{_MODULE}.get_default_registry", AsyncMock(return_value=mock_registry)):
             await warmup_registry_from_config(nat_config)
 
         assert is_registry_warm() is False

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.1"
+version = "0.29.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
When agents are deployed to a workload in a separate enclave we want the agent to survive a 1 hour downtime of the control hub where the agent card registry lives.

The strategy is to improve the in-memory cache in this PR and then add an L2 cache using the memory service in a followup PR.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Improve the in-memory cache of remote agent cards to survive a 1 hour downtime of the control hub.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime semantics for all registry-backed A2A card resolution (staleness, outage fallback, and startup prefetch before accepting traffic), which can affect remote agent routing during registry incidents or long TTL windows.
> 
> **Overview**
> **Improves central agent card registry behavior** so registry-backed `authenticated_a2a_client` function groups keep working through control-hub outages and pick up fresher cards without waiting for the first tool call.
> 
> `AgentCardRegistry` now treats `AGENT_CARD_REGISTRY_CACHE_TTL` as a **soft TTL**: lookups refresh when entries are stale, but on fetch failure they **return the last cached card** instead of failing immediately. Registered deployment/external IDs are tracked for **`refresh_all_registered()`**, which the new **30-minute background loop** runs when any registry IDs were configured.
> 
> **FastAPI startup** batch-prefetches all registry IDs collected from `workflow.yaml` (`warmup_registry_from_config`) before the server serves traffic, then starts the refresh task for the process lifetime. Docs and **0.29.2** changelog/locks document the behavior; unit tests cover stale-if-error, refresh, and warmup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eae51368565ca51ba31ebcc75ac244ef4165358. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->