### PR TITLE
[APP-6968] OTel MCP tools 3/4: wiring, stubs, integration and acceptance tests

### DIFF
--- a/.taskfiles/drmcp.yml
+++ b/.taskfiles/drmcp.yml
@@ -35,6 +35,7 @@ tasks:
         ENABLE_PREDICTIVE_TOOLS=true \
         ENABLE_WORKLOAD_TOOLS=true \
         ENABLE_FILES_API_TOOLS=true \
+        ENABLE_OTEL_TOOLS=true \
         MCP_SERVER_PORT={{.PORT}} uv run tests/drmcp/acceptance/ete_test_server.py &
       - |
         for i in {1..30}; do

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -101,6 +101,10 @@ class MCPToolConfig(DataRobotAppFrameworkBaseSettings):
         default=False,
         description="Enable/disable DataRobot Files API (filesystem) tools",
     )
+    enable_otel_tools: bool = Field(
+        default=False,
+        description="Enable/disable DataRobot OpenTelemetry observability tools",
+    )
 
     # Treat empty env values as unset so a runtime parameter (resolved by the base
     # settings sources) is not shadowed by an empty plain env var.

--- a/src/datarobot_genai/drmcp/core/constants.py
+++ b/src/datarobot_genai/drmcp/core/constants.py
@@ -34,4 +34,5 @@ MCP_CLI_OPTS: list[tuple[str, str | None, str | None]] = [
     ("vdb", None, "enable_vdb_tools"),
     ("workload", None, "enable_workload_tools"),
     ("files_api", None, "enable_files_api_tools"),
+    ("otel", None, "enable_otel_tools"),
 ]

--- a/src/datarobot_genai/drmcp/core/tool_config.py
+++ b/src/datarobot_genai/drmcp/core/tool_config.py
@@ -40,6 +40,7 @@ class ToolType(StrEnum):
     PANELS = "panels"
     WORKLOAD = "workload"
     FILES_API = "files_api"
+    OTEL = "otel"
 
 
 class ToolConfig(TypedDict):
@@ -142,6 +143,12 @@ TOOL_CONFIGS: dict[ToolType, ToolConfig] = {
         directory="files_api",
         package_prefix="datarobot_genai.drtools.files_api",
         config_field_name="enable_files_api_tools",
+    ),
+    ToolType.OTEL: ToolConfig(
+        name="otel",
+        directory="otel",
+        package_prefix="datarobot_genai.drtools.otel",
+        config_field_name="enable_otel_tools",
     ),
 }
 

--- a/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/dr_client_stubs.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 
 import polars as pl
 
+from datarobot_genai.drmcp.test_utils.stubs.otel_stubs import otel_stub_get
 from datarobot_genai.drmcp.test_utils.stubs.stub_rest_response import StubRestResponse
 from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import workload_stub_delete
 from datarobot_genai.drmcp.test_utils.stubs.workload_stubs import workload_stub_get
@@ -657,6 +658,9 @@ def test_create_dr_client() -> StubDRClient:
         workload_response = workload_stub_get(url, params, **kwargs)
         if workload_response is not None:
             return workload_response
+        otel_response = otel_stub_get(url, params, **kwargs)
+        if otel_response is not None:
+            return otel_response
         return _stub_get_non_workload(url, params)
 
     def stub_post(url: str, json: dict | None = None, **kwargs: Any) -> StubRestResponse:

--- a/src/datarobot_genai/drmcp/test_utils/stubs/otel_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/otel_stubs.py
@@ -1,0 +1,264 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""REST stubs for DataRobot OTel MCP tools (integration tests).
+
+Chained into :func:`datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs.stub_get`
+via the same fall-through-on-``None`` pattern as
+:func:`datarobot_genai.drmcp.test_utils.stubs.workload_stubs.workload_stub_get`.
+
+Tests under ``tests/drmcp/unit/otel_tools/`` build their own oversized/small trace
+fixtures (``tests/drmcp/unit/otel_tools/trace_factory.py``) because tier-2 stubs
+under ``src/`` cannot import from ``tests/``. This module's canned trace is
+deliberately small — tier 2 proves registration, the generated JSON schema, and
+serialization over the real MCP protocol, not truncation math (that is tier 1's
+job, already covered against realistic fixtures). It still carries one
+byte-identical duplicate group (``completion`` / ``gen_ai.task.output`` /
+``traceloop.entity.output``) so ``otel_trace_get(view="payloads")`` and
+``otel_span_payload_get``'s ``dropped_as_duplicate`` reporting exercise a real,
+non-trivial path end to end.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from datarobot_genai.drmcp.test_utils.stubs.stub_rest_response import StubRestResponse
+
+# Entity used by every otel_* stub route below. entity_type/entity_id are not
+# matched against the URL path (mirrors workload_stub_get's own
+# id-agnostic routing) except where a test specifically needs "no data for
+# this entity" — see STUB_OTEL_EMPTY_ENTITY_ID and _otel_stats_response.
+STUB_OTEL_ENTITY_TYPE = "deployment"
+STUB_OTEL_ENTITY_ID = "a" * 24  # 24 hex chars, per require_object_id.
+STUB_OTEL_EMPTY_ENTITY_ID = "e" * 24  # Valid id, but no OTel data for it (stats only).
+STUB_OTEL_TRACE_ID = "b" * 32  # 32 hex chars, per require_trace_id.
+STUB_OTEL_SPAN_ID_OK = "span-ok"
+STUB_OTEL_SPAN_ID_ERROR = "span-error"
+STUB_OTEL_MISSING_SPAN_ID = "span-does-not-exist"
+
+_DUPLICATED_TEXT = "A" * 250  # >= truncation.PAYLOAD_MIN_CHARS (200), so it counts as payload.
+
+_TRACE_SPANS: list[dict[str, Any]] = [
+    {
+        "span_id": STUB_OTEL_SPAN_ID_OK,
+        "parent_span_id": None,
+        "name": "root.span",
+        "status_code": "OK",
+        "status_message": "",
+        "kind": "SERVER",
+        "service_name": "stub-deployment",
+        "duration": 1.2,
+        "start_time": 1756000000000,
+        "attributes": {"gen_ai.system": "openai"},
+    },
+    {
+        "span_id": STUB_OTEL_SPAN_ID_ERROR,
+        "parent_span_id": STUB_OTEL_SPAN_ID_OK,
+        "name": "llm.chat",
+        "status_code": "ERROR",
+        "status_message": "RateLimitError: rate limit exceeded",
+        "kind": "CLIENT",
+        "service_name": "stub-deployment",
+        "duration": 3.4,
+        "start_time": 1756000000500,
+        "prompt": "stub prompt text",
+        "completion": _DUPLICATED_TEXT,
+        "attributes": {
+            # Byte-identical to 'completion' above: dropped as derived (§3), and
+            # reported under dropped_as_duplicate since 'completion' survives.
+            "gen_ai.task.output": _DUPLICATED_TEXT,
+            "traceloop.entity.output": _DUPLICATED_TEXT,
+            "gen_ai.usage.input_tokens": 42,
+        },
+    },
+]
+
+_TRACE_LIST_ROW: dict[str, Any] = {
+    "trace_id": STUB_OTEL_TRACE_ID,
+    "spans_count": len(_TRACE_SPANS),
+    "error_spans_count": 1,
+    "duration": 4.6,
+    "cost": 0.002,
+    "root_span_name": _TRACE_SPANS[0]["name"],
+    "root_service_name": _TRACE_SPANS[0]["service_name"],
+    "root_user_id": "stub_user_1",
+    "timestamp": "2026-08-24T00:00:00Z",
+    "prompt": "stub prompt text",
+    "completion": _DUPLICATED_TEXT[:80],
+    "gen_ai_usage_input_tokens": 120,
+    "gen_ai_usage_output_tokens": 45,
+    "tools": [{"name": "search", "call_count": 1}],
+}
+
+_LOG_LINE: dict[str, Any] = {
+    "timestamp": "2026-08-24T00:00:00Z",
+    "level": "error",
+    "message": "Stub error message",
+    "stacktrace": "Traceback (most recent call last):\n  ...\nRateLimitError",
+    "span_id": STUB_OTEL_SPAN_ID_ERROR,
+    "trace_id": STUB_OTEL_TRACE_ID,
+}
+
+_METRIC_CATALOG_ROW: dict[str, Any] = {
+    "otel_name": "gen_ai.tokens.total",
+    "description": "Total tokens consumed",
+    "metric_type": "counter",
+    "units": "1",
+}
+
+_AUTOCOLLECTED_METRIC_ROW: dict[str, Any] = {
+    "otel_name": "cpu.usage",
+    "display_name": "CPU Usage",
+    "aggregation": "average",
+    "level": "pod",
+    "unit": "percent",
+    "aggregated_value": 12.5,
+    "current_value": 14.0,
+    "maximumMetricOtelName": "cpu.usage.max",
+}
+
+_CONFIGURED_METRIC_ROW: dict[str, Any] = {
+    "otel_name": "custom.latency",
+    "display_name": "Custom Latency",
+    "aggregated_value": 250.0,
+    "current_value": 240.0,
+    "aggregation": "average",
+    "unit": "ms",
+    "buckets": None,
+}
+
+_ENTITY_STATS_ROWS: list[dict[str, Any]] = [
+    {"user_id": "stub_user_1", "span_count": 10, "metric_count": 2, "log_count": 100},
+    {"user_id": "stub_user_2", "span_count": 5, "metric_count": 1, "log_count": 20},
+]
+
+
+def _params_dict(params: dict[str, Any] | list[tuple[str, Any]] | None) -> dict[str, Any]:
+    if params is None:
+        return {}
+    if isinstance(params, dict):
+        return params
+    out: dict[str, Any] = {}
+    for key, value in params:
+        if key in out:
+            existing = out[key]
+            out[key] = [existing, value] if not isinstance(existing, list) else [*existing, value]
+        else:
+            out[key] = value
+    return out
+
+
+def _paginate(items: list[dict[str, Any]], params: dict[str, Any]) -> dict[str, Any]:
+    offset = int(params.get("offset", 0))
+    limit = int(params.get("limit", 100))
+    page = items[offset : offset + limit]
+    return {
+        "data": page,
+        "count": len(page),
+        "totalCount": len(items),
+        "next": None,
+        "previous": None,
+    }
+
+
+def _trace_envelope(spans: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "trace_id": STUB_OTEL_TRACE_ID,
+        "span_count": len(spans),
+        "duration": 4.6,
+        "root_span_name": spans[0]["name"] if spans else None,
+        "root_service_name": spans[0]["service_name"] if spans else None,
+        "spans": spans,
+        "metrics": {"prompt_guards": {}, "response_guards": {}},
+        "count": len(spans),
+        "offset": 0,
+        "limit": 100,
+        "total_count": len(spans),
+        "next": None,
+        "previous": None,
+    }
+
+
+def _otel_traces_response(segments: list[str], p: dict[str, Any]) -> StubRestResponse | None:
+    # GET otel/{entityType}/{entityId}/traces/  -> ["otel", et, eid, "traces"]
+    if len(segments) == 4 and segments[3] == "traces":
+        return StubRestResponse(_paginate([_TRACE_LIST_ROW], p))
+    # GET otel/{entityType}/{entityId}/traces/{traceId}/ -> [..., "traces", traceId]
+    if len(segments) == 5 and segments[3] == "traces":
+        return StubRestResponse(_trace_envelope(_TRACE_SPANS))
+    return None
+
+
+def _otel_logs_response(segments: list[str], p: dict[str, Any]) -> StubRestResponse | None:
+    # GET otel/{entityType}/{entityId}/logs/ -> ["otel", et, eid, "logs"]
+    if len(segments) == 4 and segments[3] == "logs":
+        return StubRestResponse(_paginate([_LOG_LINE], p))
+    return None
+
+
+def _otel_metrics_response(segments: list[str], p: dict[str, Any]) -> StubRestResponse | None:
+    # GET otel/{entityType}/{entityId}/metrics/{summary|values|autocollectedValues}/
+    if len(segments) != 5 or segments[3] != "metrics":
+        return None
+    kind = segments[4]
+    if kind == "summary":
+        return StubRestResponse({"data": [_METRIC_CATALOG_ROW]})
+    if kind == "values":
+        return StubRestResponse(
+            {
+                "start_time": "2026-08-24T00:00:00Z",
+                "end_time": "2026-08-24T01:00:00Z",
+                "metric_aggregations": [_CONFIGURED_METRIC_ROW],
+            }
+        )
+    if kind == "autocollectedValues":
+        return StubRestResponse({"data": [_AUTOCOLLECTED_METRIC_ROW]})
+    return None
+
+
+def _otel_stats_response(segments: list[str], p: dict[str, Any]) -> StubRestResponse | None:
+    # GET otel/stats/ -> ["otel", "stats"]
+    if segments != ["otel", "stats"]:
+        return None
+    service_name = p.get("serviceName")
+    if service_name == f"{STUB_OTEL_ENTITY_TYPE}-{STUB_OTEL_ENTITY_ID}":
+        return StubRestResponse({"data": _ENTITY_STATS_ROWS})
+    return StubRestResponse({"data": []})
+
+
+def otel_stub_get(
+    url: str, params: dict[str, Any] | list[tuple[str, Any]] | None = None, **kwargs: Any
+) -> StubRestResponse | None:
+    """Stub for ``rest_client.get()`` REST calls under ``otel/``.
+
+    Returns ``None`` for any URL it does not recognize so
+    :func:`datarobot_genai.drmcp.test_utils.stubs.dr_client_stubs.stub_get` can fall
+    through to the next handler, matching :func:`workload_stub_get`'s contract.
+    """
+    del kwargs
+    segments = url.rstrip("/").split("/")
+    if not segments or segments[0] != "otel":
+        return None
+    p = _params_dict(params)
+    for handler in (
+        _otel_traces_response,
+        _otel_logs_response,
+        _otel_metrics_response,
+        _otel_stats_response,
+    ):
+        response = handler(segments, p)
+        if response is not None:
+            return response
+    return None

