### PR TITLE
[BUZZOK-32144] Optimize L2 cache for remote agent cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `dragent`: pluggable agent card registry cache backends with stale-if-error bounded by `AGENT_CARD_REGISTRY_CACHE_TTL`.
 - `dragent`: L1 read-through of an L2 agent card hit preserves the original ``fetched_at``, so soft TTL and max-staleness are not reset on promotion.
 - `dragent`: layered agent card cache skips L2 on soft-expired L1 hits and writes L2 asynchronously so connect-time registry fetches are not blocked on MemorySpace round-trips.
+- `dragent`: agent card registry L2 lookups pass deployment/external key type to avoid probing both MemorySpace aliases; MemorySpace KV cache reuses resolved session IDs in-process to skip repeated ``Session.list`` calls.
 
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `dragent`: layered agent card cache skips L2 on soft-expired L1 hits; cold-path fresh L2 reads are bounded by a short timeout so a slow MemorySpace cannot delay registry fetch (stale-if-error L2 reads are not bounded).
 - `dragent`: agent card registry L2 lookups pass deployment/external key type to avoid probing both MemorySpace aliases; MemorySpace KV cache reuses resolved session IDs in-process to skip repeated ``Session.list`` calls.
 - `dragent`: agent card registry skips MemorySpace L2 when ``AGENT_CARD_REGISTRY_CACHE_TTL=0``.
+- `dragent`: agent card registry evicts MemorySpace L2 synchronously on successful miss so a deregistered card cannot be resurrected from L2 before background eviction completes.
 
 ## 0.29.7
 - `drmcp/core/config`: Added `oauth_claim_validation` MCP config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.8
+- `dragent`: agent card registry MemorySpace L2 uses write-behind instead of write-through so connect-time registry fetches are not blocked on MemorySpace round-trips.
+- `dragent`: layered agent card cache skips L2 on soft-expired L1 hits; cold-path L2 reads are bounded by a short timeout so a slow MemorySpace cannot delay registry fetch.
+- `dragent`: agent card registry L2 lookups pass deployment/external key type to avoid probing both MemorySpace aliases; MemorySpace KV cache reuses resolved session IDs in-process to skip repeated ``Session.list`` calls.
+- `dragent`: agent card registry skips MemorySpace L2 when ``AGENT_CARD_REGISTRY_CACHE_TTL=0``.
+
 ## 0.29.7
 - `drmcp/core/config`: Added `oauth_claim_validation` MCP config.
 - `drmcp/core/middleware.py`: Refactored MCP authorization validation middlewares
@@ -16,12 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Enable `cve-sync` automation in the repo
 
 ## 0.29.4
-- `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-behind over the agentic memory Session API) when `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
+- `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-through over the agentic memory Session API) when `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
 - `dragent`: pluggable agent card registry cache backends with stale-if-error bounded by `AGENT_CARD_REGISTRY_CACHE_TTL`.
 - `dragent`: L1 read-through of an L2 agent card hit preserves the original ``fetched_at``, so soft TTL and max-staleness are not reset on promotion.
-- `dragent`: layered agent card cache skips L2 on soft-expired L1 hits and writes L2 asynchronously so connect-time registry fetches are not blocked on MemorySpace round-trips.
-- `dragent`: agent card registry L2 lookups pass deployment/external key type to avoid probing both MemorySpace aliases; MemorySpace KV cache reuses resolved session IDs in-process to skip repeated ``Session.list`` calls.
-- `dragent`: agent card registry skips MemorySpace L2 when ``AGENT_CARD_REGISTRY_CACHE_TTL=0`` and bounds cold-path L2 reads with a short timeout so slow MemorySpace cannot delay registry fetch.
 
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `dragent`: L1 read-through of an L2 agent card hit preserves the original ``fetched_at``, so soft TTL and max-staleness are not reset on promotion.
 - `dragent`: layered agent card cache skips L2 on soft-expired L1 hits and writes L2 asynchronously so connect-time registry fetches are not blocked on MemorySpace round-trips.
 - `dragent`: agent card registry L2 lookups pass deployment/external key type to avoid probing both MemorySpace aliases; MemorySpace KV cache reuses resolved session IDs in-process to skip repeated ``Session.list`` calls.
+- `dragent`: agent card registry skips MemorySpace L2 when ``AGENT_CARD_REGISTRY_CACHE_TTL=0`` and bounds cold-path L2 reads with a short timeout so slow MemorySpace cannot delay registry fetch.
 
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.8
 - `dragent`: agent card registry MemorySpace L2 uses write-behind instead of write-through so connect-time registry fetches are not blocked on MemorySpace round-trips.
-- `dragent`: layered agent card cache skips L2 on soft-expired L1 hits; cold-path L2 reads are bounded by a short timeout so a slow MemorySpace cannot delay registry fetch.
+- `dragent`: layered agent card cache skips L2 on soft-expired L1 hits; cold-path fresh L2 reads are bounded by a short timeout so a slow MemorySpace cannot delay registry fetch (stale-if-error L2 reads are not bounded).
 - `dragent`: agent card registry L2 lookups pass deployment/external key type to avoid probing both MemorySpace aliases; MemorySpace KV cache reuses resolved session IDs in-process to skip repeated ``Session.list`` calls.
 - `dragent`: agent card registry skips MemorySpace L2 when ``AGENT_CARD_REGISTRY_CACHE_TTL=0``.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Enable `cve-sync` automation in the repo
 
 ## 0.29.4
