### PR TITLE
Bump notify-slack.yaml pin to 0.0.26 (fix duplicate PRs in digest)

### DIFF
--- a/.github/workflows/workflow-pr-automation.yaml
+++ b/.github/workflows/workflow-pr-automation.yaml
@@ -64,7 +64,7 @@ jobs:
   # event-driven mark-reviewed run was never dispatched.
   notify-slack-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.18
+    uses: datarobot-oss/github-actions/.github/workflows/notify-slack.yaml@0.0.26
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     permissions:


### PR DESCRIPTION
## Summary
- The scheduled Slack "PRs ready for review" digest was doubling every line — root-caused in datarobot-oss/github-actions#29: a jq `select(A and B)` used a generator (`.labels[]?...`), re-emitting a PR once per label matching "ready for review". `datarobot-genai` PRs carry both `Ready for review` and `00 - Ready for Review`, so every PR was duplicated.
- That's fixed in `datarobot-oss/github-actions` 0.0.26. This PR bumps `workflow-pr-automation.yaml`'s `notify-slack.yaml` pin from `@0.0.18` to `@0.0.26` to pick it up.
- Scoped to just this one `uses:` line — the other `@0.0.18` pins in this file (and in `workflow-backport.yaml`, `workflow-ensure-labels.yaml`) are untouched since they weren't part of this bug.

**Depends on:** `datarobot-oss/github-actions` tag `0.0.26` existing (being cut now) — merge after that lands.

Reported via Slack: https://datarobot.slack.com/archives/C05EDSV3VGQ/p1788161990427789

## Test plan
- [ ] After merge, confirm the next scheduled digest (every 30 min) lists each open PR once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow dependency bump for Slack notifications; no application or security logic changes.
> 
> **Overview**
> Fixes **duplicate entries** in the scheduled Slack “PRs ready for review” digest by upgrading only the `notify-slack-scheduled` job’s reusable workflow pin from `@0.0.18` to `@0.0.26` in `workflow-pr-automation.yaml`.
> 
> That release picks up a fix in `datarobot-oss/github-actions` where jq logic re-emitted each PR once per matching “ready for review” label (e.g. when both `Ready for review` and `00 - Ready for Review` are present). Other `@0.0.18` pins in this repo are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5972b4eb20c202aa3ec0645ccfe657f57daea43. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->