### PR TITLE
[MMM-24932] Propagate and read back agent identity in LlamaIndex and drmcp

### DIFF
--- a/src/datarobot_genai/drmcp/core/telemetry.py
+++ b/src/datarobot_genai/drmcp/core/telemetry.py
@@ -30,6 +30,7 @@ from fastmcp.server.middleware import CallNext
 from fastmcp.server.middleware import Middleware
 from fastmcp.server.middleware import MiddlewareContext
 from fastmcp.tools.tool import ToolResult
+from opentelemetry import baggage
 from opentelemetry import trace
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.context import attach
@@ -129,6 +130,9 @@ class OpenTelemetryMiddleware(Middleware):
                     "mcp.method.name": "tools/call",
                 }
             )
+            agent_name = baggage.get_baggage("gen_ai.agent.name")
+            if isinstance(agent_name, str) and agent_name:
+                span.set_attribute("gen_ai.agent.name", agent_name)
             started = time.perf_counter()
             try:
                 result = await call_next(context)

--- a/src/datarobot_genai/llama_index/telemetry.py
+++ b/src/datarobot_genai/llama_index/telemetry.py
@@ -32,7 +32,13 @@ from llama_index.core.instrumentation import get_dispatcher
 from llama_index.core.instrumentation.span.base import BaseSpan
 from llama_index.core.instrumentation.span_handlers import BaseSpanHandler
 from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.context import Token
 from opentelemetry.instrumentation.llamaindex import LlamaIndexInstrumentor