--- a/src/datarobot_genai/drmcp/test_utils/stubs/workload_stubs.py
+++ b/src/datarobot_genai/drmcp/test_utils/stubs/workload_stubs.py
@@ -127,7 +127,10 @@ def _workload_get_response(url: str, p: dict[str, Any]) -> StubRestResponse | No
         response = StubRestResponse(
             {"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1}]}}
         )
-    elif "/stats" in url:
+    elif url.startswith("workloads/") and "/stats" in url:
+        # Scoped to the workloads/ prefix (real shape: workloads/{id}/stats) so this
+        # never shadows the unrelated GET otel/stats/ entity-stats endpoint, which
+        # also has "/stats" in it but is a completely different route.
         response = StubRestResponse(
             {
                 "requestCount": 120,

--- a/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
+++ b/src/datarobot_genai/drmcp/test_utils/tool_base_ete.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from .clients.base import LLMResponse
+from .clients.base import ToolCall
 
 
 class ToolCallTestExpectations(BaseModel):
@@ -36,6 +37,18 @@ class ToolCallTestExpectations(BaseModel):
     )
     parameters: dict[str, Any]
     result: str | dict[str, Any]
+    forbidden_parameter_values: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Parameter values the matched call's actual arguments must NOT equal, checked "
+            "leaf-by-leaf the same way `parameters` is checked (string comparison strips "
+            "whitespace). Only checked for keys the call actually supplied — an optional "
+            "argument the model omitted, which merely defaults to the forbidden value, is not "
+            "a violation, since the call itself did not choose it. Use this to assert a model "
+            "avoided a specific, costlier variant of an otherwise-matching call, e.g. "
+            "otel_trace_get called with view='summary' rather than an explicit view='payloads'."
+        ),
+    )
 
     def allowed_tool_names(self) -> set[str]:
         return {self.name, *self.acceptable_tool_names}
@@ -54,6 +67,18 @@ class ETETestExpectations(BaseModel):
     allow_unexpected_tool_calls: bool = True
     tool_calls_expected: list[ToolCallTestExpectations]
     llm_response_content_contains_expectations: list[str]
+    forbidden_tool_names: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Logical tool names that must not appear anywhere in the whole tool-call "
+            "sequence, checked against every actual call regardless of "
+            "allow_unexpected_tool_calls. Use this to assert a model never reached for a "
+            "specific worse tool at all (e.g. a redundant otel_trace_get once trace_id and "
+            "span_id are already known), while still allowing legitimate extra calls to the "
+            "*expected* tool -- such as a paginated otel_span_payload_get(field_offset=...) "
+            "continuation -- that an exact tool_calls_expected count would incorrectly reject."
+        ),
+    )
 
 
 SHOULD_NOT_BE_EMPTY = "SHOULD_NOT_BE_EMPTY"
