### PR TITLE
[APP-6968] OTel MCP tools 2/4: the seven tool definitions

### DIFF
--- a/src/datarobot_genai/drmcputils/categories.py
+++ b/src/datarobot_genai/drmcputils/categories.py
@@ -44,6 +44,7 @@ Hierarchy:
     dr_panels
   dr_db
     dr_vdb
+  dr_otel                                (leaf — no sub-categories)
   dr_user_tools                          (user-authored tools — outside the static taxonomy)
   dr_dynamic_tools                       (hosted tools — registered separately)
 """
@@ -93,6 +94,9 @@ class MCPToolCategory(StrEnum):
     # ── database categories ──────────────────────────────────────────────────
     DR_DB = "dr_db"
     DR_VDB = "dr_vdb"
+
+    # ── observability (leaf, standalone — not parented under dr_development) ──
+    DR_OTEL = "dr_otel"
 
     # ── special / marker-resolved ────────────────────────────────────────────
     # Tools the user authored in their own MCP server code (``dr_mcp_tool``'s
@@ -291,6 +295,17 @@ LEAF_CATEGORY_TOOLS: dict[str, frozenset[str]] = {
             "vdb_query",
         }
     ),
+    MCPToolCategory.DR_OTEL: frozenset(
+        {
+            "otel_traces_list",
+            "otel_trace_get",
+            "otel_span_payload_get",
+            "otel_logs_list",
+            "otel_metrics_catalog_list",
+            "otel_metrics_values_get",
+            "otel_entity_stats_get",
+        }
+    ),
     # Marker-resolved categories — tool names are resolved at request time
     # from each tool's ``meta.tool_category`` marker, not from this static
     # map.  Present so the names are recognised as categories; the empty set
@@ -410,6 +425,8 @@ TOOL_CATEGORY_LABELS: dict[MCPToolCategory, str] = {
     # ── databases ───────────────────────────────────────────────────────────
     MCPToolCategory.DR_DB: "Databases",
     MCPToolCategory.DR_VDB: "Vector databases",
+    # ── observability (standalone leaf, top-level — see PARENT_TO_CHILDREN) ──
+    MCPToolCategory.DR_OTEL: "Observability",
     # ── marker-resolved (user MCPs only) ────────────────────────────────────
     MCPToolCategory.DR_USER_TOOLS: "Your own tools",
     MCPToolCategory.DR_DYNAMIC_TOOLS: "Deployed tools",

--- a/src/datarobot_genai/drtools/otel/entity_stats.py
+++ b/src/datarobot_genai/drtools/otel/entity_stats.py
@@ -1,0 +1,191 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OTel entity-stats tool: ``otel_entity_stats_get`` (plan §2.7).
+
+A preflight/validation tool, not a discovery tool: ``GET /otel/stats/`` takes
+only ``serviceName``, ``userId`` and a time window — there is no name search or
+type filter, so it cannot answer "which entity is relevant here". Entity
+resolution stays where it already works (``workload_list``,
+``deployment_get_info``, the user's own config). What this *is* good at is
+answering "does this entity have any OTel data, and can I read it?" before an
+agent starts paging traces — hence ``entity_type``/``entity_id`` are required
+and the tool is scoped to exactly one entity.
+
+Three things the upstream controller makes possible, all load-bearing here:
+
+1. Rows are per ``(user_id, service_name)``, not per entity — one entity
+   returns one row *per user who produced telemetry on it*. The top-level
+   counts are summed across rows; returning the first row alone would
+   undercount. ``by_user`` keeps the per-user breakdown, capped at
+   :data:`ENTITY_STATS_BY_USER_MAX` rows, while ``user_count`` stays exact
+   across every row fetched (not just the ones shown).
+2. Passing ``serviceName`` explicitly avoids the self-scoping trap: when it is
+   omitted and the caller is not an org admin, the controller silently sets
+   ``user_id = [caller]`` — "entities *you* generated telemetry for", a much
+   narrower question than it looks. Always building and passing it (as
+   ``f"{entity_type}-{entity_id}"``) is what makes "no data" mean *no data*.
+3. No feature flag or seat license is required, unlike every trace/log/metrics
+   route in this package — so this tool still answers on a cluster where those
+   403. That is the one distinction no other tool here can make, which is why
+   a 403 *from this endpoint* is reported as a real permissions failure rather
+   than folded into "no data".
+"""
+
+from typing import Annotated
+from typing import Any
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_otel_query import OtelQueryApiClient
+from datarobot_genai.drtools.core.utils import require_object_id
+from datarobot_genai.drtools.otel.constants import EntityType
+
+# OtelStatsController's own validator ceiling. Requested unconditionally so the
+# sums below are computed from the fullest page the API allows, not a
+# tool-chosen smaller page that would silently undercount.
+ENTITY_STATS_LIMIT = 1_000
+
+# Cap on the 'by_user' breakdown shown in the response. 'user_count' is NOT
+# capped by this — it counts every distinct user_id across all rows fetched
+# (up to ENTITY_STATS_LIMIT), so it stays exact even when more than this many
+# users produced telemetry on the entity.
+ENTITY_STATS_BY_USER_MAX = 20
+
+_ROW_COUNT_FIELDS: tuple[str, ...] = ("span_count", "metric_count", "log_count")
+
+
+@tool_metadata(
+    tags={"otel", "datarobot", "stats", "entity", "preflight", "observability"},
+    description=(
+        "[OTel—entity stats] Preflight check: does this entity have any OTel "
+        "data at all, and can the caller read it? Not a discovery tool — "
+        "entity_type and entity_id are required, and there is no name search "
+        "or type filter; resolve the entity first with workload_list, "
+        "deployment_get_info, or similar.\n\n"
+        "Builds service_name internally as f'{entity_type}-{entity_id}' and "
+        "always passes it — omitting it would silently scope the query to "
+        "only the calling user's own telemetry, which is why 'no data' here "
+        "actually means no data. Rows are per (user_id, service_name): "
+        "span_count/metric_count/log_count are summed across every matching "
+        f"row, and by_user keeps the breakdown (capped at "
+        f"{ENTITY_STATS_BY_USER_MAX} rows; user_count stays exact across every "
+        f"row fetched, not just the rows shown). Requests limit="
+        f"{ENTITY_STATS_LIMIT} (the API's ceiling) and adds a note if the true "
+        "total exceeds it, so the sums are never silently partial.\n\n"
+        "Unlike every trace/log/metrics tool in this set, this one needs no "
+        "feature flag or seat license — it still answers when those tools "
+        "would 403, so you can tell 'this entity has data but I can't read "
+        "it' apart from 'there is nothing here'. A 403 from this tool means "
+        "the caller cannot read this entity (a real permissions failure) and "
+        "raises rather than returning an empty result. One inherent "
+        "limitation: if OTel storage was never provisioned for this org at "
+        "all, that also comes back as has_otel_data=false — indistinguishable "
+        "from genuinely no data.\n\n"
+        "Example: otel_entity_stats_get(entity_type='deployment', entity_id='...')"
+    ),
+    display_name="OTel — Get entity stats",
+    description_ui=(
+        "Check whether an entity has any OTel data and whether the caller can "
+        "read it, before paging traces or logs."
+    ),
+)
+async def otel_entity_stats_get(
+    *,
+    entity_type: Annotated[EntityType, "Type of entity the OTel data belongs to."],
+    entity_id: Annotated[str, "24-character hex ID of the entity."],
+    start_time: Annotated[
+        str | None, "RFC3339 start of the window (e.g. '2026-08-24T00:00:00Z')."
+    ] = None,
+    end_time: Annotated[str | None, "RFC3339 end of the window."] = None,
+) -> dict[str, Any]:
+    eid = require_object_id(entity_id, "entity_id")
+    service_name = f"{entity_type}-{eid}"
+
+    try:
+        result = OtelQueryApiClient().get_entity_stats(
+            service_name, start=start_time, end=end_time, limit=ENTITY_STATS_LIMIT
+        )
+    except ClientError as exc:
+        if getattr(exc, "status_code", None) == 403:
+            raise ToolError(
+                f"Permission denied reading OTel stats for {entity_type} "
+                f"'{eid}' (service_name={service_name!r}). This is a "
+                "permissions failure, not an empty result — the caller cannot "
+                "read this entity.",
+                kind=ToolErrorKind.AUTHENTICATION,
+            ) from exc
+        raise_tool_error_for_client_error(exc)
+
+    rows = result.get("data", []) or []
+    user_ids = {row.get("user_id") for row in rows if row.get("user_id") is not None}
+
+    response: dict[str, Any] = {
+        "entity_type": entity_type,
+        "entity_id": eid,
+        "service_name": service_name,
+        "has_otel_data": bool(rows),
+        **{field: _sum_field(rows, field) for field in _ROW_COUNT_FIELDS},
+        "user_count": len(user_ids),
+        "by_user": [_by_user_row(row) for row in rows[:ENTITY_STATS_BY_USER_MAX]],
+    }
+
+    total_count = _extract_total_count(result)
+    if total_count is not None and total_count > ENTITY_STATS_LIMIT:
+        response["note"] = (
+            f"total_count ({total_count}) exceeds the request limit "
+            f"({ENTITY_STATS_LIMIT}); the counts above may be partial."
+        )
+
+    return response
+
+
+def _sum_field(rows: list[dict[str, Any]], field: str) -> int:
+    """Sum one count field across every per-(user_id, service_name) row."""
+    return sum(int(row.get(field) or 0) for row in rows)
+
+
+def _by_user_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Project one raw stats row to the by_user breakdown shape.
+
+    Normalizes a present-but-``None`` count the same way :func:`_sum_field`
+    does (``int(value or 0)``), so a row's per-user breakdown never disagrees
+    with the top-level sum it contributed to — e.g. a row with
+    ``span_count: None`` must not show up as ``None`` here while counting as
+    ``0`` in the summed total.
+    """
+    counts = {field: int(row.get(field) or 0) for field in _ROW_COUNT_FIELDS}
+    return {"user_id": row.get("user_id"), **counts}
+
+
+def _extract_total_count(result: dict[str, Any]) -> int | None:
+    """Read the server's true row count under whichever key it used.
+
+    Returns ``None`` (treated as "unknown, no note") rather than raising when
+    the value present is non-numeric — a malformed upstream field should not
+    crash an otherwise-successful call.
+    """
+    for key in ("total_count", "totalCount", "total"):
+        value = result.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None

--- a/src/datarobot_genai/drtools/otel/logs.py
+++ b/src/datarobot_genai/drtools/otel/logs.py
@@ -1,0 +1,193 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OTel log tool: ``otel_logs_list`` (plan §2.4).
+
+Near-1:1 wrapper around ``GET .../logs/`` — linear ~127 tokens/line, so a capped
+default limit and a per-line character cap are the only truncation this module
+needs; nothing here composes :mod:`datarobot_genai.drtools.otel.truncation`'s
+budget/dedup machinery, which exists for the trace tools' much larger payloads.
+
+Two traps this module exists to avoid:
+
+* ``level`` is a *minimum*, not an exact match, and the full accepted set is
+  ``debug|info|warn|warning|error|critical``. ``drmcputils.constants.LOG_LEVELS``
+  is only ``("debug", "info", "warn", "error")`` — reusing it would silently
+  reject ``warning`` and ``critical``, which this API accepts. Use
+  :data:`datarobot_genai.drtools.otel.constants.OTEL_LOG_LEVELS` instead.
+* ``max_line_chars`` truncates *characters*, not bytes — one measured attribute
+  in the trace tools was multi-byte-heavy, and byte-slicing UTF-8 breaks
+  multibyte sequences. ``message`` and ``stacktrace`` are capped independently,
+  each with its own ``…[truncated, N more chars]`` marker, so a long stacktrace
+  never eats into the message's own budget.
+"""
+
+from typing import Annotated
+from typing import Any
+from typing import Literal
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_otel_query import OtelQueryApiClient
+from datarobot_genai.drtools.core.utils import require_object_id
+from datarobot_genai.drtools.otel.constants import OTEL_LOG_LEVELS
+from datarobot_genai.drtools.otel.constants import EntityType
+from datarobot_genai.drtools.otel.truncation import cap_value
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+
+# Cap on each of a log line's 'message'/'stacktrace' fields, independently, in
+# characters. Provisional like otel_trace_get's defaults (traces.py) — plan §9
+# step 9's real-trace run may correct it; nothing else in this module repeats
+# the literal.
+DEFAULT_MAX_LINE_CHARS = 2_000
+
+# Fields capped independently by max_line_chars, each with its own marker.
+_CAPPED_LINE_FIELDS: tuple[str, ...] = ("message", "stacktrace")
+
+# Plan §2's shared conventions: GENAI_EXPERIMENTATION is required by *every*
+# /otel route, this one included — worth surfacing in the description so a 403
+# reads as configuration, not "no access to this entity's logs".
+_OTEL_403_HINT = (
+    "A 403 here usually means configuration, not missing data: the "
+    "GENAI_EXPERIMENTATION feature flag is required for every /otel route."
+)
+
+
+@tool_metadata(
+    tags={"otel", "datarobot", "logs", "list", "observability", "debug"},
+    description=(
+        "[OTel—logs] List OTel log lines for an entity: linear ~127 tokens/line "
+        "(measured 977 / 12,229 / 127,307 tokens at limit 10 / 100 / 1000).\n\n"
+        "'level' is a MINIMUM level, not an exact match — the full accepted set "
+        "is 'debug' | 'info' | 'warn' | 'warning' | 'error' | 'critical'.\n\n"
+        "trace_id and span_id are the log<->trace correlation path — the single "
+        "most useful filter here for debugging one failing request, and easy to "
+        "miss since nothing else names it.\n\n"
+        "Each line's 'message' and 'stacktrace' are capped at max_line_chars "
+        "independently (0 disables), each with its own "
+        "'…[truncated, N more chars]' marker when cut. This endpoint has no "
+        "total_count — only 'next'/'previous' for pagination.\n\n"
+        f"{_OTEL_403_HINT}\n\n"
+        "Example: otel_logs_list(entity_type='deployment', entity_id='...', level='error')\n"
+        "Example: otel_logs_list(entity_type='deployment', entity_id='...', "
+        "trace_id='...', includes=['ERROR'])"
+    ),
+    display_name="OTel — List logs",
+    description_ui=(
+        "List OTel log lines for an entity, filtered by level, time window, body "
+        "text, and span or trace ID."
+    ),
+)
+async def otel_logs_list(
+    *,
+    entity_type: Annotated[EntityType, "Type of entity the OTel data belongs to."],
+    entity_id: Annotated[str, "24-character hex ID of the entity."],
+    limit: Annotated[int, "Max log lines to return (1-100, clamped). Default 50."] = 50,
+    offset: Annotated[int, "Lines to skip for pagination. Default 0."] = 0,
+    level: Annotated[
+        Literal["debug", "info", "warn", "warning", "error", "critical"],
+        "Minimum log level to return (not an exact match). Default 'debug'.",
+    ] = "debug",
+    start_time: Annotated[
+        str | None, "RFC3339 start of the window (e.g. '2026-08-24T00:00:00Z')."
+    ] = None,
+    end_time: Annotated[str | None, "RFC3339 end of the window."] = None,
+    includes: Annotated[
+        list[str] | None,
+        "Body text substrings that must all be present (AND logic, up to 10).",
+    ] = None,
+    excludes: Annotated[
+        list[str] | None, "Body text substrings that must be absent (up to 10)."
+    ] = None,
+    span_id: Annotated[str | None, "Filter to a specific OTel span ID."] = None,
+    trace_id: Annotated[str | None, "Filter to a specific OTel trace ID."] = None,
+    max_line_chars: Annotated[
+        int,
+        "Cap each of 'message'/'stacktrace' independently, in characters. "
+        f"Default {DEFAULT_MAX_LINE_CHARS}. 0 disables.",
+    ] = DEFAULT_MAX_LINE_CHARS,
+) -> dict[str, Any]:
+    eid = require_object_id(entity_id, "entity_id")
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if level not in OTEL_LOG_LEVELS:
+        raise ToolError(
+            f"Argument validation error: 'level' must be one of {OTEL_LOG_LEVELS}.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    clamped_limit, note = clamp_limit(limit)
+    try:
+        result = OtelQueryApiClient().list_logs(
+            entity_type,
+            eid,
+            limit=clamped_limit,
+            offset=offset,
+            level=level,
+            start_time=start_time,
+            end_time=end_time,
+            includes=includes,
+            excludes=excludes,
+            span_id=span_id,
+            trace_id=trace_id,
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    logs = [_capped_log_line(entry, max_line_chars) for entry in data]
+    response = merge_pagination_metadata(
+        {"logs": logs, "count": len(logs)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+    # merge_pagination_metadata generically copies total_count/totalCount/total
+    # from the raw response when present. The logs/ endpoint is
+    # PaginatedWithoutTotalResponseValidator and never sends one in practice,
+    # but that's a property of today's upstream shape, not of this code — strip
+    # it explicitly so §2.4's "no total_count" invariant holds even if the
+    # upstream response ever grows one of those keys.
+    response.pop("total_count", None)
+    return response
+
+
+def _capped_log_line(entry: dict[str, Any], max_line_chars: int) -> dict[str, Any]:
+    """Cap 'message' and 'stacktrace' independently, each with its own marker.
+
+    A copy of ``entry`` with every other field passed through unchanged.
+    """
+    capped = dict(entry)
+    for field in _CAPPED_LINE_FIELDS:
+        value = capped.get(field)
+        if isinstance(value, str):
+            capped[field] = _capped_field(value, max_line_chars)
+    return capped
+
+
+def _capped_field(value: str, max_chars: int) -> str:
+    """Window one field and append a '…[truncated, N more chars]' marker when cut."""
+    window, info = cap_value(value, max_chars)
+    if info is None:
+        return window
+    return f"{window}…[truncated, {info['total_chars'] - info['returned_chars']} more chars]"

--- a/src/datarobot_genai/drtools/otel/metrics.py
+++ b/src/datarobot_genai/drtools/otel/metrics.py
@@ -1,0 +1,186 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OTel metrics tools: ``otel_metrics_catalog_list``, ``otel_metrics_values_get``.
+
+Plan §2.5-§2.6.
+
+``otel_metrics_values_get`` folds the doc's ``retrieve_metrics_values`` and
+``retrieve_autocollected_metrics_values`` into one tool behind a ``source``
+param, following the existing ``workload_activity_get(kind=...)`` precedent in
+``drtools/workload/workload_observability.py``.
+
+The trap this module exists to avoid: every sampled deployment in the original
+measurement had *no* configured custom metrics, so ``source='configured'``
+returning an empty ``metric_aggregations`` is the expected, common case — not a
+failure to retry. ``source='autocollected'`` is the default precisely because
+it is the one guaranteed to have data (built-in platform metrics, no
+configuration required).
+"""
+
+from typing import Annotated
+from typing import Any
+from typing import Literal
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_otel_query import OtelQueryApiClient
+from datarobot_genai.drtools.core.utils import require_object_id
+from datarobot_genai.drtools.otel.constants import EntityType
+
+# otel_metrics_catalog_list's client-side cap. The server itself is unpaginated
+# (max_length=1000); this clamps further and reports when it bit, since 1000
+# catalog entries is far more than any tool call needs to see at once.
+METRICS_CATALOG_MAX = 100
+
+# Plan §2's shared conventions: GENAI_EXPERIMENTATION is required by *every*
+# /otel route, these two included — worth surfacing in the description so a
+# 403 reads as configuration, not "no access to this entity's metrics".
+_OTEL_403_HINT = (
+    "A 403 here usually means configuration, not missing data: the "
+    "GENAI_EXPERIMENTATION feature flag is required for every /otel route."
+)
+
+
+# ------------------------------------------------------------------ #
+# otel_metrics_catalog_list                                            #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"otel", "datarobot", "metrics", "catalog", "list", "observability"},
+    description=(
+        "[OTel—metrics catalog] List the OTel metrics an entity actually emits "
+        "— the discovery step before otel_metrics_values_get. Measured 5-224 "
+        "tokens. Unpaginated server-side (up to 1000 entries); this tool clamps "
+        f"to the first {METRICS_CATALOG_MAX} and adds a note when the server "
+        "returned more. Use 'search' to narrow instead of paging.\n\n"
+        f"{_OTEL_403_HINT}\n\n"
+        "Example: otel_metrics_catalog_list(entity_type='deployment', entity_id='...')\n"
+        "Example: otel_metrics_catalog_list(entity_type='deployment', "
+        "entity_id='...', search='latency')"
+    ),
+    display_name="OTel — List metrics catalog",
+    description_ui=("List the OTel metrics an entity emits: name, description, type, and units."),
+)
+async def otel_metrics_catalog_list(
+    *,
+    entity_type: Annotated[EntityType, "Type of entity the OTel data belongs to."],
+    entity_id: Annotated[str, "24-character hex ID of the entity."],
+    search: Annotated[str | None, "Substring match on metric name."] = None,
+    metric_type: Annotated[
+        str | None, "Filter by metric type, e.g. 'counter' | 'gauge' | 'histogram'."
+    ] = None,
+) -> dict[str, Any]:
+    eid = require_object_id(entity_id, "entity_id")
+    try:
+        result = OtelQueryApiClient().list_metrics_summary(
+            entity_type, eid, search=search, metric_type=metric_type
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    truncated = len(data) > METRICS_CATALOG_MAX
+    metrics = data[:METRICS_CATALOG_MAX]
+
+    response: dict[str, Any] = {"metrics": metrics, "count": len(metrics)}
+    if truncated:
+        response["note"] = (
+            f"Server returned more than {METRICS_CATALOG_MAX} metrics; showing "
+            f"the first {METRICS_CATALOG_MAX}. Use 'search' to narrow."
+        )
+    return response
+
+
+# ------------------------------------------------------------------ #
+# otel_metrics_values_get                                              #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"otel", "datarobot", "metrics", "values", "get", "observability"},
+    description=(
+        "[OTel—metrics values] Get current metric values for an entity.\n\n"
+        "source='autocollected' (default): built-in platform metrics (CPU, "
+        "memory, request counts, ...) that always have data — no configuration "
+        "required.\n"
+        "source='configured': custom metric configurations defined for this "
+        "entity; histogram_buckets=True returns raw buckets instead of "
+        "percentiles (configured only).\n\n"
+        "IMPORTANT: an empty 'metric_aggregations' for source='configured' "
+        "means 'no custom metrics configured for this entity', NOT 'no data' — "
+        "every deployment sampled while measuring this endpoint had none "
+        "configured, so do not read an empty list as a failure and retry. "
+        "Measured 5-224 tokens; no truncation in phase 1.\n\n"
+        f"{_OTEL_403_HINT}\n\n"
+        "Example: otel_metrics_values_get(entity_type='deployment', entity_id='...')\n"
+        "Example: otel_metrics_values_get(entity_type='deployment', "
+        "entity_id='...', source='configured', histogram_buckets=True)"
+    ),
+    display_name="OTel — Get metric values",
+    description_ui=(
+        "Get current OTel metric values for an entity: built-in platform "
+        "metrics by default, or configured custom metrics."
+    ),
+)
+async def otel_metrics_values_get(
+    *,
+    entity_type: Annotated[EntityType, "Type of entity the OTel data belongs to."],
+    entity_id: Annotated[str, "24-character hex ID of the entity."],
+    source: Annotated[
+        Literal["configured", "autocollected"],
+        "'autocollected' (default): built-in platform metrics, always has "
+        "data. 'configured': custom metric configurations for this entity.",
+    ] = "autocollected",
+    start_time: Annotated[str | None, "RFC3339 start of the window."] = None,
+    end_time: Annotated[str | None, "RFC3339 end of the window."] = None,
+    histogram_buckets: Annotated[
+        bool, "source='configured' only: return raw buckets instead of percentiles."
+    ] = False,
+) -> dict[str, Any]:
+    eid = require_object_id(entity_id, "entity_id")
+    client = OtelQueryApiClient()
+
+    try:
+        if source == "autocollected":
+            result = client.get_autocollected_metrics_values(
+                entity_type, eid, start=start_time, end=end_time
+            )
+        else:
+            result = client.get_metrics_values(
+                entity_type,
+                eid,
+                histogram_buckets=histogram_buckets,
+                start=start_time,
+                end=end_time,
+            )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    if source == "autocollected":
+        data = result.get("data", []) or []
+        return {"metrics": data, "count": len(data)}
+
+    # source == "configured": a single aggregation object, not a list envelope
+    # — pass the three documented fields through explicitly rather than the
+    # raw response, so the contract stays exactly what §2.6 promises regardless
+    # of what else the server happens to include.
+    return {
+        "start_time": result.get("start_time"),
+        "end_time": result.get("end_time"),
+        "metric_aggregations": result.get("metric_aggregations", []) or [],
+    }

--- a/src/datarobot_genai/drtools/otel/traces.py
+++ b/src/datarobot_genai/drtools/otel/traces.py
@@ -54,6 +54,7 @@ from datarobot_genai.drtools.otel.constants import RESPONSE_PAYLOAD_FIELDS
 from datarobot_genai.drtools.otel.constants import EntityType
 from datarobot_genai.drtools.otel.truncation import apply_char_budget
 from datarobot_genai.drtools.otel.truncation import canonical_attributes
+from datarobot_genai.drtools.otel.truncation import cap_payload_value
 from datarobot_genai.drtools.otel.truncation import cap_value
 from datarobot_genai.drtools.otel.truncation import summarize_spans
 from datarobot_genai.drtools.pagination import clamp_limit
@@ -138,8 +139,12 @@ async def otel_traces_list(
     min_trace_duration_ns: Annotated[int | None, "Minimum trace duration, in nanoseconds."] = None,
     min_span_duration_ns: Annotated[int | None, "Minimum span duration, in nanoseconds."] = None,
     max_span_duration_ns: Annotated[int | None, "Maximum span duration, in nanoseconds."] = None,
-    min_trace_cost: Annotated[int | None, "Minimum trace cost."] = None,
-    max_trace_cost: Annotated[int | None, "Maximum trace cost."] = None,
+    min_trace_cost: Annotated[
+        float | None, "Minimum trace cost. Fractional amounts are valid (e.g. 0.01)."
+    ] = None,
+    max_trace_cost: Annotated[
+        float | None, "Maximum trace cost. Fractional amounts are valid (e.g. 0.01)."
+    ] = None,
     sort_by: Annotated[
         Literal["timestamp", "duration", "cost"] | None,
         "Field to sort by. Defaults to 'timestamp' when sort_direction is set.",
@@ -341,10 +346,13 @@ async def otel_trace_get(
         "the text is still there under its own name, just not duplicated.\n\n"
         "Each field is windowed at max_field_chars. When a field is larger than "
         "that, 'truncation.fields' names it with 'next_offset' — pass that back "
-        "as field_offset (typically with fields=[that one name]) to continue "
-        "reading it; one measured field was 740,000 chars.\n\n"
-        "Known cost: there is no per-span endpoint, so this refetches the whole "
-        "trace and filters client-side.\n\n"
+        "as field_offset together with fields=[that one name] (field_offset "
+        "requires fields, so an offset meant for one long field cannot blank "
+        "every short field beside it); include 'status_message' in fields to "
+        "continue a truncated status message. One measured field was 740,000 "
+        "chars.\n\n"
+        "Known cost: there is no per-span endpoint, so this refetches the trace "
+        "page by page and filters client-side until the span is found.\n\n"
         f"{_TRACE_403_HINT}\n\n"
         "Example: otel_span_payload_get(entity_type='deployment', entity_id='...', "
         "trace_id='...', span_id='...')\n"
@@ -371,7 +379,9 @@ async def otel_span_payload_get(
     ] = None,
     max_field_chars: Annotated[int, "Cap per field value, in characters."] = 8_000,
     field_offset: Annotated[
-        int, "Character offset to continue a previously truncated field from."
+        int,
+        "Character offset to continue a previously truncated field from. "
+        "Requires 'fields' naming the field(s) to continue.",
     ] = 0,
 ) -> dict[str, Any]:
     eid = require_object_id(entity_id, "entity_id")
@@ -382,23 +392,58 @@ async def otel_span_payload_get(
             "Argument validation error: 'field_offset' must be >= 0.",
             kind=ToolErrorKind.VALIDATION,
         )
-
-    try:
-        # No span_limit parameter on this tool (§2.3's signature has none) — the
-        # fetch page size is tied to the same DEFAULT_TRACE_SPAN_LIMIT otel_trace_get
-        # uses, so a step-9 correction to that constant covers this call site too.
-        trace = OtelQueryApiClient().get_trace(
-            entity_type, eid, tid, limit=DEFAULT_TRACE_SPAN_LIMIT
+    if field_offset > 0 and not fields:
+        raise ToolError(
+            "Argument validation error: 'field_offset' requires 'fields' naming the "
+            "field(s) to continue (e.g. fields=['gen_ai.task.output']). Without it, "
+            "every field shorter than the offset would come back as an empty window.",
+            kind=ToolErrorKind.VALIDATION,
         )
+
+    # The server emits lowercase hex span ids; match case-insensitively so a
+    # hand-pasted uppercase id still finds its span instead of a NOT_FOUND.
+    sid_lower = sid.lower()
+
+    # No span_limit parameter on this tool (§2.3's signature has none) — the fetch
+    # page size is tied to the same DEFAULT_TRACE_SPAN_LIMIT otel_trace_get uses.
+    # There is no per-span endpoint either, so page through the trace's spans until
+    # the requested one is found: otel_trace_get(span_offset=...) legitimately
+    # surfaces span ids past the first page, and stopping at page one made every
+    # one of those permanently unreachable from this tool.
+    span: dict[str, Any] | None = None
+    spans_checked = 0
+    fetched_bytes = 0
+    total_count: int | None = None
+    offset = 0
+    try:
+        client = OtelQueryApiClient()
+        while True:
+            trace = client.get_trace(
+                entity_type, eid, tid, limit=DEFAULT_TRACE_SPAN_LIMIT, offset=offset
+            )
+            # Evidence for §10's server-side field-projection ask: whole trace pages
+            # are fetched to return one span's payload. ensure_ascii=False matches
+            # truncation.py's own char/byte accounting so this approximates what was
+            # actually received on the wire, not an escape-expanded blowup of it.
+            fetched_bytes += len(json.dumps(trace, default=str, ensure_ascii=False).encode("utf-8"))
+            spans = trace.get("spans") or []
+            spans_checked += len(spans)
+            raw_total = trace.get("total_count")
+            if isinstance(raw_total, int):
+                total_count = raw_total
+            span = next(
+                (s for s in spans if str(s.get("span_id") or "").lower() == sid_lower), None
+            )
+            if span is not None:
+                break
+            if len(spans) < DEFAULT_TRACE_SPAN_LIMIT:
+                break  # short (or empty) page: the server has no more spans
+            if total_count is not None and spans_checked >= total_count:
+                break
+            offset += len(spans)
     except ClientError as exc:
         raise_tool_error_for_client_error(exc)
 
-    # Evidence for §10's server-side field-projection ask: there is no per-span
-    # endpoint, so a full trace is fetched to return one span's payload.
-    # ensure_ascii=False matches truncation.py's own char/byte accounting so this
-    # approximates what was actually received on the wire, not an escape-expanded
-    # blowup of it.
-    fetched_bytes = len(json.dumps(trace, default=str, ensure_ascii=False).encode("utf-8"))
     logger.info(
         "otel_span_payload_get: fetched %d bytes for trace %s to return span %s",
         fetched_bytes,
@@ -406,12 +451,10 @@ async def otel_span_payload_get(
         sid,
     )
 
-    spans = trace.get("spans") or []
-    span = next((s for s in spans if s.get("span_id") == sid), None)
     if span is None:
         raise ToolError(
-            f"Span '{sid}' not found in trace '{tid}' (checked {len(spans)} of "
-            f"{trace.get('total_count', len(spans))} spans in the fetched page).",
+            f"Span '{sid}' not found in trace '{tid}' (checked {spans_checked} of "
+            f"{total_count if total_count is not None else spans_checked} spans).",
             kind=ToolErrorKind.NOT_FOUND,
         )
 
@@ -420,9 +463,15 @@ async def otel_span_payload_get(
     dropped_duplicate: list[str] = []
     dropped_semconv: list[str] = []
 
+    status_message_requested = False
     if fields is not None:
-        missing = [name for name in fields if name not in merged]
-        selected = {name: merged[name] for name in fields if name in merged}
+        # 'status_message' is structural, not a merged-payload attribute: naming it
+        # in 'fields' requests offset continuation of a truncated status message
+        # rather than an attribute lookup (which would report it as not found).
+        status_message_requested = "status_message" in fields
+        requested = [name for name in fields if name != "status_message"]
+        missing = [name for name in requested if name not in merged]
+        selected = {name: merged[name] for name in requested if name in merged}
     else:
         selected, dropped = canonical_attributes(merged)
         dropped_duplicate = dropped["duplicate"]
@@ -432,11 +481,9 @@ async def otel_span_payload_get(
     attributes: dict[str, Any] = {}
     field_windows: dict[str, Any] = {}
     for name, value in selected.items():
-        window: Any = value
-        if isinstance(value, str):
-            window, info = cap_value(value, max_field_chars, field_offset)
-            if info is not None:
-                field_windows[name] = info
+        window, info = cap_payload_value(value, max_field_chars, field_offset)
+        if info is not None:
+            field_windows[name] = info
         if name in RESPONSE_PAYLOAD_FIELDS:
             response_fields[name] = window
         else:
@@ -445,12 +492,14 @@ async def otel_span_payload_get(
     # status_message is the one structural field that can carry an unbounded
     # traceback (SpanViewValidator has no server-side max_length on it — see
     # truncation.STATUS_MESSAGE_MAX_CHARS's docstring), so it gets the same
-    # field_offset windowing as every other field this tool emits rather than
-    # bypassing the tool's own windowing contract.
+    # max_field_chars window as every other field this tool emits. field_offset
+    # applies to it only when 'fields' names it — a continuation offset meant for
+    # one long attribute must not blank the (usually short) status message.
     status_message = span.get("status_message")
     if isinstance(status_message, str):
+        status_offset = field_offset if status_message_requested else 0
         status_message, status_message_info = cap_value(
-            status_message, max_field_chars, field_offset
+            status_message, max_field_chars, status_offset
         )
         if status_message_info is not None:
             field_windows["status_message"] = status_message_info
@@ -464,7 +513,7 @@ async def otel_span_payload_get(
         truncation["fields_not_found"] = missing
 
     return {
-        "span_id": sid,
+        "span_id": span.get("span_id") or sid,
         "name": span.get("name"),
         "status_code": span.get("status_code"),
         "status_message": status_message,
@@ -504,10 +553,7 @@ def _span_payload_view(span: dict[str, Any], max_field_chars: int) -> dict[str, 
     attributes: dict[str, Any] = {}
     field_windows: dict[str, Any] = {}
     for name, value in kept.items():
-        if not isinstance(value, str):
-            attributes[name] = value
-            continue
-        window, info = cap_value(value, max_field_chars)
+        window, info = cap_payload_value(value, max_field_chars)
         attributes[name] = window
         if info is not None:
             field_windows[name] = info

--- a/src/datarobot_genai/drtools/otel/traces.py
+++ b/src/datarobot_genai/drtools/otel/traces.py
@@ -1,0 +1,524 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OTel trace tools: list traces, retrieve one trace, and drill into a span's payload.
+
+Three tools, in the order an agent is meant to reach for them (plan §2.1-§2.3):
+
+* ``otel_traces_list`` — 1:1 wrapper around ``GET .../traces/``. No truncation:
+  the endpoint hard-truncates ``completion`` server-side and carries no span
+  attributes, so there is nothing here to project.
+* ``otel_trace_get`` — the tool this ticket exists for. Raw passthrough of one
+  trace can be 1,560,241 tokens (measured max); ``view="summary"`` (the default)
+  reduces that to a flat ~133 tokens/span span-tree projection with per-span
+  payload accounting (``payload_chars``/``payload_fields``) so an agent can choose
+  where to drill in deliberately. ``view="payloads"`` instead applies canonical
+  semconv selection and a hard character budget across the whole span page.
+* ``otel_span_payload_get`` — the deliberate escape hatch: one span's payload,
+  windowed by ``field_offset`` so even a 740,000-char field is reachable, with
+  every dropped duplicate/semconv field named rather than silently discarded.
+
+All truncation logic lives in :mod:`datarobot_genai.drtools.otel.truncation`; this
+module composes those helpers with pagination, id validation and error mapping —
+it does not reimplement any projection logic of its own.
+"""
+
+import json
+import logging
+from typing import Annotated
+from typing import Any
+from typing import Literal
+
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.client_exceptions import raise_tool_error_for_client_error
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import tool_metadata
+from datarobot_genai.drtools.core.clients.datarobot_otel_query import OtelQueryApiClient
+from datarobot_genai.drtools.core.utils import require_id
+from datarobot_genai.drtools.core.utils import require_object_id
+from datarobot_genai.drtools.core.utils import require_trace_id
+from datarobot_genai.drtools.otel.constants import RESPONSE_PAYLOAD_FIELDS
+from datarobot_genai.drtools.otel.constants import EntityType
+from datarobot_genai.drtools.otel.truncation import apply_char_budget
+from datarobot_genai.drtools.otel.truncation import canonical_attributes
+from datarobot_genai.drtools.otel.truncation import cap_value
+from datarobot_genai.drtools.otel.truncation import summarize_spans
+from datarobot_genai.drtools.pagination import clamp_limit
+from datarobot_genai.drtools.pagination import merge_pagination_metadata
+
+logger = logging.getLogger(__name__)
+
+# otel_trace_get's defaults, in one place. Plan §9 step 9 — a manual run against a
+# real agent trace — is deliberately NOT part of this round, so these three
+# numbers are provisional: measured on a proxy (§1's 3.1 chars/token), not on
+# Claude's own tokenizer, and not yet exercised against a real trace. Nothing else
+# in this package repeats these literals, so correcting them later (per step 9) is
+# a one-line change here rather than a hunt through the module.
+DEFAULT_TRACE_SPAN_LIMIT = 100
+DEFAULT_TRACE_MAX_FIELD_CHARS = 2_000
+DEFAULT_TRACE_MAX_TOTAL_CHARS = 60_000
+
+# TracingListQueryValidator.post_validate rejects offset + limit > 10000 server
+# side ("adjust endTime instead of using large offsets"). Pre-empted here so the
+# failure is a readable VALIDATION error instead of a raw 400.
+_TRACES_LIST_MAX_OFFSET_PLUS_LIMIT = 10_000
+
+_TRACE_403_HINT = (
+    "A 403 here usually means configuration, not missing data: the "
+    "GENAI_EXPERIMENTATION feature flag and the AGENTIC_PREDICTIVE_GOVERNANCE_BUILDER "
+    "seat license are required for every /otel trace route, and for 'deployment' or "
+    "'custom_application' entities the "
+    "MMM_DISABLE_OTEL_TRACING_VIEWING_FOR_DEPLOYMENT_AND_CUSTOM_APPS eng config can "
+    "disable trace viewing entirely."
+)
+
+
+# ------------------------------------------------------------------ #
+# otel_traces_list                                                     #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"otel", "datarobot", "traces", "list", "observability"},
+    description=(
+        "[OTel—traces] List OpenTelemetry traces for an entity: flat ~185 "
+        "tokens/trace regardless of underlying trace size (the endpoint hard-"
+        "truncates completion to 512 chars and carries no span attributes). Use "
+        "this as the default entry point before otel_trace_get. Supports "
+        "filtering by status, root span name, tool name, duration/cost bounds, "
+        "and sorting.\n\n"
+        f"{_TRACE_403_HINT}\n\n"
+        "Example: otel_traces_list(entity_type='deployment', entity_id='...')\n"
+        "Example: otel_traces_list(entity_type='deployment', entity_id='...', "
+        "status='error', sort_by='duration', sort_direction='desc')"
+    ),
+    display_name="OTel — List traces",
+    description_ui=(
+        "List OpenTelemetry traces for an entity, with filtering by status, root "
+        "span name, tool name, duration, and cost."
+    ),
+)
+async def otel_traces_list(
+    *,
+    entity_type: Annotated[EntityType, "Type of entity the OTel data belongs to."],
+    entity_id: Annotated[str, "24-character hex ID of the entity."],
+    limit: Annotated[int, "Max traces to return (1-100, clamped). Default 20."] = 20,
+    offset: Annotated[int, "Traces to skip for pagination. Default 0."] = 0,
+    start_time: Annotated[
+        str | None, "RFC3339 start of the window (e.g. '2026-08-24T00:00:00Z')."
+    ] = None,
+    end_time: Annotated[str | None, "RFC3339 end of the window."] = None,
+    status: Annotated[
+        Literal["error", "ok"] | None,
+        "'error' returns only traces with at least one error span; 'ok' the opposite.",
+    ] = None,
+    root_span_name: Annotated[
+        list[str] | None, "Filter by exact root span name (up to 50 names)."
+    ] = None,
+    tools: Annotated[
+        list[str] | None,
+        "Filter by gen_ai.tool.name (up to 50). Pass a list, not a comma-joined string.",
+    ] = None,
+    trace_type: Annotated[
+        Literal["gen_ai"] | None, "Filter by trace type. Currently only 'gen_ai'."
+    ] = None,
+    min_trace_duration_ns: Annotated[int | None, "Minimum trace duration, in nanoseconds."] = None,
+    min_span_duration_ns: Annotated[int | None, "Minimum span duration, in nanoseconds."] = None,
+    max_span_duration_ns: Annotated[int | None, "Maximum span duration, in nanoseconds."] = None,
+    min_trace_cost: Annotated[int | None, "Minimum trace cost."] = None,
+    max_trace_cost: Annotated[int | None, "Maximum trace cost."] = None,
+    sort_by: Annotated[
+        Literal["timestamp", "duration", "cost"] | None,
+        "Field to sort by. Defaults to 'timestamp' when sort_direction is set.",
+    ] = None,
+    sort_direction: Annotated[Literal["asc", "desc"] | None, "Sort direction."] = None,
+) -> dict[str, Any]:
+    eid = require_object_id(entity_id, "entity_id")
+    if offset < 0:
+        raise ToolError(
+            "Argument validation error: 'offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if tools and any(isinstance(name, str) and "," in name for name in tools):
+        raise ToolError(
+            "Argument validation error: 'tools' must be a list of tool names, not a "
+            "comma-joined string. Pass a list, not a comma-joined string.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if sort_direction is not None and sort_by is None:
+        sort_by = "timestamp"
+
+    clamped_limit, note = clamp_limit(limit)
+    if offset + clamped_limit > _TRACES_LIST_MAX_OFFSET_PLUS_LIMIT:
+        raise ToolError(
+            "Argument validation error: 'offset' + 'limit' must be <= "
+            f"{_TRACES_LIST_MAX_OFFSET_PLUS_LIMIT}. Adjust start_time/end_time instead "
+            "of paging with a large offset.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    try:
+        result = OtelQueryApiClient().list_traces(
+            entity_type,
+            eid,
+            limit=clamped_limit,
+            offset=offset,
+            start_time=start_time,
+            end_time=end_time,
+            status=status,
+            root_span_name=root_span_name,
+            tools=tools,
+            trace_type=trace_type,
+            min_trace_duration_ns=min_trace_duration_ns,
+            min_span_duration_ns=min_span_duration_ns,
+            max_span_duration_ns=max_span_duration_ns,
+            min_trace_cost=min_trace_cost,
+            max_trace_cost=max_trace_cost,
+            sort_by=sort_by,
+            sort_direction=sort_direction,
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    data = result.get("data", []) or []
+    return merge_pagination_metadata(
+        {"traces": data, "count": len(data)},
+        result,
+        note,
+        offset=offset,
+        limit=clamped_limit,
+    )
+
+
+# ------------------------------------------------------------------ #
+# otel_trace_get                                                       #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"otel", "datarobot", "trace", "get", "observability", "debug"},
+    description=(
+        "[OTel—trace] Retrieve one trace's span tree. Raw passthrough is unusable "
+        "on large traces (measured p95 = 809,639 tokens, max = 1,560,241) — span "
+        "count does not predict size, so this tool always projects.\n\n"
+        "view='summary' (default): the span tree with zero payloads — "
+        "~133 tokens/span, flat regardless of payload size. Each span carries "
+        "'payload_chars' and 'payload_fields' so you can see *where the mass is* "
+        "before drilling in with otel_span_payload_get(trace_id=..., span_id=...).\n\n"
+        "view='payloads': canonical semconv attributes only (duplicates and "
+        "derived fields dropped and named), each field capped at max_field_chars, "
+        "under a hard max_total_chars budget across the whole span page. Spans "
+        "are emitted in order until the budget is spent, then dropped — "
+        "'truncation' reports spans_returned/spans_dropped. Even this view can "
+        "still overshoot a 20k-token target on the worst traces, so prefer "
+        "summary first and drill into specific spans instead.\n\n"
+        "span_limit/span_offset page the underlying spans server-side (default "
+        f"page size {DEFAULT_TRACE_SPAN_LIMIT}, no server-side upper bound); span "
+        "ordering under pagination is not guaranteed.\n\n"
+        f"{_TRACE_403_HINT}\n\n"
+        "Example: otel_trace_get(entity_type='deployment', entity_id='...', "
+        "trace_id='...')\n"
+        "Example: otel_trace_get(entity_type='deployment', entity_id='...', "
+        "trace_id='...', view='payloads', max_total_chars=20000)"
+    ),
+    display_name="OTel — Get trace",
+    description_ui=(
+        "Retrieve one trace's span tree as a bounded summary, or its canonical "
+        "payload attributes under a hard character budget."
+    ),
+)
+async def otel_trace_get(
+    *,
+    entity_type: Annotated[EntityType, "Type of entity the OTel data belongs to."],
+    entity_id: Annotated[str, "24-character hex ID of the entity."],
+    trace_id: Annotated[str, "32-character hex OTel trace ID."],
+    view: Annotated[
+        Literal["summary", "payloads"],
+        "'summary' (default): span tree, no payloads. 'payloads': canonical "
+        "attributes, capped and budgeted.",
+    ] = "summary",
+    span_limit: Annotated[
+        int, f"Server-side span page size. Default {DEFAULT_TRACE_SPAN_LIMIT}, no upper bound."
+    ] = DEFAULT_TRACE_SPAN_LIMIT,
+    span_offset: Annotated[int, "Spans to skip for server-side pagination."] = 0,
+    max_field_chars: Annotated[
+        int, "view='payloads' only: cap per attribute value, in characters."
+    ] = DEFAULT_TRACE_MAX_FIELD_CHARS,
+    max_total_chars: Annotated[
+        int, "view='payloads' only: hard budget across the whole span page, in characters."
+    ] = DEFAULT_TRACE_MAX_TOTAL_CHARS,
+) -> dict[str, Any]:
+    eid = require_object_id(entity_id, "entity_id")
+    tid = require_trace_id(trace_id)
+    if span_offset < 0:
+        raise ToolError(
+            "Argument validation error: 'span_offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+    if span_limit < 1:
+        raise ToolError(
+            "Argument validation error: 'span_limit' must be >= 1.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    try:
+        trace = OtelQueryApiClient().get_trace(
+            entity_type, eid, tid, limit=span_limit, offset=span_offset
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    spans = trace.get("spans") or []
+
+    truncation: dict[str, Any]
+    if view == "summary":
+        summaries, stats = summarize_spans(spans)
+        result_spans: list[dict[str, Any]] = summaries
+        truncation = {
+            "mode": "summary",
+            "payloads_omitted": True,
+            "total_payload_chars": stats["total_payload_chars"],
+            "hint": (
+                "Fetch one span's payload with otel_span_payload_get(trace_id=..., span_id=...)."
+            ),
+        }
+    else:
+        items = [_span_payload_view(span, max_field_chars) for span in spans]
+        emitted, budget_stats = apply_char_budget(items, max_total_chars)
+        result_spans = emitted
+        truncation = {
+            "mode": "payloads",
+            "spans_returned": budget_stats["spans_returned"],
+            "spans_dropped": budget_stats["spans_dropped"],
+            "chars_used": budget_stats["chars_used"],
+            "max_total_chars": budget_stats["max_total_chars"],
+        }
+
+    result: dict[str, Any] = {
+        "trace_id": trace.get("trace_id", tid),
+        "span_count": trace.get("span_count"),
+        "duration": trace.get("duration"),
+        "root_span_name": trace.get("root_span_name"),
+        "root_service_name": trace.get("root_service_name"),
+    }
+    if "metrics" in trace:
+        result["metrics"] = trace["metrics"]
+    result["spans"] = result_spans
+    result["truncation"] = truncation
+    result["count"] = len(result_spans)
+
+    return merge_pagination_metadata(result, trace, offset=span_offset, limit=span_limit)
+
+
+# ------------------------------------------------------------------ #
+# otel_span_payload_get                                                #
+# ------------------------------------------------------------------ #
+
+
+@tool_metadata(
+    tags={"otel", "datarobot", "span", "payload", "observability", "debug"},
+    description=(
+        "[OTel—span payload] Drill-down escape hatch: fetch one span's payload "
+        "text in full detail, after otel_trace_get(view='summary') has told you "
+        "which span to look at.\n\n"
+        "By default returns the canonical set (rank-1 prompt/completion plus the "
+        "highest-precedence surviving semconv attributes); pass 'fields' with "
+        "exact attribute names to fetch specific fields directly, including ones "
+        "reported as dropped_as_duplicate or dropped_semconv by a previous call — "
+        "the text is still there under its own name, just not duplicated.\n\n"
+        "Each field is windowed at max_field_chars. When a field is larger than "
+        "that, 'truncation.fields' names it with 'next_offset' — pass that back "
+        "as field_offset (typically with fields=[that one name]) to continue "
+        "reading it; one measured field was 740,000 chars.\n\n"
+        "Known cost: there is no per-span endpoint, so this refetches the whole "
+        "trace and filters client-side.\n\n"
+        f"{_TRACE_403_HINT}\n\n"
+        "Example: otel_span_payload_get(entity_type='deployment', entity_id='...', "
+        "trace_id='...', span_id='...')\n"
+        "Example (continue a field): otel_span_payload_get(entity_type='deployment', "
+        "entity_id='...', trace_id='...', span_id='...', "
+        "fields=['gen_ai.task.output'], field_offset=8000)"
+    ),
+    display_name="OTel — Get span payload",
+    description_ui=(
+        "Fetch one span's full payload text, windowed field by field, including "
+        "fields dropped as duplicates by the trace summary."
+    ),
+)
+async def otel_span_payload_get(
+    *,
+    entity_type: Annotated[EntityType, "Type of entity the OTel data belongs to."],
+    entity_id: Annotated[str, "24-character hex ID of the entity."],
+    trace_id: Annotated[str, "32-character hex OTel trace ID."],
+    span_id: Annotated[str, "Id of the span within the trace."],
+    fields: Annotated[
+        list[str] | None,
+        "Exact attribute names to fetch, bypassing dedup/semconv selection. "
+        "None (default) returns the canonical set.",
+    ] = None,
+    max_field_chars: Annotated[int, "Cap per field value, in characters."] = 8_000,
+    field_offset: Annotated[
+        int, "Character offset to continue a previously truncated field from."
+    ] = 0,
+) -> dict[str, Any]:
+    eid = require_object_id(entity_id, "entity_id")
+    tid = require_trace_id(trace_id)
+    sid = require_id(span_id, "span_id")
+    if field_offset < 0:
+        raise ToolError(
+            "Argument validation error: 'field_offset' must be >= 0.",
+            kind=ToolErrorKind.VALIDATION,
+        )
+
+    try:
+        # No span_limit parameter on this tool (§2.3's signature has none) — the
+        # fetch page size is tied to the same DEFAULT_TRACE_SPAN_LIMIT otel_trace_get
+        # uses, so a step-9 correction to that constant covers this call site too.
+        trace = OtelQueryApiClient().get_trace(
+            entity_type, eid, tid, limit=DEFAULT_TRACE_SPAN_LIMIT
+        )
+    except ClientError as exc:
+        raise_tool_error_for_client_error(exc)
+
+    # Evidence for §10's server-side field-projection ask: there is no per-span
+    # endpoint, so a full trace is fetched to return one span's payload.
+    # ensure_ascii=False matches truncation.py's own char/byte accounting so this
+    # approximates what was actually received on the wire, not an escape-expanded
+    # blowup of it.
+    fetched_bytes = len(json.dumps(trace, default=str, ensure_ascii=False).encode("utf-8"))
+    logger.info(
+        "otel_span_payload_get: fetched %d bytes for trace %s to return span %s",
+        fetched_bytes,
+        tid,
+        sid,
+    )
+
+    spans = trace.get("spans") or []
+    span = next((s for s in spans if s.get("span_id") == sid), None)
+    if span is None:
+        raise ToolError(
+            f"Span '{sid}' not found in trace '{tid}' (checked {len(spans)} of "
+            f"{trace.get('total_count', len(spans))} spans in the fetched page).",
+            kind=ToolErrorKind.NOT_FOUND,
+        )
+
+    merged = _merged_payload(span)
+    missing: list[str] = []
+    dropped_duplicate: list[str] = []
+    dropped_semconv: list[str] = []
+
+    if fields is not None:
+        missing = [name for name in fields if name not in merged]
+        selected = {name: merged[name] for name in fields if name in merged}
+    else:
+        selected, dropped = canonical_attributes(merged)
+        dropped_duplicate = dropped["duplicate"]
+        dropped_semconv = dropped["semconv"]
+
+    response_fields: dict[str, Any] = {}
+    attributes: dict[str, Any] = {}
+    field_windows: dict[str, Any] = {}
+    for name, value in selected.items():
+        window: Any = value
+        if isinstance(value, str):
+            window, info = cap_value(value, max_field_chars, field_offset)
+            if info is not None:
+                field_windows[name] = info
+        if name in RESPONSE_PAYLOAD_FIELDS:
+            response_fields[name] = window
+        else:
+            attributes[name] = window
+
+    # status_message is the one structural field that can carry an unbounded
+    # traceback (SpanViewValidator has no server-side max_length on it — see
+    # truncation.STATUS_MESSAGE_MAX_CHARS's docstring), so it gets the same
+    # field_offset windowing as every other field this tool emits rather than
+    # bypassing the tool's own windowing contract.
+    status_message = span.get("status_message")
+    if isinstance(status_message, str):
+        status_message, status_message_info = cap_value(
+            status_message, max_field_chars, field_offset
+        )
+        if status_message_info is not None:
+            field_windows["status_message"] = status_message_info
+
+    truncation: dict[str, Any] = {
+        "fields": field_windows,
+        "dropped_as_duplicate": dropped_duplicate,
+        "dropped_semconv": dropped_semconv,
+    }
+    if missing:
+        truncation["fields_not_found"] = missing
+
+    return {
+        "span_id": sid,
+        "name": span.get("name"),
+        "status_code": span.get("status_code"),
+        "status_message": status_message,
+        **response_fields,
+        "attributes": attributes,
+        "truncation": truncation,
+    }
+
+
+# ------------------------------------------------------------------ #
+# helpers                                                              #
+# ------------------------------------------------------------------ #
+
+
+def _merged_payload(span: dict[str, Any]) -> dict[str, Any]:
+    """Merge a span's rank-1 response fields with its attributes, response wins.
+
+    Response fields are precedence rank 1 (never dropped, win every byte-identity
+    tie) — see ``RESPONSE_PAYLOAD_FIELDS`` and ``SEMCONV_PRECEDENCE`` in
+    ``constants.py``. ``attributes`` is a dynamic dict on the wire and can carry a
+    key literally named ``prompt``/``completion`` beside the span's own response
+    field (the same wire shape ``truncation._payload_sizes`` documents and
+    accounts for). Overlaying the response fields *after* ``attributes`` — rather
+    than merging attributes on top of them — is what makes "never dropped, wins
+    every tie" actually true: the response's own normalized text is what
+    :func:`canonical_attributes` sees under that name, not whatever an
+    instrumentation happened to also write there.
+    """
+    merged = dict(span.get("attributes") or {})
+    merged.update({name: span[name] for name in RESPONSE_PAYLOAD_FIELDS if name in span})
+    return merged
+
+
+def _span_payload_view(span: dict[str, Any], max_field_chars: int) -> dict[str, Any]:
+    """Project one span to its canonical, per-field-capped payload (view='payloads')."""
+    kept, dropped = canonical_attributes(_merged_payload(span))
+    attributes: dict[str, Any] = {}
+    field_windows: dict[str, Any] = {}
+    for name, value in kept.items():
+        if not isinstance(value, str):
+            attributes[name] = value
+            continue
+        window, info = cap_value(value, max_field_chars)
+        attributes[name] = window
+        if info is not None:
+            field_windows[name] = info
+    return {
+        "span_id": span.get("span_id"),
+        "name": span.get("name"),
+        "status_code": span.get("status_code"),
+        "attributes": attributes,
+        "truncation": {
+            "fields": field_windows,
+            "dropped_as_duplicate": dropped["duplicate"],
+            "dropped_semconv": dropped["semconv"],
+        },
+    }

--- a/tests/drmcp/unit/otel_tools/test_entity_stats.py
+++ b/tests/drmcp/unit/otel_tools/test_entity_stats.py
@@ -1,0 +1,360 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``otel_entity_stats_get``.
+
+Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
+
+Plan §2.7's three outcomes, each pinned to a distinct result:
+
+1. Entity has data            -> 200, rows        -> counts, has_otel_data=True
+2. Entity readable, no data   -> 200, data: []     -> zeros, has_otel_data=False
+3. Entity not readable (403)  -> ToolError naming the entity as a permissions
+                                  failure, never an empty result
+
+Plus the traps: service_name is always built internally as
+f"{entity_type}-{entity_id}" and always sent; rows are per (user_id,
+service_name) so top-level counts are SUMMED across rows, not read off the
+first one; by_user is capped at 20 but user_count stays exact; limit=1000 is
+always requested and a note is added if total_count exceeds it.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.otel import entity_stats
+
+_ENTITY_ID = "a" * 24
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def patched_dr_client(mock_rest_client: MagicMock) -> Iterator[MagicMock]:
+    with patch(
+        "datarobot_genai.drtools.core.clients.datarobot_otel_query.request_user_dr_client"
+    ) as mock_cm:
+        mock_cm.return_value.__enter__.return_value = mock_rest_client
+        mock_cm.return_value.__exit__.return_value = False
+        yield mock_rest_client
+
+
+def _stub_json(client: MagicMock, payload: dict[str, Any]) -> None:
+    client.get.return_value = MagicMock(json=lambda: payload)
+
+
+def _row(user_id: str, *, span_count: int = 0, metric_count: int = 0, log_count: int = 0) -> dict:
+    return {
+        "user_id": user_id,
+        "service_name": "deployment-x",
+        "span_count": span_count,
+        "metric_count": metric_count,
+        "log_count": log_count,
+    }
+
+
+# ------------------------------------------------------------------ #
+# outcome 1 — entity has data                                          #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_sums_counts_across_per_user_rows(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN three rows for the same entity, one per user who produced telemetry
+    _stub_json(
+        patched_dr_client,
+        {
+            "data": [
+                _row("user-1", span_count=4100, metric_count=0, log_count=88000),
+                _row("user-2", span_count=100, metric_count=0, log_count=291),
+                _row("user-3", span_count=13, metric_count=0, log_count=0),
+            ]
+        },
+    )
+
+    # WHEN the entity is queried
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    # THEN service_name is built internally and always sent, and the top-level
+    # counts are the SUM across rows, not the first row alone
+    patched_dr_client.get.assert_called_once_with(
+        "otel/stats/",
+        params={"serviceName": f"deployment-{_ENTITY_ID}", "limit": 1000},
+    )
+    assert result["entity_type"] == "deployment"
+    assert result["entity_id"] == _ENTITY_ID
+    assert result["service_name"] == f"deployment-{_ENTITY_ID}"
+    assert result["has_otel_data"] is True
+    assert result["span_count"] == 4213
+    assert result["metric_count"] == 0
+    assert result["log_count"] == 88291
+    assert result["user_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_by_user_capped_at_20_but_user_count_exact(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN 25 distinct users' rows for one entity
+    rows = [_row(f"user-{i}", span_count=1) for i in range(25)]
+    _stub_json(patched_dr_client, {"data": rows})
+
+    # WHEN the entity is queried
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    # THEN by_user is capped at 20 rows for display, but user_count and the
+    # summed span_count both reflect the full set of 25 rows, not just the 20 shown
+    assert len(result["by_user"]) == 20
+    assert result["user_count"] == 25
+    assert result["span_count"] == 25
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_reports_when_total_count_exceeds_limit(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a response whose true total exceeds the 1000-row request limit
+    _stub_json(
+        patched_dr_client,
+        {"data": [_row("user-1", span_count=10)], "total_count": 1500},
+    )
+
+    # WHEN the entity is queried
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    # THEN a note flags that the sums may be partial, rather than silently
+    # presenting a truncated sum as complete
+    assert "note" in result
+    assert "1500" in result["note"]
+    assert "1000" in result["note"]
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_no_note_when_total_count_within_limit(
+    patched_dr_client: MagicMock,
+) -> None:
+    _stub_json(
+        patched_dr_client,
+        {"data": [_row("user-1", span_count=10)], "total_count": 1},
+    )
+
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    assert "note" not in result
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_non_numeric_total_count_does_not_crash(
+    patched_dr_client: MagicMock,
+) -> None:
+    """A malformed upstream total_count must not surface as an unhandled ValueError.
+
+    Every other error path in this module (403/404/500) is a controlled
+    ToolError; a garbage value in an otherwise-200 response should degrade to
+    "unknown, no note" rather than crashing the call.
+    """
+    # GIVEN an upstream response whose total_count is not a number
+    _stub_json(
+        patched_dr_client,
+        {"data": [_row("user-1", span_count=10)], "total_count": "not-a-number"},
+    )
+
+    # WHEN the entity is queried
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    # THEN the call succeeds, treating the malformed field as unknown rather
+    # than raising, and adds no (necessarily wrong) note about it
+    assert result["span_count"] == 10
+    assert "note" not in result
+
+
+# ------------------------------------------------------------------ #
+# outcome 2 — entity readable, no telemetry                            #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_no_telemetry_is_zeros_not_missing(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN the entity is readable but has produced no telemetry at all
+    _stub_json(patched_dr_client, {"data": []})
+
+    # WHEN the entity is queried
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    # THEN it's a normal 200 with explicit zeros and has_otel_data=False —
+    # never an exception
+    assert result["has_otel_data"] is False
+    assert result["span_count"] == 0
+    assert result["metric_count"] == 0
+    assert result["log_count"] == 0
+    assert result["user_count"] == 0
+    assert result["by_user"] == []
+
+
+# ------------------------------------------------------------------ #
+# outcome 3 — entity not readable (403)                                #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_403_raises_permission_error_naming_entity(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN the caller cannot read this entity's telemetry (check_read_permission
+    # -> PermissionDenied -> 403)
+    patched_dr_client.get.side_effect = ClientError("403", status_code=403, json={})
+
+    # WHEN the entity is queried
+    with pytest.raises(ToolError) as exc_info:
+        await entity_stats.otel_entity_stats_get(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN it raises rather than returning an empty result, the message names
+    # the entity, and says this is a permissions issue
+    message = str(exc_info.value).lower()
+    assert "permission" in message
+    assert _ENTITY_ID in str(exc_info.value)
+    assert "deployment" in message
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_404_maps_to_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await entity_stats.otel_entity_stats_get(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_500_maps_to_upstream(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await entity_stats.otel_entity_stats_get(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# validation / plumbing                                                #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_strips_and_validates_entity_id(
+    patched_dr_client: MagicMock,
+) -> None:
+    _stub_json(patched_dr_client, {"data": []})
+
+    await entity_stats.otel_entity_stats_get(entity_type="workload", entity_id=f"  {_ENTITY_ID}  ")
+
+    patched_dr_client.get.assert_called_once_with(
+        "otel/stats/",
+        params={"serviceName": f"workload-{_ENTITY_ID}", "limit": 1000},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_malformed_entity_id_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await entity_stats.otel_entity_stats_get(entity_type="deployment", entity_id="not-hex")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_passes_time_window(patched_dr_client: MagicMock) -> None:
+    _stub_json(patched_dr_client, {"data": []})
+
+    await entity_stats.otel_entity_stats_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-02T00:00:00Z",
+    )
+
+    patched_dr_client.get.assert_called_once_with(
+        "otel/stats/",
+        params={
+            "serviceName": f"deployment-{_ENTITY_ID}",
+            "limit": 1000,
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-02T00:00:00Z",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_by_user_row_shape(patched_dr_client: MagicMock) -> None:
+    _stub_json(
+        patched_dr_client,
+        {"data": [_row("user-1", span_count=5, metric_count=1, log_count=9)]},
+    )
+
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    assert result["by_user"] == [
+        {"user_id": "user-1", "span_count": 5, "metric_count": 1, "log_count": 9}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_otel_entity_stats_get_by_user_row_agrees_with_the_summed_total_on_null_counts(
+    patched_dr_client: MagicMock,
+) -> None:
+    """A row with an explicit ``None`` count must not disagree with its own sum.
+
+    ``_sum_field`` normalizes ``None`` to 0 when summing; ``by_user`` must
+    report the same row the same way, or the two halves of one response tell
+    an agent two different stories about the same data.
+    """
+    # GIVEN a row where span_count is present but explicitly null
+    _stub_json(
+        patched_dr_client,
+        {"data": [{"user_id": "user-1", "span_count": None, "metric_count": 1, "log_count": 2}]},
+    )
+
+    # WHEN the entity is queried
+    result = await entity_stats.otel_entity_stats_get(
+        entity_type="deployment", entity_id=_ENTITY_ID
+    )
+
+    # THEN the top-level sum and the by_user breakdown agree: both 0, not one
+    # 0 and the other None
+    assert result["span_count"] == 0
+    assert result["by_user"][0]["span_count"] == 0

--- a/tests/drmcp/unit/otel_tools/test_logs.py
+++ b/tests/drmcp/unit/otel_tools/test_logs.py
@@ -1,0 +1,387 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``otel_logs_list``.
+
+Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
+
+Two traps pinned explicitly, per plan §2.4/§7:
+
+* ``level`` accepts all six of ``debug|info|warn|warning|error|critical`` — in
+  particular ``warning`` and ``critical``, which ``drmcputils.constants.LOG_LEVELS``
+  does not carry.
+* ``max_line_chars`` truncates ``message`` and ``stacktrace`` independently, in
+  characters, each with its own ``…[truncated, N more chars]`` marker.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import get_registered_tools
+from datarobot_genai.drtools.otel import logs
+from datarobot_genai.drtools.otel.constants import OTEL_LOG_LEVELS
+
+_ENTITY_ID = "a" * 24
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def patched_dr_client(mock_rest_client: MagicMock) -> Iterator[MagicMock]:
+    with patch(
+        "datarobot_genai.drtools.core.clients.datarobot_otel_query.request_user_dr_client"
+    ) as mock_cm:
+        mock_cm.return_value.__enter__.return_value = mock_rest_client
+        mock_cm.return_value.__exit__.return_value = False
+        yield mock_rest_client
+
+
+def _stub_json(client: MagicMock, payload: dict[str, Any]) -> None:
+    client.get.return_value = MagicMock(json=lambda: payload)
+
+
+# ------------------------------------------------------------------ #
+# success / pagination / wire params                                   #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_maps_data_and_merges_pagination(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a raw logs/ response with no total_count (PaginatedWithoutTotalResponseValidator)
+    _stub_json(
+        patched_dr_client,
+        {
+            "data": [
+                {"timestamp": 1.0, "level": "info", "message": "started"},
+                {"timestamp": 2.0, "level": "error", "message": "boom"},
+            ],
+            "count": 2,
+            "next": "https://example/logs/?offset=50",
+            "previous": None,
+        },
+    )
+
+    # WHEN otel_logs_list is called with only the required entity args
+    result = await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN 'data' becomes 'logs', pagination metadata is merged in, and there is
+    # no total_count anywhere in the response
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/logs/",
+        params={"limit": 50, "offset": 0, "level": "debug"},
+    )
+    assert [line["message"] for line in result["logs"]] == ["started", "boom"]
+    assert result["count"] == 2
+    assert result["offset"] == 0
+    assert result["limit"] == 50
+    assert result["next"] == "https://example/logs/?offset=50"
+    assert "previous" not in result
+    assert "total_count" not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("upstream_key", ["total_count", "totalCount", "total"])
+async def test_otel_logs_list_never_leaks_a_total_count_even_if_upstream_sends_one(
+    upstream_key: str, patched_dr_client: MagicMock
+) -> None:
+    """§2.4's 'no total_count' invariant must hold regardless of upstream shape.
+
+    merge_pagination_metadata generically copies total_count/totalCount/total
+    from any api_response that carries one; this endpoint's real response
+    never does today, but the invariant should not rest on that being true
+    forever, so otel_logs_list must strip it explicitly.
+    """
+    # GIVEN an (unrealistic, but not impossible) upstream response that DOES
+    # carry a total-shaped key
+    _stub_json(patched_dr_client, {"data": [], "count": 0, upstream_key: 999_999})
+
+    # WHEN otel_logs_list is called
+    result = await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN total_count never appears in the response
+    assert "total_count" not in result
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_strips_entity_id(patched_dr_client: MagicMock) -> None:
+    _stub_json(patched_dr_client, {"data": [], "count": 0})
+
+    await logs.otel_logs_list(entity_type="deployment", entity_id=f"  {_ENTITY_ID}  ")
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/logs/",
+        params={"limit": 50, "offset": 0, "level": "debug"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_with_filters(patched_dr_client: MagicMock) -> None:
+    _stub_json(patched_dr_client, {"data": [], "count": 0})
+
+    await logs.otel_logs_list(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        level="error",
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-02T00:00:00Z",
+        includes=["ERROR", "FATAL"],
+        excludes=["healthcheck"],
+        span_id="span-1",
+        trace_id="trace-1",
+    )
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/logs/",
+        params={
+            "limit": 50,
+            "offset": 0,
+            "level": "error",
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-02T00:00:00Z",
+            "includes": ["ERROR", "FATAL"],
+            "excludes": ["healthcheck"],
+            "spanId": "span-1",
+            "traceId": "trace-1",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_clamps_limit(patched_dr_client: MagicMock) -> None:
+    _stub_json(patched_dr_client, {"data": [], "count": 0})
+
+    result = await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID, limit=500)
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/logs/",
+        params={"limit": 100, "offset": 0, "level": "debug"},
+    )
+    assert result["limit"] == 100
+    assert "note" in result
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_negative_offset_raises() -> None:
+    with pytest.raises(ToolError) as exc_info:
+        await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID, offset=-1)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# level — the OTEL_LOG_LEVELS trap (plan §2.4, pinned by §7)           #
+# ------------------------------------------------------------------ #
+
+
+def test_otel_log_levels_constant_carries_all_six_levels() -> None:
+    # GIVEN/THEN: the module-level constant this tool validates against must be
+    # the full six-level set, not drmcputils.constants.LOG_LEVELS's four.
+    assert set(OTEL_LOG_LEVELS) == {"debug", "info", "warn", "warning", "error", "critical"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("level", list(OTEL_LOG_LEVELS))
+async def test_otel_logs_list_accepts_every_otel_log_level(
+    level: str, patched_dr_client: MagicMock
+) -> None:
+    # GIVEN a stubbed response
+    _stub_json(patched_dr_client, {"data": [], "count": 0})
+
+    # WHEN called with each of the six accepted levels, including 'warning' and
+    # 'critical' which drmcputils.constants.LOG_LEVELS would reject
+    await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID, level=level)  # type: ignore[arg-type]
+
+    # THEN the level is forwarded to the wire unchanged, never rejected
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/logs/",
+        params={"limit": 50, "offset": 0, "level": level},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_warning_level_accepted(patched_dr_client: MagicMock) -> None:
+    """Regression pinned explicitly by plan §7: 'warning' must not be rejected."""
+    _stub_json(patched_dr_client, {"data": [], "count": 0})
+
+    await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID, level="warning")
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/logs/",
+        params={"limit": 50, "offset": 0, "level": "warning"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_critical_level_accepted(patched_dr_client: MagicMock) -> None:
+    """Regression pinned explicitly by plan §7: 'critical' must not be rejected."""
+    _stub_json(patched_dr_client, {"data": [], "count": 0})
+
+    await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID, level="critical")
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/logs/",
+        params={"limit": 50, "offset": 0, "level": "critical"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_invalid_level_raises(patched_dr_client: MagicMock) -> None:
+    # GIVEN a level outside the OTel API's own accepted set (bypassing the MCP
+    # schema layer, as a direct unit-test call does)
+    with pytest.raises(ToolError) as exc_info:
+        await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID, level="verbose")  # type: ignore[arg-type]
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    patched_dr_client.get.assert_not_called()
+
+
+# ------------------------------------------------------------------ #
+# max_line_chars — independent message/stacktrace windowing             #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_truncates_long_message_with_marker(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a log line whose message is longer than max_line_chars
+    long_message = "x" * 5_000
+    _stub_json(patched_dr_client, {"data": [{"message": long_message}], "count": 1})
+
+    # WHEN read with a small max_line_chars
+    result = await logs.otel_logs_list(
+        entity_type="deployment", entity_id=_ENTITY_ID, max_line_chars=100
+    )
+
+    # THEN the message is windowed to 100 chars plus an explicit marker naming
+    # exactly how many characters were dropped
+    message = result["logs"][0]["message"]
+    assert message.startswith("x" * 100)
+    assert message == "x" * 100 + "…[truncated, 4900 more chars]"
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_truncates_message_and_stacktrace_independently(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN one line with a short message and a long stacktrace
+    short_message = "connection reset"
+    long_stacktrace = "y" * 3_000
+    _stub_json(
+        patched_dr_client,
+        {"data": [{"message": short_message, "stacktrace": long_stacktrace}], "count": 1},
+    )
+
+    # WHEN read with a max_line_chars smaller than the stacktrace but larger
+    # than the message
+    result = await logs.otel_logs_list(
+        entity_type="deployment", entity_id=_ENTITY_ID, max_line_chars=200
+    )
+
+    # THEN the short message survives untouched while the stacktrace is
+    # windowed and marked on its own — one field's cap does not eat the other's
+    line = result["logs"][0]
+    assert line["message"] == short_message
+    assert line["stacktrace"] == "y" * 200 + "…[truncated, 2800 more chars]"
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_max_line_chars_zero_disables_truncation(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a very long message
+    long_message = "z" * 10_000
+    _stub_json(patched_dr_client, {"data": [{"message": long_message}], "count": 1})
+
+    # WHEN max_line_chars=0
+    result = await logs.otel_logs_list(
+        entity_type="deployment", entity_id=_ENTITY_ID, max_line_chars=0
+    )
+
+    # THEN the message is returned in full, untruncated
+    assert result["logs"][0]["message"] == long_message
+
+
+@pytest.mark.asyncio
+async def test_otel_logs_list_passes_through_non_capped_fields_unchanged(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a line carrying span_id/trace_id/level/timestamp alongside message
+    _stub_json(
+        patched_dr_client,
+        {
+            "data": [
+                {
+                    "timestamp": 123.456,
+                    "level": "error",
+                    "message": "boom",
+                    "span_id": "span-abc",
+                    "trace_id": "trace-abc",
+                }
+            ],
+            "count": 1,
+        },
+    )
+
+    # WHEN read with default truncation
+    result = await logs.otel_logs_list(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN every field other than message/stacktrace is passed through as-is
+    line = result["logs"][0]
+    assert line["timestamp"] == 123.456
+    assert line["level"] == "error"
+    assert line["span_id"] == "span-abc"
+    assert line["trace_id"] == "trace-abc"
+
+
+# ------------------------------------------------------------------ #
+# description text — the GENAI_EXPERIMENTATION 403 hint (plan §2)      #
+# ------------------------------------------------------------------ #
+
+
+def test_otel_logs_list_description_documents_the_genai_experimentation_403_cause() -> None:
+    # GIVEN the tool's registered metadata
+    by_name = {(md.get("name") or fn.__name__): md for fn, md in get_registered_tools()}
+    description = by_name["otel_logs_list"]["description"]
+
+    # THEN a 403 is documented as a feature-flag/configuration cause, not
+    # left indistinguishable from "no access to this entity's logs"
+    assert "GENAI_EXPERIMENTATION" in description
+    assert "403" in description

--- a/tests/drmcp/unit/otel_tools/test_metrics.py
+++ b/tests/drmcp/unit/otel_tools/test_metrics.py
@@ -1,0 +1,349 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``otel_metrics_catalog_list`` and ``otel_metrics_values_get``.
+
+Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
+
+Plan §2.6's trap pinned explicitly: ``source='autocollected'`` is the default,
+and an empty ``metric_aggregations`` for ``source='configured'`` must be
+returned as a normal, unremarkable empty list — never rewritten into an error
+or a synthetic "no data" flag. That distinction lives in the tool's
+description text (asserted below), not in extra response-shape logic.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.core import get_registered_tools
+from datarobot_genai.drtools.otel import metrics
+
+_ENTITY_ID = "a" * 24
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def patched_dr_client(mock_rest_client: MagicMock) -> Iterator[MagicMock]:
+    with patch(
+        "datarobot_genai.drtools.core.clients.datarobot_otel_query.request_user_dr_client"
+    ) as mock_cm:
+        mock_cm.return_value.__enter__.return_value = mock_rest_client
+        mock_cm.return_value.__exit__.return_value = False
+        yield mock_rest_client
+
+
+def _stub_json(client: MagicMock, payload: dict[str, Any]) -> None:
+    client.get.return_value = MagicMock(json=lambda: payload)
+
+
+# ------------------------------------------------------------------ #
+# otel_metrics_catalog_list                                            #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_catalog_list_maps_data_to_metrics(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a raw metrics/summary/ response
+    _stub_json(
+        patched_dr_client,
+        {
+            "data": [
+                {"otel_name": "gen_ai.usage.input_tokens", "metric_type": "counter"},
+                {"otel_name": "gen_ai.usage.output_tokens", "metric_type": "counter"},
+            ]
+        },
+    )
+
+    # WHEN otel_metrics_catalog_list is called with only the required entity args
+    result = await metrics.otel_metrics_catalog_list(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN 'data' becomes 'metrics' and 'count' reflects the returned length,
+    # with no params sent since search/metric_type are both unset
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/metrics/summary/", params={}
+    )
+    assert result["count"] == 2
+    assert result["metrics"][0]["otel_name"] == "gen_ai.usage.input_tokens"
+    assert "note" not in result
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_catalog_list_with_search_and_type(
+    patched_dr_client: MagicMock,
+) -> None:
+    _stub_json(patched_dr_client, {"data": []})
+
+    await metrics.otel_metrics_catalog_list(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        search="latency",
+        metric_type="histogram",
+    )
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/metrics/summary/",
+        params={"search": "latency", "metricType": "histogram"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_catalog_list_clamps_to_100_with_note(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a server response at its own max_length=1000 ceiling
+    _stub_json(
+        patched_dr_client,
+        {"data": [{"otel_name": f"metric.{i}"} for i in range(150)]},
+    )
+
+    # WHEN read without narrowing via 'search'
+    result = await metrics.otel_metrics_catalog_list(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN the client-side cap of 100 applies and is reported, not silent
+    assert result["count"] == 100
+    assert len(result["metrics"]) == 100
+    assert "note" in result
+    assert "100" in result["note"]
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_catalog_list_empty_is_not_flagged(
+    patched_dr_client: MagicMock,
+) -> None:
+    _stub_json(patched_dr_client, {"data": []})
+
+    result = await metrics.otel_metrics_catalog_list(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    assert result == {"metrics": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_catalog_list_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await metrics.otel_metrics_catalog_list(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_catalog_list_not_found(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await metrics.otel_metrics_catalog_list(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# otel_metrics_values_get — source='autocollected' (the default)      #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_values_get_default_source_is_autocollected(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a raw autocollectedValues/ response
+    _stub_json(
+        patched_dr_client,
+        {"data": [{"otel_name": "cpu.usage", "aggregated_value": 0.42}]},
+    )
+
+    # WHEN otel_metrics_values_get is called with no 'source' argument at all
+    result = await metrics.otel_metrics_values_get(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN the autocollectedValues endpoint was hit (never metrics/values/)
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/metrics/autocollectedValues/",
+        params={},
+    )
+    assert result == {"metrics": [{"otel_name": "cpu.usage", "aggregated_value": 0.42}], "count": 1}
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_values_get_autocollected_explicit_with_window(
+    patched_dr_client: MagicMock,
+) -> None:
+    _stub_json(patched_dr_client, {"data": []})
+
+    await metrics.otel_metrics_values_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        source="autocollected",
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-02T00:00:00Z",
+    )
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/metrics/autocollectedValues/",
+        params={"startTime": "2026-01-01T00:00:00Z", "endTime": "2026-01-02T00:00:00Z"},
+    )
+
+
+# ------------------------------------------------------------------ #
+# otel_metrics_values_get — source='configured'                        #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_values_get_configured_maps_the_three_fields(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a raw metrics/values/ response
+    _stub_json(
+        patched_dr_client,
+        {
+            "start_time": "2026-01-01T00:00:00Z",
+            "end_time": "2026-01-02T00:00:00Z",
+            "metric_aggregations": [{"otel_name": "custom.metric", "aggregated_value": 1.0}],
+        },
+    )
+
+    # WHEN read with source='configured'
+    result = await metrics.otel_metrics_values_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, source="configured"
+    )
+
+    # THEN histogramBuckets defaults to False and the exact three documented
+    # fields are returned
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/metrics/values/",
+        params={"histogramBuckets": False},
+    )
+    assert result == {
+        "start_time": "2026-01-01T00:00:00Z",
+        "end_time": "2026-01-02T00:00:00Z",
+        "metric_aggregations": [{"otel_name": "custom.metric", "aggregated_value": 1.0}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_values_get_configured_empty_is_not_flagged_as_error(
+    patched_dr_client: MagicMock,
+) -> None:
+    """The common case: no custom metrics configured. Must NOT raise or warn."""
+    # GIVEN the server's own real-world common case: no custom metrics at all
+    _stub_json(
+        patched_dr_client,
+        {"start_time": None, "end_time": None, "metric_aggregations": []},
+    )
+
+    # WHEN read with source='configured'
+    result = await metrics.otel_metrics_values_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, source="configured"
+    )
+
+    # THEN the empty list is returned plainly — no exception, no synthetic
+    # 'no data' marker bolted onto the response
+    assert result["metric_aggregations"] == []
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_values_get_configured_missing_key_defaults_to_empty_list(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a response that omits metric_aggregations entirely
+    _stub_json(patched_dr_client, {"start_time": None, "end_time": None})
+
+    result = await metrics.otel_metrics_values_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, source="configured"
+    )
+
+    assert result["metric_aggregations"] == []
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_values_get_configured_with_histogram_buckets(
+    patched_dr_client: MagicMock,
+) -> None:
+    _stub_json(
+        patched_dr_client,
+        {"start_time": None, "end_time": None, "metric_aggregations": []},
+    )
+
+    await metrics.otel_metrics_values_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        source="configured",
+        histogram_buckets=True,
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-02T00:00:00Z",
+    )
+
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/metrics/values/",
+        params={
+            "histogramBuckets": True,
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-02T00:00:00Z",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_metrics_values_get_client_error(patched_dr_client: MagicMock) -> None:
+    patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
+    with pytest.raises(ToolError) as exc_info:
+        await metrics.otel_metrics_values_get(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# description text — the "empty means unconfigured, not no data" note  #
+# ------------------------------------------------------------------ #
+
+
+def test_otel_metrics_values_get_description_explains_empty_configured_result() -> None:
+    # GIVEN the tool's registered metadata
+    by_name = {(md.get("name") or fn.__name__): md for fn, md in get_registered_tools()}
+    description = by_name["otel_metrics_values_get"]["description"].lower()
+
+    # THEN the description spells out that an empty metric_aggregations means
+    # "not configured", not "no data" — so an agent does not read it as failure
+    assert "not 'no data'" in description
+    assert "no custom metrics configured" in description
+
+
+def test_otel_metrics_values_get_description_documents_the_genai_experimentation_403_cause() -> (
+    None
+):
+    by_name = {(md.get("name") or fn.__name__): md for fn, md in get_registered_tools()}
+    description = by_name["otel_metrics_values_get"]["description"]
+
+    # THEN a 403 is documented as a feature-flag/configuration cause, not
+    # left indistinguishable from "no access to this entity's metrics"
+    assert "GENAI_EXPERIMENTATION" in description
+    assert "403" in description
+
+
+def test_otel_metrics_catalog_list_description_documents_the_genai_experimentation_403_cause() -> (
+    None
+):
+    by_name = {(md.get("name") or fn.__name__): md for fn, md in get_registered_tools()}
+    description = by_name["otel_metrics_catalog_list"]["description"]
+
+    assert "GENAI_EXPERIMENTATION" in description
+    assert "403" in description

--- a/tests/drmcp/unit/otel_tools/test_traces.py
+++ b/tests/drmcp/unit/otel_tools/test_traces.py
@@ -1,0 +1,860 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the three OTel trace tools.
+
+Style: GIVEN preconditions / WHEN behavior under test / THEN expected outcomes.
+
+Truncation itself is exercised in isolation by test_truncation.py; these tests
+cover what the tools add on top: id validation, pagination, error mapping, and
+that the tools actually compose the truncation helpers the way the plan
+specifies. Numeric budgets that otel_trace_get owns (span_limit, max_field_chars,
+max_total_chars) are always read off ``traces.DEFAULT_TRACE_*`` rather than
+retyped here, so a later fixup to those defaults (plan §9 step 9) cannot silently
+desync the tests from the tool.
+"""
+
+import json
+import logging
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from datarobot.errors import ClientError
+
+from datarobot_genai.drmcputils.exceptions import ToolError
+from datarobot_genai.drmcputils.exceptions import ToolErrorKind
+from datarobot_genai.drtools.otel import traces
+from tests.drmcp.unit.otel_tools.trace_factory import OVERSIZED_SPAN_COUNT
+from tests.drmcp.unit.otel_tools.trace_factory import OVERSIZED_TOTAL_PAYLOAD_CHARS
+from tests.drmcp.unit.otel_tools.trace_factory import OVERSIZED_TRACE_ID
+from tests.drmcp.unit.otel_tools.trace_factory import SMALL_TRACE_ID
+
+_ENTITY_ID = "a" * 24
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def patched_dr_client(mock_rest_client: MagicMock) -> Iterator[MagicMock]:
+    with patch(
+        "datarobot_genai.drtools.core.clients.datarobot_otel_query.request_user_dr_client"
+    ) as mock_cm:
+        mock_cm.return_value.__enter__.return_value = mock_rest_client
+        mock_cm.return_value.__exit__.return_value = False
+        yield mock_rest_client
+
+
+def _stub_json(client: MagicMock, payload: dict[str, Any]) -> None:
+    client.get.return_value = MagicMock(json=lambda: payload)
+
+
+def _single_span_trace(
+    *,
+    trace_id: str,
+    span_id: str,
+    attributes: dict[str, Any],
+    completion: str | None = None,
+    status_message: str | None = None,
+) -> dict[str, Any]:
+    """Build a minimal one-span trace envelope for a specific merge/window edge case."""
+    span: dict[str, Any] = {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": None,
+        "name": "llm.chat",
+        "status_code": "ERROR" if status_message else "OK",
+        "status_message": status_message,
+        "kind": "CLIENT",
+        "service_name": "svc",
+        "duration": 1.0,
+        "start_time": 0.0,
+        "attributes": attributes,
+        "events": [],
+        "links": [],
+    }
+    if completion is not None:
+        span["completion"] = completion
+    return {
+        "trace_id": trace_id,
+        "span_count": 1,
+        "duration": 1.0,
+        "root_span_name": "llm.chat",
+        "root_service_name": "svc",
+        "spans": [span],
+        "count": 1,
+        "offset": 0,
+        "limit": 100,
+        "total_count": 1,
+        "next": None,
+        "previous": None,
+    }
+
+
+# ------------------------------------------------------------------ #
+# otel_traces_list                                                     #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_maps_data_to_traces_and_merges_pagination(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a raw traces/ response shaped like TracingListResponseValidator
+    _stub_json(
+        patched_dr_client,
+        {
+            "data": [{"trace_id": "t1"}, {"trace_id": "t2"}],
+            "count": 2,
+            "total_count": 40,
+            "next": "https://example/traces/?offset=20",
+            "previous": None,
+        },
+    )
+
+    # WHEN otel_traces_list is called with only the required entity args
+    result = await traces.otel_traces_list(entity_type="deployment", entity_id=_ENTITY_ID)
+
+    # THEN 'data' becomes 'traces', and pagination metadata is merged in
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/traces/", params={"limit": 20, "offset": 0}
+    )
+    assert result["traces"] == [{"trace_id": "t1"}, {"trace_id": "t2"}]
+    assert result["count"] == 2
+    assert result["offset"] == 0
+    assert result["limit"] == 20
+    assert result["total_count"] == 40
+    assert result["next"] == "https://example/traces/?offset=20"
+    assert "previous" not in result  # merge_pagination_metadata skips None values
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_strips_and_validates_entity_id(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a malformed entity_id
+    # WHEN / THEN otel_traces_list rejects it before making any HTTP call
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_traces_list(entity_type="deployment", entity_id="not-hex")
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    patched_dr_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_rejects_negative_offset() -> None:
+    # GIVEN a negative offset
+    # WHEN / THEN otel_traces_list raises a VALIDATION error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_traces_list(entity_type="deployment", entity_id=_ENTITY_ID, offset=-1)
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_rejects_a_comma_joined_tools_string() -> None:
+    # GIVEN a single comma-joined string passed where a list of tool names belongs
+    # WHEN / THEN otel_traces_list raises a VALIDATION error naming the fix
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_traces_list(
+            entity_type="deployment", entity_id=_ENTITY_ID, tools=["search,browse"]
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "comma" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_defaults_sort_by_to_timestamp_when_only_direction_given(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN sort_direction with no sort_by (the server 400s this combination)
+    _stub_json(patched_dr_client, {"data": []})
+
+    # WHEN otel_traces_list is called
+    await traces.otel_traces_list(
+        entity_type="deployment", entity_id=_ENTITY_ID, sort_direction="desc"
+    )
+
+    # THEN sort_by is defaulted to 'timestamp' before the call is made
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/traces/",
+        params={"limit": 20, "offset": 0, "sortBy": "timestamp", "sortDirection": "desc"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_rejects_offset_plus_limit_over_the_ceiling() -> None:
+    # GIVEN offset + limit that would exceed the server's 10,000 ceiling
+    # WHEN / THEN otel_traces_list pre-empts the server's 400 with a VALIDATION error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_traces_list(
+            entity_type="deployment", entity_id=_ENTITY_ID, offset=9_950, limit=100
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "start_time" in str(exc_info.value) or "end_time" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_clamps_an_oversized_limit_and_reports_a_note(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a limit above the 100 ceiling
+    _stub_json(patched_dr_client, {"data": []})
+
+    # WHEN otel_traces_list is called
+    result = await traces.otel_traces_list(
+        entity_type="deployment", entity_id=_ENTITY_ID, limit=500
+    )
+
+    # THEN the clamped value is what's actually sent, and a note explains it
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/traces/", params={"limit": 100, "offset": 0}
+    )
+    assert result["limit"] == 100
+    assert "note" in result
+
+
+@pytest.mark.asyncio
+async def test_otel_traces_list_wraps_a_client_error_as_a_tool_error(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN the upstream call fails
+    patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
+
+    # WHEN / THEN otel_traces_list raises an UPSTREAM ToolError, not the raw SDK error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_traces_list(entity_type="deployment", entity_id=_ENTITY_ID)
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+# ------------------------------------------------------------------ #
+# otel_trace_get                                                       #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_view_summary_default_projects_the_oversized_trace(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN the oversized trace: 12 spans, 1,022,000 payload chars
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_trace_get is called with the default view
+    result = await traces.otel_trace_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, trace_id=OVERSIZED_TRACE_ID
+    )
+
+    # THEN the trace-level structural fields, metrics, and truncation hint are
+    # present, and no span carries a payload
+    assert result["trace_id"] == OVERSIZED_TRACE_ID
+    assert result["span_count"] == OVERSIZED_SPAN_COUNT
+    assert result["root_span_name"] == "agent.run"
+    assert result["metrics"] == oversized_agent_trace["metrics"]
+    assert len(result["spans"]) == OVERSIZED_SPAN_COUNT
+    assert result["count"] == OVERSIZED_SPAN_COUNT
+    for span in result["spans"]:
+        assert "attributes" not in span
+        assert "prompt" not in span
+        assert "completion" not in span
+    assert result["truncation"] == {
+        "mode": "summary",
+        "payloads_omitted": True,
+        "total_payload_chars": OVERSIZED_TOTAL_PAYLOAD_CHARS,
+        "hint": ("Fetch one span's payload with otel_span_payload_get(trace_id=..., span_id=...)."),
+    }
+    # THEN pagination metadata is merged from the raw response plus the request
+    assert result["offset"] == 0
+    assert result["limit"] == traces.DEFAULT_TRACE_SPAN_LIMIT
+    assert result["total_count"] == oversized_agent_trace["total_count"]
+    assert "next" not in result  # the fixture's next/previous are both None
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_view_summary_stays_under_the_measured_ceiling(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    """The regression guard from §7, exercised through the tool itself.
+
+    test_truncation.py already pins summarize_spans' own output to a per-span
+    ceiling; this asserts the same property survives composition into the full
+    tool response (trace envelope + pagination + truncation block), so a future
+    change that re-attaches raw span data at the tool layer would still be caught
+    even though it wouldn't touch summarize_spans at all.
+    """
+    # GIVEN the oversized trace
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN the full tool response is serialized as it would be returned
+    result = await traces.otel_trace_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, trace_id=OVERSIZED_TRACE_ID
+    )
+    serialized_chars = len(json.dumps(result))
+
+    # THEN the whole response is still a rounding error against the payload it
+    # describes, not merely the span summaries in isolation
+    assert serialized_chars < OVERSIZED_TOTAL_PAYLOAD_CHARS / 50, (
+        f"otel_trace_get(view='summary') response grew to {serialized_chars} chars "
+        f"against {OVERSIZED_TOTAL_PAYLOAD_CHARS} payload chars it describes"
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_uses_the_shared_default_span_pagination(
+    patched_dr_client: MagicMock, small_trace: dict[str, Any]
+) -> None:
+    # GIVEN no explicit span_limit/span_offset
+    _stub_json(patched_dr_client, small_trace)
+
+    # WHEN otel_trace_get is called
+    await traces.otel_trace_get(
+        entity_type="workload", entity_id=_ENTITY_ID, trace_id=SMALL_TRACE_ID
+    )
+
+    # THEN the client is called with the single named default (traces.DEFAULT_TRACE_SPAN_LIMIT)
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/workload/{_ENTITY_ID}/traces/{SMALL_TRACE_ID}/",
+        params={"limit": traces.DEFAULT_TRACE_SPAN_LIMIT, "offset": 0},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_forwards_explicit_span_pagination(
+    patched_dr_client: MagicMock, small_trace: dict[str, Any]
+) -> None:
+    # GIVEN explicit span_limit/span_offset
+    _stub_json(patched_dr_client, small_trace)
+
+    # WHEN otel_trace_get is called with overrides
+    await traces.otel_trace_get(
+        entity_type="workload",
+        entity_id=_ENTITY_ID,
+        trace_id=SMALL_TRACE_ID,
+        span_limit=5,
+        span_offset=10,
+    )
+
+    # THEN the overrides, not the defaults, are sent
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/workload/{_ENTITY_ID}/traces/{SMALL_TRACE_ID}/",
+        params={"limit": 5, "offset": 10},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_view_payloads_fits_the_default_budget_untouched(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN the oversized trace and otel_trace_get's own defaults
+    # (max_field_chars=2,000 keeps this particular fixture's canonical payload
+    # small enough that the 60,000-char budget never has to drop anything --
+    # unlike the real 4.76 MB trace the plan measured, whose canonical payload
+    # alone was ~65k tokens even at an 8,000-char field cap)
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_trace_get is called with view='payloads' and no overrides
+    result = await traces.otel_trace_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID,
+        view="payloads",
+    )
+
+    # THEN nothing is dropped, and every span carries canonical attributes only
+    assert result["truncation"]["mode"] == "payloads"
+    assert result["truncation"]["spans_dropped"] == 0
+    assert result["truncation"]["spans_returned"] == OVERSIZED_SPAN_COUNT
+    assert result["count"] == OVERSIZED_SPAN_COUNT
+    assert result["truncation"]["chars_used"] <= traces.DEFAULT_TRACE_MAX_TOTAL_CHARS
+    for span in result["spans"]:
+        assert "attributes" in span
+        assert "truncation" in span
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_view_payloads_drops_spans_when_the_budget_is_tight(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN a wider per-field cap (8,000 chars) that pushes the canonical payload
+    # over the default 60,000-char total budget -- the same combination
+    # test_truncation.py exercises directly against apply_char_budget
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_trace_get is called with that wider field cap
+    result = await traces.otel_trace_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID,
+        view="payloads",
+        max_field_chars=8_000,
+    )
+
+    # THEN the hard stop holds and the loss is reported, never silent
+    truncation = result["truncation"]
+    assert truncation["spans_dropped"] > 0
+    assert truncation["spans_returned"] + truncation["spans_dropped"] == OVERSIZED_SPAN_COUNT
+    assert truncation["chars_used"] <= traces.DEFAULT_TRACE_MAX_TOTAL_CHARS
+    assert result["count"] == truncation["spans_returned"]
+    assert truncation["max_total_chars"] == traces.DEFAULT_TRACE_MAX_TOTAL_CHARS
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_small_trace_survives_both_views_untouched(
+    patched_dr_client: MagicMock, small_trace: dict[str, Any]
+) -> None:
+    # GIVEN the small non-agentic trace, which carries no metrics key at all
+    _stub_json(patched_dr_client, small_trace)
+
+    # WHEN both views are requested
+    summary = await traces.otel_trace_get(
+        entity_type="workload", entity_id=_ENTITY_ID, trace_id=SMALL_TRACE_ID
+    )
+    _stub_json(patched_dr_client, small_trace)
+    payloads = await traces.otel_trace_get(
+        entity_type="workload",
+        entity_id=_ENTITY_ID,
+        trace_id=SMALL_TRACE_ID,
+        view="payloads",
+    )
+
+    # THEN nothing is truncated or dropped, and the absent 'metrics' key is not
+    # fabricated
+    assert "metrics" not in summary
+    assert "metrics" not in payloads
+    assert summary["count"] == len(small_trace["spans"])
+    assert payloads["count"] == len(small_trace["spans"])
+    assert payloads["truncation"]["spans_dropped"] == 0
+    assert [s["name"] for s in summary["spans"]] == ["GET /health", "db.query", "cache.get"]
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_rejects_a_malformed_trace_id() -> None:
+    # GIVEN a trace_id that is not 32 hex characters
+    # WHEN / THEN otel_trace_get raises a VALIDATION error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_trace_get(
+            entity_type="deployment", entity_id=_ENTITY_ID, trace_id="too-short"
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_rejects_negative_span_offset() -> None:
+    # GIVEN a negative span_offset
+    # WHEN / THEN otel_trace_get raises a VALIDATION error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_trace_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_offset=-1,
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_rejects_a_non_positive_span_limit() -> None:
+    # GIVEN a span_limit of zero (the server requires > 0)
+    # WHEN / THEN otel_trace_get raises a VALIDATION error before calling the server
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_trace_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_limit=0,
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_wraps_a_404_as_not_found(patched_dr_client: MagicMock) -> None:
+    # GIVEN the upstream call 404s
+    patched_dr_client.get.side_effect = ClientError("404", status_code=404, json={})
+
+    # WHEN / THEN otel_trace_get raises a NOT_FOUND ToolError
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_trace_get(
+            entity_type="deployment", entity_id=_ENTITY_ID, trace_id=OVERSIZED_TRACE_ID
+        )
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+# ------------------------------------------------------------------ #
+# otel_span_payload_get                                                #
+# ------------------------------------------------------------------ #
+
+# Span index 3 ("tool.execute") carries a single 160,000-char value written four
+# times over by four instrumentations; its canonical set collapses to
+# {"completion", "gen_ai.tool.name", "gen_ai.tool.call.id"} with the other three
+# names reported as duplicates -- verified against the actual fixture output
+# before writing these assertions, not derived from the docstrings alone.
+_GIANT_SPAN_INDEX = 3
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_default_canonical_set_windows_the_giant_field(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN the tool.execute span whose completion is 160,000 chars
+    span = oversized_agent_trace["spans"][_GIANT_SPAN_INDEX]
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_span_payload_get is called with no fields override
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID,
+        span_id=span["span_id"],
+    )
+
+    # THEN the canonical field is windowed at the 8,000-char default and its
+    # duplicates are named, not silently dropped
+    assert result["span_id"] == span["span_id"]
+    assert result["name"] == "tool.execute"
+    assert result["completion"] == span["completion"][:8_000]
+    assert result["attributes"] == {
+        "gen_ai.tool.name": "crm_account_export",
+        "gen_ai.tool.call.id": "call_7Kq1",
+    }
+    assert result["truncation"]["fields"] == {
+        "completion": {"returned_chars": 8_000, "total_chars": 160_000, "next_offset": 8_000}
+    }
+    assert set(result["truncation"]["dropped_as_duplicate"]) == {
+        "gen_ai.task.output",
+        "input.value",
+        "traceloop.entity.output",
+    }
+    assert result["truncation"]["dropped_semconv"] == []
+    assert "fields_not_found" not in result["truncation"]
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_fields_param_fetches_a_dropped_duplicate_by_name(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN the same span, and a name the default call above reports as a
+    # dropped duplicate
+    span = oversized_agent_trace["spans"][_GIANT_SPAN_INDEX]
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_span_payload_get is called with that exact name in 'fields'
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID,
+        span_id=span["span_id"],
+        fields=["traceloop.entity.output"],
+    )
+
+    # THEN the escape hatch bypasses dedup entirely: the field comes back
+    # directly, and nothing is reported as dropped in this mode
+    assert result["attributes"] == {
+        "traceloop.entity.output": span["attributes"]["traceloop.entity.output"][:8_000]
+    }
+    assert "completion" not in result
+    assert result["truncation"]["dropped_as_duplicate"] == []
+    assert result["truncation"]["dropped_semconv"] == []
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_field_offset_continues_a_truncated_field(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN the first call's next_offset for the giant completion field
+    span = oversized_agent_trace["spans"][_GIANT_SPAN_INDEX]
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN a follow-up call continues from that offset
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID,
+        span_id=span["span_id"],
+        fields=["completion"],
+        field_offset=8_000,
+    )
+
+    # THEN the window picks up exactly where the previous one left off
+    assert result["completion"] == span["completion"][8_000:16_000]
+    assert result["truncation"]["fields"]["completion"] == {
+        "returned_chars": 8_000,
+        "total_chars": 160_000,
+        "next_offset": 16_000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_reports_fields_not_found(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN a request for a field name that does not exist on the span
+    span = oversized_agent_trace["spans"][_GIANT_SPAN_INDEX]
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_span_payload_get is called with a mix of a real and a bogus name
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID,
+        span_id=span["span_id"],
+        fields=["gen_ai.tool.name", "no.such.field"],
+    )
+
+    # THEN the real field is returned and the missing one is named, not silent
+    assert result["attributes"] == {"gen_ai.tool.name": "crm_account_export"}
+    assert result["truncation"]["fields_not_found"] == ["no.such.field"]
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_response_field_wins_over_a_colliding_attribute_name(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a span whose 'attributes' dict happens to carry a literal
+    # "completion" key beside the span's own rank-1 response field -- the exact
+    # wire shape truncation._payload_sizes already documents and accounts for
+    trace_id = "a" * 32
+    span_id = "b" * 16
+    real_completion = "REAL response-level completion text. " * 10
+    fake_attribute_completion = "FAKE attribute-level completion text. " * 10
+    trace = _single_span_trace(
+        trace_id=trace_id,
+        span_id=span_id,
+        completion=real_completion,
+        attributes={"completion": fake_attribute_completion},
+    )
+    _stub_json(patched_dr_client, trace)
+
+    # WHEN the default canonical set is requested
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, trace_id=trace_id, span_id=span_id
+    )
+
+    # THEN the true, platform-normalized response text wins -- never the
+    # colliding attribute value -- and nothing reports it as dropped, because
+    # nothing about the response field was dropped
+    assert result["completion"] == real_completion
+    assert fake_attribute_completion not in json.dumps(result)
+    assert result["truncation"]["dropped_as_duplicate"] == []
+    assert result["truncation"]["dropped_semconv"] == []
+
+    # AND the explicit 'fields' escape hatch -- meant to be the guaranteed
+    # ground-truth path -- resolves through the same guarantee
+    _stub_json(patched_dr_client, trace)
+    result_fields = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=trace_id,
+        span_id=span_id,
+        fields=["completion"],
+    )
+    assert result_fields["completion"] == real_completion
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_view_payloads_response_field_wins_over_a_colliding_attribute_name(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN the same colliding wire shape, exercised through otel_trace_get's
+    # other call site onto the same _merged_payload helper
+    trace_id = "e" * 32
+    span_id = "f" * 16
+    real_completion = "REAL response-level completion text. " * 10
+    fake_attribute_completion = "FAKE attribute-level completion text. " * 10
+    trace = _single_span_trace(
+        trace_id=trace_id,
+        span_id=span_id,
+        completion=real_completion,
+        attributes={"completion": fake_attribute_completion},
+    )
+    _stub_json(patched_dr_client, trace)
+
+    # WHEN view='payloads' is requested
+    result = await traces.otel_trace_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, trace_id=trace_id, view="payloads"
+    )
+
+    # THEN the response field's own text survives under 'completion', not the
+    # colliding attribute value
+    assert result["spans"][0]["attributes"]["completion"] == real_completion
+    assert fake_attribute_completion not in json.dumps(result)
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_windows_a_long_status_message(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN an ERROR span whose status_message is far larger than max_field_chars
+    # -- SpanViewValidator.status_message has no server-side max_length, so a
+    # traceback can arrive verbatim (see truncation.STATUS_MESSAGE_MAX_CHARS)
+    trace_id = "c" * 32
+    span_id = "d" * 16
+    long_status_message = "Traceback (most recent call last):\n" + ("frame line. " * 2_000)
+    trace = _single_span_trace(
+        trace_id=trace_id,
+        span_id=span_id,
+        attributes={},
+        status_message=long_status_message,
+    )
+    _stub_json(patched_dr_client, trace)
+
+    # WHEN otel_span_payload_get is called with a small max_field_chars
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=trace_id,
+        span_id=span_id,
+        max_field_chars=100,
+    )
+
+    # THEN status_message is windowed exactly like any other field this tool
+    # emits, not returned raw and unbounded
+    assert result["status_message"] == long_status_message[:100]
+    assert result["truncation"]["fields"]["status_message"] == {
+        "returned_chars": 100,
+        "total_chars": len(long_status_message),
+        "next_offset": 100,
+    }
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_raises_not_found_for_an_absent_span_id(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN a span_id that is not in the fetched trace
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN / THEN otel_span_payload_get raises NOT_FOUND, not a KeyError
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_id="0" * 16,
+        )
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_logs_the_fetched_byte_count(
+    patched_dr_client: MagicMock,
+    oversized_agent_trace: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # GIVEN the oversized trace (there is no per-span endpoint, so the whole
+    # trace is fetched to answer a one-span request -- §2.3's known cost)
+    span = oversized_agent_trace["spans"][_GIANT_SPAN_INDEX]
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_span_payload_get is called
+    with caplog.at_level(logging.INFO, logger="datarobot_genai.drtools.otel.traces"):
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_id=span["span_id"],
+        )
+
+    # THEN the fetched byte count is logged -- the evidence for §10's server-side
+    # field-projection ask -- and it is not a trivially small number
+    messages = [record.message for record in caplog.records if "fetched" in record.message]
+    assert len(messages) == 1
+    assert str(OVERSIZED_TRACE_ID) in messages[0]
+    assert any(char.isdigit() for char in messages[0])
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_fetches_with_the_shared_default_span_limit(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN no per-span endpoint exists, so the tool must page the trace itself
+    span = oversized_agent_trace["spans"][0]
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN otel_span_payload_get is called
+    await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID,
+        span_id=span["span_id"],
+    )
+
+    # THEN it fetches using the same named default otel_trace_get uses, not an
+    # independently hardcoded number
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/traces/{OVERSIZED_TRACE_ID}/",
+        params={"limit": traces.DEFAULT_TRACE_SPAN_LIMIT, "offset": 0},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_rejects_a_malformed_entity_id() -> None:
+    # GIVEN a malformed entity_id
+    # WHEN / THEN otel_span_payload_get raises a VALIDATION error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id="short",
+            trace_id=OVERSIZED_TRACE_ID,
+            span_id="anything",
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_rejects_an_empty_span_id() -> None:
+    # GIVEN a blank span_id
+    # WHEN / THEN otel_span_payload_get raises a VALIDATION error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_id="   ",
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_rejects_a_negative_field_offset() -> None:
+    # GIVEN a negative field_offset
+    # WHEN / THEN otel_span_payload_get raises a VALIDATION error
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_id="anything",
+            field_offset=-1,
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_wraps_a_client_error_as_a_tool_error(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN the upstream call fails with a non-404 error
+    patched_dr_client.get.side_effect = ClientError("500", status_code=500, json={})
+
+    # WHEN / THEN otel_span_payload_get raises an UPSTREAM ToolError
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_id="anything",
+        )
+    assert exc_info.value.kind is ToolErrorKind.UPSTREAM

--- a/tests/drmcp/unit/otel_tools/test_traces.py
+++ b/tests/drmcp/unit/otel_tools/test_traces.py
@@ -241,6 +241,26 @@ async def test_otel_traces_list_wraps_a_client_error_as_a_tool_error(
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
 
 
+@pytest.mark.asyncio
+async def test_otel_traces_list_forwards_fractional_cost_bounds(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN sub-dollar cost bounds — trace cost is a fractional currency amount
+    _stub_json(patched_dr_client, {"data": []})
+
+    # WHEN otel_traces_list is called with them
+    await traces.otel_traces_list(
+        entity_type="deployment", entity_id=_ENTITY_ID, min_trace_cost=0.001, max_trace_cost=0.01
+    )
+
+    # THEN they reach the wire unmangled — the int-typed signature rejected every
+    # realistic sub-dollar bound at schema validation before the tool body ran
+    patched_dr_client.get.assert_called_once_with(
+        f"otel/deployment/{_ENTITY_ID}/traces/",
+        params={"limit": 20, "offset": 0, "minTraceCost": 0.001, "maxTraceCost": 0.01},
+    )
+
+
 # ------------------------------------------------------------------ #
 # otel_trace_get                                                       #
 # ------------------------------------------------------------------ #
@@ -409,6 +429,41 @@ async def test_otel_trace_get_view_payloads_drops_spans_when_the_budget_is_tight
     assert truncation["chars_used"] <= traces.DEFAULT_TRACE_MAX_TOTAL_CHARS
     assert result["count"] == truncation["spans_returned"]
     assert truncation["max_total_chars"] == traces.DEFAULT_TRACE_MAX_TOTAL_CHARS
+
+
+@pytest.mark.asyncio
+async def test_otel_trace_get_view_payloads_caps_container_attributes_within_the_budget(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a two-span trace whose first span carries a 100k-char message list —
+    # uncapped, its serialized cost alone blows the whole 60,000-char budget and
+    # drops it plus every span after it
+    trace_id = "e" * 32
+    messages = [{"role": "user", "content": "x" * 100_000}]
+    trace = _single_span_trace(
+        trace_id=trace_id, span_id="f" * 16, attributes={"gen_ai.input.messages": messages}
+    )
+    second = dict(trace["spans"][0])
+    second["span_id"] = "a" * 16
+    second["attributes"] = {"gen_ai.tool.name": "search"}
+    trace["spans"] = [trace["spans"][0], second]
+    trace["span_count"] = trace["count"] = trace["total_count"] = 2
+    _stub_json(patched_dr_client, trace)
+
+    # WHEN view='payloads' is requested with the defaults
+    result = await traces.otel_trace_get(
+        entity_type="deployment", entity_id=_ENTITY_ID, trace_id=trace_id, view="payloads"
+    )
+
+    # THEN both spans are returned — the container was windowed at max_field_chars
+    # like any string payload — and the window is marked as serialized JSON
+    assert result["truncation"]["spans_dropped"] == 0
+    assert result["count"] == 2
+    first_span = result["spans"][0]
+    window = first_span["attributes"]["gen_ai.input.messages"]
+    assert isinstance(window, str)
+    assert len(window) == traces.DEFAULT_TRACE_MAX_FIELD_CHARS
+    assert first_span["truncation"]["fields"]["gen_ai.input.messages"]["serialized"] is True
 
 
 @pytest.mark.asyncio
@@ -858,3 +913,241 @@ async def test_otel_span_payload_get_wraps_a_client_error_as_a_tool_error(
             span_id="anything",
         )
     assert exc_info.value.kind is ToolErrorKind.UPSTREAM
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_rejects_field_offset_without_fields(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a continuation offset with no fields naming what to continue — every
+    # field shorter than the offset would come back as an empty window
+    # WHEN / THEN the tool raises a VALIDATION error before any HTTP call
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=OVERSIZED_TRACE_ID,
+            span_id="anything",
+            field_offset=8_000,
+        )
+    assert exc_info.value.kind is ToolErrorKind.VALIDATION
+    assert "fields" in str(exc_info.value)
+    patched_dr_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_field_offset_does_not_blank_the_status_message(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN an ERROR span with a short status message and one long attribute
+    trace_id = "c" * 32
+    span_id = "d" * 16
+    long_output = "o" * 20_000
+    trace = _single_span_trace(
+        trace_id=trace_id,
+        span_id=span_id,
+        attributes={"gen_ai.task.output": long_output},
+        status_message="RateLimitError: 429",
+    )
+    _stub_json(patched_dr_client, trace)
+
+    # WHEN a continuation call pages the long attribute past the message's length
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=trace_id,
+        span_id=span_id,
+        fields=["gen_ai.task.output"],
+        field_offset=8_000,
+    )
+
+    # THEN the attribute window continues while the short status message comes
+    # back whole — an offset meant for one field no longer blanks the rest
+    assert result["attributes"]["gen_ai.task.output"] == long_output[8_000:16_000]
+    assert result["status_message"] == "RateLimitError: 429"
+    assert "status_message" not in result["truncation"]["fields"]
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_continues_a_status_message_named_in_fields(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN an ERROR span whose long status_message a first call truncated
+    trace_id = "c" * 32
+    span_id = "d" * 16
+    long_status_message = "Traceback (most recent call last):\n" + ("frame line. " * 2_000)
+    trace = _single_span_trace(
+        trace_id=trace_id, span_id=span_id, attributes={}, status_message=long_status_message
+    )
+    _stub_json(patched_dr_client, trace)
+
+    # WHEN the continuation names 'status_message' in fields with an offset
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=trace_id,
+        span_id=span_id,
+        fields=["status_message"],
+        field_offset=100,
+        max_field_chars=100,
+    )
+
+    # THEN the status message window continues from the offset, and the name is
+    # not reported as fields_not_found — it is structural, not an attribute
+    assert result["status_message"] == long_status_message[100:200]
+    assert result["truncation"]["fields"]["status_message"]["next_offset"] == 200
+    assert "fields_not_found" not in result["truncation"]
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_windows_an_oversized_container_attribute(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a span whose gen_ai.prompt is a JSON-decoded message list far larger
+    # than max_field_chars — the OTLP array shape that used to come back whole,
+    # uncapped and with no truncation record
+    trace_id = "a" * 32
+    span_id = "b" * 16
+    messages = [{"role": "user", "content": "x" * 100_000}]
+    serialized = json.dumps(messages, default=str, ensure_ascii=False)
+    trace = _single_span_trace(
+        trace_id=trace_id, span_id=span_id, attributes={"gen_ai.prompt": messages}
+    )
+    _stub_json(patched_dr_client, trace)
+
+    # WHEN the span payload is fetched with the default 8,000-char field cap
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=trace_id,
+        span_id=span_id,
+        fields=["gen_ai.prompt"],
+    )
+
+    # THEN the value is windowed over its serialized JSON with a truncation
+    # record, instead of being returned whole
+    assert result["attributes"]["gen_ai.prompt"] == serialized[:8_000]
+    assert result["truncation"]["fields"]["gen_ai.prompt"] == {
+        "returned_chars": 8_000,
+        "total_chars": len(serialized),
+        "next_offset": 8_000,
+        "serialized": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_matches_ids_case_insensitively(
+    patched_dr_client: MagicMock, oversized_agent_trace: dict[str, Any]
+) -> None:
+    # GIVEN a trace id and span id pasted in uppercase — the server emits
+    # lowercase hex, and an exact == match raised NOT_FOUND for a span that exists
+    span = oversized_agent_trace["spans"][_GIANT_SPAN_INDEX]
+    _stub_json(patched_dr_client, oversized_agent_trace)
+
+    # WHEN the tool is called with uppercase ids
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=OVERSIZED_TRACE_ID.upper(),
+        span_id=span["span_id"].upper(),
+    )
+
+    # THEN the span is found, the URL carries the lowercased trace id, and the
+    # response reports the server's own span id casing
+    assert result["span_id"] == span["span_id"]
+    call_path = patched_dr_client.get.call_args[0][0]
+    assert f"/traces/{OVERSIZED_TRACE_ID}/" in call_path
+
+
+def _minimal_span(index: int, span_id: str | None = None) -> dict[str, Any]:
+    """Build the smallest span _span_payload_view and the id match can read."""
+    return {
+        "span_id": span_id or f"{index:016x}",
+        "name": f"span-{index}",
+        "status_code": "OK",
+        "status_message": None,
+        "attributes": {},
+    }
+
+
+def _span_page(
+    trace_id: str, spans: list[dict[str, Any]], offset: int, total_count: int
+) -> dict[str, Any]:
+    """Wrap one server-side span page in the trace-detail envelope."""
+    return {
+        "trace_id": trace_id,
+        "spans": spans,
+        "count": len(spans),
+        "offset": offset,
+        "limit": traces.DEFAULT_TRACE_SPAN_LIMIT,
+        "total_count": total_count,
+        "next": None,
+        "previous": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_pages_past_the_first_span_page(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN a 150-span trace whose target span sits on the second server page —
+    # otel_trace_get(span_offset=100) legitimately surfaces such span ids
+    trace_id = "a" * 32
+    target_span_id = "beef000000000120"
+    first_page = _span_page(trace_id, [_minimal_span(i) for i in range(100)], 0, 150)
+    second_page = _span_page(
+        trace_id,
+        [_minimal_span(100 + i) for i in range(20)]
+        + [_minimal_span(120, target_span_id)]
+        + [_minimal_span(121 + i) for i in range(29)],
+        100,
+        150,
+    )
+    patched_dr_client.get.side_effect = [
+        MagicMock(json=lambda: first_page),
+        MagicMock(json=lambda: second_page),
+    ]
+
+    # WHEN the drill-down tool is asked for that span
+    result = await traces.otel_span_payload_get(
+        entity_type="deployment",
+        entity_id=_ENTITY_ID,
+        trace_id=trace_id,
+        span_id=target_span_id,
+    )
+
+    # THEN the tool followed the pagination instead of raising NOT_FOUND
+    assert result["span_id"] == target_span_id
+    assert patched_dr_client.get.call_count == 2
+    patched_dr_client.get.assert_any_call(
+        f"otel/deployment/{_ENTITY_ID}/traces/{trace_id}/",
+        params={"limit": traces.DEFAULT_TRACE_SPAN_LIMIT, "offset": 100},
+    )
+
+
+@pytest.mark.asyncio
+async def test_otel_span_payload_get_raises_not_found_after_checking_every_page(
+    patched_dr_client: MagicMock,
+) -> None:
+    # GIVEN the same 150-span trace and a span id that is on none of its pages
+    trace_id = "a" * 32
+    first_page = _span_page(trace_id, [_minimal_span(i) for i in range(100)], 0, 150)
+    second_page = _span_page(trace_id, [_minimal_span(100 + i) for i in range(50)], 100, 150)
+    patched_dr_client.get.side_effect = [
+        MagicMock(json=lambda: first_page),
+        MagicMock(json=lambda: second_page),
+    ]
+
+    # WHEN / THEN the tool raises NOT_FOUND only after checking every page,
+    # and the error reports the full count it checked ("f" * 16 collides with
+    # no generated id — _minimal_span ids are zero-padded hex indexes)
+    with pytest.raises(ToolError) as exc_info:
+        await traces.otel_span_payload_get(
+            entity_type="deployment",
+            entity_id=_ENTITY_ID,
+            trace_id=trace_id,
+            span_id="f" * 16,
+        )
+    assert exc_info.value.kind is ToolErrorKind.NOT_FOUND
+    assert "150" in str(exc_info.value)
+    assert patched_dr_client.get.call_count == 2


### PR DESCRIPTION
# RATIONALE

Design doc: https://datarobot.atlassian.net/wiki/x/AoCr3AE

`otel_trace_get` defaults to `view="summary"`: the span tree with zero payloads, ~133 tokens/span flat regardless of payload size (**4,936 tokens on the 1.56M-token worst trace — 0.3%**). Each span carries `payload_chars` and `payload_fields`, which tell the agent *where the mass is* for ~15 extra tokens a span. Drill-down is then a deliberate, targeted second call to `otel_span_payload_get`, which windows within a single field via `field_offset`/`next_offset` — one measured attribute value was 740,000 chars, so "return the field" was never an option. Every dropped field is named in `dropped_as_duplicate`/`dropped_semconv`; 64.5% of the worst trace was byte-identical duplication across Traceloop/NAT/OpenInference/gen_ai, and hiding the drops would leave an agent hunting a field by name with no idea where it went.

## CHANGES

- `traces.py` — `otel_traces_list`, `otel_trace_get`, `otel_span_payload_get`
- `logs.py` — `otel_logs_list`
- `metrics.py` — `otel_metrics_catalog_list`, `otel_metrics_values_get`
- `entity_stats.py` — `otel_entity_stats_get`
- Tier-1 tests for each.

Still not registered as this point in the stack; #648 turns them on.

## NOTES

One live spec conflict, flagged rather than silently resolved: plan §3 lists `gen_ai.task.output` among the derived families dropped outright, while §2.3's example JSON keeps it. The code follows §3 and makes `fields=["gen_ai.task.output"]` the escape hatch. Worth a second opinion.

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog (added in #649, the last PR of this stack)
- [x] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST) — integration and acceptance tests for these seven tools are added in #648

## TESTING

`task drmcp-unit` (full suite) 1783 passed, coverage 85.90%. ruff-format, ruff, mypy, check-imports all clean.

## RELATED

2/4 of the OTel observability tools stack (plan §9 steps 4–5). Depends on #646. Next: #648 (wiring — turns these on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large read-only surface on OTel query APIs with nuanced auth/feature-flag behavior and heavy payload truncation; mistakes could mislead agents or over-fetch traces, but there is no data mutation and coverage is extensive.
> 
> **Overview**
> Adds a top-level **`dr_otel`** MCP category (“Observability”) mapping to seven new tools, so allowlists and the tool gallery can target OTel as a group.
> 
> Introduces **seven async MCP tools** under `drtools/otel/` that call `OtelQueryApiClient` for traces, logs, metrics, and entity stats. **Trace flow** is list → `otel_trace_get` (default `view="summary"` with payload accounting; optional budgeted `payloads`) → `otel_span_payload_get` with field windows and pagination through trace pages when there is no per-span API. **Logs** clamp pagination, honor full six minimum log levels, cap `message`/`stacktrace` independently, and strip `total_count`. **Metrics** list/catalog with a client cap; values merge autocollected vs configured sources with explicit empty-config semantics. **`otel_entity_stats_get`** preflights via `serviceName`, sums per-user rows, treats 403 as permission failure (not empty data).
> 
> **Tier-1 unit tests** cover wire mapping, validation traps, truncation behavior, and tool metadata hints (e.g. `GENAI_EXPERIMENTATION`). Tool **registration/wiring is not in this diff** (follow-up PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f6b75c61bcea3feab800c7368e721b6bb33ee3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->