### PR TITLE
[BUZZOK-32161] add support for agent card registry lookups for workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.9
+- `dragent`: `registry` in `workflow.yaml` accepts `workload_id` alongside `deployment_id` and `external_id`, so an agent served by the Workload API runtime — where its card is keyed by workload rather than deployment — is reachable through the central agent card registry. Lookups query `workloadIds`, cache under a `workload:` key (L1 and MemorySpace L2), and take part in startup prefetch, background refresh and stale-if-error like the other two kinds. A workload card that also publishes an `external.id` stays reachable by either ID.
+- `dragent`: each registry request now carries exactly **one** ID kind. `deploymentIds` + `workloadIds` in one request is rejected by the API with HTTP 400 (not an empty result like `deploymentIds` + `externalIds`), so the client fetches one kind per call and raises before issuing a request that mixes the two.
+- `dragent`: **fixed** registry requests exceeding the API's cap of 20 IDs per parameter — a workflow with more than 20 registry-backed function groups sent them all in one `deploymentIds`/`externalIds` value and got an HTTP 400. ID lists are now split into chunks of 20; entries from every chunk are merged before parsing, so `AGENT_CARD_REGISTRY_ON_DUPLICATE` still applies across the whole result set.
+
 ## 0.29.8
 - `dragent`: agent card registry MemorySpace L2 uses write-behind instead of write-through so connect-time registry fetches are not blocked on MemorySpace round-trips.
 - `dragent`: layered agent card cache skips L2 on soft-expired L1 hits; cold-path fresh L2 reads are bounded by a short timeout so a slow MemorySpace cannot delay registry fetch (stale-if-error L2 reads are not bounded).