+from pydantic import PrivateAttr
+
+from datarobot_genai.core.telemetry.agent_identity import attach_agent_name_baggage
+from datarobot_genai.core.telemetry.agent_identity import detach_agent_name_baggage
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +56,18 @@ class _AgentNameSpanHandler(BaseSpanHandler[BaseSpan]):
     current span in context - this only tags it, it never creates one.
     """
 
+    # Keyed by span id so each span's own baggage detach is independent of any
+    # other span's - nested agent spans must unwind in the same order they
+    # attached, like a stack.
+    _baggage_tokens: dict[str, Token[Context]] = PrivateAttr(default_factory=dict)
+
     @classmethod
     def class_name(cls) -> str:
         return "DataRobotAgentNameSpanHandler"
 
     def span_enter(
         self,
-        id_: str,  # noqa: ARG002
+        id_: str,
         bound_args: inspect.BoundArguments,
         instance: Any | None = None,  # noqa: ARG002
         parent_id: str | None = None,  # noqa: ARG002
@@ -69,9 +80,32 @@ class _AgentNameSpanHandler(BaseSpanHandler[BaseSpan]):
             trace.get_current_span().set_attribute(
                 DataRobotSpanAttributes.GEN_AI_AGENT_NAME, agent_name
             )
+            token = attach_agent_name_baggage(agent_name)
+            if token is not None:
+                self._baggage_tokens[id_] = token
 
     def new_span(self, *args: Any, **kwargs: Any) -> None:
         return None
+
+    def span_exit(
+        self,
+        id_: str,
+        bound_args: inspect.BoundArguments,  # noqa: ARG002
+        instance: Any | None = None,  # noqa: ARG002
+        result: Any | None = None,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        detach_agent_name_baggage(self._baggage_tokens.pop(id_, None))
+
+    def span_drop(
+        self,
+        id_: str,
+        bound_args: inspect.BoundArguments,  # noqa: ARG002
+        instance: Any | None = None,  # noqa: ARG002
+        err: BaseException | None = None,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        detach_agent_name_baggage(self._baggage_tokens.pop(id_, None))
 
     def prepare_to_exit_span(self, *args: Any, **kwargs: Any) -> None:
         return None

--- a/tests/drmcp/unit/test_telemetry.py
+++ b/tests/drmcp/unit/test_telemetry.py
@@ -20,6 +20,11 @@ from unittest.mock import patch
 
 import pytest
 from fastmcp.exceptions import ToolError as FastMCPToolError
+from opentelemetry import baggage
+from opentelemetry import context as otel_context
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import Span
 from opentelemetry.trace import SpanContext
 
@@ -595,3 +600,61 @@ class TestMiddlewareRecordsToolMetrics:
         assert name == "predict"
         assert duration >= 0
         assert error is boom
+
+
+class TestOnCallToolReadsAgentNameFromBaggage:
+    """The tool span reads ``gen_ai.agent.name`` back out of Baggage, already
+    attached by ``with_otel_context`` before this middleware's span opens.
+    """
+
+    @pytest.fixture
+    def span_exporter(self, monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        monkeypatch.setattr(
+            telemetry.trace, "get_tracer", lambda *a, **k: provider.get_tracer(__name__)
+        )
+        return exporter
+
+    @pytest.fixture
+    def middleware(self, span_exporter: InMemorySpanExporter) -> OpenTelemetryMiddleware:
+        return OpenTelemetryMiddleware()
+
+    @pytest.mark.asyncio
+    async def test_agent_name_in_baggage_is_set_on_the_tool_span(
+        self,
+        middleware: OpenTelemetryMiddleware,
+        span_exporter: InMemorySpanExporter,
+    ) -> None:
+        context = Mock()
+        context.message.name = "vdb_query"
+        context.message.arguments = {"q": "hello"}
+        call_next = AsyncMock(return_value=Mock())
+
+        token = otel_context.attach(baggage.set_baggage("gen_ai.agent.name", "researcher"))
+        try:
+            await middleware.on_call_tool(context, call_next)
+        finally:
+            otel_context.detach(token)
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].attributes["gen_ai.agent.name"] == "researcher"
+
+    @pytest.mark.asyncio
+    async def test_no_agent_name_in_baggage_leaves_the_attribute_unset(
+        self,
+        middleware: OpenTelemetryMiddleware,
+        span_exporter: InMemorySpanExporter,
+    ) -> None:
+        context = Mock()
+        context.message.name = "vdb_query"
+        context.message.arguments = {"q": "hello"}
+        call_next = AsyncMock(return_value=Mock())
+
+        await middleware.on_call_tool(context, call_next)
+
+        spans = span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert "gen_ai.agent.name" not in spans[0].attributes

--- a/tests/llamaindex/test_telemetry.py
+++ b/tests/llamaindex/test_telemetry.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 
 import pytest
 from datarobot_opentelemetry.semconv import SpanAttributes as DataRobotSpanAttributes
+from opentelemetry import baggage
 from opentelemetry.sdk.trace import Span
 from opentelemetry.sdk.trace import TracerProvider
 
@@ -163,3 +164,59 @@ def test_full_dispatcher_lifecycle_does_not_raise(outcome: str) -> None:
         handler.span_drop(id_="x", bound_args=bound_args, instance=None, err=RuntimeError("boom"))
 
     assert handler.open_spans == {}
+
+
+# ---------------------------------------------------------------------------
+# Agent name propagated as Baggage for the duration of the span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("outcome", ["exit", "drop"])
+def test_span_enter_attaches_baggage_and_span_exit_or_drop_detaches_it(
+    recording_span: Span, outcome: str
+) -> None:
+    handler = telemetry._AgentNameSpanHandler()
+    ev = SimpleNamespace(current_agent_name="researcher")
+    bound_args = MagicMock(arguments={"ev": ev})
+
+    handler.span_enter(id_="step-1", bound_args=bound_args)
+    assert baggage.get_baggage("gen_ai.agent.name") == "researcher"
+
+    if outcome == "exit":
+        handler.span_exit(id_="step-1", bound_args=bound_args, result=None)
+    else:
+        handler.span_drop(id_="step-1", bound_args=bound_args, err=RuntimeError("boom"))
+
+    assert baggage.get_baggage("gen_ai.agent.name") is None
+    assert handler._baggage_tokens == {}
+
+
+def test_span_enter_without_a_usable_agent_name_attaches_no_baggage(recording_span: Span) -> None:
+    handler = telemetry._AgentNameSpanHandler()
+    bound_args = MagicMock(arguments={})
+
+    handler.span_enter(id_="step-1", bound_args=bound_args)
+
+    assert baggage.get_baggage("gen_ai.agent.name") is None
+    assert handler._baggage_tokens == {}
+
+
+def test_nested_spans_each_detach_their_own_baggage_independently(recording_span: Span) -> None:
+    """Baggage attach/detach must layer like a stack: the inner span's detach
+    must not clobber the outer span's still-active baggage.
+    """
+    handler = telemetry._AgentNameSpanHandler()
+    outer_ev = SimpleNamespace(current_agent_name="outer_agent")
+    inner_ev = SimpleNamespace(current_agent_name="inner_agent")
+
+    handler.span_enter(id_="outer", bound_args=MagicMock(arguments={"ev": outer_ev}))
+    assert baggage.get_baggage("gen_ai.agent.name") == "outer_agent"
+
+    handler.span_enter(id_="inner", bound_args=MagicMock(arguments={"ev": inner_ev}))
+    assert baggage.get_baggage("gen_ai.agent.name") == "inner_agent"
+
+    handler.span_exit(id_="inner", bound_args=MagicMock(arguments={}), result=None)
+    assert baggage.get_baggage("gen_ai.agent.name") == "outer_agent"
+
+    handler.span_exit(id_="outer", bound_args=MagicMock(arguments={}), result=None)
+    assert baggage.get_baggage("gen_ai.agent.name") is None


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to span attributes and baggage lifecycle; no auth, data, or request-handling behavior changes.
> 
> **Overview**
> **Agent identity now flows from LlamaIndex workflow steps into downstream MCP tool traces** by putting `gen_ai.agent.name` in OpenTelemetry Baggage while an agent step span is active, then copying it onto FastMCP tool spans when present.
> 
> In **LlamaIndex telemetry**, `_AgentNameSpanHandler` still sets `gen_ai.agent.name` on the current span when `current_agent_name` is on the workflow event; it also **attaches** baggage on `span_enter` and **detaches** on `span_exit` / `span_drop`, with per-span tokens so nested agents unwind like a stack.
> 
> In **drmcp** `OpenTelemetryMiddleware.on_call_tool`, the tool span **reads** that baggage key and sets the same attribute when a non-empty string is present; otherwise the attribute is omitted.
> 
> Unit tests cover baggage on tool spans, attach/detach lifecycle (including nested spans), and the no-baggage case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e218d6d1e569fb6186606c17312b0f3487096446. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->