### PR TITLE
[BUZZOK-32131] L2 remote agent card cache using memory space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.4
-- `dragent`: optional DataRobot MemorySpace L2 cache for agent cards (`AGENT_CARD_REGISTRY_BACKEND=memory_space`) — in-process L1 read-through/write-through over the agentic memory Session API with platform-provisioned `AGENT_MEMORY_SPACE_ID` (or `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID`).
+- `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-through over the agentic memory Session API) when `AGENT_MEMORY_SPACE_ID` or `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
 - `dragent`: pluggable agent card registry cache backends with stale-if-error bounded by `AGENT_CARD_REGISTRY_CACHE_TTL`.
 
 ## 0.29.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.4
 - `dragent`: optional DataRobot MemorySpace L2 cache for agent cards (`AGENT_CARD_REGISTRY_BACKEND=memory_space`) — in-process L1 read-through/write-through over the agentic memory Session API with platform-provisioned `AGENT_MEMORY_SPACE_ID` (or `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID`).
-- `dragent`: pluggable agent card registry cache backends with configurable stale-if-error bounds (`AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS`, `AGENT_CARD_REGISTRY_STALE_IF_ERROR`).
+- `dragent`: pluggable agent card registry cache backends with stale-if-error bounded by `AGENT_CARD_REGISTRY_CACHE_TTL`.
 
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.4
-- `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-through over the agentic memory Session API) when `AGENT_MEMORY_SPACE_ID` or `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
+- `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-through over the agentic memory Session API) when `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
 - `dragent`: pluggable agent card registry cache backends with stale-if-error bounded by `AGENT_CARD_REGISTRY_CACHE_TTL`.
 
 ## 0.29.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.4
+- `dragent`: optional DataRobot MemorySpace L2 cache for agent cards (`AGENT_CARD_REGISTRY_BACKEND=memory_space`) — in-process L1 read-through/write-through over the agentic memory Session API with platform-provisioned `AGENT_MEMORY_SPACE_ID` (or `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID`).
+- `dragent`: pluggable agent card registry cache backends with configurable stale-if-error bounds (`AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS`, `AGENT_CARD_REGISTRY_STALE_IF_ERROR`).
+
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.
 - A group that resolves an `AgentCardAware` auth provider now takes its own copy of it, so the card it fetched stays with the agent it fetched it from. Configuration and credentials are unchanged and still shared.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## 0.29.4
 - `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-through over the agentic memory Session API) when `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
 - `dragent`: pluggable agent card registry cache backends with stale-if-error bounded by `AGENT_CARD_REGISTRY_CACHE_TTL`.
+- `dragent`: L1 read-through of an L2 agent card hit preserves the original ``fetched_at``, so soft TTL and max-staleness are not reset on promotion.
 
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -189,7 +189,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.1"
+version = "0.29.4"
 source = { editable = "../" }
 
 [package.metadata]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -949,7 +949,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.3"
+version = "0.29.4"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -949,7 +949,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.2"
+version = "0.29.3"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.3"
+version = "0.29.4"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -265,7 +265,6 @@ class AgentCardRegistry:
         endpoint: str | None = None,
         timeout: float | None = None,
         cache_ttl: int | None = None,
-        max_staleness_seconds: int | None = None,
         on_duplicate: DuplicateStrategy | None = None,
         cache_backend: AgentCardCacheBackend | None = None,
     ) -> None:
@@ -286,18 +285,14 @@ class AgentCardRegistry:
         self._cache_ttl = (
             cache_ttl if cache_ttl is not None else config.agent_card_registry_cache_ttl
         )
-        self._max_staleness_seconds = (
-            max_staleness_seconds if max_staleness_seconds is not None else self._cache_ttl
-        )
         self._on_duplicate: DuplicateStrategy = (
             on_duplicate if on_duplicate is not None else config.agent_card_registry_on_duplicate
         )
         self._backend = cache_backend or create_agent_card_cache_backend(config)
 
         logger.debug(
-            "AgentCardRegistry created (cache_ttl=%ds, max_staleness=%ds, l2=%s)",
+            "AgentCardRegistry created (cache_ttl=%ds, l2=%s)",
             self._cache_ttl,
-            self._max_staleness_seconds,
             isinstance(self._backend, LayeredAgentCardCacheBackend),
         )
 
@@ -405,7 +400,7 @@ class AgentCardRegistry:
         """Return a stale cached card when refresh failed."""
         record = await self._backend.get_stale(
             key,
-            max_staleness_seconds=self._max_staleness_seconds,
+            max_staleness_seconds=self._cache_ttl,
         )
         if record is None:
             return None

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -38,9 +38,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from typing import Any
 from typing import Literal
+from typing import NamedTuple
 
 import httpx
 from a2a.types import AgentCard
@@ -48,12 +48,20 @@ from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from pydantic import Field
 
 from datarobot_genai.core.config import resolve_config
+from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import LayeredAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import LookupKeyType
+from datarobot_genai.dragent.agent_card_registry_backends import MemoryAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import create_agent_card_cache_backend
 from datarobot_genai.dragent.deployment_urls import build_agent_cards_registry_url
 
 logger = logging.getLogger(__name__)
 
 # Default cache TTL: 24 hours (in seconds).
 _DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
+
+# Default hard staleness bound for stale-if-error (in seconds).
+_DEFAULT_MAX_STALENESS_SECONDS = 24 * 3600
 
 # Default HTTP timeout for registry requests (in seconds).
 _DEFAULT_TIMEOUT_SECONDS = 30.0
@@ -122,6 +130,47 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
         ),
     )
 
+    agent_card_registry_max_staleness_seconds: int = Field(
+        default=_DEFAULT_MAX_STALENESS_SECONDS,
+        ge=0,
+        description=(
+            "Maximum age in seconds for serving a cached agent card when the "
+            "registry is unreachable (stale-if-error). Default: 86400 (24 hours)."
+        ),
+    )
+
+    agent_card_registry_stale_if_error: bool = Field(
+        default=True,
+        description=(
+            "When true, return the last-known-good cached agent card if a "
+            "registry fetch fails and the entry is within "
+            "agent_card_registry_max_staleness_seconds. "
+            "Set AGENT_CARD_REGISTRY_STALE_IF_ERROR=false to disable."
+        ),
+    )
+
+    agent_card_registry_backend: Literal["memory", "memory_space"] = Field(
+        default="memory",
+        description=(
+            "Cache backend for agent cards. 'memory' uses in-process cache only; "
+            "'memory_space' adds a shared DataRobot MemorySpace L2 with "
+            "in-process L1 read-through."
+        ),
+    )
+
+    agent_card_registry_key_prefix: str = Field(
+        default="dragent:",
+        description="Key prefix for MemorySpace agent card cache entries.",
+    )
+
+    agent_card_registry_memory_space_id: str | None = Field(
+        default=None,
+        description=(
+            "DataRobot MemorySpace ID for L2 cache when agent_card_registry_backend="
+            "'memory_space'. Defaults to AGENT_MEMORY_SPACE_ID."
+        ),
+    )
+
 
 class AgentCardRegistryError(RuntimeError):
     """Raised when the central agent card registry lookup fails."""
@@ -148,10 +197,17 @@ def _resolve_settings(
     return resolved_token, resolved_endpoint
 
 
+class ParsedRegistryCards(NamedTuple):
+    """Parsed registry response with lookup key types for cache indexing."""
+
+    cards: dict[str, AgentCard]
+    key_types: dict[str, LookupKeyType]
+
+
 def _parse_registry_response(
     body: dict[str, Any],
     on_duplicate: DuplicateStrategy = "first",
-) -> dict[str, AgentCard]:
+) -> ParsedRegistryCards:
     """Parse a paginated registry response into ``{id: AgentCard}``.
 
     Each record is indexed by ``deploymentId`` (always unique) and
@@ -166,6 +222,7 @@ def _parse_registry_response(
     * ``"error"`` — raise :class:`AgentCardRegistryError`.
     """
     cards: dict[str, AgentCard] = {}
+    key_types: dict[str, LookupKeyType] = {}
     for entry in body.get("data", []):
         raw_card = entry.get("agentCard")
         if not raw_card:
