### PR TITLE
[BUZZOK-32137] Fix: A2A maintain separate agent_card copies when sharing auth_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.3
+- `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.
+- A group that resolves an `AgentCardAware` auth provider now takes its own copy of it, so the card it fetched stays with the agent it fetched it from. Configuration and credentials are unchanged and still shared.
+
 ## 0.29.2
 - `dragent`: prefetch central agent card registry lookups at FastAPI startup for all `authenticated_a2a_client` function groups with a `registry` block.
 - `dragent`: agent card registry stale-if-error for in-memory cache — serve last-known-good cards when a registry fetch fails.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.2"
+version = "0.29.3"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -14,6 +14,7 @@
 
 import abc
 import asyncio
+import copy
 import functools
 import inspect
 import logging
@@ -458,6 +459,13 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
         if config.auth_provider:
             try:
                 auth_provider = await self._builder.get_auth_provider(config.auth_provider)
+                if isinstance(auth_provider, AgentCardAware):
+                    # get_auth_provider returns one instance per configured name, shared
+                    # by every function group and every user.  A provider that keeps
+                    # agent-card state would otherwise serve whichever group connected
+                    # last, so this group takes its own copy — config and credentials
+                    # stay shared.
+                    auth_provider = copy.copy(auth_provider)
                 logger.info(
                     "Resolved authentication provider '%s' for A2A client",
                     config.auth_provider,

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -12,15 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import base64
+import json
 from contextlib import contextmanager
 from contextlib import nullcontext
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
+from urllib.parse import parse_qs
 
 import pytest
+import respx
 from a2a.types import AgentCapabilities
 from a2a.types import AgentCard
+from a2a.types import AgentExtension
+from a2a.types import ClientCredentialsOAuthFlow
+from a2a.types import OAuth2SecurityScheme
+from a2a.types import OAuthFlows
+from a2a.types import SecurityScheme
+from httpx import Response
 from nat.data_models.authentication import AuthResult
 from nat.data_models.authentication import BearerTokenCred
 from nat.data_models.authentication import HeaderCred
@@ -37,6 +48,12 @@ from datarobot_genai.dragent.plugins.auth_a2a_client import _extract_auth_header
 from datarobot_genai.dragent.plugins.auth_a2a_client import _FailedRegistryClient
 from datarobot_genai.dragent.plugins.auth_a2a_client import _sanitize_a2a_error
 from datarobot_genai.dragent.plugins.auth_a2a_client import _wrap_a2a_function
+from datarobot_genai.dragent.plugins.okta_a2a_auth import (
+    OAuth2CrossApplicationAccessAuthProviderConfig,
+)
+from datarobot_genai.dragent.plugins.okta_a2a_auth import (
+    OAuth2CrossApplicationAccessOAuth2AuthProvider,
+)
 
 _AGENT_URL = "http://agent.example.com"
 
@@ -842,3 +859,255 @@ class TestAuthenticatedA2AClientFunctionGroupRegistryError:
             await fg.__aenter__()
 
             assert isinstance(fg._client, _FailedRegistryClient)
+
+
+# ---------------------------------------------------------------------------
+# Tests: flow params belong to the group, not to the shared auth provider
+# ---------------------------------------------------------------------------
+
+_OKTA_MODULE = "datarobot_genai.dragent.plugins.okta_a2a_auth"
+
+_TRUSTED_ISSUER = "https://okta.example.com"
+_ORG_AS_TOKEN_URL = f"{_TRUSTED_ISSUER}/oauth2/v1/token"
+_INBOUND_TOKEN_HEADER = "x-datarobot-external-access-token"
+
+_FAKE_JWK_B64 = base64.b64encode(
+    json.dumps(
+        {
+            "kty": "RSA",
+            "kid": "test-kid",
+            "n": "abc",
+            "e": "AQAB",
+            "d": "def",
+            "p": "ghi",
+            "q": "jkl",
+            "dp": "mno",
+            "dq": "pqr",
+            "qi": "stu",
+        }
+    ).encode()
+).decode()
+
+
+class _Agent:
+    """One remote agent: its base URL and the XAA parameters its card advertises."""
+
+    def __init__(self, name: str) -> None:
+        self.url = f"http://{name}.example.com"
+        self.token_url = f"{_TRUSTED_ISSUER}/oauth2/aus-{name}/v1/token"
+        self.exchange_audience = f"{_TRUSTED_ISSUER}/oauth2/aus-{name}"
+        self.target_audience = f"https://api.{name}.example.com"
+        self.scope = f"{name}_scope"
+        self.final_token = f"scoped-token-for-{name}"
+
+    def card(self) -> AgentCard:
+        return AgentCard(
+            name=self.url,
+            description="",
+            url=self.url,
+            version="1.0.0",
+            skills=[],
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+            security_schemes={
+                "oauth2": SecurityScheme(
+                    root=OAuth2SecurityScheme(
+                        type="oauth2",
+                        flows=OAuthFlows(
+                            client_credentials=ClientCredentialsOAuthFlow(
+                                token_url=self.token_url,
+                                scopes={self.scope: "access"},
+                            )
+                        ),
+                    )
+                )
+            },
+            capabilities=AgentCapabilities(
+                streaming=False,
+                extensions=[
+                    AgentExtension(
+                        uri="urn:ietf:params:oauth:grant-type:jwt-bearer",
+                        description="",
+                        params={
+                            "tokenEndpointAuthMethod": "private_key_jwt",
+                            "tokenExchange": {
+                                "grantType": ("urn:ietf:params:oauth:grant-type:token-exchange"),
+                                "requestedTokenType": ("urn:ietf:params:oauth:token-type:id-jag"),
+                                "trustedIssuer": _TRUSTED_ISSUER,
+                                "audience": self.exchange_audience,
+                            },
+                            "tokenRequest": {
+                                "grantType": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                                "audience": self.target_audience,
+                            },
+                        },
+                    )
+                ],
+            ),
+        )
+
+
+def _credential_service_of(function_group):
+    """Return the credential service the group's AuthInterceptor was built with."""
+    interceptors = function_group._client._client.interceptors
+    return interceptors[0]._credential_service
+
+
+def _provider_of(function_group):
+    """Return the auth provider instance the group actually authenticates through."""
+    return function_group._client._auth_provider
+
+
+class TestSharedAuthProviderFlowParams:
+    """Two function groups, one shared auth provider, two different remote agents.
+
+    ``WorkflowBuilder.get_auth_provider`` returns one instance per configured name and
+    ``PerUserWorkflowBuilder`` delegates straight to it, so a group that kept its agent
+    card on the provider would hand its audience to every other group.  Each exchange
+    must carry the audience of the agent its own group is talking to.
+    """
+
+    @pytest.fixture
+    def agents(self):
+        return _Agent("alpha"), _Agent("beta")
+
+    @pytest.fixture
+    def shared_auth_provider(self, monkeypatch):
+        monkeypatch.setenv("XAA_TOKEN_EXCHANGE_IMPL", "http")
+        return OAuth2CrossApplicationAccessOAuth2AuthProvider(
+            config=OAuth2CrossApplicationAccessAuthProviderConfig(
+                principal_id="0oa_principal",
+                private_jwk=_FAKE_JWK_B64,
+            )
+        )
+
+    @contextmanager
+    def _patched_env(self, agents, *, user_id="test-user"):
+        """Serve each client the card of the agent at its own base URL, offline."""
+        cards = {agent.url: agent.card() for agent in agents}
+
+        async def _set_card(client_self):
+            client_self._agent_card = cards[client_self._base_url]
+
+        with (
+            patch(f"{_MODULE}.Context") as mock_ctx,
+            patch(f"{_MODULE}.httpx") as mock_httpx,
+            patch(f"{_MODULE}.ClientFactory") as mock_factory,
+            patch.object(_AuthenticatedA2ABaseClient, "_resolve_agent_card", _set_card),
+            patch.object(AuthenticatedA2AClientFunctionGroup, "_register_functions"),
+        ):
+            mock_httpx.AsyncClient.return_value = MagicMock(aclose=AsyncMock())
+            mock_ctx.get.return_value.user_id = user_id
+
+            def _create(card, interceptors=None):
+                client = MagicMock(aclose=AsyncMock())
+                client.interceptors = interceptors or []
+                return client
+
+            mock_factory.return_value.create.side_effect = _create
+            yield
+
+    async def _enter_group(self, agent, auth_provider):
+        builder = AsyncMock()
+        builder.get_auth_provider.return_value = auth_provider
+        group = AuthenticatedA2AClientFunctionGroup(
+            config=AuthenticatedA2AClientConfig(url=agent.url, auth_provider="okta_auth"),
+            builder=builder,
+        )
+        await group.__aenter__()
+        return group
+
+    @contextmanager
+    def _mocked_token_endpoints(self, agents):
+        """Mock both XAA steps; yield the step-1 route so its requests can be read."""
+        with (
+            patch(f"{_OKTA_MODULE}.Context") as mock_ctx,
+            patch(f"{_OKTA_MODULE}._make_client_assertion", return_value="jwt"),
+            respx.mock as mock_http,
+        ):
+            mock_ctx.get.return_value.metadata.headers = {
+                _INBOUND_TOKEN_HEADER: "inbound-user-token"
+            }
+            step1 = mock_http.post(_ORG_AS_TOKEN_URL).mock(
+                return_value=Response(200, json={"access_token": "id-jag"})
+            )
+            for agent in agents:
+                mock_http.post(agent.token_url).mock(
+                    return_value=Response(200, json={"access_token": agent.final_token})
+                )
+            yield step1
+
+    @staticmethod
+    def _resources_requested(step1_route):
+        """Return the ``resource`` (target audience) sent on each step-1 exchange."""
+        return [
+            parse_qs(call.request.content.decode())["resource"][0] for call in step1_route.calls
+        ]
+
+    async def test_each_group_keeps_its_own_flow_params(self, agents, shared_auth_provider):
+        """GIVEN two groups sharing a provider WHEN both connect THEN params differ."""
+        alpha, beta = agents
+        with self._patched_env(agents):
+            group_alpha = await self._enter_group(alpha, shared_auth_provider)
+            group_beta = await self._enter_group(beta, shared_auth_provider)
+
+        provider_alpha, provider_beta = _provider_of(group_alpha), _provider_of(group_beta)
+        assert provider_alpha is not provider_beta
+        assert provider_alpha._flow_params.target_audience == alpha.target_audience
+        assert provider_beta._flow_params.target_audience == beta.target_audience
+        # Nothing about either agent was written to the instance they were built from.
+        assert shared_auth_provider._flow_params is None
+
+    async def test_interleaved_calls_each_exchange_their_own_audience(
+        self, agents, shared_auth_provider
+    ):
+        """GIVEN both groups connected WHEN each calls THEN each mints its own audience.
+
+        Both cards are parsed before either call happens, so a provider that stored
+        the card would exchange beta's audience for alpha's call.
+        """
+        alpha, beta = agents
+        with self._patched_env(agents):
+            group_alpha = await self._enter_group(alpha, shared_auth_provider)
+            group_beta = await self._enter_group(beta, shared_auth_provider)
+
+            with self._mocked_token_endpoints(agents) as step1:
+                token_alpha = await _credential_service_of(group_alpha).get_credentials(
+                    "oauth2", None
+                )
+                token_beta = await _credential_service_of(group_beta).get_credentials(
+                    "oauth2", None
+                )
+
+        assert token_alpha == alpha.final_token
+        assert token_beta == beta.final_token
+        assert self._resources_requested(step1) == [
+            alpha.target_audience,
+            beta.target_audience,
+        ]
+
+    async def test_concurrent_per_user_groups_do_not_cross_audiences(
+        self, agents, shared_auth_provider
+    ):
+        """GIVEN two users' groups on one provider WHEN they call at once THEN no crossover.
+
+        ``PerUserWorkflowBuilder.get_auth_provider`` delegates to the shared builder, so
+        both users' groups authenticate through the same provider instance.
+        """
+        alpha, beta = agents
+        with self._patched_env(agents, user_id="user-a"):
+            group_alpha = await self._enter_group(alpha, shared_auth_provider)
+        with self._patched_env(agents, user_id="user-b"):
+            group_beta = await self._enter_group(beta, shared_auth_provider)
+
+        with self._mocked_token_endpoints(agents) as step1:
+            token_alpha, token_beta = await asyncio.gather(
+                _credential_service_of(group_alpha).get_credentials("oauth2", None),
+                _credential_service_of(group_beta).get_credentials("oauth2", None),
+            )
+
+        assert token_alpha == alpha.final_token
+        assert token_beta == beta.final_token
+        assert sorted(self._resources_requested(step1)) == sorted(
+            [alpha.target_audience, beta.target_audience]
+        )

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -32,6 +32,7 @@ from a2a.types import OAuth2SecurityScheme
 from a2a.types import OAuthFlows
 from a2a.types import SecurityScheme
 from httpx import Response
+from nat.authentication.interfaces import AuthProviderBase
 from nat.data_models.authentication import AuthResult
 from nat.data_models.authentication import BearerTokenCred
 from nat.data_models.authentication import HeaderCred
@@ -388,7 +389,8 @@ class TestAuthenticatedA2AClientFunctionGroup:
         assert patched_fg_env.call_args.kwargs["auth_provider"] is None
 
     async def test_resolves_and_passes_auth_provider(self, mock_builder, patched_fg_env):
-        mock_auth_provider = MagicMock()
+        """A provider that keeps no agent-card state is passed through untouched."""
+        mock_auth_provider = MagicMock(spec=AuthProviderBase)
         mock_builder.get_auth_provider.return_value = mock_auth_provider
         config = AuthenticatedA2AClientConfig(url=_AGENT_URL, auth_provider="my_auth")
 
@@ -601,7 +603,7 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
     async def test_registry_fetches_card_and_derives_base_url(
         self, registry_config, mock_builder, patched_fg_env
     ):
-        mock_auth_provider = MagicMock()
+        mock_auth_provider = MagicMock(spec=AuthProviderBase)
         mock_builder.get_auth_provider.return_value = mock_auth_provider
 
         mock_card = MagicMock()
@@ -647,7 +649,7 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
 
     async def test_registry_pre_resolved_card_skips_discovery(self, registry_config, mock_builder):
         """When registry provides a card, _AuthenticatedA2ABaseClient skips _resolve_agent_card."""
-        mock_auth_provider = AsyncMock()
+        mock_auth_provider = AsyncMock(spec=AuthProviderBase)
         mock_auth_provider.authenticate.return_value = None
         mock_builder.get_auth_provider.return_value = mock_auth_provider
 

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.2"
+version = "0.29.3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
`authenticated_a2a_client` function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one auth provider instance per configured name (and PerUserWorkflowBuilder delegates straight to it), so every group called `set_agent_card()` on the same object and whichever connected last decided `target_audience`, `token_url` and `id_jag_scopes` for all of them — meaning two groups sharing an `auth_provider`, or two concurrent users, could mint a token for the wrong agent.

## CHANGES
Fix: A group that resolves an `AgentCardAware` provider now takes its own copy.copy() of it, so the card it fetched stays with the agent it fetched it from, while config and credentials remain shared.

## TESTS
Added tests which replicate this issue

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This diff only adds automated tests and a patch version bump; it does not change production auth or A2A client logic.
> 
> **Overview**
> Bumps **datarobot-genai** to **0.29.3** (`pyproject.toml`, `uv.lock`).
> 
> Adds **`TestSharedAuthProviderFlowParams`** in `test_a2a_client.py` to guard against cross-agent OAuth/XAA mistakes when multiple **`AuthenticatedA2AClientFunctionGroup`** instances reuse the same **`WorkflowBuilder`** / per-user auth provider. The tests model two agents with different agent-card audiences and assert each group gets its **own** provider instance with the correct **`target_audience`**, the shared provider is **not** mutated (`_flow_params` stays unset), and interleaved or concurrent credential fetches send the right **`resource`** on the org token-exchange step (via **respx**-mocked Okta endpoints).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ece525bf6e84b9855cb0af3c0dd087a534113f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->