### PR TITLE
[MMM-24897] Emit agent name in langgraph, llamaIndex, dragent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.10 - 2026-08-26
+- `dragent`, `langgraph`, `llama_index`: **agent spans now carry `gen_ai.agent.name`.
+- Adds `datarobot-opentelemetry>=0.4.0,<1.0.0` to the `llamaindex` and `dragent` extras.
+
 ## 0.29.9
 - `dragent`: `registry` in `workflow.yaml` accepts `workload_id` alongside `deployment_id` and `external_id`, so an agent served by the Workload API runtime — where its card is keyed by workload rather than deployment — is reachable through the central agent card registry. Lookups query `workloadIds`, cache under a `workload:` key (L1 and MemorySpace L2), and take part in startup prefetch, background refresh and stale-if-error like the other two kinds. A workload card that also publishes an `external.id` stays reachable by either ID.
 - `dragent`: each registry request now carries exactly **one** ID kind. `deploymentIds` + `workloadIds` in one request is rejected by the API with HTTP 400 (not an empty result like `deploymentIds` + `externalIds`), so the client fetches one kind per call and raises before issuing a request that mixes the two.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -1101,11 +1101,11 @@ requires-dist = [
     { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.47,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.47,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.3.4,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.3.4,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.3.4,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.3.4,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.3.4,<12.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1353,7 +1353,7 @@ example-quickstart = [{ name = "datarobot-genai", extras = ["langgraph"], editab
 
 [[package]]
 name = "datarobot-moderations"
-version = "11.2.47"
+version = "11.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1373,7 +1373,7 @@ dependencies = [
     { name = "tiktoken" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/20/de8c6739e29a92afb28e686a465251cb989d1e405c26fccdb521f80c8540/datarobot_moderations-11.2.47-py3-none-any.whl", hash = "sha256:ae6a0ddb243704e99e27395f60b8025bfe6b0a72bd011372553fadabb81c8ecf", size = 177480, upload-time = "2026-07-24T13:14:03.425Z" },
+    { url = "https://files.pythonhosted.org/packages/51/92/023ddc77c3c730b751110f28b78bd8eb02606191ee5f0b43d7148fde81b6/datarobot_moderations-11.3.4-py3-none-any.whl", hash = "sha256:2b42b968e2a2741c69f243b98af8ef595e85f2e7a3328d85eff1a1eb6b457192", size = 178431, upload-time = "2026-08-21T17:32:01.04Z" },
 ]
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -950,7 +950,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.8"
+version = "0.29.10"
 source = { editable = "../" }
 
 [package.optional-dependencies]
@@ -987,6 +987,7 @@ dragent = [
     { name = "colorama" },
     { name = "datarobot", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
+    { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
     { name = "mem0ai" },
@@ -1035,6 +1036,7 @@ llamaindex = [
     { name = "colorama" },
     { name = "datarobot", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
+    { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
     { name = "litellm" },
@@ -1101,11 +1103,13 @@ requires-dist = [
     { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.3.4,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.3.4,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.3.4,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.3.4,<12.0.0" },
-    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.3.4,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.47,<12.0.0" },
+    { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.47,<12.0.0" },
+    { name = "datarobot-opentelemetry", marker = "extra == 'dragent'", specifier = ">=0.4.0,<1.0.0" },
+    { name = "datarobot-opentelemetry", marker = "extra == 'llamaindex'", specifier = ">=0.4.0,<1.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1394,6 +1398,15 @@ all = [
     { name = "nemo-microservices" },
     { name = "nemoguardrails" },
     { name = "openai" },
+]
+
+[[package]]
+name = "datarobot-opentelemetry"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/61/9eddb74c592b8cd6b2f240bacb80858a2b945beb5aa1855da547ea496f3e/datarobot_opentelemetry-0.4.0.tar.gz", hash = "sha256:8974c77cf4be7de853dadacc99cb3e651c5c534c6a56dec16ef6874cb7c360f7", size = 92725, upload-time = "2026-08-25T17:36:17.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/2f/ea4ae74df417bf8a6a338ac2db11ebcb2c08d26c1c87ba7fd4d074277b07/datarobot_opentelemetry-0.4.0-py3-none-any.whl", hash = "sha256:4aa839f6ec3910c07f439b787d53966d9a6476eb377bc4134d232c091882c97a", size = 24388, upload-time = "2026-08-25T17:36:16.18Z" },
 ]
 
 [[package]]
@@ -2422,17 +2435,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -2448,16 +2461,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -3735,10 +3748,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3754,10 +3767,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.9"
+version = "0.29.10"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ llamaindex = core + [
     "nvidia-nat-llama-index==1.7.0",
     "opentelemetry-instrumentation-llamaindex>=0.62.1,<1.0.0",
     "pypdf>=6.10.1,<7.0.0",  # CVE-2026-40260 fixed in 6.10.0; GHSA-jj6c-8h6c-hppx in 6.10.1
+    # >=0.4.0 for GEN_AI_AGENT_NAME (PBMP-8006 SDK-1)
+    "datarobot-opentelemetry>=0.4.0,<1.0.0",
 ]
 
 dragent = core + [
@@ -88,6 +90,8 @@ dragent = core + [
     "mem0ai>=1.0.4,<2.0.0",
     "starlette>=1.0.1",  # CVE fix
     "opentelemetry-instrumentation-fastapi>=0.64b0,<1.0.0",
+    # >=0.4.0 for GEN_AI_AGENT_NAME (PBMP-8006 SDK-1)
+    "datarobot-opentelemetry>=0.4.0,<1.0.0",
 ]
 
 # auth is standalone set of dependencies for auth utilities only

--- a/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
@@ -21,6 +21,7 @@ from ag_ui.core import RunAgentInput
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import UserMessage
+from datarobot_opentelemetry.semconv import SpanAttributes as DataRobotSpanAttributes
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_middleware
 from nat.data_models.api_server import ChatRequestOrMessage
@@ -161,13 +162,14 @@ class DataRobotOtelConventionsMiddleware(
         self,
         *args: Any,
         call_next: CallNext,
-        context: FunctionMiddlewareContext,  # noqa: ARG002
+        context: FunctionMiddlewareContext,
         **kwargs: Any,
     ) -> Any:
         with (
             use_nat_workflow_trace_context(),
             tracer.start_as_current_span(AGENT_SPAN_NAME) as span,
         ):
+            span.set_attribute(DataRobotSpanAttributes.GEN_AI_AGENT_NAME, context.name)
             prompt = self._prompt_from_args(args)
             if prompt is not None:
                 span.set_attribute(GEN_AI_PROMPT, prompt)
@@ -184,13 +186,14 @@ class DataRobotOtelConventionsMiddleware(
         self,
         *args: Any,
         call_next: CallNextStream,
-        context: FunctionMiddlewareContext,  # noqa: ARG002
+        context: FunctionMiddlewareContext,
         **kwargs: Any,
     ) -> AsyncIterator[Any]:
         with (
             use_nat_workflow_trace_context(),
             tracer.start_as_current_span(AGENT_SPAN_NAME) as span,
         ):
+            span.set_attribute(DataRobotSpanAttributes.GEN_AI_AGENT_NAME, context.name)
             prompt = self._prompt_from_args(args)
             if prompt is not None:
                 span.set_attribute(GEN_AI_PROMPT, prompt)

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -129,7 +129,13 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
         self.interrupt_before = interrupt_before
         self.interrupt_after = interrupt_after
         self.debug = debug
-        self.name = name
+        # Compiled onto the graph below and read back out by the LangChain
+        # OTel auto-instrumentor as gen_ai.agent.name - default to the
+        # concrete subclass name so multi-agent segmentation still has
+        # something to group by when a caller doesn't pass `name=`
+        # explicitly (langgraph's own default is the generic "LangGraph",
+        # identical across every agent built from this class).
+        self.name = name or type(self).__name__
         self._structured_history = structured_history
         super().__init__(
             api_key=api_key,

--- a/src/datarobot_genai/llama_index/telemetry.py
+++ b/src/datarobot_genai/llama_index/telemetry.py
@@ -12,17 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Idempotent LlamaIndex auto-instrumentation for agent telemetry."""
+"""Idempotent LlamaIndex auto-instrumentation for agent telemetry.
+
+``opentelemetry-instrumentation-llamaindex`` spans every workflow step
+(``AgentWorkflow`` is itself a ``Workflow``) but never attaches an agent
+identity to them - :class:`_AgentNameSpanHandler` fills that gap by reacting
+to the same span-enter notifications LlamaIndex's own instrumentation uses,
+without needing to re-implement span creation.
+"""
 
 from __future__ import annotations
 
+import inspect
 import logging
+from typing import Any
 
+from datarobot_opentelemetry.semconv import SpanAttributes as DataRobotSpanAttributes
+from llama_index.core.instrumentation import get_dispatcher
+from llama_index.core.instrumentation.span.base import BaseSpan
+from llama_index.core.instrumentation.span_handlers import BaseSpanHandler
+from opentelemetry import trace
 from opentelemetry.instrumentation.llamaindex import LlamaIndexInstrumentor
 
 logger = logging.getLogger(__name__)
 
 _INSTRUMENTED = {"llamaindex": False}
+
+
+class _AgentNameSpanHandler(BaseSpanHandler[BaseSpan]):
+    """Sets ``gen_ai.agent.name`` on the current span for any workflow step
+    whose event carries ``current_agent_name`` - every step in this repo's
+    ``AgentWorkflow`` (single- or multi-agent) does, via
+    ``llama_index.core.agent.workflow.workflow_events``.
+
+    Registered after :class:`LlamaIndexInstrumentor`'s own span handler, so
+    by the time this fires the OTel span it just opened is already the
+    current span in context - this only tags it, it never creates one.
+    """
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "DataRobotAgentNameSpanHandler"
+
+    def span_enter(
+        self,
+        id_: str,  # noqa: ARG002
+        bound_args: inspect.BoundArguments,
+        instance: Any | None = None,  # noqa: ARG002
+        parent_id: str | None = None,  # noqa: ARG002
+        tags: dict[str, Any] | None = None,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        ev = bound_args.arguments.get("ev")
+        agent_name = getattr(ev, "current_agent_name", None)
+        if agent_name:
+            trace.get_current_span().set_attribute(
+                DataRobotSpanAttributes.GEN_AI_AGENT_NAME, agent_name
+            )
+
+    def new_span(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def prepare_to_exit_span(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def prepare_to_drop_span(self, *args: Any, **kwargs: Any) -> None:
+        return None
 
 
 def instrument() -> None:
@@ -32,6 +87,7 @@ def instrument() -> None:
         return
     try:
         LlamaIndexInstrumentor().instrument()
+        get_dispatcher().add_span_handler(_AgentNameSpanHandler())
         _INSTRUMENTED["llamaindex"] = True
     except Exception as e:
         logger.info(f"LlamaIndex instrumentation failed: {e}")

--- a/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
@@ -37,6 +37,7 @@ from ag_ui.core import TextMessageContentEvent
 from ag_ui.core import TextMessageEndEvent
 from ag_ui.core import ToolCallStartEvent
 from ag_ui.core import UserMessage
+from datarobot_opentelemetry.semconv import SpanAttributes as DataRobotSpanAttributes
 from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.api_server import Message
 from opentelemetry.sdk.trace import ReadableSpan
@@ -247,6 +248,23 @@ async def test_invoke_sets_prompt_and_completion_for_str_output(
     assert span.attributes[GEN_AI_COMPLETION] == "4"
 
 
+async def test_invoke_sets_agent_name_from_context(
+    middleware: DataRobotOtelConventionsMiddleware,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    context = MagicMock()
+    context.name = "my_agent_function"
+
+    await middleware.function_middleware_invoke(
+        _nat_input("hi"),
+        call_next=_call_next("ok"),
+        context=context,
+    )
+
+    span = _span_named(span_exporter, AGENT_SPAN_NAME)
+    assert span.attributes[DataRobotSpanAttributes.GEN_AI_AGENT_NAME] == "my_agent_function"
+
+
 async def test_invoke_sets_prompt_from_input_message(
     middleware: DataRobotOtelConventionsMiddleware,
     span_exporter: InMemorySpanExporter,
@@ -322,6 +340,25 @@ async def test_invoke_non_text_output_sets_no_completion(
 # ---------------------------------------------------------------------------
 # function_middleware_stream
 # ---------------------------------------------------------------------------
+
+
+async def test_stream_sets_agent_name_from_context(
+    middleware: DataRobotOtelConventionsMiddleware,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    context = MagicMock()
+    context.name = "my_streaming_agent"
+
+    await _drain(
+        middleware.function_middleware_stream(
+            _nat_input("hi"),
+            call_next=_call_next_stream([]),
+            context=context,
+        )
+    )
+
+    span = _span_named(span_exporter, AGENT_SPAN_NAME)
+    assert span.attributes[DataRobotSpanAttributes.GEN_AI_AGENT_NAME] == "my_streaming_agent"
 
 
 async def test_stream_aggregates_completion_across_chunks(

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -205,6 +205,25 @@ class SimpleLangGraphAgent(LangGraphAgent):
         return {}
 
 
+# ---------------------------------------------------------------------------
+# name (compiled onto the graph, read back out by the OTel auto-instrumentor
+# as gen_ai.agent.name)
+# ---------------------------------------------------------------------------
+
+
+def test_name_defaults_to_the_concrete_subclass_name() -> None:
+    """Without an explicit name=, langgraph's own compile() falls back to the
+    generic literal "LangGraph" - identical across every agent built from this
+    class, useless for multi-agent segmentation. Defaulting to the subclass
+    name here gives every agent something distinguishing for free.
+    """
+    assert SimpleLangGraphAgent().name == "SimpleLangGraphAgent"
+
+
+def test_name_respects_an_explicit_override() -> None:
+    assert SimpleLangGraphAgent(name="my_custom_agent").name == "my_custom_agent"
+
+
 def test_datarobot_agent_class_from_langgraph_factory_receives_llm_tools_verbose() -> None:
     """graph_factory(llm, tools, verbose) is called when building workflow (each access)."""
     inner = SimpleLangGraphAgent()

--- a/tests/llamaindex/test_telemetry.py
+++ b/tests/llamaindex/test_telemetry.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from datarobot_opentelemetry.semconv import SpanAttributes as DataRobotSpanAttributes
+from opentelemetry.sdk.trace import Span
+from opentelemetry.sdk.trace import TracerProvider
 
 from datarobot_genai.llama_index import telemetry
 
@@ -29,7 +35,10 @@ def reset_state() -> Iterator[None]:
 
 
 def test_instrument_enables_instrumentor() -> None:
-    with patch.object(telemetry, "LlamaIndexInstrumentor") as instrumentor:
+    with (
+        patch.object(telemetry, "LlamaIndexInstrumentor") as instrumentor,
+        patch.object(telemetry, "get_dispatcher"),
+    ):
         telemetry.instrument()
 
     instrumentor.return_value.instrument.assert_called_once()
@@ -37,11 +46,15 @@ def test_instrument_enables_instrumentor() -> None:
 
 
 def test_instrument_is_idempotent() -> None:
-    with patch.object(telemetry, "LlamaIndexInstrumentor") as instrumentor:
+    with (
+        patch.object(telemetry, "LlamaIndexInstrumentor") as instrumentor,
+        patch.object(telemetry, "get_dispatcher") as get_dispatcher,
+    ):
         telemetry.instrument()
         telemetry.instrument()
 
     instrumentor.return_value.instrument.assert_called_once()
+    get_dispatcher.return_value.add_span_handler.assert_called_once()
 
 
 def test_instrument_swallows_errors() -> None:
@@ -51,3 +64,102 @@ def test_instrument_swallows_errors() -> None:
         telemetry.instrument()
 
     assert telemetry._INSTRUMENTED["llamaindex"] is False
+
+
+def test_instrument_registers_agent_name_span_handler() -> None:
+    with (
+        patch.object(telemetry, "LlamaIndexInstrumentor"),
+        patch.object(telemetry, "get_dispatcher") as get_dispatcher,
+    ):
+        telemetry.instrument()
+
+    (registered_handler,), _ = get_dispatcher.return_value.add_span_handler.call_args
+    assert isinstance(registered_handler, telemetry._AgentNameSpanHandler)
+
+
+# ---------------------------------------------------------------------------
+# _AgentNameSpanHandler
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def recording_span() -> Iterator[Span]:
+    """Return a real, currently-active (not yet ended) span - mirrors what
+    OpenLLMetry's own span handler would have already opened and attached to
+    context by the time ours runs (it's registered second). Still-open SDK
+    spans expose `.attributes` directly, so assertions don't need to wait for
+    export.
+    """
+    provider = TracerProvider()
+    tracer = provider.get_tracer(__name__)
+    with tracer.start_as_current_span("FunctionAgent.task") as span:
+        yield cast(Span, span)
+
+
+def test_span_enter_sets_agent_name_when_event_carries_it(recording_span: Span) -> None:
+    handler = telemetry._AgentNameSpanHandler()
+    ev = SimpleNamespace(current_agent_name="researcher")
+    bound_args = MagicMock(arguments={"ev": ev})
+
+    handler.span_enter(id_="FunctionAgent.run_agent_step-1", bound_args=bound_args)
+
+    assert recording_span.attributes is not None
+    assert recording_span.attributes[DataRobotSpanAttributes.GEN_AI_AGENT_NAME] == "researcher"
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        pytest.param({}, id="no-ev-argument"),
+        pytest.param({"ev": SimpleNamespace()}, id="ev-without-current-agent-name"),
+        pytest.param(
+            {"ev": SimpleNamespace(current_agent_name=None)}, id="current-agent-name-none"
+        ),
+    ],
+)
+def test_span_enter_is_a_noop_without_a_usable_agent_name(
+    recording_span: Span,
+    arguments: dict[str, object],
+) -> None:
+    handler = telemetry._AgentNameSpanHandler()
+    bound_args = MagicMock(arguments=arguments)
+
+    handler.span_enter(id_="SomeOtherStep-1", bound_args=bound_args)
+
+    assert recording_span.attributes is not None
+    assert DataRobotSpanAttributes.GEN_AI_AGENT_NAME not in recording_span.attributes
+
+
+def test_new_span_and_span_lifecycle_hooks_are_noops() -> None:
+    """These exist only to satisfy BaseSpanHandler's abstract interface -
+    all the real logic is in span_enter above.
+    """
+    handler = telemetry._AgentNameSpanHandler()
+    bound_args = MagicMock(arguments={})
+
+    handler.new_span(id_="x", bound_args=bound_args)
+    handler.prepare_to_exit_span(id_="x", bound_args=bound_args)
+    handler.prepare_to_drop_span(id_="x", bound_args=bound_args)
+
+
+@pytest.mark.parametrize("outcome", ["exit", "drop"])
+def test_full_dispatcher_lifecycle_does_not_raise(outcome: str) -> None:
+    """span_enter is overridden directly and never populates `open_spans`
+    (unlike the base class's own span_enter, which populates it from
+    new_span's return value). The dispatcher still calls the inherited
+    span_exit/span_drop on every handler regardless - those delete from
+    open_spans only when prepare_to_exit_span/prepare_to_drop_span return a
+    truthy span, so this only holds together because both are stubbed to
+    return None. Exercises the real dispatcher-facing methods, not just the
+    prepare_to_* stubs directly, since that's the coupling that matters.
+    """
+    handler = telemetry._AgentNameSpanHandler()
+    bound_args = MagicMock(arguments={})
+
+    handler.span_enter(id_="x", bound_args=bound_args, instance=None, parent_id=None, tags=None)
+    if outcome == "exit":
+        handler.span_exit(id_="x", bound_args=bound_args, instance=None, result=None)
+    else:
+        handler.span_drop(id_="x", bound_args=bound_args, instance=None, err=RuntimeError("boom"))
+
+    assert handler.open_spans == {}

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.9"
+version = "0.29.10"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -2769,17 +2769,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -2795,16 +2795,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -3986,10 +3986,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -4005,10 +4005,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1200,6 +1200,7 @@ dragent = [
     { name = "colorama" },
     { name = "datarobot", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
+    { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
     { name = "mem0ai" },
@@ -1332,6 +1333,7 @@ llamaindex = [
     { name = "colorama" },
     { name = "datarobot", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
+    { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
     { name = "litellm" },
@@ -1426,6 +1428,8 @@ requires-dist = [
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'langgraph'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'llamaindex'", specifier = ">=11.2.47,<12.0.0" },
+    { name = "datarobot-opentelemetry", marker = "extra == 'dragent'", specifier = ">=0.4.0,<1.0.0" },
+    { name = "datarobot-opentelemetry", marker = "extra == 'llamaindex'", specifier = ">=0.4.0,<1.0.0" },
     { name = "datarobot-predict", marker = "extra == 'core'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'crewai'", specifier = ">=1.13.2,<2.0.0" },
     { name = "datarobot-predict", marker = "extra == 'dragent'", specifier = ">=1.13.2,<2.0.0" },
@@ -1646,6 +1650,15 @@ all = [
     { name = "nemo-microservices" },
     { name = "nemoguardrails" },
     { name = "openai" },
+]
+
+[[package]]
+name = "datarobot-opentelemetry"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/61/9eddb74c592b8cd6b2f240bacb80858a2b945beb5aa1855da547ea496f3e/datarobot_opentelemetry-0.4.0.tar.gz", hash = "sha256:8974c77cf4be7de853dadacc99cb3e651c5c534c6a56dec16ef6874cb7c360f7", size = 92725, upload-time = "2026-08-25T17:36:17.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/2f/ea4ae74df417bf8a6a338ac2db11ebcb2c08d26c1c87ba7fd4d074277b07/datarobot_opentelemetry-0.4.0-py3-none-any.whl", hash = "sha256:4aa839f6ec3910c07f439b787d53966d9a6476eb377bc4134d232c091882c97a", size = 24388, upload-time = "2026-08-25T17:36:16.18Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to OpenTelemetry span attributes, a safer default graph name, and dependency pins; no auth, data, or request-handling logic is modified.
> 
> **Overview**
> Adds **`gen_ai.agent.name`** on agent traces across three stacks so multi-agent runs can be segmented in the Tracing table (MMM-24897 / PBMP-8006).
> 
> **DRAgent (NAT):** The OTel conventions middleware now sets `DataRobotSpanAttributes.GEN_AI_AGENT_NAME` from `FunctionMiddlewareContext.name` on the `datarobot_agent` span for both invoke and streaming paths.
> 
> **LangGraph:** When `name=` is omitted, the compiled graph name defaults to the **concrete agent subclass** (e.g. `SimpleLangGraphAgent`) instead of LangGraph’s generic `"LangGraph"`, so the LangChain OTel instrumentor can surface a distinguishing `gen_ai.agent.name`.
> 
> **LlamaIndex:** After enabling the stock instrumentor, a `_AgentNameSpanHandler` tags the current OTel span from workflow events’ `current_agent_name` without creating its own spans.
> 
> **Deps:** `datarobot-opentelemetry>=0.4.0` is added to the `llamaindex` and `dragent` extras; e2e lockfile bumps `datarobot-moderations` to **11.3.4**. Unit tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a07b24c6ae6daf578c4f27e3f2c0996c32b9551. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->