@@ -187,11 +244,13 @@ def _parse_registry_response(
         # Deployment IDs are unique by platform design — always overwrite.
         if dep_id := entry.get("deploymentId"):
             cards[dep_id] = card
+            key_types[dep_id] = "dep"
 
         # External IDs may have duplicates — apply the configured strategy.
         if ext_id := entry.get("externalId"):
             if ext_id not in cards:
                 cards[ext_id] = card
+                key_types[ext_id] = "ext"
             else:
                 logger.warning(
                     "Duplicate external ID '%s' in registry response (on_duplicate=%s).",
@@ -206,43 +265,9 @@ def _parse_registry_response(
                     )
                 if on_duplicate == "last":
                     cards[ext_id] = card
+                    key_types[ext_id] = "ext"
                 # "first" — keep existing entry (no-op)
-    return cards
-
-
-class _CacheEntry:
-    """A cached agent card with its fetch timestamp."""
-
-    __slots__ = ("card", "fetched_at")
-
-    def __init__(self, card: AgentCard) -> None:
-        self.card = card
-        self.fetched_at = time.monotonic()
-
-    def age_seconds(self) -> float:
-        """Return the entry age in seconds."""
-        return time.monotonic() - self.fetched_at
-
-    def is_fresh(self, cache_ttl: int) -> bool:
-        """Return *True* if this entry is within the soft TTL (*cache_ttl*).
-
-        A TTL of 0 means "never fresh" (always attempt refresh).
-        """
-        if cache_ttl == 0:
-            return False
-        return self.age_seconds() < cache_ttl
-
-    def is_expired(self, ttl: int) -> bool:
-        """Return *True* if this entry is older than *ttl* seconds.
-
-        A TTL of 0 means "always expired" (no caching).
-
-        .. deprecated::
-            Prefer :meth:`is_fresh` with the soft cache TTL.
-        """
-        if ttl == 0:
-            return True
-        return self.age_seconds() >= ttl
+    return ParsedRegistryCards(cards=cards, key_types=key_types)
 
 
 class AgentCardRegistry:
@@ -252,8 +277,9 @@ class AgentCardRegistry:
     The first ``get()`` flushes all pending IDs in ≤2 HTTP calls
     (one per ID type — API uses AND when both are mixed).
     Subsequent ``get()`` calls hit the in-memory cache until the soft TTL
-    (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails, the
-    last-known-good cached card is returned if one is present.
+    (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails and
+    ``AGENT_CARD_REGISTRY_STALE_IF_ERROR`` is enabled, a cached card may still
+    be returned up to ``AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS``.
     """
 
     def __init__(
@@ -262,11 +288,13 @@ class AgentCardRegistry:
         endpoint: str | None = None,
         timeout: float | None = None,
         cache_ttl: int | None = None,
+        max_staleness_seconds: int | None = None,
+        stale_if_error: bool | None = None,
         on_duplicate: DuplicateStrategy | None = None,
+        cache_backend: AgentCardCacheBackend | None = None,
     ) -> None:
         self._api_token = api_token
         self._endpoint = endpoint
-        self._cache: dict[str, _CacheEntry] = {}
         self._lock = asyncio.Lock()
 
         # Pending registrations (filled synchronously, flushed on first get)
@@ -282,11 +310,29 @@ class AgentCardRegistry:
         self._cache_ttl = (
             cache_ttl if cache_ttl is not None else config.agent_card_registry_cache_ttl
         )
+        self._max_staleness_seconds = (
+            max_staleness_seconds
+            if max_staleness_seconds is not None
+            else config.agent_card_registry_max_staleness_seconds
+        )
+        self._stale_if_error = (
+            stale_if_error
+            if stale_if_error is not None
+            else config.agent_card_registry_stale_if_error
+        )
         self._on_duplicate: DuplicateStrategy = (
             on_duplicate if on_duplicate is not None else config.agent_card_registry_on_duplicate
         )
+        self._backend = cache_backend or create_agent_card_cache_backend(config)
 
-        logger.debug("AgentCardRegistry created (cache_ttl=%ds)", self._cache_ttl)
+        logger.debug(
+            "AgentCardRegistry created (backend=%s, cache_ttl=%ds, max_staleness=%ds, "
+            "stale_if_error=%s)",
+            config.agent_card_registry_backend,
+            self._cache_ttl,
+            self._max_staleness_seconds,
+            self._stale_if_error,
+        )
 
     # ------------------------------------------------------------------
     # Registration (synchronous — called at config-parse time)
@@ -320,7 +366,7 @@ class AgentCardRegistry:
     # Internal HTTP
     # ------------------------------------------------------------------
 
-    async def _fetch(self, params: dict[str, str]) -> dict[str, AgentCard]:
+    async def _fetch(self, params: dict[str, str]) -> ParsedRegistryCards:
         """Execute registry HTTP GET(s) with pagination and return all parsed cards.
 
         Requests the maximum page size (100) to minimise round-trips, then
@@ -375,39 +421,55 @@ class AgentCardRegistry:
         except httpx.HTTPError as exc:
             raise AgentCardRegistryError(f"Agent card registry request failed: {exc}") from exc
 
-        cards = _parse_registry_response({"data": all_entries}, on_duplicate=self._on_duplicate)
-        logger.info("Fetched %d agent card(s) from registry (%d pages).", len(cards), pages_fetched)
-        return cards
+        parsed = _parse_registry_response({"data": all_entries}, on_duplicate=self._on_duplicate)
+        logger.info(
+            "Fetched %d agent card(s) from registry (%d pages).",
+            len(parsed.cards),
+            pages_fetched,
+        )
+        return parsed
 
-    def _is_fresh(self, key: str) -> bool:
+    async def _is_fresh(self, key: str) -> bool:
         """Return True if *key* is cached and within the soft TTL."""
-        entry = self._cache.get(key)
-        return entry is not None and entry.is_fresh(self._cache_ttl)
+        record = await self._backend.get_fresh(key, cache_ttl=self._cache_ttl)
+        return record is not None
 
-    def _is_cached(self, key: str) -> bool:
-        """Return True if *key* is cached and within the soft TTL."""
-        return self._is_fresh(key)
-
-    def _try_get_stale(self, key: str) -> AgentCard | None:
-        """Return the last-known-good cached card when a registry refresh failed."""
-        entry = self._cache.get(key)
-        if entry is None:
+    async def _try_get_stale(self, key: str) -> AgentCard | None:
+        """Return a stale cached card when refresh failed and policy allows it."""
+        if not self._stale_if_error:
+            return None
+        record = await self._backend.get_stale(
+            key,
+            max_staleness_seconds=self._max_staleness_seconds,
+        )
+        if record is None:
             return None
         logger.warning(
             "Registry unreachable; serving stale agent card for %s (age=%.0fs)",
             key,
-            entry.age_seconds(),
+            record.age_seconds(),
         )
-        return entry.card
+        return record.card
 
-    def _store_cards(self, cards: dict[str, AgentCard]) -> None:
-        for key, card in cards.items():
-            self._cache[key] = _CacheEntry(card)
+    async def _store_cards(self, parsed: ParsedRegistryCards) -> None:
+        if not parsed.cards:
+            return
+        await self._backend.store(parsed.cards, key_types=parsed.key_types)
+
+    def _age_cache_entry_for_test(self, lookup_key: str, seconds: float) -> None:
+        """Shift a cached entry's fetch time backward (tests only)."""
+        backend = self._backend
+        if isinstance(backend, MemoryAgentCardCacheBackend):
+            backend.age_entry_for_test(lookup_key, seconds)
+            return
+
+        if isinstance(backend, LayeredAgentCardCacheBackend):
+            backend.memory.age_entry_for_test(lookup_key, seconds)
 
     async def _flush_pending(self) -> None:
         """Batch-fetch all registered-but-uncached IDs.  Must be called under ``_lock``."""
-        missing_dep = [d for d in self._pending_deployment_ids if not self._is_cached(d)]
-        missing_ext = [e for e in self._pending_external_ids if not self._is_cached(e)]
+        missing_dep = [d for d in self._pending_deployment_ids if not await self._is_fresh(d)]
+        missing_ext = [e for e in self._pending_external_ids if not await self._is_fresh(e)]
 
         # Clear pending sets regardless — they've been processed
         self._pending_deployment_ids.clear()
@@ -417,12 +479,12 @@ class AgentCardRegistry:
             return
 
         if missing_dep:
-            cards = await self._fetch({"deploymentIds": ",".join(missing_dep)})
-            self._store_cards(cards)
+            parsed = await self._fetch({"deploymentIds": ",".join(missing_dep)})
+            await self._store_cards(parsed)
 
         if missing_ext:
-            cards = await self._fetch({"externalIds": ",".join(missing_ext)})
-            self._store_cards(cards)
+            parsed = await self._fetch({"externalIds": ",".join(missing_ext)})
+            await self._store_cards(parsed)
 
     # ------------------------------------------------------------------
     # Public API
@@ -450,20 +512,20 @@ class AgentCardRegistry:
             External IDs to prefetch.
         """
         async with self._lock:
-            missing_dep = [d for d in (deployment_ids or []) if not self._is_cached(d)]
-            missing_ext = [e for e in (external_ids or []) if not self._is_cached(e)]
+            missing_dep = [d for d in (deployment_ids or []) if not await self._is_fresh(d)]
+            missing_ext = [e for e in (external_ids or []) if not await self._is_fresh(e)]
 
             if not missing_dep and not missing_ext:
                 logger.debug("All requested agent cards already cached — skipping prefetch.")
                 return
 
             if missing_dep:
-                cards = await self._fetch({"deploymentIds": ",".join(missing_dep)})
-                self._store_cards(cards)
+                parsed = await self._fetch({"deploymentIds": ",".join(missing_dep)})
+                await self._store_cards(parsed)
 
             if missing_ext:
-                cards = await self._fetch({"externalIds": ",".join(missing_ext)})
-                self._store_cards(cards)
+                parsed = await self._fetch({"externalIds": ",".join(missing_ext)})
+                await self._store_cards(parsed)
 
     async def refresh_all_registered(self) -> None:
         """Re-fetch registered IDs whose cache entries are past the soft TTL.
@@ -518,20 +580,22 @@ class AgentCardRegistry:
         lookup_key: str = deployment_id or external_id  # type: ignore[assignment]
 
         # Fast path — fresh cache hit
-        if self._is_fresh(lookup_key):
-            return self._cache[lookup_key].card
+        if fresh := await self._backend.get_fresh(lookup_key, cache_ttl=self._cache_ttl):
+            return fresh.card
 
         async with self._lock:
             # Double-check after acquiring lock
-            if self._is_fresh(lookup_key):
-                return self._cache[lookup_key].card
+            if fresh := await self._backend.get_fresh(lookup_key, cache_ttl=self._cache_ttl):
+                return fresh.card
 
             try:
                 # Flush all pending registrations in a batch
                 if self._pending_deployment_ids or self._pending_external_ids:
                     await self._flush_pending()
-                    if self._is_fresh(lookup_key):
-                        return self._cache[lookup_key].card
+                    if fresh := await self._backend.get_fresh(
+                        lookup_key, cache_ttl=self._cache_ttl
+                    ):
+                        return fresh.card
 
                 # Still not fresh — fetch individually
                 params: dict[str, str] = (
@@ -539,17 +603,21 @@ class AgentCardRegistry:
                     if deployment_id
                     else {"externalIds": external_id}  # type: ignore[dict-item]
                 )
-                cards = await self._fetch(params)
-                self._store_cards(cards)
+                parsed = await self._fetch(params)
+                await self._store_cards(parsed)
 
-                if lookup_key in cards:
-                    return cards[lookup_key]
+                if lookup_key in parsed.cards:
+                    return parsed.cards[lookup_key]
+
+                if fresh := await self._backend.get_fresh(lookup_key, cache_ttl=self._cache_ttl):
+                    return fresh.card
 
                 # Successful miss — evict stale entry so stale-if-error cannot
                 # resurrect a deregistered agent on a later fetch failure.
-                self._cache.pop(lookup_key, None)
+                key_type: LookupKeyType = "dep" if deployment_id else "ext"
+                await self._backend.evict(lookup_key, key_type=key_type)
             except AgentCardRegistryError:
-                if stale_card := self._try_get_stale(lookup_key):
+                if stale_card := await self._try_get_stale(lookup_key):
                     return stale_card
                 raise
 

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -127,26 +127,18 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
         ),
     )
 
-    agent_card_registry_backend: Literal["memory", "memory_space"] = Field(
-        default="memory",
+    agent_card_registry_memory_space_id: str | None = Field(
+        default=None,
         description=(
-            "Cache backend for agent cards. 'memory' uses in-process cache only; "
-            "'memory_space' adds a shared DataRobot MemorySpace L2 with "
-            "in-process L1 read-through."
+            "DataRobot MemorySpace ID for the agent card registry L2 cache. "
+            "Defaults to AGENT_MEMORY_SPACE_ID. When unset, only in-process L1 "
+            "caching is used."
         ),
     )
 
     agent_card_registry_key_prefix: str = Field(
         default="dragent:",
         description="Key prefix for MemorySpace agent card cache entries.",
-    )
-
-    agent_card_registry_memory_space_id: str | None = Field(
-        default=None,
-        description=(
-            "DataRobot MemorySpace ID for L2 cache when agent_card_registry_backend="
-            "'memory_space'. Defaults to AGENT_MEMORY_SPACE_ID."
-        ),
     )
 
 
@@ -295,10 +287,10 @@ class AgentCardRegistry:
         self._backend = cache_backend or create_agent_card_cache_backend(config)
 
         logger.debug(
-            "AgentCardRegistry created (backend=%s, cache_ttl=%ds, max_staleness=%ds)",
-            config.agent_card_registry_backend,
+            "AgentCardRegistry created (cache_ttl=%ds, max_staleness=%ds, l2=%s)",
             self._cache_ttl,
             self._max_staleness_seconds,
+            isinstance(self._backend, LayeredAgentCardCacheBackend),
         )
 
     # ------------------------------------------------------------------

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -171,6 +171,7 @@ class ParsedRegistryCards(NamedTuple):
 
     cards: dict[str, AgentCard]
     key_types: dict[str, LookupKeyType]
+    registry_ids: dict[str, tuple[str | None, str | None]]
 
 
 def _parse_registry_response(
@@ -192,6 +193,7 @@ def _parse_registry_response(
     """
     cards: dict[str, AgentCard] = {}
     key_types: dict[str, LookupKeyType] = {}
+    registry_ids: dict[str, tuple[str | None, str | None]] = {}
     for entry in body.get("data", []):
         raw_card = entry.get("agentCard")
         if not raw_card:
@@ -210,16 +212,22 @@ def _parse_registry_response(
             )
             continue
 
+        dep_id = entry.get("deploymentId")
+        ext_id = entry.get("externalId")
+        id_pair = (dep_id, ext_id)
+
         # Deployment IDs are unique by platform design — always overwrite.
-        if dep_id := entry.get("deploymentId"):
+        if dep_id:
             cards[dep_id] = card
             key_types[dep_id] = "deployment"
+            registry_ids[dep_id] = id_pair
 
         # External IDs may have duplicates — apply the configured strategy.
-        if ext_id := entry.get("externalId"):
+        if ext_id:
             if ext_id not in cards:
                 cards[ext_id] = card
                 key_types[ext_id] = "external"
+                registry_ids[ext_id] = id_pair
             else:
                 logger.warning(
                     "Duplicate external ID '%s' in registry response (on_duplicate=%s).",
@@ -235,8 +243,9 @@ def _parse_registry_response(
                 if on_duplicate == "last":
                     cards[ext_id] = card
                     key_types[ext_id] = "external"
+                    registry_ids[ext_id] = id_pair
                 # "first" — keep existing entry (no-op)
-    return ParsedRegistryCards(cards=cards, key_types=key_types)
+    return ParsedRegistryCards(cards=cards, key_types=key_types, registry_ids=registry_ids)
 
 
 class AgentCardRegistry:
@@ -410,7 +419,11 @@ class AgentCardRegistry:
     async def _store_cards(self, parsed: ParsedRegistryCards) -> None:
         if not parsed.cards:
             return
-        await self._backend.store(parsed.cards, key_types=parsed.key_types)
+        await self._backend.store(
+            parsed.cards,
+            key_types=parsed.key_types,
+            registry_ids=parsed.registry_ids,
+        )
 
     def _age_cache_entry_for_test(self, lookup_key: str, seconds: float) -> None:
         """Shift a cached entry's fetch time backward (tests only)."""

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -213,13 +213,13 @@ def _parse_registry_response(
         # Deployment IDs are unique by platform design — always overwrite.
         if dep_id := entry.get("deploymentId"):
             cards[dep_id] = card
-            key_types[dep_id] = "dep"
+            key_types[dep_id] = "deployment"
 
         # External IDs may have duplicates — apply the configured strategy.
         if ext_id := entry.get("externalId"):
             if ext_id not in cards:
                 cards[ext_id] = card
-                key_types[ext_id] = "ext"
+                key_types[ext_id] = "external"
             else:
                 logger.warning(
                     "Duplicate external ID '%s' in registry response (on_duplicate=%s).",
@@ -234,7 +234,7 @@ def _parse_registry_response(
                     )
                 if on_duplicate == "last":
                     cards[ext_id] = card
-                    key_types[ext_id] = "ext"
+                    key_types[ext_id] = "external"
                 # "first" — keep existing entry (no-op)
     return ParsedRegistryCards(cards=cards, key_types=key_types)
 
@@ -570,7 +570,7 @@ class AgentCardRegistry:
 
                 # Successful miss — evict stale entry so stale-if-error cannot
                 # resurrect a deregistered agent on a later fetch failure.
-                key_type: LookupKeyType = "dep" if deployment_id else "ext"
+                key_type: LookupKeyType = "deployment" if deployment_id else "external"
                 await self._backend.evict(lookup_key, key_type=key_type)
             except AgentCardRegistryError:
                 if stale_card := await self._try_get_stale(lookup_key):

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -135,11 +135,6 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
         ),
     )
 
-    agent_card_registry_key_prefix: str = Field(
-        default="dragent:",
-        description="Key prefix for MemorySpace agent card cache entries.",
-    )
-
 
 class AgentCardRegistryError(RuntimeError):
     """Raised when the central agent card registry lookup fails."""

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -131,8 +131,7 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
         default=None,
         description=(
             "DataRobot MemorySpace ID for the agent card registry L2 cache. "
-            "Defaults to AGENT_MEMORY_SPACE_ID. When unset, only in-process L1 "
-            "caching is used."
+            "When unset, only in-process L1 caching is used."
         ),
     )
 

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -60,9 +60,6 @@ logger = logging.getLogger(__name__)
 # Default cache TTL: 24 hours (in seconds).
 _DEFAULT_CACHE_TTL_SECONDS = 24 * 3600
 
-# Default hard staleness bound for stale-if-error (in seconds).
-_DEFAULT_MAX_STALENESS_SECONDS = 24 * 3600
-
 # Default HTTP timeout for registry requests (in seconds).
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 
@@ -127,25 +124,6 @@ class AgentCardRegistryConfig(DataRobotAppFrameworkBaseSettings):
             "creation time (ascending), so 'first' keeps the earliest "
             "registered card, 'last' keeps the most recently registered card, "
             "and 'error' raises AgentCardRegistryError.  Default: 'first'."
-        ),
-    )
-
-    agent_card_registry_max_staleness_seconds: int = Field(
-        default=_DEFAULT_MAX_STALENESS_SECONDS,
-        ge=0,
-        description=(
-            "Maximum age in seconds for serving a cached agent card when the "
-            "registry is unreachable (stale-if-error). Default: 86400 (24 hours)."
-        ),
-    )
-
-    agent_card_registry_stale_if_error: bool = Field(
-        default=True,
-        description=(
-            "When true, return the last-known-good cached agent card if a "
-            "registry fetch fails and the entry is within "
-            "agent_card_registry_max_staleness_seconds. "
-            "Set AGENT_CARD_REGISTRY_STALE_IF_ERROR=false to disable."
         ),
     )
 
@@ -277,9 +255,8 @@ class AgentCardRegistry:
     The first ``get()`` flushes all pending IDs in ≤2 HTTP calls
     (one per ID type — API uses AND when both are mixed).
     Subsequent ``get()`` calls hit the in-memory cache until the soft TTL
-    (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails and
-    ``AGENT_CARD_REGISTRY_STALE_IF_ERROR`` is enabled, a cached card may still
-    be returned up to ``AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS``.
+    (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails, a cached
+    card may still be returned while it remains within ``AGENT_CARD_REGISTRY_CACHE_TTL``.
     """
 
     def __init__(
@@ -289,7 +266,6 @@ class AgentCardRegistry:
         timeout: float | None = None,
         cache_ttl: int | None = None,
         max_staleness_seconds: int | None = None,
-        stale_if_error: bool | None = None,
         on_duplicate: DuplicateStrategy | None = None,
         cache_backend: AgentCardCacheBackend | None = None,
     ) -> None:
@@ -311,14 +287,7 @@ class AgentCardRegistry:
             cache_ttl if cache_ttl is not None else config.agent_card_registry_cache_ttl
         )
         self._max_staleness_seconds = (
-            max_staleness_seconds
-            if max_staleness_seconds is not None
-            else config.agent_card_registry_max_staleness_seconds
-        )
-        self._stale_if_error = (
-            stale_if_error
-            if stale_if_error is not None
-            else config.agent_card_registry_stale_if_error
+            max_staleness_seconds if max_staleness_seconds is not None else self._cache_ttl
         )
         self._on_duplicate: DuplicateStrategy = (
             on_duplicate if on_duplicate is not None else config.agent_card_registry_on_duplicate
@@ -326,12 +295,10 @@ class AgentCardRegistry:
         self._backend = cache_backend or create_agent_card_cache_backend(config)
 
         logger.debug(
-            "AgentCardRegistry created (backend=%s, cache_ttl=%ds, max_staleness=%ds, "
-            "stale_if_error=%s)",
+            "AgentCardRegistry created (backend=%s, cache_ttl=%ds, max_staleness=%ds)",
             config.agent_card_registry_backend,
             self._cache_ttl,
             self._max_staleness_seconds,
-            self._stale_if_error,
         )
 
     # ------------------------------------------------------------------
@@ -435,9 +402,7 @@ class AgentCardRegistry:
         return record is not None
 
     async def _try_get_stale(self, key: str) -> AgentCard | None:
-        """Return a stale cached card when refresh failed and policy allows it."""
-        if not self._stale_if_error:
-            return None
+        """Return a stale cached card when refresh failed."""
         record = await self._backend.get_stale(
             key,
             max_staleness_seconds=self._max_staleness_seconds,

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -1,0 +1,352 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable cache backends for the central agent card registry."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from typing import Literal
+from typing import Protocol
+
+from a2a.types import AgentCard
+from pydantic import BaseModel
+from pydantic import Field
+
+from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
+from datarobot_genai.dragent.memory_space_cache import configure_datarobot_memory_client
+from datarobot_genai.dragent.memory_space_cache import resolve_memory_space_id
+
+if TYPE_CHECKING:
+    from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
+
+logger = logging.getLogger(__name__)
+
+LookupKeyType = Literal["dep", "ext"]
+_DEFAULT_KEY_PREFIX = "dragent:"
+
+
+class AgentCardCacheRecord(BaseModel):
+    """Serialized agent card cache entry shared across backends."""
+
+    version: int = 1
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    card: AgentCard
+    source: str = "registry"
+    deployment_id: str | None = None
+    external_id: str | None = None
+
+    def age_seconds(self) -> float:
+        """Return the entry age in seconds (wall clock, safe across processes)."""
+        return max(0.0, (datetime.now(UTC) - self.fetched_at).total_seconds())
+
+    def is_fresh(self, cache_ttl: int) -> bool:
+        """Return *True* if this entry is within the soft TTL."""
+        if cache_ttl == 0:
+            return False
+        return self.age_seconds() < cache_ttl
+
+    def is_within_staleness(self, max_staleness_seconds: int) -> bool:
+        """Return *True* if this entry may be served under stale-if-error."""
+        if max_staleness_seconds == 0:
+            return False
+        return self.age_seconds() <= max_staleness_seconds
+
+
+def build_cache_record(
+    card: AgentCard,
+    *,
+    lookup_key: str,
+    key_type: LookupKeyType,
+    deployment_id: str | None = None,
+    external_id: str | None = None,
+) -> AgentCardCacheRecord:
+    """Build a cache record for *lookup_key* with optional registry ID metadata."""
+    resolved_dep = (
+        deployment_id if deployment_id is not None else (lookup_key if key_type == "dep" else None)
+    )
+    resolved_ext = (
+        external_id if external_id is not None else (lookup_key if key_type == "ext" else None)
+    )
+    return AgentCardCacheRecord(
+        card=card,
+        deployment_id=resolved_dep,
+        external_id=resolved_ext,
+    )
+
+
+class AgentCardCacheBackend(Protocol):
+    """Async cache backend for agent card registry entries."""
+
+    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
+        """Return a cached record when within the soft TTL."""
+
+    async def get_stale(
+        self,
+        lookup_key: str,
+        *,
+        max_staleness_seconds: int,
+    ) -> AgentCardCacheRecord | None:
+        """Return a cached record within the hard staleness bound."""
+
+    async def store(
+        self,
+        cards: dict[str, AgentCard],
+        *,
+        key_types: dict[str, LookupKeyType],
+    ) -> None:
+        """Persist one or more cards keyed by lookup ID."""
+
+    async def evict(
+        self,
+        lookup_key: str,
+        *,
+        key_type: LookupKeyType | None = None,
+    ) -> None:
+        """Remove a cached entry so stale-if-error cannot resurrect it."""
+
+
+class MemoryAgentCardCacheBackend:
+    """In-process dict cache (L1)."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, AgentCardCacheRecord] = {}
+
+    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
+        record = self._entries.get(lookup_key)
+        if record is None or not record.is_fresh(cache_ttl):
+            return None
+        return record
+
+    async def get_stale(
+        self,
+        lookup_key: str,
+        *,
+        max_staleness_seconds: int,
+    ) -> AgentCardCacheRecord | None:
+        record = self._entries.get(lookup_key)
+        if record is None or not record.is_within_staleness(max_staleness_seconds):
+            return None
+        return record
+
+    async def store(
+        self,
+        cards: dict[str, AgentCard],
+        *,
+        key_types: dict[str, LookupKeyType],
+    ) -> None:
+        for lookup_key, card in cards.items():
+            key_type = key_types.get(lookup_key, "dep")
+            self._entries[lookup_key] = build_cache_record(
+                card, lookup_key=lookup_key, key_type=key_type
+            )
+
+    async def evict(
+        self,
+        lookup_key: str,
+        *,
+        key_type: LookupKeyType | None = None,
+    ) -> None:
+        self._entries.pop(lookup_key, None)
+
+    def age_entry_for_test(self, lookup_key: str, seconds: float) -> None:
+        """Shift *lookup_key* fetch time backward (tests only)."""
+        record = self._entries.get(lookup_key)
+        if record is None:
+            return
+        record.fetched_at -= timedelta(seconds=seconds)
+
+
+class MemorySpaceAgentCardCacheBackend:
+    """Shared DataRobot MemorySpace L2 cache using JSON payloads."""
+
+    def __init__(
+        self,
+        *,
+        kv_cache: MemorySpaceKVCache,
+    ) -> None:
+        self._kv = kv_cache
+
+    def _storage_keys_for_record(self, record: AgentCardCacheRecord) -> list[str]:
+        keys: list[str] = []
+        if record.deployment_id:
+            keys.append(f"dep:{record.deployment_id}")
+        if record.external_id:
+            keys.append(f"ext:{record.external_id}")
+        return keys
+
+    def _storage_keys_for_lookup(
+        self,
+        lookup_key: str,
+        *,
+        key_type: LookupKeyType | None = None,
+    ) -> list[str]:
+        if key_type == "dep":
+            return [f"dep:{lookup_key}"]
+        if key_type == "ext":
+            return [f"ext:{lookup_key}"]
+        return [f"dep:{lookup_key}", f"ext:{lookup_key}"]
+
+    async def _get_record(self, storage_key: str) -> AgentCardCacheRecord | None:
+        payload = await self._kv.get_value(storage_key, kind="agent_card")
+        if payload is None:
+            return None
+        try:
+            return AgentCardCacheRecord.model_validate_json(payload)
+        except Exception:
+            logger.warning("Ignoring invalid MemorySpace agent card payload for %s", storage_key)
+            return None
+
+    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
+        for storage_key in self._storage_keys_for_lookup(lookup_key):
+            record = await self._get_record(storage_key)
+            if record is not None and record.is_fresh(cache_ttl):
+                return record
+        return None
+
+    async def get_stale(
+        self,
+        lookup_key: str,
+        *,
+        max_staleness_seconds: int,
+    ) -> AgentCardCacheRecord | None:
+        for storage_key in self._storage_keys_for_lookup(lookup_key):
+            record = await self._get_record(storage_key)
+            if record is not None and record.is_within_staleness(max_staleness_seconds):
+                return record
+        return None
+
+    async def store(
+        self,
+        cards: dict[str, AgentCard],
+        *,
+        key_types: dict[str, LookupKeyType],
+    ) -> None:
+        for lookup_key, card in cards.items():
+            key_type = key_types.get(lookup_key, "dep")
+            record = build_cache_record(card, lookup_key=lookup_key, key_type=key_type)
+            payload = record.model_dump_json()
+            for storage_key in self._storage_keys_for_record(record):
+                await self._kv.set_value(storage_key, payload, kind="agent_card")
+
+    async def evict(
+        self,
+        lookup_key: str,
+        *,
+        key_type: LookupKeyType | None = None,
+    ) -> None:
+        for storage_key in self._storage_keys_for_lookup(lookup_key, key_type=key_type):
+            await self._kv.delete_value(storage_key, kind="agent_card")
+
+
+class LayeredAgentCardCacheBackend:
+    """L1 memory read-through / write-through over an L2 backend."""
+
+    def __init__(self, l1: MemoryAgentCardCacheBackend, l2: AgentCardCacheBackend) -> None:
+        self._l1 = l1
+        self._l2 = l2
+
+    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
+        if record := await self._l1.get_fresh(lookup_key, cache_ttl=cache_ttl):
+            return record
+        if record := await self._l2.get_fresh(lookup_key, cache_ttl=cache_ttl):
+            await self._l1.store(
+                {lookup_key: record.card},
+                key_types={lookup_key: _infer_key_type(record, lookup_key)},
+            )
+            return record
+        return None
+
+    async def get_stale(
+        self,
+        lookup_key: str,
+        *,
+        max_staleness_seconds: int,
+    ) -> AgentCardCacheRecord | None:
+        if record := await self._l1.get_stale(
+            lookup_key,
+            max_staleness_seconds=max_staleness_seconds,
+        ):
+            return record
+        if record := await self._l2.get_stale(
+            lookup_key,
+            max_staleness_seconds=max_staleness_seconds,
+        ):
+            await self._l1.store(
+                {lookup_key: record.card},
+                key_types={lookup_key: _infer_key_type(record, lookup_key)},
+            )
+            return record
+        return None
+
+    async def store(
+        self,
+        cards: dict[str, AgentCard],
+        *,
+        key_types: dict[str, LookupKeyType],
+    ) -> None:
+        await self._l1.store(cards, key_types=key_types)
+        await self._l2.store(cards, key_types=key_types)
+
+    async def evict(
+        self,
+        lookup_key: str,
+        *,
+        key_type: LookupKeyType | None = None,
+    ) -> None:
+        await self._l1.evict(lookup_key, key_type=key_type)
+        await self._l2.evict(lookup_key, key_type=key_type)
+
+    @property
+    def memory(self) -> MemoryAgentCardCacheBackend:
+        """Expose the L1 backend (tests)."""
+        return self._l1
+
+
+def _infer_key_type(record: AgentCardCacheRecord, lookup_key: str) -> LookupKeyType:
+    if record.deployment_id == lookup_key:
+        return "dep"
+    if record.external_id == lookup_key:
+        return "ext"
+    return "dep"
+
+
+def create_agent_card_cache_backend(
+    config: AgentCardRegistryConfig,
+) -> AgentCardCacheBackend:
+    """Instantiate the configured cache backend."""
+    backend = config.agent_card_registry_backend
+    if backend == "memory":
+        return MemoryAgentCardCacheBackend()
+
+    if backend == "memory_space":
+        memory_space_id = resolve_memory_space_id(config.agent_card_registry_memory_space_id)
+        configure_datarobot_memory_client()
+        kv_cache = MemorySpaceKVCache(
+            memory_space_id=memory_space_id,
+            key_prefix=config.agent_card_registry_key_prefix,
+        )
+        return LayeredAgentCardCacheBackend(
+            MemoryAgentCardCacheBackend(),
+            MemorySpaceAgentCardCacheBackend(kv_cache=kv_cache),
+        )
+
+    raise ValueError(
+        f"Unsupported agent card registry cache backend: {backend!r}. "
+        "Expected 'memory' or 'memory_space'."
+    )

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 LookupKeyType = Literal["deployment", "external"]
-_DEFAULT_KEY_PREFIX = "dragent:"
 
 
 class AgentCardCacheRecord(BaseModel):
@@ -371,10 +370,7 @@ def create_agent_card_cache_backend(
         )
         return l1
 
-    kv_cache = MemorySpaceKVCache(
-        memory_space_id=memory_space_id,
-        key_prefix=config.agent_card_registry_key_prefix,
-    )
+    kv_cache = MemorySpaceKVCache(memory_space_id=memory_space_id)
     logger.debug(
         "Agent card registry cache: L1 + MemorySpace L2 (space_id=%s)",
         memory_space_id,

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -158,6 +158,10 @@ class MemoryAgentCardCacheBackend:
                 card, lookup_key=lookup_key, key_type=key_type
             )
 
+    async def store_record(self, lookup_key: str, record: AgentCardCacheRecord) -> None:
+        """Insert *record* as-is, preserving ``fetched_at`` for L1 read-through."""
+        self._entries[lookup_key] = record.model_copy()
+
     async def evict(
         self,
         lookup_key: str,
@@ -267,10 +271,7 @@ class LayeredAgentCardCacheBackend:
         if record := await self._l1.get_fresh(lookup_key, cache_ttl=cache_ttl):
             return record
         if record := await self._l2.get_fresh(lookup_key, cache_ttl=cache_ttl):
-            await self._l1.store(
-                {lookup_key: record.card},
-                key_types={lookup_key: _infer_key_type(record, lookup_key)},
-            )
+            await self._promote_to_l1(lookup_key, record)
             return record
         return None
 
@@ -289,12 +290,12 @@ class LayeredAgentCardCacheBackend:
             lookup_key,
             max_staleness_seconds=max_staleness_seconds,
         ):
-            await self._l1.store(
-                {lookup_key: record.card},
-                key_types={lookup_key: _infer_key_type(record, lookup_key)},
-            )
+            await self._promote_to_l1(lookup_key, record)
             return record
         return None
+
+    async def _promote_to_l1(self, lookup_key: str, record: AgentCardCacheRecord) -> None:
+        await self._l1.store_record(lookup_key, record)
 
     async def store(
         self,
@@ -318,14 +319,6 @@ class LayeredAgentCardCacheBackend:
     def memory(self) -> MemoryAgentCardCacheBackend:
         """Expose the L1 backend (tests)."""
         return self._l1
-
-
-def _infer_key_type(record: AgentCardCacheRecord, lookup_key: str) -> LookupKeyType:
-    if record.deployment_id == lookup_key:
-        return "deployment"
-    if record.external_id == lookup_key:
-        return "external"
-    return "deployment"
 
 
 def create_agent_card_cache_backend(

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-LookupKeyType = Literal["dep", "ext"]
+LookupKeyType = Literal["deployment", "external"]
 _DEFAULT_KEY_PREFIX = "dragent:"
 
 
@@ -78,10 +78,12 @@ def build_cache_record(
 ) -> AgentCardCacheRecord:
     """Build a cache record for *lookup_key* with optional registry ID metadata."""
     resolved_dep = (
-        deployment_id if deployment_id is not None else (lookup_key if key_type == "dep" else None)
+        deployment_id
+        if deployment_id is not None
+        else (lookup_key if key_type == "deployment" else None)
     )
     resolved_ext = (
-        external_id if external_id is not None else (lookup_key if key_type == "ext" else None)
+        external_id if external_id is not None else (lookup_key if key_type == "external" else None)
     )
     return AgentCardCacheRecord(
         card=card,
@@ -151,7 +153,7 @@ class MemoryAgentCardCacheBackend:
         key_types: dict[str, LookupKeyType],
     ) -> None:
         for lookup_key, card in cards.items():
-            key_type = key_types.get(lookup_key, "dep")
+            key_type = key_types.get(lookup_key, "deployment")
             self._entries[lookup_key] = build_cache_record(
                 card, lookup_key=lookup_key, key_type=key_type
             )
@@ -185,9 +187,9 @@ class MemorySpaceAgentCardCacheBackend:
     def _storage_keys_for_record(self, record: AgentCardCacheRecord) -> list[str]:
         keys: list[str] = []
         if record.deployment_id:
-            keys.append(f"dep:{record.deployment_id}")
+            keys.append(f"deployment:{record.deployment_id}")
         if record.external_id:
-            keys.append(f"ext:{record.external_id}")
+            keys.append(f"external:{record.external_id}")
         return keys
 
     def _storage_keys_for_lookup(
@@ -196,11 +198,11 @@ class MemorySpaceAgentCardCacheBackend:
         *,
         key_type: LookupKeyType | None = None,
     ) -> list[str]:
-        if key_type == "dep":
-            return [f"dep:{lookup_key}"]
-        if key_type == "ext":
-            return [f"ext:{lookup_key}"]
-        return [f"dep:{lookup_key}", f"ext:{lookup_key}"]
+        if key_type == "deployment":
+            return [f"deployment:{lookup_key}"]
+        if key_type == "external":
+            return [f"external:{lookup_key}"]
+        return [f"deployment:{lookup_key}", f"external:{lookup_key}"]
 
     async def _get_record(self, storage_key: str) -> AgentCardCacheRecord | None:
         payload = await self._kv.get_value(storage_key, kind="agent_card")
@@ -238,7 +240,7 @@ class MemorySpaceAgentCardCacheBackend:
         key_types: dict[str, LookupKeyType],
     ) -> None:
         for lookup_key, card in cards.items():
-            key_type = key_types.get(lookup_key, "dep")
+            key_type = key_types.get(lookup_key, "deployment")
             record = build_cache_record(card, lookup_key=lookup_key, key_type=key_type)
             payload = record.model_dump_json()
             for storage_key in self._storage_keys_for_record(record):
@@ -320,10 +322,10 @@ class LayeredAgentCardCacheBackend:
 
 def _infer_key_type(record: AgentCardCacheRecord, lookup_key: str) -> LookupKeyType:
     if record.deployment_id == lookup_key:
-        return "dep"
+        return "deployment"
     if record.external_id == lookup_key:
-        return "ext"
-    return "dep"
+        return "external"
+    return "deployment"
 
 
 def create_agent_card_cache_backend(

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -29,8 +29,8 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
-from datarobot_genai.dragent.memory_space_cache import configure_datarobot_memory_client
-from datarobot_genai.dragent.memory_space_cache import resolve_memory_space_id
+from datarobot_genai.dragent.memory_space_cache import try_configure_datarobot_memory_client
+from datarobot_genai.dragent.memory_space_cache import try_resolve_memory_space_id
 
 if TYPE_CHECKING:
     from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
@@ -329,24 +329,29 @@ def _infer_key_type(record: AgentCardCacheRecord, lookup_key: str) -> LookupKeyT
 def create_agent_card_cache_backend(
     config: AgentCardRegistryConfig,
 ) -> AgentCardCacheBackend:
-    """Instantiate the configured cache backend."""
-    backend = config.agent_card_registry_backend
-    if backend == "memory":
-        return MemoryAgentCardCacheBackend()
+    """Instantiate the agent card cache backend (L1, plus MemorySpace L2 when available)."""
+    l1 = MemoryAgentCardCacheBackend()
+    memory_space_id = try_resolve_memory_space_id(config.agent_card_registry_memory_space_id)
+    if memory_space_id is None:
+        logger.debug("Agent card registry cache: L1 only (no MemorySpace ID configured)")
+        return l1
 
-    if backend == "memory_space":
-        memory_space_id = resolve_memory_space_id(config.agent_card_registry_memory_space_id)
-        configure_datarobot_memory_client()
-        kv_cache = MemorySpaceKVCache(
-            memory_space_id=memory_space_id,
-            key_prefix=config.agent_card_registry_key_prefix,
+    if not try_configure_datarobot_memory_client():
+        logger.warning(
+            "Agent card registry cache: L1 only — MemorySpace L2 unavailable "
+            "(set DATAROBOT_API_TOKEN and DATAROBOT_ENDPOINT)"
         )
-        return LayeredAgentCardCacheBackend(
-            MemoryAgentCardCacheBackend(),
-            MemorySpaceAgentCardCacheBackend(kv_cache=kv_cache),
-        )
+        return l1
 
-    raise ValueError(
-        f"Unsupported agent card registry cache backend: {backend!r}. "
-        "Expected 'memory' or 'memory_space'."
+    kv_cache = MemorySpaceKVCache(
+        memory_space_id=memory_space_id,
+        key_prefix=config.agent_card_registry_key_prefix,
+    )
+    logger.debug(
+        "Agent card registry cache: L1 + MemorySpace L2 (space_id=%s)",
+        memory_space_id,
+    )
+    return LayeredAgentCardCacheBackend(
+        l1,
+        MemorySpaceAgentCardCacheBackend(kv_cache=kv_cache),
     )

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -205,7 +205,7 @@ class MemorySpaceAgentCardCacheBackend:
         return [f"deployment:{lookup_key}", f"external:{lookup_key}"]
 
     async def _get_record(self, storage_key: str) -> AgentCardCacheRecord | None:
-        payload = await self._kv.get_value(storage_key, kind="agent_card")
+        payload = await self._kv.get_value(storage_key)
         if payload is None:
             return None
         try:
@@ -244,7 +244,7 @@ class MemorySpaceAgentCardCacheBackend:
             record = build_cache_record(card, lookup_key=lookup_key, key_type=key_type)
             payload = record.model_dump_json()
             for storage_key in self._storage_keys_for_record(record):
-                await self._kv.set_value(storage_key, payload, kind="agent_card")
+                await self._kv.set_value(storage_key, payload)
 
     async def evict(
         self,
@@ -253,7 +253,7 @@ class MemorySpaceAgentCardCacheBackend:
         key_type: LookupKeyType | None = None,
     ) -> None:
         for storage_key in self._storage_keys_for_lookup(lookup_key, key_type=key_type):
-            await self._kv.delete_value(storage_key, kind="agent_card")
+            await self._kv.delete_value(storage_key)
 
 
 class LayeredAgentCardCacheBackend:

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -111,6 +111,7 @@ class AgentCardCacheBackend(Protocol):
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
+        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
     ) -> None:
         """Persist one or more cards keyed by lookup ID."""
 
@@ -151,11 +152,18 @@ class MemoryAgentCardCacheBackend:
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
+        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
     ) -> None:
+        id_pairs = registry_ids or {}
         for lookup_key, card in cards.items():
             key_type = key_types.get(lookup_key, "deployment")
+            dep_id, ext_id = id_pairs.get(lookup_key, (None, None))
             self._entries[lookup_key] = build_cache_record(
-                card, lookup_key=lookup_key, key_type=key_type
+                card,
+                lookup_key=lookup_key,
+                key_type=key_type,
+                deployment_id=dep_id,
+                external_id=ext_id,
             )
 
     async def store_record(self, lookup_key: str, record: AgentCardCacheRecord) -> None:
@@ -168,7 +176,15 @@ class MemoryAgentCardCacheBackend:
         *,
         key_type: LookupKeyType | None = None,
     ) -> None:
-        self._entries.pop(lookup_key, None)
+        keys_to_evict = {lookup_key}
+        record = self._entries.get(lookup_key)
+        if record is not None:
+            if record.deployment_id:
+                keys_to_evict.add(record.deployment_id)
+            if record.external_id:
+                keys_to_evict.add(record.external_id)
+        for key in keys_to_evict:
+            self._entries.pop(key, None)
 
     def age_entry_for_test(self, lookup_key: str, seconds: float) -> None:
         """Shift *lookup_key* fetch time backward (tests only)."""
@@ -242,10 +258,19 @@ class MemorySpaceAgentCardCacheBackend:
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
+        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
     ) -> None:
+        id_pairs = registry_ids or {}
         for lookup_key, card in cards.items():
             key_type = key_types.get(lookup_key, "deployment")
-            record = build_cache_record(card, lookup_key=lookup_key, key_type=key_type)
+            dep_id, ext_id = id_pairs.get(lookup_key, (None, None))
+            record = build_cache_record(
+                card,
+                lookup_key=lookup_key,
+                key_type=key_type,
+                deployment_id=dep_id,
+                external_id=ext_id,
+            )
             payload = record.model_dump_json()
             for storage_key in self._storage_keys_for_record(record):
                 await self._kv.set_value(storage_key, payload)
@@ -256,7 +281,14 @@ class MemorySpaceAgentCardCacheBackend:
         *,
         key_type: LookupKeyType | None = None,
     ) -> None:
-        for storage_key in self._storage_keys_for_lookup(lookup_key, key_type=key_type):
+        keys_to_evict = set(self._storage_keys_for_lookup(lookup_key, key_type=key_type))
+        record: AgentCardCacheRecord | None = None
+        for storage_key in keys_to_evict:
+            if record is None:
+                record = await self._get_record(storage_key)
+        if record is not None:
+            keys_to_evict.update(self._storage_keys_for_record(record))
+        for storage_key in keys_to_evict:
             await self._kv.delete_value(storage_key)
 
 
@@ -302,9 +334,10 @@ class LayeredAgentCardCacheBackend:
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
+        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
     ) -> None:
-        await self._l1.store(cards, key_types=key_types)
-        await self._l2.store(cards, key_types=key_types)
+        await self._l1.store(cards, key_types=key_types, registry_ids=registry_ids)
+        await self._l2.store(cards, key_types=key_types, registry_ids=registry_ids)
 
     async def evict(
         self,

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -30,7 +30,6 @@ import hashlib
 import logging
 import os
 from typing import Any
-from typing import Literal
 
 import datarobot as dr
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
@@ -46,8 +45,7 @@ DRAGENT_CACHE_PARTICIPANT_ID = hashlib.sha256(b"datarobot-genai:dragent-cache").
 CACHE_METADATA_VERSION = 1
 CACHE_EVENT_TYPE = "status"
 DEDUPLICATION_KEY_LENGTH = 64
-
-CacheKind = Literal["agent_card", "xaa_token"]
+CACHE_KIND = "agent_card"
 
 _MEMORY_SPACE_REQUIRED_MSG = (
     "Memory space cache backends require a provisioned DataRobot MemorySpace ID. "
@@ -130,12 +128,12 @@ def _cache_session_description(logical_key: str) -> str:
     return f"/dragent/cache/{logical_key}"
 
 
-def _cache_session_metadata(logical_key: str, *, kind: CacheKind) -> dict[str, Any]:
+def _cache_session_metadata(logical_key: str) -> dict[str, Any]:
     return {
         "v": CACHE_METADATA_VERSION,
         "dragent_cache": True,
         "cache_key": logical_key,
-        "cache_kind": kind,
+        "cache_kind": CACHE_KIND,
     }
 
 
@@ -154,14 +152,13 @@ def _create_cache_session(
     memory_space_id: str,
     *,
     logical_key: str,
-    kind: CacheKind,
 ) -> Session:
     """Create a cache session, adopting an existing one on deduplication collision."""
     try:
         return Session.create(
             memory_space_id,
             [DRAGENT_CACHE_PARTICIPANT_ID],
-            metadata=_cache_session_metadata(logical_key, kind=kind),
+            metadata=_cache_session_metadata(logical_key),
             description=_cache_session_description(logical_key),
             deduplication_key=_cache_deduplication_key(logical_key),
         )
@@ -210,12 +207,12 @@ class MemorySpaceKVCache:
         normalized = key_prefix if key_prefix.endswith(":") else f"{key_prefix}:"
         self._key_prefix = normalized
 
-    def _logical_key(self, key: str, *, kind: CacheKind) -> str:
-        return f"{self._key_prefix}{kind}:{key}"
+    def _logical_key(self, key: str) -> str:
+        return f"{self._key_prefix}{CACHE_KIND}:{key}"
 
-    async def get_value(self, key: str, *, kind: CacheKind) -> str | None:
+    async def get_value(self, key: str) -> str | None:
         """Return the stored JSON payload for *key*, or ``None`` when missing."""
-        logical_key = self._logical_key(key, kind=kind)
+        logical_key = self._logical_key(key)
 
         def _get() -> str | None:
             session = _find_cache_session(self._memory_space_id, logical_key)
@@ -229,9 +226,9 @@ class MemorySpaceKVCache:
             logger.exception("MemorySpace cache read failed for %s", logical_key)
             return None
 
-    async def set_value(self, key: str, payload: str, *, kind: CacheKind) -> None:
+    async def set_value(self, key: str, payload: str) -> None:
         """Upsert a JSON payload for *key*."""
-        logical_key = self._logical_key(key, kind=kind)
+        logical_key = self._logical_key(key)
 
         def _set() -> None:
             session = _find_cache_session(self._memory_space_id, logical_key)
@@ -239,7 +236,6 @@ class MemorySpaceKVCache:
                 session = _create_cache_session(
                     self._memory_space_id,
                     logical_key=logical_key,
-                    kind=kind,
                 )
             _write_payload(session, payload)
 
@@ -248,9 +244,9 @@ class MemorySpaceKVCache:
         except Exception:
             logger.exception("MemorySpace cache write failed for %s", logical_key)
 
-    async def delete_value(self, key: str, *, kind: CacheKind) -> None:
+    async def delete_value(self, key: str) -> None:
         """Remove a cached payload for *key* when present."""
-        logical_key = self._logical_key(key, kind=kind)
+        logical_key = self._logical_key(key)
 
         def _delete() -> None:
             session = _find_cache_session(self._memory_space_id, logical_key)

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -61,8 +61,7 @@ class MemorySpaceCacheConfig(DataRobotAppFrameworkBaseSettings):
     agent_card_registry_memory_space_id: str | None = Field(
         default=None,
         description=(
-            "DataRobot MemorySpace ID for dragent L2 caches when "
-            "AGENT_CARD_REGISTRY_BACKEND=memory_space. "
+            "DataRobot MemorySpace ID for the agent card registry L2 cache. "
             "Defaults to AGENT_MEMORY_SPACE_ID."
         ),
     )
@@ -83,13 +82,35 @@ class MemorySpaceCacheConfig(DataRobotAppFrameworkBaseSettings):
     )
 
 
-def resolve_memory_space_id(explicit: str | None = None) -> str:
-    """Return the MemorySpace ID for cache backends."""
+def try_resolve_memory_space_id(explicit: str | None = None) -> str | None:
+    """Return the MemorySpace ID for cache backends, or ``None`` when unset."""
     cfg = MemorySpaceCacheConfig()
     space_id = explicit or cfg.agent_card_registry_memory_space_id or cfg.agent_memory_space_id
     if not space_id or not space_id.strip():
-        raise ValueError(_MEMORY_SPACE_REQUIRED_MSG)
+        return None
     return space_id.strip()
+
+
+def resolve_memory_space_id(explicit: str | None = None) -> str:
+    """Return the MemorySpace ID for cache backends."""
+    space_id = try_resolve_memory_space_id(explicit)
+    if space_id is None:
+        raise ValueError(_MEMORY_SPACE_REQUIRED_MSG)
+    return space_id
+
+
+def try_configure_datarobot_memory_client(
+    *,
+    endpoint: str | None = None,
+    api_token: str | None = None,
+) -> bool:
+    """Configure the DataRobot client for memory Session API calls when possible."""
+    try:
+        configure_datarobot_memory_client(endpoint=endpoint, api_token=api_token)
+    except Exception as exc:
+        logger.debug("MemorySpace client unavailable: %s", exc)
+        return False
+    return True
 
 
 def configure_datarobot_memory_client(

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -51,7 +51,7 @@ CacheKind = Literal["agent_card", "xaa_token"]
 
 _MEMORY_SPACE_REQUIRED_MSG = (
     "Memory space cache backends require a provisioned DataRobot MemorySpace ID. "
-    "Set AGENT_CARD_REGISTRY_MEMORY_SPACE_ID or AGENT_MEMORY_SPACE_ID."
+    "Set AGENT_CARD_REGISTRY_MEMORY_SPACE_ID."
 )
 
 
@@ -60,15 +60,7 @@ class MemorySpaceCacheConfig(DataRobotAppFrameworkBaseSettings):
 
     agent_card_registry_memory_space_id: str | None = Field(
         default=None,
-        description=(
-            "DataRobot MemorySpace ID for the agent card registry L2 cache. "
-            "Defaults to AGENT_MEMORY_SPACE_ID."
-        ),
-    )
-
-    agent_memory_space_id: str | None = Field(
-        default=None,
-        description="Platform-injected MemorySpace ID (AGENT_MEMORY_SPACE_ID).",
+        description="DataRobot MemorySpace ID for the agent card registry L2 cache.",
     )
 
     datarobot_endpoint: str | None = Field(
@@ -83,9 +75,9 @@ class MemorySpaceCacheConfig(DataRobotAppFrameworkBaseSettings):
 
 
 def try_resolve_memory_space_id(explicit: str | None = None) -> str | None:
-    """Return the MemorySpace ID for cache backends, or ``None`` when unset."""
+    """Return the agent card registry MemorySpace ID, or ``None`` when unset."""
     cfg = MemorySpaceCacheConfig()
-    space_id = explicit or cfg.agent_card_registry_memory_space_id or cfg.agent_memory_space_id
+    space_id = explicit or cfg.agent_card_registry_memory_space_id
     if not space_id or not space_id.strip():
         return None
     return space_id.strip()

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -1,0 +1,250 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DataRobot MemorySpace-backed KV cache for dragent shared caches.
+
+Uses the agentic memory **Session API** (``datarobot.models.memory.Session``) — the same
+surface the agent-application recipe uses for chat history when
+``USE_APPLICATION_MEMORY_SPACE`` is enabled — not the mem0-compatible sub-route.
+
+Each provisioned memory space has a unique ``memory_space_id`` and platform-level
+access control scoped to the deploying user or workload API token. Unlike shared
+Redis, no per-deployment namespace or HMAC signing is required for this backend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from typing import Any
+from typing import Literal
+
+import datarobot as dr
+from datarobot.core.config import DataRobotAppFrameworkBaseSettings
+from datarobot.errors import MemorySessionDeduplicationError
+from datarobot.models.memory import Session
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+# Stable 24-hex participant id (BSON ObjectId length) for cache sessions.
+DRAGENT_CACHE_PARTICIPANT_ID = hashlib.sha256(b"datarobot-genai:dragent-cache").hexdigest()[:24]
+
+CACHE_METADATA_VERSION = 1
+CACHE_EVENT_TYPE = "status"
+DEDUPLICATION_KEY_LENGTH = 64
+
+CacheKind = Literal["agent_card", "xaa_token"]
+
+_MEMORY_SPACE_REQUIRED_MSG = (
+    "Memory space cache backends require a provisioned DataRobot MemorySpace ID. "
+    "Set AGENT_CARD_REGISTRY_MEMORY_SPACE_ID or AGENT_MEMORY_SPACE_ID."
+)
+
+
+class MemorySpaceCacheConfig(DataRobotAppFrameworkBaseSettings):
+    """Connection settings for DataRobot MemorySpace cache backends."""
+
+    agent_card_registry_memory_space_id: str | None = Field(
+        default=None,
+        description=(
+            "DataRobot MemorySpace ID for dragent L2 caches when "
+            "AGENT_CARD_REGISTRY_BACKEND=memory_space. "
+            "Defaults to AGENT_MEMORY_SPACE_ID."
+        ),
+    )
+
+    agent_memory_space_id: str | None = Field(
+        default=None,
+        description="Platform-injected MemorySpace ID (AGENT_MEMORY_SPACE_ID).",
+    )
+
+    datarobot_endpoint: str | None = Field(
+        default=None,
+        description="DataRobot API base URL (DATAROBOT_ENDPOINT).",
+    )
+
+    datarobot_api_token: str | None = Field(
+        default=None,
+        description="DataRobot API token (DATAROBOT_API_TOKEN).",
+    )
+
+
+def resolve_memory_space_id(explicit: str | None = None) -> str:
+    """Return the MemorySpace ID for cache backends."""
+    cfg = MemorySpaceCacheConfig()
+    space_id = explicit or cfg.agent_card_registry_memory_space_id or cfg.agent_memory_space_id
+    if not space_id or not space_id.strip():
+        raise ValueError(_MEMORY_SPACE_REQUIRED_MSG)
+    return space_id.strip()
+
+
+def configure_datarobot_memory_client(
+    *,
+    endpoint: str | None = None,
+    api_token: str | None = None,
+) -> None:
+    """Configure the process-global DataRobot client for memory Session API calls."""
+    cfg = MemorySpaceCacheConfig()
+    token = api_token or cfg.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
+    base = endpoint or cfg.datarobot_endpoint or os.getenv("DATAROBOT_ENDPOINT")
+    if not token:
+        raise ValueError("DATAROBOT_API_TOKEN is required when using memory_space cache backends.")
+    if not base:
+        raise ValueError("DATAROBOT_ENDPOINT is required when using memory_space cache backends.")
+    dr.Client(token=token, endpoint=base)
+
+
+def _cache_deduplication_key(logical_key: str) -> str:
+    raw = "dragent-cache\0" + logical_key
+    return hashlib.sha256(raw.encode()).hexdigest()[:DEDUPLICATION_KEY_LENGTH]
+
+
+def _cache_session_description(logical_key: str) -> str:
+    return f"/dragent/cache/{logical_key}"
+
+
+def _cache_session_metadata(logical_key: str, *, kind: CacheKind) -> dict[str, Any]:
+    return {
+        "v": CACHE_METADATA_VERSION,
+        "dragent_cache": True,
+        "cache_key": logical_key,
+        "cache_kind": kind,
+    }
+
+
+def _payload_event_body(payload: str) -> dict[str, Any]:
+    return {"v": CACHE_METADATA_VERSION, "payload": payload}
+
+
+def _payload_from_event_body(body: dict[str, Any] | None) -> str | None:
+    if not body or body.get("v") != CACHE_METADATA_VERSION:
+        return None
+    value = body.get("payload")
+    return str(value) if value is not None else None
+
+
+def _create_cache_session(
+    memory_space_id: str,
+    *,
+    logical_key: str,
+    kind: CacheKind,
+) -> Session:
+    """Create a cache session, adopting an existing one on deduplication collision."""
+    try:
+        return Session.create(
+            memory_space_id,
+            [DRAGENT_CACHE_PARTICIPANT_ID],
+            metadata=_cache_session_metadata(logical_key, kind=kind),
+            description=_cache_session_description(logical_key),
+            deduplication_key=_cache_deduplication_key(logical_key),
+        )
+    except MemorySessionDeduplicationError as exc:
+        if exc.existing_session_id is None:
+            raise
+        return Session.get(memory_space_id, exc.existing_session_id)
+
+
+def _find_cache_session(memory_space_id: str, logical_key: str) -> Session | None:
+    description = _cache_session_description(logical_key)
+    sessions = Session.list(
+        memory_space_id,
+        participants=[DRAGENT_CACHE_PARTICIPANT_ID],
+        description=description,
+        limit=1,
+    )
+    return sessions[0] if sessions else None
+
+
+def _read_payload(session: Session) -> str | None:
+    events = session.events(last_n=1)
+    if not events:
+        return None
+    return _payload_from_event_body(events[0].body)
+
+
+def _write_payload(session: Session, payload: str) -> None:
+    body = _payload_event_body(payload)
+    events = session.events(last_n=1)
+    if events and events[0].sequence_id is not None:
+        session.update_event(events[0].sequence_id, body=body)
+        return
+    session.post_event(
+        body=body,
+        emitter={"type": "agent"},
+        event_type=CACHE_EVENT_TYPE,
+    )
+
+
+class MemorySpaceKVCache:
+    """Store opaque JSON payloads in a DataRobot MemorySpace by logical key."""
+
+    def __init__(self, *, memory_space_id: str, key_prefix: str = "dragent:") -> None:
+        self._memory_space_id = memory_space_id
+        normalized = key_prefix if key_prefix.endswith(":") else f"{key_prefix}:"
+        self._key_prefix = normalized
+
+    def _logical_key(self, key: str, *, kind: CacheKind) -> str:
+        return f"{self._key_prefix}{kind}:{key}"
+
+    async def get_value(self, key: str, *, kind: CacheKind) -> str | None:
+        """Return the stored JSON payload for *key*, or ``None`` when missing."""
+        logical_key = self._logical_key(key, kind=kind)
+
+        def _get() -> str | None:
+            session = _find_cache_session(self._memory_space_id, logical_key)
+            if session is None:
+                return None
+            return _read_payload(session)
+
+        try:
+            return await asyncio.to_thread(_get)
+        except Exception:
+            logger.exception("MemorySpace cache read failed for %s", logical_key)
+            return None
+
+    async def set_value(self, key: str, payload: str, *, kind: CacheKind) -> None:
+        """Upsert a JSON payload for *key*."""
+        logical_key = self._logical_key(key, kind=kind)
+
+        def _set() -> None:
+            session = _find_cache_session(self._memory_space_id, logical_key)
+            if session is None:
+                session = _create_cache_session(
+                    self._memory_space_id,
+                    logical_key=logical_key,
+                    kind=kind,
+                )
+            _write_payload(session, payload)
+
+        try:
+            await asyncio.to_thread(_set)
+        except Exception:
+            logger.exception("MemorySpace cache write failed for %s", logical_key)
+
+    async def delete_value(self, key: str, *, kind: CacheKind) -> None:
+        """Remove a cached payload for *key* when present."""
+        logical_key = self._logical_key(key, kind=kind)
+
+        def _delete() -> None:
+            session = _find_cache_session(self._memory_space_id, logical_key)
+            if session is not None:
+                session.delete()
+
+        try:
+            await asyncio.to_thread(_delete)
+        except Exception:
+            logger.exception("MemorySpace cache delete failed for %s", logical_key)

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -123,24 +123,16 @@ class TestAgentCardRegistryConfig:
         config = AgentCardRegistryConfig(agent_card_registry_on_duplicate="last")
         assert config.agent_card_registry_on_duplicate == "last"
 
-    def test_backend_default_memory(self):
-        config = AgentCardRegistryConfig()
-        assert config.agent_card_registry_backend == "memory"
-
     def test_max_staleness_derived_from_cache_ttl(self):
         registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=1800)
         assert registry._max_staleness_seconds == 1800
 
-    def test_memory_space_backend_from_env(self):
+    def test_memory_space_id_from_env(self):
         with patch.dict(
             "os.environ",
-            {
-                "AGENT_CARD_REGISTRY_BACKEND": "memory_space",
-                "AGENT_CARD_REGISTRY_MEMORY_SPACE_ID": "space-123",
-            },
+            {"AGENT_CARD_REGISTRY_MEMORY_SPACE_ID": "space-123"},
         ):
             config = AgentCardRegistryConfig()
-            assert config.agent_card_registry_backend == "memory_space"
             assert config.agent_card_registry_memory_space_id == "space-123"
 
 

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -123,22 +123,13 @@ class TestAgentCardRegistryConfig:
         config = AgentCardRegistryConfig(agent_card_registry_on_duplicate="last")
         assert config.agent_card_registry_on_duplicate == "last"
 
-    def test_stale_if_error_default(self):
-        config = AgentCardRegistryConfig()
-        assert config.agent_card_registry_stale_if_error is True
-
-    def test_max_staleness_default(self):
-        config = AgentCardRegistryConfig()
-        assert config.agent_card_registry_max_staleness_seconds == 24 * 3600
-
-    def test_stale_if_error_from_env(self):
-        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_STALE_IF_ERROR": "false"}):
-            config = AgentCardRegistryConfig()
-            assert config.agent_card_registry_stale_if_error is False
-
     def test_backend_default_memory(self):
         config = AgentCardRegistryConfig()
         assert config.agent_card_registry_backend == "memory"
+
+    def test_max_staleness_derived_from_cache_ttl(self):
+        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=1800)
+        assert registry._max_staleness_seconds == 1800
 
     def test_memory_space_backend_from_env(self):
         with patch.dict(
@@ -453,40 +444,18 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=3600,
-            stale_if_error=True,
+            max_staleness_seconds=120,
             cache_backend=cache_backend,
         )
 
         card1 = await registry.get(deployment_id="dep-1")
-        registry._age_cache_entry_for_test("dep-1", 120)
+        registry._age_cache_entry_for_test("dep-1", 90)
 
         card2 = await registry.get(deployment_id="dep-1")
 
         assert card1 is stale_card
         assert card2 is stale_card
         assert mock_fetch.await_count == 2
-
-    async def test_raises_when_stale_if_error_disabled(self, mock_fetch, cache_backend):
-        stale_card = _card()
-        mock_fetch.side_effect = [
-            _parsed({"dep-1": stale_card}),
-            AgentCardRegistryError("registry down"),
-        ]
-        registry = _memory_registry(
-            api_token="tok",
-            endpoint="https://ep",
-            cache_ttl=60,
-            max_staleness_seconds=3600,
-            stale_if_error=False,
-            cache_backend=cache_backend,
-        )
-
-        await registry.get(deployment_id="dep-1")
-        registry._age_cache_entry_for_test("dep-1", 120)
-
-        with pytest.raises(AgentCardRegistryError, match="registry down"):
-            await registry.get(deployment_id="dep-1")
 
     async def test_raises_when_beyond_max_staleness(self, mock_fetch, cache_backend):
         stale_card = _card()
@@ -499,7 +468,6 @@ class TestAgentCardRegistryStaleIfError:
             endpoint="https://ep",
             cache_ttl=60,
             max_staleness_seconds=30,
-            stale_if_error=True,
             cache_backend=cache_backend,
         )
 
@@ -526,12 +494,11 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=3600,
-            stale_if_error=True,
+            max_staleness_seconds=120,
             cache_backend=cache_backend,
         )
         await registry.get(deployment_id="dep-1")
-        registry._age_cache_entry_for_test("dep-1", 120)
+        registry._age_cache_entry_for_test("dep-1", 90)
 
         registry.register(deployment_id="dep-2")
         card = await registry.get(deployment_id="dep-1")
@@ -556,7 +523,7 @@ class TestAgentCardRegistryStaleIfError:
         with pytest.raises(AgentCardRegistryError, match="No agent card found"):
             await registry.get(deployment_id="dep-1")
 
-        assert await cache_backend.get_stale("dep-1", max_staleness_seconds=3600) is None
+        assert await cache_backend.get_stale("dep-1", max_staleness_seconds=60) is None
 
     async def test_deregistered_not_resurrected_by_stale_if_error(self, mock_fetch, cache_backend):
         stale_card = _card()
@@ -570,11 +537,10 @@ class TestAgentCardRegistryStaleIfError:
             endpoint="https://ep",
             cache_ttl=60,
             max_staleness_seconds=3600,
-            stale_if_error=True,
             cache_backend=cache_backend,
         )
         await registry.get(deployment_id="dep-1")
