### PR TITLE
[MMM-24652] Verify guard OTel metrics reach the queryable Datavolt store

### DIFF
--- a/src/datarobot_genai/core/telemetry/agent.py
+++ b/src/datarobot_genai/core/telemetry/agent.py
@@ -106,9 +106,14 @@ def instrument() -> None:
     # (via setup_otel_env_variables) are not double-bootstrapped. See
     # https://github.com/datarobot/datarobot-user-models/blob/master/public_dropin_environments/python311_genai_agents/run_agent.py#L188
     if is_hosted_runtime():
+        from .datarobot_otel import bootstrap_otel_meter_provider_for_datarobot
         from .datarobot_otel import bootstrap_otel_provider_for_datarobot
 
         bootstrap_otel_provider_for_datarobot()
+        # Same rationale as the tracer bootstrap above, for datarobot_dome's
+        # guard metrics: without this, they record through a no-op meter and
+        # never reach the DataRobot OTel ingest.
+        bootstrap_otel_meter_provider_for_datarobot()
 
     _instrument_threading()
     _instrument_http_clients()

--- a/src/datarobot_genai/core/telemetry/agent.py
+++ b/src/datarobot_genai/core/telemetry/agent.py
@@ -48,8 +48,10 @@ def _instrument_http_clients() -> None:
     try:
         requests_module = importlib.import_module("opentelemetry.instrumentation.requests")
         requests_instrumentor = getattr(requests_module, "RequestsInstrumentor")
-        # Don't trace the OTel exporter's own POST to the collector
-        requests_instrumentor().instrument(excluded_urls="otel/v1/traces")
+        # Don't trace the OTel exporters' own POSTs to the collector (traces and,
+        # since the meter provider bootstrap, metrics too - both OTLP HTTP
+        # exporters are requests-based).
+        requests_instrumentor().instrument(excluded_urls="otel/v1/(traces|metrics)")
     except Exception as e:
         logger.debug(f"requests instrumentation skipped: {e}")
     try:

--- a/src/datarobot_genai/core/telemetry/datarobot_otel.py
+++ b/src/datarobot_genai/core/telemetry/datarobot_otel.py
@@ -14,7 +14,7 @@
 
 """DataRobot OTel ingest endpoint helpers.
 
-Two responsibilities, intentionally co-located so a single import covers
+Three responsibilities, intentionally co-located so a single import covers
 both the NAT telemetry exporter
 (``datarobot_genai.dragent.plugins.datarobot_otelcollector``) and
 the framework-instrumentor bootstrap (``datarobot_genai.core.telemetry.agent``):
@@ -22,10 +22,14 @@ the framework-instrumentor bootstrap (``datarobot_genai.core.telemetry.agent``):
 * ``resolve_*_from_env`` — read ``MLOPS_DEPLOYMENT_ID`` / ``WORKLOAD_ID`` /
   ``DATAROBOT_API_TOKEN`` / ``DATAROBOT_(PUBLIC_)ENDPOINT`` and shape them into
   the values the OTel ingest expects (``deployment-<id>`` or ``workload-<id>``
-  entity id; ``<host>/otel/v1/traces`` endpoint).
+  entity id; ``<host>/otel/v1/traces`` or ``<host>/otel/v1/metrics`` endpoint).
 * ``bootstrap_otel_provider_for_datarobot`` — install a global OTel SDK
   ``TracerProvider`` pointed at the DataRobot ingest so framework
   auto-instrumentors actually export spans.
+* ``bootstrap_otel_meter_provider_for_datarobot`` — same, for metrics: without
+  it, ``datarobot_dome`` (moderations) guard metrics record through the OTel
+  SDK's no-op default ``MeterProvider`` and are silently dropped, since
+  nothing else in this SDK's bootstrap path ever installs a real one.
 """
 
 from __future__ import annotations
@@ -55,6 +59,10 @@ _BOOTSTRAP_STATE: dict[str, bool] = {"installed": False}
 # can't drift.
 DEPLOYMENT_ENTITY_ID_PREFIX = "deployment-"
 WORKLOAD_ENTITY_ID_PREFIX = "workload-"
+
+# Idempotency state for bootstrap_otel_meter_provider_for_datarobot, separate
+# from _BOOTSTRAP_STATE (traces) since either can succeed or fail independently.
+_METER_BOOTSTRAP_STATE: dict[str, bool] = {"installed": False}
 
 
 class _OtelSettings(DataRobotAppFrameworkBaseSettings):  # type: ignore[misc]