-- `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-through over the agentic memory Session API) when `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
+- `dragent`: agent card registry uses in-process L1 cache with optional DataRobot MemorySpace L2 (read-through/write-behind over the agentic memory Session API) when `AGENT_CARD_REGISTRY_MEMORY_SPACE_ID` is set; falls back to L1-only when no memory space is configured.
 - `dragent`: pluggable agent card registry cache backends with stale-if-error bounded by `AGENT_CARD_REGISTRY_CACHE_TTL`.
 - `dragent`: L1 read-through of an L2 agent card hit preserves the original ``fetched_at``, so soft TTL and max-staleness are not reset on promotion.
+- `dragent`: layered agent card cache skips L2 on soft-expired L1 hits and writes L2 asynchronously so connect-time registry fetches are not blocked on MemorySpace round-trips.
 
 ## 0.29.3
 - `dragent`: **fixed `authenticated_a2a_client` groups overwriting each other's agent card on a shared `auth_provider`.** Function groups are built per user, but `WorkflowBuilder.get_auth_provider` returns one instance per configured name and `PerUserWorkflowBuilder` delegates to it — so every group called `set_agent_card()` on the same object and the last one to connect decided `target_audience`, `token_url` and `id_jag_scopes` for all of them. Two A2A function groups sharing an `auth_provider`, or two users active at once, could mint a token for the wrong agent; the receiving agent rejects it on the audience check, so this failed closed, but it showed up as intermittent auth failures.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.6"
+version = "0.29.7"
 source = { editable = "../" }
 
 [package.metadata]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.7"
+version = "0.29.8"
 source = { editable = "../" }
 
 [package.metadata]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -950,7 +950,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.7"
+version = "0.29.8"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -950,7 +950,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.6"
+version = "0.29.7"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.7"
+version = "0.29.8"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -386,16 +386,21 @@ class AgentCardRegistry:
         )
         return parsed
 
-    async def _is_fresh(self, key: str) -> bool:
+    async def _is_fresh(self, key: str, *, key_type: LookupKeyType) -> bool:
         """Return True if *key* is cached and within the soft TTL."""
-        record = await self._backend.get_fresh(key, cache_ttl=self._cache_ttl)
+        record = await self._backend.get_fresh(
+            key,
+            cache_ttl=self._cache_ttl,
+            key_type=key_type,
+        )
         return record is not None
 
-    async def _try_get_stale(self, key: str) -> AgentCard | None:
+    async def _try_get_stale(self, key: str, *, key_type: LookupKeyType) -> AgentCard | None:
         """Return a stale cached card when refresh failed."""
         record = await self._backend.get_stale(
             key,
             max_staleness_seconds=self._cache_ttl,
+            key_type=key_type,
         )
         if record is None:
             return None
@@ -427,8 +432,16 @@ class AgentCardRegistry:
 
     async def _flush_pending(self) -> None:
         """Batch-fetch all registered-but-uncached IDs.  Must be called under ``_lock``."""
-        missing_dep = [d for d in self._pending_deployment_ids if not await self._is_fresh(d)]
-        missing_ext = [e for e in self._pending_external_ids if not await self._is_fresh(e)]
+        missing_dep = [
+            d
+            for d in self._pending_deployment_ids
+            if not await self._is_fresh(d, key_type="deployment")
+        ]
+        missing_ext = [
+            e
+            for e in self._pending_external_ids
+            if not await self._is_fresh(e, key_type="external")
+        ]
 
         # Clear pending sets regardless — they've been processed
         self._pending_deployment_ids.clear()