-        registry._age_cache_entry_for_test("dep-1", 120)
+        registry._age_cache_entry_for_test("dep-1", 60)
 
         with pytest.raises(AgentCardRegistryError, match="No agent card found"):
             await registry.get(deployment_id="dep-1")

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -82,7 +82,7 @@ def _card(**overrides) -> AgentCard:
 
 def _parsed(cards: dict, *, key_types: dict | None = None) -> ParsedRegistryCards:
     if key_types is None:
-        key_types = {key: "dep" for key in cards}
+        key_types = {key: "deployment" for key in cards}
     return ParsedRegistryCards(cards=cards, key_types=key_types)
 
 
@@ -226,8 +226,8 @@ class TestParseRegistryResponse:
         assert "dep-1" in parsed.cards
         assert "ext-1" in parsed.cards
         assert parsed.cards["dep-1"] is parsed.cards["ext-1"]
-        assert parsed.key_types["dep-1"] == "dep"
-        assert parsed.key_types["ext-1"] == "ext"
+        assert parsed.key_types["dep-1"] == "deployment"
+        assert parsed.key_types["ext-1"] == "external"
 
     def test_skips_entries_without_agent_card(self):
         body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": None})
@@ -352,7 +352,7 @@ class TestAgentCardRegistry:
         expected = _card()
         mock_fetch.return_value = _parsed(
             {"ext-1": expected},
-            key_types={"ext-1": "ext"},
+            key_types={"ext-1": "external"},
         )
         registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         card = await registry.get(external_id="ext-1")