@@ -201,6 +226,54 @@ def _check_dict_params_match(
     return True
 
 
+def _forbidden_parameter_violations(
+    forbidden: dict[str, Any],
+    actual: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the subset of ``forbidden`` that ``actual`` actually violates.
+
+    Only keys present in ``actual`` are considered — an optional argument the caller
+    omitted, which merely defaults to the forbidden value, was not a choice the call made and
+    is not a violation. A scalar leaf compares via :func:`_param_leaf_matches` (whitespace-
+    stripped for strings); a nested-dict leaf recurses via :func:`_check_dict_params_match`'s
+    own subset semantics, the same way ``parameters`` itself is checked, so a forbidden nested
+    shape is flagged even when ``actual``'s value carries additional fields alongside it.
+    """
+    violations: dict[str, Any] = {}
+    for key, value in forbidden.items():
+        if key not in actual:
+            continue
+        actual_v = actual[key]
+        if isinstance(value, dict):
+            if isinstance(actual_v, dict) and _check_dict_params_match(value, actual_v):
+                violations[key] = actual_v
+        elif _param_leaf_matches(value, actual_v):
+            violations[key] = actual_v
+    return violations
+
+
+def _forbidden_tool_call_violations(
+    forbidden_names: list[str],
+    tool_calls: list[ToolCall],
+) -> list[str]:
+    """Return the raw tool names in ``tool_calls`` that match a logical ``forbidden_names`` entry.
+
+    Checked against every call regardless of position or ``allow_unexpected_tool_calls`` — this
+    is a whole-sequence assertion ("the model never reached for tool X at all"), not a per-step
+    one, so it does not interact with how many times the *expected* tool is called. That keeps
+    a legitimate multi-call continuation of an expected tool (e.g. paging a truncated field with
+    ``field_offset``) from being mistaken for the specific worse call this is meant to catch.
+    """
+    if not forbidden_names:
+        return []
+    forbidden = set(forbidden_names)
+    return [
+        tool_call.tool_name
+        for tool_call in tool_calls
+        if _normalize_tool_name(tool_call.tool_name) in forbidden
+    ]
+
+
 def _check_dict_has_keys(
     expected: dict[str, Any],
     actual: dict[str, Any] | list[dict[str, Any]],
@@ -295,6 +368,8 @@ class ToolBaseE2E:
                 - tool_calls_expected: List of expected tool calls with their parameters and results
                 - allow_unexpected_tool_calls: Default True — expected calls must appear in order,
                   with optional extra calls allowed. Set False for strict exact count.
+                - forbidden_tool_names: Logical tool names that must never appear in the actual
+                  tool-call sequence, checked independently of allow_unexpected_tool_calls.
                 - llm_response_content_contains_expectations: Expected content in the LLM response
             openai_llm_client: The OpenAI LLM client
             mcp_session: The test session
@@ -307,6 +382,15 @@ class ToolBaseE2E:
         # Act
         response: LLMResponse = await openai_llm_client.process_prompt_with_mcp_support(
             prompt, mcp_session, output_file_name
+        )
+
+        violating_calls = _forbidden_tool_call_violations(
+            test_expectations.forbidden_tool_names, response.tool_calls
+        )
+        assert not violating_calls, (
+            f"Should not have called any of {sorted(set(test_expectations.forbidden_tool_names))}, "
+            f"but got: {violating_calls}\n"
+            f"{_build_failure_diagnostics(test_expectations.tool_calls_expected, response)}"
         )
 
         # sometimes llm are too smart and doesn't call tools especially for the case when file
@@ -374,6 +458,15 @@ class ToolBaseE2E:
                     f"but got: {tool_call.parameters}\n"
                     f"{diagnostics}"
                 )
+                if expected_call.forbidden_parameter_values:
+                    violations = _forbidden_parameter_violations(
+                        expected_call.forbidden_parameter_values, tool_call.parameters
+                    )
+                    assert not violations, (
+                        f"{canonical} should not have been called with {violations} — "
+                        f"got parameters: {tool_call.parameters}\n"
+                        f"{diagnostics}"
+                    )
                 if expected_call.result != SHOULD_NOT_BE_EMPTY:
                     expected_result = expected_call.result
                     if isinstance(expected_result, str):

--- a/src/datarobot_genai/drmcputils/ard_catalog.py
+++ b/src/datarobot_genai/drmcputils/ard_catalog.py
@@ -24,8 +24,8 @@ source of truth in :mod:`datarobot_genai.drmcputils.global_mcp_tools`
 which packages to load. So ARD and registration cannot drift: enabling/disabling a package or
 excluding a tool is a one-line edit there, reflected in both. Today's enabled surface is
 predictive (catalog / modeling / deployments / predictions), use_case, perplexity, tavily,
-dr_docs, vdb, files_api, and workload; connectors, panels, hosted/dynamic categories, and the
-``dr_mcpapps`` placeholder are not registered, so they are not advertised. ``file_upload`` is
+dr_docs, vdb, files_api, workload, and otel; connectors, panels, hosted/dynamic categories, and
+the ``dr_mcpapps`` placeholder are not registered, so they are not advertised. ``file_upload`` is
 excluded from files_api (needs local disk access).
 
 A cross-check test in global-mcp asserts this catalog matches ``register_all_drtools`` output,

--- a/src/datarobot_genai/drmcputils/global_mcp_tools.py
+++ b/src/datarobot_genai/drmcputils/global_mcp_tools.py
@@ -50,6 +50,7 @@ GLOBAL_MCP_PACKAGE_CATEGORIES: dict[str, frozenset[MCPToolCategory]] = {
     "vdb": frozenset({MCPToolCategory.DR_VDB}),
     "files_api": frozenset({MCPToolCategory.DR_FILE}),
     "workload": frozenset({MCPToolCategory.DR_WORKLOAD}),
+    "otel": frozenset({MCPToolCategory.DR_OTEL}),
 }
 
 # Per-tool opt-out applied on top of the enabled packages — the single place a specific tool is

--- a/tests/drmcp/acceptance/conftest.py
+++ b/tests/drmcp/acceptance/conftest.py
@@ -120,6 +120,102 @@ def nonexistent_workload_id() -> str:
     return "000000000000000000000001"
 
 
+@pytest.fixture(scope="session")
+def otel_entity_type() -> str:
+    """Entity type for OTel acceptance tests (``TEST_OTEL_ENTITY_TYPE`` env, default deployment)."""
+    return os.environ.get("TEST_OTEL_ENTITY_TYPE", "deployment")
+
+
+@pytest.fixture(scope="session")
+def otel_entity_id() -> str:
+    """Entity id for OTel acceptance tests, from the required ``TEST_OTEL_ENTITY_ID`` env var.
+
+    Unlike ``workload_id``, there is no generic "pick any entity" fallback here: these cases
+    need a *specific* entity known to carry real OTel data (and, for the failure-diagnosis
+    cases, at least one real error-status trace) -- an entity with zero OTel data would fail
+    these tests for a data reason, not a tool-description reason. See plan §9 step 9's own
+    reference deployment ("[agent-application-dev] [agent]", whose median trace is 807k
+    tokens) for the kind of entity this should point at.
+    """
+    value = os.environ.get("TEST_OTEL_ENTITY_ID")
+    if not value:
+        pytest.skip(
+            "TEST_OTEL_ENTITY_ID is not set; OTel acceptance cases need a specific entity "
+            "known to carry real OTel traces/logs to be meaningful."
+        )
+    return value
+
+
+@pytest.fixture(scope="session")
+def otel_failing_trace_id(dr_client: Any, otel_entity_type: str, otel_entity_id: str) -> str:
+    """Discover a trace_id with an error span on the configured OTel entity.
+
+    ``TEST_OTEL_FAILING_TRACE_ID`` overrides discovery. Otherwise this calls
+    ``GET otel/{entity_type}/{entity_id}/traces/?status=error&limit=1`` directly against the
+    DataRobot REST API (bypassing the LLM entirely), the same way ``workload_id`` discovers a
+    workload id -- tier 3 tests whether the model picks the right *tool and parameters* given a
+    real, live failure, not whether it can also locate one blind with no test-side help.
+    """
+    override = os.environ.get("TEST_OTEL_FAILING_TRACE_ID")
+    if override:
+        return override
+    try:
+        result = (
+            dr_client.client.get_client()
+            .get(
+                f"otel/{otel_entity_type}/{otel_entity_id}/traces/",
+                params={"status": "error", "limit": 1},
+            )
+            .json()
+        )
+        traces = result.get("traces") or result.get("data") or []
+        if not traces:
+            pytest.skip(
+                f"No error-status OTel traces found for {otel_entity_type}/{otel_entity_id}; "
+                "set TEST_OTEL_FAILING_TRACE_ID to a known failing trace_id to run this case."
+            )
+        return str(traces[0]["trace_id"])
+    except Exception as exc:
+        pytest.skip(f"Could not discover a failing OTel trace for acceptance tests: {exc}")
+
+
+@pytest.fixture(scope="session")
+def otel_failing_span_id(
+    dr_client: Any,
+    otel_entity_type: str,
+    otel_entity_id: str,
+    otel_failing_trace_id: str,
+) -> str:
+    """Discover the span_id of an ERROR-status span within ``otel_failing_trace_id``.
+
+    ``TEST_OTEL_FAILING_SPAN_ID`` overrides discovery. Otherwise this fetches the trace
+    directly (same bypass-the-LLM rationale as ``otel_failing_trace_id``) and picks the first
+    span whose ``status_code`` is ``ERROR``.
+    """
+    override = os.environ.get("TEST_OTEL_FAILING_SPAN_ID")
+    if override:
+        return override
+    try:
+        result = (
+            dr_client.client.get_client()
+            .get(
+                f"otel/{otel_entity_type}/{otel_entity_id}/traces/{otel_failing_trace_id}/",
+                params={"limit": 100},
+            )
+            .json()
+        )
+        spans = result.get("spans") or []
+        error_spans = [s for s in spans if s.get("status_code") == "ERROR"]
+        if not error_spans:
+            pytest.skip(
+                f"Trace {otel_failing_trace_id} has no ERROR-status span in the first 100; "
+                "set TEST_OTEL_FAILING_SPAN_ID to run this case."
+            )
+        return str(error_spans[0]["span_id"])
+    except Exception as exc:
+        pytest.skip(f"Could not discover a failing OTel span for acceptance tests: {exc}")
+
+
 _FILES_API_TEST_FILENAME = "acceptance-test.txt"
 _FILES_API_TEST_CONTENT = b"mcp files api acceptance test\n"
 

--- a/tests/drmcp/acceptance/conftest.py
+++ b/tests/drmcp/acceptance/conftest.py
@@ -13,14 +13,28 @@
 # limitations under the License.
 
 import os
+import time
+import uuid
 from pathlib import Path
 from typing import Any
 
 import pytest
+from datarobot.errors import ClientError
 from datarobot.fs import DataRobotFileSystem
 
 from datarobot_genai.drmcp.test_utils.clients.dr_gateway import DRLLMGatewayMCPClient
 from datarobot_genai.drmcp.test_utils.mcp_utils_ete import get_dr_llm_gateway_client_config
+from tests.drmcp.helpers.otel_entity import OTEL_ACCEPTANCE_ENTITY_TYPE
+from tests.drmcp.helpers.otel_entity import USE_CASE_NAME_PREFIX
+from tests.drmcp.helpers.otel_entity import OtelAcceptanceEntity
+from tests.drmcp.helpers.otel_entity import cleanup_use_case
+from tests.drmcp.helpers.otel_entity import emit_failing_agent_run
+from tests.drmcp.helpers.otel_entity import list_error_span_ids
+from tests.drmcp.helpers.otel_entity import list_error_trace_ids
+from tests.drmcp.helpers.otel_entity import otel_ingest_base_url
+from tests.drmcp.helpers.otel_entity import otel_ingest_headers
+from tests.drmcp.helpers.otel_entity import provision_use_case
+from tests.drmcp.helpers.otel_entity import wait_for_otel_ingestion
 
 # Acceptance tests require real DataRobot credentials from .env (mcp_utils_ete loads it on import).
 os.environ["MCP_USE_CLIENT_STUBS"] = "false"
@@ -120,100 +134,167 @@ def nonexistent_workload_id() -> str:
     return "000000000000000000000001"
 
 
-@pytest.fixture(scope="session")
-def otel_entity_type() -> str:
-    """Entity type for OTel acceptance tests (``TEST_OTEL_ENTITY_TYPE`` env, default deployment)."""
-    return os.environ.get("TEST_OTEL_ENTITY_TYPE", "deployment")
+def _external_otel_entity(dr_client: Any, entity_id: str) -> OtelAcceptanceEntity:
+    """Resolve ``TEST_OTEL_ENTITY_ID`` (+ optional type/trace/span overrides) to an entity.
 
-
-@pytest.fixture(scope="session")
-def otel_entity_id() -> str:
-    """Entity id for OTel acceptance tests, from the required ``TEST_OTEL_ENTITY_ID`` env var.
-
-    Unlike ``workload_id``, there is no generic "pick any entity" fallback here: these cases
-    need a *specific* entity known to carry real OTel data (and, for the failure-diagnosis
-    cases, at least one real error-status trace) -- an entity with zero OTel data would fail
-    these tests for a data reason, not a tool-description reason. See plan §9 step 9's own
-    reference deployment ("[agent-application-dev] [agent]", whose median trace is 807k
-    tokens) for the kind of entity this should point at.
+    The opt-in path for running the cases against a *real*, externally-instrumented
+    entity -- e.g. plan §9 step 9's reference deployment, whose median trace is 807k
+    tokens -- rather than the small provisioned one. ``TEST_OTEL_FAILING_TRACE_ID`` /
+    ``TEST_OTEL_FAILING_SPAN_ID`` override discovery; otherwise the newest error-status
+    trace and its first ERROR span are looked up directly against the REST API (bypassing
+    the LLM entirely) -- tier 3 tests whether the model picks the right *tool and
+    parameters* given a real, live failure, not whether it can also locate one blind.
     """
-    value = os.environ.get("TEST_OTEL_ENTITY_ID")
-    if not value:
-        pytest.skip(
-            "TEST_OTEL_ENTITY_ID is not set; OTel acceptance cases need a specific entity "
-            "known to carry real OTel traces/logs to be meaningful."
-        )
-    return value
-
-
-@pytest.fixture(scope="session")
-def otel_failing_trace_id(dr_client: Any, otel_entity_type: str, otel_entity_id: str) -> str:
-    """Discover a trace_id with an error span on the configured OTel entity.
-
-    ``TEST_OTEL_FAILING_TRACE_ID`` overrides discovery. Otherwise this calls
-    ``GET otel/{entity_type}/{entity_id}/traces/?status=error&limit=1`` directly against the
-    DataRobot REST API (bypassing the LLM entirely), the same way ``workload_id`` discovers a
-    workload id -- tier 3 tests whether the model picks the right *tool and parameters* given a
-    real, live failure, not whether it can also locate one blind with no test-side help.
-    """
-    override = os.environ.get("TEST_OTEL_FAILING_TRACE_ID")
-    if override:
-        return override
-    try:
-        result = (
-            dr_client.client.get_client()
-            .get(
-                f"otel/{otel_entity_type}/{otel_entity_id}/traces/",
-                params={"status": "error", "limit": 1},
-            )
-            .json()
-        )
-        traces = result.get("traces") or result.get("data") or []
-        if not traces:
+    entity_type = os.environ.get("TEST_OTEL_ENTITY_TYPE", "deployment")
+    rest_client = dr_client.client.get_client()
+    trace_id = os.environ.get("TEST_OTEL_FAILING_TRACE_ID")
+    if not trace_id:
+        try:
+            trace_ids = list_error_trace_ids(rest_client, entity_type, entity_id)
+        except Exception as exc:
+            pytest.skip(f"Could not discover a failing OTel trace for acceptance tests: {exc}")
+        if not trace_ids:
             pytest.skip(
-                f"No error-status OTel traces found for {otel_entity_type}/{otel_entity_id}; "
-                "set TEST_OTEL_FAILING_TRACE_ID to a known failing trace_id to run this case."
+                f"No error-status OTel traces found for {entity_type}/{entity_id}; set "
+                "TEST_OTEL_FAILING_TRACE_ID to a known failing trace_id to run this case."
             )
-        return str(traces[0]["trace_id"])
-    except Exception as exc:
-        pytest.skip(f"Could not discover a failing OTel trace for acceptance tests: {exc}")
+        trace_id = trace_ids[0]
+    span_id = os.environ.get("TEST_OTEL_FAILING_SPAN_ID")
+    if not span_id:
+        try:
+            span_ids = list_error_span_ids(rest_client, entity_type, entity_id, trace_id)
+        except Exception as exc:
+            pytest.skip(f"Could not discover a failing OTel span for acceptance tests: {exc}")
+        if not span_ids:
+            pytest.skip(
+                f"Trace {trace_id} has no ERROR-status span in the first 100; set "
+                "TEST_OTEL_FAILING_SPAN_ID to run this case."
+            )
+        span_id = span_ids[0]
+    return OtelAcceptanceEntity(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        failing_trace_id=trace_id,
+        failing_span_id=span_id,
+    )
 
 
 @pytest.fixture(scope="session")
-def otel_failing_span_id(
-    dr_client: Any,
-    otel_entity_type: str,
-    otel_entity_id: str,
-    otel_failing_trace_id: str,
-) -> str:
-    """Discover the span_id of an ERROR-status span within ``otel_failing_trace_id``.
+def otel_acceptance_entity(request: pytest.FixtureRequest, dr_client: Any) -> OtelAcceptanceEntity:
+    """Provision (or resolve) the entity the OTel acceptance cases run against.
 
-    ``TEST_OTEL_FAILING_SPAN_ID`` overrides discovery. Otherwise this fetches the trace
-    directly (same bypass-the-LLM rationale as ``otel_failing_trace_id``) and picks the first
-    span whose ``status_code`` is ``ERROR``.
+    With no configuration this creates a Use Case (OTel entity type
+    ``experiment_container``), OTLP-exports a small failing agentic run into it -- one
+    error-status trace whose ``llm.chat`` span errored with a 429 and carries LLM output,
+    one healthy trace, and an error-level log line correlated to the failing span -- waits
+    until the REST API can read all of it back, and deletes everything at session end.
+    That gives the three tier-3 cases a reproducible entity with exactly the data they
+    assume, instead of depending on whatever real entity someone happens to have.
+
+    Overrides:
+
+    * ``TEST_OTEL_ENTITY_ID`` (+ ``TEST_OTEL_ENTITY_TYPE``, default ``deployment``) --
+      skip provisioning and run against that entity instead; see
+      :func:`_external_otel_entity`.
+    * ``TEST_OTEL_KEEP_ENTITY`` -- leave the provisioned Use Case and its telemetry in
+      place for inspection (``dr xp --entity-id <id>``) instead of deleting them.
     """
-    override = os.environ.get("TEST_OTEL_FAILING_SPAN_ID")
+    override = os.environ.get("TEST_OTEL_ENTITY_ID")
     if override:
-        return override
+        return _external_otel_entity(dr_client, override)
+
+    rest_client = dr_client.client.get_client()
+    run_label = uuid.uuid4().hex[:8]
+    name = (
+        f"{USE_CASE_NAME_PREFIX} {time.strftime('%Y-%m-%d %H:%M:%SZ', time.gmtime())} {run_label}"
+    )
     try:
-        result = (
-            dr_client.client.get_client()
-            .get(
-                f"otel/{otel_entity_type}/{otel_entity_id}/traces/{otel_failing_trace_id}/",
-                params={"limit": 100},
-            )
-            .json()
+        use_case_id = provision_use_case(
+            dr_client,
+            name=name,
+            description=(
+                "Created by datarobot-genai's OTel MCP acceptance tests "
+                "(tests/drmcp/acceptance/test_otel_tools.py) as an OTel telemetry target. "
+                "Deleted automatically at the end of the run; safe to delete if left behind."
+            ),
         )
-        spans = result.get("spans") or []
-        error_spans = [s for s in spans if s.get("status_code") == "ERROR"]
-        if not error_spans:
-            pytest.skip(
-                f"Trace {otel_failing_trace_id} has no ERROR-status span in the first 100; "
-                "set TEST_OTEL_FAILING_SPAN_ID to run this case."
-            )
-        return str(error_spans[0]["span_id"])
     except Exception as exc:
-        pytest.skip(f"Could not discover a failing OTel span for acceptance tests: {exc}")
+        pytest.skip(f"Could not create a Use Case for the OTel acceptance tests: {exc}")
+
+    def _teardown() -> None:
+        for warning in cleanup_use_case(dr_client, rest_client, use_case_id):
+            print(f"Warning: {warning}")
+
+    if os.environ.get("TEST_OTEL_KEEP_ENTITY"):
+        print(
+            f"TEST_OTEL_KEEP_ENTITY set: keeping use case {use_case_id} "
+            f"(dr xp --entity-id {use_case_id} --enable-logs)"
+        )
+    else:
+        request.addfinalizer(_teardown)
+
+    ingest_base_url = otel_ingest_base_url(rest_client.endpoint)
+    try:
+        emitted = emit_failing_agent_run(
+            ingest_base_url=ingest_base_url,
+            headers=otel_ingest_headers(
+                OTEL_ACCEPTANCE_ENTITY_TYPE,
+                use_case_id,
+                rest_client.token or os.environ.get("DATAROBOT_API_TOKEN", ""),
+            ),
+            run_label=run_label,
+        )
+    except RuntimeError as exc:
+        pytest.fail(f"OTLP export to {ingest_base_url} for use case {use_case_id} failed: {exc}")
+    try:
+        elapsed = wait_for_otel_ingestion(
+            rest_client, OTEL_ACCEPTANCE_ENTITY_TYPE, use_case_id, emitted
+        )
+    except ClientError as exc:
+        if exc.status_code == 403:
+            pytest.skip(
+                f"Cannot read OTel data for {OTEL_ACCEPTANCE_ENTITY_TYPE}/{use_case_id} "
+                f"(403 -- usually the GENAI_EXPERIMENTATION flag or the "
+                f"AGENTIC_PREDICTIVE_GOVERNANCE_BUILDER seat license): {exc}"
+            )
+        raise
+    except TimeoutError as exc:
+        pytest.fail(str(exc))
+    print(
+        f"Provisioned OTel acceptance entity {OTEL_ACCEPTANCE_ENTITY_TYPE}/{use_case_id}: "
+        f"failing trace {emitted.failing_trace_id} span {emitted.failing_span_id} "
+        f"(readable {elapsed:.0f}s after export)"
+    )
+    return OtelAcceptanceEntity(
+        entity_type=OTEL_ACCEPTANCE_ENTITY_TYPE,
+        entity_id=use_case_id,
+        failing_trace_id=emitted.failing_trace_id,
+        failing_span_id=emitted.failing_span_id,
+    )
+
+
+@pytest.fixture(scope="session")
+def otel_entity_type(otel_acceptance_entity: OtelAcceptanceEntity) -> str:
+    """Entity type for OTel acceptance tests (``experiment_container`` when provisioned)."""
+    return otel_acceptance_entity.entity_type
+
+
+@pytest.fixture(scope="session")
+def otel_entity_id(otel_acceptance_entity: OtelAcceptanceEntity) -> str:
+    """Entity id for OTel acceptance tests (the provisioned Use Case id by default)."""
+    return otel_acceptance_entity.entity_id
+
+
+@pytest.fixture(scope="session")
+def otel_failing_trace_id(otel_acceptance_entity: OtelAcceptanceEntity) -> str:
+    """trace_id of an error-status trace on the OTel acceptance entity."""
+    return otel_acceptance_entity.failing_trace_id
+
+
+@pytest.fixture(scope="session")
+def otel_failing_span_id(otel_acceptance_entity: OtelAcceptanceEntity) -> str:
+    """span_id of an ERROR-status span within ``otel_failing_trace_id``."""
+    return otel_acceptance_entity.failing_span_id
 
 
 _FILES_API_TEST_FILENAME = "acceptance-test.txt"

--- a/tests/drmcp/acceptance/test_otel_tools.py
+++ b/tests/drmcp/acceptance/test_otel_tools.py
@@ -28,11 +28,16 @@ first. The three cases below are the ones plan §7 names explicitly:
   directly is the right move, not re-fetching the whole trace again.
 * "any errors in the logs for this deployment?" -> otel_logs_list(level="error").
 
-These need a real, already-failing entity to be meaningful (an entity with no
+These need an entity that is actually failing to be meaningful (an entity with no
 OTel data, or no error traces, would fail these tests for a data reason, not a
-tool-description reason) -- see the ``otel_entity_id``/``otel_failing_trace_id``/
-``otel_failing_span_id`` fixtures in conftest.py for how that entity is
-configured or discovered.
+tool-description reason). Rather than depend on a real one existing somewhere,
+the ``otel_acceptance_entity`` fixture in conftest.py provisions its own: a Use
+Case (``experiment_container``) into which it OTLP-exports a small failing
+agentic run -- an ``agent.run`` whose ``llm.chat`` span errored with a 429 and
+carries LLM output, plus an error-level log line correlated to that span --
+waits for the REST API to read it back, and deletes it at session end (see
+``tests/drmcp/helpers/otel_entity.py``). ``TEST_OTEL_ENTITY_ID`` opts back into
+running against a real, externally-instrumented entity instead.
 """
 
 import inspect
@@ -124,7 +129,7 @@ def expectations_for_show_llm_output_on_failing_span(
 
 
 @pytest.fixture(scope="session")
-def expectations_for_logs_errors_for_deployment(
+def expectations_for_logs_errors_for_entity(
     otel_entity_type: str, otel_entity_id: str
 ) -> ETETestExpectations:
     return ETETestExpectations(
@@ -203,12 +208,12 @@ class TestOtelToolsE2E(ToolBaseE2E):
                 test_name,
             )
 
-    async def test_logs_errors_for_deployment(
+    async def test_logs_errors_for_entity(
         self,
         llm_client: Any,
         otel_entity_type: str,
         otel_entity_id: str,
-        expectations_for_logs_errors_for_deployment: ETETestExpectations,
+        expectations_for_logs_errors_for_entity: ETETestExpectations,
     ) -> None:
         """LLM checks for error-level OTel logs via otel_logs_list(level="error")."""
         prompt = (
@@ -217,10 +222,10 @@ class TestOtelToolsE2E(ToolBaseE2E):
         )
         async with ete_test_mcp_session() as session:
             frame = inspect.currentframe()
-            test_name = frame.f_code.co_name if frame else "test_logs_errors_for_deployment"
+            test_name = frame.f_code.co_name if frame else "test_logs_errors_for_entity"
             await self._run_test_with_expectations(
                 prompt,
-                expectations_for_logs_errors_for_deployment,
+                expectations_for_logs_errors_for_entity,
                 llm_client,
                 session,
                 test_name,

--- a/tests/drmcp/acceptance/test_otel_tools.py
+++ b/tests/drmcp/acceptance/test_otel_tools.py
@@ -1,0 +1,227 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Acceptance tests for OTel MCP tools (plan §7 tier 3).
+
+Unlike the other tiers, this one measures tool-*description* quality: whether a
+Sonnet-class model reaches for the right tool, and the right variant of that tool,
+from a plain-English question -- without churning through the expensive option
+first. The three cases below are the ones plan §7 names explicitly:
+
+* "why did this trace fail?" -> otel_traces_list(status="error") then
+  otel_trace_get, and specifically NOT otel_trace_get(view="payloads") on that
+  first hop into the trace -- summary is enough to name the failing span; the
+  much larger payloads view is not the tool this question calls for.
+* "show me the LLM output on the failing span" -> otel_span_payload_get, not a
+  second otel_trace_get -- when the trace and span are already known, drilling in
+  directly is the right move, not re-fetching the whole trace again.
+* "any errors in the logs for this deployment?" -> otel_logs_list(level="error").
+
+These need a real, already-failing entity to be meaningful (an entity with no
+OTel data, or no error traces, would fail these tests for a data reason, not a
+tool-description reason) -- see the ``otel_entity_id``/``otel_failing_trace_id``/
+``otel_failing_span_id`` fixtures in conftest.py for how that entity is
+configured or discovered.
+"""
+
+import inspect
+import os
+from typing import Any
+
+import pytest
+
+from datarobot_genai.drmcp import ETETestExpectations
+from datarobot_genai.drmcp import ToolBaseE2E
+from datarobot_genai.drmcp import ToolCallTestExpectations
+from datarobot_genai.drmcp import ete_test_mcp_session
+from datarobot_genai.drmcp.test_utils.tool_base_ete import SHOULD_NOT_BE_EMPTY
+
+
+@pytest.fixture(scope="session")
+def expectations_for_why_did_this_trace_fail(
+    otel_entity_type: str, otel_entity_id: str
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="otel_traces_list",
+                parameters={
+                    "entity_type": otel_entity_type,
+                    "entity_id": otel_entity_id,
+                    "status": "error",
+                },
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+            ToolCallTestExpectations(
+                name="otel_trace_get",
+                parameters={
+                    "entity_type": otel_entity_type,
+                    "entity_id": otel_entity_id,
+                },
+                result=SHOULD_NOT_BE_EMPTY,
+                # The whole point of this case: otel_trace_get's summary view is
+                # enough to name the failing span. An explicit view="payloads" on
+                # this first hop means the description failed to steer the model
+                # away from the much larger, budget-truncated view.
+                forbidden_parameter_values={"view": "payloads"},
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "error",
+            "fail",
+            "failed",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_show_llm_output_on_failing_span(
+    otel_entity_type: str,
+    otel_entity_id: str,
+    otel_failing_trace_id: str,
+    otel_failing_span_id: str,
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        # trace_id and span_id are already known, so otel_span_payload_get is the only
+        # tool call this case expects -- but a legitimate paging continuation of that
+        # same call (field_offset=... after a truncated field, which the tool's own
+        # description invites) must stay allowed. What this case actually forbids, per
+        # the plan's literal wording, is "a second otel_trace_get": re-fetching the
+        # whole trace to get what the span_id already identifies is exactly the churn
+        # this case exists to catch -- so that is asserted directly, rather than via a
+        # blanket exact-tool-call-count that would also reject the legitimate
+        # continuation call above.
+        forbidden_tool_names=["otel_trace_get"],
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="otel_span_payload_get",
+                parameters={
+                    "entity_type": otel_entity_type,
+                    "entity_id": otel_entity_id,
+                    "trace_id": otel_failing_trace_id,
+                    "span_id": otel_failing_span_id,
+                },
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "output",
+            "completion",
+            "response",
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def expectations_for_logs_errors_for_deployment(
+    otel_entity_type: str, otel_entity_id: str
+) -> ETETestExpectations:
+    return ETETestExpectations(
+        tool_calls_expected=[
+            ToolCallTestExpectations(
+                name="otel_logs_list",
+                parameters={
+                    "entity_type": otel_entity_type,
+                    "entity_id": otel_entity_id,
+                    "level": "error",
+                },
+                result=SHOULD_NOT_BE_EMPTY,
+            ),
+        ],
+        llm_response_content_contains_expectations=[
+            "error",
+            "log",
+        ],
+    )
+
+
+@pytest.mark.skipif(
+    not os.getenv("ENABLE_OTEL_TOOLS"),
+    reason="OTel tools are not enabled on the MCP server",
+)
+@pytest.mark.asyncio
+class TestOtelToolsE2E(ToolBaseE2E):
+    """End-to-end acceptance tests for OTel MCP tools."""
+
+    async def test_why_did_this_trace_fail(
+        self,
+        llm_client: Any,
+        otel_entity_type: str,
+        otel_entity_id: str,
+        expectations_for_why_did_this_trace_fail: ETETestExpectations,
+    ) -> None:
+        """LLM diagnoses a failing trace via otel_traces_list then otel_trace_get(summary)."""
+        prompt = (
+            f"Something went wrong recently with {otel_entity_type} '{otel_entity_id}'. "
+            "Why did one of its OTel traces fail? Investigate and explain the root cause."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_why_did_this_trace_fail"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_why_did_this_trace_fail,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_show_llm_output_on_failing_span(
+        self,
+        llm_client: Any,
+        otel_entity_type: str,
+        otel_entity_id: str,
+        otel_failing_trace_id: str,
+        otel_failing_span_id: str,
+        expectations_for_show_llm_output_on_failing_span: ETETestExpectations,
+    ) -> None:
+        """LLM fetches the LLM output on an already-identified failing span directly."""
+        prompt = (
+            f"In OTel trace '{otel_failing_trace_id}' for {otel_entity_type} "
+            f"'{otel_entity_id}', span '{otel_failing_span_id}' is the one that errored. "
+            "Show me the LLM output (the completion text) that span produced."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_show_llm_output_on_failing_span"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_show_llm_output_on_failing_span,
+                llm_client,
+                session,
+                test_name,
+            )
+
+    async def test_logs_errors_for_deployment(
+        self,
+        llm_client: Any,
+        otel_entity_type: str,
+        otel_entity_id: str,
+        expectations_for_logs_errors_for_deployment: ETETestExpectations,
+    ) -> None:
+        """LLM checks for error-level OTel logs via otel_logs_list(level="error")."""
+        prompt = (
+            f"Are there any errors in the OTel logs for {otel_entity_type} "
+            f"'{otel_entity_id}'? If so, summarize what's failing."
+        )
+        async with ete_test_mcp_session() as session:
+            frame = inspect.currentframe()
+            test_name = frame.f_code.co_name if frame else "test_logs_errors_for_deployment"
+            await self._run_test_with_expectations(
+                prompt,
+                expectations_for_logs_errors_for_deployment,
+                llm_client,
+                session,
+                test_name,
+            )

--- a/tests/drmcp/helpers/otel_entity.py
+++ b/tests/drmcp/helpers/otel_entity.py
@@ -1,0 +1,487 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-provisioned OTel entity for the tier-3 OTel acceptance cases.
+
+The acceptance cases in ``tests/drmcp/acceptance/test_otel_tools.py`` need an entity
+that carries OTel data with a known shape: at least one error-status trace whose
+failing span holds LLM output, and at least one error-level log line. Pointing them
+at whatever real entity happens to exist is not reproducible -- its traces change,
+get deleted, or belong to a cluster the next developer cannot reach.
+
+So the fixture builds its own. The entity is a **Use Case** (OTel entity type
+``experiment_container``), which is the same target the ``dr xp`` experimentation
+dashboard and the ``datarobot-external-agent-monitoring`` skill use for
+externally-instrumented agents: creating one needs nothing but an API token, and
+telemetry is attached to it purely by the ``X-DataRobot-Entity-Id`` header on the
+OTLP export, so no deployment, model, or workload has to exist first.
+
+Three steps, each a plain function so the conftest stays a thin pytest wrapper:
+
+1. :func:`provision_use_case` -- create the Use Case.
+2. :func:`emit_failing_agent_run` -- OTLP/HTTP-export a small but realistically
+   shaped agentic run into it: one failing trace (``agent.run`` -> tool call ->
+   ``llm.chat`` that errors with a 429 and carries ``gen_ai.*`` prompt/completion
+   attributes) plus one healthy trace, and an error-level log line correlated to
+   the failing span. Every export result is recorded so an auth/entity/flag
+   problem fails loudly instead of surfacing minutes later as a polling timeout.
+3. :func:`wait_for_otel_ingestion` -- poll the same ``GET /otel/...`` REST endpoints
+   the tools read until the failing trace, its ERROR span, and the error log are
+   all visible. Ingestion is asynchronous (collector -> Elasticsearch), and the
+   tests are about tool selection, not ingest latency, so the wait happens here.
+
+:func:`cleanup_use_case` deletes the telemetry and the Use Case at session end.
+"""
+
+import dataclasses
+import json
+import logging
+import re
+import time
+from collections.abc import Sequence
+from typing import Any
+
+from datarobot.errors import ClientError
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs import LoggingHandler
+from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace import Status
+from opentelemetry.trace import StatusCode
+
+# The OTel entity type of a Use Case, on the wire and in the tools' ``entity_type``.
+OTEL_ACCEPTANCE_ENTITY_TYPE = "experiment_container"
+
+# Prefix every provisioned Use Case carries, so a leftover from an interrupted run is
+# recognisable in the UI and safe to delete by hand.
+USE_CASE_NAME_PREFIX = "MCP OTel acceptance"
+
+# Realistic agentic content. Kept short: these tests measure tool selection, not
+# truncation -- the oversized-trace population is covered by the tier-1 fixtures.
+_QUESTION = (
+    "Which of my deployments are erroring right now, and does the Q3 renewal quote "
+    "already include the negotiated multi-year discount?"
+)
+_TOOL_RESULT = (
+    "14 rows returned from deployments_list, of which 3 are in an errored state and 1 "
+    "has been stuck in provisioning for 41 minutes."
+)
+_PARTIAL_COMPLETION = (
+    "Three deployments are currently erroring: churn-scorer-prod, renewal-quote-v2 and "
+    "support-triage. The renewal-quote-v2 failure is the one that affects the Q3 quote, "
+    "because that deployment computes the multi-year discount. Before I can confirm the "
+    "corrected total I need to"
+)
+_OK_COMPLETION = (
+    "All 14 deployments are healthy. The Q3 renewal quote already includes the "
+    "negotiated 12% multi-year discount, so the total of $184,300 stands."
+)
+_LLM_ERROR = (
+    "HTTPError 429 Too Many Requests from the LLM gateway after 3 retries with exponential backoff"
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class EmittedTelemetry:
+    """What :func:`emit_failing_agent_run` sent, as the read API will identify it."""
+
+    failing_trace_id: str
+    failing_span_id: str
+    ok_trace_id: str
+    error_log_message: str
+    run_label: str
+
+
+@dataclasses.dataclass(frozen=True)
+class OtelAcceptanceEntity:
+    """The entity the OTel acceptance cases run against, provisioned or external."""
+
+    entity_type: str
+    entity_id: str
+    failing_trace_id: str
+    failing_span_id: str
+
+
+def otel_ingest_base_url(api_endpoint: str) -> str:
+    """Derive the OTLP ingest base (``https://host/otel``) from a ``/api/v2`` endpoint.
+
+    The collector ingress lives at the same host as the REST API but off ``/otel``, not
+    under ``/api/v2`` -- the same derivation the monitoring skill's
+    ``create_use_case.py`` and this repo's ``core/telemetry/datarobot_otel.py`` make.
+    """
+    base = api_endpoint.rstrip("/").removesuffix("/api/v2")
+    return f"{base}/otel"
+
+
+def otel_ingest_headers(entity_type: str, entity_id: str, api_token: str) -> dict[str, str]:
+    """Headers that route an OTLP export to one entity and authenticate it."""
+    return {
+        "X-DataRobot-Entity-Id": f"{entity_type}-{entity_id}",
+        "X-DataRobot-Api-Key": api_token,
+    }
+
+
+def otel_api_field(row: dict[str, Any], name: str) -> Any:
+    """Read one snake_case field from a *raw* ``/otel`` row, whichever case the API used.
+
+    These helpers call the REST API directly rather than going through
+    ``OtelQueryApiClient``, so they see drflask's camelCase on the wire (``traceId``,
+    ``statusCode``) rather than the snake_case that client normalizes to. Accepting both
+    spellings keeps them working on either side of that normalization -- and, more to the
+    point, stops a spelling mismatch from being swallowed as a ``pytest.skip``.
+    """
+    if name in row:
+        return row[name]
+    return row.get(re.sub(r"_(\w)", lambda m: m.group(1).upper(), name))
+
+
+# --- provisioning ---------------------------------------------------------------------
+
+
+def provision_use_case(dr_module: Any, *, name: str, description: str) -> str:
+    """Create a Use Case through the configured ``datarobot`` SDK; return its id."""
+    use_case = dr_module.UseCase.create(name=name, description=description)
+    return str(use_case.id)
+
+
+def cleanup_use_case(dr_module: Any, rest_client: Any, use_case_id: str) -> list[str]:
+    """Best-effort teardown: delete the entity's traces and logs, then the Use Case.
+
+    Deleting the Use Case does not delete the telemetry attached to it (that lives in
+    the OTel store, keyed by ``experiment_container-<id>``), so both are removed. Each
+    step is independent -- a 403 on the OTel deletes must not leave the Use Case behind.
+    Returns the failures as messages rather than raising: teardown runs in a session
+    finalizer, where an exception would only mask the test results.
+    """
+    warnings: list[str] = []
+    for signal in ("traces", "logs"):
+        try:
+            rest_client.delete(f"otel/{OTEL_ACCEPTANCE_ENTITY_TYPE}/{use_case_id}/{signal}/")
+        except Exception as exc:  # noqa: BLE001 - reported, not raised, in a finalizer
+            warnings.append(f"could not delete OTel {signal} for use case {use_case_id}: {exc}")
+    try:
+        dr_module.UseCase.delete(use_case_id)
+    except Exception as exc:  # noqa: BLE001 - reported, not raised, in a finalizer
+        warnings.append(f"could not delete use case {use_case_id}: {exc}")
+    return warnings
+
+
+# --- emission -------------------------------------------------------------------------
+
+
+class _RecordingSpanExporter(OTLPSpanExporter):
+    """OTLP span exporter that keeps every export result.
+
+    ``SimpleSpanProcessor`` swallows export failures (it logs and moves on), so without
+    this a bad token or a mistyped entity id would only show up as a polling timeout
+    minutes later. Recording the results lets :func:`emit_failing_agent_run` fail at
+    the export, with the HTTP status the exporter logged, instead.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.results: list[Any] = []
+        self.errors: list[str] = []
+
+    def export(self, spans: Sequence[Any]) -> Any:
+        try:
+            result = super().export(spans)
+        except Exception as exc:  # noqa: BLE001 - recorded so the caller can raise
+            self.errors.append(repr(exc))
+            raise
+        self.results.append(result)
+        return result
+
+
+class _RecordingLogExporter(OTLPLogExporter):
+    """Log-record twin of :class:`_RecordingSpanExporter`."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.results: list[Any] = []
+        self.errors: list[str] = []
+
+    def export(self, batch: Sequence[Any]) -> Any:
+        try:
+            result = super().export(batch)
+        except Exception as exc:  # noqa: BLE001 - recorded so the caller can raise
+            self.errors.append(repr(exc))
+            raise
+        self.results.append(result)
+        return result
+
+
+def _hex_trace_id(span: Any) -> str:
+    return format(span.get_span_context().trace_id, "032x")
+
+
+def _hex_span_id(span: Any) -> str:
+    return format(span.get_span_context().span_id, "016x")
+
+
+def _set_gen_ai_prompt(span: Any, prompt: str) -> None:
+    # Both the flat attribute the tracing UI's Prompt column reads and the indexed
+    # ``gen_ai.prompt.N.*`` form the platform's enrich_trace folds into
+    # ``gen_ai.input.messages`` -> the trace's ``prompt`` field.
+    span.set_attribute("gen_ai.prompt", prompt)
+    span.set_attribute("gen_ai.prompt.0.role", "user")
+    span.set_attribute("gen_ai.prompt.0.content", prompt)
+
+
+def _set_gen_ai_completion(span: Any, completion: str) -> None:
+    span.set_attribute("gen_ai.completion", completion)
+    span.set_attribute("gen_ai.completion.0.role", "assistant")
+    span.set_attribute("gen_ai.completion.0.content", completion)
+    # Traceloop-instrumented agents write the same text again under their own key; the
+    # byte-identical twin is what the tools' dedup reports as ``dropped_as_duplicate``.
+    span.set_attribute("traceloop.entity.output", completion)
+
+
+def _emit_ok_run(tracer: Any, logger: logging.Logger, run_label: str) -> str:
+    with tracer.start_as_current_span("agent.run", kind=SpanKind.SERVER) as root:
+        root.set_attribute("datarobot.acceptance_test", run_label)
+        _set_gen_ai_prompt(root, _QUESTION)
+        logger.info("agent.run started [%s]", run_label)
+        with tracer.start_as_current_span("tool.deployments_list", kind=SpanKind.INTERNAL) as tool:
+            tool.set_attribute("tool_name", "deployments_list")
+            tool.set_attribute("gen_ai.tool.name", "deployments_list")
+            tool.set_attribute("tool.parameters", json.dumps({"limit": 20}))
+            tool.set_attribute(
+                "tool.result", "14 rows returned from deployments_list, all healthy."
+            )
+        with tracer.start_as_current_span("llm.chat", kind=SpanKind.CLIENT) as llm:
+            llm.set_attribute("gen_ai.system", "datarobot-llm-gateway")
+            llm.set_attribute("gen_ai.request.model", "gpt-4o")
+            _set_gen_ai_prompt(llm, f"{_QUESTION}\n\nTool result: {_TOOL_RESULT}")
+            _set_gen_ai_completion(llm, _OK_COMPLETION)
+            llm.set_attribute("gen_ai.usage.prompt_tokens", 398)
+            llm.set_attribute("gen_ai.usage.completion_tokens", 41)
+        _set_gen_ai_completion(root, _OK_COMPLETION)
+        logger.info("agent.run completed [%s]", run_label)
+        return _hex_trace_id(root)
+
+
+def _emit_failing_run(tracer: Any, logger: logging.Logger, run_label: str) -> tuple[str, str, str]:
+    error_log_message = f"LLM gateway call failed; giving up after 3 retries [{run_label}]"
+    with tracer.start_as_current_span("agent.run", kind=SpanKind.SERVER) as root:
+        root.set_attribute("datarobot.acceptance_test", run_label)
+        _set_gen_ai_prompt(root, _QUESTION)
+        logger.info("agent.run started [%s]", run_label)
+        with tracer.start_as_current_span("tool.deployments_list", kind=SpanKind.INTERNAL) as tool:
+            tool.set_attribute("tool_name", "deployments_list")
+            tool.set_attribute("gen_ai.tool.name", "deployments_list")
+            tool.set_attribute("tool.parameters", json.dumps({"limit": 20}))
+            tool.set_attribute("tool.result", _TOOL_RESULT)
+        with tracer.start_as_current_span("llm.chat", kind=SpanKind.CLIENT) as llm:
+            llm.set_attribute("gen_ai.system", "datarobot-llm-gateway")
+            llm.set_attribute("gen_ai.request.model", "gpt-4o")
+            _set_gen_ai_prompt(llm, f"{_QUESTION}\n\nTool result: {_TOOL_RESULT}")
+            # The gateway streamed part of an answer before the 429 -- so the failing
+            # span really does carry LLM output, which is what the drill-down case asks
+            # for.
+            _set_gen_ai_completion(llm, _PARTIAL_COMPLETION)
+            llm.set_attribute("gen_ai.usage.prompt_tokens", 412)
+            llm.set_attribute("gen_ai.usage.completion_tokens", 57)
+            llm.set_attribute("llm.gateway.retries", 3)
+            error = RuntimeError(_LLM_ERROR)
+            llm.record_exception(error)
+            llm.set_status(Status(StatusCode.ERROR, _LLM_ERROR))
+            try:
+                raise error
+            except RuntimeError:
+                # ``exception`` -> level ERROR with a stack trace, emitted inside the span
+                # so the log record carries this trace_id/span_id for correlation.
+                logger.exception(error_log_message)
+            failing_span_id = _hex_span_id(llm)
+        root.set_status(Status(StatusCode.ERROR, f"agent run failed: llm.chat raised {_LLM_ERROR}"))
+        return _hex_trace_id(root), failing_span_id, error_log_message
+
+
+def _check_exports(kind: str, results: Sequence[Any], errors: Sequence[str]) -> None:
+    # Compared by member name, not identity: the span exporter returns
+    # ``SpanExportResult`` while the log exporter returns ``LogRecordExportResult`` (of
+    # which ``LogExportResult`` is a distinct, older enum), and both spell success the
+    # same way.
+    failed = [r for r in results if r.name != "SUCCESS"]
+    if not results:
+        raise RuntimeError(f"no {kind} were exported at all")
+    if failed or errors:
+        raise RuntimeError(
+            f"{len(failed)} of {len(results)} {kind} exports failed"
+            + (f" ({'; '.join(errors)})" if errors else "")
+            + ". Common causes: an invalid DATAROBOT_API_TOKEN, an X-DataRobot-Entity-Id the "
+            "token cannot access, or a cluster without the OTel ingest enabled. The exporter "
+            "logged the HTTP status above."
+        )
+
+
+def emit_failing_agent_run(
+    *, ingest_base_url: str, headers: dict[str, str], run_label: str
+) -> EmittedTelemetry:
+    """OTLP-export one failing and one healthy agentic run, plus correlated logs.
+
+    Uses private ``TracerProvider``/``LoggerProvider`` instances (never the OTel globals,
+    which other code in the pytest process may own) with simple, synchronous processors,
+    so by the time this returns every span and log record has been exported and its
+    result recorded. Raises ``RuntimeError`` if any export failed.
+    """
+    resource = Resource.create({"datarobot.acceptance_test": run_label})
+
+    span_exporter = _RecordingSpanExporter(
+        endpoint=f"{ingest_base_url}/v1/traces", headers=headers, timeout=30
+    )
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = tracer_provider.get_tracer("datarobot_genai.tests.acceptance.otel")
+
+    log_exporter = _RecordingLogExporter(
+        endpoint=f"{ingest_base_url}/v1/logs", headers=headers, timeout=30
+    )
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(SimpleLogRecordProcessor(log_exporter))
+    # ``opentelemetry-sdk`` deprecates this handler in favour of
+    # ``opentelemetry-instrumentation-logging``, which this repo does not depend on. It
+    # is still what the monitoring skill's generated ``configure_otel()`` and the
+    # platform's own OTel acceptance tests use, so the records it produces (body,
+    # severity, exception stack trace, current-span correlation) are the shape real
+    # instrumented agents send.
+    handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
+    logger = logging.getLogger(f"datarobot_genai.tests.acceptance.otel.{run_label}")
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    logger.addHandler(handler)
+    try:
+        ok_trace_id = _emit_ok_run(tracer, logger, run_label)
+        failing_trace_id, failing_span_id, error_log_message = _emit_failing_run(
+            tracer, logger, run_label
+        )
+    finally:
+        logger.removeHandler(handler)
+        tracer_provider.shutdown()
+        logger_provider.shutdown()
+
+    _check_exports("span", span_exporter.results, span_exporter.errors)
+    _check_exports("log", log_exporter.results, log_exporter.errors)
+    return EmittedTelemetry(
+        failing_trace_id=failing_trace_id,
+        failing_span_id=failing_span_id,
+        ok_trace_id=ok_trace_id,
+        error_log_message=error_log_message,
+        run_label=run_label,
+    )
+
+
+# --- read-back ------------------------------------------------------------------------
+
+
+def list_error_trace_ids(rest_client: Any, entity_type: str, entity_id: str) -> list[str]:
+    """``trace_id``s of the newest error-status traces on the entity (raw REST call)."""
+    result = (
+        rest_client.get(
+            f"otel/{entity_type}/{entity_id}/traces/", params={"status": "error", "limit": 50}
+        )
+    ).json()
+    rows = result.get("traces") or result.get("data") or []
+    return [str(otel_api_field(row, "trace_id")) for row in rows]
+
+
+def list_error_span_ids(
+    rest_client: Any, entity_type: str, entity_id: str, trace_id: str
+) -> list[str]:
+    """``span_id``s of the ERROR-status spans in one trace (first 100 spans, raw REST).
+
+    The comparison is case-insensitive: the API reports ``"Error"``, not the ``"ERROR"``
+    OTel itself uses. A 404 (trace not ingested yet) reads as "no error spans yet".
+    """
+    try:
+        result = rest_client.get(
+            f"otel/{entity_type}/{entity_id}/traces/{trace_id}/", params={"limit": 100}
+        ).json()
+    except ClientError as exc:
+        if exc.status_code == 404:  # not ingested yet
+            return []
+        raise
+    return [
+        str(otel_api_field(span, "span_id"))
+        for span in result.get("spans") or []
+        if str(otel_api_field(span, "status_code") or "").upper() == "ERROR"
+    ]
+
+
+def list_error_log_messages(
+    rest_client: Any, entity_type: str, entity_id: str, *, includes: str
+) -> list[str]:
+    """Messages of error-level log lines containing ``includes`` (raw REST call)."""
+    result = rest_client.get(
+        f"otel/{entity_type}/{entity_id}/logs/",
+        params={"level": "error", "limit": 50, "includes": includes},
+    ).json()
+    return [str(row.get("message") or "") for row in result.get("data") or []]
+
+
+def wait_for_otel_ingestion(
+    rest_client: Any,
+    entity_type: str,
+    entity_id: str,
+    emitted: EmittedTelemetry,
+    *,
+    timeout_s: float = 180.0,
+    interval_s: float = 3.0,
+) -> float:
+    """Block until the emitted failing trace, its ERROR span, and the error log are readable.
+
+    Polls the three REST reads the acceptance cases' tools depend on, dropping each
+    condition as it becomes true, so a partial ingest (traces landed, logs did not) is
+    named precisely in the ``TimeoutError``. Returns the seconds it took. Any
+    ``ClientError`` from the reads propagates -- a 403 here is a permissions/feature-flag
+    problem the caller should report as such, not retry.
+    """
+    started = time.monotonic()
+    deadline = started + timeout_s
+    pending = {
+        "error trace listed by GET traces/?status=error",
+        "ERROR span visible in GET traces/{trace_id}/",
+        "error log visible in GET logs/?level=error",
+    }
+    while True:
+        if "error trace listed by GET traces/?status=error" in pending and (
+            emitted.failing_trace_id in list_error_trace_ids(rest_client, entity_type, entity_id)
+        ):
+            pending.discard("error trace listed by GET traces/?status=error")
+        if "ERROR span visible in GET traces/{trace_id}/" in pending and (
+            emitted.failing_span_id
+            in list_error_span_ids(rest_client, entity_type, entity_id, emitted.failing_trace_id)
+        ):
+            pending.discard("ERROR span visible in GET traces/{trace_id}/")
+        if "error log visible in GET logs/?level=error" in pending and any(
+            emitted.run_label in message
+            for message in list_error_log_messages(
+                rest_client, entity_type, entity_id, includes=emitted.run_label
+            )
+        ):
+            pending.discard("error log visible in GET logs/?level=error")
+        if not pending:
+            return time.monotonic() - started
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"OTel data for {entity_type}/{entity_id} (trace {emitted.failing_trace_id}) "
+                f"was not readable {timeout_s:.0f}s after export; still missing: "
+                f"{sorted(pending)}"
+            )
+        time.sleep(interval_s)

--- a/tests/drmcp/integration/test_otel_tools.py
+++ b/tests/drmcp/integration/test_otel_tools.py
@@ -1,0 +1,440 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for DataRobot OTel MCP tools.
+
+Real MCP protocol over stdio with stubbed REST (plan §7 tier 2): proves
+registration, the generated JSON schema, and serialization. Truncation/dedup
+correctness against realistic (oversized) traces is tier 1's job
+(``tests/drmcp/unit/otel_tools/``) — this module's stub trace is deliberately
+small, with just enough structure (one byte-identical duplicate group) to
+exercise the dedup/drop-reporting path end to end over the real protocol.
+"""
+
+import json
+
+import pytest
+from mcp.types import TextContent
+
+from datarobot_genai.drmcp.test_utils.mcp_utils_integration import integration_test_mcp_session
+from datarobot_genai.drmcp.test_utils.mcp_utils_integration import (
+    integration_test_server_params_with_env,
+)
+from datarobot_genai.drmcp.test_utils.stubs.otel_stubs import STUB_OTEL_EMPTY_ENTITY_ID
+from datarobot_genai.drmcp.test_utils.stubs.otel_stubs import STUB_OTEL_ENTITY_ID
+from datarobot_genai.drmcp.test_utils.stubs.otel_stubs import STUB_OTEL_ENTITY_TYPE
+from datarobot_genai.drmcp.test_utils.stubs.otel_stubs import STUB_OTEL_MISSING_SPAN_ID
+from datarobot_genai.drmcp.test_utils.stubs.otel_stubs import STUB_OTEL_SPAN_ID_ERROR
+from datarobot_genai.drmcp.test_utils.stubs.otel_stubs import STUB_OTEL_TRACE_ID
+
+_EXPECTED_TOOLS = frozenset(
+    {
+        "otel_traces_list",
+        "otel_trace_get",
+        "otel_span_payload_get",
+        "otel_logs_list",
+        "otel_metrics_catalog_list",
+        "otel_metrics_values_get",
+        "otel_entity_stats_get",
+    }
+)
+
+
+def _otel_server_params():
+    """Return server params with OTel tools enabled."""
+    return integration_test_server_params_with_env({"ENABLE_OTEL_TOOLS": "true"})
+
+
+def _parse_result(result: object) -> dict:
+    assert not getattr(result, "isError", True)
+    content = getattr(result, "content", [])
+    assert len(content) > 0
+    assert isinstance(content[0], TextContent)
+    return json.loads(content[0].text)
+
+
+def _schema_enum(schema: dict) -> list:
+    """Read an ``enum`` list from a JSON-schema property, direct or ``anyOf``-wrapped."""
+    if "enum" in schema:
+        return schema["enum"]
+    for variant in schema.get("anyOf", []):
+        if "enum" in variant:
+            return variant["enum"]
+    return []
+
+
+@pytest.mark.asyncio
+class TestMCPOtelToolsRegistration:
+    """Verify OTel tools are registered, with the generated JSON schema shape."""
+
+    async def test_tools_registered(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.list_tools()
+            tool_names = {t.name for t in result.tools}
+            missing = _EXPECTED_TOOLS - tool_names
+            assert not missing, f"otel tools not registered: {missing}"
+
+    async def test_every_otel_tool_has_display_metadata(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.list_tools()
+            otel_tools = {t.name: t for t in result.tools if t.name in _EXPECTED_TOOLS}
+            assert set(otel_tools) == _EXPECTED_TOOLS
+            for name, tool in otel_tools.items():
+                assert tool.description, f"{name} missing a description"
+
+    async def test_entity_type_schema_is_an_enum_of_all_eight_types(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.list_tools()
+            tool = next(t for t in result.tools if t.name == "otel_traces_list")
+            entity_type_schema = tool.inputSchema["properties"]["entity_type"]
+            values = _schema_enum(entity_type_schema)
+            assert set(values) == {
+                "deployment",
+                "use_case",
+                "experiment_container",
+                "custom_application",
+                "workload",
+                "execution_environment",
+                "custom_job",
+                "artifact",
+            }
+
+    async def test_otel_trace_get_view_schema_is_summary_or_payloads(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.list_tools()
+            tool = next(t for t in result.tools if t.name == "otel_trace_get")
+            view_schema = tool.inputSchema["properties"]["view"]
+            assert set(_schema_enum(view_schema)) == {"summary", "payloads"}
+
+    async def test_otel_logs_list_level_schema_has_all_six_levels(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.list_tools()
+            tool = next(t for t in result.tools if t.name == "otel_logs_list")
+            level_schema = tool.inputSchema["properties"]["level"]
+            assert set(_schema_enum(level_schema)) == {
+                "debug",
+                "info",
+                "warn",
+                "warning",
+                "error",
+                "critical",
+            }
+
+    async def test_otel_metrics_values_get_source_schema(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.list_tools()
+            tool = next(t for t in result.tools if t.name == "otel_metrics_values_get")
+            source_schema = tool.inputSchema["properties"]["source"]
+            assert set(_schema_enum(source_schema)) == {"configured", "autocollected"}
+
+
+@pytest.mark.asyncio
+class TestMCPOtelTracesListIntegration:
+    """Integration tests for otel_traces_list."""
+
+    async def test_otel_traces_list_returns_traces(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_traces_list",
+                    {"entity_type": STUB_OTEL_ENTITY_TYPE, "entity_id": STUB_OTEL_ENTITY_ID},
+                )
+            )
+            assert "traces" in data
+            assert data["count"] >= 1
+            trace_ids = [t["trace_id"] for t in data["traces"]]
+            assert STUB_OTEL_TRACE_ID in trace_ids
+
+    async def test_otel_traces_list_invalid_entity_id(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.call_tool(
+                "otel_traces_list",
+                {"entity_type": STUB_OTEL_ENTITY_TYPE, "entity_id": "not-a-hex-id"},
+            )
+            assert result.isError
+
+    async def test_otel_traces_list_rejects_comma_joined_tools(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.call_tool(
+                "otel_traces_list",
+                {
+                    "entity_type": STUB_OTEL_ENTITY_TYPE,
+                    "entity_id": STUB_OTEL_ENTITY_ID,
+                    "tools": ["search,fetch"],
+                },
+            )
+            assert result.isError
+
+
+@pytest.mark.asyncio
+class TestMCPOtelTraceGetIntegration:
+    """Integration tests for otel_trace_get."""
+
+    async def test_otel_trace_get_summary_view(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_trace_get",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_ENTITY_ID,
+                        "trace_id": STUB_OTEL_TRACE_ID,
+                    },
+                )
+            )
+            assert data["trace_id"] == STUB_OTEL_TRACE_ID
+            assert data["truncation"]["mode"] == "summary"
+            assert data["truncation"]["payloads_omitted"] is True
+            span_ids = [s["span_id"] for s in data["spans"]]
+            assert STUB_OTEL_SPAN_ID_ERROR in span_ids
+            error_span = next(s for s in data["spans"] if s["span_id"] == STUB_OTEL_SPAN_ID_ERROR)
+            # prompt/completion + the duplicate group all count toward payload_chars
+            # in the pre-dedup summary accounting.
+            assert error_span["payload_chars"] > 0
+            assert "completion" in error_span["payload_fields"]
+
+    async def test_otel_trace_get_payloads_view_reports_duplicate_drop(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_trace_get",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_ENTITY_ID,
+                        "trace_id": STUB_OTEL_TRACE_ID,
+                        "view": "payloads",
+                    },
+                )
+            )
+            assert data["truncation"]["mode"] == "payloads"
+            assert "spans_returned" in data["truncation"]
+            assert "spans_dropped" in data["truncation"]
+            error_span = next(s for s in data["spans"] if s["span_id"] == STUB_OTEL_SPAN_ID_ERROR)
+            dropped = error_span["truncation"]["dropped_as_duplicate"]
+            assert "gen_ai.task.output" in dropped
+            assert "traceloop.entity.output" in dropped
+            assert error_span["attributes"]["completion"]
+
+    async def test_otel_trace_get_invalid_trace_id_length(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.call_tool(
+                "otel_trace_get",
+                {
+                    "entity_type": STUB_OTEL_ENTITY_TYPE,
+                    "entity_id": STUB_OTEL_ENTITY_ID,
+                    "trace_id": "too-short",
+                },
+            )
+            assert result.isError
+
+
+@pytest.mark.asyncio
+class TestMCPOtelSpanPayloadGetIntegration:
+    """Integration tests for otel_span_payload_get."""
+
+    async def test_default_fields_reports_dropped_as_duplicate(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_span_payload_get",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_ENTITY_ID,
+                        "trace_id": STUB_OTEL_TRACE_ID,
+                        "span_id": STUB_OTEL_SPAN_ID_ERROR,
+                    },
+                )
+            )
+            assert data["span_id"] == STUB_OTEL_SPAN_ID_ERROR
+            assert data["status_code"] == "ERROR"
+            assert data["completion"]
+            dropped = data["truncation"]["dropped_as_duplicate"]
+            assert "gen_ai.task.output" in dropped
+            assert "traceloop.entity.output" in dropped
+
+    async def test_explicit_fields_bypasses_dedup(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_span_payload_get",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_ENTITY_ID,
+                        "trace_id": STUB_OTEL_TRACE_ID,
+                        "span_id": STUB_OTEL_SPAN_ID_ERROR,
+                        "fields": ["gen_ai.task.output"],
+                    },
+                )
+            )
+            assert data["attributes"]["gen_ai.task.output"]
+            assert not data["truncation"]["dropped_as_duplicate"]
+
+    async def test_unknown_field_name_is_reported_not_found(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_span_payload_get",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_ENTITY_ID,
+                        "trace_id": STUB_OTEL_TRACE_ID,
+                        "span_id": STUB_OTEL_SPAN_ID_ERROR,
+                        "fields": ["nonexistent.field"],
+                    },
+                )
+            )
+            assert data["truncation"]["fields_not_found"] == ["nonexistent.field"]
+
+    async def test_span_not_found_is_a_tool_error(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.call_tool(
+                "otel_span_payload_get",
+                {
+                    "entity_type": STUB_OTEL_ENTITY_TYPE,
+                    "entity_id": STUB_OTEL_ENTITY_ID,
+                    "trace_id": STUB_OTEL_TRACE_ID,
+                    "span_id": STUB_OTEL_MISSING_SPAN_ID,
+                },
+            )
+            assert result.isError
+
+
+@pytest.mark.asyncio
+class TestMCPOtelLogsListIntegration:
+    """Integration tests for otel_logs_list."""
+
+    async def test_otel_logs_list_returns_logs(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_logs_list",
+                    {"entity_type": STUB_OTEL_ENTITY_TYPE, "entity_id": STUB_OTEL_ENTITY_ID},
+                )
+            )
+            assert "logs" in data
+            assert data["count"] >= 1
+            assert data["logs"][0]["trace_id"] == STUB_OTEL_TRACE_ID
+
+    async def test_otel_logs_list_never_carries_total_count(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_logs_list",
+                    {"entity_type": STUB_OTEL_ENTITY_TYPE, "entity_id": STUB_OTEL_ENTITY_ID},
+                )
+            )
+            assert "total_count" not in data
+
+    async def test_otel_logs_list_accepts_warning_and_critical(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            for level in ("warning", "critical"):
+                result = await session.call_tool(
+                    "otel_logs_list",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_ENTITY_ID,
+                        "level": level,
+                    },
+                )
+                assert not result.isError, f"level={level!r} should be accepted"
+
+    async def test_otel_logs_list_invalid_level(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            result = await session.call_tool(
+                "otel_logs_list",
+                {
+                    "entity_type": STUB_OTEL_ENTITY_TYPE,
+                    "entity_id": STUB_OTEL_ENTITY_ID,
+                    "level": "verbose",
+                },
+            )
+            assert result.isError
+
+
+@pytest.mark.asyncio
+class TestMCPOtelMetricsToolsIntegration:
+    """Integration tests for otel_metrics_catalog_list and otel_metrics_values_get."""
+
+    async def test_otel_metrics_catalog_list(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_metrics_catalog_list",
+                    {"entity_type": STUB_OTEL_ENTITY_TYPE, "entity_id": STUB_OTEL_ENTITY_ID},
+                )
+            )
+            assert data["count"] >= 1
+            names = [m["otel_name"] for m in data["metrics"]]
+            assert "gen_ai.tokens.total" in names
+
+    async def test_otel_metrics_values_get_autocollected_default(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_metrics_values_get",
+                    {"entity_type": STUB_OTEL_ENTITY_TYPE, "entity_id": STUB_OTEL_ENTITY_ID},
+                )
+            )
+            assert "metrics" in data
+            names = [m["otel_name"] for m in data["metrics"]]
+            assert "cpu.usage" in names
+
+    async def test_otel_metrics_values_get_configured(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_metrics_values_get",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_ENTITY_ID,
+                        "source": "configured",
+                    },
+                )
+            )
+            assert "metric_aggregations" in data
+            names = [m["otel_name"] for m in data["metric_aggregations"]]
+            assert "custom.latency" in names
+
+
+@pytest.mark.asyncio
+class TestMCPOtelEntityStatsGetIntegration:
+    """Integration tests for otel_entity_stats_get."""
+
+    async def test_entity_with_data(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_entity_stats_get",
+                    {"entity_type": STUB_OTEL_ENTITY_TYPE, "entity_id": STUB_OTEL_ENTITY_ID},
+                )
+            )
+            assert data["has_otel_data"] is True
+            assert data["span_count"] == 15
+            assert data["user_count"] == 2
+            assert len(data["by_user"]) == 2
+
+    async def test_entity_without_data(self) -> None:
+        async with integration_test_mcp_session(server_params=_otel_server_params()) as session:
+            data = _parse_result(
+                await session.call_tool(
+                    "otel_entity_stats_get",
+                    {
+                        "entity_type": STUB_OTEL_ENTITY_TYPE,
+                        "entity_id": STUB_OTEL_EMPTY_ENTITY_ID,
+                    },
+                )
+            )
+            assert data["has_otel_data"] is False
+            assert data["span_count"] == 0
+            assert data["by_user"] == []

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -419,6 +419,28 @@ class TestMCPCLIConfigs:
             assert config.tool_config.enable_tavily_tools is False
             self._reset_config()
 
+    def test_otel_enabled_when_in_mcp_cli_configs(self) -> None:
+        """OTel is wired into MCP_CLI_OPTS: MCP_CLI_CONFIGS='otel' enables its tools.
+
+        Regression guard: otel was the only ToolType missing from MCP_CLI_OPTS, so
+        MCP_CLI_CONFIGS=otel silently came up without any otel_* tools.
+        """
+        with patch.dict(os.environ, {"MCP_CLI_CONFIGS": "otel"}, clear=True):
+            self._reset_config()
+            config = get_config()
+            assert config.tool_config.enable_otel_tools is True
+            assert config.tool_config.enable_predictive_tools is False
+            self._reset_config()
+
+    def test_otel_disabled_when_absent_from_mcp_cli_configs(self) -> None:
+        """Like every listed package, otel is off when MCP_CLI_CONFIGS names others only."""
+        with patch.dict(os.environ, {"MCP_CLI_CONFIGS": "predictive"}, clear=True):
+            self._reset_config()
+            config = get_config()
+            assert config.tool_config.enable_predictive_tools is True
+            assert config.tool_config.enable_otel_tools is False
+            self._reset_config()
+
     def test_predictive_in_mcp_cli_configs_but_env_false_respected(self) -> None:
         """ENABLE_PREDICTIVE_TOOLS=false with predictive in list: env wins, stays False."""
         with patch.dict(

--- a/tests/drmcp/unit/test_routes.py
+++ b/tests/drmcp/unit/test_routes.py
@@ -782,6 +782,7 @@ class TestMetadataRoute:
         mock_tool_config.enable_panels_tools = False
         mock_tool_config.enable_workload_tools = False
         mock_tool_config.enable_files_api_tools = False
+        mock_tool_config.enable_otel_tools = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config
@@ -910,6 +911,7 @@ class TestMetadataRoute:
                     "panels",
                     "workload",
                     "files_api",
+                    "otel",
                 )
             }
         )
@@ -968,6 +970,7 @@ class TestMetadataRoute:
         mock_tool_config.enable_panels_tools = False
         mock_tool_config.enable_workload_tools = False
         mock_tool_config.enable_files_api_tools = False
+        mock_tool_config.enable_otel_tools = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config
@@ -1034,6 +1037,7 @@ class TestMetadataRoute:
         mock_tool_config.enable_panels_tools = False
         mock_tool_config.enable_workload_tools = False
         mock_tool_config.enable_files_api_tools = False
+        mock_tool_config.enable_otel_tools = False
 
         mock_config.tool_config = mock_tool_config
         mock_get_config.return_value = mock_config

--- a/tests/drmcp/unit/test_tool_base_ete.py
+++ b/tests/drmcp/unit/test_tool_base_ete.py
@@ -14,6 +14,7 @@
 
 """Unit tests for tool_base_ete.py module."""
 
+from datarobot_genai.drmcp.test_utils.clients.base import ToolCall
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ANY_NONEMPTY_STRING
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ETETestExpectations
 from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolBaseE2E
@@ -21,6 +22,8 @@ from datarobot_genai.drmcp.test_utils.tool_base_ete import ToolCallTestExpectati
 from datarobot_genai.drmcp.test_utils.tool_base_ete import _canonical_tool_name_for_expectation
 from datarobot_genai.drmcp.test_utils.tool_base_ete import _check_dict_has_keys
 from datarobot_genai.drmcp.test_utils.tool_base_ete import _check_dict_params_match
+from datarobot_genai.drmcp.test_utils.tool_base_ete import _forbidden_parameter_violations
+from datarobot_genai.drmcp.test_utils.tool_base_ete import _forbidden_tool_call_violations
 
 
 class TestToolCallTestExpectations:
@@ -54,6 +57,23 @@ class TestToolCallTestExpectations:
 
         assert isinstance(expectations.result, dict)
         assert expectations.result["status"] == "success"
+
+    def test_tool_call_test_expectations_forbidden_parameter_values_defaults_empty(self) -> None:
+        """Test forbidden_parameter_values defaults to an empty dict."""
+        expectations = ToolCallTestExpectations(name="test_tool", parameters={}, result="result")
+
+        assert expectations.forbidden_parameter_values == {}
+
+    def test_tool_call_test_expectations_forbidden_parameter_values_stores_value(self) -> None:
+        """Test forbidden_parameter_values stores the value it is given."""
+        expectations = ToolCallTestExpectations(
+            name="otel_trace_get",
+            parameters={"trace_id": "abc"},
+            result="result",
+            forbidden_parameter_values={"view": "payloads"},
+        )
+
+        assert expectations.forbidden_parameter_values == {"view": "payloads"}
 
 
 class TestCanonicalToolNameForExpectation:
@@ -106,6 +126,25 @@ class TestETETestExpectations:
         )
 
         assert expectations.potential_no_tool_calls is True
+
+    def test_ete_test_expectations_forbidden_tool_names_defaults_empty(self) -> None:
+        """Test forbidden_tool_names defaults to an empty list."""
+        expectations = ETETestExpectations(
+            tool_calls_expected=[],
+            llm_response_content_contains_expectations=[],
+        )
+
+        assert expectations.forbidden_tool_names == []
+
+    def test_ete_test_expectations_forbidden_tool_names_stores_value(self) -> None:
+        """Test forbidden_tool_names stores the value it is given."""
+        expectations = ETETestExpectations(
+            tool_calls_expected=[],
+            llm_response_content_contains_expectations=[],
+            forbidden_tool_names=["otel_trace_get"],
+        )
+
+        assert expectations.forbidden_tool_names == ["otel_trace_get"]
 
 
 class TestCheckDictHasKeys:
@@ -249,6 +288,115 @@ class TestCheckDictParamsMatch:
         expected = {"job_id": ANY_NONEMPTY_STRING}
         assert _check_dict_params_match(expected, {"job_id": ""}) is False
         assert _check_dict_params_match(expected, {"job_id": "   "}) is False
+
+
+class TestForbiddenParameterViolations:
+    """Test cases for _forbidden_parameter_violations function."""
+
+    def test_no_violation_when_key_absent(self) -> None:
+        """An omitted optional arg is not a violation, even if it defaults to that value."""
+        forbidden = {"view": "payloads"}
+        actual: dict = {"trace_id": "abc"}
+
+        assert _forbidden_parameter_violations(forbidden, actual) == {}
+
+    def test_no_violation_when_value_differs(self) -> None:
+        """The call explicitly chose a different, acceptable value."""
+        forbidden = {"view": "payloads"}
+        actual = {"view": "summary"}
+
+        assert _forbidden_parameter_violations(forbidden, actual) == {}
+
+    def test_violation_when_value_matches(self) -> None:
+        """The call explicitly chose the forbidden value."""
+        forbidden = {"view": "payloads"}
+        actual = {"view": "payloads", "trace_id": "abc"}
+
+        assert _forbidden_parameter_violations(forbidden, actual) == {"view": "payloads"}
+
+    def test_violation_string_comparison_strips_whitespace(self) -> None:
+        """String comparison strips whitespace, matching _param_leaf_matches elsewhere."""
+        forbidden = {"view": "payloads"}
+        actual = {"view": "  payloads  "}
+
+        assert _forbidden_parameter_violations(forbidden, actual) == {"view": "  payloads  "}
+
+    def test_empty_forbidden_yields_no_violations(self) -> None:
+        """An empty forbidden dict never reports a violation."""
+        assert _forbidden_parameter_violations({}, {"view": "payloads"}) == {}
+
+    def test_nested_dict_violation_recurses_with_subset_semantics(self) -> None:
+        """A forbidden nested shape is flagged even when actual carries extra sibling fields.
+
+        This mirrors ``parameters``' own subset matching (via ``_check_dict_params_match``) --
+        the docstring's claim that nested values are "checked the same way `parameters` is
+        checked" must actually hold, not just for the top level.
+        """
+        forbidden = {"filters": {"status": "error"}}
+        actual = {"filters": {"status": "error", "extra": "x"}}
+
+        assert _forbidden_parameter_violations(forbidden, actual) == {
+            "filters": {"status": "error", "extra": "x"}
+        }
+
+    def test_nested_dict_no_violation_when_inner_value_differs(self) -> None:
+        """A nested dict that does not match the forbidden subset is not a violation."""
+        forbidden = {"filters": {"status": "error"}}
+        actual = {"filters": {"status": "ok"}}
+
+        assert _forbidden_parameter_violations(forbidden, actual) == {}
+
+    def test_nested_dict_no_violation_when_actual_value_is_not_a_dict(self) -> None:
+        """A forbidden nested dict never matches a scalar actual value at that key."""
+        forbidden = {"filters": {"status": "error"}}
+        actual = {"filters": "error"}
+
+        assert _forbidden_parameter_violations(forbidden, actual) == {}
+
+
+class TestForbiddenToolCallViolations:
+    """Test cases for _forbidden_tool_call_violations function."""
+
+    def test_empty_forbidden_names_yields_no_violations(self) -> None:
+        """No forbidden names means nothing can violate, regardless of what was called."""
+        calls = [ToolCall(tool_name="otel_trace_get", parameters={}, reasoning="")]
+
+        assert _forbidden_tool_call_violations([], calls) == []
+
+    def test_no_violation_when_forbidden_tool_never_called(self) -> None:
+        """A call to an unrelated tool is not a violation."""
+        calls = [ToolCall(tool_name="otel_span_payload_get", parameters={}, reasoning="")]
+
+        assert _forbidden_tool_call_violations(["otel_trace_get"], calls) == []
+
+    def test_violation_when_forbidden_tool_is_called(self) -> None:
+        """A call to the forbidden tool is reported by its raw name."""
+        calls = [ToolCall(tool_name="otel_trace_get", parameters={}, reasoning="")]
+
+        assert _forbidden_tool_call_violations(["otel_trace_get"], calls) == ["otel_trace_get"]
+
+    def test_violation_regardless_of_position_in_the_call_sequence(self) -> None:
+        """The forbidden tool is caught even when it is not the first or only call.
+
+        This is what lets a legitimate extra call to the *expected* tool (e.g. a paginated
+        otel_span_payload_get continuation) coexist with a strict "never call X" assertion --
+        the check scans every call rather than assuming a fixed position or count.
+        """
+        calls = [
+            ToolCall(tool_name="otel_span_payload_get", parameters={}, reasoning=""),
+            ToolCall(tool_name="otel_trace_get", parameters={}, reasoning=""),
+            ToolCall(tool_name="otel_span_payload_get", parameters={}, reasoning=""),
+        ]
+
+        assert _forbidden_tool_call_violations(["otel_trace_get"], calls) == ["otel_trace_get"]
+
+    def test_normalizes_namespaced_tool_names_before_matching(self) -> None:
+        """A namespaced MCP tool name still matches its bare logical forbidden name."""
+        calls = [ToolCall(tool_name="mcp_someserver_otel_trace_get", parameters={}, reasoning="")]
+
+        assert _forbidden_tool_call_violations(["otel_trace_get"], calls) == [
+            "mcp_someserver_otel_trace_get"
+        ]
 
 
 class TestToolBaseE2E:

--- a/tests/drmcputils/test_ard_catalog.py
+++ b/tests/drmcputils/test_ard_catalog.py
@@ -76,6 +76,7 @@ _ENABLED_CATEGORIES = {
     "dr_vdb",
     "dr_file",
     "dr_workload",
+    "dr_otel",
 }
 
 
@@ -130,6 +131,17 @@ class TestIncludedSurface:
             "artifact_get",
         } <= names
         assert "file_upload" not in names
+
+    def test_otel_included(self, names: set[str]) -> None:
+        assert {
+            "otel_traces_list",
+            "otel_trace_get",
+            "otel_span_payload_get",
+            "otel_logs_list",
+            "otel_metrics_catalog_list",
+            "otel_metrics_values_get",
+            "otel_entity_stats_get",
+        } <= names
 
 
 class TestMcpUrl:

--- a/tests/drmcputils/test_global_mcp_tools.py
+++ b/tests/drmcputils/test_global_mcp_tools.py
@@ -36,6 +36,7 @@ class TestEnabledPackages:
             "vdb",
             "files_api",
             "workload",
+            "otel",
         }
 
 


### PR DESCRIPTION
# RATIONALE

Design doc: https://datarobot.atlassian.net/wiki/x/AoCr3AE

This is the PR that actually turns the tools on. #646 and #647 added the foundation and the seven tool definitions but left them unregistered so each could be reviewed in isolation — "is the design right" separately from "is it wired correctly and does it work end-to-end," which is what this PR's integration and acceptance tests cover.

The `DR_OTEL` category is left **unparented** so it is top-level and independently filterable in the tool gallery, alongside `dr_documentation`/`dr_use_cases`/`dr_deployments`, rather than buried under DevOps.

## CHANGES

Wiring (five edits):
- `drmcp/core/tool_config.py` — `ToolType.OTEL` + `TOOL_CONFIGS` entry
- `drmcp/core/config.py` — `enable_otel_tools` on `MCPToolConfig` (env `ENABLE_OTEL_TOOLS`, default `false`)
- `drmcputils/categories.py` — `MCPToolCategory.DR_OTEL`, all seven tools in `LEAF_CATEGORY_TOOLS`, label "Observability"
- `drmcputils/global_mcp_tools.py` — `GLOBAL_MCP_PACKAGE_CATEGORIES` entry
- `.taskfiles/drmcp.yml` — `ENABLE_OTEL_TOOLS=true` on the dev server

Testing:
- `drmcp/test_utils/stubs/otel_stubs.py` + tier-2 integration tests (25 passing) with an `_EXPECTED_TOOLS` frozenset so an unregistered tool fails the build
- Tier-3 acceptance cases

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog (added in #649, the last PR of this stack)
- [x] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST) — added in this PR

## TESTING

`task drmcp-unit` (full suite) 1783 passed, coverage 85.90%. `task drmcp-integration` 199 passed / 4 skipped. Taxonomy suite green. ruff-format, ruff, mypy, check-imports all clean.

## RELATED

3/4 of the OTel observability tools stack (plan §9 steps 6–8). Depends on #647. Next: #649 (docs and release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a new observability tool surface on global-mcp and MCP servers when flags are on; changes are mostly gated by `ENABLE_OTEL_TOOLS` (default false) but acceptance provisioning touches live Use Cases and OTLP ingest.
> 
> **Overview**
> **Turns on** the previously defined OpenTelemetry MCP tools by wiring them through the same enablement path as other `drtools` packages: `ToolType.OTEL`, `ENABLE_OTEL_TOOLS` / `MCP_CLI_CONFIGS=otel`, and registration metadata updates. The dev acceptance server task now sets `ENABLE_OTEL_TOOLS=true`.
> 
> **Global MCP** advertises the `otel` package (`DR_OTEL`) in `GLOBAL_MCP_PACKAGE_CATEGORIES` and the ARD catalog, so discovery stays aligned with what gets registered.
> 
> **Test support** adds REST `otel_stubs` (chained ahead of generic stubs), fixes workload `/stats` routing so it no longer matches `GET otel/stats/`, and extends E2E expectations with `forbidden_tool_names` and `forbidden_parameter_values` so tier-3 cases can assert the model avoids expensive or redundant tool choices.
> 
> **Coverage**: tier-2 MCP integration tests over stubbed REST; tier-3 acceptance tests that provision a Use Case (or use `TEST_OTEL_ENTITY_ID`), OTLP-export failing agent telemetry, poll until readable, and run LLM-driven scenarios for trace diagnosis, span payload drill-down, and error logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236747341b4c4730f1852426d392f3bd0fa45802. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->