### PR TITLE
[APP-6968] OTel MCP tools 1/4: truncation module, query client, and fixtures

### DIFF
--- a/src/datarobot_genai/drtools/core/clients/datarobot_otel_query.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_otel_query.py
@@ -1,0 +1,240 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OTel query API methods backed by the per-request DataRobot REST client.
+
+Named ``datarobot_otel_query.py``, not ``datarobot_otel.py``, to stay visually
+distinct from ``core/telemetry/datarobot_otel.py`` (which *emits* telemetry).
+Same reason the class below is ``OtelQueryApiClient``, not ``OtelApiClient`` —
+this package reads OTel data; it does not produce any.
+
+Direct mirror of :class:`WorkloadApiClient`: one thin method per
+``GET /otel/*``, each wrapped in :func:`request_user_dr_client` so credentials
+come from the requesting user's headers. Pure transport — camelCase query-param
+assembly and ``.json()``, nothing else. No truncation, no validation: callers
+(the ``otel`` tools) are responsible for both.
+"""
+
+import logging
+from typing import Any
+
+from datarobot_genai.drmcputils.clients.datarobot import request_user_dr_client
+
+logger = logging.getLogger(__name__)
+
+
+class OtelQueryApiClient:
+    """OTel query API methods backed by the per-request DataRobot REST client.
+
+    Each call runs inside :func:`request_user_dr_client` so credentials come from
+    the requesting user's headers::
+
+        client = OtelQueryApiClient()
+        result = client.list_traces(entity_type="deployment", entity_id="...")
+    """
+
+    # ------------------------------------------------------------------ #
+    # Traces                                                               #
+    # ------------------------------------------------------------------ #
+
+    def list_traces(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        status: str | None = None,
+        root_span_name: list[str] | None = None,
+        tools: list[str] | None = None,
+        trace_type: str | None = None,
+        min_trace_duration_ns: int | None = None,
+        min_span_duration_ns: int | None = None,
+        max_span_duration_ns: int | None = None,
+        min_trace_cost: int | None = None,
+        max_trace_cost: int | None = None,
+        sort_by: str | None = None,
+        sort_direction: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /otel/{entityType}/{entityId}/traces/ — paginated trace list."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if start_time:
+            params["startTime"] = start_time
+        if end_time:
+            params["endTime"] = end_time
+        if status:
+            params["status"] = status
+        if root_span_name:
+            params["rootSpanName"] = root_span_name
+        if tools:
+            params["tools"] = tools
+        if trace_type:
+            params["traceType"] = trace_type
+        if min_trace_duration_ns is not None:
+            params["minTraceDuration"] = min_trace_duration_ns
+        if min_span_duration_ns is not None:
+            params["minSpanDuration"] = min_span_duration_ns
+        if max_span_duration_ns is not None:
+            params["maxSpanDuration"] = max_span_duration_ns
+        if min_trace_cost is not None:
+            params["minTraceCost"] = min_trace_cost
+        if max_trace_cost is not None:
+            params["maxTraceCost"] = max_trace_cost
+        if sort_by:
+            params["sortBy"] = sort_by
+        if sort_direction:
+            params["sortDirection"] = sort_direction
+        with request_user_dr_client() as client:
+            return client.get(f"otel/{entity_type}/{entity_id}/traces/", params=params).json()
+
+    def get_trace(
+        self,
+        entity_type: str,
+        entity_id: str,
+        trace_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """GET /otel/{entityType}/{entityId}/traces/{traceId}/ — one trace, spans paginated."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        with request_user_dr_client() as client:
+            return client.get(
+                f"otel/{entity_type}/{entity_id}/traces/{trace_id}/", params=params
+            ).json()
+
+    # ------------------------------------------------------------------ #
+    # Logs                                                                 #
+    # ------------------------------------------------------------------ #
+
+    def list_logs(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        level: str = "debug",
+        start_time: str | None = None,
+        end_time: str | None = None,
+        includes: list[str] | None = None,
+        excludes: list[str] | None = None,
+        span_id: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /otel/{entityType}/{entityId}/logs/ — OTel log lines for an entity."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset, "level": level}
+        if start_time:
+            params["startTime"] = start_time
+        if end_time:
+            params["endTime"] = end_time
+        if includes:
+            params["includes"] = includes
+        if excludes:
+            params["excludes"] = excludes
+        if span_id:
+            params["spanId"] = span_id
+        if trace_id:
+            params["traceId"] = trace_id
+        with request_user_dr_client() as client:
+            return client.get(f"otel/{entity_type}/{entity_id}/logs/", params=params).json()
+
+    # ------------------------------------------------------------------ #
+    # Metrics                                                              #
+    # ------------------------------------------------------------------ #
+
+    def list_metrics_summary(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        search: str | None = None,
+        metric_type: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /otel/{entityType}/{entityId}/metrics/summary/ — catalog of emitted metrics."""
+        params: dict[str, Any] = {}
+        if search:
+            params["search"] = search
+        if metric_type:
+            params["metricType"] = metric_type
+        with request_user_dr_client() as client:
+            return client.get(
+                f"otel/{entity_type}/{entity_id}/metrics/summary/", params=params
+            ).json()
+
+    def get_metrics_values(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        histogram_buckets: bool = False,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /otel/{entityType}/{entityId}/metrics/values/ — configured metric values."""
+        params: dict[str, Any] = {"histogramBuckets": histogram_buckets}
+        if start:
+            params["startTime"] = start
+        if end:
+            params["endTime"] = end
+        with request_user_dr_client() as client:
+            return client.get(
+                f"otel/{entity_type}/{entity_id}/metrics/values/", params=params
+            ).json()
+
+    def get_autocollected_metrics_values(
+        self,
+        entity_type: str,
+        entity_id: str,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /otel/{entityType}/{entityId}/metrics/autocollectedValues/ — platform metrics."""
+        params: dict[str, Any] = {}
+        if start:
+            params["startTime"] = start
+        if end:
+            params["endTime"] = end
+        with request_user_dr_client() as client:
+            return client.get(
+                f"otel/{entity_type}/{entity_id}/metrics/autocollectedValues/", params=params
+            ).json()
+
+    # ------------------------------------------------------------------ #
+    # Stats                                                                #
+    # ------------------------------------------------------------------ #
+
+    def get_entity_stats(
+        self,
+        service_name: str,
+        *,
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 1000,
+    ) -> dict[str, Any]:
+        """GET /otel/stats/ — per-(user, service) OTel volume for one entity.
+
+        ``service_name`` is ``f"{entity_type}-{entity_id}"``, built by the
+        caller — this client never constructs it.
+        """
+        params: dict[str, Any] = {"serviceName": service_name, "limit": limit}
+        if start:
+            params["startTime"] = start
+        if end:
+            params["endTime"] = end
+        with request_user_dr_client() as client:
+            return client.get("otel/stats/", params=params).json()

--- a/src/datarobot_genai/drtools/core/clients/datarobot_otel_query.py
+++ b/src/datarobot_genai/drtools/core/clients/datarobot_otel_query.py
@@ -64,8 +64,8 @@ class OtelQueryApiClient:
         min_trace_duration_ns: int | None = None,
         min_span_duration_ns: int | None = None,
         max_span_duration_ns: int | None = None,
-        min_trace_cost: int | None = None,
-        max_trace_cost: int | None = None,
+        min_trace_cost: float | None = None,
+        max_trace_cost: float | None = None,
         sort_by: str | None = None,
         sort_direction: str | None = None,
     ) -> dict[str, Any]:

--- a/src/datarobot_genai/drtools/core/utils.py
+++ b/src/datarobot_genai/drtools/core/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Shared utilities for drtools and drmcp."""
 
+import re
 from typing import Any
 from urllib.parse import urlparse
 
@@ -22,6 +23,9 @@ from datarobot_genai.drmcputils.constants import MAX_INLINE_SIZE
 from datarobot_genai.drmcputils.exceptions import ToolError
 from datarobot_genai.drmcputils.exceptions import ToolErrorKind
 
+_OBJECT_ID_PATTERN = re.compile(r"^[0-9a-fA-F]{24}$")
+_TRACE_ID_PATTERN = re.compile(r"^[0-9a-fA-F]{32}$")
+
 
 def require_id(value: str, name: str) -> str:
     if not value or not value.strip():
@@ -30,6 +34,45 @@ def require_id(value: str, name: str) -> str:
             kind=ToolErrorKind.VALIDATION,
         )
     return value.strip()
+
+
+def require_object_id(value: str, name: str) -> str:
+    """Validate a 24-character hex DataRobot object id (mirrors ``MongoIdField``).
+
+    Raised up front so a malformed id fails with a readable message instead of
+    a server 422.
+    """
+    if not isinstance(value, str):
+        raise ToolError(
+            f"Argument validation error: '{name}' must be a string, got {type(value).__name__}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    stripped = require_id(value, name)
+    if not _OBJECT_ID_PATTERN.fullmatch(stripped):
+        raise ToolError(
+            f"Argument validation error: '{name}' must be a 24-character hex ID, got {value!r}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    return stripped
+
+
+def require_trace_id(value: str) -> str:
+    """Validate an exactly-32-character hex OTel trace id.
+
+    Mirrors ``TracingRetrieveParamValidator.trace_id``.
+    """
+    if not isinstance(value, str):
+        raise ToolError(
+            f"Argument validation error: 'trace_id' must be a string, got {type(value).__name__}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    stripped = require_id(value, "trace_id")
+    if not _TRACE_ID_PATTERN.fullmatch(stripped):
+        raise ToolError(
+            f"Argument validation error: 'trace_id' must be a 32-character hex ID, got {value!r}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    return stripped
 
 
 def is_valid_url(url: str) -> bool:

--- a/src/datarobot_genai/drtools/core/utils.py
+++ b/src/datarobot_genai/drtools/core/utils.py
@@ -57,9 +57,11 @@ def require_object_id(value: str, name: str) -> str:
 
 
 def require_trace_id(value: str) -> str:
-    """Validate an exactly-32-character hex OTel trace id.
+    """Validate an exactly-32-character hex OTel trace id, returned lowercased.
 
-    Mirrors ``TracingRetrieveParamValidator.trace_id``.
+    Mirrors ``TracingRetrieveParamValidator.trace_id``. Lowercasing matters: the
+    server emits and matches lowercase hex, so an uppercase id pasted by a human
+    would otherwise miss an existing trace.
     """
     if not isinstance(value, str):
         raise ToolError(
@@ -72,7 +74,7 @@ def require_trace_id(value: str) -> str:
             f"Argument validation error: 'trace_id' must be a 32-character hex ID, got {value!r}.",
             kind=ToolErrorKind.VALIDATION,
         )
-    return stripped
+    return stripped.lower()
 
 
 def is_valid_url(url: str) -> bool:

--- a/src/datarobot_genai/drtools/otel/__init__.py
+++ b/src/datarobot_genai/drtools/otel/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/datarobot_genai/drtools/otel/constants.py
+++ b/src/datarobot_genai/drtools/otel/constants.py
@@ -1,0 +1,111 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Constants shared by the OTel query tools.
+
+Registers no tools; drmcp's loader globs this module but finds nothing to bind.
+"""
+
+from typing import Literal
+from typing import NamedTuple
+from typing import get_args
+
+# Entity types the /otel routes accept. These are snake_case on the wire and in
+# the path: drflask's camelize() only rewrites underscores in *keys*, and the
+# ChoiceField behind entityType sets initial_camelization=False. So 'use_case'
+# stays 'use_case' and must never be sent as 'useCase'.
+EntityType = Literal[
+    "deployment",
+    "use_case",
+    "experiment_container",
+    "custom_application",
+    "workload",
+    "execution_environment",
+    "custom_job",
+    "artifact",
+]
+
+OTEL_ENTITY_TYPES: tuple[str, ...] = get_args(EntityType)
+
+# Minimum log levels accepted by GET /otel/{entityType}/{entityId}/logs/.
+#
+# Deliberately NOT drmcputils.constants.LOG_LEVELS, which is only
+# ("debug", "info", "warn", "error"). Reusing that tuple would reject 'warning'
+# and 'critical', which this API accepts. 'level' is a *minimum*, not an exact
+# match.
+OTEL_LOG_LEVELS: tuple[str, ...] = (
+    "debug",
+    "info",
+    "warn",
+    "warning",
+    "error",
+    "critical",
+)
+
+
+class SemconvFamily(NamedTuple):
+    """One semantic-convention family, matched by exact name or by prefix."""
+
+    name: str
+    exact: frozenset[str] = frozenset()
+    prefixes: tuple[str, ...] = ()
+
+
+# Precedence rank 1: the response's own normalized fields. The platform's
+# enrich_trace() copies the best available prompt-/completion-like attribute into
+# these, so they are guaranteed to carry the text of any derived attribute
+# dropped below. Never dropped, and they win every byte-identity tie.
+RESPONSE_PAYLOAD_FIELDS: tuple[str, ...] = ("prompt", "completion")
+
+# Which family wins when several carry the same text, highest precedence first.
+# Traceloop, NAT, OpenInference and gen_ai semconv each independently write the
+# same prompt/completion text; on the worst measured trace 64.5% of the payload
+# was byte-identical duplication.
+SEMCONV_PRECEDENCE: tuple[SemconvFamily, ...] = (
+    SemconvFamily("response", exact=frozenset(RESPONSE_PAYLOAD_FIELDS)),
+    SemconvFamily("gen_ai", prefixes=("gen_ai.",)),
+    SemconvFamily("openinference", exact=frozenset({"input.value", "output.value"})),
+    SemconvFamily("traceloop", prefixes=("traceloop.",)),
+    SemconvFamily("nat", prefixes=("nat.",)),
+)
+
+# Rank assigned to attributes belonging to no known family. Lowest precedence, so
+# an unknown attribute loses a byte-identity tie against every known family.
+UNRANKED_SEMCONV_PRECEDENCE: int = len(SEMCONV_PRECEDENCE)
+
+# Attributes dropped outright as derived or duplicated (plan §3's drop list).
+# Usually lossless: the platform's enrich_trace() copies the best available
+# prompt-/completion-like attribute into RESPONSE_PAYLOAD_FIELDS, so the text
+# survives there. Not lossless *unconditionally* — §3's own field breakdown of the
+# worst trace measures 'completion' at 23% against a 20% gen_ai.task.output /
+# traceloop.entity.output pair, i.e. text that is byte-identical to its twin but
+# not to 'completion'. When a whole byte-identical group is dropped,
+# canonical_attributes reports it as 'semconv' rather than claiming a surviving
+# duplicate, and an agent can fetch the field back by exact name (§2.3 'fields').
+# Every drop is reported.
+DERIVED_ATTRIBUTE_NAMES: frozenset[str] = frozenset(
+    {
+        "gen_ai.task.input",
+        "gen_ai.task.output",
+        "traceloop.entity.input",
+        "traceloop.entity.output",
+        "nat.metadata",
+    }
+)
+
+# Same list, for the entries that need a glob. Matched with fnmatch.fnmatchcase.
+DERIVED_ATTRIBUTE_PATTERNS: tuple[str, ...] = (
+    "gen_ai.completion.*.content",
+    "*.value_obj",
+)

--- a/src/datarobot_genai/drtools/otel/truncation.py
+++ b/src/datarobot_genai/drtools/otel/truncation.py
@@ -1,0 +1,314 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bounded projections of OTel trace payloads.
+
+Pure helpers: no HTTP, no tool registration. drmcp's loader globs this module and
+finds nothing to bind.
+
+Why this is not drtools/panels/truncate.py: ``truncate_for_llm`` is
+structure-preserving and generic (uniform per-string cap, per-array/-object caps,
+depth collapse). It has no notion of a *total* budget, no notion of which of two
+byte-identical attributes to keep, and its ``max_array_items=5`` would silently
+drop 32 of a 37-span trace's spans. Wrong shape for this problem.
+
+The number that sets the design: on the worst measured trace (4.76 MB, 37 spans,
+1,560,241 tokens) even *perfect* dedup leaves 423,300 tokens of genuinely unique
+text — still 2x a context window. Dedup does not solve this. Only
+summary-by-default plus a hard character cap does. Weakening
+``apply_char_budget`` in favour of smarter dedup is a regression.
+"""
+
+import json
+from fnmatch import fnmatchcase
+from typing import Any
+
+from datarobot_genai.drtools.otel.constants import DERIVED_ATTRIBUTE_NAMES
+from datarobot_genai.drtools.otel.constants import DERIVED_ATTRIBUTE_PATTERNS
+from datarobot_genai.drtools.otel.constants import RESPONSE_PAYLOAD_FIELDS
+from datarobot_genai.drtools.otel.constants import SEMCONV_PRECEDENCE
+from datarobot_genai.drtools.otel.constants import UNRANKED_SEMCONV_PRECEDENCE
+
+# A string field at least this long is treated as payload text: counted in
+# ``payload_chars``, listed in ``payload_fields``, and eligible for byte-identity
+# dedup. Shorter values (model names, token counts, ids) are metadata, and
+# deduplicating those would drop unrelated attributes that merely share a value.
+PAYLOAD_MIN_CHARS = 200
+
+# Cap on the ``payload_fields`` list, so a span carrying hundreds of large
+# attributes cannot make the summary grow with the payload. ``payload_chars``
+# still counts every field; the omitted count is reported.
+PAYLOAD_FIELDS_MAX = 12
+
+# Cap on ``status_message`` in the summary projection. It is the one structural
+# field that carries arbitrary text: ``SpanViewValidator.status_message`` is a
+# StringField with no server-side max_length, so an exception traceback arrives
+# verbatim. Nothing else backstops the summary view — §2.2 puts
+# ``max_total_chars`` on view="payloads" only — and uncapped, a single
+# 48,000-char traceback grows the projection 13x past the measured ~133 tok/span
+# rate. Capped, the summary is O(span_count) rather than O(input size). 500 chars
+# holds an exception type, its message and the first frame.
+STATUS_MESSAGE_MAX_CHARS = 500
+
+# Structural fields kept by ``summarize_spans``, in emission order.
+SPAN_SUMMARY_FIELDS: tuple[str, ...] = (
+    "span_id",
+    "parent_span_id",
+    "name",
+    "status_code",
+    "status_message",
+    "kind",
+    "service_name",
+    "duration",
+    "start_time",
+)
+
+# Chars each emitted item costs beyond its own JSON: json.dumps' default ", "
+# separator, or the enclosing "[]" for the last item. Charging it makes
+# ``chars_used`` equal to len(json.dumps(returned)) rather than an undercount, so
+# the budget is a real bound on what reaches the model.
+_ITEM_OVERHEAD_CHARS = 2
+
+
+def summarize_spans(spans: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Span tree projection with per-span payload accounting.
+
+    Returns (summaries, stats). Each summary carries the structural fields plus
+    ``payload_chars`` and ``payload_fields``; ``stats`` carries the trace-wide
+    ``total_payload_chars``. ~133 tokens per span, independent of payload size.
+
+    ``payload_chars`` and ``payload_fields`` are the load-bearing detail: they
+    tell the agent *where the mass is* for ~15 extra tokens a span, which turns
+    drill-down into a deliberate, targeted second call instead of a blind one.
+    Accounting is pre-dedup and pre-cap — it reports the raw payload as it exists
+    on the trace, including byte-identical twins, because that is what an agent
+    needs to see to choose a span. ``payload_fields`` is ordered largest first
+    and capped at ``PAYLOAD_FIELDS_MAX``, adding ``payload_fields_omitted`` when
+    the cap bites. ``status_message`` is capped at ``STATUS_MESSAGE_MAX_CHARS``
+    with a ``…[truncated, N more chars]`` marker — it is the only structural field
+    that can carry an unbounded traceback, and the summary view has no total
+    budget behind it.
+    """
+    summaries: list[dict[str, Any]] = []
+    total_payload_chars = 0
+
+    for span in spans:
+        summary: dict[str, Any] = {field: span.get(field) for field in SPAN_SUMMARY_FIELDS}
+        summary["status_message"] = _capped_status_message(span.get("status_message"))
+        sizes = _payload_sizes(span)
+        payload_chars = sum(sizes.values())
+        names = list(sizes)
+
+        summary["payload_chars"] = payload_chars
+        summary["payload_fields"] = names[:PAYLOAD_FIELDS_MAX]
+        if len(names) > PAYLOAD_FIELDS_MAX:
+            summary["payload_fields_omitted"] = len(names) - PAYLOAD_FIELDS_MAX
+
+        total_payload_chars += payload_chars
+        summaries.append(summary)
+
+    return summaries, {"total_payload_chars": total_payload_chars}
+
+
+def canonical_attributes(attributes: dict[str, Any]) -> tuple[dict[str, Any], dict[str, list[str]]]:
+    """Drop byte-identical twins and non-canonical semconv families.
+
+    Returns (kept, dropped) where ``dropped`` distinguishes ``duplicate`` from
+    ``semconv`` so callers can report which and why. Measured reduction: 36% from
+    dedup, 42% from semconv selection, on the worst trace.
+
+    Callers may include the span's own ``prompt`` and ``completion`` in
+    ``attributes``: those are precedence rank 1, are never dropped, and win every
+    byte-identity tie.
+
+    A name lands in ``duplicate`` only when a byte-identical copy of its value
+    actually survives in ``kept``, and in ``semconv`` when its text survives
+    nowhere. §3 drops the derived families unconditionally, so the second case is
+    reachable: a span instrumented only by Traceloop and gen_ai whose
+    ``prompt``/``completion`` the platform's ``enrich_trace`` left empty — or
+    filled with different text — has no surviving carrier for its output. Saying
+    ``semconv`` there is the honest report; telling an agent "you already have
+    this" about text the response does not contain is not. Either way the name is
+    surfaced, so §2.3's ``fields`` parameter can fetch the field back by exact
+    name. Both lists are sorted; no drop is silent.
+    """
+    names = list(attributes)
+    derived = {name: _is_derived(name) for name in names}
+    ranks = {name: _semconv_rank(name) for name in names}
+    order = {name: index for index, name in enumerate(names)}
+
+    twins: dict[str, list[str]] = {}
+    for name in names:
+        value = attributes[name]
+        if isinstance(value, str) and len(value) >= PAYLOAD_MIN_CHARS:
+            twins.setdefault(value, []).append(name)
+
+    # Within a group of byte-identical values the keeper is the highest-precedence
+    # member that is not itself a derived family: electing a derived member and
+    # then dropping it would wipe out a group that had a viable carrier.
+    keepers: set[str] = set()
+    duplicated: set[str] = set()
+    for members in twins.values():
+        if len(members) < 2:
+            continue
+        duplicated.update(members)
+        candidates = [name for name in members if not derived[name]]
+        if candidates:
+            keepers.add(min(candidates, key=lambda name: (ranks[name], order[name])))
+
+    kept: dict[str, Any] = {}
+    dropped_names: list[str] = []
+    for name in names:
+        if name in RESPONSE_PAYLOAD_FIELDS:
+            kept[name] = attributes[name]
+        elif derived[name] or (name in duplicated and name not in keepers):
+            dropped_names.append(name)
+        else:
+            kept[name] = attributes[name]
+
+    # Bucket by what actually survived, not by why the drop was decided. The
+    # surviving set is length-unbounded on purpose: a short byte-identical twin is
+    # still a duplicate even though it never entered the dedup map above.
+    surviving = {value for value in kept.values() if isinstance(value, str)}
+    dropped: dict[str, list[str]] = {"duplicate": [], "semconv": []}
+    for name in dropped_names:
+        value = attributes[name]
+        bucket = "duplicate" if isinstance(value, str) and value in surviving else "semconv"
+        dropped[bucket].append(name)
+
+    dropped["duplicate"].sort()
+    dropped["semconv"].sort()
+    return kept, dropped
+
+
+def cap_value(value: str, max_chars: int, offset: int = 0) -> tuple[str, dict[str, Any] | None]:
+    """Window one string; second element records returned/total/next_offset.
+
+    Windows, not dumps: one measured attribute value was 54,799 tokens and the
+    largest was 740,000 chars, so "return the whole field" is not an option and
+    ``next_offset`` is how an agent continues. ``next_offset`` is None at the end
+    of the value.
+
+    Both bounds are in characters, not bytes — we are slicing decoded ``str``,
+    and byte-slicing UTF-8 breaks multibyte sequences. ``max_chars <= 0`` disables
+    the cap; a negative ``offset`` clamps to 0 and an ``offset`` past the end
+    returns an empty window. The second element is None only when the whole value
+    is returned from offset 0 — the test is the *requested* offset, not the clamped
+    one, so an out-of-range offset against an empty value still gets a record
+    rather than looking like an untruncated field.
+    """
+    total_chars = len(value)
+    start = max(0, min(offset, total_chars))
+    end = total_chars if max_chars <= 0 else min(start + max_chars, total_chars)
+    window = value[start:end]
+
+    if offset <= 0 and end == total_chars:
+        return window, None
+
+    return window, {
+        "returned_chars": len(window),
+        "total_chars": total_chars,
+        "next_offset": end if end < total_chars else None,
+    }
+
+
+def apply_char_budget(
+    items: list[dict[str, Any]], max_total_chars: int
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Emit items in order until the budget is spent; report what was dropped.
+
+    This is the hard stop, and the only thing that actually bounds output. Dedup
+    (36%) and canonical-semconv selection (42%) are worth doing *before* the cap,
+    never instead of it: strategy E — canonical semconv only, every value capped —
+    still measured 64,641 tokens on the worst trace, which is why the character
+    budget is not advisory.
+
+    Cost is an item's serialized JSON length plus the array overhead it adds, so
+    ``chars_used`` equals ``len(json.dumps(returned, ensure_ascii=False))`` and
+    never undercounts what reaches the model. ``ensure_ascii=False`` is load-bearing,
+    not cosmetic: the budget's unit is characters (§1's 3.1 chars/token conversion,
+    §2.4's "chars, not bytes") and MCP does not escape non-ASCII on the wire, so
+    measuring escape-expanded JSON charged a CJK payload ~6x its size and made the
+    number of spans returned depend on the language of the trace. Emission stops at
+    the first item that does not fit and every item from there on is dropped, which
+    keeps the order the caller chose. ``max_total_chars <= 0`` disables the budget.
+    Stat keys are span-named because paging a trace's spans is the caller this
+    exists for.
+    """
+    emitted: list[dict[str, Any]] = []
+    chars_used = 0
+
+    for item in items:
+        cost = len(json.dumps(item, default=str, ensure_ascii=False)) + _ITEM_OVERHEAD_CHARS
+        if max_total_chars > 0 and chars_used + cost > max_total_chars:
+            break
+        emitted.append(item)
+        chars_used += cost
+
+    return emitted, {
+        "spans_returned": len(emitted),
+        "spans_dropped": len(items) - len(emitted),
+        "chars_used": chars_used,
+        "max_total_chars": max_total_chars,
+    }
+
+
+def _capped_status_message(value: Any) -> Any:
+    """Cap the one structural field that can carry an arbitrary-length traceback."""
+    if not isinstance(value, str):
+        return value
+    window, info = cap_value(value, STATUS_MESSAGE_MAX_CHARS)
+    if info is None:
+        return window
+    return f"{window}…[truncated, {info['total_chars'] - info['returned_chars']} more chars]"
+
+
+def _payload_sizes(span: dict[str, Any]) -> dict[str, int]:
+    """Map a span's payload-sized string fields to their char counts, largest first.
+
+    ``attributes`` is a dynamic dict on the wire, so it can carry a key literally
+    named ``prompt`` or ``completion`` beside the span's own response field. Sizes
+    accumulate under the shared name instead of overwriting, so ``payload_chars``
+    counts both and never undercounts the payload actually on the span.
+    """
+    sizes: dict[str, int] = {}
+
+    def add(name: str, value: Any) -> None:
+        if isinstance(value, str) and len(value) >= PAYLOAD_MIN_CHARS:
+            sizes[name] = sizes.get(name, 0) + len(value)
+
+    for name in RESPONSE_PAYLOAD_FIELDS:
+        add(name, span.get(name))
+
+    attributes = span.get("attributes")
+    if isinstance(attributes, dict):
+        for name, value in attributes.items():
+            add(str(name), value)
+
+    return dict(sorted(sizes.items(), key=lambda item: (-item[1], item[0])))
+
+
+def _semconv_rank(name: str) -> int:
+    """Rank an attribute name by semconv family; lower wins a byte-identity tie."""
+    for rank, family in enumerate(SEMCONV_PRECEDENCE):
+        if name in family.exact or (family.prefixes and name.startswith(family.prefixes)):
+            return rank
+    return UNRANKED_SEMCONV_PRECEDENCE
+
+
+def _is_derived(name: str) -> bool:
+    """Report whether an attribute is a derived or duplicated family, dropped outright."""
+    if name in DERIVED_ATTRIBUTE_NAMES:
+        return True
+    return any(fnmatchcase(name, pattern) for pattern in DERIVED_ATTRIBUTE_PATTERNS)

--- a/src/datarobot_genai/drtools/otel/truncation.py
+++ b/src/datarobot_genai/drtools/otel/truncation.py
@@ -150,9 +150,9 @@ def canonical_attributes(attributes: dict[str, Any]) -> tuple[dict[str, Any], di
 
     twins: dict[str, list[str]] = {}
     for name in names:
-        value = attributes[name]
-        if isinstance(value, str) and len(value) >= PAYLOAD_MIN_CHARS:
-            twins.setdefault(value, []).append(name)
+        text = _payload_text(attributes[name])
+        if text is not None and len(text) >= PAYLOAD_MIN_CHARS:
+            twins.setdefault(text, []).append(name)
 
     # Within a group of byte-identical values the keeper is the highest-precedence
     # member that is not itself a derived family: electing a derived member and
@@ -180,11 +180,13 @@ def canonical_attributes(attributes: dict[str, Any]) -> tuple[dict[str, Any], di
     # Bucket by what actually survived, not by why the drop was decided. The
     # surviving set is length-unbounded on purpose: a short byte-identical twin is
     # still a duplicate even though it never entered the dedup map above.
-    surviving = {value for value in kept.values() if isinstance(value, str)}
+    surviving = {
+        text for text in (_payload_text(value) for value in kept.values()) if text is not None
+    }
     dropped: dict[str, list[str]] = {"duplicate": [], "semconv": []}
     for name in dropped_names:
-        value = attributes[name]
-        bucket = "duplicate" if isinstance(value, str) and value in surviving else "semconv"
+        text = _payload_text(attributes[name])
+        bucket = "duplicate" if text is not None and text in surviving else "semconv"
         dropped[bucket].append(name)
 
     dropped["duplicate"].sort()
@@ -221,6 +223,32 @@ def cap_value(value: str, max_chars: int, offset: int = 0) -> tuple[str, dict[st
         "total_chars": total_chars,
         "next_offset": end if end < total_chars else None,
     }
+
+
+def cap_payload_value(
+    value: Any, max_chars: int, offset: int = 0
+) -> tuple[Any, dict[str, Any] | None]:
+    """Window any payload value; containers are windowed over their JSON text.
+
+    A string behaves exactly as :func:`cap_value`. A list/dict that fits whole
+    (requested from offset 0) is returned as-is, native; one that does not is
+    returned as a window of its serialized JSON with ``"serialized": True`` in
+    the record, so the caller knows the window is JSON text of a container
+    rather than a raw string value. OTLP allows array attributes and
+    instrumentations send JSON-decoded message lists (``gen_ai.prompt`` as a
+    100k-char list was observed), so capping only ``str`` values let those
+    through every cap whole. Numbers, bools and None pass through untouched —
+    they are metadata-sized by construction.
+    """
+    if isinstance(value, str):
+        return cap_value(value, max_chars, offset)
+    if isinstance(value, (list, dict)):
+        window, info = cap_value(_container_text(value), max_chars, offset)
+        if info is None:
+            return value, None
+        info["serialized"] = True
+        return window, info
+    return value, None
 
 
 def apply_char_budget(
@@ -274,19 +302,43 @@ def _capped_status_message(value: Any) -> Any:
     return f"{window}…[truncated, {info['total_chars'] - info['returned_chars']} more chars]"
 
 
+def _container_text(value: list[Any] | dict[str, Any]) -> str:
+    """Serialize a container exactly the way ``apply_char_budget`` charges it."""
+    return json.dumps(value, default=str, ensure_ascii=False)
+
+
+def _payload_text(value: Any) -> str | None:
+    """Return the text a value contributes to payload accounting and dedup.
+
+    A str is its own text; a list/dict is measured over its serialized JSON — the
+    same serialization ``apply_char_budget`` charges — so accounting, byte-identity
+    dedup, caps and the budget agree on one size. Anything else is metadata-sized:
+    None.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (list, dict)):
+        return _container_text(value)
+    return None
+
+
 def _payload_sizes(span: dict[str, Any]) -> dict[str, int]:
-    """Map a span's payload-sized string fields to their char counts, largest first.
+    """Map a span's payload-sized fields to their char counts, largest first.
 
     ``attributes`` is a dynamic dict on the wire, so it can carry a key literally
     named ``prompt`` or ``completion`` beside the span's own response field. Sizes
     accumulate under the shared name instead of overwriting, so ``payload_chars``
-    counts both and never undercounts the payload actually on the span.
+    counts both and never undercounts the payload actually on the span. Container
+    values count their serialized JSON via ``_payload_text`` — counting only
+    ``str`` values reported a 100k-char ``gen_ai.prompt`` list as 0 payload chars,
+    pointing the agent away from exactly the span it needed.
     """
     sizes: dict[str, int] = {}
 
     def add(name: str, value: Any) -> None:
-        if isinstance(value, str) and len(value) >= PAYLOAD_MIN_CHARS:
-            sizes[name] = sizes.get(name, 0) + len(value)
+        text = _payload_text(value)
+        if text is not None and len(text) >= PAYLOAD_MIN_CHARS:
+            sizes[name] = sizes.get(name, 0) + len(text)
 
     for name in RESPONSE_PAYLOAD_FIELDS:
         add(name, span.get(name))

--- a/tests/drmcp/unit/otel_tools/conftest.py
+++ b/tests/drmcp/unit/otel_tools/conftest.py
@@ -1,0 +1,34 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fixtures for the OTel tool tests: the two trace populations from APP-6967."""
+
+from typing import Any
+
+import pytest
+
+from tests.drmcp.unit.otel_tools.trace_factory import build_oversized_agent_trace
+from tests.drmcp.unit.otel_tools.trace_factory import build_small_trace
+
+
+@pytest.fixture
+def oversized_agent_trace() -> dict[str, Any]:
+    """Build the population this ticket exists for: 12 spans, 1,022,000 payload chars."""
+    return build_oversized_agent_trace()
+
+
+@pytest.fixture
+def small_trace() -> dict[str, Any]:
+    """Build the other population: a non-agentic trace of ~450 tokens end to end."""
+    return build_small_trace()

--- a/tests/drmcp/unit/otel_tools/test_client.py
+++ b/tests/drmcp/unit/otel_tools/test_client.py
@@ -159,6 +159,24 @@ def test_list_traces_sends_zero_valued_duration_and_cost_filters(
     )
 
 
+def test_list_traces_forwards_fractional_cost_bounds(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN sub-dollar cost bounds — trace cost is a fractional currency amount
+    # (the SDK types it Float; the stub trace's own cost is 0.002)
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_traces is called with fractional bounds
+    client.list_traces("deployment", "abc123", min_trace_cost=0.001, max_trace_cost=0.01)
+
+    # THEN they are forwarded unmangled — an int-typed signature rejected every
+    # realistic sub-dollar bound before the request was ever made
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/traces/",
+        params={"limit": 20, "offset": 0, "minTraceCost": 0.001, "maxTraceCost": 0.01},
+    )
+
+
 # ------------------------------------------------------------------ #
 # get_trace                                                            #
 # ------------------------------------------------------------------ #

--- a/tests/drmcp/unit/otel_tools/test_client.py
+++ b/tests/drmcp/unit/otel_tools/test_client.py
@@ -1,0 +1,434 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for OtelQueryApiClient.
+
+Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
+
+The client is pure transport (camelCase param assembly + path construction),
+so that assembly is the whole point of these tests. No tools exist yet — the
+client is exercised directly, the same way tests/drmcp/unit/workload_tools/
+exercises WorkloadApiClient's HTTP calls through request_user_dr_client.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from datarobot_genai.drtools.core.clients.datarobot_otel_query import OtelQueryApiClient
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def patched_dr_client(mock_rest_client: MagicMock) -> Iterator[MagicMock]:
+    with patch(
+        "datarobot_genai.drtools.core.clients.datarobot_otel_query.request_user_dr_client"
+    ) as mock_cm:
+        mock_cm.return_value.__enter__.return_value = mock_rest_client
+        mock_cm.return_value.__exit__.return_value = False
+        yield mock_rest_client
+
+
+@pytest.fixture
+def client() -> OtelQueryApiClient:
+    return OtelQueryApiClient()
+
+
+# ------------------------------------------------------------------ #
+# list_traces                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_list_traces_builds_path_from_entity_type_and_id_with_default_params(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN no optional filters
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_traces is called with only the required entity args
+    result = client.list_traces("deployment", "abc123")
+
+    # THEN the path is built from entity_type/entity_id and only limit/offset are sent
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/traces/", params={"limit": 20, "offset": 0}
+    )
+    assert result == {"data": []}
+
+
+def test_list_traces_camelizes_every_optional_filter(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN every optional filter set, including the *_ns duration params
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_traces is called with all filters
+    client.list_traces(
+        "use_case",
+        "xyz789",
+        limit=50,
+        offset=10,
+        start_time="2026-08-01T00:00:00Z",
+        end_time="2026-08-02T00:00:00Z",
+        status="error",
+        root_span_name=["agent.run"],
+        tools=["search"],
+        trace_type="gen_ai",
+        min_trace_duration_ns=1_000,
+        min_span_duration_ns=2_000,
+        max_span_duration_ns=3_000,
+        min_trace_cost=1,
+        max_trace_cost=100,
+        sort_by="duration",
+        sort_direction="desc",
+    )
+
+    # THEN every filter key is camelCase on the wire, and snake_case values
+    # (status, trace_type) are passed through unchanged per §2's convention
+    patched_dr_client.get.assert_called_once_with(
+        "otel/use_case/xyz789/traces/",
+        params={
+            "limit": 50,
+            "offset": 10,
+            "startTime": "2026-08-01T00:00:00Z",
+            "endTime": "2026-08-02T00:00:00Z",
+            "status": "error",
+            "rootSpanName": ["agent.run"],
+            "tools": ["search"],
+            "traceType": "gen_ai",
+            "minTraceDuration": 1_000,
+            "minSpanDuration": 2_000,
+            "maxSpanDuration": 3_000,
+            "minTraceCost": 1,
+            "maxTraceCost": 100,
+            "sortBy": "duration",
+            "sortDirection": "desc",
+        },
+    )
+
+
+def test_list_traces_omits_unset_optional_filters(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN optional list filters passed as empty lists (falsy)
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_traces is called with empty-list filters and no other optionals
+    client.list_traces("deployment", "abc123", root_span_name=[], tools=[])
+
+    # THEN the empty lists are not sent as query params
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/traces/", params={"limit": 20, "offset": 0}
+    )
+
+
+def test_list_traces_sends_zero_valued_duration_and_cost_filters(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN duration/cost filters explicitly set to 0 (a valid value, not "unset")
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_traces is called with those filters at 0
+    client.list_traces(
+        "deployment",
+        "abc123",
+        min_trace_duration_ns=0,
+        min_trace_cost=0,
+    )
+
+    # THEN 0 is sent, not treated as absent (checked via "is not None", not truthiness)
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/traces/",
+        params={"limit": 20, "offset": 0, "minTraceDuration": 0, "minTraceCost": 0},
+    )
+
+
+# ------------------------------------------------------------------ #
+# get_trace                                                            #
+# ------------------------------------------------------------------ #
+
+
+def test_get_trace_builds_path_with_trace_id_and_default_span_pagination(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN a trace_id
+    trace_id = "a" * 32
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"spans": []})
+
+    # WHEN get_trace is called with no explicit pagination
+    result = client.get_trace("deployment", "abc123", trace_id)
+
+    # THEN the path includes the trace id and default span limit/offset are sent
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/abc123/traces/{trace_id}/", params={"limit": 100, "offset": 0}
+    )
+    assert result == {"spans": []}
+
+
+def test_get_trace_forwards_explicit_span_pagination(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN explicit span_limit/span_offset-equivalent pagination
+    trace_id = "b" * 32
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"spans": []})
+
+    # WHEN get_trace is called with limit/offset overrides
+    client.get_trace("workload", "wkld-1", trace_id, limit=10, offset=5)
+
+    # THEN limit/offset page the spans, sent unchanged (already lowercase on the wire)
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/workload/wkld-1/traces/{trace_id}/", params={"limit": 10, "offset": 5}
+    )
+
+
+# ------------------------------------------------------------------ #
+# list_logs                                                            #
+# ------------------------------------------------------------------ #
+
+
+def test_list_logs_builds_path_and_defaults_level_to_debug(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN no optional filters
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_logs is called with only the required entity args
+    client.list_logs("custom_application", "app-1")
+
+    # THEN limit/offset/level default and no other keys are sent
+    patched_dr_client.get.assert_called_once_with(
+        "otel/custom_application/app-1/logs/",
+        params={"limit": 50, "offset": 0, "level": "debug"},
+    )
+
+
+def test_list_logs_camelizes_span_and_trace_id_and_forwards_body_filters(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN every optional filter set, including the six-level minimum ('warning')
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_logs is called with all filters
+    client.list_logs(
+        "deployment",
+        "abc123",
+        limit=25,
+        offset=5,
+        level="warning",
+        start_time="2026-08-01T00:00:00Z",
+        end_time="2026-08-02T00:00:00Z",
+        includes=["timeout"],
+        excludes=["retry"],
+        span_id="span-1",
+        trace_id="c" * 32,
+    )
+
+    # THEN spanId/traceId are camelCase and includes/excludes pass through as lists
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/logs/",
+        params={
+            "limit": 25,
+            "offset": 5,
+            "level": "warning",
+            "startTime": "2026-08-01T00:00:00Z",
+            "endTime": "2026-08-02T00:00:00Z",
+            "includes": ["timeout"],
+            "excludes": ["retry"],
+            "spanId": "span-1",
+            "traceId": "c" * 32,
+        },
+    )
+
+
+# ------------------------------------------------------------------ #
+# list_metrics_summary                                                 #
+# ------------------------------------------------------------------ #
+
+
+def test_list_metrics_summary_sends_no_params_when_unfiltered(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN no search/metric_type
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"metrics": []})
+
+    # WHEN list_metrics_summary is called with only entity args
+    client.list_metrics_summary("deployment", "abc123")
+
+    # THEN no query params are sent at all
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/metrics/summary/", params={}
+    )
+
+
+def test_list_metrics_summary_camelizes_metric_type(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN search and metric_type filters
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"metrics": []})
+
+    # WHEN list_metrics_summary is called with both
+    client.list_metrics_summary("deployment", "abc123", search="latency", metric_type="counter")
+
+    # THEN metric_type becomes metricType on the wire
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/metrics/summary/",
+        params={"search": "latency", "metricType": "counter"},
+    )
+
+
+# ------------------------------------------------------------------ #
+# get_metrics_values / get_autocollected_metrics_values                #
+# ------------------------------------------------------------------ #
+
+
+def test_get_metrics_values_always_sends_histogram_buckets(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN the default (unset) histogram_buckets
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"metric_aggregations": []})
+
+    # WHEN get_metrics_values is called with no other args
+    client.get_metrics_values("deployment", "abc123")
+
+    # THEN histogramBuckets is sent even at its False default (not Optional)
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/metrics/values/", params={"histogramBuckets": False}
+    )
+
+
+def test_get_metrics_values_forwards_window_and_histogram_flag(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN a time window and histogram_buckets=True
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"metric_aggregations": []})
+
+    # WHEN get_metrics_values is called with start/end and the flag set
+    client.get_metrics_values(
+        "deployment",
+        "abc123",
+        histogram_buckets=True,
+        start="2026-08-01T00:00:00Z",
+        end="2026-08-02T00:00:00Z",
+    )
+
+    # THEN start/end become startTime/endTime and the flag is forwarded
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/metrics/values/",
+        params={
+            "histogramBuckets": True,
+            "startTime": "2026-08-01T00:00:00Z",
+            "endTime": "2026-08-02T00:00:00Z",
+        },
+    )
+
+
+def test_get_autocollected_metrics_values_has_no_histogram_param(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN a time window (autocollected has no histogram_buckets concept)
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"metrics": []})
+
+    # WHEN get_autocollected_metrics_values is called
+    client.get_autocollected_metrics_values(
+        "deployment", "abc123", start="2026-08-01T00:00:00Z", end="2026-08-02T00:00:00Z"
+    )
+
+    # THEN only startTime/endTime are sent, on the autocollectedValues path
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/metrics/autocollectedValues/",
+        params={"startTime": "2026-08-01T00:00:00Z", "endTime": "2026-08-02T00:00:00Z"},
+    )
+
+
+def test_get_autocollected_metrics_values_sends_no_params_when_unfiltered(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN no time window
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"metrics": []})
+
+    # WHEN get_autocollected_metrics_values is called with only entity args
+    client.get_autocollected_metrics_values("deployment", "abc123")
+
+    # THEN no query params are sent
+    patched_dr_client.get.assert_called_once_with(
+        "otel/deployment/abc123/metrics/autocollectedValues/", params={}
+    )
+
+
+# ------------------------------------------------------------------ #
+# get_entity_stats                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_get_entity_stats_hits_the_flat_stats_path_with_service_name_and_default_limit(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN a pre-built service_name (the caller's job, not this client's)
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN get_entity_stats is called with only service_name
+    result = client.get_entity_stats("deployment-abc123")
+
+    # THEN the path is the flat /otel/stats/ endpoint, and limit defaults to the
+    # validator's ceiling of 1000 so per-user sums are never silently partial
+    patched_dr_client.get.assert_called_once_with(
+        "otel/stats/", params={"serviceName": "deployment-abc123", "limit": 1000}
+    )
+    assert result == {"data": []}
+
+
+def test_get_entity_stats_forwards_time_window(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN a time window and an explicit limit
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN get_entity_stats is called with start/end/limit
+    client.get_entity_stats(
+        "workload-wkld-1", start="2026-08-01T00:00:00Z", end="2026-08-02T00:00:00Z", limit=500
+    )
+
+    # THEN start/end become startTime/endTime and limit is forwarded
+    patched_dr_client.get.assert_called_once_with(
+        "otel/stats/",
+        params={
+            "serviceName": "workload-wkld-1",
+            "limit": 500,
+            "startTime": "2026-08-01T00:00:00Z",
+            "endTime": "2026-08-02T00:00:00Z",
+        },
+    )
+
+
+# ------------------------------------------------------------------ #
+# request_user_dr_client usage                                        #
+# ------------------------------------------------------------------ #
+
+
+def test_each_method_scopes_the_rest_client_to_a_single_with_block(
+    client: OtelQueryApiClient, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN a client call
+    patched_dr_client.get.return_value = MagicMock(json=lambda: {"data": []})
+
+    # WHEN list_traces is called
+    client.list_traces("deployment", "abc123")
+
+    # THEN exactly one GET is issued through the per-request credentialed client
+    assert patched_dr_client.get.call_count == 1

--- a/tests/drmcp/unit/otel_tools/test_id_helpers.py
+++ b/tests/drmcp/unit/otel_tools/test_id_helpers.py
@@ -127,6 +127,16 @@ def test_require_trace_id_accepts_32_lowercase_hex_chars() -> None:
     assert result == _VALID_TRACE_ID
 
 
+def test_require_trace_id_lowercases_uppercase_hex() -> None:
+    # GIVEN a 32-char trace id pasted with uppercase hex digits
+    # WHEN require_trace_id validates it
+    result = require_trace_id(_VALID_TRACE_ID.upper())
+
+    # THEN it is accepted and lowercased — the server emits and matches lowercase
+    # hex, so forwarding the uppercase form verbatim would miss an existing trace
+    assert result == _VALID_TRACE_ID
+
+
 def test_require_trace_id_strips_surrounding_whitespace() -> None:
     # GIVEN a valid trace id with surrounding whitespace
     # WHEN require_trace_id validates it

--- a/tests/drmcp/unit/otel_tools/test_id_helpers.py
+++ b/tests/drmcp/unit/otel_tools/test_id_helpers.py
@@ -1,0 +1,193 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for require_object_id and require_trace_id (drtools/core/utils.py).
+
+Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
+
+These are the local-validation helpers the OTel tools (traces.py et al., not yet
+built) will use to reject a malformed id before it reaches the server, per §2's
+"Local validation before the call" convention. Housed alongside the OTel client
+tests because this round is what first needs them; require_id itself predates
+this package and is only exercised indirectly here.
+"""
+
+import pytest
+
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core.utils import require_object_id
+from datarobot_genai.drtools.core.utils import require_trace_id
+
+_VALID_OBJECT_ID = "0123456789abcdef01234567"  # 24 hex chars
+_VALID_TRACE_ID = "0123456789abcdef" * 2  # 32 hex chars
+
+
+# ------------------------------------------------------------------ #
+# require_object_id                                                    #
+# ------------------------------------------------------------------ #
+
+
+def test_require_object_id_accepts_24_lowercase_hex_chars() -> None:
+    # GIVEN a well-formed 24-char hex id
+    # WHEN require_object_id validates it
+    result = require_object_id(_VALID_OBJECT_ID, "entity_id")
+
+    # THEN it is returned unchanged
+    assert result == _VALID_OBJECT_ID
+
+
+def test_require_object_id_accepts_uppercase_hex_chars() -> None:
+    # GIVEN a 24-char id using uppercase hex digits (MongoIdField accepts both cases)
+    # WHEN require_object_id validates it
+    result = require_object_id("ABCDEF0123456789ABCDEF01", "entity_id")
+
+    # THEN it is accepted and returned unchanged
+    assert result == "ABCDEF0123456789ABCDEF01"
+
+
+def test_require_object_id_strips_surrounding_whitespace() -> None:
+    # GIVEN a valid id with surrounding whitespace
+    # WHEN require_object_id validates it
+    result = require_object_id(f"  {_VALID_OBJECT_ID}  ", "entity_id")
+
+    # THEN the whitespace is stripped before length/pattern checks
+    assert result == _VALID_OBJECT_ID
+
+
+def test_require_object_id_rejects_wrong_length() -> None:
+    # GIVEN a 23-char (too short) hex string
+    # WHEN require_object_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_object_id(_VALID_OBJECT_ID[:-1], "entity_id")
+
+    # THEN a VALIDATION error names the argument and the expected shape
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "entity_id" in str(exc_info.value)
+    assert "24-character hex" in str(exc_info.value)
+
+
+def test_require_object_id_rejects_non_hex_characters() -> None:
+    # GIVEN a 24-char string containing a non-hex character
+    not_hex = "g" + _VALID_OBJECT_ID[1:]
+
+    # WHEN require_object_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_object_id(not_hex, "entity_id")
+
+    # THEN it is rejected as a VALIDATION error
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+def test_require_object_id_rejects_empty_value() -> None:
+    # GIVEN an empty string
+    # WHEN require_object_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_object_id("", "entity_id")
+
+    # THEN it fails via require_id's own empty check, naming the argument
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "entity_id" in str(exc_info.value)
+
+
+def test_require_object_id_rejects_non_string_value() -> None:
+    # GIVEN a non-str value (e.g. a caller passed an int id)
+    # WHEN require_object_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_object_id(123456789012345678901234, "entity_id")  # type: ignore[arg-type]
+
+    # THEN it fails with a readable VALIDATION error, not an AttributeError
+    # from require_id's unguarded `.strip()` on a non-str value
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "entity_id" in str(exc_info.value)
+
+
+# ------------------------------------------------------------------ #
+# require_trace_id                                                     #
+# ------------------------------------------------------------------ #
+
+
+def test_require_trace_id_accepts_32_lowercase_hex_chars() -> None:
+    # GIVEN a well-formed 32-char hex trace id
+    # WHEN require_trace_id validates it
+    result = require_trace_id(_VALID_TRACE_ID)
+
+    # THEN it is returned unchanged
+    assert result == _VALID_TRACE_ID
+
+
+def test_require_trace_id_strips_surrounding_whitespace() -> None:
+    # GIVEN a valid trace id with surrounding whitespace
+    # WHEN require_trace_id validates it
+    result = require_trace_id(f"  {_VALID_TRACE_ID}  ")
+
+    # THEN the whitespace is stripped before length/pattern checks
+    assert result == _VALID_TRACE_ID
+
+
+def test_require_trace_id_rejects_24_char_object_id_shaped_value() -> None:
+    # GIVEN a value shaped like a 24-char object id, not a 32-char trace id
+    # WHEN require_trace_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_trace_id(_VALID_OBJECT_ID)
+
+    # THEN it is rejected — the two id shapes are not interchangeable
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "trace_id" in str(exc_info.value)
+    assert "32-character hex" in str(exc_info.value)
+
+
+def test_require_trace_id_rejects_wrong_length() -> None:
+    # GIVEN a 33-char (too long) hex string
+    # WHEN require_trace_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_trace_id(_VALID_TRACE_ID + "0")
+
+    # THEN it is rejected as a VALIDATION error
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+def test_require_trace_id_rejects_non_hex_characters() -> None:
+    # GIVEN a 32-char string containing a non-hex character
+    not_hex = "z" + _VALID_TRACE_ID[1:]
+
+    # WHEN require_trace_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_trace_id(not_hex)
+
+    # THEN it is rejected as a VALIDATION error
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+def test_require_trace_id_rejects_empty_value() -> None:
+    # GIVEN an empty string
+    # WHEN require_trace_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_trace_id("")
+
+    # THEN it fails via require_id's own empty check, naming 'trace_id'
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "trace_id" in str(exc_info.value)
+
+
+def test_require_trace_id_rejects_non_string_value() -> None:
+    # GIVEN a non-str value (e.g. a caller passed an int id)
+    # WHEN require_trace_id validates it
+    with pytest.raises(ToolError) as exc_info:
+        require_trace_id(12345678901234567890123456789012)  # type: ignore[arg-type]
+
+    # THEN it fails with a readable VALIDATION error, not an AttributeError
+    # from require_id's unguarded `.strip()` on a non-str value
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "trace_id" in str(exc_info.value)

--- a/tests/drmcp/unit/otel_tools/test_truncation.py
+++ b/tests/drmcp/unit/otel_tools/test_truncation.py
@@ -33,6 +33,7 @@ from datarobot_genai.drtools.otel.truncation import PAYLOAD_MIN_CHARS
 from datarobot_genai.drtools.otel.truncation import STATUS_MESSAGE_MAX_CHARS
 from datarobot_genai.drtools.otel.truncation import apply_char_budget
 from datarobot_genai.drtools.otel.truncation import canonical_attributes
+from datarobot_genai.drtools.otel.truncation import cap_payload_value
 from datarobot_genai.drtools.otel.truncation import cap_value
 from datarobot_genai.drtools.otel.truncation import summarize_spans
 from tests.drmcp.unit.otel_tools.trace_factory import CHARS_PER_TOKEN
@@ -247,6 +248,29 @@ def test_summarize_spans_counts_a_response_field_and_a_same_named_attribute() ->
     assert summaries[0]["payload_chars"] == 800
     assert stats["total_payload_chars"] == 800
     assert summaries[0]["payload_fields"] == ["prompt"]
+
+
+def test_summarize_spans_counts_container_payloads_by_their_serialized_size() -> None:
+    # GIVEN a span whose only payload is a JSON-decoded message list — the wire
+    # shape OTLP array attributes and instrumentations actually produce
+    messages = [{"role": "user", "content": "x" * 100_000}]
+    span = {
+        "span_id": "aaaa0000bbbb1111",
+        "name": "llm.chat",
+        "attributes": {"gen_ai.prompt": messages, "gen_ai.usage.input_tokens": 38_211},
+    }
+
+    # WHEN the span is summarized
+    summaries, stats = summarize_spans([span])
+
+    # THEN the list is counted at its serialized size, not reported as 0 payload
+    # chars — 'where the mass is' must include non-str payload carriers
+    expected = len(json.dumps(messages, default=str, ensure_ascii=False))
+    assert summaries[0]["payload_chars"] == expected
+    assert summaries[0]["payload_fields"] == ["gen_ai.prompt"]
+    assert stats["total_payload_chars"] == expected
+    # THEN scalar metadata still never masquerades as payload
+    assert "gen_ai.usage.input_tokens" not in summaries[0]["payload_fields"]
 
 
 def test_summarize_spans_caps_a_traceback_in_status_message(
@@ -510,6 +534,23 @@ def test_canonical_attributes_passes_through_non_string_values() -> None:
     assert dropped == {"duplicate": [], "semconv": []}
 
 
+def test_canonical_attributes_dedups_byte_identical_container_twins() -> None:
+    # GIVEN the same message list written by two instrumentations
+    messages = [{"role": "user", "content": "m" * (PAYLOAD_MIN_CHARS * 2)}]
+    payload = {
+        "gen_ai.input.messages": list(messages),
+        "traceloop.entity.input": list(messages),
+    }
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN the higher-precedence carrier survives and the twin is a duplicate —
+    # container twins dedup over their serialized JSON just like string twins
+    assert list(kept) == ["gen_ai.input.messages"]
+    assert dropped == {"duplicate": ["traceloop.entity.input"], "semconv": []}
+
+
 def test_canonical_attributes_does_not_mutate_its_input(
     oversized_agent_trace: dict[str, Any],
 ) -> None:
@@ -643,6 +684,77 @@ def test_cap_value_counts_characters_not_bytes() -> None:
     assert info is not None
     assert info["total_chars"] == len(value)
     assert len(value.encode("utf-8")) > len(value)
+
+
+# ------------------------------------------------------------------ #
+# cap_payload_value                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_cap_payload_value_passes_a_small_container_through_natively() -> None:
+    # GIVEN a container attribute whose JSON fits the cap
+    value = [{"role": "user", "content": "hi"}]
+
+    # WHEN it is capped
+    window, info = cap_payload_value(value, MAX_FIELD_CHARS_SPAN_VIEW)
+
+    # THEN it comes back as the container itself, with no truncation record
+    assert window == value
+    assert info is None
+
+
+def test_cap_payload_value_windows_an_oversized_list_over_its_json() -> None:
+    # GIVEN a gen_ai.prompt-shaped list whose content dwarfs the cap — OTLP allows
+    # array attributes, and 'cap only str' used to return this whole
+    value = [{"role": "user", "content": "x" * 100_000}]
+    serialized = json.dumps(value, default=str, ensure_ascii=False)
+
+    # WHEN it is capped
+    window, info = cap_payload_value(value, 2_000)
+
+    # THEN the window is the serialized JSON's first 2,000 chars and the record
+    # marks it as serialized, with next_offset for continuation
+    assert window == serialized[:2_000]
+    assert info == {
+        "returned_chars": 2_000,
+        "total_chars": len(serialized),
+        "next_offset": 2_000,
+        "serialized": True,
+    }
+
+
+def test_cap_payload_value_continues_a_container_from_an_offset() -> None:
+    # GIVEN the same oversized container and the first call's next_offset
+    value = [{"role": "user", "content": "x" * 100_000}]
+    serialized = json.dumps(value, default=str, ensure_ascii=False)
+
+    # WHEN the next window is requested
+    window, info = cap_payload_value(value, 2_000, 2_000)
+
+    # THEN the window continues contiguously over the serialized text
+    assert window == serialized[2_000:4_000]
+    assert info is not None
+    assert info["serialized"] is True
+    assert info["next_offset"] == 4_000
+
+
+def test_cap_payload_value_matches_cap_value_for_strings() -> None:
+    # GIVEN a plain string value
+    value = "y" * 5_000
+
+    # WHEN both helpers cap it
+    # THEN they agree exactly — strings take the cap_value path unchanged
+    assert cap_payload_value(value, 2_000) == cap_value(value, 2_000)
+    assert cap_payload_value(value, 2_000, 2_000) == cap_value(value, 2_000, 2_000)
+
+
+def test_cap_payload_value_leaves_scalars_untouched() -> None:
+    # GIVEN metadata-sized scalar values
+    # WHEN they are capped
+    # THEN they pass through with no record — numbers, bools and None are
+    # metadata-sized by construction
+    for scalar in (200, 0.5, True, None):
+        assert cap_payload_value(scalar, 10) == (scalar, None)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/drmcp/unit/otel_tools/test_truncation.py
+++ b/tests/drmcp/unit/otel_tools/test_truncation.py
@@ -1,0 +1,902 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the OTel truncation module and its constants.
+
+Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
+
+No tools exist yet — these exercise the helpers in isolation against the two
+generated trace populations, which is the point of doing the hard part first.
+"""
+
+import copy
+import json
+from typing import Any
+
+from datarobot_genai.drmcputils.constants import LOG_LEVELS
+from datarobot_genai.drtools.otel.constants import OTEL_ENTITY_TYPES
+from datarobot_genai.drtools.otel.constants import OTEL_LOG_LEVELS
+from datarobot_genai.drtools.otel.constants import EntityType
+from datarobot_genai.drtools.otel.truncation import PAYLOAD_FIELDS_MAX
+from datarobot_genai.drtools.otel.truncation import PAYLOAD_MIN_CHARS
+from datarobot_genai.drtools.otel.truncation import STATUS_MESSAGE_MAX_CHARS
+from datarobot_genai.drtools.otel.truncation import apply_char_budget
+from datarobot_genai.drtools.otel.truncation import canonical_attributes
+from datarobot_genai.drtools.otel.truncation import cap_value
+from datarobot_genai.drtools.otel.truncation import summarize_spans
+from tests.drmcp.unit.otel_tools.trace_factory import CHARS_PER_TOKEN
+from tests.drmcp.unit.otel_tools.trace_factory import OVERSIZED_CANONICAL_PAYLOAD_CHARS
+from tests.drmcp.unit.otel_tools.trace_factory import OVERSIZED_GIANT_ATTRIBUTE_CHARS
+from tests.drmcp.unit.otel_tools.trace_factory import OVERSIZED_SPAN_COUNT
+from tests.drmcp.unit.otel_tools.trace_factory import OVERSIZED_TOTAL_PAYLOAD_CHARS
+from tests.drmcp.unit.otel_tools.trace_factory import SMALL_TRACE_MAX_TOKENS
+
+# Pinned defaults from the plan. 60,000 chars is ~20k tokens at the measured 3.1
+# chars per token. Both per-field caps govern payload projections only — §2.2's
+# view="summary" has no field to cap, and §2.2 marks max_field_chars/max_total_chars
+# 'view="payloads" only'.
+MAX_TOTAL_CHARS_DEFAULT = 60_000  # otel_trace_get(max_total_chars), §2.2
+MAX_FIELD_CHARS_TRACE_VIEW = 2_000  # otel_trace_get(max_field_chars), §2.2
+MAX_FIELD_CHARS_SPAN_VIEW = 8_000  # otel_span_payload_get(max_field_chars), §2.3
+
+# Measured cost of the summary projection: 4,936 tokens over 37 spans on the
+# 1.56M-token trace, i.e. ~133 tokens a span, flat and independent of payload
+# size. The summary projection must stay under that rate.
+SUMMARY_TOKENS_PER_SPAN_CEILING = 133
+
+
+# ------------------------------------------------------------------ #
+# constants                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_otel_log_levels_accept_warning_and_critical_unlike_the_workload_tuple() -> None:
+    # GIVEN the /otel logs endpoint accepts six minimum levels
+    # WHEN OTEL_LOG_LEVELS is compared with drmcputils' four-level workload tuple
+    # THEN it is a strict superset, and 'warning'/'critical' are the difference
+    assert OTEL_LOG_LEVELS == ("debug", "info", "warn", "warning", "error", "critical")
+    assert set(OTEL_LOG_LEVELS) > set(LOG_LEVELS)
+    assert set(OTEL_LOG_LEVELS) - set(LOG_LEVELS) == {"warning", "critical"}
+    # Reusing LOG_LEVELS here would silently reject two levels the API accepts.
+    assert "warning" not in LOG_LEVELS
+    assert "critical" not in LOG_LEVELS
+
+
+def test_otel_entity_types_stay_snake_case_on_the_wire() -> None:
+    # GIVEN entityType is a ChoiceField with initial_camelization=False
+    # WHEN the tuple is inspected
+    # THEN every value is snake_case, and it is exactly the EntityType Literal
+    assert OTEL_ENTITY_TYPES == (
+        "deployment",
+        "use_case",
+        "experiment_container",
+        "custom_application",
+        "workload",
+        "execution_environment",
+        "custom_job",
+        "artifact",
+    )
+    assert set(OTEL_ENTITY_TYPES) == set(EntityType.__args__)
+    assert not any(character.isupper() for value in OTEL_ENTITY_TYPES for character in value)
+
+
+# ------------------------------------------------------------------ #
+# summarize_spans                                                    #
+# ------------------------------------------------------------------ #
+
+
+def test_summarize_spans_projects_structure_and_drops_every_payload(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the oversized trace, whose spans carry 1,022,000 chars of payload
+    # WHEN the spans are summarized
+    summaries, _ = summarize_spans(oversized_agent_trace["spans"])
+
+    # THEN every span keeps its structural fields and no payload survives
+    assert len(summaries) == OVERSIZED_SPAN_COUNT
+    for summary in summaries:
+        assert set(summary) >= {
+            "span_id",
+            "parent_span_id",
+            "name",
+            "status_code",
+            "status_message",
+            "kind",
+            "service_name",
+            "duration",
+            "start_time",
+            "payload_chars",
+            "payload_fields",
+        }
+        assert "prompt" not in summary
+        assert "completion" not in summary
+        assert "attributes" not in summary
+    # THEN the ERROR span's status message is preserved — it is why you drilled in
+    error_summaries = [s for s in summaries if s["status_code"] == "ERROR"]
+    assert len(error_summaries) == 1
+    assert "RateLimitError" in error_summaries[0]["status_message"]
+
+
+def test_summarize_spans_payload_chars_sum_to_the_fixtures_real_total(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN a fixture whose payload plan declares 1,022,000 chars
+    # WHEN the spans are summarized
+    summaries, stats = summarize_spans(oversized_agent_trace["spans"])
+
+    # THEN the accounting is correct, not merely present
+    assert stats["total_payload_chars"] == OVERSIZED_TOTAL_PAYLOAD_CHARS
+    assert sum(s["payload_chars"] for s in summaries) == OVERSIZED_TOTAL_PAYLOAD_CHARS
+    # THEN the fixture really is the oversized population (>= 200k tokens)
+    assert OVERSIZED_TOTAL_PAYLOAD_CHARS / CHARS_PER_TOKEN >= 200_000
+
+
+def test_summarize_spans_payload_fields_point_at_where_the_mass_is(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN one tool span whose 160,000-char output is written by four
+    # instrumentations, and a second span with no payload at all
+    summaries, _ = summarize_spans(oversized_agent_trace["spans"])
+    giant = max(summaries, key=lambda summary: summary["payload_chars"])
+    payload_free = [s for s in summaries if s["name"] == "guardrail.check"]
+
+    # WHEN / THEN the heaviest span names all four carriers, largest first
+    assert giant["name"] == "tool.execute"
+    assert giant["payload_chars"] == 4 * OVERSIZED_GIANT_ATTRIBUTE_CHARS
+    assert set(giant["payload_fields"]) == {
+        "completion",
+        "gen_ai.task.output",
+        "input.value",
+        "traceloop.entity.output",
+    }
+    # THEN small metadata attributes never masquerade as payload
+    assert "gen_ai.tool.name" not in giant["payload_fields"]
+    # THEN a payload-free span reports zero rather than omitting the accounting
+    assert payload_free[0]["payload_chars"] == 0
+    assert payload_free[0]["payload_fields"] == []
+
+
+def test_summary_projection_of_the_oversized_trace_stays_under_the_measured_ceiling(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the oversized trace: 1,022,000 payload chars, ~330k tokens
+    # WHEN the summary projection is serialized as it would be returned
+    summaries, stats = summarize_spans(oversized_agent_trace["spans"])
+    serialized_chars = len(json.dumps(summaries))
+    ceiling = OVERSIZED_SPAN_COUNT * SUMMARY_TOKENS_PER_SPAN_CEILING * CHARS_PER_TOKEN
+
+    # THEN it fits the measured ~133 tokens-a-span rate and is a rounding error
+    # against the payload it describes. This is the regression guard for the whole
+    # summary-by-default design.
+    assert serialized_chars < ceiling, (
+        f"summary projection grew to {serialized_chars} chars, over the "
+        f"{ceiling:.0f}-char ceiling implied by the measured 133 tokens a span"
+    )
+    assert serialized_chars < stats["total_payload_chars"] / 100
+
+
+def test_summary_projection_size_does_not_grow_with_payload_size(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the same trace with every payload string inflated tenfold
+    baseline_summaries, baseline_stats = summarize_spans(oversized_agent_trace["spans"])
+    inflated_summaries, inflated_stats = summarize_spans(
+        _inflate_payloads(copy.deepcopy(oversized_agent_trace)["spans"], 10)
+    )
+
+    # WHEN the two projections are compared
+    baseline_chars = len(json.dumps(baseline_summaries))
+    inflated_chars = len(json.dumps(inflated_summaries))
+
+    # THEN the payload grew by ~9.2M chars and the summary by less than 64 — the
+    # digits of payload_chars. Span-count-bounded, not payload-bounded.
+    assert inflated_stats["total_payload_chars"] == baseline_stats["total_payload_chars"] * 10
+    assert inflated_chars - baseline_chars < 64
+    assert [s["payload_fields"] for s in inflated_summaries] == [
+        s["payload_fields"] for s in baseline_summaries
+    ]
+
+
+def test_summarize_spans_caps_payload_fields_and_reports_the_omission() -> None:
+    # GIVEN a span carrying more large attributes than the payload_fields cap
+    span = {
+        "span_id": "aaaa0000bbbb1111",
+        "name": "llm.chat",
+        "attributes": {f"vendor.blob.{index:02d}": "x" * (1_000 + index) for index in range(20)},
+    }
+
+    # WHEN the span is summarized
+    summaries, stats = summarize_spans([span])
+
+    # THEN the list is capped, ordered largest first, and the omission is reported
+    assert len(summaries[0]["payload_fields"]) == PAYLOAD_FIELDS_MAX
+    assert summaries[0]["payload_fields"][0] == "vendor.blob.19"
+    assert summaries[0]["payload_fields_omitted"] == 20 - PAYLOAD_FIELDS_MAX
+    # THEN payload_chars still counts every field, capped list or not
+    assert summaries[0]["payload_chars"] == sum(1_000 + index for index in range(20))
+    assert stats["total_payload_chars"] == summaries[0]["payload_chars"]
+
+
+def test_summarize_spans_counts_a_response_field_and_a_same_named_attribute() -> None:
+    # GIVEN a span whose attributes carry their own key named 'prompt' beside the
+    # response field of the same name. SpanViewValidator.attributes is a dynamic
+    # dict, so the collision is reachable on the wire.
+    span = {
+        "span_id": "aaaa0000bbbb1111",
+        "name": "llm.chat",
+        "prompt": "A" * 300,
+        "attributes": {"prompt": "B" * 500},
+    }
+
+    # WHEN the span is summarized
+    summaries, stats = summarize_spans([span])
+
+    # THEN both fields are counted — 800 chars, not the 500 an overwrite reports.
+    # payload_chars is what an agent uses to pick a span, so it must not undercount.
+    assert summaries[0]["payload_chars"] == 800
+    assert stats["total_payload_chars"] == 800
+    assert summaries[0]["payload_fields"] == ["prompt"]
+
+
+def test_summarize_spans_caps_a_traceback_in_status_message(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    """status_message is the one structural field that can blow the summary view.
+
+    ``SpanViewValidator.status_message`` is a StringField with no server-side
+    max_length, and §2.2 puts ``max_total_chars`` on view="payloads" only — so
+    nothing else stands behind the summary projection. Uncapped, one 48,000-char
+    traceback grew this fixture's projection from 4,094 to 64,077 chars, 13x the
+    §7 ceiling and past the whole 60,000-char budget.
+    """
+    # GIVEN every span carrying a 48,000-char traceback
+    baseline = len(json.dumps(summarize_spans(oversized_agent_trace["spans"])[0]))
+    traceback = 'Traceback (most recent call last):\n  File "agent.py", line 41\n' * 800
+    assert len(traceback) > 48_000
+    spans = copy.deepcopy(oversized_agent_trace["spans"])
+    for span in spans:
+        span["status_message"] = traceback
+
+    # WHEN the spans are summarized
+    summaries, _ = summarize_spans(spans)
+
+    # THEN each message is windowed and the loss is marked, never silent
+    remainder = len(traceback) - STATUS_MESSAGE_MAX_CHARS
+    for summary in summaries:
+        assert summary["status_message"].startswith(traceback[:STATUS_MESSAGE_MAX_CHARS])
+        assert summary["status_message"].endswith(f"…[truncated, {remainder} more chars]")
+
+    # THEN the projection grew by the cap times the span count, not by the input:
+    # O(span_count), which is the property §2.2's flat ~133 tok/span rate rests on
+    inflated = len(json.dumps(summaries))
+    assert inflated - baseline < OVERSIZED_SPAN_COUNT * (STATUS_MESSAGE_MAX_CHARS + 64), (
+        f"summary grew {inflated - baseline} chars on {len(traceback) * OVERSIZED_SPAN_COUNT} "
+        "chars of status_message — the summary view must stay bounded by span count"
+    )
+
+
+def test_summarize_spans_does_not_mutate_the_spans_it_reads(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the oversized trace and a snapshot of it
+    before = copy.deepcopy(oversized_agent_trace["spans"])
+
+    # WHEN the spans are summarized
+    summarize_spans(oversized_agent_trace["spans"])
+
+    # THEN the caller's spans are untouched — the projection is a copy
+    assert oversized_agent_trace["spans"] == before
+
+
+# ------------------------------------------------------------------ #
+# canonical_attributes                                               #
+# ------------------------------------------------------------------ #
+
+
+def test_canonical_attributes_reports_every_dropped_field(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN every span of the oversized trace, reduced both the way a tool will
+    # call it (rank-1 response fields merged in) and the way its §3 signature
+    # alone allows (bare attributes, no merge)
+    for span in oversized_agent_trace["spans"]:
+        for payload in (_merged_payload(span), dict(span["attributes"])):
+            # WHEN its payload fields are reduced to the canonical set
+            kept, dropped = canonical_attributes(payload)
+
+            # THEN nothing vanishes silently: every input name is either kept or
+            # reported in exactly one drop bucket
+            reported = set(kept) | set(dropped["duplicate"]) | set(dropped["semconv"])
+            assert reported == set(payload)
+            assert not set(dropped["duplicate"]) & set(dropped["semconv"])
+            assert not set(dropped["duplicate"]) & set(kept)
+            assert not set(dropped["semconv"]) & set(kept)
+
+            # THEN every name in 'duplicate' really is a duplicate: §2.3 surfaces
+            # that bucket as "you already have this text", so a name may only land
+            # there when a byte-identical copy survives in kept
+            surviving = {value for value in kept.values() if isinstance(value, str)}
+            for name in dropped["duplicate"]:
+                assert payload[name] in surviving, (
+                    f"{name} was reported as a duplicate but no copy of its text "
+                    "survives in the response"
+                )
+
+
+def test_canonical_attributes_drops_the_traceloop_gen_ai_twins_as_duplicates(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the llm.chat span whose prompt and completion are each written by
+    # four instrumentations byte for byte
+    span = oversized_agent_trace["spans"][2]
+    payload = _merged_payload(span)
+    assert payload["gen_ai.task.input"] == payload["traceloop.entity.input"] == payload["prompt"]
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN the twins are dropped as duplicates and named, so an agent looking for
+    # traceloop.entity.output by name is told where it went
+    assert dropped["duplicate"] == [
+        "gen_ai.completion.0.content",
+        "gen_ai.task.input",
+        "gen_ai.task.output",
+        "input.value",
+        "traceloop.entity.input",
+        "traceloop.entity.output",
+    ]
+    # THEN the text itself survives on the rank-1 response fields
+    assert kept["prompt"] == payload["prompt"]
+    assert kept["completion"] == payload["completion"]
+
+
+def test_canonical_attributes_separates_derived_families_from_duplicates(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN a span carrying derived families whose text appears nowhere else
+    span = oversized_agent_trace["spans"][2]
+
+    # WHEN the payload is reduced
+    _, dropped = canonical_attributes(_merged_payload(span))
+
+    # THEN they land in the semconv bucket, not the duplicate one — the caller
+    # reports which and why
+    assert dropped["semconv"] == ["input.value_obj", "nat.metadata"]
+
+
+def test_canonical_attributes_never_drops_the_rank_one_response_fields() -> None:
+    # GIVEN a span where prompt and completion happen to hold the same text
+    echoed = "e" * (PAYLOAD_MIN_CHARS * 3)
+    payload = {"prompt": echoed, "completion": echoed, "traceloop.entity.output": echoed}
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN both response fields survive and only the attribute twin is dropped
+    assert kept == {"prompt": echoed, "completion": echoed}
+    assert dropped == {"duplicate": ["traceloop.entity.output"], "semconv": []}
+
+
+def test_canonical_attributes_keeps_the_highest_precedence_carrier() -> None:
+    # GIVEN the same text under gen_ai, openinference, traceloop and an unknown
+    # family, with no response field to win the tie
+    shared = "s" * (PAYLOAD_MIN_CHARS * 5)
+    payload = {
+        "vendor.custom.output": shared,
+        "traceloop.llm.response": shared,
+        "output.value": shared,
+        "gen_ai.output.messages": shared,
+    }
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN gen_ai wins per the §3 precedence order, whatever the input order was
+    assert list(kept) == ["gen_ai.output.messages"]
+    assert dropped["duplicate"] == [
+        "output.value",
+        "traceloop.llm.response",
+        "vendor.custom.output",
+    ]
+
+
+def test_canonical_attributes_ranks_openinference_over_traceloop_over_nat() -> None:
+    # GIVEN the same text under §3's ranks 3, 4 and 5, with no higher family
+    # present to decide the tie for them
+    shared = "p" * (PAYLOAD_MIN_CHARS * 4)
+
+    # WHEN all three compete
+    kept, dropped = canonical_attributes(
+        {"nat.output": shared, "traceloop.llm.response": shared, "output.value": shared}
+    )
+
+    # THEN openinference (rank 3) wins, whatever order the attributes arrived in
+    assert list(kept) == ["output.value"]
+    assert dropped["duplicate"] == ["nat.output", "traceloop.llm.response"]
+
+    # WHEN openinference is absent, THEN traceloop (rank 4) still outranks nat (5)
+    kept, dropped = canonical_attributes({"nat.output": shared, "traceloop.llm.response": shared})
+    assert list(kept) == ["traceloop.llm.response"]
+    assert dropped["duplicate"] == ["nat.output"]
+
+    # WHEN a family no table names competes, THEN it loses to every known one
+    kept, _ = canonical_attributes({"vendor.blob.output": shared, "nat.output": shared})
+    assert list(kept) == ["nat.output"]
+
+
+def test_canonical_attributes_reports_a_wholly_dropped_group_as_semconv_not_duplicate() -> None:
+    """A drop is a 'duplicate' only if a copy of its text really survives.
+
+    §3's field breakdown of the worst trace measures ``completion`` at 23% against
+    a 20% ``gen_ai.task.output`` / ``traceloop.entity.output`` pair — byte-identical
+    to each other but, at a different size, not to ``completion``. Both are on §3's
+    unconditional drop list, so no field carries that text out. Reporting it as
+    ``dropped_as_duplicate`` would tell the agent it already has text the response
+    does not contain; §2.3's contract is the opposite — it names twins of a field
+    that *is* returned.
+    """
+    # GIVEN a Traceloop-plus-gen_ai span whose completion differs from its derived
+    # output pair, the combination that leaves no non-derived output carrier
+    completion = "c" * 4_700
+    orphaned = "d" * 5_000
+    payload = {
+        "completion": completion,
+        "gen_ai.task.output": orphaned,
+        "traceloop.entity.output": orphaned,
+    }
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN the pair is reported under semconv, and every name in 'duplicate' is
+    # backed by text the response still contains
+    assert kept == {"completion": completion}
+    assert dropped == {
+        "duplicate": [],
+        "semconv": ["gen_ai.task.output", "traceloop.entity.output"],
+    }
+    assert all(payload[name] in set(kept.values()) for name in dropped["duplicate"])
+
+
+def test_canonical_attributes_reports_a_short_byte_identical_twin_as_a_duplicate() -> None:
+    # GIVEN a derived twin below the dedup threshold, so it never enters the
+    # byte-identity map at all
+    short = "s" * (PAYLOAD_MIN_CHARS - 50)
+    payload = {"prompt": short, "traceloop.entity.input": short}
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN it is still reported as a duplicate, because its text does survive on
+    # 'prompt'. The bucket describes what happened to the text, not which code path
+    # decided the drop — §2.3 surfaces the two buckets to the agent as distinct
+    # reasons.
+    assert kept == {"prompt": short}
+    assert dropped == {"duplicate": ["traceloop.entity.input"], "semconv": []}
+
+
+def test_canonical_attributes_does_not_dedup_short_metadata_values() -> None:
+    # GIVEN two unrelated metadata attributes that merely share a short value
+    payload = {"gen_ai.system": "openai", "vendor.llm.provider": "openai", "http.status": "200"}
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN nothing is dropped: dedup applies to payload text, not to metadata
+    assert kept == payload
+    assert dropped == {"duplicate": [], "semconv": []}
+
+
+def test_canonical_attributes_passes_through_non_string_values() -> None:
+    # GIVEN attribute values that are not strings, two of them equal
+    payload = {"gen_ai.usage.input_tokens": 0, "gen_ai.usage.output_tokens": 0, "ok": True}
+
+    # WHEN the payload is reduced
+    kept, dropped = canonical_attributes(payload)
+
+    # THEN they are kept untouched — byte-identity dedup is for text only
+    assert kept == payload
+    assert dropped == {"duplicate": [], "semconv": []}
+
+
+def test_canonical_attributes_does_not_mutate_its_input(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN a span payload and a snapshot of it
+    payload = _merged_payload(oversized_agent_trace["spans"][2])
+    before = dict(payload)
+
+    # WHEN the payload is reduced
+    canonical_attributes(payload)
+
+    # THEN the caller's mapping is untouched
+    assert payload == before
+
+
+# ------------------------------------------------------------------ #
+# cap_value                                                          #
+# ------------------------------------------------------------------ #
+
+
+def test_cap_value_returns_the_whole_value_untouched_when_it_fits() -> None:
+    # GIVEN a value shorter than the cap
+    value = "short completion"
+
+    # WHEN it is capped
+    window, info = cap_value(value, MAX_FIELD_CHARS_SPAN_VIEW)
+
+    # THEN it comes back whole with no truncation record at all
+    assert window == value
+    assert info is None
+
+
+def test_cap_value_windows_are_contiguous_and_next_offset_lands_on_the_boundary(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the single 160,000-char attribute value (~52k tokens on its own)
+    value = oversized_agent_trace["spans"][3]["attributes"]["traceloop.entity.output"]
+    assert len(value) == OVERSIZED_GIANT_ATTRIBUTE_CHARS
+    assert len(value) / CHARS_PER_TOKEN > 50_000
+
+    # WHEN it is paged one field window at a time, following next_offset
+    windows: list[str] = []
+    offsets: list[int] = []
+    offset: int | None = 0
+    while offset is not None:
+        offsets.append(offset)
+        window, info = cap_value(value, MAX_FIELD_CHARS_SPAN_VIEW, offset)
+        windows.append(window)
+        assert info is not None
+        assert info["total_chars"] == OVERSIZED_GIANT_ATTRIBUTE_CHARS
+        assert info["returned_chars"] == len(window)
+        offset = info["next_offset"]
+
+    # THEN the windows are contiguous, complete, and next_offset is None exactly
+    # once — at the end of the value
+    assert "".join(windows) == value
+    assert offsets == list(range(0, OVERSIZED_GIANT_ATTRIBUTE_CHARS, MAX_FIELD_CHARS_SPAN_VIEW))
+    assert len(windows) == OVERSIZED_GIANT_ATTRIBUTE_CHARS // MAX_FIELD_CHARS_SPAN_VIEW
+    assert all(len(window) == MAX_FIELD_CHARS_SPAN_VIEW for window in windows)
+
+
+def test_cap_value_reports_the_final_partial_window_as_the_end() -> None:
+    # GIVEN a value that does not divide evenly by the cap
+    value = "x" * 25
+
+    # WHEN the last window is requested
+    window, info = cap_value(value, 10, 20)
+
+    # THEN it is short, and next_offset says there is nothing left
+    assert window == "x" * 5
+    assert info == {"returned_chars": 5, "total_chars": 25, "next_offset": None}
+
+
+def test_cap_value_offset_past_the_end_returns_an_empty_window() -> None:
+    # GIVEN an offset beyond the value
+    # WHEN the value is capped
+    window, info = cap_value("x" * 10, 10, 500)
+
+    # THEN the caller gets nothing plus an explicit record, not an exception
+    assert window == ""
+    assert info == {"returned_chars": 0, "total_chars": 10, "next_offset": None}
+
+
+def test_cap_value_offset_past_the_end_of_an_empty_value_still_reports() -> None:
+    # GIVEN an empty field and an out-of-range field_offset
+    # WHEN the value is capped
+    window, info = cap_value("", MAX_FIELD_CHARS_SPAN_VIEW, 500)
+
+    # THEN the agent is told its offset found nothing, rather than getting a bare
+    # empty string with no entry in truncation.fields, which reads as an
+    # untruncated field
+    assert window == ""
+    assert info == {"returned_chars": 0, "total_chars": 0, "next_offset": None}
+    # THEN offset 0 on the same empty value is genuinely 'whole value returned'
+    assert cap_value("", MAX_FIELD_CHARS_SPAN_VIEW) == ("", None)
+
+
+def test_cap_value_non_positive_max_chars_disables_the_cap() -> None:
+    # GIVEN a long value and a disabled cap
+    value = "y" * 5_000
+
+    # WHEN it is capped with 0 and with a negative bound
+    whole, info = cap_value(value, 0)
+    tail, tail_info = cap_value(value, -1, 4_000)
+
+    # THEN the whole remainder comes back
+    assert whole == value
+    assert info is None
+    assert tail == value[4_000:]
+    assert tail_info == {"returned_chars": 1_000, "total_chars": 5_000, "next_offset": None}
+
+
+def test_cap_value_negative_offset_clamps_to_the_start() -> None:
+    # GIVEN a negative offset, which slicing would otherwise read from the end
+    # WHEN the value is capped
+    window, info = cap_value("abcdef", 3, -4)
+
+    # THEN it reads from the start
+    assert window == "abc"
+    assert info == {"returned_chars": 3, "total_chars": 6, "next_offset": 3}
+
+
+def test_cap_value_counts_characters_not_bytes() -> None:
+    # GIVEN a multibyte value: byte-slicing it would split a code point
+    value = "café—naïve—" * 10
+
+    # WHEN it is capped at four characters
+    window, info = cap_value(value, 4)
+
+    # THEN exactly four characters come back and the totals are in characters
+    assert window == "café"
+    assert info is not None
+    assert info["total_chars"] == len(value)
+    assert len(value.encode("utf-8")) > len(value)
+
+
+# ------------------------------------------------------------------ #
+# apply_char_budget                                                  #
+# ------------------------------------------------------------------ #
+
+
+def test_apply_char_budget_never_exceeds_the_budget_and_reports_spans_dropped(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the oversized trace projected to payload views with an 8,000-char
+    # per-field cap: 80,187 chars, over the 60,000-char ceiling
+    items = [
+        _payload_view(span, MAX_FIELD_CHARS_SPAN_VIEW) for span in oversized_agent_trace["spans"]
+    ]
+    assert len(json.dumps(items, ensure_ascii=False)) > MAX_TOTAL_CHARS_DEFAULT
+
+    # WHEN the budget is applied
+    emitted, stats = apply_char_budget(items, MAX_TOTAL_CHARS_DEFAULT)
+
+    # THEN the hard stop holds and the loss is reported, never silent
+    assert len(json.dumps(emitted, ensure_ascii=False)) <= MAX_TOTAL_CHARS_DEFAULT
+    assert stats["chars_used"] <= MAX_TOTAL_CHARS_DEFAULT
+    assert stats["spans_dropped"] > 0
+    assert stats["spans_returned"] + stats["spans_dropped"] == OVERSIZED_SPAN_COUNT
+    assert stats["max_total_chars"] == MAX_TOTAL_CHARS_DEFAULT
+    # THEN emission kept the caller's order
+    assert [item["span_id"] for item in emitted] == [
+        item["span_id"] for item in items[: len(emitted)]
+    ]
+
+
+def test_apply_char_budget_reports_zero_dropped_when_everything_fits(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    # GIVEN the same trace under the summary view's 2,000-char per-field cap
+    items = [
+        _payload_view(span, MAX_FIELD_CHARS_TRACE_VIEW) for span in oversized_agent_trace["spans"]
+    ]
+
+    # WHEN the budget is applied
+    emitted, stats = apply_char_budget(items, MAX_TOTAL_CHARS_DEFAULT)
+
+    # THEN nothing is dropped and spans_dropped is still reported
+    assert len(emitted) == OVERSIZED_SPAN_COUNT
+    assert stats["spans_dropped"] == 0
+    assert "spans_dropped" in stats
+
+
+def test_apply_char_budget_stops_at_the_first_item_that_does_not_fit() -> None:
+    # GIVEN three items where the second is too large for the remaining budget
+    items = [{"n": 0, "text": "a" * 10}, {"n": 1, "text": "b" * 500}, {"n": 2, "text": "c" * 10}]
+
+    # WHEN a budget that only the first item fits is applied
+    emitted, stats = apply_char_budget(items, 60)
+
+    # THEN emission stops rather than skipping ahead to the smaller third item,
+    # so the order the caller chose is the order the agent sees
+    assert emitted == [items[0]]
+    assert stats["spans_returned"] == 1
+    assert stats["spans_dropped"] == 2
+
+
+def test_apply_char_budget_returns_nothing_when_the_first_item_alone_overflows() -> None:
+    # GIVEN a single item larger than the whole budget
+    items = [{"text": "z" * 1_000}]
+
+    # WHEN the budget is applied
+    emitted, stats = apply_char_budget(items, 100)
+
+    # THEN the budget still holds — a too-small budget yields an empty page and a
+    # report, not an over-budget response
+    assert emitted == []
+    assert stats == {
+        "spans_returned": 0,
+        "spans_dropped": 1,
+        "chars_used": 0,
+        "max_total_chars": 100,
+    }
+
+
+def test_apply_char_budget_non_positive_budget_disables_the_cap() -> None:
+    # GIVEN a budget of zero
+    items = [{"text": "z" * 1_000}, {"text": "y" * 1_000}]
+
+    # WHEN the budget is applied
+    emitted, stats = apply_char_budget(items, 0)
+
+    # THEN everything is emitted and the accounting says so
+    assert emitted == items
+    assert stats["spans_returned"] == 2
+    assert stats["spans_dropped"] == 0
+
+
+def test_apply_char_budget_chars_used_matches_the_serialized_page() -> None:
+    # GIVEN items that all fit
+    items = [{"n": index, "text": "a" * 100} for index in range(5)]
+
+    # WHEN the budget is applied
+    emitted, stats = apply_char_budget(items, MAX_TOTAL_CHARS_DEFAULT)
+
+    # THEN chars_used is what actually reaches the model, not an undercount
+    assert stats["chars_used"] == len(json.dumps(emitted, ensure_ascii=False))
+
+
+def test_apply_char_budget_charges_non_ascii_payload_its_character_count() -> None:
+    # GIVEN two pages with identical character counts, one ASCII and one CJK
+    ascii_items = [{"text": "a" * 2_000} for _ in range(OVERSIZED_SPAN_COUNT)]
+    cjk_items = [{"text": "あ" * 2_000} for _ in range(OVERSIZED_SPAN_COUNT)]
+
+    # WHEN the same budget is applied to both
+    ascii_emitted, ascii_stats = apply_char_budget(ascii_items, MAX_TOTAL_CHARS_DEFAULT)
+    cjk_emitted, cjk_stats = apply_char_budget(cjk_items, MAX_TOTAL_CHARS_DEFAULT)
+
+    # THEN the budget's unit is characters (§1's 3.1 chars/token conversion, §2.4's
+    # "chars, not bytes"), so the language of a trace does not decide how many
+    # spans come back. Measuring escape-expanded JSON charged CJK ~6x and returned
+    # 4 spans of 12 where ASCII got all 12.
+    assert len(ascii_emitted) == OVERSIZED_SPAN_COUNT
+    assert len(cjk_emitted) == len(ascii_emitted)
+    assert cjk_stats["chars_used"] == ascii_stats["chars_used"]
+    assert cjk_stats["chars_used"] == len(json.dumps(cjk_emitted, ensure_ascii=False))
+
+
+# ------------------------------------------------------------------ #
+# the §3 regression guard                                            #
+# ------------------------------------------------------------------ #
+
+
+def test_dedup_alone_still_blows_the_budget_so_weakening_the_cap_is_a_regression(
+    oversized_agent_trace: dict[str, Any],
+) -> None:
+    """Perfect dedup is not a substitute for the hard character cap.
+
+    On the worst measured trace, 423,300 tokens of genuinely unique text remain
+    after perfect dedup — still 2x a context window. Any change to this module
+    that weakens ``apply_char_budget`` in favour of smarter dedup is a regression.
+    """
+    # GIVEN the oversized trace, reduced by perfect dedup and canonical semconv
+    # selection with no cap applied at all
+    unique_chars = 0
+    for span in oversized_agent_trace["spans"]:
+        kept, _ = canonical_attributes(_merged_payload(span))
+        unique_chars += sum(
+            len(value)
+            for value in kept.values()
+            if isinstance(value, str) and len(value) >= PAYLOAD_MIN_CHARS
+        )
+
+    # WHEN the remainder is measured against otel_trace_get's ceiling
+    overshoot = unique_chars / MAX_TOTAL_CHARS_DEFAULT
+
+    # THEN dedup removed most of the payload and is STILL nowhere near enough
+    assert unique_chars == OVERSIZED_CANONICAL_PAYLOAD_CHARS
+    assert unique_chars < OVERSIZED_TOTAL_PAYLOAD_CHARS * 0.4
+    assert overshoot > 5, (
+        f"Dedup left {unique_chars} chars ({unique_chars / CHARS_PER_TOKEN:.0f} tokens) "
+        f"of genuinely unique text — {overshoot:.1f}x the {MAX_TOTAL_CHARS_DEFAULT}-char "
+        "budget. Dedup does not bound output; only the hard character cap does. "
+        "WEAKENING apply_char_budget IN FAVOUR OF SMARTER DEDUP IS A REGRESSION."
+    )
+
+    # THEN the cap, and only the cap, brings the response inside the budget
+    items = [
+        _payload_view(span, MAX_FIELD_CHARS_SPAN_VIEW) for span in oversized_agent_trace["spans"]
+    ]
+    emitted, stats = apply_char_budget(items, MAX_TOTAL_CHARS_DEFAULT)
+    assert len(json.dumps(emitted, ensure_ascii=False)) <= MAX_TOTAL_CHARS_DEFAULT
+    assert stats["spans_dropped"] > 0
+
+
+# ------------------------------------------------------------------ #
+# the small, easy population                                         #
+# ------------------------------------------------------------------ #
+
+
+def test_small_trace_survives_the_pipeline_untouched(small_trace: dict[str, Any]) -> None:
+    # GIVEN the small non-agentic trace: no prompts, no completions, ~450 tokens
+    assert len(json.dumps(small_trace)) / CHARS_PER_TOKEN < SMALL_TRACE_MAX_TOKENS
+
+    # WHEN it goes through the summary projection and the budget
+    summaries, stats = summarize_spans(small_trace["spans"])
+    items = [_payload_view(span, MAX_FIELD_CHARS_TRACE_VIEW) for span in small_trace["spans"]]
+    emitted, budget_stats = apply_char_budget(items, MAX_TOTAL_CHARS_DEFAULT)
+
+    # THEN nothing is truncated, dropped or mangled: the easy case stays easy
+    assert stats["total_payload_chars"] == 0
+    assert all(summary["payload_chars"] == 0 for summary in summaries)
+    assert all(summary["payload_fields"] == [] for summary in summaries)
+    assert budget_stats["spans_dropped"] == 0
+    assert len(emitted) == len(small_trace["spans"])
+    for item in emitted:
+        assert item["truncation"] == {
+            "fields": {},
+            "dropped_as_duplicate": [],
+            "dropped_semconv": [],
+        }
+    # THEN the span tree is intact, root first
+    assert [summary["name"] for summary in summaries] == ["GET /health", "db.query", "cache.get"]
+    assert summaries[0]["parent_span_id"] is None
+    assert all(summary["parent_span_id"] == summaries[0]["span_id"] for summary in summaries[1:])
+
+
+# ------------------------------------------------------------------ #
+# helpers                                                            #
+# ------------------------------------------------------------------ #
+
+
+def _merged_payload(span: dict[str, Any]) -> dict[str, Any]:
+    """Merge a span's rank-1 response fields with its attributes, response first."""
+    merged = {name: span[name] for name in ("prompt", "completion") if name in span}
+    merged.update(span.get("attributes") or {})
+    return merged
+
+
+def _payload_view(span: dict[str, Any], max_field_chars: int) -> dict[str, Any]:
+    """Compose the helpers the way otel_trace_get(view='payloads') will (§2.2).
+
+    Lives here rather than in the module under test because no tool exists yet;
+    it proves the four functions compose into the projection the plan specifies.
+    """
+    kept, dropped = canonical_attributes(_merged_payload(span))
+    attributes: dict[str, Any] = {}
+    fields: dict[str, Any] = {}
+    for name, value in kept.items():
+        if not isinstance(value, str):
+            attributes[name] = value
+            continue
+        window, info = cap_value(value, max_field_chars)
+        attributes[name] = window
+        if info is not None:
+            fields[name] = info
+    return {
+        "span_id": span["span_id"],
+        "name": span["name"],
+        "attributes": attributes,
+        "truncation": {
+            "fields": fields,
+            "dropped_as_duplicate": dropped["duplicate"],
+            "dropped_semconv": dropped["semconv"],
+        },
+    }
+
+
+def _inflate_payloads(spans: list[dict[str, Any]], factor: int) -> list[dict[str, Any]]:
+    """Multiply every payload-sized string in place, leaving metadata alone."""
+    for span in spans:
+        for field in ("prompt", "completion"):
+            if isinstance(span.get(field), str) and len(span[field]) >= PAYLOAD_MIN_CHARS:
+                span[field] = span[field] * factor
+        span["attributes"] = {
+            name: value * factor
+            if isinstance(value, str) and len(value) >= PAYLOAD_MIN_CHARS
+            else value
+            for name, value in span["attributes"].items()
+        }
+    return spans

--- a/tests/drmcp/unit/otel_tools/trace_factory.py
+++ b/tests/drmcp/unit/otel_tools/trace_factory.py
@@ -1,0 +1,375 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic builders for the two OTel trace populations under test.
+
+Built, not checked in: the real thing is a 4.76 MB blob, and a generator is
+cheap, reproducible and CI-safe. No RNG at all — every string is produced by
+cycling a fixed sentence pool and sliced to an exact length, so byte-identity and
+every char count below are stable across runs, machines and Python versions.
+
+Two populations, both drawn from the measurements in APP-6967:
+
+* ``build_oversized_agent_trace`` — the population this ticket exists for. 12
+  spans, 1,022,000 chars of payload (~330k tokens at the measured 3.1 chars per
+  token), containing byte-identical Traceloop/gen_ai twin pairs and one single
+  attribute value of 160,000 chars (~52k tokens on its own).
+* ``build_small_trace`` — the other population, ~400 tokens end to end, to prove
+  the summary projection does not mangle the easy case.
+
+The char-count constants are the declared intent of the payload plan. Tests
+assert the truncation module's accounting against them, so editing the plan means
+editing the constant — which is the point.
+"""
+
+from typing import Any
+
+# Measured on the real trace JSON in APP-6967: ~3.1 chars per token. Every token
+# figure in this module and its tests is derived from this ratio rather than a
+# tokenizer, because drtools may not take a tokenizer dependency.
+CHARS_PER_TOKEN = 3.1
+
+# Payload plan of the oversized fixture, as built below.
+OVERSIZED_SPAN_COUNT = 12
+OVERSIZED_TOTAL_PAYLOAD_CHARS = 1_022_000
+OVERSIZED_CANONICAL_PAYLOAD_CHARS = 393_500
+OVERSIZED_GIANT_ATTRIBUTE_CHARS = 160_000
+
+OVERSIZED_TRACE_ID = "9f2c41ab7d0e4c8b93a5e17fd6b04c2a"
+
+# Small-population ceiling. The fixture measures ~450 tokens end to end rather
+# than exactly 400: SpanViewValidator makes trace_id, events and links required on
+# every span, which costs ~50 chars a span that a real response also pays. Keeping
+# the wire shape faithful is worth 50 tokens.
+SMALL_TRACE_ID = "3b71d0e6c4a94f2280ab5c19e7d3f068"
+SMALL_TRACE_MAX_TOKENS = 500
+
+_AGENT_SERVICE = "deployment-6889f1c4a2b7d3e5f0a91c22"
+_WORKLOAD_SERVICE = "workload-5f10cb73a9e24d8c1b06f4a7"
+_SPAN_ID_BASE = 0x7F3A9C1D00000000
+_START_TIME = 1756_339_201.418
+
+_SENTENCES = (
+    "The customer asked whether the Q3 renewal quote already includes the "
+    "negotiated multi-year discount, and if not, what the corrected total is.",
+    "Tool result: 14 rows returned from deployments_list, of which 3 are in an "
+    "errored state and 1 has been stuck in provisioning for 41 minutes.",
+    "I should check the accuracy drift report before recommending a retrain, "
+    "because a data-quality issue upstream would explain both symptoms.",
+    "Assistant: based on the prediction explanations, the top three drivers are "
+    "tenure_months, monthly_charges and contract_type, in that order.",
+    "Observation: the span named drum.chat.completions.stream carries the full "
+    "completion, so the parent span's copy is redundant for this analysis.",
+    "The retrieved document says feature discovery runs before Autopilot and may "
+    "add derived features from secondary datasets registered to the use case.",
+    "Error: HTTPError 429 from the LLM gateway after 3 retries with exponential "
+    "backoff; falling back to the smaller model for this turn only.",
+    "Plan: summarize the failing traces, group them by root_span_name, then pull "
+    "the payload of the single most expensive span for a closer look.",
+)
+
+
+def build_oversized_agent_trace() -> dict[str, Any]:
+    """Build the oversized agent trace: 12 spans, 1,022,000 payload chars.
+
+    Deliberately carries every shape the truncation module has to survive:
+
+    * a byte-identical Traceloop/gen_ai twin pair on the input side and another
+      on the output side of one llm.chat span, plus an OpenInference twin of the
+      same text and an indexed ``gen_ai.completion.0.content`` copy;
+    * a tool span whose 160,000-char output is written four times over by four
+      different instrumentations — the single-attribute case that no per-field cap
+      alone can rescue;
+    * derived families that are *not* duplicated anywhere (``nat.metadata``,
+      ``input.value_obj``), so the semconv bucket is exercised separately from
+      the duplicate bucket;
+    * spans with no payload at all, and one ERROR span with a status message.
+    """
+    twin_prompt = _text("conversation-transcript", 40_000)
+    twin_completion = _text("assistant-turn", 8_000)
+    giant_tool_output = _text("crm-export", OVERSIZED_GIANT_ATTRIBUTE_CHARS)
+
+    spans = [
+        _span(
+            index=0,
+            parent=None,
+            name="agent.run",
+            kind="SERVER",
+            duration=41.907,
+            prompt=_text("user-question", 1_000),
+            completion=_text("final-answer", 2_500),
+            attributes={
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.agent.name": "renewal-assistant",
+                "gen_ai.usage.input_tokens": "38211",
+                "gen_ai.usage.output_tokens": "1804",
+            },
+        ),
+        _span(
+            index=1,
+            parent=0,
+            name="agent.plan",
+            kind="INTERNAL",
+            duration=0.311,
+            attributes={"nat.function.name": "plan", "nat.event.type": "SPAN_START"},
+        ),
+        _span(
+            index=2,
+            parent=0,
+            name="llm.chat",
+            kind="CLIENT",
+            duration=8.204,
+            prompt=twin_prompt,
+            completion=twin_completion,
+            attributes={
+                "gen_ai.system": "openai",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.response.finish_reasons": "tool_calls",
+                # Twins: same bytes, four different instrumentations.
+                "gen_ai.task.input": twin_prompt,
+                "traceloop.entity.input": twin_prompt,
+                "input.value": twin_prompt,
+                "gen_ai.task.output": twin_completion,
+                "traceloop.entity.output": twin_completion,
+                "gen_ai.completion.0.content": twin_completion,
+                # Derived, but duplicated nowhere: the semconv bucket.
+                "input.value_obj": _text("input-value-obj", 3_000),
+                "nat.metadata": _text("nat-metadata", 1_500),
+            },
+        ),
+        _span(
+            index=3,
+            parent=0,
+            name="tool.execute",
+            kind="INTERNAL",
+            duration=12.663,
+            completion=giant_tool_output,
+            attributes={
+                "gen_ai.tool.name": "crm_account_export",
+                "gen_ai.tool.call.id": "call_7Kq1",
+                "traceloop.entity.output": giant_tool_output,
+                "gen_ai.task.output": giant_tool_output,
+                "input.value": giant_tool_output,
+            },
+        ),
+        _span(
+            index=4,
+            parent=0,
+            name="tool.execute",
+            kind="INTERNAL",
+            duration=1.084,
+            completion=_text("deployment-list", 18_000),
+            attributes={"gen_ai.tool.name": "deployments_list"},
+        ),
+        _span(
+            index=5,
+            parent=0,
+            name="llm.chat",
+            kind="CLIENT",
+            duration=6.771,
+            prompt=_text("conversation-transcript-2", 55_000),
+            completion=_text("assistant-turn-2", 9_000),
+            attributes={"gen_ai.system": "openai", "gen_ai.request.model": "gpt-4o"},
+        ),
+        _span(
+            index=6,
+            parent=0,
+            name="tool.execute",
+            kind="INTERNAL",
+            duration=0.492,
+            completion=_text("drift-report", 9_500),
+            attributes={"gen_ai.tool.name": "deployment_drift_get"},
+        ),
+        _span(
+            index=7,
+            parent=0,
+            name="llm.chat",
+            kind="CLIENT",
+            status_code="ERROR",
+            status_message="RateLimitError: 429 Too Many Requests after 3 retries",
+            duration=30.008,
+            prompt=_text("conversation-transcript-3", 60_000),
+            completion=_text("truncated-assistant-turn", 500),
+            attributes={"gen_ai.system": "openai", "gen_ai.request.model": "gpt-4o"},
+        ),
+        _span(
+            index=8,
+            parent=0,
+            name="guardrail.check",
+            kind="INTERNAL",
+            duration=0.203,
+            attributes={"datarobot.moderation.name": "prompt_injection", "score": "0.02"},
+        ),
+        _span(
+            index=9,
+            parent=4,
+            name="db.query",
+            kind="CLIENT",
+            duration=0.148,
+            attributes={"db.system": "postgresql", "db.operation.name": "SELECT"},
+        ),
+        _span(
+            index=10,
+            parent=3,
+            name="http.post",
+            kind="CLIENT",
+            duration=11.902,
+            attributes={"http.request.method": "POST", "http.response.status_code": "200"},
+        ),
+        _span(
+            index=11,
+            parent=0,
+            name="agent.finalize",
+            kind="INTERNAL",
+            duration=2.117,
+            completion=_text("final-report", 30_000),
+            attributes={"nat.function.name": "finalize"},
+        ),
+    ]
+
+    return _trace(
+        trace_id=OVERSIZED_TRACE_ID,
+        spans=spans,
+        duration=41.907,
+        root_span_name="agent.run",
+        service_name=_AGENT_SERVICE,
+        metrics={
+            "prompt_guards": {"prompt_injection": {"average": 0.02, "count": 4}},
+            "response_guards": {"toxicity": {"average": 0.0, "count": 4}},
+        },
+    )
+
+
+def build_small_trace() -> dict[str, Any]:
+    """Build the small non-agentic trace: 3 spans, no payload, ~400 tokens total."""
+    spans = [
+        _span(
+            index=0,
+            parent=None,
+            name="GET /health",
+            kind="SERVER",
+            duration=0.104,
+            service_name=_WORKLOAD_SERVICE,
+            attributes={"http.response.status_code": "200"},
+        ),
+        _span(
+            index=1,
+            parent=0,
+            name="db.query",
+            kind="CLIENT",
+            duration=0.041,
+            service_name=_WORKLOAD_SERVICE,
+            attributes={"db.system": "postgresql"},
+        ),
+        _span(
+            index=2,
+            parent=0,
+            name="cache.get",
+            kind="CLIENT",
+            duration=0.002,
+            service_name=_WORKLOAD_SERVICE,
+            attributes={"cache.hit": "true"},
+        ),
+    ]
+
+    return _trace(
+        trace_id=SMALL_TRACE_ID,
+        spans=spans,
+        duration=0.104,
+        root_span_name="GET /health",
+        service_name=_WORKLOAD_SERVICE,
+    )
+
+
+def _text(label: str, target_chars: int) -> str:
+    """Build exactly ``target_chars`` chars of stable, realistic-looking prose."""
+    if target_chars <= 0:
+        return ""
+    lines: list[str] = []
+    length = 0
+    index = 0
+    while length <= target_chars:
+        line = f"[{label} {index:05d}] {_SENTENCES[index % len(_SENTENCES)]}"
+        lines.append(line)
+        length += len(line) + 1
+        index += 1
+    return "\n".join(lines)[:target_chars]
+
+
+def _span(
+    *,
+    index: int,
+    parent: int | None,
+    name: str,
+    kind: str,
+    duration: float,
+    attributes: dict[str, str],
+    status_code: str = "OK",
+    status_message: str | None = None,
+    service_name: str = _AGENT_SERVICE,
+    prompt: str | None = None,
+    completion: str | None = None,
+) -> dict[str, Any]:
+    """Build one span in the shape SpanViewValidator serializes."""
+    span: dict[str, Any] = {
+        "trace_id": OVERSIZED_TRACE_ID,
+        "span_id": f"{_SPAN_ID_BASE + index:016x}",
+        "parent_span_id": None if parent is None else f"{_SPAN_ID_BASE + parent:016x}",
+        "name": name,
+        "status_code": status_code,
+        "status_message": status_message,
+        "kind": kind,
+        "service_name": service_name,
+        "duration": duration,
+        "start_time": _START_TIME + index,
+        "attributes": dict(attributes),
+        "events": [],
+        "links": [],
+    }
+    if prompt is not None:
+        span["prompt"] = prompt
+    if completion is not None:
+        span["completion"] = completion
+    return span
+
+
+def _trace(
+    *,
+    trace_id: str,
+    spans: list[dict[str, Any]],
+    duration: float,
+    root_span_name: str,
+    service_name: str,
+    metrics: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Wrap spans in the trace-detail response envelope, pagination fields included."""
+    for span in spans:
+        span["trace_id"] = trace_id
+    trace: dict[str, Any] = {
+        "trace_id": trace_id,
+        "span_count": len(spans),
+        "duration": duration,
+        "root_span_name": root_span_name,
+        "root_service_name": service_name,
+        "spans": spans,
+        "count": len(spans),
+        "offset": 0,
+        "limit": 100,
+        "total_count": len(spans),
+        "next": None,
+        "previous": None,
+    }
+    if metrics is not None:
+        trace["metrics"] = metrics
+    return trace


### PR DESCRIPTION
# RATIONALE

Design doc: https://datarobot.atlassian.net/wiki/x/AoCr3AE

A raw trace passed through as-is is unusable: measured p50/p95/max is **1,129 / 809,639 / 1,560,241 tokens**, and span count does not predict size (86x tokens-per-span spread). Budgets are in characters, not tokens — `drtools` may import only `drtools`/`drmcputils`, so no tokenizer dependency was added; a measured 3.1 chars/token sets the conversion.

The hard character cap is load-bearing and the tests say so by name. Even after perfect deduplication, ~423,300 tokens of genuinely unique text remain on the worst measured trace, so dedup alone cannot bound output. A change that weakens the cap in favour of smarter dedup is a regression.

This PR is scoped to the foundation only — **no tools are registered here**; that's what #647 builds on top of it.

## CHANGES

- `drtools/otel/truncation.py` — the four projection helpers: `summarize_spans`, `canonical_attributes`, `cap_value`, `apply_char_budget`.
- `drtools/otel/constants.py` — `EntityType`, `OTEL_ENTITY_TYPES`, `OTEL_LOG_LEVELS` (all six levels — deliberately *not* `drmcputils.constants.LOG_LEVELS`, which lacks `warning`/`critical` that the API accepts), and the semconv precedence tables.
- `drtools/core/clients/datarobot_otel_query.py` — `OtelQueryApiClient`, a thin transport mirror of `WorkloadApiClient`. One method per `GET /otel/*`, camelCase param assembly, no truncation or validation.
- `require_object_id` / `require_trace_id` in `drtools/core/utils.py` (24- and 32-hex).
- Tier-1 tests plus a deterministic fixture generator (not a checked-in blob): an oversized 12-span agent trace carrying 1,022,000 payload chars with byte-identical Traceloop/gen_ai twin pairs and one 160,000-char attribute, and a small non-agentic trace.

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog (added in #649, the last PR of this stack)
- [x] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST) — N/A, no new tools in this PR (foundation module only)

## TESTING

`task drmcp-unit` (full suite) 1783 passed, coverage 85.90%. ruff-format, ruff, mypy, check-imports all clean. Rebased on `main` @ 31ef16d6.

## RELATED

1/4 of the OTel observability tools stack (plan §9 steps 2–3). Next: #647 (the seven tool definitions built on this foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new library surface (REST client plus complex truncation) that upcoming OTel tools will depend on; mistakes could mis-size agent context or mishandle API params, though behavior is heavily unit-tested and nothing is exposed as MCP tools yet.
> 
> **Overview**
> Adds the **foundation for OTel observability MCP tools** (no tools registered in this PR). Upcoming tools will query traces/logs/metrics through this layer and return **bounded** projections instead of multi‑MB raw payloads.
> 
> **`OtelQueryApiClient`** mirrors `WorkloadApiClient`: one method per `GET /otel/*`, user credentials via `request_user_dr_client`, camelCase query params only—no validation or truncation in the client.
> 
> **`drtools/otel/truncation.py`** implements summary-by-default and hard caps: `summarize_spans` (structure + `payload_chars` / `payload_fields` for drill-down), `canonical_attributes` (semconv precedence and byte-identical dedup with explicit `duplicate` vs `semconv` reporting), `cap_value` / `cap_payload_value` (paged windows), and **`apply_char_budget`** as the non-negotiable total output bound. **`constants.py`** adds snake_case `EntityType`, six-level `OTEL_LOG_LEVELS`, and semconv drop/precedence tables.
> 
> **`require_object_id`** and **`require_trace_id`** in `core/utils.py` fail fast with `ToolError` before API calls (trace IDs normalized to lowercase).
> 
> Unit tests cover the client wire format, ID helpers, and truncation against deterministic **oversized** (~1M payload chars) and **small** trace fixtures from a generator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14961da1812d27afa715ace615d74c703e6e7916. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->