@@ -556,7 +556,7 @@ class TestAgentCardRegistryRegisterFlush:
         """Registered IDs are batch-fetched on first get()."""
         mock_fetch.side_effect = [
             _parsed({"dep-1": _card(), "dep-2": _card(name="Second Agent")}),
-            _parsed({"ext-1": _card(name="Third Agent")}, key_types={"ext-1": "ext"}),
+            _parsed({"ext-1": _card(name="Third Agent")}, key_types={"ext-1": "external"}),
         ]
         registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         registry.register(deployment_id="dep-1")
@@ -630,7 +630,7 @@ class TestAgentCardRegistryPrefetch:
     async def test_prefetch_mixed_issues_separate_calls(self, mock_fetch):
         mock_fetch.side_effect = [
             _parsed({"dep-1": _card()}),
-            _parsed({"ext-1": _card(name="Second Agent")}, key_types={"ext-1": "ext"}),
+            _parsed({"ext-1": _card(name="Second Agent")}, key_types={"ext-1": "external"}),
         ]
         registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         await registry.prefetch(deployment_ids=["dep-1"], external_ids=["ext-1"])

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -130,10 +130,6 @@ class TestAgentCardRegistryConfig:
         config = AgentCardRegistryConfig(agent_card_registry_on_duplicate="last")
         assert config.agent_card_registry_on_duplicate == "last"
 
