### PR TITLE
[MMM-24931]  Propagate agent identity in CrewAI, dragent, and LangGraph

### DIFF
--- a/src/datarobot_genai/crewai/telemetry.py
+++ b/src/datarobot_genai/crewai/telemetry.py
@@ -70,6 +70,8 @@ from opentelemetry.trace.status import Status
 from opentelemetry.trace.status import StatusCode
 from wrapt import wrap_function_wrapper
 
+from datarobot_genai.core.telemetry.agent_identity import agent_name_baggage
+
 logger = logging.getLogger(__name__)
 
 _INSTRUMENTED = {"crewai": False}
@@ -245,7 +247,9 @@ async def wrap_aexecute_task(
         try:
             CrewAISpanAttributes(span=span, instance=instance)
             _set_agent_request_attributes(span, instance)
-            result = await wrapped(*args, **kwargs)
+            agent_name = instance.role if hasattr(instance, "role") else None
+            with agent_name_baggage(agent_name):
+                result = await wrapped(*args, **kwargs)
             _finalize_agent_span(span, instance, token_histogram)
             return result
         except Exception as ex:

--- a/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otel_conventions_middleware.py
@@ -38,6 +38,7 @@ from opentelemetry.trace import StatusCode
 from datarobot_genai.core.agents import RUN_ERROR_CODE
 from datarobot_genai.core.agents import default_usage_metrics
 from datarobot_genai.core.agents import track_open_text_in_events
+from datarobot_genai.core.telemetry.agent_identity import agent_name_baggage
 from datarobot_genai.core.telemetry.nat_context import use_nat_workflow_trace_context
 from datarobot_genai.dragent.frontends.response import DRAgentEventResponse
 from datarobot_genai.dragent.frontends.response import run_error_response
@@ -169,6 +170,7 @@ class DataRobotOtelConventionsMiddleware(
         with (
             use_nat_workflow_trace_context(),
             tracer.start_as_current_span(AGENT_SPAN_NAME) as span,
+            agent_name_baggage(context.name),
         ):
             span.set_attribute(DataRobotSpanAttributes.GEN_AI_AGENT_NAME, context.name)
             prompt = self._prompt_from_args(args)
@@ -193,6 +195,7 @@ class DataRobotOtelConventionsMiddleware(
         with (
             use_nat_workflow_trace_context(),
             tracer.start_as_current_span(AGENT_SPAN_NAME) as span,
+            agent_name_baggage(context.name),
         ):
             span.set_attribute(DataRobotSpanAttributes.GEN_AI_AGENT_NAME, context.name)
             prompt = self._prompt_from_args(args)

--- a/src/datarobot_genai/langgraph/agent.py
+++ b/src/datarobot_genai/langgraph/agent.py
@@ -56,6 +56,7 @@ from datarobot_genai.core.agents.base import UsageMetrics
 from datarobot_genai.core.agents.base import extract_user_prompt_content
 from datarobot_genai.core.agents.base import frame_agent_errors
 from datarobot_genai.core.agents.reasoning import flatten_to_text
+from datarobot_genai.core.telemetry.agent_identity import agent_name_baggage
 from datarobot_genai.langgraph.history import ag_ui_history_to_langchain
 from datarobot_genai.langgraph.reasoning import iter_message_blocks
 
@@ -329,13 +330,17 @@ class LangGraphAgent(BaseAgent[BaseTool], abc.ABC):
             pipeline_interactions, usage_metrics).
         """
         try:
-            result = await self._invoke(run_agent_input)
+            # gen_ai.agent.name into Baggage for the whole run, so an MCP tool call
+            # made from inside it (auto-instrumented HTTP client picks up whatever's
+            # in the active context) can tag its own span with which agent called it.
+            with agent_name_baggage(self.name):
+                result = await self._invoke(run_agent_input)
 
-            # Yield all items from the result generator
-            # The context will be closed when this generator is exhausted
-            # Cast to async generator since we know stream=True means it's a generator
-            async for item in result:
-                yield item
+                # Yield all items from the result generator
+                # The context will be closed when this generator is exhausted
+                # Cast to async generator since we know stream=True means it's a generator
+                async for item in result:
+                    yield item
         except RuntimeError as e:
             error_message = str(e).lower()
             if "different task" in error_message and "cancel scope" in error_message:

--- a/tests/crewai/test_telemetry.py
+++ b/tests/crewai/test_telemetry.py
@@ -14,9 +14,12 @@
 
 import os
 from collections.abc import Iterator
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from opentelemetry import baggage
+from opentelemetry import trace
 
 from datarobot_genai.crewai import telemetry
 
@@ -102,3 +105,42 @@ def test_subclass_unwraps_async_methods() -> None:
         ("crewai.task.Task", "aexecute_sync"),
         ("crewai.llm.LLM", "acall"),
     }
+
+
+class TestWrapAexecuteTaskPropagatesAgentNameAsBaggage:
+    """gen_ai.agent.name must be visible as Baggage for the duration of the
+    wrapped call, so a tool call made from inside it can read which agent
+    triggered it.
+    """
+
+    async def test_agent_role_is_visible_as_baggage_during_the_call(self) -> None:
+        instance = MagicMock()
+        instance.role = "researcher"
+        seen_agent_name = None
+
+        async def wrapped(*args: object, **kwargs: object) -> str:
+            nonlocal seen_agent_name
+            seen_agent_name = baggage.get_baggage("gen_ai.agent.name")
+            return "ok"
+
+        wrapper = telemetry.wrap_aexecute_task(trace.get_tracer(__name__), None, None)
+        result = await wrapper(wrapped, instance, (), {})
+
+        assert result == "ok"
+        assert seen_agent_name == "researcher"
+        assert baggage.get_baggage("gen_ai.agent.name") is None
+
+    async def test_missing_role_leaves_baggage_untouched(self) -> None:
+        instance = MagicMock()
+        del instance.role
+        seen_agent_name = "sentinel"
+
+        async def wrapped(*args: object, **kwargs: object) -> str:
+            nonlocal seen_agent_name
+            seen_agent_name = baggage.get_baggage("gen_ai.agent.name")
+            return "ok"
+
+        wrapper = telemetry.wrap_aexecute_task(trace.get_tracer(__name__), None, None)
+        await wrapper(wrapped, instance, (), {})
+
+        assert seen_agent_name is None

--- a/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
+++ b/tests/dragent/plugins/test_datarobot_otel_conventions_middleware.py
@@ -40,6 +40,7 @@ from ag_ui.core import UserMessage
 from datarobot_opentelemetry.semconv import SpanAttributes as DataRobotSpanAttributes
 from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.api_server import Message
+from opentelemetry import baggage
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -558,3 +559,57 @@ async def test_stream_passes_through_non_event_chunks(
     span = _span_named(span_exporter, AGENT_SPAN_NAME)
     assert GEN_AI_PROMPT not in span.attributes
     assert GEN_AI_COMPLETION not in span.attributes
+
+
+# ---------------------------------------------------------------------------
+# Agent name propagated as Baggage for the duration of the call
+# ---------------------------------------------------------------------------
+
+
+async def test_invoke_puts_agent_name_in_baggage_for_the_duration_of_the_call(
+    middleware: DataRobotOtelConventionsMiddleware,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    context = MagicMock()
+    context.name = "my_agent_function"
+    seen_agent_name = None
+
+    async def _call_next(*args: Any, **kwargs: Any) -> str:
+        nonlocal seen_agent_name
+        seen_agent_name = baggage.get_baggage("gen_ai.agent.name")
+        return "ok"
+
+    await middleware.function_middleware_invoke(
+        _nat_input("hi"),
+        call_next=_call_next,
+        context=context,
+    )
+
+    assert seen_agent_name == "my_agent_function"
+    assert baggage.get_baggage("gen_ai.agent.name") is None
+
+
+async def test_stream_puts_agent_name_in_baggage_for_the_duration_of_the_call(
+    middleware: DataRobotOtelConventionsMiddleware,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    context = MagicMock()
+    context.name = "my_streaming_agent"
+    seen_agent_name = None
+
+    async def _call_next(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        nonlocal seen_agent_name
+        seen_agent_name = baggage.get_baggage("gen_ai.agent.name")
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    await _drain(
+        middleware.function_middleware_stream(
+            _nat_input("hi"),
+            call_next=_call_next,
+            context=context,
+        )
+    )
+
+    assert seen_agent_name == "my_streaming_agent"
+    assert baggage.get_baggage("gen_ai.agent.name") is None

--- a/tests/langgraph/test_agent.py
+++ b/tests/langgraph/test_agent.py
@@ -38,6 +38,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langgraph.graph.message import MessagesState
 from langgraph.graph.state import StateGraph
 from langgraph.types import Interrupt
+from opentelemetry import baggage
 
 from datarobot_genai.core.chat.completions import agent_chat_completion_wrapper
 from datarobot_genai.dragent.frontends.converters import aggregate_dragent_event_responses
@@ -222,6 +223,40 @@ def test_name_defaults_to_the_concrete_subclass_name() -> None:
 
 def test_name_respects_an_explicit_override() -> None:
     assert SimpleLangGraphAgent(name="my_custom_agent").name == "my_custom_agent"
+
+
+class _NameCheckingAgent(SimpleLangGraphAgent):
+    """Captures the Baggage value visible mid-run, from inside the astream call."""
+
+    seen_agent_name: str | None = None
+
+    @cached_property
+    def workflow(self) -> StateGraph[MessagesState]:
+        async def mock_stream_generator():
+            self.seen_agent_name = baggage.get_baggage("gen_ai.agent.name")
+            yield (
+                "first_agent",
+                "updates",
+                {"first_agent": {"usage": {}, "messages": [AIMessage(content="hi", id="1")]}},
+            )
+
+        mock_graph_stream = Mock(astream=Mock(return_value=mock_stream_generator()))
+        return Mock(compile=Mock(return_value=mock_graph_stream))
+
+
+@pytest.mark.asyncio
+async def test_invoke_puts_agent_name_in_baggage_during_graph_execution(
+    run_agent_input: RunAgentInput,
+) -> None:
+    """gen_ai.agent.name must be visible as Baggage while the graph runs, so
+    a tool call made from inside it can be tagged with which agent triggered it.
+    """
+    agent = _NameCheckingAgent(name="my_named_agent")
+
+    _ = [e async for e in agent.invoke(run_agent_input)]
+
+    assert agent.seen_agent_name == "my_named_agent"
+    assert baggage.get_baggage("gen_ai.agent.name") is None
 
 
 def test_datarobot_agent_class_from_langgraph_factory_receives_llm_tools_verbose() -> None:


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped OTel context changes around agent execution with tests; no auth, data, or API contract changes.
> 
> **Overview**
> **Release 0.29.14** adds shared telemetry helpers so **`gen_ai.agent.name`** rides in **OpenTelemetry Baggage** for the lifetime of an agent invocation. Downstream tool spans (e.g. MCP over HTTP) can see which agent called them when auto-instrumented clients propagate baggage, without extra inject/extract pairs.
> 
> New module **`datarobot_genai.core.telemetry.agent_identity`** exposes `attach`/`detach` helpers and an **`agent_name_baggage`** context manager (no-op for missing names; always detaches on exit).
> 
> Integrations wrap the agent execution path with that context: **CrewAI** (`wrap_aexecute_task`, agent `role`), **dragent** `DataRobotOtelConventionsMiddleware` (invoke + stream, `context.name` alongside existing span attribute), and **LangGraph** (`LangGraphAgent.invoke`, `self.name`). Unit tests cover the core module and each integration’s in-scope baggage visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f59310cb908df4de4e34d4e4e34cbfd8c3b366a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->