@@ -471,8 +484,14 @@ class AgentCardRegistry:
             External IDs to prefetch.
         """
         async with self._lock:
-            missing_dep = [d for d in (deployment_ids or []) if not await self._is_fresh(d)]
-            missing_ext = [e for e in (external_ids or []) if not await self._is_fresh(e)]
+            missing_dep = [
+                d
+                for d in (deployment_ids or [])
+                if not await self._is_fresh(d, key_type="deployment")
+            ]
+            missing_ext = [
+                e for e in (external_ids or []) if not await self._is_fresh(e, key_type="external")
+            ]
 
             if not missing_dep and not missing_ext:
                 logger.debug("All requested agent cards already cached — skipping prefetch.")
@@ -537,14 +556,23 @@ class AgentCardRegistry:
             raise AgentCardRegistryError("Specify exactly one of 'deployment_id' or 'external_id'.")
 
         lookup_key: str = deployment_id or external_id  # type: ignore[assignment]
+        lookup_key_type: LookupKeyType = "deployment" if deployment_id else "external"
 
         # Fast path — fresh cache hit
-        if fresh := await self._backend.get_fresh(lookup_key, cache_ttl=self._cache_ttl):
+        if fresh := await self._backend.get_fresh(
+            lookup_key,
+            cache_ttl=self._cache_ttl,
+            key_type=lookup_key_type,
+        ):
             return fresh.card
 
         async with self._lock:
             # Double-check after acquiring lock
-            if fresh := await self._backend.get_fresh(lookup_key, cache_ttl=self._cache_ttl):
+            if fresh := await self._backend.get_fresh(
+                lookup_key,
+                cache_ttl=self._cache_ttl,
+                key_type=lookup_key_type,
+            ):
                 return fresh.card
 
             try:
@@ -552,7 +580,9 @@ class AgentCardRegistry:
                 if self._pending_deployment_ids or self._pending_external_ids:
                     await self._flush_pending()
                     if fresh := await self._backend.get_fresh(
-                        lookup_key, cache_ttl=self._cache_ttl
+                        lookup_key,
+                        cache_ttl=self._cache_ttl,
+                        key_type=lookup_key_type,
                     ):
                         return fresh.card
 
@@ -568,15 +598,18 @@ class AgentCardRegistry:
                 if lookup_key in parsed.cards:
                     return parsed.cards[lookup_key]
 
-                if fresh := await self._backend.get_fresh(lookup_key, cache_ttl=self._cache_ttl):
+                if fresh := await self._backend.get_fresh(
+                    lookup_key,
+                    cache_ttl=self._cache_ttl,
+                    key_type=lookup_key_type,
+                ):
                     return fresh.card
 
                 # Successful miss — evict stale entry so stale-if-error cannot
                 # resurrect a deregistered agent on a later fetch failure.
-                key_type: LookupKeyType = "deployment" if deployment_id else "external"
-                await self._backend.evict(lookup_key, key_type=key_type)
+                await self._backend.evict(lookup_key, key_type=lookup_key_type)
             except AgentCardRegistryError:
-                if stale_card := await self._try_get_stale(lookup_key):
+                if stale_card := await self._try_get_stale(lookup_key, key_type=lookup_key_type):
                     return stale_card
                 raise
 

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -42,6 +42,9 @@ logger = logging.getLogger(__name__)
 
 LookupKeyType = Literal["deployment", "external"]
 
+# Bound cold-path L2 read latency so a slow MemorySpace does not delay registry fetch.
+_DEFAULT_L2_READ_TIMEOUT_SECONDS = 0.2
+
 
 class AgentCardCacheRecord(BaseModel):
     """Serialized agent card cache entry shared across backends."""
@@ -322,9 +325,16 @@ class MemorySpaceAgentCardCacheBackend:
 class LayeredAgentCardCacheBackend:
     """L1 memory read-through / write-behind over an L2 backend."""
 
-    def __init__(self, l1: MemoryAgentCardCacheBackend, l2: AgentCardCacheBackend) -> None:
+    def __init__(
+        self,
+        l1: MemoryAgentCardCacheBackend,
+        l2: AgentCardCacheBackend,
+        *,
+        l2_read_timeout: float = _DEFAULT_L2_READ_TIMEOUT_SECONDS,
+    ) -> None:
         self._l1 = l1
         self._l2 = l2
+        self._l2_read_timeout = l2_read_timeout
         self._l2_tasks: set[asyncio.Task[Any]] = set()
 
     def _schedule_l2(self, coro: Coroutine[Any, Any, Any]) -> None:
@@ -352,6 +362,22 @@ class LayeredAgentCardCacheBackend:
         tasks = list(self._l2_tasks)
         await asyncio.gather(*tasks, return_exceptions=True)
 
+    async def _read_l2_with_timeout(
+        self,
+        coro: Coroutine[Any, Any, AgentCardCacheRecord | None],
+    ) -> AgentCardCacheRecord | None:
+        """Run an L2 read with a bounded wait; return ``None`` on timeout."""
+        if self._l2_read_timeout <= 0:
+            return await coro
+        try:
+            return await asyncio.wait_for(coro, timeout=self._l2_read_timeout)
+        except TimeoutError:
+            logger.debug(
+                "Agent card registry L2 read timed out after %.2fs",
+                self._l2_read_timeout,
+            )
+            return None
+
     async def get_fresh(
         self,
         lookup_key: str,
@@ -364,10 +390,12 @@ class LayeredAgentCardCacheBackend:
         # L1 holds a stale entry with the same fetched_at L2 would return — skip L2.
         if self._l1.has_entry(lookup_key):
             return None
-        if record := await self._l2.get_fresh(
-            lookup_key,
-            cache_ttl=cache_ttl,
-            key_type=key_type,
+        if record := await self._read_l2_with_timeout(
+            self._l2.get_fresh(
+                lookup_key,
+                cache_ttl=cache_ttl,
+                key_type=key_type,
+            )
         ):
             await self._promote_to_l1(lookup_key, record)
             return record
@@ -386,10 +414,12 @@ class LayeredAgentCardCacheBackend:
             key_type=key_type,
         ):
             return record
-        if record := await self._l2.get_stale(
-            lookup_key,
-            max_staleness_seconds=max_staleness_seconds,
-            key_type=key_type,
+        if record := await self._read_l2_with_timeout(
+            self._l2.get_stale(
+                lookup_key,
+                max_staleness_seconds=max_staleness_seconds,
+                key_type=key_type,
+            )
         ):
             await self._promote_to_l1(lookup_key, record)
             return record
@@ -428,6 +458,10 @@ def create_agent_card_cache_backend(
 ) -> AgentCardCacheBackend:
     """Instantiate the agent card cache backend (L1, plus MemorySpace L2 when available)."""
     l1 = MemoryAgentCardCacheBackend()
+    if config.agent_card_registry_cache_ttl == 0:
+        logger.debug("Agent card registry cache: L1 only (cache_ttl=0)")
+        return l1
+
     memory_space_id = try_resolve_memory_space_id(config.agent_card_registry_memory_space_id)
     if memory_space_id is None:
         logger.debug("Agent card registry cache: L1 only (no MemorySpace ID configured)")

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -444,7 +444,9 @@ class LayeredAgentCardCacheBackend:
         key_type: LookupKeyType | None = None,
     ) -> None:
         await self._l1.evict(lookup_key, key_type=key_type)
-        self._schedule_l2(self._l2.evict(lookup_key, key_type=key_type))
+        # Evict L2 before returning — write-behind store must not let a later
+        # get_fresh read a deregistered card from L2 after L1 was cleared.
+        await self._l2.evict(lookup_key, key_type=key_type)
 
     @property
     def memory(self) -> MemoryAgentCardCacheBackend:

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -16,11 +16,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Coroutine
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Literal
 from typing import Protocol
 
@@ -169,6 +172,10 @@ class MemoryAgentCardCacheBackend:
         """Insert *record* as-is, preserving ``fetched_at`` for L1 read-through."""
         self._entries[lookup_key] = record.model_copy()
 
+    def has_entry(self, lookup_key: str) -> bool:
+        """Return *True* when *lookup_key* is present in L1 (fresh or stale)."""
+        return lookup_key in self._entries
+
     async def evict(
         self,
         lookup_key: str,
@@ -292,15 +299,44 @@ class MemorySpaceAgentCardCacheBackend:
 
 
 class LayeredAgentCardCacheBackend:
-    """L1 memory read-through / write-through over an L2 backend."""
+    """L1 memory read-through / write-behind over an L2 backend."""
 
     def __init__(self, l1: MemoryAgentCardCacheBackend, l2: AgentCardCacheBackend) -> None:
         self._l1 = l1
         self._l2 = l2
+        self._l2_tasks: set[asyncio.Task[Any]] = set()
+
+    def _schedule_l2(self, coro: Coroutine[Any, Any, Any]) -> None:
+        """Run an L2 operation in the background without blocking callers."""
+        task = asyncio.create_task(coro)
+        self._l2_tasks.add(task)
+        task.add_done_callback(self._l2_tasks.discard)
+        task.add_done_callback(self._log_l2_task_failure)
+
+    @staticmethod
+    def _log_l2_task_failure(task: asyncio.Task[Any]) -> None:
+        if task.cancelled():
+            return
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            logger.warning("Agent card registry L2 background task failed", exc_info=exc)
+
+    async def flush_l2_tasks(self) -> None:
+        """Await in-flight L2 writes/evictions (tests and graceful shutdown)."""
+        if not self._l2_tasks:
+            return
+        tasks = list(self._l2_tasks)
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
         if record := await self._l1.get_fresh(lookup_key, cache_ttl=cache_ttl):
             return record
+        # L1 holds a stale entry with the same fetched_at L2 would return — skip L2.
+        if self._l1.has_entry(lookup_key):
+            return None
         if record := await self._l2.get_fresh(lookup_key, cache_ttl=cache_ttl):
             await self._promote_to_l1(lookup_key, record)
             return record
@@ -336,7 +372,7 @@ class LayeredAgentCardCacheBackend:
         registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
     ) -> None:
         await self._l1.store(cards, key_types=key_types, registry_ids=registry_ids)
-        await self._l2.store(cards, key_types=key_types, registry_ids=registry_ids)
+        self._schedule_l2(self._l2.store(cards, key_types=key_types, registry_ids=registry_ids))
 
     async def evict(
         self,
@@ -345,7 +381,7 @@ class LayeredAgentCardCacheBackend:
         key_type: LookupKeyType | None = None,
     ) -> None:
         await self._l1.evict(lookup_key, key_type=key_type)
-        await self._l2.evict(lookup_key, key_type=key_type)
+        self._schedule_l2(self._l2.evict(lookup_key, key_type=key_type))
 
     @property
     def memory(self) -> MemoryAgentCardCacheBackend:

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -97,7 +97,13 @@ def build_cache_record(
 class AgentCardCacheBackend(Protocol):
     """Async cache backend for agent card registry entries."""
 
-    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
+    async def get_fresh(
+        self,
+        lookup_key: str,
+        *,
+        cache_ttl: int,
+        key_type: LookupKeyType | None = None,
+    ) -> AgentCardCacheRecord | None:
         """Return a cached record when within the soft TTL."""
 
     async def get_stale(
@@ -105,6 +111,7 @@ class AgentCardCacheBackend(Protocol):
         lookup_key: str,
         *,
         max_staleness_seconds: int,
+        key_type: LookupKeyType | None = None,
     ) -> AgentCardCacheRecord | None:
         """Return a cached record within the hard staleness bound."""
 
@@ -132,7 +139,13 @@ class MemoryAgentCardCacheBackend:
     def __init__(self) -> None:
         self._entries: dict[str, AgentCardCacheRecord] = {}
 
-    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
+    async def get_fresh(
+        self,
+        lookup_key: str,
+        *,
+        cache_ttl: int,
+        key_type: LookupKeyType | None = None,
+    ) -> AgentCardCacheRecord | None:
         record = self._entries.get(lookup_key)
         if record is None or not record.is_fresh(cache_ttl):
             return None
@@ -143,6 +156,7 @@ class MemoryAgentCardCacheBackend:
         lookup_key: str,
         *,
         max_staleness_seconds: int,
+        key_type: LookupKeyType | None = None,
     ) -> AgentCardCacheRecord | None:
         record = self._entries.get(lookup_key)
         if record is None or not record.is_within_staleness(max_staleness_seconds):
@@ -240,8 +254,14 @@ class MemorySpaceAgentCardCacheBackend:
             logger.warning("Ignoring invalid MemorySpace agent card payload for %s", storage_key)
             return None
 
-    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
-        for storage_key in self._storage_keys_for_lookup(lookup_key):
+    async def get_fresh(
+        self,
+        lookup_key: str,
+        *,
+        cache_ttl: int,
+        key_type: LookupKeyType | None = None,
+    ) -> AgentCardCacheRecord | None:
+        for storage_key in self._storage_keys_for_lookup(lookup_key, key_type=key_type):
             record = await self._get_record(storage_key)
             if record is not None and record.is_fresh(cache_ttl):
                 return record
@@ -252,8 +272,9 @@ class MemorySpaceAgentCardCacheBackend:
         lookup_key: str,
         *,
         max_staleness_seconds: int,
+        key_type: LookupKeyType | None = None,
     ) -> AgentCardCacheRecord | None:
-        for storage_key in self._storage_keys_for_lookup(lookup_key):
+        for storage_key in self._storage_keys_for_lookup(lookup_key, key_type=key_type):
             record = await self._get_record(storage_key)
             if record is not None and record.is_within_staleness(max_staleness_seconds):
                 return record
@@ -331,13 +352,23 @@ class LayeredAgentCardCacheBackend:
         tasks = list(self._l2_tasks)
         await asyncio.gather(*tasks, return_exceptions=True)
 
-    async def get_fresh(self, lookup_key: str, *, cache_ttl: int) -> AgentCardCacheRecord | None:
-        if record := await self._l1.get_fresh(lookup_key, cache_ttl=cache_ttl):
+    async def get_fresh(
+        self,
+        lookup_key: str,
+        *,
+        cache_ttl: int,
+        key_type: LookupKeyType | None = None,
+    ) -> AgentCardCacheRecord | None:
+        if record := await self._l1.get_fresh(lookup_key, cache_ttl=cache_ttl, key_type=key_type):
             return record
         # L1 holds a stale entry with the same fetched_at L2 would return — skip L2.
         if self._l1.has_entry(lookup_key):
             return None
-        if record := await self._l2.get_fresh(lookup_key, cache_ttl=cache_ttl):
+        if record := await self._l2.get_fresh(
+            lookup_key,
+            cache_ttl=cache_ttl,
+            key_type=key_type,
+        ):
             await self._promote_to_l1(lookup_key, record)
             return record
         return None
@@ -347,15 +378,18 @@ class LayeredAgentCardCacheBackend:
         lookup_key: str,
         *,
         max_staleness_seconds: int,
+        key_type: LookupKeyType | None = None,
     ) -> AgentCardCacheRecord | None:
         if record := await self._l1.get_stale(
             lookup_key,
             max_staleness_seconds=max_staleness_seconds,
+            key_type=key_type,
         ):
             return record
         if record := await self._l2.get_stale(
             lookup_key,
             max_staleness_seconds=max_staleness_seconds,
+            key_type=key_type,
         ):
             await self._promote_to_l1(lookup_key, record)
             return record

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -414,12 +414,11 @@ class LayeredAgentCardCacheBackend:
             key_type=key_type,
         ):
             return record
-        if record := await self._read_l2_with_timeout(
-            self._l2.get_stale(
-                lookup_key,
-                max_staleness_seconds=max_staleness_seconds,
-                key_type=key_type,
-            )
+        # Stale-if-error runs only after a registry fetch failed — wait for L2.
+        if record := await self._l2.get_stale(
+            lookup_key,
+            max_staleness_seconds=max_staleness_seconds,
+            key_type=key_type,
         ):
             await self._promote_to_l1(lookup_key, record)
             return record

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -206,16 +206,41 @@ class MemorySpaceKVCache:
         self._memory_space_id = memory_space_id
         normalized = key_prefix if key_prefix.endswith(":") else f"{key_prefix}:"
         self._key_prefix = normalized
+        self._session_ids: dict[str, str] = {}
 
     def _logical_key(self, key: str) -> str:
         return f"{self._key_prefix}{CACHE_KIND}:{key}"
+
+    def _cache_session_id(self, logical_key: str, session: Session) -> None:
+        self._session_ids[logical_key] = session.id
+
+    def _invalidate_session_id(self, logical_key: str) -> None:
+        self._session_ids.pop(logical_key, None)
+
+    def _resolve_session(self, logical_key: str) -> Session | None:
+        """Return the cache session, using a process-local session-id cache when possible."""
+        if session_id := self._session_ids.get(logical_key):
+            try:
+                return Session.get(self._memory_space_id, session_id)
+            except Exception:
+                logger.debug(
+                    "MemorySpace session cache miss for %s (session_id=%s)",
+                    logical_key,
+                    session_id,
+                )
+                self._invalidate_session_id(logical_key)
+
+        session = _find_cache_session(self._memory_space_id, logical_key)
+        if session is not None:
+            self._cache_session_id(logical_key, session)
+        return session
 
     async def get_value(self, key: str) -> str | None:
         """Return the stored JSON payload for *key*, or ``None`` when missing."""
         logical_key = self._logical_key(key)
 
         def _get() -> str | None:
-            session = _find_cache_session(self._memory_space_id, logical_key)
+            session = self._resolve_session(logical_key)
             if session is None:
                 return None
             return _read_payload(session)
@@ -231,12 +256,13 @@ class MemorySpaceKVCache:
         logical_key = self._logical_key(key)
 
         def _set() -> None:
-            session = _find_cache_session(self._memory_space_id, logical_key)
+            session = self._resolve_session(logical_key)
             if session is None:
                 session = _create_cache_session(
                     self._memory_space_id,
                     logical_key=logical_key,
                 )
+                self._cache_session_id(logical_key, session)
             _write_payload(session, payload)
 
         try:
@@ -249,9 +275,10 @@ class MemorySpaceKVCache:
         logical_key = self._logical_key(key)
 
         def _delete() -> None:
-            session = _find_cache_session(self._memory_space_id, logical_key)
+            session = self._resolve_session(logical_key)
             if session is not None:
                 session.delete()
+            self._invalidate_session_id(logical_key)
 
         try:
             await asyncio.to_thread(_delete)

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
@@ -231,3 +232,52 @@ class TestLayeredAgentCardCacheBackend:
         assert await l1.get_fresh("dep-1", cache_ttl=60) is None
         assert await l1.get_stale("dep-1", max_staleness_seconds=80) is None
         assert await l1.get_stale("dep-1", max_staleness_seconds=120) is not None
+
+    async def test_get_fresh_skips_l2_when_l1_has_stale_entry(self):
+        l1 = MemoryAgentCardCacheBackend()
+        l2 = AsyncMock()
+        l2.get_fresh = AsyncMock(return_value=None)
+        layered = LayeredAgentCardCacheBackend(l1, l2)
+
+        await l1.store({"dep-1": _SAMPLE_AGENT_CARD}, key_types={"dep-1": "deployment"})
+        l1.age_entry_for_test("dep-1", 120)
+
+        assert await layered.get_fresh("dep-1", cache_ttl=60) is None
+        l2.get_fresh.assert_not_awaited()
+
+    async def test_store_write_behind_does_not_block_on_l2(self):
+        l1 = MemoryAgentCardCacheBackend()
+        l2_blocked = asyncio.Event()
+        l2_started = asyncio.Event()
+
+        async def slow_store(*args, **kwargs):
+            l2_started.set()
+            await l2_blocked.wait()
+
+        l2 = AsyncMock()
+        l2.store = AsyncMock(side_effect=slow_store)
+        layered = LayeredAgentCardCacheBackend(l1, l2)
+
+        await layered.store({"dep-1": _SAMPLE_AGENT_CARD}, key_types={"dep-1": "deployment"})
+
+        assert await l1.get_fresh("dep-1", cache_ttl=3600) is not None
+        await asyncio.wait_for(l2_started.wait(), timeout=1.0)
+        l2.store.assert_awaited_once()
+        l2_blocked.set()
+        await layered.flush_l2_tasks()
+
+    async def test_evict_write_behind_clears_l1_before_l2(self):
+        l1 = MemoryAgentCardCacheBackend()
+        l2 = MemoryAgentCardCacheBackend()
+        layered = LayeredAgentCardCacheBackend(l1, l2)
+
+        await layered.store({"dep-1": _SAMPLE_AGENT_CARD}, key_types={"dep-1": "deployment"})
+        await layered.flush_l2_tasks()
+        assert await l2.get_fresh("dep-1", cache_ttl=3600) is not None
+
+        await layered.evict("dep-1", key_type="deployment")
+        assert not l1.has_entry("dep-1")
+        assert await l2.get_fresh("dep-1", cache_ttl=3600) is not None
+
+        await layered.flush_l2_tasks()
+        assert await l2.get_fresh("dep-1", cache_ttl=3600) is None

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -148,6 +148,8 @@ class TestMemorySpaceAgentCardCacheBackend:
             assert await memory_space_backend.get_fresh("dep-1", cache_ttl=3600) is None
 
         assert get_calls == ["deployment:dep-1", "external:dep-1"]
+
+    async def test_evict_removes_sibling_l2_key(self, memory_space_backend):
         """Typed eviction must delete every storage alias for the card."""
         record = build_cache_record(
             _SAMPLE_AGENT_CARD,

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -117,7 +117,36 @@ class TestMemorySpaceAgentCardCacheBackend:
         assert record.deployment_id == "dep-1"
         assert record.external_id == "ext-1"
 
-    async def test_evict_removes_sibling_l2_key(self, memory_space_backend):
+    async def test_get_fresh_uses_key_type_for_single_storage_probe(self, memory_space_backend):
+        get_calls: list[str] = []
+
+        async def track_get(key: str) -> str | None:
+            get_calls.append(key)
+            return None
+
+        with patch.object(memory_space_backend._kv, "get_value", side_effect=track_get):
+            assert (
+                await memory_space_backend.get_fresh(
+                    "dep-1",
+                    cache_ttl=3600,
+                    key_type="deployment",
+                )
+                is None
+            )
+
+        assert get_calls == ["deployment:dep-1"]
+
+    async def test_get_fresh_without_key_type_probes_both_aliases(self, memory_space_backend):
+        get_calls: list[str] = []
+
+        async def track_get(key: str) -> str | None:
+            get_calls.append(key)
+            return None
+
+        with patch.object(memory_space_backend._kv, "get_value", side_effect=track_get):
+            assert await memory_space_backend.get_fresh("dep-1", cache_ttl=3600) is None
+
+        assert get_calls == ["deployment:dep-1", "external:dep-1"]
         """Typed eviction must delete every storage alias for the card."""
         record = build_cache_record(
             _SAMPLE_AGENT_CARD,

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -293,6 +293,29 @@ class TestLayeredAgentCardCacheBackend:
         assert await layered.get_fresh("dep-1", cache_ttl=60) is None
         l2.get_fresh.assert_not_awaited()
 
+    async def test_get_stale_waits_for_slow_l2(self):
+        l1 = MemoryAgentCardCacheBackend()
+        stale_record = build_cache_record(
+            _SAMPLE_AGENT_CARD,
+            lookup_key="dep-1",
+            key_type="deployment",
+            deployment_id="dep-1",
+            external_id=None,
+        )
+
+        async def slow_get_stale(*args, **kwargs):
+            await asyncio.sleep(0.15)
+            return stale_record
+
+        l2 = AsyncMock()
+        l2.get_stale = AsyncMock(side_effect=slow_get_stale)
+        layered = LayeredAgentCardCacheBackend(l1, l2, l2_read_timeout=0.05)
+
+        record = await layered.get_stale("dep-1", max_staleness_seconds=3600)
+
+        assert record is stale_record
+        l2.get_stale.assert_awaited_once()
+
     async def test_get_fresh_l2_read_timeout_falls_through(self):
         l1 = MemoryAgentCardCacheBackend()
         l2_started = asyncio.Event()

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -356,7 +356,7 @@ class TestLayeredAgentCardCacheBackend:
         l2_blocked.set()
         await layered.flush_l2_tasks()
 
-    async def test_evict_write_behind_clears_l1_before_l2(self):
+    async def test_evict_clears_l2_before_returning(self):
         l1 = MemoryAgentCardCacheBackend()
         l2 = MemoryAgentCardCacheBackend()
         layered = LayeredAgentCardCacheBackend(l1, l2)
@@ -367,7 +367,5 @@ class TestLayeredAgentCardCacheBackend:
 
         await layered.evict("dep-1", key_type="deployment")
         assert not l1.has_entry("dep-1")
-        assert await l2.get_fresh("dep-1", cache_ttl=3600) is not None
-
-        await layered.flush_l2_tasks()
         assert await l2.get_fresh("dep-1", cache_ttl=3600) is None
+        assert await layered.get_fresh("dep-1", cache_ttl=3600) is None

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import time
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
@@ -195,6 +196,24 @@ class TestCreateAgentCardCacheBackend:
 
         assert type(backend) is MemoryAgentCardCacheBackend
 
+    def test_l1_only_when_cache_ttl_zero_even_with_memory_space(self):
+        config = AgentCardRegistryConfig(
+            agent_card_registry_memory_space_id="space-123",
+            agent_card_registry_cache_ttl=0,
+        )
+        with patch(
+            "datarobot_genai.dragent.agent_card_registry_backends.try_configure_datarobot_memory_client",
+            return_value=True,
+        ) as configure_mock:
+            from datarobot_genai.dragent.agent_card_registry_backends import (
+                MemoryAgentCardCacheBackend,
+            )
+
+            backend = create_agent_card_cache_backend(config)
+
+        assert type(backend) is MemoryAgentCardCacheBackend
+        configure_mock.assert_not_called()
+
     def test_l1_only_when_memory_client_unconfigured(self):
         config = AgentCardRegistryConfig(agent_card_registry_memory_space_id="space-123")
         with patch(
@@ -273,6 +292,25 @@ class TestLayeredAgentCardCacheBackend:
 
         assert await layered.get_fresh("dep-1", cache_ttl=60) is None
         l2.get_fresh.assert_not_awaited()
+
+    async def test_get_fresh_l2_read_timeout_falls_through(self):
+        l1 = MemoryAgentCardCacheBackend()
+        l2_started = asyncio.Event()
+
+        async def slow_get_fresh(*args, **kwargs):
+            l2_started.set()
+            await asyncio.sleep(1.0)
+
+        l2 = AsyncMock()
+        l2.get_fresh = AsyncMock(side_effect=slow_get_fresh)
+        layered = LayeredAgentCardCacheBackend(l1, l2, l2_read_timeout=0.05)
+
+        started = time.monotonic()
+        assert await layered.get_fresh("dep-1", cache_ttl=3600) is None
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 0.5
+        await asyncio.wait_for(l2_started.wait(), timeout=1.0)
 
     async def test_store_write_behind_does_not_block_on_l2(self):
         l1 = MemoryAgentCardCacheBackend()

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -94,13 +94,12 @@ class TestMemorySpaceKVCache:
                 "datarobot_genai.dragent.memory_space_cache._create_cache_session",
                 return_value=session,
             ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache.Session.get",
+                return_value=session,
+            ),
         ):
             await kv_cache.set_value("dep-1", '{"version": 1}')
-
-        with patch(
-            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-            return_value=session,
-        ):
             assert await kv_cache.get_value("dep-1") == '{"version": 1}'
 
         session.post_event.assert_called_once()
@@ -108,13 +107,49 @@ class TestMemorySpaceKVCache:
         assert kwargs["event_type"] == CACHE_EVENT_TYPE
         assert kwargs["body"]["payload"] == '{"version": 1}'
 
+    async def test_get_reuses_cached_session_id_without_list(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        session = _FakeSession()
+        find_mock = MagicMock(return_value=None)
+        get_mock = MagicMock(return_value=session)
+        session.post_event(body={"v": 1, "payload": "cached"})
+
+        with (
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+                find_mock,
+            ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._create_cache_session",
+                return_value=session,
+            ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache.Session.get",
+                get_mock,
+            ),
+        ):
+            await kv_cache.set_value("dep-1", "cached")
+            find_mock.reset_mock()
+            get_mock.reset_mock()
+            assert await kv_cache.get_value("dep-1") == "cached"
+
+        find_mock.assert_not_called()
+        get_mock.assert_called_once_with("space-1", "sess-1")
+
     async def test_update_existing_entry(self, kv_cache: MemorySpaceKVCache) -> None:
         session = _FakeSession()
         session.post_event(body={"v": 1, "payload": "v1"})
 
-        with patch(
-            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-            return_value=session,
+        with (
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+                return_value=session,
+            ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache.Session.get",
+                return_value=session,
+            ),
         ):
             await kv_cache.set_value("dep-1", "v2")
 
@@ -142,9 +177,15 @@ class TestMemorySpaceKVCache:
     async def test_delete_removes_session(self, kv_cache: MemorySpaceKVCache) -> None:
         session = _FakeSession()
 
-        with patch(
-            "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-            return_value=session,
+        with (
+            patch(
+                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
+                return_value=session,
+            ),
+            patch(
+                "datarobot_genai.dragent.memory_space_cache.Session.get",
+                return_value=session,
+            ),
         ):
             await kv_cache.delete_value("dep-1")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.7"
+version = "0.29.8"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
These are some optimizations to mitigate possible performance degradation when including the L2 cache for remote agent cards.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Write-behind instead of write-through. Skip L2 on soft-expired L1 hits. Pass deployment/external key type for L2 lookups. Skip L2 if TTL is 0.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connect-time caching for remote A2A agent cards (write-behind L2, bounded L2 reads, and altered L1/L2 interaction); failures degrade to registry fetch or stale-if-error rather than blocking, but brief L1/L2 skew is possible if background L2 writes fail.
> 
> **Overview**
> **Release 0.29.5** — speeds up central agent card registry when MemorySpace L2 is enabled, without changing registry API semantics.
> 
> The layered cache is now **write-behind** to L2: `store`/`evict` update L1 immediately and schedule MemorySpace work in background tasks (with `flush_l2_tasks` for tests/shutdown). **Cold L2 reads** are capped at ~200ms via `asyncio.wait_for`; on timeout the path falls through like a miss instead of blocking connect/registry fetch.
> 
> **Lookup behavior** threads `deployment` vs `external` `key_type` from `AgentCardRegistry` through fresh/stale checks so MemorySpace probes a single storage alias instead of both. If L1 has any entry for a key (including soft-expired), **`get_fresh` skips L2** so a stale L1 hit is not refreshed from L2 with the same `fetched_at`. **`AGENT_CARD_REGISTRY_CACHE_TTL=0`** forces L1-only and skips MemorySpace setup entirely.
> 
> **`MemorySpaceKVCache`** keeps an in-process map of logical key → session id so repeat get/set/delete use `Session.get` instead of listing sessions every time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522912630b0d1dd4c66b3ca5c473dd3407c9f55f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->