-    def test_max_staleness_derived_from_cache_ttl(self):
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=1800)
-        assert registry._max_staleness_seconds == 1800
-
     def test_memory_space_id_from_env(self):
         with patch.dict(
             "os.environ",
@@ -445,20 +441,22 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=120,
             cache_backend=cache_backend,
         )
 
         card1 = await registry.get(deployment_id="dep-1")
-        registry._age_cache_entry_for_test("dep-1", 90)
-
-        card2 = await registry.get(deployment_id="dep-1")
+        fixed_now = datetime.now(UTC)
+        cache_backend._entries["dep-1"].fetched_at = fixed_now - timedelta(seconds=60)
+        with patch("datarobot_genai.dragent.agent_card_registry_backends.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.UTC = UTC
+            card2 = await registry.get(deployment_id="dep-1")
 
         assert card1 is stale_card
         assert card2 is stale_card
         assert mock_fetch.await_count == 2
 
-    async def test_raises_when_beyond_max_staleness(self, mock_fetch, cache_backend):
+    async def test_raises_when_beyond_cache_ttl(self, mock_fetch, cache_backend):
         stale_card = _card()
         mock_fetch.side_effect = [
             _parsed({"dep-1": stale_card}),
@@ -468,7 +466,6 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=30,
             cache_backend=cache_backend,
         )
 
@@ -495,14 +492,17 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=120,
             cache_backend=cache_backend,
         )
         await registry.get(deployment_id="dep-1")
-        registry._age_cache_entry_for_test("dep-1", 90)
+        fixed_now = datetime.now(UTC)
+        cache_backend._entries["dep-1"].fetched_at = fixed_now - timedelta(seconds=60)
 
         registry.register(deployment_id="dep-2")
-        card = await registry.get(deployment_id="dep-1")
+        with patch("datarobot_genai.dragent.agent_card_registry_backends.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.UTC = UTC
+            card = await registry.get(deployment_id="dep-1")
 
         assert card is stale_card
 
@@ -537,7 +537,6 @@ class TestAgentCardRegistryStaleIfError:
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
-            max_staleness_seconds=3600,
             cache_backend=cache_backend,
         )
         await registry.get(deployment_id="dep-1")

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -80,10 +80,17 @@ def _card(**overrides) -> AgentCard:
     return AgentCard.model_validate({**_SAMPLE_AGENT_CARD, **overrides})
 
 
-def _parsed(cards: dict, *, key_types: dict | None = None) -> ParsedRegistryCards:
+def _parsed(
+    cards: dict,
+    *,
+    key_types: dict | None = None,
+    registry_ids: dict | None = None,
+) -> ParsedRegistryCards:
     if key_types is None:
         key_types = {key: "deployment" for key in cards}
-    return ParsedRegistryCards(cards=cards, key_types=key_types)
+    if registry_ids is None:
+        registry_ids = {}
+    return ParsedRegistryCards(cards=cards, key_types=key_types, registry_ids=registry_ids)
 
 
 def _memory_registry(**kwargs) -> AgentCardRegistry:
@@ -228,6 +235,8 @@ class TestParseRegistryResponse:
         assert parsed.cards["dep-1"] is parsed.cards["ext-1"]
         assert parsed.key_types["dep-1"] == "deployment"
         assert parsed.key_types["ext-1"] == "external"
+        assert parsed.registry_ids["dep-1"] == ("dep-1", "ext-1")
+        assert parsed.registry_ids["ext-1"] == ("dep-1", "ext-1")
 
     def test_skips_entries_without_agent_card(self):
         body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": None})
@@ -539,6 +548,33 @@ class TestAgentCardRegistryStaleIfError:
 
         with pytest.raises(AgentCardRegistryError, match="registry down"):
             await registry.get(deployment_id="dep-1")
+
+    async def test_deregistered_sibling_id_evicted_from_cache(self, mock_fetch, cache_backend):
+        """Evicting on a deployment miss must drop the external-ID alias too."""
+        stale_card = _card()
+        id_pair = ("dep-1", "ext-1")
+        mock_fetch.side_effect = [
+            _parsed(
+                {"dep-1": stale_card, "ext-1": stale_card},
+                key_types={"dep-1": "deployment", "ext-1": "external"},
+                registry_ids={"dep-1": id_pair, "ext-1": id_pair},
+            ),
+            _parsed({}),
+        ]
+        registry = _memory_registry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            cache_backend=cache_backend,
+        )
+        await registry.get(deployment_id="dep-1")
+        registry._age_cache_entry_for_test("dep-1", 60)
+
+        with pytest.raises(AgentCardRegistryError, match="No agent card found"):
+            await registry.get(deployment_id="dep-1")
+
+        assert await cache_backend.get_stale("dep-1", max_staleness_seconds=3600) is None
+        assert await cache_backend.get_stale("ext-1", max_staleness_seconds=3600) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -12,24 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import httpx
 import pytest
+from a2a.types import AgentCard
 
 from datarobot_genai.dragent.agent_card_registry import _MAX_PAGES
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
 from datarobot_genai.dragent.agent_card_registry import DataRobotRegistrySettings
-from datarobot_genai.dragent.agent_card_registry import _CacheEntry
+from datarobot_genai.dragent.agent_card_registry import ParsedRegistryCards
 from datarobot_genai.dragent.agent_card_registry import _parse_registry_response
 from datarobot_genai.dragent.agent_card_registry import _resolve_settings
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
 from datarobot_genai.dragent.agent_card_registry import get_default_registry_sync
 from datarobot_genai.dragent.agent_card_registry import reset_default_registry
+from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheRecord
+from datarobot_genai.dragent.agent_card_registry_backends import MemoryAgentCardCacheBackend
 
 _MODULE = "datarobot_genai.dragent.agent_card_registry"
 
@@ -70,6 +76,21 @@ def _entry(dep_id=None, ext_id=None, card=_SAMPLE_AGENT_CARD):
     }
 
 