@@ -106,17 +114,17 @@ def resolve_datarobot_headers_from_env() -> dict[str, str] | None:
     return None
 
 
-def resolve_otel_traces_endpoint_from_env() -> str:
+def _resolve_otel_endpoint_from_env(signal_path: str) -> str:
     # if OTEL_EXPORTER_OTLP_ENDPOINT is set: do not override it
     if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
         # The convention for OTEL_EXPORTER_OTLP_ENDPOINT is to be base url
-        # so we need to append /v1/traces
+        # so we need to append the signal-specific path.
         otel_endpoint = os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"].rstrip("/")
-        return f"{otel_endpoint}/v1/traces"
+        return f"{otel_endpoint}{signal_path}"
 
     # Derive from the DR API base URL: e.g. https://app.datarobot.com/api/v2
     # → https://app.datarobot.com/otel/v1/traces. The OTel collector ingress
-    # lives at the same host, off /otel/v1/traces, not under /api/v2. We
+    # lives at the same host, off /otel/v1/<signal>, not under /api/v2. We
     # only honour explicitly set env vars (no built-in default) so an
     # unconfigured env never silently targets app.datarobot.com.
     base = os.getenv("DATAROBOT_PUBLIC_API_ENDPOINT") or os.getenv("DATAROBOT_ENDPOINT")
@@ -125,7 +133,15 @@ def resolve_otel_traces_endpoint_from_env() -> str:
     parsed = urllib.parse.urlsplit(base)
     if not parsed.scheme or not parsed.netloc:
         return ""
-    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "/otel/v1/traces", "", ""))
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, f"/otel{signal_path}", "", ""))
+
+
+def resolve_otel_traces_endpoint_from_env() -> str:
+    return _resolve_otel_endpoint_from_env("/v1/traces")
+
+
+def resolve_otel_metrics_endpoint_from_env() -> str:
+    return _resolve_otel_endpoint_from_env("/v1/metrics")
 
 
 def _use_simple_span_processor() -> bool:
@@ -270,6 +286,88 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
     logger.info(
         "DataRobot OTel span processor %s → %s (entity_id=%s)",
         action,
+        endpoint,
+        lower_headers.get("x-datarobot-entity-id", ""),
+    )
+    return True
+
+
+def bootstrap_otel_meter_provider_for_datarobot() -> bool:
+    """Ensure datarobot_dome (moderations) guard metrics reach the DataRobot OTel ingest.
+
+    ``OtelMetricSession`` defers to the OTel SDK's global ``MeterProvider``
+    (``get_meter_provider()``) whenever none is passed explicitly - but unlike
+    traces, nothing else in this SDK's bootstrap path ever installs one. Left
+    unfixed, every guard metric records through the SDK's no-op default meter
+    and is silently dropped before it ever reaches an exporter.
+
+    Same install-only shape as ``bootstrap_otel_provider_for_datarobot``, with
+    one real difference: there is no "attach" mode here. A ``TracerProvider``
+    can take an additional span processor after construction; an SDK
+    ``MeterProvider``'s metric readers are constructor-only and immutable
+    once built, so if an SDK ``MeterProvider`` is already installed globally
+    when this runs, we can't add our exporter to it and skip instead - the
+    same fail-safe behavior as an unrecognized provider type on the trace side.
+
+    Returns ``True`` when a provider was installed by this call, ``False``
+    (silently) when the hosted-runtime env is incomplete, an SDK
+    ``MeterProvider`` is already installed, or this has already run once in
+    this process.
+    """
+    if _METER_BOOTSTRAP_STATE["installed"]:
+        return False
+
+    headers = resolve_datarobot_headers_from_env()
+    endpoint = resolve_otel_metrics_endpoint_from_env()
+    if not headers or not endpoint:
+        logger.info(
+            "Skipping OTel MeterProvider bootstrap: hosted-runtime env "
+            "(MLOPS_DEPLOYMENT_ID or WORKLOAD_ID / DATAROBOT_API_TOKEN / "
+            "DATAROBOT_(PUBLIC_)ENDPOINT) not fully set."
+        )
+        return False
+
+    # Imported lazily, same rationale as the trace bootstrap above.
+    from opentelemetry import metrics
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+    from opentelemetry.metrics._internal import _ProxyMeterProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    try:
+        current = metrics.get_meter_provider()
+        if not isinstance(current, _ProxyMeterProvider):
+            logger.debug(
+                "Skipping OTel MeterProvider bootstrap: an SDK MeterProvider "
+                "is already installed (%s); its metric readers can't be "
+                "extended after construction.",
+                type(current).__name__,
+            )
+            return False
+
+        exporter = OTLPMetricExporter(endpoint=endpoint, headers=headers)
+        reader = PeriodicExportingMetricReader(exporter)
+        sdk_version = _get_opentelemetry_sdk_version()
+        resource = Resource.create(
+            {
+                "telemetry.sdk.language": "python",
+                "telemetry.sdk.name": "opentelemetry",
+                "telemetry.sdk.version": sdk_version,
+                "service.name": _resolve_service_name(),
+            }
+        )
+        provider = MeterProvider(metric_readers=[reader], resource=resource)
+        metrics.set_meter_provider(provider)
+    except Exception:
+        # Never let telemetry setup take down the agent.
+        logger.exception("Failed to bootstrap DataRobot OTel MeterProvider")
+        return False
+
+    _METER_BOOTSTRAP_STATE["installed"] = True
+    lower_headers = {k.lower(): v for k, v in headers.items()}
+    logger.info(
+        "DataRobot OTel meter provider installed → %s (entity_id=%s)",
         endpoint,
         lower_headers.get("x-datarobot-entity-id", ""),
     )

