### PR TITLE
[BUZZOK-32180] Use application-utils-persistence for L2 agent card cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.15 - 2026-08-28
+- `dragent`: the agent card registry's MemorySpace L2 cache is now built on the `datarobot.application_utils.persistence` Memory Service light ORM (`datarobot[application-utils]`) instead of a hand-rolled client against `datarobot.models.memory.Session`. Same on-the-wire cache behavior (soft TTL, stale-if-error, write-behind, session-id reuse) — no dependent-facing change.
+
 ## 0.29.14 - 2026-08-31
 - Raise the `nltk` floor from `>=3.10.0` to `>=3.10.2`.
 

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "../" }
 
 [package.metadata]

--- a/e2e-tests/pyproject.toml
+++ b/e2e-tests/pyproject.toml
@@ -59,6 +59,10 @@ exclude-dependencies = [
     "llama-index-llms-nvidia",
     "llama-index-llms-openai",
     "uv",                       # package manager bundled by crewai; runtime unnecessary
+    "datarobot",                # stable client pulled in transitively by datarobot-predict/
+                                 # datarobot-moderations; both provide the "datarobot" import
+                                 # namespace as datarobot-early-access, which we depend on
+                                 # directly, so keeping both installed is redundant and unsafe
     "langchain-milvus",         # Milvus vector DB adapter pulled in by nvidia-nat-langchain; not used
     "pymilvus",                 # Milvus client pulled in by langchain-milvus; not used
     "flask",                    # web framework pulled in by nvidia-nat 1.6.0; not used

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -919,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "datarobot"
-version = "3.18.0"
+version = "3.19.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -934,9 +934,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/87/fe696ed62eb8f72a29b036a71086434e39db7ef096a280526c8073017652/datarobot-3.18.0.tar.gz", hash = "sha256:47f289b65211416fba37b384b57a0ec82efdb76546aabda95c1ff7076b41e72c", size = 834279, upload-time = "2026-07-28T18:34:22.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/55/51ef34d52e66bb8215c29a0ec59a4d05e673426cabf2e88abf71340a897c/datarobot-3.19.0rc0.tar.gz", hash = "sha256:b23b4d5be1f9bf2a4e3250ab52ebba1016be065b28d8ac0027daa3ecd6e71536", size = 850577, upload-time = "2026-08-18T20:21:57.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/5a/999f30688e3f352110e02034681f3393133a0fcc2db2bc88ee92377b15c8/datarobot-3.18.0-py3-none-any.whl", hash = "sha256:c1272693b9ebb3cbf6e4e4066bb714e003208cb3957d4489d751a380e7062a97", size = 900686, upload-time = "2026-07-28T18:34:20.498Z" },
+    { url = "https://files.pythonhosted.org/packages/41/4f/5b0c9ac1afdc55cd70c67d988df95cff444ef9be0e1c415816cc8cdbd507/datarobot-3.19.0rc0-py3-none-any.whl", hash = "sha256:b8238fe5fe5f566057d2cd9bb1dcce67dfe7bdb616f6747efb8e88fa49536876", size = 916997, upload-time = "2026-08-18T20:21:56.346Z" },
 ]
 
 [package.optional-dependencies]
