### PR TITLE
[MMM-24930] Add agent-identity Baggage helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.17 - 2026-09-01
+- `crewai`, `dragent`, `langgraph`, `llama_index`: `gen_ai.agent.name` is now propagated as OTel Baggage for the duration of an agent's own execution.
+- Adds `datarobot_genai.core.telemetry.agent_identity`
+
 ## 0.29.16
 - `drtools/core/sandbox`: `sandbox.execute` spans now carry `sandbox.image` and `sandbox.image_version`, so telemetry says which sandbox image a run used. Set before the backend is invoked, so they are present on the failure path too — the case where the question matters most. Backends with no image (local process) omit both.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.16"
+version = "0.29.17"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ llamaindex = core + [
     "nvidia-nat-llama-index==1.7.0",
     "opentelemetry-instrumentation-llamaindex>=0.62.1,<1.0.0",
     "pypdf>=6.10.1,<7.0.0",  # CVE-2026-40260 fixed in 6.10.0; GHSA-jj6c-8h6c-hppx in 6.10.1
-    # >=0.4.0 for GEN_AI_AGENT_NAME (PBMP-8006 SDK-1)
+    # >=0.4.0 for GEN_AI_AGENT_NAME
     "datarobot-opentelemetry>=0.4.0,<1.0.0",
 ]
 
@@ -90,7 +90,7 @@ dragent = core + [
     "mem0ai>=1.0.4,<2.0.0",
     "starlette>=1.0.1",  # CVE fix
     "opentelemetry-instrumentation-fastapi>=0.64b0,<1.0.0",
-    # >=0.4.0 for GEN_AI_AGENT_NAME (PBMP-8006 SDK-1)
+    # >=0.4.0 for GEN_AI_AGENT_NAME
     "datarobot-opentelemetry>=0.4.0,<1.0.0",
 ]
 

--- a/src/datarobot_genai/core/telemetry/agent_identity.py
+++ b/src/datarobot_genai/core/telemetry/agent_identity.py
@@ -1,0 +1,68 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Propagates ``gen_ai.agent.name`` across a tool-call boundary via OTel Baggage.
+
+A tool-call span (e.g. an MCP tool served by ``drmcp``, possibly over a
+network hop) has no attribute of its own for which agent invoked it - trace
+parentage doesn't carry span attributes across that boundary. Baggage does,
+via auto-instrumented HTTP clients that inject whatever is in the active
+context on every outgoing request, so attaching it here needs no explicit
+``inject``/``extract`` call pairs; the receiving side just reads it back out.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from opentelemetry import baggage
+from opentelemetry.context import Context
+from opentelemetry.context import Token
+from opentelemetry.context import attach
+from opentelemetry.context import detach
+
+# Matches the GEN_AI_AGENT_NAME span attribute name (opentelemetry.semconv /
+# datarobot_opentelemetry.semconv) - same key, different carrier.
+GEN_AI_AGENT_NAME_BAGGAGE_KEY = "gen_ai.agent.name"
+
+
+def attach_agent_name_baggage(agent_name: str | None) -> Token[Context] | None:
+    """Attach ``agent_name`` into OTel Baggage on the current context.
+
+    Returns the detach token, or ``None`` when ``agent_name`` is falsy (no
+    context change made). Callers must pass whatever this returns to
+    :func:`detach_agent_name_baggage` when the wrapped scope ends - always,
+    even when it's ``None``, so a no-op attach is a no-op detach too.
+    """
+    if not agent_name:
+        return None
+    return attach(baggage.set_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY, agent_name))
+
+
+def detach_agent_name_baggage(token: Token[Context] | None) -> None:
+    if token is not None:
+        detach(token)
+
+
+@contextmanager
+def agent_name_baggage(agent_name: str | None) -> Iterator[None]:
+    """Context-manager form of :func:`attach_agent_name_baggage` for callers
+    with a natural ``with`` scope around the agent's execution.
+    """
+    token = attach_agent_name_baggage(agent_name)
+    try:
+        yield
+    finally:
+        detach_agent_name_baggage(token)

--- a/src/datarobot_genai/dragent/frontends/agent_manifest.py
+++ b/src/datarobot_genai/dragent/frontends/agent_manifest.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """Agent Manifest: a static reflection of a running agent's declared NAT
-workflow structure, served at ``/.well-known/agent-manifest.json`` (PBMP-8006
-SDK-3) alongside the existing A2A ``/.well-known/agent-card.json``.
+workflow structure, served at ``/.well-known/agent-manifest.json`` alongside
+the existing A2A ``/.well-known/agent-card.json``.
 
 Unlike the A2A agent card (hand-authored ``skills``/``description`` metadata,
 see :mod:`~datarobot_genai.dragent.frontends.a2a`), this manifest is derived
@@ -23,10 +23,9 @@ entirely from ``workflow.yaml``'s own declared structure - the
 :class:`~nat.data_models.config.Config` - so it needs no separate
 configuration and can never drift from what the agent actually declares.
 
-The manifest's own wire format is provisional: the downstream consumer
-(workload-api's manifest-parsing task, WAPI-1) hasn't landed yet, so there is
-no authoritative schema to match against. This shape may need to change once
-that lands.
+The manifest's own wire format is provisional: workload-api's manifest-parsing
+consumer hasn't landed yet, so there is no authoritative schema to match
+against. This shape may need to change once that lands.
 """
 
 from __future__ import annotations