+def _card(**overrides) -> AgentCard:
+    return AgentCard.model_validate({**_SAMPLE_AGENT_CARD, **overrides})
+
+
+def _parsed(cards: dict, *, key_types: dict | None = None) -> ParsedRegistryCards:
+    if key_types is None:
+        key_types = {key: "dep" for key in cards}
+    return ParsedRegistryCards(cards=cards, key_types=key_types)
+
+
+def _memory_registry(**kwargs) -> AgentCardRegistry:
+    kwargs.setdefault("cache_backend", MemoryAgentCardCacheBackend())
+    return AgentCardRegistry(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Tests: AgentCardRegistryConfig
 # ---------------------------------------------------------------------------
@@ -102,28 +123,64 @@ class TestAgentCardRegistryConfig:
         config = AgentCardRegistryConfig(agent_card_registry_on_duplicate="last")
         assert config.agent_card_registry_on_duplicate == "last"
 
+    def test_stale_if_error_default(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_stale_if_error is True
+
+    def test_max_staleness_default(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_max_staleness_seconds == 24 * 3600
+
+    def test_stale_if_error_from_env(self):
+        with patch.dict("os.environ", {"AGENT_CARD_REGISTRY_STALE_IF_ERROR": "false"}):
+            config = AgentCardRegistryConfig()
+            assert config.agent_card_registry_stale_if_error is False
+
+    def test_backend_default_memory(self):
+        config = AgentCardRegistryConfig()
+        assert config.agent_card_registry_backend == "memory"
+
+    def test_memory_space_backend_from_env(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "AGENT_CARD_REGISTRY_BACKEND": "memory_space",
+                "AGENT_CARD_REGISTRY_MEMORY_SPACE_ID": "space-123",
+            },
+        ):
+            config = AgentCardRegistryConfig()
+            assert config.agent_card_registry_backend == "memory_space"
+            assert config.agent_card_registry_memory_space_id == "space-123"
+
 
 # ---------------------------------------------------------------------------
-# Tests: _CacheEntry
+# Tests: AgentCardCacheRecord
 # ---------------------------------------------------------------------------
 
 
-class TestCacheEntry:
+class TestAgentCardCacheRecord:
     def test_not_expired_within_ttl(self):
-        entry = _CacheEntry(MagicMock())
+        entry = AgentCardCacheRecord(card=_card())
         assert entry.is_fresh(3600)
-        assert not entry.is_expired(3600)
 
-    def test_expired_with_zero_ttl(self):
-        entry = _CacheEntry(MagicMock())
+    def test_not_fresh_with_zero_ttl(self):
+        entry = AgentCardCacheRecord(card=_card())
         assert not entry.is_fresh(0)
-        assert entry.is_expired(0)
 
-    def test_expired_after_ttl(self):
-        entry = _CacheEntry(MagicMock())
-        entry.fetched_at -= 100  # Simulate 100s ago
+    def test_not_fresh_after_ttl(self):
+        entry = AgentCardCacheRecord(card=_card())
+        entry.fetched_at = datetime.now(UTC) - timedelta(seconds=100)
         assert not entry.is_fresh(50)
-        assert entry.is_expired(50)
+
+    def test_within_staleness(self):
+        entry = AgentCardCacheRecord(card=_card())
+        entry.fetched_at = datetime.now(UTC) - timedelta(seconds=100)
+        assert entry.is_within_staleness(3600)
+        assert not entry.is_within_staleness(50)
+
+    def test_zero_max_staleness_never_servable(self):
+        entry = AgentCardCacheRecord(card=_card())
+        assert not entry.is_within_staleness(0)
 
 
 # ---------------------------------------------------------------------------
@@ -182,19 +239,21 @@ class TestResolveSettings:
 class TestParseRegistryResponse:
     def test_indexes_by_both_ids(self):
         body = _registry_response(_entry(dep_id="dep-1", ext_id="ext-1"))
-        cards = _parse_registry_response(body)
-        assert "dep-1" in cards
-        assert "ext-1" in cards
-        assert cards["dep-1"] is cards["ext-1"]
+        parsed = _parse_registry_response(body)
+        assert "dep-1" in parsed.cards
+        assert "ext-1" in parsed.cards
+        assert parsed.cards["dep-1"] is parsed.cards["ext-1"]
+        assert parsed.key_types["dep-1"] == "dep"
+        assert parsed.key_types["ext-1"] == "ext"
 
     def test_skips_entries_without_agent_card(self):
         body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": None})
-        assert _parse_registry_response(body) == {}
+        assert _parse_registry_response(body).cards == {}
 
     def test_skips_entries_with_invalid_card(self):
         body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": {"bad": True}})
-        cards = _parse_registry_response(body)
-        assert cards == {}
+        parsed = _parse_registry_response(body)
+        assert parsed.cards == {}
 
 
 class TestParseRegistryResponseDuplicates:
@@ -207,15 +266,15 @@ class TestParseRegistryResponseDuplicates:
         )
 
     def test_first_keeps_first_card(self):
-        cards = _parse_registry_response(self._body_with_duplicate_ext(), on_duplicate="first")
-        assert cards["shared-ext"].name == "Test Agent"
+        parsed = _parse_registry_response(self._body_with_duplicate_ext(), on_duplicate="first")
+        assert parsed.cards["shared-ext"].name == "Test Agent"
         # Both deployment IDs are still indexed independently
-        assert "dep-1" in cards
-        assert "dep-2" in cards
+        assert "dep-1" in parsed.cards
+        assert "dep-2" in parsed.cards
 
     def test_last_keeps_last_card(self):
-        cards = _parse_registry_response(self._body_with_duplicate_ext(), on_duplicate="last")
-        assert cards["shared-ext"].name == "Second Agent"
+        parsed = _parse_registry_response(self._body_with_duplicate_ext(), on_duplicate="last")
+        assert parsed.cards["shared-ext"].name == "Second Agent"
 
     def test_error_raises_on_duplicate(self):
         with pytest.raises(AgentCardRegistryError, match="Multiple agent cards found"):
@@ -227,13 +286,13 @@ class TestParseRegistryResponseDuplicates:
             _entry(dep_id="dep-1", ext_id="ext-1"),
             _entry(dep_id="dep-2", ext_id="ext-2"),
         )
-        cards = _parse_registry_response(body, on_duplicate="error")
-        assert "ext-1" in cards
-        assert "ext-2" in cards
+        parsed = _parse_registry_response(body, on_duplicate="error")
+        assert "ext-1" in parsed.cards
+        assert "ext-2" in parsed.cards
 
     def test_default_strategy_is_first(self):
-        cards = _parse_registry_response(self._body_with_duplicate_ext())
-        assert cards["shared-ext"].name == "Test Agent"
+        parsed = _parse_registry_response(self._body_with_duplicate_ext())
+        assert parsed.cards["shared-ext"].name == "Test Agent"
 
 
 _SAMPLE_AGENT_CARD_3 = {
@@ -265,20 +324,20 @@ class TestParseRegistryResponseMultiIdBatch:
         )
 
     def test_first_picks_first_of_three(self):
-        cards = _parse_registry_response(self._batch_response(), on_duplicate="first")
+        parsed = _parse_registry_response(self._batch_response(), on_duplicate="first")
         # agent-A → first card (Test Agent)
-        assert cards["agent-A"].name == "Test Agent"
+        assert parsed.cards["agent-A"].name == "Test Agent"
         # agent-B has no duplicates → stored as-is
-        assert cards["agent-B"].name == "Second Agent"
+        assert parsed.cards["agent-B"].name == "Second Agent"
         # All deployment IDs are independently indexed
-        assert len({cards[k].name for k in ["dep-a1", "dep-a2", "dep-a3", "dep-b1"]}) == 3
+        assert len({parsed.cards[k].name for k in ["dep-a1", "dep-a2", "dep-a3", "dep-b1"]}) == 3
 
     def test_last_picks_last_of_three(self):
-        cards = _parse_registry_response(self._batch_response(), on_duplicate="last")
+        parsed = _parse_registry_response(self._batch_response(), on_duplicate="last")
         # agent-A → last card (Third Agent)
-        assert cards["agent-A"].name == "Third Agent"
+        assert parsed.cards["agent-A"].name == "Third Agent"
         # agent-B unaffected
-        assert cards["agent-B"].name == "Second Agent"
+        assert parsed.cards["agent-B"].name == "Second Agent"
 
     def test_error_raises_for_duplicate_id_only(self):
         """Error is raised for agent-A (3 cards) — agent-B (1 card) never reached."""