@@ -1086,6 +1086,7 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
+    { name = "datarobot", extras = ["application-utils"], marker = "extra == 'dragent'", specifier = ">=3.19.0rc0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
@@ -2433,17 +2434,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -2459,16 +2460,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -3746,10 +3747,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3765,10 +3766,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -63,6 +63,7 @@ overrides = [
 excludes = [
     "annoy",
     "build",
+    "datarobot",
     "flask",
     "kubernetes",
     "lancedb",
@@ -918,28 +919,6 @@ wheels = [
 ]
 
 [[package]]
-name = "datarobot"
-version = "3.19.0rc0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "strenum" },
-    { name = "trafaret" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/55/51ef34d52e66bb8215c29a0ec59a4d05e673426cabf2e88abf71340a897c/datarobot-3.19.0rc0.tar.gz", hash = "sha256:b23b4d5be1f9bf2a4e3250ab52ebba1016be065b28d8ac0027daa3ecd6e71536", size = 850577, upload-time = "2026-08-18T20:21:57.999Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/4f/5b0c9ac1afdc55cd70c67d988df95cff444ef9be0e1c415816cc8cdbd507/datarobot-3.19.0rc0-py3-none-any.whl", hash = "sha256:b8238fe5fe5f566057d2cd9bb1dcce67dfe7bdb616f6747efb8e88fa49536876", size = 916997, upload-time = "2026-08-18T20:21:56.346Z" },
-]
-
-[[package]]
 name = "datarobot-early-access"
 version = "3.19.0.2026.8.31.172953"
 source = { registry = "https://pypi.org/simple" }
@@ -1408,7 +1387,6 @@ wheels = [
 
 [package.optional-dependencies]
 all = [
-    { name = "datarobot" },
     { name = "datarobot-predict" },
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
@@ -1441,7 +1419,6 @@ version = "1.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "datarobot" },
     { name = "pandas" },
     { name = "py4j" },
     { name = "requests" },

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -948,7 +948,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -939,7 +939,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/4f/5b0c9ac1afdc55cd70c67d988df95cff444ef9be0e1c415816cc8cdbd507/datarobot-3.19.0rc0-py3-none-any.whl", hash = "sha256:b8238fe5fe5f566057d2cd9bb1dcce67dfe7bdb616f6747efb8e88fa49536876", size = 916997, upload-time = "2026-08-18T20:21:56.346Z" },
 ]
 
+[[package]]
+name = "datarobot-early-access"
+version = "3.19.0.2026.8.31.172953"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "strenum" },
+    { name = "trafaret" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/07/b31ad6dd4964bbc6924a96ef2d95f4cded35448a01c1014713bfc5a96050/datarobot_early_access-3.19.0.2026.8.31.172953.tar.gz", hash = "sha256:bbc4e1064559d11a6edc430520ace1c3057f1a379c027956d3845364b7e1fa0b", size = 1149556, upload-time = "2026-08-31T17:29:58.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/f2/a951b54293e3a6f02f0d100cd9acb8bc8482b9ac77215c45041d596686cb/datarobot_early_access-3.19.0.2026.8.31.172953-py3-none-any.whl", hash = "sha256:bd2f011a3b0d116bcca530e165680d23fd32c30fed8ee4eec72105b25a01738a", size = 1326487, upload-time = "2026-08-31T17:29:56.015Z" },
+]
+
 [package.optional-dependencies]
+application-utils = [
+    { name = "ag-ui-protocol" },
+    { name = "httpx" },
+    { name = "pydantic" },
+]
 core = [
     { name = "psutil" },
     { name = "pydantic" },
@@ -959,7 +986,7 @@ crewai = [
     { name = "colorama" },
     { name = "crewai" },
     { name = "crewai-tools", extra = ["mcp"] },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -983,7 +1010,7 @@ dragent = [
     { name = "ag-ui-protocol" },
     { name = "anyio" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["application-utils", "core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
@@ -1009,7 +1036,7 @@ dragent = [
 langgraph = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1032,7 +1059,7 @@ langgraph = [
 llamaindex = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
@@ -1086,22 +1113,22 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
-    { name = "datarobot", extras = ["application-utils"], marker = "extra == 'dragent'", specifier = ">=3.19.0rc0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "datarobot-early-access", extras = ["application-utils"], marker = "extra == 'dragent'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ datarobot_genai = [
 package = true
 exclude-dependencies = [
   "uv",                       # package manager bundled by crewai; runtime unnecessary
+  "datarobot",                # stable client pulled in transitively by datarobot-predict/
+                               # datarobot-moderations; both provide the "datarobot" import
+                               # namespace as datarobot-early-access, which we depend on
+                               # directly, so keeping both installed is redundant and unsafe
   "langchain-milvus",         # Milvus vector DB adapter pulled in by nvidia-nat-langchain; not used
   "pymilvus",                 # Milvus client pulled in by langchain-milvus; not used
   "flask",                    # web framework pulled in by nvidia-nat 1.6.0; not used

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ core = [
     "requests>=2.32.4,<3.0.0",
     # datarobot.core.config's LLMConfig / LLMType / resolve_llm_config, which
     # datarobot_genai.core.config consumes instead of redefining, ship in stable 3.18.0.
-    "datarobot[core]>=3.18.0,<4.0.0",
+    "datarobot-early-access[core]>=3.19.0.2026.8.31.172953,<4.0.0",
     "datarobot-predict>=1.13.2,<2.0.0",
     "openai>=2.0.0,<3.0.0",
     "pyjwt>=2.12.0,<3.0.0",  # CVE-2026-32597 fixed in 2.12.0
@@ -94,12 +94,12 @@ dragent = core + [
     "datarobot-opentelemetry>=0.4.0,<1.0.0",
     # Memory Service light ORM (DRMemorySpace/DRSession/DREvent), used to back the
     # agent card registry's MemorySpace L2 cache instead of a hand-rolled Session client.
-    "datarobot[application-utils]>=3.19.0rc0,<4.0.0",  # rc0: application_utils.persistence is unreleased
+    "datarobot-early-access[application-utils]>=3.19.0.2026.8.31.172953,<4.0.0",  # rc0: application_utils.persistence is unreleased
 ]
 
 # auth is standalone set of dependencies for auth utilities only
 auth = [
-  "datarobot[auth]>=3.18.0,<4.0.0",
+  "datarobot-early-access[auth]>=3.19.0.2026.8.31.172953,<4.0.0",
   "aiohttp>=3.13.3,<4.0.0",  # CVE-2025-69229 & CVE-2025-69230 fixed in 3.13.3
   "pydantic>=2.6.1,<3.0.0",
   "httpx>=0.28.1,<1.0.0",
@@ -110,7 +110,7 @@ auth = [
 
 # drmcputils is a leaf subpackage: no imports from other datarobot_genai subpackages.
 drmcputils = auth + [
-    "datarobot[fs]>=3.18.0,<4.0.0",
+    "datarobot-early-access[fs]>=3.19.0.2026.8.31.172953,<4.0.0",
 ]
 
 # drtools: no subpackages dependencies other than auth and drmcputils.

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ dragent = core + [
     "opentelemetry-instrumentation-fastapi>=0.64b0,<1.0.0",
     # >=0.4.0 for GEN_AI_AGENT_NAME (PBMP-8006 SDK-1)
     "datarobot-opentelemetry>=0.4.0,<1.0.0",
+    # Memory Service light ORM (DRMemorySpace/DRSession/DREvent), used to back the
+    # agent card registry's MemorySpace L2 cache instead of a hand-rolled Session client.
+    "datarobot[application-utils]>=3.19.0rc0,<4.0.0",  # rc0: application_utils.persistence is unreleased
 ]
 
 # auth is standalone set of dependencies for auth utilities only

--- a/src/datarobot_genai/dragent/agent_card_registry_backends.py
+++ b/src/datarobot_genai/dragent/agent_card_registry_backends.py
@@ -33,7 +33,7 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
-from datarobot_genai.dragent.memory_space_cache import try_configure_datarobot_memory_client
+from datarobot_genai.dragent.memory_space_cache import try_build_memory_service_client
 from datarobot_genai.dragent.memory_space_cache import try_resolve_memory_space_id
 
 if TYPE_CHECKING:
@@ -502,14 +502,15 @@ def create_agent_card_cache_backend(
         logger.debug("Agent card registry cache: L1 only (no MemorySpace ID configured)")
         return l1
 
-    if not try_configure_datarobot_memory_client():
+    client = try_build_memory_service_client()
+    if client is None:
         logger.warning(
             "Agent card registry cache: L1 only — MemorySpace L2 unavailable "
             "(set DATAROBOT_API_TOKEN and DATAROBOT_ENDPOINT)"
         )
         return l1
 
-    kv_cache = MemorySpaceKVCache(memory_space_id=memory_space_id)
+    kv_cache = MemorySpaceKVCache(memory_space_id=memory_space_id, client=client)
     logger.debug(
         "Agent card registry cache: L1 + MemorySpace L2 (space_id=%s)",
         memory_space_id,

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -14,40 +14,41 @@
 
 """DataRobot MemorySpace-backed KV cache for dragent shared caches.
 
-Uses the agentic memory **Session API** (``datarobot.models.memory.Session``) — the same
-surface the agent-application recipe uses for chat history when
-``USE_APPLICATION_MEMORY_SPACE`` is enabled — not the mem0-compatible sub-route.
+Built on the Memory Service light ORM (``datarobot.application_utils.persistence``,
+the ``datarobot[application-utils]`` extra) — the same surface
+``datarobot.application_utils.chat_history`` uses for AG-UI chat history — instead
+of hand-rolling session management against ``datarobot.models.memory.Session``.
 
 Each provisioned memory space has a unique ``memory_space_id`` and platform-level
 access control scoped to the deploying user or workload API token. Unlike shared
 Redis, no per-deployment namespace or HMAC signing is required for this backend.
+
+Each cache entry is one Memory Service session — found by an exact-match
+``DRDeduplicationKey`` lookup on the logical cache key — carrying a single event
+whose ``content`` is the opaque JSON payload. ``set_value`` patches that event in
+place instead of appending; the cache only ever needs the current value, never a
+history.
 """
 
 from __future__ import annotations
 
-import asyncio
-import hashlib
 import logging
 import os
-from typing import Any
-from typing import cast
+from typing import Annotated
 
-import datarobot as dr
+from datarobot.application_utils.persistence import DRDeduplicationKey
+from datarobot.application_utils.persistence import DREvent
+from datarobot.application_utils.persistence import DRMemoryNotFoundError
+from datarobot.application_utils.persistence import DRMemoryServiceClient
+from datarobot.application_utils.persistence import DRMemorySpace
+from datarobot.application_utils.persistence import DRSession
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
-from datarobot.errors import MemorySessionDeduplicationError
-from datarobot.models.memory import Session
 from pydantic import Field
 
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
 
 logger = logging.getLogger(__name__)
 
-# Stable 24-hex participant id (BSON ObjectId length) for cache sessions.
-DRAGENT_CACHE_PARTICIPANT_ID = hashlib.sha256(b"datarobot-genai:dragent-cache").hexdigest()[:24]
-
-CACHE_METADATA_VERSION = 1
-CACHE_EVENT_TYPE = "status"
-DEDUPLICATION_KEY_LENGTH = 64
 CACHE_KIND = "agent_card"
 
 _MEMORY_SPACE_REQUIRED_MSG = (
@@ -92,119 +93,75 @@ def resolve_memory_space_id(explicit: str | None = None) -> str:
     return space_id
 
 
-def try_configure_datarobot_memory_client(
+def try_build_memory_service_client(
     *,
     endpoint: str | None = None,
     api_token: str | None = None,
-) -> bool:
-    """Configure the DataRobot client for memory Session API calls when possible."""
-    try:
-        configure_datarobot_memory_client(endpoint=endpoint, api_token=api_token)
-    except Exception as exc:
-        logger.debug("MemorySpace client unavailable: %s", exc)
-        return False
-    return True
+) -> DRMemoryServiceClient | None:
+    """Build a Memory Service ORM client, or ``None`` when unconfigured.
 
-
-def configure_datarobot_memory_client(
-    *,
-    endpoint: str | None = None,
-    api_token: str | None = None,
-) -> None:
-    """Configure the process-global DataRobot client for memory Session API calls."""
+    Does no I/O: only resolves ``DATAROBOT_ENDPOINT``/``DATAROBOT_API_TOKEN``
+    (explicit argument > settings > environment) and constructs the client —
+    building a :class:`DRMemoryServiceClient` merely opens an ``httpx.AsyncClient``
+    and stores headers; the first network call happens lazily on first use. Safe
+    to call from a synchronous, I/O-free constructor such as
+    :class:`~datarobot_genai.dragent.agent_card_registry.AgentCardRegistry`'s.
+    """
     cfg = MemorySpaceCacheConfig()
     token = api_token or cfg.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
     if not token:
-        raise ValueError("DATAROBOT_API_TOKEN is required when using memory_space cache backends.")
-    base = cast(str, endpoint or resolve_datarobot_endpoint(require=True))
-    dr.Client(token=token, endpoint=base.rstrip("/"))
-
-
-def _cache_deduplication_key(logical_key: str) -> str:
-    raw = "dragent-cache\0" + logical_key
-    return hashlib.sha256(raw.encode()).hexdigest()[:DEDUPLICATION_KEY_LENGTH]
-
-
-def _cache_session_description(logical_key: str) -> str:
-    return f"/dragent/cache/{logical_key}"
-
-
-def _cache_session_metadata(logical_key: str) -> dict[str, Any]:
-    return {
-        "v": CACHE_METADATA_VERSION,
-        "dragent_cache": True,
-        "cache_key": logical_key,
-        "cache_kind": CACHE_KIND,
-    }
-
-
-def _payload_event_body(payload: str) -> dict[str, Any]:
-    return {"v": CACHE_METADATA_VERSION, "payload": payload}
-
-
-def _payload_from_event_body(body: dict[str, Any] | None) -> str | None:
-    if not body or body.get("v") != CACHE_METADATA_VERSION:
+        logger.debug("MemorySpace client unavailable: no DATAROBOT_API_TOKEN configured.")
         return None
-    value = body.get("payload")
-    return str(value) if value is not None else None
-
-
-def _create_cache_session(
-    memory_space_id: str,
-    *,
-    logical_key: str,
-) -> Session:
-    """Create a cache session, adopting an existing one on deduplication collision."""
     try:
-        return Session.create(
-            memory_space_id,
-            [DRAGENT_CACHE_PARTICIPANT_ID],
-            metadata=_cache_session_metadata(logical_key),
-            description=_cache_session_description(logical_key),
-            deduplication_key=_cache_deduplication_key(logical_key),
-        )
-    except MemorySessionDeduplicationError as exc:
-        if exc.existing_session_id is None:
-            raise
-        return Session.get(memory_space_id, exc.existing_session_id)
-
-
-def _find_cache_session(memory_space_id: str, logical_key: str) -> Session | None:
-    description = _cache_session_description(logical_key)
-    sessions = Session.list(
-        memory_space_id,
-        participants=[DRAGENT_CACHE_PARTICIPANT_ID],
-        description=description,
-        limit=1,
-    )
-    return sessions[0] if sessions else None
-
-
-def _read_payload(session: Session) -> str | None:
-    events = session.events(last_n=1)
-    if not events:
+        base = endpoint or resolve_datarobot_endpoint(require=True)
+    except ValueError as exc:
+        logger.debug("MemorySpace client unavailable: %s", exc)
         return None
-    return _payload_from_event_body(events[0].body)
+    return DRMemoryServiceClient(endpoint=base, api_token=token)
 
 
-def _write_payload(session: Session, payload: str) -> None:
-    body = _payload_event_body(payload)
-    events = session.events(last_n=1)
-    if events and events[0].sequence_id is not None:
-        session.update_event(events[0].sequence_id, body=body)
-        return
-    session.post_event(
-        body=body,
-        emitter={"type": "agent"},
-        event_type=CACHE_EVENT_TYPE,
-    )
+class _CacheEntrySession(DRSession):
+    """One Memory Service session per logical cache key."""
+
+    __description_prefix__ = "dragent-cache"
+
+    key: Annotated[str, DRDeduplicationKey]
+
+
+class _CacheEntryEvent(DREvent, session=_CacheEntrySession):  # type: ignore[call-arg]
+    """The single event carrying a cache entry's opaque JSON payload."""
+
+    __event_type__ = "status"
 
 
 class MemorySpaceKVCache:
-    """Store opaque JSON payloads in a DataRobot MemorySpace by logical key."""
+    """Store opaque JSON payloads in a DataRobot MemorySpace by logical key.
 
-    def __init__(self, *, memory_space_id: str, key_prefix: str = "dragent:") -> None:
-        self._memory_space_id = memory_space_id
+    Parameters
+    ----------
+    memory_space_id : str
+        Provisioned MemorySpace ID to store cache entries in.
+    client : DRMemoryServiceClient
+        Memory Service ORM client (see :func:`try_build_memory_service_client`).
+        Required explicitly rather than resolved internally, since the ORM has no
+        global client to fall back on.
+    key_prefix : str
+        Prefix namespacing every logical key this cache writes.
+    """
+
+    def __init__(
+        self,
+        *,
+        memory_space_id: str,
+        client: DRMemoryServiceClient,
+        key_prefix: str = "dragent:",
+    ) -> None:
+        self._client = client
+        # Wrap the space ID directly rather than fetching it via `DRMemorySpace.get()`:
+        # DRSession/DREvent calls only ever read `space.id` and `space._client`, so a
+        # round trip for metadata (user_id/tenant_id) this cache never uses would be
+        # pure overhead — and, more importantly, would make construction perform I/O.
+        self._space = DRMemorySpace(client, id=memory_space_id, user_id="", tenant_id="")
         normalized = key_prefix if key_prefix.endswith(":") else f"{key_prefix}:"
         self._key_prefix = normalized
         self._session_ids: dict[str, str] = {}
@@ -212,18 +169,18 @@ class MemorySpaceKVCache:
     def _logical_key(self, key: str) -> str:
         return f"{self._key_prefix}{CACHE_KIND}:{key}"
 
-    def _cache_session_id(self, logical_key: str, session: Session) -> None:
+    def _cache_session_id(self, logical_key: str, session: _CacheEntrySession) -> None:
         self._session_ids[logical_key] = session.id
 
     def _invalidate_session_id(self, logical_key: str) -> None:
         self._session_ids.pop(logical_key, None)
 
-    def _resolve_session(self, logical_key: str) -> Session | None:
+    async def _resolve_session(self, logical_key: str) -> _CacheEntrySession | None:
         """Return the cache session, using a process-local session-id cache when possible."""
         if session_id := self._session_ids.get(logical_key):
             try:
-                return Session.get(self._memory_space_id, session_id)
-            except Exception:
+                return await _CacheEntrySession.get(self._space, id=session_id)
+            except DRMemoryNotFoundError:
                 logger.debug(
                     "MemorySpace session cache miss for %s (session_id=%s)",
                     logical_key,
@@ -231,43 +188,41 @@ class MemorySpaceKVCache:
                 )
                 self._invalidate_session_id(logical_key)
 
-        session = _find_cache_session(self._memory_space_id, logical_key)
-        if session is not None:
-            self._cache_session_id(logical_key, session)
+        try:
+            session = await _CacheEntrySession.get(self._space, key=logical_key)
+        except DRMemoryNotFoundError:
+            return None
+        self._cache_session_id(logical_key, session)
         return session
 
     async def get_value(self, key: str) -> str | None:
         """Return the stored JSON payload for *key*, or ``None`` when missing."""
         logical_key = self._logical_key(key)
 
-        def _get() -> str | None:
-            session = self._resolve_session(logical_key)
+        try:
+            session = await self._resolve_session(logical_key)
             if session is None:
                 return None
-            return _read_payload(session)
-
-        try:
-            return await asyncio.to_thread(_get)
+            events = await _CacheEntryEvent.last(session, n=1)
         except Exception:
             logger.exception("MemorySpace cache read failed for %s", logical_key)
             return None
+        return events[0].content if events else None
 
     async def set_value(self, key: str, payload: str) -> None:
         """Upsert a JSON payload for *key*."""
         logical_key = self._logical_key(key)
 
-        def _set() -> None:
-            session = self._resolve_session(logical_key)
-            if session is None:
-                session = _create_cache_session(
-                    self._memory_space_id,
-                    logical_key=logical_key,
-                )
-                self._cache_session_id(logical_key, session)
-            _write_payload(session, payload)
-
         try:
-            await asyncio.to_thread(_set)
+            session = await self._resolve_session(logical_key)
+            if session is None:
+                session = await _CacheEntrySession.post(self._space, key=logical_key)
+                self._cache_session_id(logical_key, session)
+            events = await _CacheEntryEvent.last(session, n=1)
+            if events:
+                await events[0].patch(content=payload)
+            else:
+                await _CacheEntryEvent.post(session=session, content=payload, emitter_type="agent")
         except Exception:
             logger.exception("MemorySpace cache write failed for %s", logical_key)
 
@@ -275,13 +230,11 @@ class MemorySpaceKVCache:
         """Remove a cached payload for *key* when present."""
         logical_key = self._logical_key(key)
 
-        def _delete() -> None:
-            session = self._resolve_session(logical_key)
-            if session is not None:
-                session.delete()
-            self._invalidate_session_id(logical_key)
-
         try:
-            await asyncio.to_thread(_delete)
+            session = await self._resolve_session(logical_key)
+            if session is not None:
+                await session.delete()
         except Exception:
             logger.exception("MemorySpace cache delete failed for %s", logical_key)
+        finally:
+            self._invalidate_session_id(logical_key)

--- a/tests/dragent/test_agent_card_registry_memory_space.py
+++ b/tests/dragent/test_agent_card_registry_memory_space.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 
 import pytest
 from a2a.types import AgentCard
+from datarobot.application_utils.persistence import DRMemoryServiceClient
 
 from datarobot_genai.dragent.agent_card_registry import AgentCardRegistryConfig
 from datarobot_genai.dragent.agent_card_registry_backends import AgentCardCacheRecord
@@ -52,7 +53,10 @@ _IDS = RegistryIds(deployment_id="dep-1", external_id="ext-1")
 
 @pytest.fixture
 def memory_space_backend():
-    kv = MemorySpaceKVCache(memory_space_id="space-1")
+    client = DRMemoryServiceClient(
+        endpoint="https://app.datarobot.com/api/v2", api_token="test-token"
+    )
+    kv = MemorySpaceKVCache(memory_space_id="space-1", client=client)
     return MemorySpaceAgentCardCacheBackend(kv_cache=kv)
 
 
@@ -304,9 +308,11 @@ class TestCreateAgentCardCacheBackend:
             agent_card_registry_cache_ttl=0,
         )
         with patch(
-            "datarobot_genai.dragent.agent_card_registry_backends.try_configure_datarobot_memory_client",
-            return_value=True,
-        ) as configure_mock:
+            "datarobot_genai.dragent.agent_card_registry_backends.try_build_memory_service_client",
+            return_value=DRMemoryServiceClient(
+                endpoint="https://app.datarobot.com/api/v2", api_token="test-token"
+            ),
+        ) as build_client_mock:
             from datarobot_genai.dragent.agent_card_registry_backends import (
                 MemoryAgentCardCacheBackend,
             )
@@ -314,13 +320,13 @@ class TestCreateAgentCardCacheBackend:
             backend = create_agent_card_cache_backend(config)
 
         assert type(backend) is MemoryAgentCardCacheBackend
-        configure_mock.assert_not_called()
+        build_client_mock.assert_not_called()
 
     def test_l1_only_when_memory_client_unconfigured(self):
         config = AgentCardRegistryConfig(agent_card_registry_memory_space_id="space-123")
         with patch(
-            "datarobot_genai.dragent.agent_card_registry_backends.try_configure_datarobot_memory_client",
-            return_value=False,
+            "datarobot_genai.dragent.agent_card_registry_backends.try_build_memory_service_client",
+            return_value=None,
         ):
             from datarobot_genai.dragent.agent_card_registry_backends import (
                 MemoryAgentCardCacheBackend,
@@ -338,13 +344,15 @@ class TestCreateAgentCardCacheBackend:
         }
         with patch.dict("os.environ", env, clear=False):
             with patch(
-                "datarobot_genai.dragent.agent_card_registry_backends.try_configure_datarobot_memory_client",
-                return_value=True,
-            ) as configure_mock:
+                "datarobot_genai.dragent.agent_card_registry_backends.try_build_memory_service_client",
+                return_value=DRMemoryServiceClient(
+                    endpoint="https://app.datarobot.com/api/v2", api_token="test-token"
+                ),
+            ) as build_client_mock:
                 backend = create_agent_card_cache_backend(config)
 
         assert isinstance(backend, LayeredAgentCardCacheBackend)
-        configure_mock.assert_called_once()
+        build_client_mock.assert_called_once()
 
 
 class TestLayeredAgentCardCacheBackend:

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -14,57 +14,74 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
-from unittest.mock import MagicMock
-from unittest.mock import patch
 
+import httpx
 import pytest
+import respx
+from datarobot.application_utils.persistence import DRMemoryServiceClient
+from datarobot.application_utils.persistence.markers import SYSTEM_PARTICIPANT
 
-from datarobot_genai.dragent.memory_space_cache import CACHE_EVENT_TYPE
-from datarobot_genai.dragent.memory_space_cache import DRAGENT_CACHE_PARTICIPANT_ID
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
-from datarobot_genai.dragent.memory_space_cache import configure_datarobot_memory_client
 from datarobot_genai.dragent.memory_space_cache import resolve_memory_space_id
+from datarobot_genai.dragent.memory_space_cache import try_build_memory_service_client
 from datarobot_genai.dragent.memory_space_cache import try_resolve_memory_space_id
 
+BASE = "https://app.datarobot.com/api/v2"
+MEMORY_BASE = f"{BASE}/memory"
+SPACE_ID = "space-1"
+SESSIONS_URL = f"{MEMORY_BASE}/{SPACE_ID}/sessions/"
+SESSION_ID = "sess-1"
+SESSION_URL = f"{SESSIONS_URL}{SESSION_ID}/"
+EVENTS_URL = f"{SESSION_URL[:-1]}/events/"
+LOGICAL_KEY = "dragent:agent_card:dep-1"
 
-class _FakeEvent:
-    def __init__(self, *, sequence_id: int, body: dict[str, Any] | None) -> None:
-        self.sequence_id = sequence_id
-        self.body = body
+
+def _session_wire(
+    *,
+    session_id: str = SESSION_ID,
+    dedup_key: str = LOGICAL_KEY,
+    version: int = 1,
+) -> dict[str, Any]:
+    return {
+        "id": session_id,
+        "participants": [SYSTEM_PARTICIPANT],
+        "description": "//dragent-cache/",
+        "deduplicationKey": dedup_key,
+        "metadata": {},
+        "lifecycleStrategies": [],
+        "version": version,
+        "createdAt": "2026-06-30T00:00:00Z",
+    }
 
 
-class _FakeSession:
-    def __init__(self, session_id: str = "sess-1") -> None:
-        self.id = session_id
-        self.metadata: dict[str, Any] = {}
-        self._events: list[_FakeEvent] = []
-        self.post_event = MagicMock(side_effect=self._post_event)
-        self.update_event = MagicMock(side_effect=self._update_event)
-        self.delete = MagicMock()
+def _event_wire(*, sequence_id: int = 0, content: str = "payload") -> dict[str, Any]:
+    return {
+        "sequenceId": sequence_id,
+        "createdAt": "2026-06-30T00:00:01Z",
+        "eventType": "status",
+        "emitterType": "agent",
+        "emitterId": None,
+        "body": {"content": content},
+    }
 
-    def events(self, **kwargs: Any) -> list[_FakeEvent]:
-        if "last_n" in kwargs:
-            return self._events[-kwargs["last_n"] :]
-        return list(self._events)
 
-    def _post_event(self, **kwargs: Any) -> _FakeEvent:
-        event = _FakeEvent(sequence_id=len(self._events) + 1, body=kwargs.get("body"))
-        self._events.append(event)
-        return event
+def _items(*wires: dict[str, Any]) -> dict[str, Any]:
+    return {"items": list(wires), "total": len(wires)}
 
-    def _update_event(self, sequence_id: int, **kwargs: Any) -> None:
-        for event in self._events:
-            if event.sequence_id == sequence_id:
-                if "body" in kwargs:
-                    event.body = kwargs["body"]
-                return
-        raise KeyError(sequence_id)
+
+def _client() -> DRMemoryServiceClient:
+    return DRMemoryServiceClient(
+        endpoint=BASE,
+        api_token="test-token",
+        http_client=httpx.AsyncClient(),
+    )
 
 
 @pytest.fixture
 def kv_cache() -> MemorySpaceKVCache:
-    return MemorySpaceKVCache(memory_space_id="space-1")
+    return MemorySpaceKVCache(memory_space_id=SPACE_ID, client=_client())
 
 
 class TestResolveMemorySpaceId:
@@ -82,7 +99,17 @@ class TestResolveMemorySpaceId:
         assert try_resolve_memory_space_id(None) is None
 
 
-class TestConfigureDatarobotMemoryClient:
+class TestTryBuildMemoryServiceClient:
+    def test_returns_none_without_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+        assert try_build_memory_service_client() is None
+
+    def test_returns_none_without_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DATAROBOT_API_TOKEN", "token")
+        monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
+        monkeypatch.delenv("DATAROBOT_PUBLIC_API_ENDPOINT", raising=False)
+        assert try_build_memory_service_client() is None
+
     def test_uses_public_api_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DATAROBOT_API_TOKEN", "token")
         monkeypatch.setenv(
@@ -91,121 +118,142 @@ class TestConfigureDatarobotMemoryClient:
         )
         monkeypatch.setenv("DATAROBOT_ENDPOINT", "http://datarobot-nginx/api/v2")
 
-        with patch("datarobot_genai.dragent.memory_space_cache.dr.Client") as client_mock:
-            configure_datarobot_memory_client()
+        client = try_build_memory_service_client()
 
-        client_mock.assert_called_once_with(
-            token="token",
-            endpoint="https://staging.datarobot.com/api/v2",
+        assert client is not None
+        assert client.base_url == "https://staging.datarobot.com/api/v2/memory"
+
+    def test_explicit_args_take_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DATAROBOT_API_TOKEN", raising=False)
+        monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
+
+        client = try_build_memory_service_client(
+            endpoint="https://explicit.datarobot.com/api/v2",
+            api_token="explicit-token",
         )
+
+        assert client is not None
+        assert client.base_url == "https://explicit.datarobot.com/api/v2/memory"
 
 
 class TestMemorySpaceKVCache:
-    async def test_set_and_get_round_trip(self, kv_cache: MemorySpaceKVCache) -> None:
-        session = _FakeSession()
-
-        with (
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-                return_value=None,
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._create_cache_session",
-                return_value=session,
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache.Session.get",
-                return_value=session,
-            ),
-        ):
-            await kv_cache.set_value("dep-1", '{"version": 1}')
-            assert await kv_cache.get_value("dep-1") == '{"version": 1}'
-
-        session.post_event.assert_called_once()
-        kwargs = session.post_event.call_args.kwargs
-        assert kwargs["event_type"] == CACHE_EVENT_TYPE
-        assert kwargs["body"]["payload"] == '{"version": 1}'
-
-    async def test_get_reuses_cached_session_id_without_list(
+    @respx.mock
+    async def test_get_value_returns_none_when_no_session(
         self, kv_cache: MemorySpaceKVCache
     ) -> None:
-        session = _FakeSession()
-        find_mock = MagicMock(return_value=None)
-        get_mock = MagicMock(return_value=session)
-        session.post_event(body={"v": 1, "payload": "cached"})
+        respx.get(SESSIONS_URL).mock(return_value=httpx.Response(200, json=_items()))
 
-        with (
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-                find_mock,
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._create_cache_session",
-                return_value=session,
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache.Session.get",
-                get_mock,
-            ),
-        ):
-            await kv_cache.set_value("dep-1", "cached")
-            find_mock.reset_mock()
-            get_mock.reset_mock()
-            assert await kv_cache.get_value("dep-1") == "cached"
+        assert await kv_cache.get_value("dep-1") is None
 
-        find_mock.assert_not_called()
-        get_mock.assert_called_once_with("space-1", "sess-1")
+    @respx.mock
+    async def test_set_value_creates_session_and_event_when_missing(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        captured: dict[str, Any] = {}
 
-    async def test_update_existing_entry(self, kv_cache: MemorySpaceKVCache) -> None:
-        session = _FakeSession()
-        session.post_event(body={"v": 1, "payload": "v1"})
+        def _capture_post(req: httpx.Request) -> httpx.Response:
+            captured["session_body"] = json.loads(req.content)
+            return httpx.Response(201, json=_session_wire())
 
-        with (
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-                return_value=session,
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache.Session.get",
-                return_value=session,
-            ),
-        ):
-            await kv_cache.set_value("dep-1", "v2")
+        # Dedup lookup misses, so post() creates the session, then post()s the first event.
+        respx.get(SESSIONS_URL).mock(return_value=httpx.Response(200, json=_items()))
+        respx.post(SESSIONS_URL).mock(side_effect=_capture_post)
+        respx.get(EVENTS_URL).mock(return_value=httpx.Response(200, json=_items()))
 
-        session.update_event.assert_called_once_with(1, body={"v": 1, "payload": "v2"})
-        assert session.post_event.call_count == 1
+        def _capture_event(req: httpx.Request) -> httpx.Response:
+            captured["event_body"] = json.loads(req.content)
+            return httpx.Response(201, json=_event_wire(content="payload-v1"))
 
-    async def test_create_uses_cache_participant(self, kv_cache: MemorySpaceKVCache) -> None:
-        session = _FakeSession()
+        respx.post(EVENTS_URL).mock(side_effect=_capture_event)
 
-        with (
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-                return_value=None,
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache.Session.create",
-                return_value=session,
-            ) as create_mock,
-        ):
-            await kv_cache.set_value("dep-1", "payload")
+        await kv_cache.set_value("dep-1", "payload-v1")
 
-        create_mock.assert_called_once()
-        assert create_mock.call_args.args[1] == [DRAGENT_CACHE_PARTICIPANT_ID]
+        assert captured["session_body"]["deduplicationKey"] == LOGICAL_KEY
+        assert captured["session_body"]["participants"] == [SYSTEM_PARTICIPANT]
+        assert captured["event_body"]["body"]["content"] == "payload-v1"
+        assert captured["event_body"]["emitter"]["type"] == "agent"
 
-    async def test_delete_removes_session(self, kv_cache: MemorySpaceKVCache) -> None:
-        session = _FakeSession()
+    @respx.mock
+    async def test_set_value_patches_existing_event_in_place(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        respx.get(SESSIONS_URL).mock(return_value=httpx.Response(200, json=_items(_session_wire())))
+        respx.get(EVENTS_URL).mock(
+            return_value=httpx.Response(200, json=_items(_event_wire(content="v1")))
+        )
 
-        with (
-            patch(
-                "datarobot_genai.dragent.memory_space_cache._find_cache_session",
-                return_value=session,
-            ),
-            patch(
-                "datarobot_genai.dragent.memory_space_cache.Session.get",
-                return_value=session,
-            ),
-        ):
-            await kv_cache.delete_value("dep-1")
+        patch_calls: list[dict[str, Any]] = []
 
-        session.delete.assert_called_once()
+        def _capture_patch(req: httpx.Request) -> httpx.Response:
+            patch_calls.append(json.loads(req.content))
+            return httpx.Response(200, json=_event_wire(content="v2"))
+
+        patch_route = respx.patch(f"{EVENTS_URL}0/").mock(side_effect=_capture_patch)
+        post_route = respx.post(EVENTS_URL).mock(
+            return_value=httpx.Response(201, json=_event_wire())
+        )
+
+        await kv_cache.set_value("dep-1", "v2")
+
+        assert patch_route.called
+        assert not post_route.called
+        assert patch_calls[0]["body"]["content"] == "v2"
+
+    @respx.mock
+    async def test_set_value_swallows_errors(self, kv_cache: MemorySpaceKVCache) -> None:
+        respx.get(SESSIONS_URL).mock(return_value=httpx.Response(500, json={"detail": "boom"}))
+
+        # Must not raise -- L2 failures degrade to an L1-only cache, never break the caller.
+        await kv_cache.set_value("dep-1", "payload")
+
+    @respx.mock
+    async def test_get_value_uses_cached_session_id_and_skips_dedup_lookup(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        kv_cache._session_ids[LOGICAL_KEY] = SESSION_ID  # noqa: SLF001
+        list_route = respx.get(SESSIONS_URL).mock(return_value=httpx.Response(200, json=_items()))
+        respx.get(SESSION_URL).mock(return_value=httpx.Response(200, json=_session_wire()))
+        respx.get(EVENTS_URL).mock(
+            return_value=httpx.Response(200, json=_items(_event_wire(content="cached")))
+        )
+
+        assert await kv_cache.get_value("dep-1") == "cached"
+        assert not list_route.called
+
+    @respx.mock
+    async def test_get_value_falls_back_to_dedup_lookup_on_stale_session_id(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        kv_cache._session_ids[LOGICAL_KEY] = "stale-session"  # noqa: SLF001
+        respx.get(f"{SESSIONS_URL}stale-session/").mock(
+            return_value=httpx.Response(404, json={"detail": "not found"})
+        )
+        respx.get(SESSIONS_URL).mock(return_value=httpx.Response(200, json=_items(_session_wire())))
+        respx.get(EVENTS_URL).mock(
+            return_value=httpx.Response(200, json=_items(_event_wire(content="recovered")))
+        )
+
+        assert await kv_cache.get_value("dep-1") == "recovered"
+        assert kv_cache._session_ids[LOGICAL_KEY] == SESSION_ID  # noqa: SLF001
+
+    @respx.mock
+    async def test_delete_value_removes_session_and_invalidates_cache(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        kv_cache._session_ids[LOGICAL_KEY] = SESSION_ID  # noqa: SLF001
+        respx.get(SESSION_URL).mock(return_value=httpx.Response(200, json=_session_wire()))
+        delete_route = respx.delete(SESSION_URL).mock(return_value=httpx.Response(204))
+
+        await kv_cache.delete_value("dep-1")
+
+        assert delete_route.called
+        assert LOGICAL_KEY not in kv_cache._session_ids  # noqa: SLF001
+
+    @respx.mock
+    async def test_delete_value_no_op_when_missing(self, kv_cache: MemorySpaceKVCache) -> None:
+        respx.get(SESSIONS_URL).mock(return_value=httpx.Response(200, json=_items()))
+        delete_route = respx.delete(SESSION_URL)
+
+        await kv_cache.delete_value("dep-1")
+
+        assert not delete_route.called

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ overrides = [
 ]
 excludes = [
     "build",
+    "datarobot",
     "flask",
     "kubernetes",
     "lancedb",
@@ -1080,28 +1081,6 @@ wheels = [
 ]
 
 [[package]]
-name = "datarobot"
-version = "3.19.0rc0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "strenum" },
-    { name = "trafaret" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/55/51ef34d52e66bb8215c29a0ec59a4d05e673426cabf2e88abf71340a897c/datarobot-3.19.0rc0.tar.gz", hash = "sha256:b23b4d5be1f9bf2a4e3250ab52ebba1016be065b28d8ac0027daa3ecd6e71536", size = 850577, upload-time = "2026-08-18T20:21:57.999Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/4f/5b0c9ac1afdc55cd70c67d988df95cff444ef9be0e1c415816cc8cdbd507/datarobot-3.19.0rc0-py3-none-any.whl", hash = "sha256:b8238fe5fe5f566057d2cd9bb1dcce67dfe7bdb616f6747efb8e88fa49536876", size = 916997, upload-time = "2026-08-18T20:21:56.346Z" },
-]
-
-[[package]]
 name = "datarobot-asgi-middleware"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1653,7 +1632,6 @@ wheels = [
 
 [package.optional-dependencies]
 all = [
-    { name = "datarobot" },
     { name = "datarobot-predict" },
     { name = "deepeval" },
     { name = "google-cloud-aiplatform" },
@@ -1687,7 +1665,6 @@ version = "1.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "datarobot" },
     { name = "pandas" },
     { name = "py4j" },
     { name = "requests" },

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "datarobot"
-version = "3.18.0"
+version = "3.19.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -1096,9 +1096,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/87/fe696ed62eb8f72a29b036a71086434e39db7ef096a280526c8073017652/datarobot-3.18.0.tar.gz", hash = "sha256:47f289b65211416fba37b384b57a0ec82efdb76546aabda95c1ff7076b41e72c", size = 834279, upload-time = "2026-07-28T18:34:22.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/55/51ef34d52e66bb8215c29a0ec59a4d05e673426cabf2e88abf71340a897c/datarobot-3.19.0rc0.tar.gz", hash = "sha256:b23b4d5be1f9bf2a4e3250ab52ebba1016be065b28d8ac0027daa3ecd6e71536", size = 850577, upload-time = "2026-08-18T20:21:57.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/5a/999f30688e3f352110e02034681f3393133a0fcc2db2bc88ee92377b15c8/datarobot-3.18.0-py3-none-any.whl", hash = "sha256:c1272693b9ebb3cbf6e4e4066bb714e003208cb3957d4489d751a380e7062a97", size = 900686, upload-time = "2026-07-28T18:34:20.498Z" },
+    { url = "https://files.pythonhosted.org/packages/41/4f/5b0c9ac1afdc55cd70c67d988df95cff444ef9be0e1c415816cc8cdbd507/datarobot-3.19.0rc0-py3-none-any.whl", hash = "sha256:b8238fe5fe5f566057d2cd9bb1dcce67dfe7bdb616f6747efb8e88fa49536876", size = 916997, upload-time = "2026-08-18T20:21:56.346Z" },
 ]
 
 [package.optional-dependencies]
@@ -1400,6 +1400,7 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
+    { name = "datarobot", extras = ["application-utils"], marker = "extra == 'dragent'", specifier = ">=3.19.0rc0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
@@ -2761,17 +2762,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -2787,16 +2788,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -3978,10 +3979,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3997,10 +3998,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1101,7 +1101,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/4f/5b0c9ac1afdc55cd70c67d988df95cff444ef9be0e1c415816cc8cdbd507/datarobot-3.19.0rc0-py3-none-any.whl", hash = "sha256:b8238fe5fe5f566057d2cd9bb1dcce67dfe7bdb616f6747efb8e88fa49536876", size = 916997, upload-time = "2026-08-18T20:21:56.346Z" },
 ]
 
+[[package]]
+name = "datarobot-asgi-middleware"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/10/b7651ffa919c76ec808db0af521e30e43adb18af9f4ee2413a4f854e7b6f/datarobot_asgi_middleware-0.2.0.tar.gz", hash = "sha256:44588d6b16a8420ed8b6b8a198a8326be61f48d39a27f7df1a6511dc319b467b", size = 14018, upload-time = "2025-06-17T02:03:29.82Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/9c/df8319321f8b606580cc0dab2884dcf58373aa567b8539c4a0681c96dfcc/datarobot_asgi_middleware-0.2.0-py3-none-any.whl", hash = "sha256:ac6f999a568c04964673d6f2f5134e2ce4ad67ef3eebb4c2896981c0f5291493", size = 8034, upload-time = "2025-06-17T02:03:29.047Z" },
+]
+
+[[package]]
+name = "datarobot-early-access"
+version = "3.19.0.2026.8.31.172953"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "strenum" },
+    { name = "trafaret" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/07/b31ad6dd4964bbc6924a96ef2d95f4cded35448a01c1014713bfc5a96050/datarobot_early_access-3.19.0.2026.8.31.172953.tar.gz", hash = "sha256:bbc4e1064559d11a6edc430520ace1c3057f1a379c027956d3845364b7e1fa0b", size = 1149556, upload-time = "2026-08-31T17:29:58.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/f2/a951b54293e3a6f02f0d100cd9acb8bc8482b9ac77215c45041d596686cb/datarobot_early_access-3.19.0.2026.8.31.172953-py3-none-any.whl", hash = "sha256:bd2f011a3b0d116bcca530e165680d23fd32c30fed8ee4eec72105b25a01738a", size = 1326487, upload-time = "2026-08-31T17:29:56.015Z" },
+]
+
 [package.optional-dependencies]
+application-utils = [
+    { name = "ag-ui-protocol" },
+    { name = "httpx" },
+    { name = "pydantic" },
+]
 auth = [
     { name = "httpx" },
     { name = "pydantic" },
@@ -1116,18 +1155,6 @@ fs = [
 ]
 
 [[package]]
-name = "datarobot-asgi-middleware"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/10/b7651ffa919c76ec808db0af521e30e43adb18af9f4ee2413a4f854e7b6f/datarobot_asgi_middleware-0.2.0.tar.gz", hash = "sha256:44588d6b16a8420ed8b6b8a198a8326be61f48d39a27f7df1a6511dc319b467b", size = 14018, upload-time = "2025-06-17T02:03:29.82Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/9c/df8319321f8b606580cc0dab2884dcf58373aa567b8539c4a0681c96dfcc/datarobot_asgi_middleware-0.2.0-py3-none-any.whl", hash = "sha256:ac6f999a568c04964673d6f2f5134e2ce4ad67ef3eebb4c2896981c0f5291493", size = 8034, upload-time = "2025-06-17T02:03:29.047Z" },
-]
-
-[[package]]
 name = "datarobot-genai"
 version = "0.29.15"
 source = { editable = "." }
@@ -1135,7 +1162,7 @@ source = { editable = "." }
 [package.optional-dependencies]
 auth = [
     { name = "aiohttp" },
-    { name = "datarobot", extra = ["auth"] },
+    { name = "datarobot-early-access", extra = ["auth"] },
     { name = "httpx" },
     { name = "okta-client-python" },
     { name = "pydantic" },
@@ -1145,7 +1172,7 @@ auth = [
 core = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1166,7 +1193,7 @@ crewai = [
     { name = "colorama" },
     { name = "crewai" },
     { name = "crewai-tools", extra = ["mcp"] },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1190,7 +1217,7 @@ dragent = [
     { name = "ag-ui-protocol" },
     { name = "anyio" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["application-utils", "core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
@@ -1219,8 +1246,8 @@ drmcp = [
     { name = "async-lru" },
     { name = "beautifulsoup4" },
     { name = "cachetools" },
-    { name = "datarobot", extra = ["auth", "fs"] },
     { name = "datarobot-asgi-middleware" },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "datarobot-predict" },
     { name = "fastmcp" },
     { name = "httpx" },
@@ -1251,7 +1278,7 @@ drmcpbase = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
     { name = "cachetools" },
-    { name = "datarobot", extra = ["auth", "fs"] },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "okta-client-python" },
@@ -1265,7 +1292,7 @@ drmcpbase = [
 ]
 drmcputils = [
     { name = "aiohttp" },
-    { name = "datarobot", extra = ["auth", "fs"] },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "httpx" },
     { name = "okta-client-python" },
     { name = "pydantic" },
@@ -1275,7 +1302,7 @@ drmcputils = [
 drtools = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
-    { name = "datarobot", extra = ["auth", "fs"] },
+    { name = "datarobot-early-access", extra = ["auth", "fs"] },
     { name = "datarobot-predict" },
     { name = "httpx" },
     { name = "okta-client-python" },
@@ -1300,7 +1327,7 @@ eval = [
 langgraph = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-predict" },
     { name = "httpx-retries" },
@@ -1323,7 +1350,7 @@ langgraph = [
 llamaindex = [
     { name = "ag-ui-protocol" },
     { name = "colorama" },
-    { name = "datarobot", extra = ["core"] },
+    { name = "datarobot-early-access", extra = ["core"] },
     { name = "datarobot-moderations", extra = ["all"] },
     { name = "datarobot-opentelemetry" },
     { name = "datarobot-predict" },
@@ -1400,22 +1427,22 @@ requires-dist = [
     { name = "colorama", marker = "extra == 'llamaindex'", specifier = ">=0.4.6,<1.0.0" },
     { name = "crewai", extras = ["litellm"], marker = "extra == 'crewai'", specifier = ">=1.11.0" },
     { name = "crewai-tools", extras = ["mcp"], marker = "extra == 'crewai'", specifier = ">=0.69.0,<0.77.0" },
-    { name = "datarobot", extras = ["application-utils"], marker = "extra == 'dragent'", specifier = ">=3.19.0rc0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.18.0,<4.0.0" },
-    { name = "datarobot", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.18.0,<4.0.0" },
     { name = "datarobot-asgi-middleware", marker = "extra == 'drmcp'", specifier = ">=0.2.0,<1.0.0" },
+    { name = "datarobot-early-access", extras = ["application-utils"], marker = "extra == 'dragent'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'auth'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcp'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["auth"], marker = "extra == 'drtools'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'core'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'crewai'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'dragent'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'langgraph'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["core"], marker = "extra == 'llamaindex'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcp'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcpbase'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drmcputils'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
+    { name = "datarobot-early-access", extras = ["fs"], marker = "extra == 'drtools'", specifier = ">=3.19.0.2026.8.31.172953,<4.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'core'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'crewai'", specifier = ">=11.2.47,<12.0.0" },
     { name = "datarobot-moderations", extras = ["all"], marker = "extra == 'dragent'", specifier = ">=11.2.47,<12.0.0" },


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
Recently a lightweight ORM for the DR memory API was merged to `datarobot`.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Use the ORM to standardize the L2 agent card cache.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the shared agent-card L2 cache implementation and pins an RC `datarobot[application-utils]` dependency; failures degrade to L1 but cache correctness depends on the new ORM wire behavior.
> 
> **Overview**
> **dragent**’s agent card registry **MemorySpace L2** is reimplemented on `datarobot.application_utils.persistence` (`datarobot[application-utils]`) instead of a custom `datarobot.models.memory.Session` client. Release **0.29.14** adds that extra (floor `datarobot>=3.19.0rc0` for the dragent optional) and refreshes lockfiles.
> 
> `MemorySpaceKVCache` now takes an explicit `DRMemoryServiceClient` from `try_build_memory_service_client()` (replacing global `dr.Client` configuration). Cache entries are modeled as `_CacheEntrySession` / `_CacheEntryEvent` with dedup lookup on the logical key; reads/writes/deletes are **native async** rather than `asyncio.to_thread`. `create_agent_card_cache_backend` still falls back to **L1-only** when the client cannot be built.
> 
> Tests move from Session mocks to **respx** HTTP fixtures against the Memory Service API; registry backend tests inject a client into `MemorySpaceKVCache`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98654b726c54d01744ee478be61df69d55474ce1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->