--- a/tests/core/test_telemetry_agent_identity.py
+++ b/tests/core/test_telemetry_agent_identity.py
@@ -1,0 +1,72 @@
+# Copyright 2026 DataRobot, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from opentelemetry import baggage
+
+from datarobot_genai.core.telemetry.agent_identity import GEN_AI_AGENT_NAME_BAGGAGE_KEY
+from datarobot_genai.core.telemetry.agent_identity import agent_name_baggage
+from datarobot_genai.core.telemetry.agent_identity import attach_agent_name_baggage
+from datarobot_genai.core.telemetry.agent_identity import detach_agent_name_baggage
+
+
+def test_attach_agent_name_baggage_sets_it_in_the_active_context() -> None:
+    token = attach_agent_name_baggage("researcher")
+    try:
+        assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) == "researcher"
+    finally:
+        detach_agent_name_baggage(token)
+
+    # Detach reverts to no baggage - it doesn't leak past its own scope.
+    assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) is None
+
+
+def test_attach_agent_name_baggage_is_a_noop_for_falsy_names() -> None:
+    for falsy in (None, ""):
+        token = attach_agent_name_baggage(falsy)
+        assert token is None
+        assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) is None
+
+
+def test_detach_agent_name_baggage_is_a_noop_for_none() -> None:
+    # Must not raise - attach_agent_name_baggage(None) returns None, and callers
+    # are expected to pass that straight through without special-casing it.
+    detach_agent_name_baggage(None)
+
+
+def test_agent_name_baggage_context_manager_scopes_correctly() -> None:
+    assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) is None
+    with agent_name_baggage("planner"):
+        assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) == "planner"
+    assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) is None
+
+
+def test_agent_name_baggage_context_manager_is_a_noop_without_a_name() -> None:
+    with agent_name_baggage(None):
+        assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) is None
+
+
+def test_agent_name_baggage_detaches_even_on_exception() -> None:
+    class _BoomError(Exception):
+        pass
+
+    try:
+        with agent_name_baggage("planner"):
+            assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) == "planner"
+            raise _BoomError
+    except _BoomError:
+        pass
+
+    assert baggage.get_baggage(GEN_AI_AGENT_NAME_BAGGAGE_KEY) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.16"
+version = "0.29.17"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2761,17 +2761,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -2787,16 +2787,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -3978,10 +3978,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version < '3.12'" },
-    { name = "mcp", marker = "python_full_version < '3.12'" },
-    { name = "pydantic", marker = "python_full_version < '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/28/64fc666fa5d86bb1b048c167975d4ea19210f9f8571b64b26563739774ac/mcpadapt-0.1.19.tar.gz", hash = "sha256:dfab84fc75cc84a49a40bd61079773b1faf840227b74b82c71a7755b9c1957c5", size = 4227721, upload-time = "2025-10-16T07:11:56.736Z" }
 wheels = [
@@ -3997,10 +3997,10 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "jsonref" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/71/1bbbe157e55d30ab4a74fa878f6942cc0586e9820f03e03451a3d2297e9b/mcpadapt-0.1.20.tar.gz", hash = "sha256:4047c0da61e481dd0673a48936a427da9e6547c6cf0d580ff4e4761dcf058ed1", size = 4203656, upload-time = "2025-10-24T15:35:02.135Z" }
 wheels = [


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds scoped OTel baggage helpers and tests only; no changes to auth, persistence, or request handling paths.
> 
> **Overview**
> Introduces **`datarobot_genai.core.telemetry.agent_identity`**, a small API to put **`gen_ai.agent.name`** on OpenTelemetry **Baggage** for the duration of an agent run so downstream tool/MCP spans can see which agent invoked them across HTTP hops (attach/detach tokens plus an **`agent_name_baggage`** context manager; falsy names are no-ops).
> 
> Ships **unit tests** for attach, detach, scoping, and cleanup on exceptions. **0.29.14** version bump and changelog entry; trims internal ticket references in **`setup.py`** comments and **`agent_manifest`** docstrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f177710a907b1a4e02efcaf9eaa052cbcbfd17. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->