@@ -299,38 +358,44 @@ class TestAgentCardRegistry:
             yield m
 
     async def test_get_single_deployment_id(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        expected = _card()
+        mock_fetch.return_value = _parsed({"dep-1": expected})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         card = await registry.get(deployment_id="dep-1")
-        assert card is mock_fetch.return_value["dep-1"]
+        assert card is expected
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1"})
 
     async def test_get_single_external_id(self, mock_fetch):
-        mock_fetch.return_value = {"ext-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        expected = _card()
+        mock_fetch.return_value = _parsed(
+            {"ext-1": expected},
+            key_types={"ext-1": "ext"},
+        )
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         card = await registry.get(external_id="ext-1")
-        assert card is mock_fetch.return_value["ext-1"]
+        assert card is expected
         mock_fetch.assert_awaited_once_with({"externalIds": "ext-1"})
 
     async def test_get_raises_when_both_ids(self):
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         with pytest.raises(AgentCardRegistryError, match="exactly one"):
             await registry.get(deployment_id="d", external_id="e")
 
     async def test_get_raises_when_neither_id(self):
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         with pytest.raises(AgentCardRegistryError, match="exactly one"):
             await registry.get()
 
     async def test_get_raises_when_not_found(self, mock_fetch):
-        mock_fetch.return_value = {}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        mock_fetch.return_value = _parsed({})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         with pytest.raises(AgentCardRegistryError, match="No agent card found"):
             await registry.get(deployment_id="missing")
 
     async def test_get_uses_cache(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        card = _card()
+        mock_fetch.return_value = _parsed({"dep-1": card})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
 
         card1 = await registry.get(deployment_id="dep-1")
         card2 = await registry.get(deployment_id="dep-1")
@@ -340,9 +405,9 @@ class TestAgentCardRegistry:
 
     async def test_cache_ttl_zero_always_refetches(self, mock_fetch):
         """cache_ttl=0 means every get() triggers a fresh fetch."""
-        card_mock = MagicMock(name="card1")
-        mock_fetch.return_value = {"dep-1": card_mock}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=0)
+        card_mock = _card()
+        mock_fetch.return_value = _parsed({"dep-1": card_mock})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=0)
 
         await registry.get(deployment_id="dep-1")
         await registry.get(deployment_id="dep-1")
@@ -350,14 +415,15 @@ class TestAgentCardRegistry:
         assert mock_fetch.await_count == 2
 
     async def test_expired_cache_triggers_refetch(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
+        card = _card()
+        mock_fetch.return_value = _parsed({"dep-1": card})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=60)
 
         await registry.get(deployment_id="dep-1")
-        # Simulate expiry
-        registry._cache["dep-1"].fetched_at -= 120
+        registry._age_cache_entry_for_test("dep-1", 120)
 
-        mock_fetch.return_value = {"dep-1": MagicMock(name="card1-refreshed")}
+        refreshed = _card(name="Refreshed Agent")
+        mock_fetch.return_value = _parsed({"dep-1": refreshed})
         await registry.get(deployment_id="dep-1")
         assert mock_fetch.await_count == 2
 
@@ -373,20 +439,27 @@ class TestAgentCardRegistryStaleIfError:
         with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
             yield m
 
-    async def test_serves_stale_when_refresh_fails(self, mock_fetch):
-        stale_card = MagicMock(name="stale-card")
+    @pytest.fixture
+    def cache_backend(self):
+        return MemoryAgentCardCacheBackend()
+
+    async def test_serves_stale_when_refresh_fails(self, mock_fetch, cache_backend):
+        stale_card = _card()
         mock_fetch.side_effect = [
-            {"dep-1": stale_card},
+            _parsed({"dep-1": stale_card}),
             AgentCardRegistryError("registry down"),
         ]
-        registry = AgentCardRegistry(
+        registry = _memory_registry(
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
+            max_staleness_seconds=3600,
+            stale_if_error=True,
+            cache_backend=cache_backend,
         )
 
         card1 = await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120  # past soft TTL
+        registry._age_cache_entry_for_test("dep-1", 120)
 
         card2 = await registry.get(deployment_id="dep-1")
 
@@ -394,65 +467,114 @@ class TestAgentCardRegistryStaleIfError:
         assert card2 is stale_card
         assert mock_fetch.await_count == 2
 
-    async def test_raises_when_no_cached_card(self, mock_fetch):
-        mock_fetch.side_effect = AgentCardRegistryError("registry down")
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
+    async def test_raises_when_stale_if_error_disabled(self, mock_fetch, cache_backend):
+        stale_card = _card()
+        mock_fetch.side_effect = [
+            _parsed({"dep-1": stale_card}),
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = _memory_registry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            max_staleness_seconds=3600,
+            stale_if_error=False,
+            cache_backend=cache_backend,
+        )
+
+        await registry.get(deployment_id="dep-1")
+        registry._age_cache_entry_for_test("dep-1", 120)
 
         with pytest.raises(AgentCardRegistryError, match="registry down"):
             await registry.get(deployment_id="dep-1")
 
-    async def test_stale_if_error_on_flush_pending_failure(self, mock_fetch):
-        stale_card = MagicMock(name="stale-card")
+    async def test_raises_when_beyond_max_staleness(self, mock_fetch, cache_backend):
+        stale_card = _card()
         mock_fetch.side_effect = [
-            {"dep-1": stale_card},
+            _parsed({"dep-1": stale_card}),
             AgentCardRegistryError("registry down"),
         ]
-        registry = AgentCardRegistry(
+        registry = _memory_registry(
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
+            max_staleness_seconds=30,
+            stale_if_error=True,
+            cache_backend=cache_backend,
+        )
+
+        await registry.get(deployment_id="dep-1")
+        registry._age_cache_entry_for_test("dep-1", 120)
+
+        with pytest.raises(AgentCardRegistryError, match="registry down"):
+            await registry.get(deployment_id="dep-1")
+
+    async def test_raises_when_no_cached_card(self, mock_fetch):
+        mock_fetch.side_effect = AgentCardRegistryError("registry down")
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=60)
+
+        with pytest.raises(AgentCardRegistryError, match="registry down"):
+            await registry.get(deployment_id="dep-1")
+
+    async def test_stale_if_error_on_flush_pending_failure(self, mock_fetch, cache_backend):
+        stale_card = _card()
+        mock_fetch.side_effect = [
+            _parsed({"dep-1": stale_card}),
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = _memory_registry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            max_staleness_seconds=3600,
+            stale_if_error=True,
+            cache_backend=cache_backend,
         )
         await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120
+        registry._age_cache_entry_for_test("dep-1", 120)
 
         registry.register(deployment_id="dep-2")
         card = await registry.get(deployment_id="dep-1")
 
         assert card is stale_card
 
-    async def test_raises_when_deregistered_after_soft_ttl(self, mock_fetch):
-        stale_card = MagicMock(name="stale-card")
+    async def test_raises_when_deregistered_after_soft_ttl(self, mock_fetch, cache_backend):
+        stale_card = _card()
         mock_fetch.side_effect = [
-            {"dep-1": stale_card},
-            {},
+            _parsed({"dep-1": stale_card}),
+            _parsed({}),
         ]
-        registry = AgentCardRegistry(
+        registry = _memory_registry(
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
+            cache_backend=cache_backend,
         )
         await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120
+        registry._age_cache_entry_for_test("dep-1", 120)
 
         with pytest.raises(AgentCardRegistryError, match="No agent card found"):
             await registry.get(deployment_id="dep-1")
 
-        assert "dep-1" not in registry._cache
+        assert await cache_backend.get_stale("dep-1", max_staleness_seconds=3600) is None
 
-    async def test_deregistered_not_resurrected_by_stale_if_error(self, mock_fetch):
-        stale_card = MagicMock(name="stale-card")
+    async def test_deregistered_not_resurrected_by_stale_if_error(self, mock_fetch, cache_backend):
+        stale_card = _card()
         mock_fetch.side_effect = [
-            {"dep-1": stale_card},
-            {},
+            _parsed({"dep-1": stale_card}),
+            _parsed({}),
             AgentCardRegistryError("registry down"),
         ]
-        registry = AgentCardRegistry(
+        registry = _memory_registry(
             api_token="tok",
             endpoint="https://ep",
             cache_ttl=60,
+            max_staleness_seconds=3600,
+            stale_if_error=True,
+            cache_backend=cache_backend,
         )
         await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120
+        registry._age_cache_entry_for_test("dep-1", 120)
 
         with pytest.raises(AgentCardRegistryError, match="No agent card found"):
             await registry.get(deployment_id="dep-1")
@@ -475,10 +597,10 @@ class TestAgentCardRegistryRegisterFlush:
     async def test_register_then_get_flushes_batch(self, mock_fetch):
         """Registered IDs are batch-fetched on first get()."""
         mock_fetch.side_effect = [
-            {"dep-1": MagicMock(name="c1"), "dep-2": MagicMock(name="c2")},
-            {"ext-1": MagicMock(name="c3")},
+            _parsed({"dep-1": _card(), "dep-2": _card(name="Second Agent")}),
+            _parsed({"ext-1": _card(name="Third Agent")}, key_types={"ext-1": "ext"}),
         ]
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         registry.register(deployment_id="dep-1")
         registry.register(deployment_id="dep-2")
         registry.register(external_id="ext-1")
@@ -500,8 +622,8 @@ class TestAgentCardRegistryRegisterFlush:
         mock_fetch.assert_not_awaited()
 
     async def test_register_deduplicates(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="c1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        mock_fetch.return_value = _parsed({"dep-1": _card()})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         registry.register(deployment_id="dep-1")
         registry.register(deployment_id="dep-1")
         registry.register(deployment_id="dep-1")
@@ -510,8 +632,8 @@ class TestAgentCardRegistryRegisterFlush:
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1"})
 
     async def test_pending_cleared_after_flush(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="c1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        mock_fetch.return_value = _parsed({"dep-1": _card()})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         registry.register(deployment_id="dep-1")
 
         await registry.get(deployment_id="dep-1")
@@ -532,11 +654,13 @@ class TestAgentCardRegistryPrefetch:
             yield m
 
     async def test_prefetch_deployment_ids(self, mock_fetch):
-        mock_fetch.return_value = {
-            "dep-1": MagicMock(name="card1"),
-            "dep-2": MagicMock(name="card2"),
-        }
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        mock_fetch.return_value = _parsed(
+            {
+                "dep-1": _card(),
+                "dep-2": _card(name="Second Agent"),
+            }
+        )
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         await registry.prefetch(deployment_ids=["dep-1", "dep-2"])
 
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1,dep-2"})
@@ -547,10 +671,10 @@ class TestAgentCardRegistryPrefetch:
 
     async def test_prefetch_mixed_issues_separate_calls(self, mock_fetch):
         mock_fetch.side_effect = [
-            {"dep-1": MagicMock(name="card1")},
-            {"ext-1": MagicMock(name="card2")},
+            _parsed({"dep-1": _card()}),
+            _parsed({"ext-1": _card(name="Second Agent")}, key_types={"ext-1": "ext"}),
         ]
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         await registry.prefetch(deployment_ids=["dep-1"], external_ids=["ext-1"])
 
         assert mock_fetch.await_count == 2
@@ -559,13 +683,13 @@ class TestAgentCardRegistryPrefetch:
         assert calls[1].args[0] == {"externalIds": "ext-1"}
 
     async def test_prefetch_skips_already_cached(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="card1")}
-        registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        mock_fetch.return_value = _parsed({"dep-1": _card()})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
 
         await registry.prefetch(deployment_ids=["dep-1"])
         mock_fetch.reset_mock()
 
-        mock_fetch.return_value = {"dep-2": MagicMock(name="card2")}
+        mock_fetch.return_value = _parsed({"dep-2": _card(name="Second Agent")})
         await registry.prefetch(deployment_ids=["dep-1", "dep-2"])
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-2"})
 
@@ -594,13 +718,13 @@ class TestAgentCardRegistryFetch:
 
     async def test_fetch_passes_params_and_auth(self, mock_httpx_client):
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_httpx_client):
-            registry = AgentCardRegistry(
+            registry = _memory_registry(
                 api_token="my-tok", endpoint="https://app.dr.com/api/v2", cache_ttl=3600
             )
-            cards = await registry._fetch({"deploymentIds": "dep-1,dep-2"})
+            parsed = await registry._fetch({"deploymentIds": "dep-1,dep-2"})
 
-        assert "dep-1" in cards
-        assert "dep-2" in cards
+        assert "dep-1" in parsed.cards
+        assert "dep-2" in parsed.cards
         call_kwargs = mock_httpx_client.get.call_args.kwargs
         assert call_kwargs["params"]["deploymentIds"] == "dep-1,dep-2"
         assert call_kwargs["params"]["limit"] == "100"
@@ -619,7 +743,7 @@ class TestAgentCardRegistryFetch:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
             with pytest.raises(AgentCardRegistryError, match="HTTP 403"):
                 await registry._fetch({"deploymentIds": "dep-1"})
 
@@ -664,15 +788,15 @@ class TestAgentCardRegistryFetch:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            registry = AgentCardRegistry(
+            registry = _memory_registry(
                 api_token="my-tok", endpoint="https://app.dr.com/api/v2", cache_ttl=3600
             )
-            cards = await registry._fetch({"deploymentIds": "dep-1,dep-2,dep-3"})
+            parsed = await registry._fetch({"deploymentIds": "dep-1,dep-2,dep-3"})
 
-        assert "dep-1" in cards
-        assert "dep-2" in cards
-        assert "dep-3" in cards
-        assert len(cards) == 3
+        assert "dep-1" in parsed.cards
+        assert "dep-2" in parsed.cards
+        assert "dep-3" in parsed.cards
+        assert len(parsed.cards) == 3
         assert mock_client.get.await_count == 3
 
     async def test_fetch_no_pagination_when_next_absent(self):
@@ -692,10 +816,10 @@ class TestAgentCardRegistryFetch:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
-            cards = await registry._fetch({"deploymentIds": "dep-1"})
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            parsed = await registry._fetch({"deploymentIds": "dep-1"})
 
-        assert "dep-1" in cards
+        assert "dep-1" in parsed.cards
         assert mock_client.get.await_count == 1
 
     async def test_fetch_pagination_error_on_second_page_raises(self):
@@ -722,7 +846,7 @@ class TestAgentCardRegistryFetch:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
             with pytest.raises(AgentCardRegistryError, match="HTTP 500"):
                 await registry._fetch({"deploymentIds": "dep-1,dep-2"})
 
@@ -750,12 +874,12 @@ class TestAgentCardRegistryFetch:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch(f"{_MODULE}.httpx.AsyncClient", return_value=mock_client):
-            registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
-            cards = await registry._fetch({"deploymentIds": "dep-0"})
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            parsed = await registry._fetch({"deploymentIds": "dep-0"})
 
         # Should have fetched exactly _MAX_PAGES (stopped at the safety limit)
         assert mock_client.get.await_count == _MAX_PAGES
-        assert len(cards) == _MAX_PAGES
+        assert len(parsed.cards) == _MAX_PAGES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -24,6 +24,7 @@ from a2a.types import AgentCard
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheRecord
 from datarobot_genai.dragent.agent_card_registry_backends import LayeredAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import MemoryAgentCardCacheBackend
 from datarobot_genai.dragent.agent_card_registry_backends import MemorySpaceAgentCardCacheBackend
 from datarobot_genai.dragent.agent_card_registry_backends import create_agent_card_cache_backend
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
@@ -141,3 +142,40 @@ class TestCreateAgentCardCacheBackend:
 
         assert isinstance(backend, LayeredAgentCardCacheBackend)
         configure_mock.assert_called_once()
+
+
+class TestLayeredAgentCardCacheBackend:
+    async def test_get_fresh_read_through_preserves_fetched_at(self):
+        l1 = MemoryAgentCardCacheBackend()
+        l2 = MemoryAgentCardCacheBackend()
+        layered = LayeredAgentCardCacheBackend(l1, l2)
+
+        # GIVEN an L2 record that is already 30s old
+        await l2.store({"dep-1": _SAMPLE_AGENT_CARD}, key_types={"dep-1": "deployment"})
+        l2.age_entry_for_test("dep-1", 30)
+
+        # WHEN L1 misses and L2 hits within the 60s soft TTL
+        record = await layered.get_fresh("dep-1", cache_ttl=60)
+
+        # THEN the promoted L1 entry keeps the original fetch time
+        assert record is not None
+        assert await l1.get_fresh("dep-1", cache_ttl=60) is not None
+        assert await l1.get_fresh("dep-1", cache_ttl=20) is None
+
+    async def test_get_stale_read_through_does_not_reset_soft_ttl(self):
+        l1 = MemoryAgentCardCacheBackend()
+        l2 = MemoryAgentCardCacheBackend()
+        layered = LayeredAgentCardCacheBackend(l1, l2)
+
+        # GIVEN an L2 record past the 60s soft TTL but within max staleness
+        await l2.store({"dep-1": _SAMPLE_AGENT_CARD}, key_types={"dep-1": "deployment"})
+        l2.age_entry_for_test("dep-1", 90)
+
+        # WHEN L1 misses and L2 serves a stale-if-error hit
+        record = await layered.get_stale("dep-1", max_staleness_seconds=120)
+
+        # THEN L1 must not treat the promoted card as freshly fetched
+        assert record is not None
+        assert await l1.get_fresh("dep-1", cache_ttl=60) is None
+        assert await l1.get_stale("dep-1", max_staleness_seconds=80) is None
+        assert await l1.get_stale("dep-1", max_staleness_seconds=120) is not None

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -46,7 +46,7 @@ _SAMPLE_AGENT_CARD = AgentCard.model_validate(
 
 @pytest.fixture
 def memory_space_backend():
-    kv = MemorySpaceKVCache(memory_space_id="space-1", key_prefix="dragent:")
+    kv = MemorySpaceKVCache(memory_space_id="space-1")
     return MemorySpaceAgentCardCacheBackend(kv_cache=kv)
 
 

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -26,6 +26,7 @@ from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheR
 from datarobot_genai.dragent.agent_card_registry_backends import LayeredAgentCardCacheBackend
 from datarobot_genai.dragent.agent_card_registry_backends import MemoryAgentCardCacheBackend
 from datarobot_genai.dragent.agent_card_registry_backends import MemorySpaceAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import build_cache_record
 from datarobot_genai.dragent.agent_card_registry_backends import create_agent_card_cache_backend
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
 
@@ -95,6 +96,57 @@ class TestMemorySpaceAgentCardCacheBackend:
 
         assert stale is not None
         assert stale.card.name == "MemorySpace Agent"
+
+    async def test_store_writes_both_storage_keys_when_ids_known(self, memory_space_backend):
+        storage: dict[str, str] = {}
+
+        async def capture_set(key: str, payload: str) -> None:
+            storage[key] = payload
+
+        with patch.object(memory_space_backend._kv, "set_value", side_effect=capture_set):
+            await memory_space_backend.store(
+                {"dep-1": _SAMPLE_AGENT_CARD, "ext-1": _SAMPLE_AGENT_CARD},
+                key_types={"dep-1": "deployment", "ext-1": "external"},
+                registry_ids={"dep-1": ("dep-1", "ext-1"), "ext-1": ("dep-1", "ext-1")},
+            )
+
+        assert "deployment:dep-1" in storage
+        assert "external:ext-1" in storage
+        record = AgentCardCacheRecord.model_validate_json(storage["deployment:dep-1"])
+        assert record.deployment_id == "dep-1"
+        assert record.external_id == "ext-1"
+
+    async def test_evict_removes_sibling_l2_key(self, memory_space_backend):
+        """Typed eviction must delete every storage alias for the card."""
+        record = build_cache_record(
+            _SAMPLE_AGENT_CARD,
+            lookup_key="dep-1",
+            key_type="deployment",
+            deployment_id="dep-1",
+            external_id="ext-1",
+        )
+        payload = record.model_dump_json()
+        storage = {
+            "deployment:dep-1": payload,
+            "external:ext-1": payload,
+        }
+        deleted: list[str] = []
+
+        async def mock_get(key: str) -> str | None:
+            return storage.get(key)
+
+        async def mock_delete(key: str) -> None:
+            deleted.append(key)
+            storage.pop(key, None)
+
+        with (
+            patch.object(memory_space_backend._kv, "get_value", side_effect=mock_get),
+            patch.object(memory_space_backend._kv, "delete_value", side_effect=mock_delete),
+        ):
+            await memory_space_backend.evict("dep-1", key_type="deployment")
+
+        assert sorted(deleted) == ["deployment:dep-1", "external:ext-1"]
+        assert storage == {}
 
 
 class TestCreateAgentCardCacheBackend:

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -64,7 +64,7 @@ class TestMemorySpaceAgentCardCacheBackend:
         ):
             await memory_space_backend.store(
                 {"dep-1": _SAMPLE_AGENT_CARD},
-                key_types={"dep-1": "dep"},
+                key_types={"dep-1": "deployment"},
             )
             record = await memory_space_backend.get_fresh("dep-1", cache_ttl=3600)
 
@@ -87,7 +87,7 @@ class TestMemorySpaceAgentCardCacheBackend:
         ):
             await memory_space_backend.store(
                 {"dep-1": _SAMPLE_AGENT_CARD},
-                key_types={"dep-1": "dep"},
+                key_types={"dep-1": "deployment"},
             )
             assert await memory_space_backend.get_fresh("dep-1", cache_ttl=60) is None
             stale = await memory_space_backend.get_stale("dep-1", max_staleness_seconds=3600)

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -1,0 +1,126 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+from a2a.types import AgentCard
+
+from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
+from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheRecord
+from datarobot_genai.dragent.agent_card_registry_backends import LayeredAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import MemorySpaceAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import create_agent_card_cache_backend
+from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
+
+_SAMPLE_AGENT_CARD = AgentCard.model_validate(
+    {
+        "name": "MemorySpace Agent",
+        "description": "Cached in MemorySpace",
+        "url": "https://agent.example.com/a2a/",
+        "version": "1.0.0",
+        "skills": [],
+        "defaultInputModes": ["text"],
+        "defaultOutputModes": ["text"],
+        "capabilities": {"streaming": False},
+    }
+)
+
+
+@pytest.fixture
+def memory_space_backend():
+    kv = MemorySpaceKVCache(memory_space_id="space-1", key_prefix="dragent:")
+    return MemorySpaceAgentCardCacheBackend(kv_cache=kv)
+
+
+class TestMemorySpaceAgentCardCacheBackend:
+    async def test_store_and_get_fresh_by_deployment_id(self, memory_space_backend):
+        with (
+            patch.object(
+                memory_space_backend._kv,
+                "set_value",
+                wraps=memory_space_backend._kv.set_value,
+            ) as set_mock,
+            patch.object(
+                memory_space_backend._kv,
+                "get_value",
+                return_value=AgentCardCacheRecord(card=_SAMPLE_AGENT_CARD).model_dump_json(),
+            ),
+        ):
+            await memory_space_backend.store(
+                {"dep-1": _SAMPLE_AGENT_CARD},
+                key_types={"dep-1": "dep"},
+            )
+            record = await memory_space_backend.get_fresh("dep-1", cache_ttl=3600)
+
+        set_mock.assert_awaited()
+        assert record is not None
+        assert record.card.name == "MemorySpace Agent"
+
+    async def test_get_stale_after_soft_ttl(self, memory_space_backend):
+        stale_record = AgentCardCacheRecord(card=_SAMPLE_AGENT_CARD)
+        stale_record.fetched_at = datetime.now(UTC) - timedelta(seconds=120)
+        stale_json = stale_record.model_dump_json()
+
+        with (
+            patch.object(memory_space_backend._kv, "set_value", new_callable=AsyncMock),
+            patch.object(
+                memory_space_backend._kv,
+                "get_value",
+                return_value=stale_json,
+            ),
+        ):
+            await memory_space_backend.store(
+                {"dep-1": _SAMPLE_AGENT_CARD},
+                key_types={"dep-1": "dep"},
+            )
+            assert await memory_space_backend.get_fresh("dep-1", cache_ttl=60) is None
+            stale = await memory_space_backend.get_stale("dep-1", max_staleness_seconds=3600)
+
+        assert stale is not None
+        assert stale.card.name == "MemorySpace Agent"
+
+
+class TestCreateAgentCardCacheBackendMemorySpace:
+    def test_memory_space_backend_requires_space_id(self):
+        config = AgentCardRegistryConfig(agent_card_registry_backend="memory_space")
+        env = {
+            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+            "DATAROBOT_API_TOKEN": "token",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError, match="MemorySpace ID"):
+                create_agent_card_cache_backend(config)
+
+    def test_memory_space_backend_creates_layered_backend(self):
+        config = AgentCardRegistryConfig(
+            agent_card_registry_backend="memory_space",
+            agent_card_registry_memory_space_id="space-123",
+        )
+        env = {
+            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+            "DATAROBOT_API_TOKEN": "token",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            with patch(
+                "datarobot_genai.dragent.agent_card_registry_backends.configure_datarobot_memory_client"
+            ) as configure_mock:
+                backend = create_agent_card_cache_backend(config)
+
+        assert isinstance(backend, LayeredAgentCardCacheBackend)
+        configure_mock.assert_called_once()

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -96,29 +96,46 @@ class TestMemorySpaceAgentCardCacheBackend:
         assert stale.card.name == "MemorySpace Agent"
 
 
-class TestCreateAgentCardCacheBackendMemorySpace:
-    def test_memory_space_backend_requires_space_id(self):
-        config = AgentCardRegistryConfig(agent_card_registry_backend="memory_space")
+class TestCreateAgentCardCacheBackend:
+    def test_l1_only_when_no_memory_space_id(self):
+        config = AgentCardRegistryConfig()
         env = {
             "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
             "DATAROBOT_API_TOKEN": "token",
         }
         with patch.dict("os.environ", env, clear=True):
-            with pytest.raises(ValueError, match="MemorySpace ID"):
-                create_agent_card_cache_backend(config)
+            from datarobot_genai.dragent.agent_card_registry_backends import (
+                MemoryAgentCardCacheBackend,
+            )
 
-    def test_memory_space_backend_creates_layered_backend(self):
-        config = AgentCardRegistryConfig(
-            agent_card_registry_backend="memory_space",
-            agent_card_registry_memory_space_id="space-123",
-        )
+            backend = create_agent_card_cache_backend(config)
+
+        assert type(backend) is MemoryAgentCardCacheBackend
+
+    def test_l1_only_when_memory_client_unconfigured(self):
+        config = AgentCardRegistryConfig(agent_card_registry_memory_space_id="space-123")
+        with patch(
+            "datarobot_genai.dragent.agent_card_registry_backends.try_configure_datarobot_memory_client",
+            return_value=False,
+        ):
+            from datarobot_genai.dragent.agent_card_registry_backends import (
+                MemoryAgentCardCacheBackend,
+            )
+
+            backend = create_agent_card_cache_backend(config)
+
+        assert type(backend) is MemoryAgentCardCacheBackend
+
+    def test_creates_layered_backend_when_memory_space_configured(self):
+        config = AgentCardRegistryConfig(agent_card_registry_memory_space_id="space-123")
         env = {
             "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
             "DATAROBOT_API_TOKEN": "token",
         }
         with patch.dict("os.environ", env, clear=False):
             with patch(
-                "datarobot_genai.dragent.agent_card_registry_backends.configure_datarobot_memory_client"
+                "datarobot_genai.dragent.agent_card_registry_backends.try_configure_datarobot_memory_client",
+                return_value=True,
             ) as configure_mock:
                 backend = create_agent_card_cache_backend(config)
 

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -1,0 +1,170 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.dragent.memory_space_cache import CACHE_EVENT_TYPE
+from datarobot_genai.dragent.memory_space_cache import DRAGENT_CACHE_PARTICIPANT_ID
+from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
+from datarobot_genai.dragent.memory_space_cache import resolve_memory_space_id
+
+
+class _FakeEvent:
+    def __init__(self, *, sequence_id: int, body: dict[str, Any] | None) -> None:
+        self.sequence_id = sequence_id
+        self.body = body
+
+
+class _FakeSession:
+    def __init__(self, session_id: str = "sess-1") -> None:
+        self.id = session_id
+        self.metadata: dict[str, Any] = {}
+        self._events: list[_FakeEvent] = []
+        self.post_event = MagicMock(side_effect=self._post_event)
+        self.update_event = MagicMock(side_effect=self._update_event)
+        self.delete = MagicMock()
+
+    def events(self, **kwargs: Any) -> list[_FakeEvent]:
+        if "last_n" in kwargs:
+            return self._events[-kwargs["last_n"] :]
+        return list(self._events)
+
+    def _post_event(self, **kwargs: Any) -> _FakeEvent:
+        event = _FakeEvent(sequence_id=len(self._events) + 1, body=kwargs.get("body"))
+        self._events.append(event)
+        return event
+
+    def _update_event(self, sequence_id: int, **kwargs: Any) -> None:
+        for event in self._events:
+            if event.sequence_id == sequence_id:
+                if "body" in kwargs:
+                    event.body = kwargs["body"]
+                return
+        raise KeyError(sequence_id)
+
+
+@pytest.fixture
+def kv_cache() -> MemorySpaceKVCache:
+    return MemorySpaceKVCache(memory_space_id="space-1", key_prefix="dragent:")
+
+
+class TestResolveMemorySpaceId:
+    def test_explicit_id(self) -> None:
+        assert resolve_memory_space_id("space-explicit") == "space-explicit"
+
+    def test_missing_id_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGENT_MEMORY_SPACE_ID", raising=False)
+        monkeypatch.delenv("AGENT_CARD_REGISTRY_MEMORY_SPACE_ID", raising=False)
+        with pytest.raises(ValueError, match="MemorySpace ID"):
+            resolve_memory_space_id(None)
+
+
+class TestMemorySpaceKVCache:
+    async def test_set_and_get_round_trip(self, kv_cache: MemorySpaceKVCache) -> None:
+        session = _FakeSession()
+
+        with (
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+                return_value=None,
+            ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._create_cache_session",
+                return_value=session,
+            ),
+        ):
+            await kv_cache.set_value("dep-1", '{"version": 1}', kind="agent_card")
+
+        with patch(
+            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+            return_value=session,
+        ):
+            assert await kv_cache.get_value("dep-1", kind="agent_card") == '{"version": 1}'
+
+        session.post_event.assert_called_once()
+        kwargs = session.post_event.call_args.kwargs
+        assert kwargs["event_type"] == CACHE_EVENT_TYPE
+        assert kwargs["body"]["payload"] == '{"version": 1}'
+
+    async def test_update_existing_entry(self, kv_cache: MemorySpaceKVCache) -> None:
+        session = _FakeSession()
+        session.post_event(body={"v": 1, "payload": "v1"})
+
+        with patch(
+            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+            return_value=session,
+        ):
+            await kv_cache.set_value("dep-1", "v2", kind="agent_card")
+
+        session.update_event.assert_called_once_with(1, body={"v": 1, "payload": "v2"})
+        assert session.post_event.call_count == 1
+
+    async def test_different_kinds_are_isolated(self, kv_cache: MemorySpaceKVCache) -> None:
+        agent_session = _FakeSession("sess-agent")
+        xaa_session = _FakeSession("sess-xaa")
+
+        with (
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+                side_effect=[None, None],
+            ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._create_cache_session",
+                side_effect=[agent_session, xaa_session],
+            ),
+        ):
+            await kv_cache.set_value("same-key", "agent", kind="agent_card")
+            await kv_cache.set_value("same-key", "xaa", kind="xaa_token")
+
+        with patch(
+            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+            side_effect=[agent_session, xaa_session],
+        ):
+            assert await kv_cache.get_value("same-key", kind="agent_card") == "agent"
+            assert await kv_cache.get_value("same-key", kind="xaa_token") == "xaa"
+
+    async def test_create_uses_cache_participant(self, kv_cache: MemorySpaceKVCache) -> None:
+        session = _FakeSession()
+
+        with (
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+                return_value=None,
+            ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache.Session.create",
+                return_value=session,
+            ) as create_mock,
+        ):
+            await kv_cache.set_value("dep-1", "payload", kind="agent_card")
+
+        create_mock.assert_called_once()
+        assert create_mock.call_args.args[1] == [DRAGENT_CACHE_PARTICIPANT_ID]
+
+    async def test_delete_removes_session(self, kv_cache: MemorySpaceKVCache) -> None:
+        session = _FakeSession()
+
+        with patch(
+            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+            return_value=session,
+        ):
+            await kv_cache.delete_value("dep-1", kind="agent_card")
+
+        session.delete.assert_called_once()

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -95,13 +95,13 @@ class TestMemorySpaceKVCache:
                 return_value=session,
             ),
         ):
-            await kv_cache.set_value("dep-1", '{"version": 1}', kind="agent_card")
+            await kv_cache.set_value("dep-1", '{"version": 1}')
 
         with patch(
             "datarobot_genai.dragent.memory_space_cache._find_cache_session",
             return_value=session,
         ):
-            assert await kv_cache.get_value("dep-1", kind="agent_card") == '{"version": 1}'
+            assert await kv_cache.get_value("dep-1") == '{"version": 1}'
 
         session.post_event.assert_called_once()
         kwargs = session.post_event.call_args.kwargs
@@ -116,34 +116,10 @@ class TestMemorySpaceKVCache:
             "datarobot_genai.dragent.memory_space_cache._find_cache_session",
             return_value=session,
         ):
