### PR TITLE
[BUZZOK-32219] Include "content" in body for L2 agent card cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.15 - 2026-08-31
+- Include `"content"` in the body of the request when storing an agent card in the memory space.
+
 ## 0.29.14 - 2026-08-31
 - Raise the `nltk` floor from `>=3.10.0` to `>=3.10.2`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.15 - 2026-08-31
 - Include `"content"` in the body of the request when storing an agent card in the memory space.
+- `dragent`: fixed the agent card registry's MemorySpace (L2) cache raising `requests.exceptions.ConnectionError` (`RemoteDisconnected`/`ProtocolError`, "Remote end closed connection without response") when a pooled keep-alive connection sat idle across the infrequent L1-cache-miss / 30-minute registry-refresh calls in `memory_space_cache.py` for longer than the remote end's idle-connection timeout. That error isn't retried by the DataRobot client's own `handle_connection_reset` wrapper (which only retries `ConnectionResetError`), so it previously surfaced on every stale-connection hit even though the cache already degrades gracefully to a miss. All memory-space Session API calls in the module now retry once on `ConnectionError` before giving up.
 
 ## 0.29.14 - 2026-08-31
 - Raise the `nltk` floor from `>=3.10.0` to `>=3.10.2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.15 - 2026-08-31
-- Include `"content"` in the body of the request when storing an agent card in the memory space.
+- `dragent`: simplified the agent card registry's MemorySpace L2 cache event encoding to store the payload directly as the event's `content` field, dropping the now-redundant `v`/`payload` envelope (`content` already carried the same value, so existing cache entries remain readable). Brings the stable-`datarobot[core]`-based cache's shape closer to the `datarobot[application-utils]` Memory Service ORM design from BUZZOK-32180 without taking the pre-release `datarobot-early-access` dependency — see the module docstring in `memory_space_cache.py` for what still differs and why.
 - `dragent`: fixed the agent card registry's MemorySpace (L2) cache raising `requests.exceptions.ConnectionError` (`RemoteDisconnected`/`ProtocolError`, "Remote end closed connection without response") when a pooled keep-alive connection sat idle across the infrequent L1-cache-miss / 30-minute registry-refresh calls in `memory_space_cache.py` for longer than the remote end's idle-connection timeout. That error isn't retried by the DataRobot client's own `handle_connection_reset` wrapper (which only retries `ConnectionResetError`), so it previously surfaced on every stale-connection hit even though the cache already degrades gracefully to a miss. All memory-space Session API calls in the module now retry once on `ConnectionError` before giving up.
 
 ## 0.29.14 - 2026-08-31

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "../" }
 
 [package.metadata]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -948,7 +948,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -29,10 +29,13 @@ import asyncio
 import hashlib
 import logging
 import os
+from collections.abc import Callable
 from typing import Any
+from typing import TypeVar
 from typing import cast
 
 import datarobot as dr
+import requests
 from datarobot.core.config import DataRobotAppFrameworkBaseSettings
 from datarobot.errors import MemorySessionDeduplicationError
 from datarobot.models.memory import Session
@@ -41,6 +44,48 @@ from pydantic import Field
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# `dr.Client()` keeps a single process-lifetime `requests.Session` (and pooled
+# `HTTPAdapter`) shared by every DataRobot API call -- see
+# `datarobot.rest.RESTClientObject`. Memory-space cache calls are infrequent
+# (on-demand L1-cache misses, plus the agent card registry's 30-minute
+# background refresh), so a pooled keep-alive connection can sit idle longer
+# than the server side's (or an intervening proxy's) idle-connection timeout.
+# The next reuse then fails with a `ConnectionError` wrapping
+# `RemoteDisconnected`/`ProtocolError` ("Remote end closed connection without
+# response") -- not the `ConnectionResetError` that the DataRobot client's own
+# `handle_connection_reset` retry wrapper looks for, so it is never retried
+# there and surfaces on every call that lands on a stale connection.
+#
+# Retrying here is a cheap, safe mitigation: the failed attempt evicts the
+# dead connection from the pool, so the retry opens a fresh one.
+_STALE_CONNECTION_RETRIES = 2
+
+
+def _call_with_stale_connection_retry(func: Callable[[], T], *, op: str) -> T:
+    """Call *func*, retrying on a stale pooled-connection ``ConnectionError``.
+
+    Only ``requests.exceptions.ConnectionError`` (e.g. a stale keep-alive
+    connection closed by the remote end) is retried; any other exception --
+    including a real API error -- propagates immediately.
+    """
+    for attempt in range(_STALE_CONNECTION_RETRIES + 1):
+        try:
+            return func()
+        except requests.exceptions.ConnectionError as exc:
+            if attempt >= _STALE_CONNECTION_RETRIES:
+                raise
+            logger.debug(
+                "MemorySpace %s hit a connection error (attempt %d/%d), retrying: %s",
+                op,
+                attempt + 1,
+                _STALE_CONNECTION_RETRIES + 1,
+                exc,
+            )
+    raise AssertionError("unreachable")  # pragma: no cover
+
 
 # Stable 24-hex participant id (BSON ObjectId length) for cache sessions.
 DRAGENT_CACHE_PARTICIPANT_ID = hashlib.sha256(b"datarobot-genai:dragent-cache").hexdigest()[:24]
@@ -161,32 +206,42 @@ def _create_cache_session(
 ) -> Session:
     """Create a cache session, adopting an existing one on deduplication collision."""
     try:
-        return Session.create(
-            memory_space_id,
-            [DRAGENT_CACHE_PARTICIPANT_ID],
-            metadata=_cache_session_metadata(logical_key),
-            description=_cache_session_description(logical_key),
-            deduplication_key=_cache_deduplication_key(logical_key),
+        return _call_with_stale_connection_retry(
+            lambda: Session.create(
+                memory_space_id,
+                [DRAGENT_CACHE_PARTICIPANT_ID],
+                metadata=_cache_session_metadata(logical_key),
+                description=_cache_session_description(logical_key),
+                deduplication_key=_cache_deduplication_key(logical_key),
+            ),
+            op="create_cache_session",
         )
     except MemorySessionDeduplicationError as exc:
         if exc.existing_session_id is None:
             raise
-        return Session.get(memory_space_id, exc.existing_session_id)
+        existing_session_id = exc.existing_session_id
+        return _call_with_stale_connection_retry(
+            lambda: Session.get(memory_space_id, existing_session_id),
+            op="get_cache_session",
+        )
 
 
 def _find_cache_session(memory_space_id: str, logical_key: str) -> Session | None:
     description = _cache_session_description(logical_key)
-    sessions = Session.list(
-        memory_space_id,
-        participants=[DRAGENT_CACHE_PARTICIPANT_ID],
-        description=description,
-        limit=1,
+    sessions = _call_with_stale_connection_retry(
+        lambda: Session.list(
+            memory_space_id,
+            participants=[DRAGENT_CACHE_PARTICIPANT_ID],
+            description=description,
+            limit=1,
+        ),
+        op="find_cache_session",
     )
     return sessions[0] if sessions else None
 
 
 def _read_payload(session: Session) -> str | None:
-    events = session.events(last_n=1)
+    events = _call_with_stale_connection_retry(lambda: session.events(last_n=1), op="read_payload")
     if not events:
         return None
     return _payload_from_event_body(events[0].body)
@@ -194,14 +249,23 @@ def _read_payload(session: Session) -> str | None:
 
 def _write_payload(session: Session, payload: str) -> None:
     body = _payload_event_body(payload)
-    events = session.events(last_n=1)
+    events = _call_with_stale_connection_retry(
+        lambda: session.events(last_n=1), op="write_payload_read"
+    )
     if events and events[0].sequence_id is not None:
-        session.update_event(events[0].sequence_id, body=body)
+        sequence_id = events[0].sequence_id
+        _call_with_stale_connection_retry(
+            lambda: session.update_event(sequence_id, body=body),
+            op="write_payload_update",
+        )
         return
-    session.post_event(
-        body=body,
-        emitter={"type": "agent"},
-        event_type=CACHE_EVENT_TYPE,
+    _call_with_stale_connection_retry(
+        lambda: session.post_event(
+            body=body,
+            emitter={"type": "agent"},
+            event_type=CACHE_EVENT_TYPE,
+        ),
+        op="write_payload_post",
     )
 
 
@@ -227,7 +291,10 @@ class MemorySpaceKVCache:
         """Return the cache session, using a process-local session-id cache when possible."""
         if session_id := self._session_ids.get(logical_key):
             try:
-                return Session.get(self._memory_space_id, session_id)
+                return _call_with_stale_connection_retry(
+                    lambda: Session.get(self._memory_space_id, session_id),
+                    op="resolve_session_get",
+                )
             except Exception:
                 logger.debug(
                     "MemorySpace session cache miss for %s (session_id=%s)",
@@ -283,7 +350,7 @@ class MemorySpaceKVCache:
         def _delete() -> None:
             session = self._resolve_session(logical_key)
             if session is not None:
-                session.delete()
+                _call_with_stale_connection_retry(session.delete, op="delete_session")
             self._invalidate_session_id(logical_key)
 
         try:

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -139,7 +139,12 @@ def _cache_session_metadata(logical_key: str) -> dict[str, Any]:
 
 
 def _payload_event_body(payload: str) -> dict[str, Any]:
-    return {"v": CACHE_METADATA_VERSION, "payload": payload}
+    # The Memory Sessions Events API requires a top-level "content" field on every
+    # event body (schema validation: `body.content` is required). The cache payload
+    # itself is carried separately in "payload" so `_payload_from_event_body` can
+    # keep reading it verbatim; "content" just satisfies the API contract and
+    # doubles as a human-readable preview of the cached value.
+    return {"v": CACHE_METADATA_VERSION, "payload": payload, "content": payload}
 
 
 def _payload_from_event_body(body: dict[str, Any] | None) -> str | None:

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -48,6 +48,18 @@ migration to the ORM should pick back up:
   without giving up the pooled, keep-alive ``requests.Session`` this module
   relies on (see the note on ``_STALE_CONNECTION_RETRIES`` below).
 
+  ``datarobot.client.client_configuration()`` -- the ``ContextVar``-scoped,
+  non-mutating pattern ``drmcputils.clients.datarobot`` uses for per-request
+  credentials -- was considered here and rejected: it calls the SDK's
+  ``_create_client()`` (and, through it, a live ``GET {endpoint}/version/``
+  compatibility check) on *every* entry, with no bypass. Wrapping each
+  ``get_value``/``set_value``/``delete_value`` call in it would silently double
+  this cache's API traffic. That check runs once today, at startup, as a side
+  effect of ``configure_datarobot_memory_client``'s one-time ``dr.Client()``
+  call -- which is a real reason (not just inertia) to keep the client
+  process-global here, unlike the per-request ``drmcputils`` clients, which
+  already pay a fresh round trip per call for a different token each time.
+
 Once ``application_utils.persistence`` ships in a stable ``datarobot`` release,
 this module should be replaced with that ORM the same way BUZZOK-32180 did.
 """

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -21,6 +21,35 @@ surface the agent-application recipe uses for chat history when
 Each provisioned memory space has a unique ``memory_space_id`` and platform-level
 access control scoped to the deploying user or workload API token. Unlike shared
 Redis, no per-deployment namespace or HMAC signing is required for this backend.
+
+Each cache entry is one Memory Service session — found by a ``description``-filtered
+lookup on the logical cache key — carrying a single event whose ``body["content"]``
+is the opaque JSON payload. ``set_value`` patches that event in place instead of
+appending; the cache only ever needs the current value, never a history.
+
+Deliberately built on stable ``datarobot[core]`` rather than the Memory Service
+light ORM (``DRMemorySpace`` / ``DRSession`` / ``DREvent`` /
+``DRDeduplicationKey``) that BUZZOK-32180 standardizes this cache on: that ORM
+ships only as ``application_utils.persistence`` in the pre-release
+``datarobot-early-access`` distribution today, which we can't take as a
+production dependency. Two things fall out of that constraint that a future
+migration to the ORM should pick back up:
+
+* **Session lookup by logical key** goes through ``Session.list(description=...)``
+  (see ``_find_cache_session``) rather than an exact-match ``deduplicationKey``
+  point lookup — the stable SDK's ``Session.list`` has no such filter, so a
+  ``deduplication_key`` here only dedupes concurrent *creates*
+  (``MemorySessionDeduplicationError``), not reads.
+* **The DataRobot client is process-global** (``dr.Client()``, configured once by
+  ``configure_datarobot_memory_client``), not an object explicitly threaded into
+  ``MemorySpaceKVCache`` the way ``DRMemoryServiceClient`` is. Stable
+  ``datarobot.models.memory.Session`` always resolves credentials through
+  ``datarobot.client.get_client()``; there's no per-instance client to inject
+  without giving up the pooled, keep-alive ``requests.Session`` this module
+  relies on (see the note on ``_STALE_CONNECTION_RETRIES`` below).
+
+Once ``application_utils.persistence`` ships in a stable ``datarobot`` release,
+this module should be replaced with that ORM the same way BUZZOK-32180 did.
 """
 
 from __future__ import annotations
@@ -90,7 +119,6 @@ def _call_with_stale_connection_retry(func: Callable[[], T], *, op: str) -> T:
 # Stable 24-hex participant id (BSON ObjectId length) for cache sessions.
 DRAGENT_CACHE_PARTICIPANT_ID = hashlib.sha256(b"datarobot-genai:dragent-cache").hexdigest()[:24]
 
-CACHE_METADATA_VERSION = 1
 CACHE_EVENT_TYPE = "status"
 DEDUPLICATION_KEY_LENGTH = 64
 CACHE_KIND = "agent_card"
@@ -142,7 +170,13 @@ def try_configure_datarobot_memory_client(
     endpoint: str | None = None,
     api_token: str | None = None,
 ) -> bool:
-    """Configure the DataRobot client for memory Session API calls when possible."""
+    """Configure the DataRobot client for memory Session API calls when possible.
+
+    Mirrors the ``client is None`` gate BUZZOK-32180's
+    ``try_build_memory_service_client`` uses, but returns ``bool`` rather than a
+    client object: stable ``datarobot.models.memory.Session`` has no per-instance
+    client to construct and hand back -- see the module docstring.
+    """
     try:
         configure_datarobot_memory_client(endpoint=endpoint, api_token=api_token)
     except Exception as exc:
@@ -176,27 +210,10 @@ def _cache_session_description(logical_key: str) -> str:
 
 def _cache_session_metadata(logical_key: str) -> dict[str, Any]:
     return {
-        "v": CACHE_METADATA_VERSION,
         "dragent_cache": True,
         "cache_key": logical_key,
         "cache_kind": CACHE_KIND,
     }
-
-
-def _payload_event_body(payload: str) -> dict[str, Any]:
-    # The Memory Sessions Events API requires a top-level "content" field on every
-    # event body (schema validation: `body.content` is required). The cache payload
-    # itself is carried separately in "payload" so `_payload_from_event_body` can
-    # keep reading it verbatim; "content" just satisfies the API contract and
-    # doubles as a human-readable preview of the cached value.
-    return {"v": CACHE_METADATA_VERSION, "payload": payload, "content": payload}
-
-
-def _payload_from_event_body(body: dict[str, Any] | None) -> str | None:
-    if not body or body.get("v") != CACHE_METADATA_VERSION:
-        return None
-    value = body.get("payload")
-    return str(value) if value is not None else None
 
 
 def _create_cache_session(
@@ -241,14 +258,26 @@ def _find_cache_session(memory_space_id: str, logical_key: str) -> Session | Non
 
 
 def _read_payload(session: Session) -> str | None:
+    """Return the cache entry's payload, or ``None`` when the session has no event yet.
+
+    The payload is the event's ``content`` directly -- no cache-specific envelope
+    or schema version -- matching how BUZZOK-32180's ``DREvent.content`` is read.
+    """
     events = _call_with_stale_connection_retry(lambda: session.events(last_n=1), op="read_payload")
     if not events:
         return None
-    return _payload_from_event_body(events[0].body)
+    body = events[0].body
+    if not body:
+        return None
+    value = body.get("content")
+    return str(value) if value is not None else None
 
 
 def _write_payload(session: Session, payload: str) -> None:
-    body = _payload_event_body(payload)
+    # The Memory Sessions Events API requires a top-level "content" field on every
+    # event body (schema validation: `body.content` is required), so the payload
+    # is stored there directly -- no extra wrapper field is needed.
+    body = {"content": payload}
     events = _call_with_stale_connection_retry(
         lambda: session.events(last_n=1), op="write_payload_read"
     )

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -19,10 +19,13 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+import requests
 
+from datarobot_genai.dragent.memory_space_cache import _STALE_CONNECTION_RETRIES
 from datarobot_genai.dragent.memory_space_cache import CACHE_EVENT_TYPE
 from datarobot_genai.dragent.memory_space_cache import DRAGENT_CACHE_PARTICIPANT_ID
 from datarobot_genai.dragent.memory_space_cache import MemorySpaceKVCache
+from datarobot_genai.dragent.memory_space_cache import _find_cache_session
 from datarobot_genai.dragent.memory_space_cache import configure_datarobot_memory_client
 from datarobot_genai.dragent.memory_space_cache import resolve_memory_space_id
 from datarobot_genai.dragent.memory_space_cache import try_resolve_memory_space_id
@@ -211,3 +214,62 @@ class TestMemorySpaceKVCache:
             await kv_cache.delete_value("dep-1")
 
         session.delete.assert_called_once()
+
+
+class TestStaleConnectionRetry:
+    """Regression tests for the stale pooled-connection retry (RemoteDisconnected)."""
+
+    async def test_find_cache_session_retries_transient_connection_error(self) -> None:
+        session = _FakeSession()
+        list_mock = MagicMock(
+            side_effect=[
+                requests.exceptions.ConnectionError("stale connection"),
+                [session],
+            ]
+        )
+
+        with patch("datarobot_genai.dragent.memory_space_cache.Session.list", list_mock):
+            result = _find_cache_session("space-1", "dragent:agent_card:dep-1")
+
+        assert result is session
+        assert list_mock.call_count == 2
+
+    async def test_find_cache_session_raises_after_exhausting_retries(self) -> None:
+        list_mock = MagicMock(side_effect=requests.exceptions.ConnectionError("stale connection"))
+
+        with (
+            patch("datarobot_genai.dragent.memory_space_cache.Session.list", list_mock),
+            pytest.raises(requests.exceptions.ConnectionError),
+        ):
+            _find_cache_session("space-1", "dragent:agent_card:dep-1")
+
+        assert list_mock.call_count == _STALE_CONNECTION_RETRIES + 1
+
+    async def test_get_value_survives_a_single_transient_connection_error(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        session = _FakeSession()
+        session.post_event(body={"v": 1, "payload": "cached"})
+        list_mock = MagicMock(
+            side_effect=[
+                requests.exceptions.ConnectionError("stale connection"),
+                [session],
+            ]
+        )
+
+        with patch("datarobot_genai.dragent.memory_space_cache.Session.list", list_mock):
+            assert await kv_cache.get_value("dep-1") == "cached"
+
+        assert list_mock.call_count == 2
+
+    async def test_get_value_falls_back_to_none_once_retries_are_exhausted(
+        self, kv_cache: MemorySpaceKVCache
+    ) -> None:
+        list_mock = MagicMock(side_effect=requests.exceptions.ConnectionError("stale connection"))
+
+        with patch("datarobot_genai.dragent.memory_space_cache.Session.list", list_mock):
+            # Still degrades to a cache miss rather than raising -- get_value's own
+            # try/except is the last line of defense once the retry is exhausted.
+            assert await kv_cache.get_value("dep-1") is None
+
+        assert list_mock.call_count == _STALE_CONNECTION_RETRIES + 1

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -127,7 +127,7 @@ class TestMemorySpaceKVCache:
         session.post_event.assert_called_once()
         kwargs = session.post_event.call_args.kwargs
         assert kwargs["event_type"] == CACHE_EVENT_TYPE
-        assert kwargs["body"]["payload"] == '{"version": 1}'
+        assert kwargs["body"]["content"] == '{"version": 1}'
 
     async def test_get_reuses_cached_session_id_without_list(
         self, kv_cache: MemorySpaceKVCache
@@ -135,7 +135,7 @@ class TestMemorySpaceKVCache:
         session = _FakeSession()
         find_mock = MagicMock(return_value=None)
         get_mock = MagicMock(return_value=session)
-        session.post_event(body={"v": 1, "payload": "cached"})
+        session.post_event(body={"content": "cached"})
 
         with (
             patch(
@@ -161,7 +161,7 @@ class TestMemorySpaceKVCache:
 
     async def test_update_existing_entry(self, kv_cache: MemorySpaceKVCache) -> None:
         session = _FakeSession()
-        session.post_event(body={"v": 1, "payload": "v1"})
+        session.post_event(body={"content": "v1"})
 
         with (
             patch(
@@ -175,9 +175,7 @@ class TestMemorySpaceKVCache:
         ):
             await kv_cache.set_value("dep-1", "v2")
 
-        session.update_event.assert_called_once_with(
-            1, body={"v": 1, "payload": "v2", "content": "v2"}
-        )
+        session.update_event.assert_called_once_with(1, body={"content": "v2"})
         assert session.post_event.call_count == 1
 
     async def test_create_uses_cache_participant(self, kv_cache: MemorySpaceKVCache) -> None:
@@ -249,7 +247,7 @@ class TestStaleConnectionRetry:
         self, kv_cache: MemorySpaceKVCache
     ) -> None:
         session = _FakeSession()
-        session.post_event(body={"v": 1, "payload": "cached"})
+        session.post_event(body={"content": "cached"})
         list_mock = MagicMock(
             side_effect=[
                 requests.exceptions.ConnectionError("stale connection"),

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -172,7 +172,9 @@ class TestMemorySpaceKVCache:
         ):
             await kv_cache.set_value("dep-1", "v2")
 
-        session.update_event.assert_called_once_with(1, body={"v": 1, "payload": "v2"})
+        session.update_event.assert_called_once_with(
+            1, body={"v": 1, "payload": "v2", "content": "v2"}
+        )
         assert session.post_event.call_count == 1
 
     async def test_create_uses_cache_participant(self, kv_cache: MemorySpaceKVCache) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
"content" is a required field for the memory API. It was missing so agent cards were not actually cached.

`datarobot-early-access` has `application-utils` that provides an ORM to standardize memory access. Once it is in `datarobot` we should adopt it for the agent card cache.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Align with `application-utils` as much as possible without importing `datarobot-early-access` or recreating the ORM.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API-contract fix for cache write bodies; no auth, data-model, or read-path changes.
> 
> **Overview**
> **Fixes L2 agent card caching** by adding the Memory Sessions Events API–required top-level **`content`** field when writing cache events to MemorySpace.
> 
> `_payload_event_body` now returns **`content`** alongside the existing **`payload`** (both set to the cached string). Reads still use **`payload`** only, so behavior for `_payload_from_event_body` is unchanged. Without **`content`**, API schema validation rejected writes, so agent cards were not actually persisted in the L2 cache.
> 
> The update-path unit test expectation for `session.update_event` was aligned to include **`content`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712efbbab04f2f49776f3d94a0bc0abc2f99159d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->