--- a/tests/core/test_datarobot_otel.py
+++ b/tests/core/test_datarobot_otel.py
@@ -15,7 +15,10 @@
 from __future__ import annotations
 
 import pytest
+from opentelemetry import metrics
 from opentelemetry import trace
+from opentelemetry.metrics._internal import _ProxyMeterProvider
+from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace import ProxyTracerProvider
 from opentelemetry.util._once import Once
@@ -37,14 +40,17 @@ _ENV_VARS = (
 
 @pytest.fixture
 def clean_env(monkeypatch):
-    """Strip env vars + reset OTel global TracerProvider + module bootstrap flag."""
+    """Strip env vars + reset OTel global Tracer/MeterProvider + bootstrap flags."""
     for var in _ENV_VARS:
         monkeypatch.delenv(var, raising=False)
-    # OTel guards set_tracer_provider behind Once(); resetting both lets each
-    # test exercise a fresh global slot without leaking to siblings.
+    # OTel guards set_tracer_provider/set_meter_provider behind Once(); resetting
+    # both lets each test exercise a fresh global slot without leaking to siblings.
     monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER", None)
     monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr("opentelemetry.metrics._internal._METER_PROVIDER", None)
+    monkeypatch.setattr("opentelemetry.metrics._internal._METER_PROVIDER_SET_ONCE", Once())
     monkeypatch.setitem(datarobot_otel._BOOTSTRAP_STATE, "installed", False)
+    monkeypatch.setitem(datarobot_otel._METER_BOOTSTRAP_STATE, "installed", False)
     return monkeypatch
 
 
@@ -118,6 +124,23 @@ class TestEnvResolvers:
         assert (
             datarobot_otel.resolve_otel_traces_endpoint_from_env()
             == "https://collector.test/v1/traces"
+        )
+
+    def test_metrics_endpoint_strips_api_path(self, clean_env):
+        clean_env.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
+        assert (
+            datarobot_otel.resolve_otel_metrics_endpoint_from_env()
+            == "https://example.test/otel/v1/metrics"
+        )
+
+    def test_metrics_endpoint_empty_when_unset(self, clean_env):
+        assert datarobot_otel.resolve_otel_metrics_endpoint_from_env() == ""
+
+    def test_metrics_explicit_otlp_base_url_appends_metrics_path(self, clean_env):
+        clean_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.test:4318")
+        assert (
+            datarobot_otel.resolve_otel_metrics_endpoint_from_env()
+            == "https://collector.test:4318/v1/metrics"
         )
 
 
@@ -368,3 +391,118 @@ class TestBootstrapOtelProvider:
         self._set_full_env(clean_env)
         assert datarobot_otel.bootstrap_otel_provider_for_datarobot() is False
         assert trace.get_tracer_provider() is third_party
+
+
+class TestBootstrapOtelMeterProvider:
+    """Covers bootstrap_otel_meter_provider_for_datarobot - without it,
+    datarobot_dome's guard metrics record through the OTel SDK's no-op
+    default MeterProvider and are silently dropped (see module docstring).
+    """
+
+    @staticmethod
+    def _set_full_env(monkeypatch):
+        monkeypatch.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
+        monkeypatch.setenv("DATAROBOT_API_TOKEN", "tok")
+        monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
+
+    def test_skips_when_env_missing(self, clean_env):
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is False
+        assert isinstance(metrics.get_meter_provider(), _ProxyMeterProvider)
+
+    def test_skips_when_api_key_only(self, clean_env):
+        clean_env.setenv("DATAROBOT_API_TOKEN", "tok")
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is False
+        assert isinstance(metrics.get_meter_provider(), _ProxyMeterProvider)
+
+    def test_installs_provider_when_env_present(self, clean_env):
+        self._set_full_env(clean_env)
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is True
+
+        provider = metrics.get_meter_provider()
+        assert isinstance(provider, MeterProvider)
+        attrs = provider._sdk_config.resource.attributes
+        assert attrs["service.name"] == "deployment-abc123"
+        assert attrs["telemetry.sdk.language"] == "python"
+
+    def test_installs_provider_with_workload_env(self, clean_env):
+        clean_env.setenv("WORKLOAD_ID", "wkl42")
+        clean_env.setenv("DATAROBOT_API_TOKEN", "tok")
+        clean_env.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is True
+
+        provider = metrics.get_meter_provider()
+        assert provider._sdk_config.resource.attributes["service.name"] == "workload-wkl42"
+
+    def test_exporter_endpoint_and_headers(self, clean_env, monkeypatch):
+        captured = {}
+
+        from opentelemetry.exporter.otlp.proto.http import metric_exporter as exporter_module
+
+        real_exporter_cls = exporter_module.OTLPMetricExporter
+
+        def spy_exporter(**kwargs):
+            captured.update(kwargs)
+            return real_exporter_cls(**kwargs)
+
+        monkeypatch.setattr(exporter_module, "OTLPMetricExporter", spy_exporter)
+
+        self._set_full_env(clean_env)
+        datarobot_otel.bootstrap_otel_meter_provider_for_datarobot()
+
+        assert captured["endpoint"] == "https://example.test/otel/v1/metrics"
+        assert captured["headers"]["X-DataRobot-Api-Key"] == "tok"
+        assert captured["headers"]["X-DataRobot-Entity-Id"] == "deployment-abc123"
+
+    def test_idempotent_second_call(self, clean_env):
+        self._set_full_env(clean_env)
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is True
+        provider_first = metrics.get_meter_provider()
+
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is False
+        assert metrics.get_meter_provider() is provider_first
+
+    def test_skips_when_sdk_provider_already_installed(self, clean_env):
+        # Unlike traces, an SDK MeterProvider's metric readers are
+        # constructor-only - there's no "attach a reader" fallback, so an
+        # already-installed SDK provider must be left untouched.
+        from opentelemetry.sdk.resources import Resource
+
+        pre_existing = MeterProvider(resource=Resource.create({"service.name": "preexisting"}))
+        metrics.set_meter_provider(pre_existing)
+
+        self._set_full_env(clean_env)
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is False
+        assert metrics.get_meter_provider() is pre_existing
+
+    def test_datarobot_dome_metric_session_uses_the_bootstrapped_provider(self, clean_env):
+        """The regression test that matters most here: confirms datarobot_dome's
+        OtelMetricSession - which defers to get_meter_provider() with no
+        provider passed explicitly - picks up the bootstrapped provider and
+        its service.name, rather than the SDK's no-op default. Without the
+        bootstrap this session runs against, every guard metric silently
+        vanishes: confirmed directly (test_no_bootstrap_means_dome_gets_the_
+        no_op_proxy_provider below), not assumed.
+        """
+        from datarobot_dome.otel.metric_session import OtelMetricSession
+
+        self._set_full_env(clean_env)
+        assert datarobot_otel.bootstrap_otel_meter_provider_for_datarobot() is True
+
+        session = OtelMetricSession()
+
+        assert isinstance(session.provider, MeterProvider)
+        assert session.provider is metrics.get_meter_provider()
+        attrs = session.provider._sdk_config.resource.attributes
+        assert attrs["service.name"] == "deployment-abc123"
+
+    def test_no_bootstrap_means_dome_gets_the_no_op_proxy_provider(self, clean_env):
+        """The bug this task exists to fix, proven rather than asserted: with
+        no bootstrap call at all (the state of every guard-emitting process
+        before this task), OtelMetricSession's provider is the SDK's default
+        proxy - metrics recorded against it are never exported anywhere.
+        """
+        from datarobot_dome.otel.metric_session import OtelMetricSession
+
+        session = OtelMetricSession()
+
+        assert isinstance(session.provider, _ProxyMeterProvider)

--- a/tests/core/test_telemetry_agent.py
+++ b/tests/core/test_telemetry_agent.py
@@ -26,17 +26,31 @@ def test_instrument_skips_bootstrap_without_deployment_id(monkeypatch) -> None:
     monkeypatch.delenv("MLOPS_DEPLOYMENT_ID", raising=False)
     monkeypatch.delenv("WORKLOAD_ID", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_HEADERS", raising=False)
-    with patch(
-        "datarobot_genai.core.telemetry.datarobot_otel.bootstrap_otel_provider_for_datarobot"
-    ) as mock:
+    with (
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel.bootstrap_otel_provider_for_datarobot"
+        ) as mock_trace,
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel."
+            "bootstrap_otel_meter_provider_for_datarobot"
+        ) as mock_meter,
+    ):
         instrument()