--- a/docs/src/nat/a2a-client.md
+++ b/docs/src/nat/a2a-client.md
@@ -96,13 +96,25 @@ function_groups:
     auth_provider: okta_auth
 ```
 
+**Lookup by workload ID** (for an agent served by the Workload API runtime, where the card is keyed by workload rather than deployment):
+
+```yaml
+function_groups:
+  remote_agent:
+    _type: authenticated_a2a_client
+    registry:
+      workload_id: "64a1b2c3d4e5f6a7b8c9d0e2"
+    auth_provider: okta_auth
+```
+
 > [!NOTE]
 > When using the registry the RPC base URL is derived from the card's advertised `url` — you do not need to specify it.
 
 #### Batch fetching
 
-When a workflow has many registry-backed function groups, all cards are resolved in a maximum of two HTTP calls: one for deployment IDs, one for external IDs. Results are cached in-memory and
-reused until the TTL expires.
+When a workflow has many registry-backed function groups, all cards are resolved in a maximum of three HTTP calls: one per ID kind (deployment, external, workload). ID kinds are never mixed in a single request — `deploymentIds` together with `workloadIds` is rejected with HTTP 400, and either combined with `externalIds` matches nothing. Results are cached in-memory and reused until the TTL expires.
+
+The registry API caps each ID parameter at 20 values, so a longer list of one kind is split into chunks of 20 and issued as consecutive requests; the responses are merged into a single result set before the duplicate strategy is applied.
 
 On dragent startup, all registry IDs from `workflow.yaml` are **prefetched** in the same batch before the server accepts traffic.
 
@@ -134,12 +146,13 @@ files, file secrets, Runtime Parameters, and Pulumi config.
 
 ### `registry` block
 
-Exactly one field must be set.
+Exactly one of the three fields must be set.
 
 | Field | Description |
 |-------|-------------|
 | `deployment_id` | DataRobot deployment ID. |
 | `external_id` | External agent catalogue identifier. |
+| `workload_id` | DataRobot workload ID (Workload API runtime). |
 
 ## Troubleshooting
 
@@ -149,6 +162,8 @@ Exactly one field must be set.
 | `AgentCardRegistryError: DataRobot API token is required` | `DATAROBOT_API_TOKEN` not set. | Export the variable or add it to `.env`. |
 | `AgentCardRegistryError: DataRobot API endpoint is required` | `DATAROBOT_ENDPOINT` not set. | Export the variable or add it to `.env`. |
 | `AgentCardRegistryError: … HTTP 401` | Token invalid or expired. | Regenerate your API token in the DataRobot console. |
-| `AgentCardRegistryError: No agent card found …` | Deployment not in the registry. | Confirm the deployment has an A2A agent card published. |
+| `AgentCardRegistryError: No agent card found …` | The deployment or workload is not in the registry. | Confirm the agent is running and has an A2A agent card published. |
 | `ValueError: … 'url' … or 'registry' …, not both` | Both fields set. | Remove one — they are mutually exclusive. |
+| `ValueError: Specify exactly one of 'deployment_id', 'external_id' or 'workload_id' …` | More than one identifier set inside `registry`. | Keep only the one that identifies the agent. |
+| `AgentCardRegistryError: Cannot request 'deploymentIds' and 'workloadIds' in the same … request` | Both ID kinds reached one registry request — the API answers HTTP 400. | Internal invariant; report it, as each kind is meant to be fetched separately. |
 | Stale card after redeployment | Cache TTL has not expired. | Set `AGENT_CARD_REGISTRY_CACHE_TTL=0` or wait for TTL to elapse. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.8"
+version = "0.29.9"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterable
 from collections.abc import Iterator
 from typing import Any
 from typing import Literal
@@ -528,50 +529,38 @@ class AgentCardRegistry:
         if isinstance(backend, LayeredAgentCardCacheBackend):
             backend.memory.age_entry_for_test(lookup_key, seconds)
 
+    async def _uncached(self, ids: Iterable[str], *, key_type: LookupKeyType) -> list[str]:
+        """Return the *ids* of *key_type* that are not cached within the soft TTL."""
+        return [i for i in ids if not await self._is_fresh(i, key_type=key_type)]
+
     async def _flush_pending(self) -> None:
         """Batch-fetch all registered-but-uncached IDs.  Must be called under ``_lock``."""
-        missing_dep = [
-            d
-            for d in self._pending_deployment_ids
-            if not await self._is_fresh(d, key_type="deployment")
-        ]
-        missing_ext = [
-            e
-            for e in self._pending_external_ids
-            if not await self._is_fresh(e, key_type="external")
-        ]
-        missing_wl = [
-            w
-            for w in self._pending_workload_ids
-            if not await self._is_fresh(w, key_type="workload")
-        ]
+        missing: dict[LookupKeyType, list[str]] = {
+            "deployment": await self._uncached(self._pending_deployment_ids, key_type="deployment"),
+            "external": await self._uncached(self._pending_external_ids, key_type="external"),
+            "workload": await self._uncached(self._pending_workload_ids, key_type="workload"),
+        }
 
         # Clear pending sets regardless — they've been processed
         self._pending_deployment_ids.clear()
         self._pending_external_ids.clear()
         self._pending_workload_ids.clear()
 
-        await self._fetch_and_store_by_kind(missing_dep, missing_ext, missing_wl)
+        await self._fetch_and_store_by_kind(missing)
 
     async def _fetch_and_store_by_kind(
         self,
-        deployment_ids: list[str],
-        external_ids: list[str],
-        workload_ids: list[str],
+        ids_by_kind: dict[LookupKeyType, list[str]],
     ) -> None:
         """Fetch and cache each ID kind in its **own** request.
 
         Kinds are never combined: ``deploymentIds`` + ``workloadIds`` is an HTTP
         400, and either mixed with ``externalIds`` AND-matches to nothing.
         """
-        for param, ids in (
-            (_DEPLOYMENT_IDS_PARAM, deployment_ids),
-            (_EXTERNAL_IDS_PARAM, external_ids),
-            (_WORKLOAD_IDS_PARAM, workload_ids),
-        ):
+        for key_type, ids in ids_by_kind.items():
             if not ids:
                 continue
-            parsed = await self._fetch({param: ",".join(ids)})
+            parsed = await self._fetch({_id_param_for(key_type): ",".join(ids)})
             await self._store_cards(parsed)
 
     # ------------------------------------------------------------------
@@ -603,23 +592,17 @@ class AgentCardRegistry:
             Workload IDs to prefetch.
         """
         async with self._lock:
-            missing_dep = [
-                d
-                for d in (deployment_ids or [])
-                if not await self._is_fresh(d, key_type="deployment")
-            ]
-            missing_ext = [
-                e for e in (external_ids or []) if not await self._is_fresh(e, key_type="external")
-            ]
-            missing_wl = [
-                w for w in (workload_ids or []) if not await self._is_fresh(w, key_type="workload")
-            ]
+            missing: dict[LookupKeyType, list[str]] = {
+                "deployment": await self._uncached(deployment_ids or [], key_type="deployment"),
+                "external": await self._uncached(external_ids or [], key_type="external"),
+                "workload": await self._uncached(workload_ids or [], key_type="workload"),
+            }
 
-            if not missing_dep and not missing_ext and not missing_wl:
+            if not any(missing.values()):
                 logger.debug("All requested agent cards already cached — skipping prefetch.")
                 return
 
-            await self._fetch_and_store_by_kind(missing_dep, missing_ext, missing_wl)
+            await self._fetch_and_store_by_kind(missing)
 
     async def refresh_all_registered(self) -> None:
         """Re-fetch registered IDs whose cache entries are past the soft TTL.

--- a/src/datarobot_genai/dragent/agent_card_registry.py
+++ b/src/datarobot_genai/dragent/agent_card_registry.py
@@ -28,16 +28,23 @@ automatically triggers a single batch prefetch for all pending IDs on its
 first invocation — no explicit ``prefetch()`` call required.
 
 .. note::
-    The registry API uses AND semantics when both ``deploymentIds`` and
-    ``externalIds`` parameters are provided in a single request, which would
-    return empty results.  Therefore the registry issues **separate** HTTP
-    calls for deployment IDs and external IDs.
+    The registry issues **one HTTP call per ID kind** — deployment, external
+    and workload IDs are never mixed in a single request.  Sending
+    ``deploymentIds`` together with ``workloadIds`` is rejected by the API with
+    HTTP 400 (the two are mutually exclusive), and combining either with
+    ``externalIds`` AND-matches, returning empty results.
+
+.. note::
+    The API caps each ID parameter at 20 values, so :meth:`AgentCardRegistry._fetch`
+    splits longer ID lists into chunks of 20 and accumulates the entries before
+    parsing them as one result set.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterator
 from typing import Any
 from typing import Literal
 from typing import NamedTuple
@@ -52,6 +59,7 @@ from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheB
 from datarobot_genai.dragent.agent_card_registry_backends import LayeredAgentCardCacheBackend
 from datarobot_genai.dragent.agent_card_registry_backends import LookupKeyType
 from datarobot_genai.dragent.agent_card_registry_backends import MemoryAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import RegistryIds
 from datarobot_genai.dragent.agent_card_registry_backends import create_agent_card_cache_backend
 from datarobot_genai.dragent.deployment_urls import build_agent_cards_registry_url
 
@@ -65,6 +73,15 @@ _DEFAULT_TIMEOUT_SECONDS = 30.0
 
 # Maximum page size accepted by the registry API.
 _MAX_PAGE_SIZE = 100
+
+# Maximum number of IDs the registry API accepts in a single ID parameter.
+_MAX_IDS_PER_REQUEST = 20
+
+# Registry query parameter per lookup key type.
+_DEPLOYMENT_IDS_PARAM = "deploymentIds"
+_EXTERNAL_IDS_PARAM = "externalIds"
+_WORKLOAD_IDS_PARAM = "workloadIds"
+_ID_PARAMS = (_DEPLOYMENT_IDS_PARAM, _EXTERNAL_IDS_PARAM, _WORKLOAD_IDS_PARAM)
 
 # Safety limit to prevent infinite pagination loops.
 _MAX_PAGES = 100
@@ -161,12 +178,57 @@ def _resolve_settings(
     return resolved_token, resolved_endpoint
 
 
+def _id_param_for(key_type: LookupKeyType) -> str:
+    """Return the registry query parameter that looks up *key_type* IDs."""
+    return {
+        "deployment": _DEPLOYMENT_IDS_PARAM,
+        "external": _EXTERNAL_IDS_PARAM,
+        "workload": _WORKLOAD_IDS_PARAM,
+    }[key_type]
+
+
+def _chunk_id_params(params: dict[str, str]) -> Iterator[dict[str, str]]:
+    """Split *params* into requests that respect the API's per-parameter ID cap.
+
+    Yields *params* unchanged when no ID parameter exceeds
+    :data:`_MAX_IDS_PER_REQUEST`; otherwise yields one dict per chunk of IDs.
+    Only one ID parameter is ever present per request (callers issue one call
+    per ID kind), so chunking never has to combine chunks across parameters.
+
+    Raises
+    ------
+    AgentCardRegistryError
+        If ``deploymentIds`` and ``workloadIds`` are both present.  The API
+        rejects that combination with HTTP 400, so this catches the mistake at
+        the call site instead of as an opaque request failure.
+    """
+    if _DEPLOYMENT_IDS_PARAM in params and _WORKLOAD_IDS_PARAM in params:
+        raise AgentCardRegistryError(
+            f"Cannot request '{_DEPLOYMENT_IDS_PARAM}' and '{_WORKLOAD_IDS_PARAM}' in the "
+            "same agent card registry request — the API rejects the combination. "
+            "Issue one request per ID kind."
+        )
+
+    id_params = [key for key in _ID_PARAMS if key in params]
+    for key in id_params:
+        ids = params[key].split(",")
+        if len(ids) <= _MAX_IDS_PER_REQUEST:
+            continue
+        other = {k: v for k, v in params.items() if k != key}
+        for start in range(0, len(ids), _MAX_IDS_PER_REQUEST):
+            chunk = ids[start : start + _MAX_IDS_PER_REQUEST]
+            yield {**other, key: ",".join(chunk)}
+        return
+
+    yield params
+
+
 class ParsedRegistryCards(NamedTuple):
     """Parsed registry response with lookup key types for cache indexing."""
 
     cards: dict[str, AgentCard]
     key_types: dict[str, LookupKeyType]
-    registry_ids: dict[str, tuple[str | None, str | None]]
+    registry_ids: dict[str, RegistryIds]
 
 
 def _parse_registry_response(
@@ -175,9 +237,12 @@ def _parse_registry_response(
 ) -> ParsedRegistryCards:
     """Parse a paginated registry response into ``{id: AgentCard}``.
 
-    Each record is indexed by ``deploymentId`` (always unique) and
-    ``externalId`` (may have duplicates).  The ``on_duplicate`` strategy
-    controls what happens when multiple entries share the same external ID.
+    Each record is indexed by its primary key — ``deploymentId`` or
+    ``workloadId``, both unique by platform design — and, independently, by
+    ``externalId`` (which may have duplicates).  A workload-hosted agent that
+    also publishes an external ID is therefore reachable by either.  The
+    ``on_duplicate`` strategy controls what happens when multiple entries share
+    the same external ID.
 
     The registry API returns entries sorted by ``_id`` ascending (creation
     time), so the iteration order matches chronological registration order:
@@ -188,7 +253,7 @@ def _parse_registry_response(
     """
     cards: dict[str, AgentCard] = {}
     key_types: dict[str, LookupKeyType] = {}
-    registry_ids: dict[str, tuple[str | None, str | None]] = {}
+    registry_ids: dict[str, RegistryIds] = {}
     for entry in body.get("data", []):
         raw_card = entry.get("agentCard")
         if not raw_card:
@@ -209,20 +274,27 @@ def _parse_registry_response(
 
         dep_id = entry.get("deploymentId")
         ext_id = entry.get("externalId")
-        id_pair = (dep_id, ext_id)
+        wl_id = entry.get("workloadId")
+        ids = RegistryIds(deployment_id=dep_id, external_id=ext_id, workload_id=wl_id)
 
         # Deployment IDs are unique by platform design — always overwrite.
         if dep_id:
             cards[dep_id] = card
             key_types[dep_id] = "deployment"
-            registry_ids[dep_id] = id_pair
+            registry_ids[dep_id] = ids
+
+        # Workload IDs are unique by platform design too — always overwrite.
+        if wl_id:
+            cards[wl_id] = card
+            key_types[wl_id] = "workload"
+            registry_ids[wl_id] = ids
 
         # External IDs may have duplicates — apply the configured strategy.
         if ext_id:
             if ext_id not in cards:
                 cards[ext_id] = card
                 key_types[ext_id] = "external"
-                registry_ids[ext_id] = id_pair
+                registry_ids[ext_id] = ids
             else:
                 logger.warning(
                     "Duplicate external ID '%s' in registry response (on_duplicate=%s).",
@@ -238,7 +310,7 @@ def _parse_registry_response(
                 if on_duplicate == "last":
                     cards[ext_id] = card
                     key_types[ext_id] = "external"
-                    registry_ids[ext_id] = id_pair
+                    registry_ids[ext_id] = ids
                 # "first" — keep existing entry (no-op)
     return ParsedRegistryCards(cards=cards, key_types=key_types, registry_ids=registry_ids)
 
@@ -247,8 +319,9 @@ class AgentCardRegistry:
     """Batch-capable, TTL-cached client for the central agent card registry.
 
     IDs are ``register()``-ed synchronously at config-parse time (no I/O).
-    The first ``get()`` flushes all pending IDs in ≤2 HTTP calls
-    (one per ID type — API uses AND when both are mixed).
+    The first ``get()`` flushes all pending IDs in ≤3 HTTP calls — one per ID
+    kind (deployment, external, workload), never mixed in a single request, plus
+    one extra call per 20 IDs of the same kind (the API's per-parameter cap).
     Subsequent ``get()`` calls hit the in-memory cache until the soft TTL
     (``AGENT_CARD_REGISTRY_CACHE_TTL``) expires.  When a refresh fails, a cached
     card may still be returned while it remains within ``AGENT_CARD_REGISTRY_CACHE_TTL``.
@@ -270,10 +343,12 @@ class AgentCardRegistry:
         # Pending registrations (filled synchronously, flushed on first get)
         self._pending_deployment_ids: set[str] = set()
         self._pending_external_ids: set[str] = set()
+        self._pending_workload_ids: set[str] = set()
 
         # All IDs registered at config-parse time (used for background refresh)
         self._registered_deployment_ids: set[str] = set()
         self._registered_external_ids: set[str] = set()
+        self._registered_workload_ids: set[str] = set()
 
         config = AgentCardRegistryConfig()
         self._timeout = timeout if timeout is not None else config.agent_card_registry_timeout
@@ -300,13 +375,15 @@ class AgentCardRegistry:
         *,
         deployment_id: str | None = None,
         external_id: str | None = None,
+        workload_id: str | None = None,
     ) -> None:
         """Declare intent to look up an agent card.
 
         Call this at config-parse/validation time so that the first
         :meth:`get` can batch all pending IDs into a single prefetch.
 
-        Exactly one of ``deployment_id`` or ``external_id`` must be given.
+        Exactly one of ``deployment_id``, ``external_id`` or ``workload_id``
+        must be given.
         """
         if deployment_id:
             self._pending_deployment_ids.add(deployment_id)
@@ -314,22 +391,44 @@ class AgentCardRegistry:
         elif external_id:
             self._pending_external_ids.add(external_id)
             self._registered_external_ids.add(external_id)
+        elif workload_id:
+            self._pending_workload_ids.add(workload_id)
+            self._registered_workload_ids.add(workload_id)
 
     def has_registered_lookups(self) -> bool:
         """Return whether any registry lookup IDs were registered."""
-        return bool(self._registered_deployment_ids or self._registered_external_ids)
+        return bool(
+            self._registered_deployment_ids
+            or self._registered_external_ids
+            or self._registered_workload_ids
+        )
 
     # ------------------------------------------------------------------
     # Internal HTTP
     # ------------------------------------------------------------------
 
     async def _fetch(self, params: dict[str, str]) -> ParsedRegistryCards:
-        """Execute registry HTTP GET(s) with pagination and return all parsed cards.
+        """Fetch and parse all agent cards matching *params*.
+
+        Splits ID lists longer than the API's per-parameter cap
+        (:data:`_MAX_IDS_PER_REQUEST`) into several requests, accumulating the
+        raw entries so that the ``on_duplicate`` strategy is applied once
+        across the full result set — the same way pagination is accumulated
+        inside :meth:`_fetch_entries`.
+        """
+        all_entries: list[dict[str, Any]] = []
+        for chunk_params in _chunk_id_params(params):
+            all_entries.extend(await self._fetch_entries(chunk_params))
+
+        parsed = _parse_registry_response({"data": all_entries}, on_duplicate=self._on_duplicate)
+        logger.info("Fetched %d agent card(s) from registry.", len(parsed.cards))
+        return parsed
+
+    async def _fetch_entries(self, params: dict[str, str]) -> list[dict[str, Any]]:
+        """Execute a single registry HTTP GET with pagination, returning raw entries.
 
         Requests the maximum page size (100) to minimise round-trips, then
-        follows ``next`` links until all pages are consumed.  All entries are
-        accumulated and parsed together so that the ``on_duplicate`` strategy
-        is applied consistently across the full result set.
+        follows ``next`` links until all pages are consumed.
         """
         token, endpoint = _resolve_settings(self._api_token, self._endpoint)
         registry_url = build_agent_cards_registry_url(endpoint)
@@ -378,13 +477,12 @@ class AgentCardRegistry:
         except httpx.HTTPError as exc:
             raise AgentCardRegistryError(f"Agent card registry request failed: {exc}") from exc
 
-        parsed = _parse_registry_response({"data": all_entries}, on_duplicate=self._on_duplicate)
-        logger.info(
-            "Fetched %d agent card(s) from registry (%d pages).",
-            len(parsed.cards),
+        logger.debug(
+            "Fetched %d registry entry(ies) over %d page(s).",
+            len(all_entries),
             pages_fetched,
         )
-        return parsed
+        return all_entries
 
     async def _is_fresh(self, key: str, *, key_type: LookupKeyType) -> bool:
         """Return True if *key* is cached and within the soft TTL."""
@@ -442,20 +540,38 @@ class AgentCardRegistry:
             for e in self._pending_external_ids
             if not await self._is_fresh(e, key_type="external")
         ]
+        missing_wl = [
+            w
+            for w in self._pending_workload_ids
+            if not await self._is_fresh(w, key_type="workload")
+        ]
 
         # Clear pending sets regardless — they've been processed
         self._pending_deployment_ids.clear()
         self._pending_external_ids.clear()
+        self._pending_workload_ids.clear()
 
-        if not missing_dep and not missing_ext:
-            return
+        await self._fetch_and_store_by_kind(missing_dep, missing_ext, missing_wl)
 
-        if missing_dep:
-            parsed = await self._fetch({"deploymentIds": ",".join(missing_dep)})
-            await self._store_cards(parsed)
+    async def _fetch_and_store_by_kind(
+        self,
+        deployment_ids: list[str],
+        external_ids: list[str],
+        workload_ids: list[str],
+    ) -> None:
+        """Fetch and cache each ID kind in its **own** request.
 
-        if missing_ext:
-            parsed = await self._fetch({"externalIds": ",".join(missing_ext)})
+        Kinds are never combined: ``deploymentIds`` + ``workloadIds`` is an HTTP
+        400, and either mixed with ``externalIds`` AND-matches to nothing.
+        """
+        for param, ids in (
+            (_DEPLOYMENT_IDS_PARAM, deployment_ids),
+            (_EXTERNAL_IDS_PARAM, external_ids),
+            (_WORKLOAD_IDS_PARAM, workload_ids),
+        ):
+            if not ids:
+                continue
+            parsed = await self._fetch({param: ",".join(ids)})
             await self._store_cards(parsed)
 
     # ------------------------------------------------------------------
@@ -467,12 +583,13 @@ class AgentCardRegistry:
         *,
         deployment_ids: list[str] | None = None,
         external_ids: list[str] | None = None,
+        workload_ids: list[str] | None = None,
     ) -> None:
         """Batch-fetch and cache agent cards in a minimum number of HTTP calls.
 
-        Issues **separate** requests for ``deployment_ids`` and
-        ``external_ids`` because the API uses AND semantics when both
-        parameters are present in a single request.
+        Issues **separate** requests per ID kind: ``deploymentIds`` together
+        with ``workloadIds`` is rejected with HTTP 400, and either combined with
+        ``externalIds`` AND-matches and returns nothing.
 
         Already-cached (non-expired) IDs are skipped.
 
@@ -482,6 +599,8 @@ class AgentCardRegistry:
             Deployment IDs to prefetch.
         external_ids:
             External IDs to prefetch.
+        workload_ids:
+            Workload IDs to prefetch.
         """
         async with self._lock:
             missing_dep = [
@@ -492,18 +611,15 @@ class AgentCardRegistry:
             missing_ext = [
                 e for e in (external_ids or []) if not await self._is_fresh(e, key_type="external")
             ]
+            missing_wl = [
+                w for w in (workload_ids or []) if not await self._is_fresh(w, key_type="workload")
+            ]
 
-            if not missing_dep and not missing_ext:
+            if not missing_dep and not missing_ext and not missing_wl:
                 logger.debug("All requested agent cards already cached — skipping prefetch.")
                 return
 
-            if missing_dep:
-                parsed = await self._fetch({"deploymentIds": ",".join(missing_dep)})
-                await self._store_cards(parsed)
-
-            if missing_ext:
-                parsed = await self._fetch({"externalIds": ",".join(missing_ext)})
-                await self._store_cards(parsed)
+            await self._fetch_and_store_by_kind(missing_dep, missing_ext, missing_wl)
 
     async def refresh_all_registered(self) -> None:
         """Re-fetch registered IDs whose cache entries are past the soft TTL.
@@ -511,21 +627,25 @@ class AgentCardRegistry:
         Failures are logged and existing cache entries are left in place so
         stale-if-error can continue serving them during registry outages.
         """
-        if not self._registered_deployment_ids and not self._registered_external_ids:
+        if not self.has_registered_lookups():
             logger.debug("No registered agent card IDs; skipping background refresh.")
             return
 
         deployment_ids = sorted(self._registered_deployment_ids)
         external_ids = sorted(self._registered_external_ids)
+        workload_ids = sorted(self._registered_workload_ids)
         logger.debug(
-            "Refreshing registered agent cards (deployment_ids=%s, external_ids=%s)",
+            "Refreshing registered agent cards "
+            "(deployment_ids=%s, external_ids=%s, workload_ids=%s)",
             deployment_ids,
             external_ids,
+            workload_ids,
         )
         try:
             await self.prefetch(
                 deployment_ids=deployment_ids or None,
                 external_ids=external_ids or None,
+                workload_ids=workload_ids or None,
             )
         except AgentCardRegistryError:
             logger.warning(
@@ -538,25 +658,32 @@ class AgentCardRegistry:
         *,
         deployment_id: str | None = None,
         external_id: str | None = None,
+        workload_id: str | None = None,
     ) -> AgentCard:
         """Return a single agent card, using the cache or fetching on demand.
 
         On the first call, all IDs previously passed to :meth:`register`
-        are batch-fetched in a single prefetch (at most 2 HTTP calls).
+        are batch-fetched in a single prefetch (one HTTP call per ID kind).
         Subsequent calls for already-cached, non-expired cards are instant.
 
-        Exactly one of ``deployment_id`` or ``external_id`` must be provided.
+        Exactly one of ``deployment_id``, ``external_id`` or ``workload_id``
+        must be provided.
 
         Raises
         ------
         AgentCardRegistryError
             If the card cannot be found or the request fails.
         """
-        if bool(deployment_id) == bool(external_id):
-            raise AgentCardRegistryError("Specify exactly one of 'deployment_id' or 'external_id'.")
+        provided = [i for i in (deployment_id, external_id, workload_id) if i]
+        if len(provided) != 1:
+            raise AgentCardRegistryError(
+                "Specify exactly one of 'deployment_id', 'external_id' or 'workload_id'."
+            )
 
-        lookup_key: str = deployment_id or external_id  # type: ignore[assignment]
-        lookup_key_type: LookupKeyType = "deployment" if deployment_id else "external"
+        lookup_key: str = provided[0]
+        lookup_key_type: LookupKeyType = (
+            "deployment" if deployment_id else "external" if external_id else "workload"
+        )
 
         # Fast path — fresh cache hit
         if fresh := await self._backend.get_fresh(
@@ -577,7 +704,11 @@ class AgentCardRegistry:
 
             try:
                 # Flush all pending registrations in a batch
-                if self._pending_deployment_ids or self._pending_external_ids:
+                if (
+                    self._pending_deployment_ids
+                    or self._pending_external_ids
+                    or self._pending_workload_ids
+                ):
                     await self._flush_pending()
                     if fresh := await self._backend.get_fresh(
                         lookup_key,
@@ -587,11 +718,7 @@ class AgentCardRegistry:
                         return fresh.card
 
                 # Still not fresh — fetch individually
-                params: dict[str, str] = (
-                    {"deploymentIds": deployment_id}
-                    if deployment_id
-                    else {"externalIds": external_id}  # type: ignore[dict-item]
-                )
+                params: dict[str, str] = {_id_param_for(lookup_key_type): lookup_key}
                 parsed = await self._fetch(params)
                 await self._store_cards(parsed)
 
@@ -614,12 +741,10 @@ class AgentCardRegistry:
                 raise
 
         # Fetch succeeded but the requested key was absent from the response.
-        id_label = (
-            f"deployment_id='{deployment_id}'" if deployment_id else f"external_id='{external_id}'"
-        )
         raise AgentCardRegistryError(
-            f"No agent card found in the central registry for {id_label}. "
-            "Verify that the deployment exists and is registered in your organisation."
+            f"No agent card found in the central registry for "
+            f"{lookup_key_type}_id='{lookup_key}'. Verify that the agent exists and is "
+            "registered in your organisation."
         )
 
 

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -25,6 +25,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
+from typing import NamedTuple
 from typing import Protocol
 
 from a2a.types import AgentCard
@@ -40,7 +41,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-LookupKeyType = Literal["deployment", "external"]
+LookupKeyType = Literal["deployment", "external", "workload"]
+
+
+class RegistryIds(NamedTuple):
+    """The registry identifiers a single agent card entry carries.
+
+    A card is keyed by exactly one of ``deployment_id`` / ``workload_id`` (the
+    platform enforces this) and may additionally publish an ``external_id``.
+    Named fields rather than a positional tuple because three optional strings
+    in a row are indistinguishable at a call site.
+    """
+
+    deployment_id: str | None = None
+    external_id: str | None = None
+    workload_id: str | None = None
+
 
 # Bound cold-path L2 read latency so a slow MemorySpace does not delay registry fetch.
 _DEFAULT_L2_READ_TIMEOUT_SECONDS = 0.2
@@ -55,6 +71,7 @@ class AgentCardCacheRecord(BaseModel):
     source: str = "registry"
     deployment_id: str | None = None
     external_id: str | None = None
+    workload_id: str | None = None
 
     def age_seconds(self) -> float:
         """Return the entry age in seconds (wall clock, safe across processes)."""
@@ -80,6 +97,7 @@ def build_cache_record(
     key_type: LookupKeyType,
     deployment_id: str | None = None,
     external_id: str | None = None,
+    workload_id: str | None = None,
 ) -> AgentCardCacheRecord:
     """Build a cache record for *lookup_key* with optional registry ID metadata."""
     resolved_dep = (
@@ -90,10 +108,14 @@ def build_cache_record(
     resolved_ext = (
         external_id if external_id is not None else (lookup_key if key_type == "external" else None)
     )
+    resolved_wl = (
+        workload_id if workload_id is not None else (lookup_key if key_type == "workload" else None)
+    )
     return AgentCardCacheRecord(
         card=card,
         deployment_id=resolved_dep,
         external_id=resolved_ext,
+        workload_id=resolved_wl,
     )
 
 
@@ -123,7 +145,7 @@ class AgentCardCacheBackend(Protocol):
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
-        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
+        registry_ids: dict[str, RegistryIds] | None = None,
     ) -> None:
         """Persist one or more cards keyed by lookup ID."""
 
@@ -171,18 +193,19 @@ class MemoryAgentCardCacheBackend:
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
-        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
+        registry_ids: dict[str, RegistryIds] | None = None,
     ) -> None:
-        id_pairs = registry_ids or {}
+        id_sets = registry_ids or {}
         for lookup_key, card in cards.items():
             key_type = key_types.get(lookup_key, "deployment")
-            dep_id, ext_id = id_pairs.get(lookup_key, (None, None))
+            ids = id_sets.get(lookup_key, RegistryIds())
             self._entries[lookup_key] = build_cache_record(
                 card,
                 lookup_key=lookup_key,
                 key_type=key_type,
-                deployment_id=dep_id,
-                external_id=ext_id,
+                deployment_id=ids.deployment_id,
+                external_id=ids.external_id,
+                workload_id=ids.workload_id,
             )
 
     async def store_record(self, lookup_key: str, record: AgentCardCacheRecord) -> None:
@@ -206,6 +229,8 @@ class MemoryAgentCardCacheBackend:
                 keys_to_evict.add(record.deployment_id)
             if record.external_id:
                 keys_to_evict.add(record.external_id)
+            if record.workload_id:
+                keys_to_evict.add(record.workload_id)
         for key in keys_to_evict:
             self._entries.pop(key, None)
 
@@ -233,6 +258,8 @@ class MemorySpaceAgentCardCacheBackend:
             keys.append(f"deployment:{record.deployment_id}")
         if record.external_id:
             keys.append(f"external:{record.external_id}")
+        if record.workload_id:
+            keys.append(f"workload:{record.workload_id}")
         return keys
 
     def _storage_keys_for_lookup(
@@ -245,7 +272,13 @@ class MemorySpaceAgentCardCacheBackend:
             return [f"deployment:{lookup_key}"]
         if key_type == "external":
             return [f"external:{lookup_key}"]
-        return [f"deployment:{lookup_key}", f"external:{lookup_key}"]
+        if key_type == "workload":
+            return [f"workload:{lookup_key}"]
+        return [
+            f"deployment:{lookup_key}",
+            f"external:{lookup_key}",
+            f"workload:{lookup_key}",
+        ]
 
     async def _get_record(self, storage_key: str) -> AgentCardCacheRecord | None:
         payload = await self._kv.get_value(storage_key)
@@ -288,18 +321,19 @@ class MemorySpaceAgentCardCacheBackend:
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
-        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
+        registry_ids: dict[str, RegistryIds] | None = None,
     ) -> None:
-        id_pairs = registry_ids or {}
+        id_sets = registry_ids or {}
         for lookup_key, card in cards.items():
             key_type = key_types.get(lookup_key, "deployment")
-            dep_id, ext_id = id_pairs.get(lookup_key, (None, None))
+            ids = id_sets.get(lookup_key, RegistryIds())
             record = build_cache_record(
                 card,
                 lookup_key=lookup_key,
                 key_type=key_type,
-                deployment_id=dep_id,
-                external_id=ext_id,
+                deployment_id=ids.deployment_id,
+                external_id=ids.external_id,
+                workload_id=ids.workload_id,
             )
             payload = record.model_dump_json()
             for storage_key in self._storage_keys_for_record(record):
@@ -432,7 +466,7 @@ class LayeredAgentCardCacheBackend:
         cards: dict[str, AgentCard],
         *,
         key_types: dict[str, LookupKeyType],
-        registry_ids: dict[str, tuple[str | None, str | None]] | None = None,
+        registry_ids: dict[str, RegistryIds] | None = None,
     ) -> None:
         await self._l1.store(cards, key_types=key_types, registry_ids=registry_ids)
         self._schedule_l2(self._l2.store(cards, key_types=key_types, registry_ids=registry_ids))

--- a/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
+++ b/src/datarobot_genai/dragent/plugins/auth_a2a_client.py
@@ -204,15 +204,21 @@ class _AuthenticatedA2ABaseClient(A2ABaseClient):
 class AgentCardRegistryLookup(BaseModel):
     """Identifies an agent card in the central DataRobot agent card registry.
 
-    Exactly one of ``deployment_id`` or ``external_id`` must be specified.
-    The registry is queried using standard DataRobot API-token authentication
-    (``DATAROBOT_API_TOKEN``), which avoids the chicken-and-egg problem where the
-    agent's own card endpoint requires per-agent AuthN/AuthZ.
+    Exactly one of ``deployment_id``, ``external_id`` or ``workload_id`` must be
+    specified.  The registry is queried using standard DataRobot API-token
+    authentication (``DATAROBOT_API_TOKEN``), which avoids the chicken-and-egg
+    problem where the agent's own card endpoint requires per-agent AuthN/AuthZ.
 
     Example YAML::
 
         registry:
           deployment_id: "64a1b2c3d4e5f6a7b8c9d0e1"
+
+    An agent served by the Workload API runtime is keyed by its workload ID
+    instead::
+
+        registry:
+          workload_id: "64a1b2c3d4e5f6a7b8c9d0e2"
     """
 
     deployment_id: str | None = Field(
@@ -223,18 +229,29 @@ class AgentCardRegistryLookup(BaseModel):
         default=None,
         description="External agent identifier to look up in the central agent card registry.",
     )
+    workload_id: str | None = Field(
+        default=None,
+        description="DataRobot workload ID to look up in the central agent card registry.",
+    )
 
     @model_validator(mode="after")
     def _exactly_one_identifier(self) -> "AgentCardRegistryLookup":
-        if self.deployment_id and self.external_id:
+        identifiers = {
+            "deployment_id": self.deployment_id,
+            "external_id": self.external_id,
+            "workload_id": self.workload_id,
+        }
+        provided = sorted(name for name, value in identifiers.items() if value)
+        if len(provided) > 1:
             raise ValueError(
-                "Specify exactly one of 'deployment_id' or 'external_id' inside 'registry', "
-                "not both. Each identifies the agent card differently in the central registry."
+                f"Specify exactly one of 'deployment_id', 'external_id' or 'workload_id' "
+                f"inside 'registry', not {len(provided)} ({', '.join(provided)}). "
+                "Each identifies the agent card differently in the central registry."
             )
-        if not self.deployment_id and not self.external_id:
+        if not provided:
             raise ValueError(
-                "The 'registry' block requires exactly one of 'deployment_id' or 'external_id' "
-                "to identify the agent card in the central registry."
+                "The 'registry' block requires exactly one of 'deployment_id', 'external_id' "
+                "or 'workload_id' to identify the agent card in the central registry."
             )
         return self
 
@@ -253,10 +270,10 @@ class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_clie
             url: "http://agent.example.com:8080"
             auth_provider: my_auth
 
-    **Central registry lookup** — set ``registry`` with either ``deployment_id``
-    or ``external_id``.  The card is fetched from the DataRobot central agent card
-    registry using ``DATAROBOT_API_TOKEN``, and the agent's RPC URL is derived
-    from the card's advertised ``url``::
+    **Central registry lookup** — set ``registry`` with one of ``deployment_id``,
+    ``external_id`` or ``workload_id``.  The card is fetched from the DataRobot
+    central agent card registry using ``DATAROBOT_API_TOKEN``, and the agent's RPC
+    URL is derived from the card's advertised ``url``::
 
         function_groups:
           my_agent:
@@ -306,6 +323,7 @@ class AuthenticatedA2AClientConfig(A2AClientConfig, name="authenticated_a2a_clie
             registry.register(
                 deployment_id=self.registry.deployment_id,  # type: ignore[union-attr]
                 external_id=self.registry.external_id,  # type: ignore[union-attr]
+                workload_id=self.registry.workload_id,  # type: ignore[union-attr]
             )
         return self
 
@@ -491,6 +509,7 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
                 pre_resolved_card = await registry.get(
                     deployment_id=config.registry.deployment_id,
                     external_id=config.registry.external_id,
+                    workload_id=config.registry.workload_id,
                 )
             except AgentCardRegistryError as exc:
                 error_msg = str(exc)
@@ -508,10 +527,11 @@ class AuthenticatedA2AClientFunctionGroup(A2AClientFunctionGroup):
 
             base_url = str(pre_resolved_card.url)
             logger.info(
-                "Agent card resolved via central registry (deployment_id=%s, external_id=%s), "
-                "RPC base URL derived from card: %s",
+                "Agent card resolved via central registry (deployment_id=%s, external_id=%s, "
+                "workload_id=%s), RPC base URL derived from card: %s",
                 config.registry.deployment_id,
                 config.registry.external_id,
+                config.registry.workload_id,
                 base_url,
             )
         else:

--- a/src/datarobot_genai/dragent/registry_warmup.py
+++ b/src/datarobot_genai/dragent/registry_warmup.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
+from typing import NamedTuple
 
 from datarobot_genai.dragent.agent_card_registry import get_default_registry
 from datarobot_genai.dragent.plugins.auth_a2a_client import AuthenticatedA2AClientConfig
@@ -53,18 +54,26 @@ def reset_registry_warm_state() -> None:
     _WarmState.warm = False
 
 
-def collect_registry_lookup_ids(
-    config: Config,
-) -> tuple[list[str], list[str]]:
-    """Return deduplicated ``(deployment_ids, external_ids)`` from *config*.
+class RegistryLookupIds(NamedTuple):
+    """Registry lookup IDs collected from a workflow config, by ID kind."""
+
+    deployment_ids: list[str]
+    external_ids: list[str]
+    workload_ids: list[str]
+
+    def is_empty(self) -> bool:
+        """Return whether no registry lookups were configured at all."""
+        return not (self.deployment_ids or self.external_ids or self.workload_ids)
+
+
+def collect_registry_lookup_ids(config: Config) -> RegistryLookupIds:
+    """Return deduplicated registry lookup IDs per kind from *config*.
 
     Only ``authenticated_a2a_client`` function groups with a ``registry`` block
     contribute IDs. Order is preserved (first-seen).
     """
-    deployment_ids: list[str] = []
-    external_ids: list[str] = []
-    seen_dep: set[str] = set()
-    seen_ext: set[str] = set()
+    collected = RegistryLookupIds(deployment_ids=[], external_ids=[], workload_ids=[])
+    seen: dict[str, set[str]] = {"deployment": set(), "external": set(), "workload": set()}
 
     function_groups = getattr(config, "function_groups", None) or {}
     for fg_config in function_groups.values():
@@ -72,16 +81,16 @@ def collect_registry_lookup_ids(
             continue
         if fg_config.registry is None:
             continue
-        if dep_id := fg_config.registry.deployment_id:
-            if dep_id not in seen_dep:
-                seen_dep.add(dep_id)
-                deployment_ids.append(dep_id)
-        if ext_id := fg_config.registry.external_id:
-            if ext_id not in seen_ext:
-                seen_ext.add(ext_id)
-                external_ids.append(ext_id)
+        for kind, lookup_id, ids in (
+            ("deployment", fg_config.registry.deployment_id, collected.deployment_ids),
+            ("external", fg_config.registry.external_id, collected.external_ids),
+            ("workload", fg_config.registry.workload_id, collected.workload_ids),
+        ):
+            if lookup_id and lookup_id not in seen[kind]:
+                seen[kind].add(lookup_id)
+                ids.append(lookup_id)
 
-    return deployment_ids, external_ids
+    return collected
 
 
 async def warmup_registry_from_config(config: Config) -> None:
@@ -90,24 +99,27 @@ async def warmup_registry_from_config(config: Config) -> None:
     No-op when no registry lookups are configured. On failure, logs an error and
     leaves :func:`is_registry_warm` as ``False``.
     """
-    deployment_ids, external_ids = collect_registry_lookup_ids(config)
-    if not deployment_ids and not external_ids:
+    collected = collect_registry_lookup_ids(config)
+    if collected.is_empty():
         logger.debug("No registry-backed A2A function groups; skipping agent card prefetch.")
         _WarmState.warm = True
         return
 
     _WarmState.warm = False
     logger.info(
-        "Prefetching agent cards from central registry (deployment_ids=%s, external_ids=%s)",
-        deployment_ids,
-        external_ids,
+        "Prefetching agent cards from central registry "
+        "(deployment_ids=%s, external_ids=%s, workload_ids=%s)",
+        collected.deployment_ids,
+        collected.external_ids,
+        collected.workload_ids,
     )
 
     try:
         registry = await get_default_registry()
         await registry.prefetch(
-            deployment_ids=deployment_ids or None,
-            external_ids=external_ids or None,
+            deployment_ids=collected.deployment_ids or None,
+            external_ids=collected.external_ids or None,
+            workload_ids=collected.workload_ids or None,
         )
     except Exception:
         logger.exception(
@@ -118,7 +130,9 @@ async def warmup_registry_from_config(config: Config) -> None:
 
     _WarmState.warm = True
     logger.info(
-        "Agent card registry prefetch complete (%d deployment ID(s), %d external ID(s)).",
-        len(deployment_ids),
-        len(external_ids),
+        "Agent card registry prefetch complete "
+        "(%d deployment ID(s), %d external ID(s), %d workload ID(s)).",
+        len(collected.deployment_ids),
+        len(collected.external_ids),
+        len(collected.workload_ids),
     )

--- a/tests/dragent/plugins/fixtures/workflow_with_a2a.yaml
+++ b/tests/dragent/plugins/fixtures/workflow_with_a2a.yaml
@@ -35,3 +35,9 @@ function_groups:
     registry:
       external_id: "abcd"
     auth_provider: okta_auth
+
+  a2a_agent_with_registry3:
+    _type: authenticated_a2a_client
+    registry:
+      workload_id: "wl-5678"
+    auth_provider: okta_auth

--- a/tests/dragent/plugins/test_a2a_client.py
+++ b/tests/dragent/plugins/test_a2a_client.py
@@ -39,6 +39,7 @@ from nat.data_models.authentication import HeaderCred
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryError
+from datarobot_genai.dragent.agent_card_registry import get_default_registry_sync
 from datarobot_genai.dragent.agent_card_registry import reset_default_registry
 from datarobot_genai.dragent.plugins.auth_a2a_client import A2ADiscoveryAuthMixin
 from datarobot_genai.dragent.plugins.auth_a2a_client import AgentCardRegistryLookup
@@ -210,9 +211,36 @@ class TestAgentCardRegistryLookup:
         assert lookup.external_id == "ext-456"
         assert lookup.deployment_id is None
 
+    def test_workload_id_only(self):
+        lookup = AgentCardRegistryLookup(workload_id="wl-789")
+        assert lookup.workload_id == "wl-789"
+        assert lookup.deployment_id is None
+        assert lookup.external_id is None
+
     def test_both_ids_raises(self):
-        with pytest.raises(ValueError, match="not both"):
+        with pytest.raises(ValueError, match="not 2"):
             AgentCardRegistryLookup(deployment_id="dep-1", external_id="ext-1")
+
+    @pytest.mark.parametrize(
+        "ids",
+        [
+            {"deployment_id": "dep-1", "external_id": "ext-1"},
+            {"deployment_id": "dep-1", "workload_id": "wl-1"},
+            {"external_id": "ext-1", "workload_id": "wl-1"},
+        ],
+    )
+    def test_any_pair_of_ids_raises(self, ids):
+        """GIVEN two identifiers WHEN validated THEN the pair is rejected by name."""
+        with pytest.raises(ValueError, match="not 2"):
+            AgentCardRegistryLookup(**ids)
+
+    def test_all_three_ids_raises(self):
+        with pytest.raises(ValueError, match="not 3"):
+            AgentCardRegistryLookup(
+                deployment_id="dep-1",
+                external_id="ext-1",
+                workload_id="wl-1",
+            )
 
     def test_neither_id_raises(self):
         with pytest.raises(ValueError, match="requires exactly one"):
@@ -239,6 +267,20 @@ class TestAuthenticatedA2AClientConfig:
         cfg = AuthenticatedA2AClientConfig(registry=AgentCardRegistryLookup(external_id="ext-456"))
         assert cfg.registry is not None
         assert cfg.registry.external_id == "ext-456"
+
+    def test_registry_with_workload_id(self):
+        cfg = AuthenticatedA2AClientConfig(registry=AgentCardRegistryLookup(workload_id="wl-789"))
+        assert cfg.registry is not None
+        assert cfg.registry.workload_id == "wl-789"
+        assert cfg.url is None
+
+    def test_registry_with_workload_id_registers_lookup(self):
+        """GIVEN a workload registry block WHEN parsed THEN the ID is queued for prefetch."""
+        AuthenticatedA2AClientConfig(registry=AgentCardRegistryLookup(workload_id="wl-789"))
+
+        registry = get_default_registry_sync()
+        assert registry.has_registered_lookups() is True
+        assert "wl-789" in registry._registered_workload_ids
 
     def test_url_and_registry_raises(self):
         with pytest.raises(ValueError, match="not both"):
@@ -600,6 +642,12 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
             registry=AgentCardRegistryLookup(external_id="ext-001"),
         )
 
+    @pytest.fixture
+    def registry_config_workload(self):
+        return AuthenticatedA2AClientConfig(
+            registry=AgentCardRegistryLookup(workload_id="wl-001"),
+        )
+
     async def test_registry_fetches_card_and_derives_base_url(
         self, registry_config, mock_builder, patched_fg_env
     ):
@@ -621,6 +669,7 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
             mock_registry.get.assert_awaited_once_with(
                 deployment_id="dep-001",
                 external_id=None,
+                workload_id=None,
             )
             # Verify base_url derived from card.url
             assert patched_fg_env.call_args.kwargs["base_url"] == "https://agent.example.com/a2a/"
@@ -645,6 +694,36 @@ class TestAuthenticatedA2AClientFunctionGroupRegistry:
             mock_registry.get.assert_awaited_once_with(
                 deployment_id=None,
                 external_id="ext-001",
+                workload_id=None,
+            )
+
+    async def test_registry_workload_id_path(
+        self, registry_config_workload, mock_builder, patched_fg_env
+    ):
+        """GIVEN a workload registry block WHEN entered THEN the card is looked up by workload ID
+        and the RPC base URL comes from the card.
+        """
+        mock_card = MagicMock()
+        mock_card.url = "https://workload.example.com/a2a/"
+
+        mock_registry = AsyncMock()
+        mock_registry.get = AsyncMock(return_value=mock_card)
+
+        with patch(
+            f"{_MODULE}.get_default_registry", new_callable=AsyncMock, return_value=mock_registry
+        ):
+            fg = AuthenticatedA2AClientFunctionGroup(
+                config=registry_config_workload, builder=mock_builder
+            )
+            await fg.__aenter__()
+
+            mock_registry.get.assert_awaited_once_with(
+                deployment_id=None,
+                external_id=None,
+                workload_id="wl-001",
+            )
+            assert (
+                patched_fg_env.call_args.kwargs["base_url"] == "https://workload.example.com/a2a/"
             )
 
     async def test_registry_pre_resolved_card_skips_discovery(self, registry_config, mock_builder):

--- a/tests/dragent/test_agent_card_registry.py
+++ b/tests/dragent/test_agent_card_registry.py
@@ -36,6 +36,7 @@ from datarobot_genai.dragent.agent_card_registry import get_default_registry_syn
 from datarobot_genai.dragent.agent_card_registry import reset_default_registry
 from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheRecord
 from datarobot_genai.dragent.agent_card_registry_backends import MemoryAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import RegistryIds
 
 _MODULE = "datarobot_genai.dragent.agent_card_registry"
 
@@ -67,11 +68,12 @@ def _registry_response(*entries):
     return {"data": list(entries), "count": len(entries), "totalCount": len(entries)}
 
 
-def _entry(dep_id=None, ext_id=None, card=_SAMPLE_AGENT_CARD):
+def _entry(dep_id=None, ext_id=None, wl_id=None, card=_SAMPLE_AGENT_CARD):
     return {
-        "id": f"doc-{dep_id or ext_id}",
+        "id": f"doc-{dep_id or wl_id or ext_id}",
         "deploymentId": dep_id,
         "externalId": ext_id,
+        "workloadId": wl_id,
         "agentCard": card,
     }
 
@@ -231,8 +233,12 @@ class TestParseRegistryResponse:
         assert parsed.cards["dep-1"] is parsed.cards["ext-1"]
         assert parsed.key_types["dep-1"] == "deployment"
         assert parsed.key_types["ext-1"] == "external"
-        assert parsed.registry_ids["dep-1"] == ("dep-1", "ext-1")
-        assert parsed.registry_ids["ext-1"] == ("dep-1", "ext-1")
+        assert parsed.registry_ids["dep-1"] == RegistryIds(
+            deployment_id="dep-1", external_id="ext-1"
+        )
+        assert parsed.registry_ids["ext-1"] == RegistryIds(
+            deployment_id="dep-1", external_id="ext-1"
+        )
 
     def test_skips_entries_without_agent_card(self):
         body = _registry_response({"id": "x", "deploymentId": "d", "agentCard": None})
@@ -551,7 +557,7 @@ class TestAgentCardRegistryStaleIfError:
     async def test_deregistered_sibling_id_evicted_from_cache(self, mock_fetch, cache_backend):
         """Evicting on a deployment miss must drop the external-ID alias too."""
         stale_card = _card()
-        id_pair = ("dep-1", "ext-1")
+        id_pair = RegistryIds(deployment_id="dep-1", external_id="ext-1")
         mock_fetch.side_effect = [
             _parsed(
                 {"dep-1": stale_card, "ext-1": stale_card},
@@ -907,3 +913,369 @@ class TestGetDefaultRegistry:
         r1 = get_default_registry_sync()
         r2 = await get_default_registry()
         assert r1 is r2
+
+
+# ---------------------------------------------------------------------------
+# Tests: workload ID lookups
+# ---------------------------------------------------------------------------
+
+
+class TestParseRegistryResponseWorkload:
+    def test_indexes_by_workload_id(self):
+        """GIVEN a workload-keyed entry WHEN parsed THEN it is indexed as 'workload'."""
+        body = _registry_response(_entry(wl_id="wl-1"))
+        parsed = _parse_registry_response(body)
+        assert "wl-1" in parsed.cards
+        assert parsed.key_types["wl-1"] == "workload"
+        assert parsed.registry_ids["wl-1"] == RegistryIds(workload_id="wl-1")
+
+    def test_workload_card_with_external_id_reachable_by_either(self):
+        """GIVEN a workload card that also publishes an external ID
+        WHEN parsed THEN both IDs resolve to the same card.
+        """
+        body = _registry_response(_entry(wl_id="wl-1", ext_id="ext-1"))
+        parsed = _parse_registry_response(body)
+
+        assert parsed.cards["wl-1"] is parsed.cards["ext-1"]
+        assert parsed.key_types["wl-1"] == "workload"
+        assert parsed.key_types["ext-1"] == "external"
+        expected_ids = RegistryIds(external_id="ext-1", workload_id="wl-1")
+        assert parsed.registry_ids["wl-1"] == expected_ids
+        assert parsed.registry_ids["ext-1"] == expected_ids
+
+    def test_duplicate_workload_id_always_overwrites(self):
+        """GIVEN two entries for one workload ID (unique by platform design)
+        WHEN parsed THEN the later entry wins without duplicate handling.
+        """
+        body = _registry_response(
+            _entry(wl_id="wl-1"),
+            _entry(wl_id="wl-1", card=_SAMPLE_AGENT_CARD_2),
+        )
+        parsed = _parse_registry_response(body, on_duplicate="error")
+        assert parsed.cards["wl-1"].name == "Second Agent"
+
+
+class TestAgentCardRegistryWorkload:
+    @pytest.fixture
+    def mock_fetch(self):
+        with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
+            yield m
+
+    @pytest.fixture
+    def cache_backend(self):
+        return MemoryAgentCardCacheBackend()
+
+    def _parsed_workload(self, cards: dict) -> ParsedRegistryCards:
+        return _parsed(cards, key_types={key: "workload" for key in cards})
+
+    async def test_get_single_workload_id(self, mock_fetch):
+        """GIVEN a workload-keyed card WHEN got by workload ID THEN workloadIds is queried."""
+        expected = _card()
+        mock_fetch.return_value = self._parsed_workload({"wl-1": expected})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+
+        card = await registry.get(workload_id="wl-1")
+
+        assert card is expected
+        mock_fetch.assert_awaited_once_with({"workloadIds": "wl-1"})
+
+    async def test_get_raises_when_workload_and_deployment_id(self):
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        with pytest.raises(AgentCardRegistryError, match="exactly one"):
+            await registry.get(deployment_id="dep-1", workload_id="wl-1")
+
+    async def test_get_raises_when_workload_and_external_id(self):
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        with pytest.raises(AgentCardRegistryError, match="exactly one"):
+            await registry.get(external_id="ext-1", workload_id="wl-1")
+
+    async def test_not_found_message_names_workload_id(self, mock_fetch):
+        mock_fetch.return_value = _parsed({})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        with pytest.raises(AgentCardRegistryError, match="workload_id='wl-missing'"):
+            await registry.get(workload_id="wl-missing")
+
+    async def test_get_uses_cache(self, mock_fetch):
+        mock_fetch.return_value = self._parsed_workload({"wl-1": _card()})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+
+        first = await registry.get(workload_id="wl-1")
+        second = await registry.get(workload_id="wl-1")
+
+        assert first is second
+        mock_fetch.assert_awaited_once()
+
+    async def test_register_then_get_flushes_batch(self, mock_fetch):
+        """GIVEN registered workload IDs WHEN one is got THEN both are fetched in one call."""
+        mock_fetch.return_value = self._parsed_workload(
+            {"wl-1": _card(), "wl-2": _card(name="Second Agent")}
+        )
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry.register(workload_id="wl-1")
+        registry.register(workload_id="wl-2")
+        assert registry.has_registered_lookups() is True
+
+        await registry.get(workload_id="wl-1")
+
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.call_args_list[0].args[0].keys() == {"workloadIds"}
+        assert set(mock_fetch.call_args_list[0].args[0]["workloadIds"].split(",")) == {
+            "wl-1",
+            "wl-2",
+        }
+        mock_fetch.reset_mock()
+        await registry.get(workload_id="wl-2")
+        mock_fetch.assert_not_awaited()
+
+    async def test_prefetch_workload_ids(self, mock_fetch):
+        mock_fetch.return_value = self._parsed_workload(
+            {"wl-1": _card(), "wl-2": _card(name="Second Agent")}
+        )
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        await registry.prefetch(workload_ids=["wl-1", "wl-2"])
+
+        mock_fetch.assert_awaited_once_with({"workloadIds": "wl-1,wl-2"})
+        mock_fetch.reset_mock()
+        await registry.get(workload_id="wl-1")
+        await registry.get(workload_id="wl-2")
+        mock_fetch.assert_not_awaited()
+
+    async def test_refresh_all_registered_includes_workload_ids(self, mock_fetch):
+        mock_fetch.return_value = self._parsed_workload({"wl-1": _card()})
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=60)
+        registry.register(workload_id="wl-1")
+        await registry.get(workload_id="wl-1")
+        registry._age_cache_entry_for_test("wl-1", 120)
+
+        mock_fetch.reset_mock()
+        await registry.refresh_all_registered()
+
+        mock_fetch.assert_awaited_once_with({"workloadIds": "wl-1"})
+
+    async def test_serves_stale_when_refresh_fails(self, mock_fetch, cache_backend):
+        """GIVEN a soft-expired workload card WHEN the registry is down THEN it is served."""
+        stale_card = _card()
+        mock_fetch.side_effect = [
+            self._parsed_workload({"wl-1": stale_card}),
+            AgentCardRegistryError("registry down"),
+        ]
+        registry = _memory_registry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            cache_backend=cache_backend,
+        )
+        first = await registry.get(workload_id="wl-1")
+        fixed_now = datetime.now(UTC)
+        cache_backend._entries["wl-1"].fetched_at = fixed_now - timedelta(seconds=60)
+        with patch("datarobot_genai.dragent.agent_card_registry_backends.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.UTC = UTC
+            second = await registry.get(workload_id="wl-1")
+
+        assert first is stale_card
+        assert second is stale_card
+        assert mock_fetch.await_count == 2
+
+    async def test_deregistered_workload_evicted_from_cache(self, mock_fetch, cache_backend):
+        """GIVEN a stopped workload WHEN its card is gone THEN the alias is evicted too."""
+        stale_card = _card()
+        ids = RegistryIds(external_id="ext-1", workload_id="wl-1")
+        mock_fetch.side_effect = [
+            _parsed(
+                {"wl-1": stale_card, "ext-1": stale_card},
+                key_types={"wl-1": "workload", "ext-1": "external"},
+                registry_ids={"wl-1": ids, "ext-1": ids},
+            ),
+            _parsed({}),
+        ]
+        registry = _memory_registry(
+            api_token="tok",
+            endpoint="https://ep",
+            cache_ttl=60,
+            cache_backend=cache_backend,
+        )
+        await registry.get(workload_id="wl-1")
+        registry._age_cache_entry_for_test("wl-1", 60)
+
+        with pytest.raises(AgentCardRegistryError, match="No agent card found"):
+            await registry.get(workload_id="wl-1")
+
+        assert await cache_backend.get_stale("wl-1", max_staleness_seconds=3600) is None
+        assert await cache_backend.get_stale("ext-1", max_staleness_seconds=3600) is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: ID kinds are never mixed in one request
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIdKindIsolation:
+    """``deploymentIds`` + ``workloadIds`` in one request is an HTTP 400."""
+
+    @pytest.fixture
+    def mock_fetch(self):
+        with patch.object(AgentCardRegistry, "_fetch", new_callable=AsyncMock) as m:
+            m.return_value = _parsed({})
+            yield m
+
+    @staticmethod
+    def _assert_one_id_kind_per_request(mock_fetch):
+        id_params = {"deploymentIds", "externalIds", "workloadIds"}
+        for call in mock_fetch.call_args_list:
+            params = call.args[0]
+            assert len(id_params & params.keys()) == 1, params
+            assert not {"deploymentIds", "workloadIds"} <= params.keys(), params
+
+    async def test_prefetch_of_all_kinds_issues_one_call_per_kind(self, mock_fetch):
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        await registry.prefetch(
+            deployment_ids=["dep-1"],
+            external_ids=["ext-1"],
+            workload_ids=["wl-1"],
+        )
+
+        assert mock_fetch.await_count == 3
+        self._assert_one_id_kind_per_request(mock_fetch)
+        assert [call.args[0] for call in mock_fetch.call_args_list] == [
+            {"deploymentIds": "dep-1"},
+            {"externalIds": "ext-1"},
+            {"workloadIds": "wl-1"},
+        ]
+
+    async def test_flush_pending_of_all_kinds_issues_one_call_per_kind(self, mock_fetch):
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        registry.register(deployment_id="dep-1")
+        registry.register(external_id="ext-1")
+        registry.register(workload_id="wl-1")
+
+        with pytest.raises(AgentCardRegistryError, match="No agent card found"):
+            await registry.get(workload_id="wl-1")
+
+        # 3 flush calls (one per kind) + 1 individual retry for the missing key
+        assert mock_fetch.await_count == 4
+        self._assert_one_id_kind_per_request(mock_fetch)
+
+    async def test_fetch_rejects_deployment_and_workload_ids_together(self):
+        """The guard fires before any HTTP call is made."""
+        registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+        with patch(f"{_MODULE}.httpx.AsyncClient") as mock_client_cls:
+            with pytest.raises(AgentCardRegistryError, match="same agent card registry request"):
+                await registry._fetch({"deploymentIds": "dep-1", "workloadIds": "wl-1"})
+
+        mock_client_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: ID list chunking (API caps each ID parameter at 20 values)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCardRegistryIdChunking:
+    @staticmethod
+    def _sequenced_client(bodies):
+        """Return an httpx client mock answering each GET with the next body."""
+        responses = []
+        for body in bodies:
+            response = MagicMock(spec=httpx.Response)
+            response.status_code = 200
+            response.json.return_value = body
+            response.raise_for_status = MagicMock()
+            responses.append(response)
+
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=responses)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        return client
+
+    @staticmethod
+    def _requested_ids(client, param):
+        """Return the per-request ID lists sent under *param*."""
+        return [call.kwargs["params"][param].split(",") for call in client.get.call_args_list]
+
+    async def test_more_than_20_ids_split_into_several_requests(self):
+        """GIVEN 21 deployment IDs WHEN fetched THEN two capped requests are issued."""
+        ids = [f"dep-{i}" for i in range(21)]
+        client = self._sequenced_client(
+            [
+                _registry_response(*[_entry(dep_id=i) for i in ids[:20]]),
+                _registry_response(_entry(dep_id=ids[20])),
+            ]
+        )
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=client):
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            parsed = await registry._fetch({"deploymentIds": ",".join(ids)})
+
+        requested = self._requested_ids(client, "deploymentIds")
+        assert [len(chunk) for chunk in requested] == [20, 1]
+        assert [i for chunk in requested for i in chunk] == ids
+        assert set(parsed.cards) == set(ids)
+
+    async def test_workload_ids_are_chunked_too(self):
+        ids = [f"wl-{i}" for i in range(25)]
+        client = self._sequenced_client(
+            [
+                _registry_response(*[_entry(wl_id=i) for i in ids[:20]]),
+                _registry_response(*[_entry(wl_id=i) for i in ids[20:]]),
+            ]
+        )
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=client):
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            parsed = await registry._fetch({"workloadIds": ",".join(ids)})
+
+        assert [len(chunk) for chunk in self._requested_ids(client, "workloadIds")] == [20, 5]
+        assert set(parsed.cards) == set(ids)
+        assert parsed.key_types["wl-24"] == "workload"
+
+    async def test_20_ids_stay_in_one_request(self):
+        ids = [f"dep-{i}" for i in range(20)]
+        client = self._sequenced_client([_registry_response(*[_entry(dep_id=i) for i in ids])])
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=client):
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            await registry._fetch({"deploymentIds": ",".join(ids)})
+
+        assert client.get.await_count == 1
+
+    async def test_on_duplicate_applies_across_chunks(self):
+        """GIVEN a duplicate external ID split across two chunks
+        WHEN fetched THEN on_duplicate resolves it as one result set.
+        """
+        ids = [f"ext-{i}" for i in range(20)] + ["ext-dup"]
+        client = self._sequenced_client(
+            [
+                _registry_response(_entry(ext_id="ext-dup")),
+                _registry_response(_entry(ext_id="ext-dup", card=_SAMPLE_AGENT_CARD_2)),
+            ]
+        )
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=client):
+            registry = _memory_registry(
+                api_token="tok",
+                endpoint="https://ep",
+                cache_ttl=3600,
+                on_duplicate="first",
+            )
+            parsed = await registry._fetch({"externalIds": ",".join(ids)})
+
+        assert client.get.await_count == 2
+        assert parsed.cards["ext-dup"].name == "Test Agent"
+
+    async def test_prefetch_chunks_registered_ids(self):
+        """GIVEN more than 20 registered workload IDs WHEN prefetched THEN requests are capped."""
+        ids = [f"wl-{i}" for i in range(21)]
+        client = self._sequenced_client(
+            [
+                _registry_response(*[_entry(wl_id=i) for i in ids[:20]]),
+                _registry_response(_entry(wl_id=ids[20])),
+            ]
+        )
+
+        with patch(f"{_MODULE}.httpx.AsyncClient", return_value=client):
+            registry = _memory_registry(api_token="tok", endpoint="https://ep", cache_ttl=3600)
+            await registry.prefetch(workload_ids=ids)
+
+        assert [len(chunk) for chunk in self._requested_ids(client, "workloadIds")] == [20, 1]

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import json
 import time
 from datetime import UTC
 from datetime import datetime
@@ -28,6 +29,7 @@ from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheR
 from datarobot_genai.dragent.agent_card_registry_backends import LayeredAgentCardCacheBackend
 from datarobot_genai.dragent.agent_card_registry_backends import MemoryAgentCardCacheBackend
 from datarobot_genai.dragent.agent_card_registry_backends import MemorySpaceAgentCardCacheBackend
+from datarobot_genai.dragent.agent_card_registry_backends import RegistryIds
 from datarobot_genai.dragent.agent_card_registry_backends import build_cache_record
 from datarobot_genai.dragent.agent_card_registry_backends import create_agent_card_cache_backend
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
@@ -44,6 +46,8 @@ _SAMPLE_AGENT_CARD = AgentCard.model_validate(
         "capabilities": {"streaming": False},
     }
 )
+
+_IDS = RegistryIds(deployment_id="dep-1", external_id="ext-1")
 
 
 @pytest.fixture
@@ -109,7 +113,7 @@ class TestMemorySpaceAgentCardCacheBackend:
             await memory_space_backend.store(
                 {"dep-1": _SAMPLE_AGENT_CARD, "ext-1": _SAMPLE_AGENT_CARD},
                 key_types={"dep-1": "deployment", "ext-1": "external"},
-                registry_ids={"dep-1": ("dep-1", "ext-1"), "ext-1": ("dep-1", "ext-1")},
+                registry_ids={"dep-1": _IDS, "ext-1": _IDS},
             )
 
         assert "deployment:dep-1" in storage
@@ -137,7 +141,7 @@ class TestMemorySpaceAgentCardCacheBackend:
 
         assert get_calls == ["deployment:dep-1"]
 
-    async def test_get_fresh_without_key_type_probes_both_aliases(self, memory_space_backend):
+    async def test_get_fresh_without_key_type_probes_every_alias(self, memory_space_backend):
         get_calls: list[str] = []
 
         async def track_get(key: str) -> str | None:
@@ -147,7 +151,7 @@ class TestMemorySpaceAgentCardCacheBackend:
         with patch.object(memory_space_backend._kv, "get_value", side_effect=track_get):
             assert await memory_space_backend.get_fresh("dep-1", cache_ttl=3600) is None
 
-        assert get_calls == ["deployment:dep-1", "external:dep-1"]
+        assert get_calls == ["deployment:dep-1", "external:dep-1", "workload:dep-1"]
 
     async def test_evict_removes_sibling_l2_key(self, memory_space_backend):
         """Typed eviction must delete every storage alias for the card."""
@@ -180,6 +184,102 @@ class TestMemorySpaceAgentCardCacheBackend:
 
         assert sorted(deleted) == ["deployment:dep-1", "external:ext-1"]
         assert storage == {}
+
+
+class TestMemorySpaceAgentCardCacheBackendWorkload:
+    async def test_store_writes_workload_storage_key(self, memory_space_backend):
+        """GIVEN a workload card with an external ID
+        WHEN stored THEN both aliases are written under their own prefixes.
+        """
+        storage: dict[str, str] = {}
+
+        async def capture_set(key: str, payload: str) -> None:
+            storage[key] = payload
+
+        ids = RegistryIds(external_id="ext-1", workload_id="wl-1")
+        with patch.object(memory_space_backend._kv, "set_value", side_effect=capture_set):
+            await memory_space_backend.store(
+                {"wl-1": _SAMPLE_AGENT_CARD, "ext-1": _SAMPLE_AGENT_CARD},
+                key_types={"wl-1": "workload", "ext-1": "external"},
+                registry_ids={"wl-1": ids, "ext-1": ids},
+            )
+
+        assert "workload:wl-1" in storage
+        assert "external:ext-1" in storage
+        assert "deployment:wl-1" not in storage
+        record = AgentCardCacheRecord.model_validate_json(storage["workload:wl-1"])
+        assert record.workload_id == "wl-1"
+        assert record.external_id == "ext-1"
+        assert record.deployment_id is None
+
+    async def test_get_fresh_reads_workload_storage_key(self, memory_space_backend):
+        """GIVEN a card stored under 'workload:' WHEN looked up by ID THEN it is found."""
+        record = build_cache_record(
+            _SAMPLE_AGENT_CARD,
+            lookup_key="wl-1",
+            key_type="workload",
+        )
+        storage = {"workload:wl-1": record.model_dump_json()}
+
+        async def mock_get(key: str) -> str | None:
+            return storage.get(key)
+
+        with patch.object(memory_space_backend._kv, "get_value", side_effect=mock_get):
+            found = await memory_space_backend.get_fresh("wl-1", cache_ttl=3600)
+
+        assert found is not None
+        assert found.workload_id == "wl-1"
+
+    async def test_evict_removes_sibling_workload_key(self, memory_space_backend):
+        """Evicting an external alias must drop the workload storage key too."""
+        record = build_cache_record(
+            _SAMPLE_AGENT_CARD,
+            lookup_key="wl-1",
+            key_type="workload",
+            external_id="ext-1",
+        )
+        payload = record.model_dump_json()
+        storage = {"workload:wl-1": payload, "external:ext-1": payload}
+        deleted: list[str] = []
+
+        async def mock_get(key: str) -> str | None:
+            return storage.get(key)
+
+        async def mock_delete(key: str) -> None:
+            deleted.append(key)
+            storage.pop(key, None)
+
+        with (
+            patch.object(memory_space_backend._kv, "get_value", side_effect=mock_get),
+            patch.object(memory_space_backend._kv, "delete_value", side_effect=mock_delete),
+        ):
+            await memory_space_backend.evict("ext-1", key_type="external")
+
+        assert sorted(deleted) == ["external:ext-1", "workload:wl-1"]
+        assert storage == {}
+
+
+class TestAgentCardCacheRecordCompatibility:
+    def test_record_without_workload_id_still_deserializes(self):
+        """GIVEN a v1 payload written before workload IDs existed
+        WHEN deserialized THEN it loads with workload_id unset.
+        """
+        legacy_payload = json.dumps(
+            {
+                "version": 1,
+                "fetched_at": datetime.now(UTC).isoformat(),
+                "card": _SAMPLE_AGENT_CARD.model_dump(mode="json", by_alias=True),
+                "source": "registry",
+                "deployment_id": "dep-1",
+                "external_id": "ext-1",
+            }
+        )
+
+        record = AgentCardCacheRecord.model_validate_json(legacy_payload)
+
+        assert record.workload_id is None
+        assert record.deployment_id == "dep-1"
+        assert record.card.name == "MemorySpace Agent"
 
 
 class TestCreateAgentCardCacheBackend:

--- a/tests/dragent/test_registry_warmup.py
+++ b/tests/dragent/test_registry_warmup.py
@@ -54,9 +54,10 @@ def nat_config(workflow_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 class TestCollectRegistryLookupIds:
     def test_collects_ids_from_yaml_config(self, nat_config):
-        dep_ids, ext_ids = collect_registry_lookup_ids(nat_config)
-        assert dep_ids == ["1234"]
-        assert ext_ids == ["abcd"]
+        collected = collect_registry_lookup_ids(nat_config)
+        assert collected.deployment_ids == ["1234"]
+        assert collected.external_ids == ["abcd"]
+        assert collected.workload_ids == ["wl-5678"]
 
     def test_deduplicates_ids(self):
         config = MagicMock()
@@ -65,15 +66,28 @@ class TestCollectRegistryLookupIds:
             "a": AuthenticatedA2AClientConfig(registry=shared_registry, auth_provider="x"),
             "b": AuthenticatedA2AClientConfig(registry=shared_registry, auth_provider="x"),
         }
-        dep_ids, ext_ids = collect_registry_lookup_ids(config)
-        assert dep_ids == ["dep-1"]
-        assert ext_ids == []
+        collected = collect_registry_lookup_ids(config)
+        assert collected.deployment_ids == ["dep-1"]
+        assert collected.external_ids == []
+        assert collected.workload_ids == []
+
+    def test_deduplicates_workload_ids(self):
+        """GIVEN two groups sharing a workload ID WHEN collected THEN it appears once."""
+        config = MagicMock()
+        shared_registry = AgentCardRegistryLookup(workload_id="wl-1")
+        config.function_groups = {
+            "a": AuthenticatedA2AClientConfig(registry=shared_registry, auth_provider="x"),
+            "b": AuthenticatedA2AClientConfig(registry=shared_registry, auth_provider="x"),
+        }
+        collected = collect_registry_lookup_ids(config)
+        assert collected.workload_ids == ["wl-1"]
+        assert collected.deployment_ids == []
 
     def test_skips_url_only_a2a_clients(self, nat_config):
-        dep_ids, ext_ids = collect_registry_lookup_ids(nat_config)
+        collected = collect_registry_lookup_ids(nat_config)
         # workflow also has a2a_agent with url only — must not appear
-        assert "http://agent.example.com:8080" not in dep_ids
-        assert len(dep_ids) == 1
+        assert "http://agent.example.com:8080" not in collected.deployment_ids
+        assert len(collected.deployment_ids) == 1
 
     def test_empty_when_no_registry_groups(self):
         config = MagicMock()
@@ -84,9 +98,11 @@ class TestCollectRegistryLookupIds:
                 auth_provider="auth",
             ),
         }
-        dep_ids, ext_ids = collect_registry_lookup_ids(config)
-        assert dep_ids == []
-        assert ext_ids == []
+        collected = collect_registry_lookup_ids(config)
+        assert collected.deployment_ids == []
+        assert collected.external_ids == []
+        assert collected.workload_ids == []
+        assert collected.is_empty() is True
 
 
 class TestWarmupRegistryFromConfig:
@@ -98,6 +114,7 @@ class TestWarmupRegistryFromConfig:
         mock_registry.prefetch.assert_awaited_once_with(
             deployment_ids=["1234"],
             external_ids=["abcd"],
+            workload_ids=["wl-5678"],
         )
         assert is_registry_warm() is True
 

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.8"
+version = "0.29.9"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent discovery and registry HTTP batching on the path to remote A2A tools; misconfiguration or chunking bugs could break multi-agent workflows, though behavior is heavily covered by new tests.
> 
> **Overview**
> **Release 0.29.8** extends central agent card registry support so `authenticated_a2a_client` can resolve agents by **`workload_id`** (Workload API runtime) in `workflow.yaml`, alongside existing `deployment_id` and `external_id`. Cards are fetched with `workloadIds`, cached under workload aliases in L1 and MemorySpace, and included in startup prefetch and background refresh like the other lookup kinds.
> 
> Registry HTTP behavior is tightened: **one ID kind per request** (mixing `deploymentIds` and `workloadIds` is rejected client-side; prefetch/flush issue separate calls per kind). Lists longer than the API’s **20-ID cap** are **chunked** and merged before duplicate handling, fixing HTTP 400s for large workflows. Config validation, warmup collection, and docs/troubleshooting are updated for the third identifier and the new batching rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8153656d1a0803a6209440a7676300d0e6444e22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->