### PR TITLE
[MMM-24714] Fix dragent's legacy tool-name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.11 - 2026-08-26
+- `dragent`: tool-call spans now carry `gen_ai.tool.name` instead of the bare legacy `tool_name` attribute, so NAT-based tool calls stop landing in Datavolt's deprecated attribute bucket (PBMP-8006 SDK-2).
+
 ## 0.29.10 - 2026-08-26
 - `dragent`, `langgraph`, `llama_index`: **agent spans now carry `gen_ai.agent.name`.
 - Adds `datarobot-opentelemetry>=0.4.0,<1.0.0` to the `llamaindex` and `dragent` extras.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.11 - 2026-08-26
-- `dragent`: tool-call spans now carry `gen_ai.tool.name` instead of the bare legacy `tool_name` attribute, so NAT-based tool calls stop landing in Datavolt's deprecated attribute bucket (PBMP-8006 SDK-2).
+- `dragent`: tool-call spans now carry `gen_ai.tool.name` instead of the bare legacy `tool_name` attributeg.
 
 ## 0.29.10 - 2026-08-26
 - `dragent`, `langgraph`, `llama_index`: **agent spans now carry `gen_ai.agent.name`.

--- a/e2e-tests/dragent_tests/otel_helpers.py
+++ b/e2e-tests/dragent_tests/otel_helpers.py
@@ -77,7 +77,7 @@ OTEL_EXPORTER_OTLP_HEADERS = (
 # ``datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware``.
 GEN_AI_PROMPT = "gen_ai.prompt"  # Prompt column
 GEN_AI_COMPLETION = "gen_ai.completion"  # Completion column
-TOOL_NAME = "tool_name"  # Tools column
+GEN_AI_TOOL_NAME = "gen_ai.tool.name"  # Tools column
 
 # HTTP client spans that fire during import / runtime bootstrap -- before any
 # workflow trace exists -- so they legitimately root their own trace rather than
@@ -637,8 +637,8 @@ def assert_tracing_conventions(
       single ``trace_id``, and
     * the export carried the DataRobot ingest auth headers.
 
-    When *expect_tool_name* is set, also requires a ``tool_name`` span in the
-    same trace (frameworks that surface tool calls as AG-UI events).
+    When *expect_tool_name* is set, also requires a ``gen_ai.tool.name`` span
+    in the same trace (frameworks that surface tool calls as AG-UI events).
 
     When *framework* is set (e.g. ``"crewai"``), also requires that framework's
     characteristic auto-instrumentor spans in the same trace — see
@@ -682,9 +682,9 @@ def assert_tracing_conventions(
 
     if expect_tool_name:
         spans_in_trace = [s for s in collector.spans() if s.trace_id in agent_trace_ids]
-        tool_spans = [s for s in spans_in_trace if s.attributes.get(TOOL_NAME)]
+        tool_spans = [s for s in spans_in_trace if s.attributes.get(GEN_AI_TOOL_NAME)]
         assert tool_spans, (
-            f"Expected a span carrying {TOOL_NAME!r} in the same trace as the "
+            f"Expected a span carrying {GEN_AI_TOOL_NAME!r} in the same trace as the "
             f"agent span for the tool-calling request; "
             f"got span names {sorted({s.name for s in spans_in_trace})}."
         )

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -950,7 +950,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.10"
+version = "0.29.11"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.10"
+version = "0.29.11"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/agent_manifest.py
+++ b/src/datarobot_genai/dragent/frontends/agent_manifest.py
@@ -1,0 +1,108 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent Manifest: a static reflection of a running agent's declared NAT
+workflow structure, served at ``/.well-known/agent-manifest.json`` (PBMP-8006
+SDK-3) alongside the existing A2A ``/.well-known/agent-card.json``.
+
+Unlike the A2A agent card (hand-authored ``skills``/``description`` metadata,
+see :mod:`~datarobot_genai.dragent.frontends.a2a`), this manifest is derived
+entirely from ``workflow.yaml``'s own declared structure - the
+``functions``/``function_groups``/``workflow`` sections of the NAT
+:class:`~nat.data_models.config.Config` - so it needs no separate
+configuration and can never drift from what the agent actually declares.
+
+The manifest's own wire format is provisional: the downstream consumer
+(workload-api's manifest-parsing task, WAPI-1) hasn't landed yet, so there is
+no authoritative schema to match against. This shape may need to change once
+that lands.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from nat.data_models.config import Config
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class AgentManifestRootAgent(BaseModel):
+    """The workflow's entry-point function - ``workflow:`` in workflow.yaml."""
+
+    name: str = Field(description="Display name, falling back to the registered type")
+    type: str = Field(description="Registered NAT component type, e.g. 'streaming_memory_agent'")
+    description: str | None = Field(
+        default=None, description="Only present when the concrete config type declares one"
+    )
+
+
+class AgentManifestComponent(BaseModel):
+    """One declared ``functions:`` or ``function_groups:`` entry."""
+
+    name: str = Field(description="The workflow.yaml key this component is declared under")
+    type: str = Field(description="Registered NAT component type")
+    kind: Literal["function", "function_group"]
+    description: str | None = Field(
+        default=None, description="Only present when the concrete config type declares one"
+    )
+
+
+class AgentManifest(BaseModel):
+    root_agent: AgentManifestRootAgent
+    components: list[AgentManifestComponent]
+
+
+def _root_agent_from_config(config: Config) -> AgentManifestRootAgent:
+    workflow_config = config.workflow
+    return AgentManifestRootAgent(
+        name=workflow_config.name or workflow_config.type,
+        type=workflow_config.type,
+        description=getattr(workflow_config, "description", None),
+    )
+
+
+def _components_from_config(config: Config) -> list[AgentManifestComponent]:
+    components = [
+        AgentManifestComponent(
+            name=name,
+            type=function_config.type,
+            kind="function",
+            description=getattr(function_config, "description", None),
+        )
+        for name, function_config in config.functions.items()
+    ]
+    components += [
+        AgentManifestComponent(
+            name=name,
+            type=group_config.type,
+            kind="function_group",
+            description=getattr(group_config, "description", None),
+        )
+        for name, group_config in config.function_groups.items()
+    ]
+    return components
+
+
+def build_agent_manifest(config: Config) -> AgentManifest:
+    """Build the manifest from a NAT ``Config`` alone - no build/execution needed.
+
+    ``config.workflow``/``config.functions``/``config.function_groups`` are
+    already fully-parsed ``workflow.yaml`` declarations by the time a
+    ``Config`` exists, so this never runs any agent code.
+    """
+    return AgentManifest(
+        root_agent=_root_agent_from_config(config),
+        components=_components_from_config(config),
+    )

--- a/src/datarobot_genai/dragent/frontends/fastapi.py
+++ b/src/datarobot_genai/dragent/frontends/fastapi.py
@@ -37,6 +37,8 @@ from datarobot_genai.dragent.registry_warmup import warmup_registry_from_config
 from .a2a import A2A_MOUNT_PATH
 from .a2a import DRAgentA2AFrontEndPluginWorker
 from .a2a import create_agent_card
+from .agent_manifest import AgentManifest
+from .agent_manifest import build_agent_manifest
 from .claim_validation import GeneralOAuthClaimValidationMiddleware
 from .register import DRAgentA2AConfig
 from .session import DRAgentAGUISessionManager
@@ -267,6 +269,7 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
         # Register DataRobot health routes (/, /ping, /ping/, /health, /health/).
         # NAT 1.6 no longer calls self.add_health_route() so we register here.
         self._register_health_routes(app)
+        self._register_agent_manifest_route(app)
 
         self._add_audience_validation_middleware(app)
 
@@ -319,6 +322,30 @@ class DRAgentFastApiFrontEndPluginWorker(FastApiFrontEndPluginWorker):
             )
 
             logger.info(f"Added health check endpoint at {path}")
+
+    def _register_agent_manifest_route(self, app: FastAPI) -> None:
+        """Register the well-known Agent Manifest endpoint.
+
+        Built once from ``self._config`` here (not per-request) since the
+        manifest is a static reflection of the declared workflow.yaml
+        structure, not a live computation.
+        """
+        manifest = build_agent_manifest(self._config)
+
+        async def agent_manifest() -> AgentManifest:
+            """Return the declared components, tools, and root agent for this running agent."""
+            return manifest
+
+        app.add_api_route(
+            path="/.well-known/agent-manifest.json",
+            endpoint=agent_manifest,
+            methods=["GET"],
+            response_model=AgentManifest,
+            description="Declared components, tools, and root agent for this running agent",
+            tags=["Agent Manifest"],
+        )
+
+        logger.info("Added Agent Manifest endpoint at /.well-known/agent-manifest.json")
 
 
 class _GunicornSettings(DataRobotAppFrameworkBaseSettings):

--- a/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
@@ -53,7 +53,6 @@ AGENT_SPAN_NAME = "datarobot_agent"
 # Span attributes that map to deployment Tracing table columns.
 GEN_AI_PROMPT = "gen_ai.prompt"  # Prompt column
 GEN_AI_COMPLETION = "gen_ai.completion"  # Completion column
-TOOL_NAME = "tool_name"  # Tools column
 ERROR_TYPE = "error.type"  # Failed span classification
 
 # AG-UI event types that carry assistant text deltas.
@@ -104,17 +103,19 @@ def _mark_span_error_on_run_error(span: trace.Span, response: DRAgentEventRespon
 
 
 def _emit_tool_call_spans(response: DRAgentEventResponse) -> None:
-    """Emit a short-lived span carrying ``tool_name`` for each tool-call start.
+    """Emit a short-lived span carrying ``gen_ai.tool.name`` for each tool-call start.
 
     NAT reports tool execution via intermediate-step end events we can't wrap,
     but it does surface a ``ToolCallStartEvent``. Creating and immediately
-    ending a span with the ``tool_name`` attribute is enough to populate the
-    Tracing table Tools column.
+    ending a span with the ``gen_ai.tool.name`` attribute is enough to populate
+    the Tracing table Tools column - using the semconv name directly (rather
+    than the bare ``tool_name`` this used to set) keeps these calls out of
+    Datavolt's deprecated-attribute bucket.
     """
     for event in response.events:
         if isinstance(event, ToolCallStartEvent):
             with tracer.start_as_current_span(event.tool_call_name) as span:
-                span.set_attribute(TOOL_NAME, event.tool_call_name)
+                span.set_attribute(DataRobotSpanAttributes.GEN_AI_TOOL_NAME, event.tool_call_name)
 
 
 class DataRobotOtelConventionsMiddlewareConfig(

--- a/tests/dragent/frontends/test_agent_manifest.py
+++ b/tests/dragent/frontends/test_agent_manifest.py
@@ -1,0 +1,92 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nat.data_models.config import Config
+from nat.data_models.config import GeneralConfig
+from nat.data_models.function import FunctionBaseConfig
+from nat.data_models.function import FunctionGroupBaseConfig
+
+from datarobot_genai.dragent.frontends.agent_manifest import build_agent_manifest
+
+
+class _FakeToolConfig(FunctionBaseConfig, name="fake_tool"):  # type: ignore[call-arg, misc]
+    """A function config whose concrete type declares ``description`` -
+    mirrors how real function configs (e.g. StreamingMemoryAgentConfig) do,
+    unlike the base FunctionBaseConfig, which has no such field.
+
+    Not a type NAT's plugin registry knows about, so ``Config(...)``'s normal
+    validation would reject it (it looks up every declared ``_type`` against
+    installed plugins) - tests build the ``Config`` via ``model_construct``
+    instead, which skips that lookup and just stores the objects directly.
+    ``build_agent_manifest`` only reads attributes off an already-built
+    ``Config``, so this is a faithful enough double for it.
+    """
+
+    description: str | None = None
+
+
+class _FakeGroupConfig(FunctionGroupBaseConfig, name="fake_group"):  # type: ignore[call-arg, misc]
+    description: str | None = None
+
+
+def test_build_agent_manifest_on_empty_config() -> None:
+    """A config with no declared functions/function_groups and the default
+    (unset) workflow still produces a valid manifest, not an error - this is
+    the shape `worker` fixtures across this test suite construct by default.
+    """
+    config = Config(general=GeneralConfig())
+
+    manifest = build_agent_manifest(config)
+
+    assert manifest.components == []
+    assert manifest.root_agent.type == "EmptyFunctionConfig"
+    # No explicit name was set, so it falls back to the type.
+    assert manifest.root_agent.name == "EmptyFunctionConfig"
+    assert manifest.root_agent.description is None
+
+
+def test_build_agent_manifest_lists_functions_and_function_groups() -> None:
+    config = Config.model_construct(
+        general=GeneralConfig(),
+        functions={
+            "planner": _FakeToolConfig(description="plans things"),
+            "writer": _FakeToolConfig(),
+        },
+        function_groups={"mcp_tools": _FakeGroupConfig(description="exposes MCP tools")},
+        workflow=_FakeToolConfig(name="My Root", description="the entry point"),
+    )
+
+    manifest = build_agent_manifest(config)
+
+    assert manifest.root_agent.name == "My Root"
+    assert manifest.root_agent.type == "fake_tool"
+    assert manifest.root_agent.description == "the entry point"
+
+    by_name = {c.name: c for c in manifest.components}
+    assert by_name["planner"].kind == "function"
+    assert by_name["planner"].type == "fake_tool"
+    assert by_name["planner"].description == "plans things"
+    # A function without a description reports None, not an empty string or KeyError.
+    assert by_name["writer"].description is None
+    assert by_name["mcp_tools"].kind == "function_group"
+    assert by_name["mcp_tools"].description == "exposes MCP tools"
+
+
+def test_build_agent_manifest_root_agent_falls_back_to_type_without_a_name() -> None:
+    config = Config.model_construct(general=GeneralConfig(), workflow=_FakeToolConfig())
+
+    manifest = build_agent_manifest(config)
+
+    assert manifest.root_agent.name == "fake_tool"
+    assert manifest.root_agent.type == "fake_tool"

--- a/tests/dragent/frontends/test_fastapi.py
+++ b/tests/dragent/frontends/test_fastapi.py
@@ -192,6 +192,22 @@ class TestDRAgentFastApiFrontEndPluginWorker:
             assert response.status_code == 200, f"Expected 200 at {path}"
             assert response.json() == {"status": "healthy"}, f"Unexpected response at {path}"
 
+    def test_agent_manifest_route_returns_declared_structure(self, app_with_health):
+        """Served alongside the health routes by the same build_app() call - proves
+        the route is actually wired up, not just that build_agent_manifest() works
+        in isolation (covered separately in test_agent_manifest.py).
+        """
+        with TestClient(app_with_health) as client:
+            response = client.get("/.well-known/agent-manifest.json")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["components"] == []
+        # `worker`'s Config has no workflow= set, so it defaults to NAT's
+        # EmptyFunctionConfig - same empty-config shape asserted directly
+        # against build_agent_manifest() in test_agent_manifest.py.
+        assert body["root_agent"]["type"] == "EmptyFunctionConfig"
+
     def test_step_adaptor(self, worker):
         assert isinstance(worker.get_step_adaptor(), DRAgentNestedReasoningStepAdaptor)
 

--- a/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
@@ -16,7 +16,7 @@
 
 The middleware wraps every workflow invocation in a ``datarobot_agent`` SDK
 span and maps the last user message to ``gen_ai.prompt``, the workflow output to
-``gen_ai.completion``, and tool-call starts to short-lived ``tool_name`` spans.
+``gen_ai.completion``, and tool-call starts to short-lived ``gen_ai.tool.name`` spans.
 Tests drive the middleware against a real in-memory span exporter so assertions
 look at the spans/attributes that would actually be exported.
 """
@@ -52,7 +52,6 @@ from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware impor
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import ERROR_TYPE
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import GEN_AI_COMPLETION
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import GEN_AI_PROMPT
-from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import TOOL_NAME
 from datarobot_genai.dragent.plugins.datarobot_otel_conventions_middleware import (
     DataRobotOtelConventionsMiddleware,
 )
@@ -303,7 +302,7 @@ async def test_invoke_event_response_sets_completion_and_tool_spans(
     assert agent_span.attributes[GEN_AI_COMPLETION] == "done"
 
     tool_span = _span_named(span_exporter, "lookup")
-    assert tool_span.attributes[TOOL_NAME] == "lookup"
+    assert tool_span.attributes[DataRobotSpanAttributes.GEN_AI_TOOL_NAME] == "lookup"
 
 
 async def test_invoke_unknown_input_sets_no_prompt(
@@ -520,7 +519,7 @@ async def test_stream_emits_tool_spans(
     )
 
     tool_span = _span_named(span_exporter, "search")
-    assert tool_span.attributes[TOOL_NAME] == "search"
+    assert tool_span.attributes[DataRobotSpanAttributes.GEN_AI_TOOL_NAME] == "search"
 
 
 async def test_stream_without_text_sets_no_completion(

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.10"
+version = "0.29.11"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
Serve the Agent Manifest
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only span attribute rename with no auth, data, or workflow logic changes; tests updated to match.
> 
> **Overview**
> **dragent** OTel conventions middleware now tags short-lived tool-call spans with the semconv attribute **`gen_ai.tool.name`** (`DataRobotSpanAttributes.GEN_AI_TOOL_NAME`) instead of the legacy **`tool_name`** key, so deployment Tracing / Datavolt no longer treat those attributes as deprecated.
> 
> Behavior is unchanged: each `ToolCallStartEvent` still gets an immediate child span named after the tool, still aimed at the Tracing table Tools column. **CHANGELOG** 0.29.7 documents the change; unit tests assert the new attribute on invoke and stream paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 203bdbf5de9ead73b623fa54225886da89942b1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->