-            await kv_cache.set_value("dep-1", "v2", kind="agent_card")
+            await kv_cache.set_value("dep-1", "v2")
 
         session.update_event.assert_called_once_with(1, body={"v": 1, "payload": "v2"})
         assert session.post_event.call_count == 1
-
-    async def test_different_kinds_are_isolated(self, kv_cache: MemorySpaceKVCache) -> None:
-        agent_session = _FakeSession("sess-agent")
-        xaa_session = _FakeSession("sess-xaa")
-
-        with (
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-                side_effect=[None, None],
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._create_cache_session",
-                side_effect=[agent_session, xaa_session],
-            ),
-        ):
-            await kv_cache.set_value("same-key", "agent", kind="agent_card")
-            await kv_cache.set_value("same-key", "xaa", kind="xaa_token")
-
-        with patch(
-            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-            side_effect=[agent_session, xaa_session],
-        ):
-            assert await kv_cache.get_value("same-key", kind="agent_card") == "agent"
-            assert await kv_cache.get_value("same-key", kind="xaa_token") == "xaa"
 
     async def test_create_uses_cache_participant(self, kv_cache: MemorySpaceKVCache) -> None:
         session = _FakeSession()
@@ -158,7 +134,7 @@ class TestMemorySpaceKVCache:
                 return_value=session,
             ) as create_mock,
         ):
-            await kv_cache.set_value("dep-1", "payload", kind="agent_card")
+            await kv_cache.set_value("dep-1", "payload")
 
         create_mock.assert_called_once()
         assert create_mock.call_args.args[1] == [DRAGENT_CACHE_PARTICIPANT_ID]
@@ -170,6 +146,6 @@ class TestMemorySpaceKVCache:
             "datarobot_genai.dragent.memory_space_cache._find_cache_session",
             return_value=session,
         ):
-            await kv_cache.delete_value("dep-1", kind="agent_card")
+            await kv_cache.delete_value("dep-1")
 
         session.delete.assert_called_once()

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -24,6 +24,7 @@ from datarobot_genai.dragent.memory_space_cache import CACHE_EVENT_TYPE
 from datarobot_genai.dragent.memory_space_cache import DRAGENT_CACHE_PARTICIPANT_ID
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
 from datarobot_genai.dragent.memory_space_cache import resolve_memory_space_id
+from datarobot_genai.dragent.memory_space_cache import try_resolve_memory_space_id
 
 
 class _FakeEvent:
@@ -70,10 +71,14 @@ class TestResolveMemorySpaceId:
         assert resolve_memory_space_id("space-explicit") == "space-explicit"
 
     def test_missing_id_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("AGENT_MEMORY_SPACE_ID", raising=False)
         monkeypatch.delenv("AGENT_CARD_REGISTRY_MEMORY_SPACE_ID", raising=False)
         with pytest.raises(ValueError, match="MemorySpace ID"):
             resolve_memory_space_id(None)
+
+    def test_agent_memory_space_id_is_not_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGENT_CARD_REGISTRY_MEMORY_SPACE_ID", raising=False)
+        monkeypatch.setenv("AGENT_MEMORY_SPACE_ID", "mem0-space")
+        assert try_resolve_memory_space_id(None) is None
 
 
 class TestMemorySpaceKVCache:

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -63,7 +63,7 @@ class _FakeSession:
 
 @pytest.fixture
 def kv_cache() -> MemorySpaceKVCache:
-    return MemorySpaceKVCache(memory_space_id="space-1", key_prefix="dragent:")
+    return MemorySpaceKVCache(memory_space_id="space-1")
 
 
 class TestResolveMemorySpaceId:

--- a/tests/dragent/test_registry_refresh.py
+++ b/tests/dragent/test_registry_refresh.py
@@ -21,10 +21,32 @@ import pytest
 
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistry
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
+from datarobot_genai.dragent.agent_card_registry import ParsedRegistryCards
 from datarobot_genai.dragent.registry_refresh import registry_refresh_lifespan
 from datarobot_genai.dragent.registry_refresh import registry_refresh_loop
 
 _MODULE = "datarobot_genai.dragent.registry_refresh"
+
+_SAMPLE_AGENT_CARD = {
+    "name": "Test Agent",
+    "description": "A test agent",
+    "url": "https://agent.example.com/a2a/",
+    "version": "1.0.0",
+    "skills": [],
+    "defaultInputModes": ["text"],
+    "defaultOutputModes": ["text"],
+    "capabilities": {"streaming": False},
+}
+
+
+def _card(**overrides):
+    from a2a.types import AgentCard
+
+    return AgentCard.model_validate({**_SAMPLE_AGENT_CARD, **overrides})
+
+
+def _parsed(cards: dict) -> ParsedRegistryCards:
+    return ParsedRegistryCards(cards=cards, key_types={key: "dep" for key in cards})
 
 
 class TestAgentCardRegistryRefresh:
@@ -34,7 +56,7 @@ class TestAgentCardRegistryRefresh:
             yield m
 
     async def test_refresh_skips_fresh_entries(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="card")}
+        mock_fetch.return_value = _parsed({"dep-1": _card()})
         registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
         registry.register(deployment_id="dep-1")
         await registry.get(deployment_id="dep-1")
@@ -44,27 +66,27 @@ class TestAgentCardRegistryRefresh:
         mock_fetch.assert_not_awaited()
 
     async def test_refresh_refetches_soft_expired_entries(self, mock_fetch):
-        mock_fetch.return_value = {"dep-1": MagicMock(name="card")}
+        mock_fetch.return_value = _parsed({"dep-1": _card()})
         registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
         registry.register(deployment_id="dep-1")
         await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120
+        registry._age_cache_entry_for_test("dep-1", 120)
 
         mock_fetch.reset_mock()
-        mock_fetch.return_value = {"dep-1": MagicMock(name="refreshed")}
+        mock_fetch.return_value = _parsed({"dep-1": _card(name="Refreshed Agent")})
         await registry.refresh_all_registered()
 
         mock_fetch.assert_awaited_once_with({"deploymentIds": "dep-1"})
 
     async def test_refresh_logs_on_failure_without_raising(self, mock_fetch):
         mock_fetch.side_effect = [
-            {"dep-1": MagicMock(name="card")},
+            _parsed({"dep-1": _card()}),
             AgentCardRegistryError("registry down"),
         ]
         registry = AgentCardRegistry(api_token="tok", endpoint="https://ep", cache_ttl=60)
         registry.register(deployment_id="dep-1")
         await registry.get(deployment_id="dep-1")
-        registry._cache["dep-1"].fetched_at -= 120
+        registry._age_cache_entry_for_test("dep-1", 120)
 
         await registry.refresh_all_registered()
 

--- a/tests/dragent/test_registry_refresh.py
+++ b/tests/dragent/test_registry_refresh.py
@@ -46,7 +46,11 @@ def _card(**overrides):
 
 
 def _parsed(cards: dict) -> ParsedRegistryCards:
-    return ParsedRegistryCards(cards=cards, key_types={key: "deployment" for key in cards})
+    return ParsedRegistryCards(
+        cards=cards,
+        key_types={key: "deployment" for key in cards},
+        registry_ids={},
+    )
 
 
 class TestAgentCardRegistryRefresh:

--- a/tests/dragent/test_registry_refresh.py
+++ b/tests/dragent/test_registry_refresh.py
@@ -46,7 +46,7 @@ def _card(**overrides):
 
 
 def _parsed(cards: dict) -> ParsedRegistryCards:
-    return ParsedRegistryCards(cards=cards, key_types={key: "dep" for key in cards})
+    return ParsedRegistryCards(cards=cards, key_types={key: "deployment" for key in cards})
 
 
 class TestAgentCardRegistryRefresh:

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.3"
+version = "0.29.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
When an agent is deployed to an enclave it needs to survive a 1 hour downtime of the control hub which includes the agent card registry for remote agent cards.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Implement an L2 cache for remote agent cards using the memory service to back up the in-memory cache.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote agent cards are cached and served during registry failures, including new platform MemorySpace I/O and API token/endpoint requirements when the L2 backend is enabled.
> 
> **Overview**
> **Adds optional shared L2 caching for central agent card registry lookups**, aimed at surviving control-hub outages (e.g. enclave deployments) while keeping the default in-process-only behavior.
> 
> `AgentCardRegistry` no longer owns an internal dict cache; it delegates to a **pluggable backend** (`memory` or `memory_space`). Stale-if-error is now **explicitly configurable** via `AGENT_CARD_REGISTRY_STALE_IF_ERROR` and bounded by `AGENT_CARD_REGISTRY_MAX_STALENESS_SECONDS` (default 24h). Registry parsing returns deployment vs external key types so caches can store and evict correctly when an agent disappears from the registry.
> 
> With `AGENT_CARD_REGISTRY_BACKEND=memory_space`, the stack uses **L1 in-memory read-through/write-through over a DataRobot MemorySpace L2** (`MemorySpaceKVCache` on the agentic memory **Session API**), keyed by deployment/external IDs and resolved from `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` or `AGENT_MEMORY_SPACE_ID`. Release **0.29.3** and changelog/lock updates accompany the change; tests cover memory backends, MemorySpace layering, and KV session behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c384ddc97b6b8353e204dc5ecdc7132adbcc9eef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->