-    mock.assert_not_called()
+    mock_trace.assert_not_called()
+    mock_meter.assert_not_called()
 
 
 def test_instrument_bootstraps_when_deployment_id_set(monkeypatch) -> None:
     monkeypatch.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
-    with patch(
-        "datarobot_genai.core.telemetry.datarobot_otel.bootstrap_otel_provider_for_datarobot"
-    ) as mock:
+    with (
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel.bootstrap_otel_provider_for_datarobot"
+        ) as mock_trace,
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel."
+            "bootstrap_otel_meter_provider_for_datarobot"
+        ) as mock_meter,
+    ):
         instrument()
-    mock.assert_called_once()
+    mock_trace.assert_called_once()
+    mock_meter.assert_called_once()

--- a/tests/core/test_telemetry_agent.py
+++ b/tests/core/test_telemetry_agent.py
@@ -14,6 +14,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from datarobot_genai.core.telemetry.agent import instrument
 
 
@@ -54,3 +56,25 @@ def test_instrument_bootstraps_when_deployment_id_set(monkeypatch) -> None:
         instrument()
     mock_trace.assert_called_once()
     mock_meter.assert_called_once()
+
+
+def test_instrument_http_clients_excludes_both_otel_exporters(monkeypatch) -> None:
+    """Both OTLP HTTP exporters (traces and metrics) are requests-based, so their
+    own POSTs to the collector must not be self-instrumented into spans.
+    """
+    pytest.importorskip("opentelemetry.instrumentation.requests")
+    from opentelemetry.util.http import parse_excluded_urls
+
+    from datarobot_genai.core.telemetry.agent import _INSTRUMENTATION_STATE
+    from datarobot_genai.core.telemetry.agent import _instrument_http_clients
+
+    monkeypatch.setitem(_INSTRUMENTATION_STATE, "http", False)
+    with patch(
+        "opentelemetry.instrumentation.requests.RequestsInstrumentor.instrument"
+    ) as mock_instrument:
+        _instrument_http_clients()
+
+    excluded = parse_excluded_urls(mock_instrument.call_args.kwargs["excluded_urls"])
+    assert excluded.url_disabled("https://example.test/otel/v1/traces")
+    assert excluded.url_disabled("https://example.test/otel/v1/metrics")
+    assert not excluded.url_disabled("https://example.test/api/v2/deployments")


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change gated on hosted runtime and full DR OTel env; failures are caught and do not affect agent execution, with behavior matching the existing trace bootstrap pattern.
> 
> **Overview**
> **Fixes moderation guard metrics being dropped** because `datarobot_dome`’s `OtelMetricSession` uses the global `MeterProvider`, which was never installed—only traces were bootstrapped—so recordings went through the SDK no-op meter.
> 
> On **hosted runtime**, `instrument()` now calls **`bootstrap_otel_meter_provider_for_datarobot()`** right after the existing tracer bootstrap. That installs a global SDK `MeterProvider` with an OTLP HTTP exporter pointed at DataRobot’s **`/otel/v1/metrics`** ingest (same auth headers and entity id as traces).
> 
> **`datarobot_otel`** adds metrics endpoint resolution (shared **`_resolve_otel_endpoint_from_env`** with traces), separate idempotency state, and install-only behavior: if a real SDK `MeterProvider` is already global, bootstrap skips (no attach path, unlike traces). Tests cover resolvers, bootstrap edge cases, and that `OtelMetricSession` uses the bootstrapped provider vs the proxy when bootstrap is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637ac66f5add00883ffb2b41d0021110b3550aa9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->