### PR TITLE
[MODEL-24737] Add well known metadata info in MCP AuthZ error response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.19
+- `drmcp/core/middleware.py`: Add well-known metadata info in MCP 403 authorization error response
+
 ## 0.29.18 - 2026-09-01
 - Add a minimum version for `hydra-core`: `>=1.3.4`.
 - Raise the minimum `nltk` version from `>=3.10.2` to `>=3.10.3`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.18"
+version = "0.29.19"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/dr_mcp_server.py
+++ b/src/datarobot_genai/drmcp/core/dr_mcp_server.py
@@ -31,6 +31,7 @@ from datarobot_genai.drmcp.core.lineage.enums import LRSEnvVarIsNotSetError
 from datarobot_genai.drmcp.core.lineage.manager import LineageManager
 from datarobot_genai.drmcp.core.middleware import GeneralOAuthClaimValidationMiddleware
 from datarobot_genai.drmcp.core.middleware import OAuthJWTTokenHandlerMiddleware
+from datarobot_genai.drmcp.core.middleware import OAuthMCPToolCallScopeValidationMiddleware
 from datarobot_genai.drmcp.core.middleware import initialize_oauth_middleware
 from datarobot_genai.drmcp.core.oauth_scopes import wire_scopes
 from datarobot_genai.drmcpbase.fastmcp_transforms import register_mcp_catalog_transform
@@ -107,6 +108,7 @@ def get_ordered_list_of_starlette_middlewares() -> list[Middleware]:
         Middleware(TrailingSlashNormalizer),
         Middleware(OAuthJWTTokenHandlerMiddleware),
         Middleware(GeneralOAuthClaimValidationMiddleware),
+        Middleware(OAuthMCPToolCallScopeValidationMiddleware),
         # Request headers in context for REST routes only (skips MCP path).
         Middleware(RequestHeadersMiddleware),
         Middleware(OtelASGIMiddleware),

--- a/src/datarobot_genai/drmcp/core/middleware.py
+++ b/src/datarobot_genai/drmcp/core/middleware.py
@@ -175,7 +175,14 @@ class OAuthJWTTokenHandlerMiddleware(BaseHTTPMiddleware):
             request.headers,
         )
         if not access_token:
-            return ErrorResponse.INVALID_JWT_TOKEN.to_starlette_response()
+            return build_http_response_from_auth_error(
+                status_code=HTTPStatus.UNAUTHORIZED,
+                auth_error_response=AuthErrorResponse(
+                    resource_metadata=build_well_known_protected_resource_url(request),
+                    error_code=ErrorCodeInAuthErrorResponse.INVALID_TOKEN,
+                    error_description="Invalid JWT token.",
+                ),
+            )
 
         scope = request.scope
         self.update_scope_with_auth_credentials(scope, access_token)

--- a/src/datarobot_genai/drmcp/core/middleware.py
+++ b/src/datarobot_genai/drmcp/core/middleware.py
@@ -14,9 +14,11 @@
 
 """Wire drmcpbase FastMCP middleware to drtools auth resolution."""
 
+import json
 import logging
 from enum import Enum
 from enum import auto
+from http import HTTPMethod
 from http import HTTPStatus
 from typing import Any
 
@@ -30,12 +32,19 @@ from starlette.responses import Response
 from starlette.types import Scope
 
 from datarobot_genai.drmcp.core.config import get_config
+from datarobot_genai.drmcp.core.runtime_identity import resolve_self_url
 from datarobot_genai.drmcpbase.auth.exceptions import AudienceClaimValidationError
+from datarobot_genai.drmcpbase.auth.exceptions import MCPToolScopeClaimValidationError
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenClaimsValidator
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenHandler
 from datarobot_genai.drmcpbase.middleware import AuthContextExtractor
 from datarobot_genai.drmcpbase.middleware import OAuthMiddleWare
 from datarobot_genai.drmcpbase.middleware import register_oauth_middleware
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import AuthErrorResponse
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    ErrorCodeInAuthErrorResponse,
+)
+from datarobot_genai.drmcpbase.oauth_scopes import declared_scopes_for_one_tool
 from datarobot_genai.drmcputils.auth import extract_auth_context_from_headers
 from datarobot_genai.drmcputils.auth import set_auth_context
 from datarobot_genai.drmcputils.auth import set_request_headers
@@ -96,6 +105,29 @@ class ErrorResponse(Enum):
             self.INVALID_JWT_TOKEN: "Invalid JWT token.",
         }
         return mapping[self]
+
+
+def build_well_known_protected_resource_url(request: Request) -> str:
+    if resolve_self_url():
+        well_known_path = f"{resolve_self_url()}/.well-known/oauth-protected-resource"
+    else:
+        well_known_path = f"{request.url.path.rstrip('/')}/.well-known/oauth-protected-resource"
+    return str(request.url.replace(path=well_known_path, query=""))
+
+
+def build_http_response_from_auth_error(
+    status_code: HTTPStatus,
+    auth_error_response: AuthErrorResponse,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=auth_error_response.to_response_content(),
+        headers={auth_error_response.get_header_name(): auth_error_response.to_header_value()},
+    )
+
+
+def get_user_from_request_scope(request: Request) -> AuthenticatedUser | None:
+    return request.scope.get("user")
 
 
 class OAuthJWTTokenHandlerMiddleware(BaseHTTPMiddleware):
@@ -161,22 +193,13 @@ class GeneralOAuthClaimValidationMiddleware(BaseHTTPMiddleware):
         mcp_server_config = get_config()
         return mcp_server_config.mcp_xaa_token_audience
 
-    @staticmethod
-    def get_user_from_request_scope(request: Request) -> AuthenticatedUser | None:
-        return request.scope.get("user")
-
     async def dispatch(
         self,
         request: Request,
         call_next: Any,
     ) -> Response:
-        user = self.get_user_from_request_scope(request)
+        user = get_user_from_request_scope(request)
         if not user:
-            message = (
-                "No AuthenticatedUser is found in inbound request scope. "
-                f"Skip {self.__class__.__name__}."
-            )
-            logger.info(message)
             return await call_next(request)
 
         try:
@@ -185,6 +208,75 @@ class GeneralOAuthClaimValidationMiddleware(BaseHTTPMiddleware):
         except AudienceClaimValidationError as ex:
             error_message = str(ex)
             logger.info(error_message)
-            return ErrorResponse.INVALID_OAUTH_AUDIENCE_CLAIM.to_starlette_response(error_message)
+            return build_http_response_from_auth_error(
+                status_code=HTTPStatus.FORBIDDEN,
+                auth_error_response=AuthErrorResponse(
+                    resource_metadata=build_well_known_protected_resource_url(request),
+                    error_code=ErrorCodeInAuthErrorResponse.INVALID_TOKEN,
+                    error_description=error_message,
+                ),
+            )
+
+        return await call_next(request)
+
+
+class OAuthMCPToolCallScopeValidationMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware validating the scope claim in a JWT token. It is now enforced only on
+    ``tools/call`` requests.
+    This middleware is expected to be triggered after OAuthJWTTokenHandlerMiddleware which
+    parses JWT token and sets it the request scope which is to be validated in this middleware.
+    """
+
+    @staticmethod
+    async def get_mcp_tool_name_in_request(request: Request) -> str | None:
+        if request.method != HTTPMethod.POST:
+            return None
+        request_body = await request.body()
+        try:
+            payload = json.loads(request_body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+
+        if not isinstance(payload, dict) or payload.get("method") != "tools/call":
+            return None
+        params = payload.get("params")
+        name = params.get("name") if isinstance(params, dict) else None
+        return name if isinstance(name, str) else None
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Any,
+    ) -> Response:
+        mcp_tool_name = await self.get_mcp_tool_name_in_request(request)
+        if not mcp_tool_name:
+            return await call_next(request)
+
+        declared_scopes = await declared_scopes_for_one_tool(
+            request.app.state.fastmcp_server,
+            mcp_tool_name,
+        )
+        if not declared_scopes:
+            return await call_next(request)
+
+        user = get_user_from_request_scope(request)
+        if not user:
+            return await call_next(request)
+
+        try:
+            claims_validator = JWTTokenClaimsValidator(user)
+            claims_validator.validate_mcp_tool_scope_claims(declared_scopes)
+        except MCPToolScopeClaimValidationError as ex:
+            error_message = str(ex)
+            logger.info(error_message)
+            return build_http_response_from_auth_error(
+                status_code=HTTPStatus.FORBIDDEN,
+                auth_error_response=AuthErrorResponse(
+                    resource_metadata=build_well_known_protected_resource_url(request),
+                    error_code=ErrorCodeInAuthErrorResponse.INSUFFICIENT_SCOPE,
+                    error_description=error_message,
+                    scopes=sorted(declared_scopes),
+                ),
+            )
 
         return await call_next(request)

--- a/src/datarobot_genai/drmcp/core/middleware.py
+++ b/src/datarobot_genai/drmcp/core/middleware.py
@@ -108,11 +108,15 @@ class ErrorResponse(Enum):
 
 
 def build_well_known_protected_resource_url(request: Request) -> str:
-    if resolve_self_url():
-        well_known_path = f"{resolve_self_url()}/.well-known/oauth-protected-resource"
-    else:
-        well_known_path = f"{request.url.path.rstrip('/')}/.well-known/oauth-protected-resource"
-    return str(request.url.replace(path=well_known_path, query=""))
+    self_url = resolve_self_url()
+    if self_url:
+        return f"{self_url.rstrip('/')}/.well-known/oauth-protected-resource"
+    return str(
+        request.url.replace(
+            path=prefix_mount_path("/.well-known/oauth-protected-resource"),
+            query="",
+        )
+    )
 
 
 def build_http_response_from_auth_error(

--- a/src/datarobot_genai/drmcpbase/auth/exceptions.py
+++ b/src/datarobot_genai/drmcpbase/auth/exceptions.py
@@ -27,3 +27,7 @@ class NoDataRobotBearerTokenFoundInRequestContextError(Exception):
 
 class AudienceClaimValidationError(Exception):
     pass
+
+
+class MCPToolScopeClaimValidationError(Exception):
+    pass

--- a/src/datarobot_genai/drmcpbase/auth/jwt.py
+++ b/src/datarobot_genai/drmcpbase/auth/jwt.py
@@ -21,6 +21,7 @@ from fastmcp.server.auth import AccessToken
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 
 from datarobot_genai.drmcpbase.auth.exceptions import AudienceClaimValidationError
+from datarobot_genai.drmcpbase.auth.exceptions import MCPToolScopeClaimValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,7 @@ class JWTTokenHandler:
 
 @dataclass
 class AuthorizationClaims:
+    scopes: frozenset[str]
     # RFC-7519: aud can be a single string or a list (case-sensitive); None when absent.
     audience: str | list[str] | None = None
 
@@ -115,6 +117,7 @@ class AuthorizationClaims:
     def from_access_token(cls, access_token: AccessToken) -> "AuthorizationClaims":
         return cls(
             audience=access_token.claims.get("aud", None),
+            scopes=frozenset(access_token.scopes) if access_token.scopes else frozenset(),
         )
 
     def audience_is_a_list(self) -> bool:
@@ -127,6 +130,12 @@ class AuthorizationClaims:
         if isinstance(self.audience, list):
             return expected_audience in self.audience
         return expected_audience == self.audience
+
+    def has_scope_claims(self) -> bool:
+        return len(self.scopes) > 0
+
+    def are_expected_scopes_subset_of_scope_claims(self, expected_scopes: frozenset[str]) -> bool:
+        return expected_scopes.issubset(self.scopes)
 
 
 class JWTTokenClaimsValidator:
@@ -151,3 +160,22 @@ class JWTTokenClaimsValidator:
             raise AudienceClaimValidationError("Authorization audience claim validation failed")
 
         logger.info("Audience claim validation succeeded.")
+
+    def validate_mcp_tool_scope_claims(self, expected_scopes: frozenset[str] | None) -> None:
+        if expected_scopes is None or not len(expected_scopes):
+            logger.info(
+                "Authorization MCP tool scope claim validation is not executed. "
+                "There is no expected scope claim provided."
+            )
+            return
+        if not self.claims.has_scope_claims():
+            error_message = (
+                "Authorization MCP tool scope claim is not found in the inbound JWT bearer token."
+            )
+            logger.info(error_message)
+            raise MCPToolScopeClaimValidationError(error_message)
+
+        if not self.claims.are_expected_scopes_subset_of_scope_claims(expected_scopes):  # type: ignore[union-attr]
+            raise MCPToolScopeClaimValidationError("Authorization scope claim validation failed")
+
+        logger.info("MCP tool scope claim validation succeeded.")

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
@@ -236,7 +236,7 @@ class ErrorCodeInAuthErrorResponse(Enum):
 @dataclass
 class AuthErrorResponse:
     resource_metadata: str
-    error_code: ErrorCodeInAuthErrorResponse | None = ErrorCodeInAuthErrorResponse.UNKNOWN
+    error_code: ErrorCodeInAuthErrorResponse = ErrorCodeInAuthErrorResponse.UNKNOWN
     scopes: list[str] | None = None
     error_description: str | None = None
 

--- a/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
+++ b/src/datarobot_genai/drmcpbase/oauth_protected_resource_metadata/entities.py
@@ -14,6 +14,8 @@
 import logging
 from dataclasses import asdict
 from dataclasses import dataclass
+from enum import Enum
+from enum import auto
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -217,3 +219,45 @@ class MCPOAuthProtectedResourceMetadata(BaseDataClass):
             scopes_supported=user_config.scopes_supported,
             cross_application_access=user_config.cross_application_access,
         )
+
+
+class ErrorCodeInAuthErrorResponse(Enum):
+    """It is based on https://www.rfc-editor.org/info/rfc6750/#section-3.1."""
+
+    INVALID_REQUEST = auto()
+    INVALID_TOKEN = auto()
+    INSUFFICIENT_SCOPE = auto()
+    UNKNOWN = auto()  # This is not the part of the spec. I added here for better code readability.
+
+    def to_value(self) -> str:
+        return self.name.lower()
+
+
+@dataclass
+class AuthErrorResponse:
+    resource_metadata: str
+    error_code: ErrorCodeInAuthErrorResponse | None = ErrorCodeInAuthErrorResponse.UNKNOWN
+    scopes: list[str] | None = None
+    error_description: str | None = None
+
+    def get_scopes_string_representation(self) -> str | None:
+        if self.scopes:
+            return " ".join(self.scopes)
+        return None
+
+    @staticmethod
+    def get_header_name() -> str:
+        return "WWW-Authenticate"
+
+    def to_header_value(self) -> str:
+        parts = [f'resource_metadata="{self.resource_metadata}"']
+        if self.scopes:
+            parts.append(f'scope="{self.get_scopes_string_representation()}"')
+        if self.error_code != ErrorCodeInAuthErrorResponse.UNKNOWN:
+            parts.append(f'error="{self.error_code.to_value()}"')
+        if self.error_description:
+            parts.append(f'error_description="{self.error_description}"')
+        return "Bearer " + ", ".join(parts)
+
+    def to_response_content(self) -> dict[str, str | None]:
+        return {"error": self.error_code.to_value(), "error_description": self.error_description}

--- a/src/datarobot_genai/drmcpbase/oauth_scopes.py
+++ b/src/datarobot_genai/drmcpbase/oauth_scopes.py
@@ -624,6 +624,16 @@ async def collect_code_declared_scopes(mcp: Any) -> set[str]:
     return found
 
 
+async def declared_scopes_for_one_tool(mcp: Any, tool_name: str) -> frozenset[str] | None:
+    for tool in await mcp._list_tools():
+        if tool.name == tool_name:
+            required: set[str] = set()
+            for check in _as_check_list(tool.auth):
+                required.update(_declared_scopes_of(check))
+            return frozenset(required)
+    return None
+
+
 async def apply_tag_scopes(mcp: Any) -> int:
     """Attach per-tag scope requirements to the components carrying those tags.
 

--- a/tests/drmcp/unit/core/test_middleware.py
+++ b/tests/drmcp/unit/core/test_middleware.py
@@ -14,6 +14,7 @@
 import json
 from collections.abc import Iterator
 from http import HTTPStatus
+from typing import Any
 from unittest.mock import ANY
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
@@ -28,13 +29,19 @@ from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from datarobot_genai.drmcp.core.middleware import ErrorResponse
 from datarobot_genai.drmcp.core.middleware import GeneralOAuthClaimValidationMiddleware
 from datarobot_genai.drmcp.core.middleware import OAuthJWTTokenHandlerMiddleware
+from datarobot_genai.drmcp.core.middleware import OAuthMCPToolCallScopeValidationMiddleware
+from datarobot_genai.drmcp.core.middleware import build_http_response_from_auth_error
 from datarobot_genai.drmcp.core.middleware import is_path_exempt_from_oauth_validation
 from datarobot_genai.drmcpbase.auth.exceptions import AudienceClaimValidationError
+from datarobot_genai.drmcpbase.auth.exceptions import MCPToolScopeClaimValidationError
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenClaimsValidator
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenHandler
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import AuthErrorResponse
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    ErrorCodeInAuthErrorResponse,
+)
 
 
 async def _ok_response(_request: Request) -> PlainTextResponse:
@@ -60,14 +67,37 @@ def module_under_test() -> str:
     return "datarobot_genai.drmcp.core.middleware"
 
 
-class TestErrorResponse:
-    def test_unauthorized(self) -> None:
-        expected = JSONResponse(
-            status_code=HTTPStatus.UNAUTHORIZED,
-            content={"detail": "Audience claim validation failed."},
+@pytest.fixture
+def mock_get_user_from_request_scope(module_under_test: str) -> Iterator[Mock]:
+    with patch(f"{module_under_test}.get_user_from_request_scope") as mock_func:
+        yield mock_func
+
+
+@pytest.fixture
+def mock_jwt_token_claims_validator_cls(module_under_test: str) -> Iterator[Mock]:
+    with patch(f"{module_under_test}.JWTTokenClaimsValidator") as mock_cls:
+        yield mock_cls
+
+
+class TestAuthErrorHTTPResponseGeneration:
+    @pytest.fixture
+    def mock_json_response_cls(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.JSONResponse") as mock_cls:
+            yield mock_cls
+
+    def test_build_http_response_from_auth_error(self, mock_json_response_cls: Mock) -> None:
+        mock_status_code = Mock()
+        mock_error_response = Mock()
+        output = build_http_response_from_auth_error(mock_status_code, mock_error_response)
+
+        expected_header_name = mock_error_response.get_header_name.return_value
+        expected_header_value = mock_error_response.to_header_value.return_value
+        mock_json_response_cls.assert_called_once_with(
+            status_code=mock_status_code,
+            content=mock_error_response.to_response_content.return_value,
+            headers={expected_header_name: expected_header_value},
         )
-        actual = ErrorResponse.INVALID_OAUTH_AUDIENCE_CLAIM.to_starlette_response()
-        assert (expected.body, expected.status_code) == (actual.body, actual.status_code)
+        assert output == mock_json_response_cls.return_value
 
 
 class TestPathExemptFromOAuthValidation:
@@ -218,21 +248,8 @@ class TestGeneralOAuthClaimValidationMiddleware:
             yield mock_func
 
     @pytest.fixture
-    def mock_jwt_token_claims_validator_cls(self, module_under_test: str) -> Iterator[Mock]:
-        with patch(f"{module_under_test}.JWTTokenClaimsValidator") as mock_cls:
-            yield mock_cls
-
-    @pytest.fixture
     def mock_validate_audience_claim(self) -> Iterator[Mock]:
         with patch.object(JWTTokenClaimsValidator, "validate_audience_claim") as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_get_user_from_request_scope(self) -> Iterator[Mock]:
-        with patch.object(
-            GeneralOAuthClaimValidationMiddleware,
-            "get_user_from_request_scope",
-        ) as mock_func:
             yield mock_func
 
     @pytest.fixture
@@ -241,6 +258,14 @@ class TestGeneralOAuthClaimValidationMiddleware:
             GeneralOAuthClaimValidationMiddleware,
             "get_expected_audience_claim",
         ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_build_well_known_protected_resource_url(
+        self, module_under_test: str
+    ) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.build_well_known_protected_resource_url") as mock_func:
+            mock_func.return_value = "https://mcp.example.com/.well-known/oauth-protected-resource"
             yield mock_func
 
     def test_get_expected_audience_claim(self, mock_get_config: Mock) -> None:
@@ -288,6 +313,7 @@ class TestGeneralOAuthClaimValidationMiddleware:
     @pytest.mark.usefixtures(
         "mock_get_expected_audience_claim",
         "mock_get_user_from_request_scope",
+        "mock_build_well_known_protected_resource_url",
     )
     async def test_run_claim_validation_fails(
         self,
@@ -305,6 +331,273 @@ class TestGeneralOAuthClaimValidationMiddleware:
 
         output = await middleware.dispatch(request, mock_call_next)
         assert isinstance(output, JSONResponse)
-        assert output.status_code == HTTPStatus.UNAUTHORIZED
-        assert json.loads(output.body) == {"detail": error_message}
+        assert output.status_code == HTTPStatus.FORBIDDEN
+        assert json.loads(output.body) == {
+            "error": "invalid_token",
+            "error_description": error_message,
+        }
+        assert output.headers["www-authenticate"] == (
+            "Bearer "
+            'resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", '
+            'error="invalid_token", '
+            f'error_description="{error_message}"'
+        )
+        mock_call_next.assert_not_called()
+
+
+class TestOAuthMCPToolCallScopeValidationMiddleware:
+    @pytest.fixture
+    def mock_json_loads(self) -> Iterator[Mock]:
+        with patch.object(json, "loads") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_mcp_tool_name_in_request(self) -> Iterator[AsyncMock]:
+        with patch.object(
+            OAuthMCPToolCallScopeValidationMiddleware,
+            "get_mcp_tool_name_in_request",
+        ) as mock_func:
+            mock_func.return_value = "mcp_tool_name"
+            yield mock_func
+
+    @pytest.fixture
+    def mock_declared_scopes_for_one_tool(self, module_under_test: str) -> Iterator[AsyncMock]:
+        with patch(f"{module_under_test}.declared_scopes_for_one_tool") as mock_func:
+            mock_func.return_value = {"mcp:tools:write"}
+            yield mock_func
+
+    @pytest.fixture
+    def mock_build_http_response_from_auth_error(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.build_http_response_from_auth_error") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_build_well_known_protected_resource_url(
+        self, module_under_test: str
+    ) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.build_well_known_protected_resource_url") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_request_not_post_method(self) -> Iterator[Mock]:
+        yield Mock()
+
+    @pytest.fixture
+    def mock_request_body(self) -> dict[str, Any]:
+        return {
+            "method": "tools/call",
+            "params": {"name": "tool_name"},
+        }
+
+    @pytest.fixture
+    def mock_request(self, mock_request_body: dict[str, Any]) -> Iterator[Mock]:
+        _request = Mock()
+        _request.method = "POST"
+        _request.body = AsyncMock(return_value=mock_request_body)
+
+        yield _request
+
+    async def test_get_mcp_tool_name(
+        self,
+        mock_request: Mock,
+        mock_request_body: dict[str, Any],
+        mock_json_loads: Mock,
+    ) -> None:
+        mock_json_loads.return_value = mock_request_body
+
+        output = await OAuthMCPToolCallScopeValidationMiddleware.get_mcp_tool_name_in_request(
+            mock_request
+        )
+
+        mock_request.body.assert_called_once_with()
+        mock_json_loads.assert_called_once_with(mock_request.body.return_value)
+        assert output == mock_request_body["params"]["name"]
+
+    async def test_get_mcp_tool_name_return_none_if_not_a_post_method(
+        self,
+        mock_request_not_post_method: Mock,
+    ) -> None:
+        output = await OAuthMCPToolCallScopeValidationMiddleware.get_mcp_tool_name_in_request(
+            mock_request_not_post_method
+        )
+
+        assert output is None
+
+    @pytest.mark.parametrize(
+        "raised_error",
+        [
+            json.JSONDecodeError("Expecting value", "", 0),
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+        ],
+        ids=["JSONDecodeError", "UnicodeDecodeError"],
+    )
+    async def test_get_mcp_tool_name_return_none_if_request_payload_invalid(
+        self,
+        raised_error: json.JSONDecodeError | UnicodeDecodeError,
+        mock_request: Mock,
+        mock_json_loads: Mock,
+    ) -> None:
+        mock_json_loads.side_effect = raised_error
+
+        output = await OAuthMCPToolCallScopeValidationMiddleware.get_mcp_tool_name_in_request(
+            mock_request
+        )
+
+        mock_request.body.assert_called_once_with()
+        assert output is None
+
+    @pytest.mark.parametrize(
+        "json_loads_output",
+        [None, {"method": "tools/not_a_call"}, {"not_a_method": "dafa"}],
+        ids=str,
+    )
+    async def test_get_mcp_tool_name_return_none_if_not_mcp_tool_call(
+        self,
+        json_loads_output: dict[str, Any],
+        mock_request: Mock,
+        mock_json_loads: Mock,
+    ) -> None:
+        mock_json_loads.return_value = json_loads_output
+
+        output = await OAuthMCPToolCallScopeValidationMiddleware.get_mcp_tool_name_in_request(
+            mock_request,
+        )
+
+        assert output is None
+
+    @pytest.mark.parametrize(
+        "params_in_request",
+        [None, {"not_a_name": "dafa"}],
+        ids=str,
+    )
+    async def test_get_mcp_tool_name_return_none_if_no_name_in_request_payload(
+        self,
+        params_in_request: dict[str, Any],
+        mock_request: Mock,
+        mock_json_loads: Mock,
+    ) -> None:
+        mock_json_loads.return_value = {"params": params_in_request}
+
+        output = await OAuthMCPToolCallScopeValidationMiddleware.get_mcp_tool_name_in_request(
+            mock_request,
+        )
+
+        assert output is None
+
+    async def test_run_claim_validation_succeeds(
+        self,
+        mock_get_user_from_request_scope: Mock,
+        mock_jwt_token_claims_validator_cls: Mock,
+        mock_build_well_known_protected_resource_url: Mock,
+        mock_declared_scopes_for_one_tool: Mock,
+        mock_get_mcp_tool_name_in_request: Mock,
+        mock_request: Mock,
+    ) -> None:
+        mock_call_next = AsyncMock()
+        middleware = OAuthMCPToolCallScopeValidationMiddleware(app=Mock())
+
+        await middleware.dispatch(mock_request, mock_call_next)
+
+        mock_get_user_from_request_scope.assert_called_once_with(mock_request)
+        mock_declared_scopes_for_one_tool.assert_called_once_with(
+            mock_request.app.state.fastmcp_server,
+            mock_get_mcp_tool_name_in_request.return_value,
+        )
+        mock_get_user_from_request_scope.assert_called_once_with(mock_request)
+        mock_user = mock_get_user_from_request_scope.return_value
+        mock_jwt_token_claims_validator_cls.assert_called_once_with(mock_user)
+        claim_validator = mock_jwt_token_claims_validator_cls.return_value
+        claim_validator.validate_mcp_tool_scope_claims.assert_called_once_with(
+            mock_declared_scopes_for_one_tool.return_value,
+        )
+
+        mock_call_next.assert_called_once_with(mock_request)
+
+    async def test_skip_validation_if_not_a_valid_mcp_tool_call(
+        self,
+        mock_get_mcp_tool_name_in_request: AsyncMock,
+    ) -> None:
+        mock_get_mcp_tool_name_in_request.return_value = None
+
+        request = Mock()
+        mock_call_next = AsyncMock()
+        middleware = OAuthMCPToolCallScopeValidationMiddleware(app=Mock())
+        await middleware.dispatch(request, mock_call_next)
+
+        mock_get_mcp_tool_name_in_request.assert_called_once_with(request)
+        mock_call_next.assert_called_once_with(request)
+
+    async def test_skip_validation_if_no_registered_scope_found_in_mcp_tool(
+        self,
+        mock_get_mcp_tool_name_in_request: AsyncMock,
+        mock_declared_scopes_for_one_tool: AsyncMock,
+    ) -> None:
+        mock_declared_scopes_for_one_tool.return_value = None
+
+        request = Mock()
+        mock_call_next = AsyncMock()
+        middleware = OAuthMCPToolCallScopeValidationMiddleware(app=Mock())
+        await middleware.dispatch(request, mock_call_next)
+
+        mock_declared_scopes_for_one_tool.assert_called_once_with(
+            request.app.state.fastmcp_server,
+            mock_get_mcp_tool_name_in_request.return_value,
+        )
+        mock_call_next.assert_called_once_with(request)
+
+    @pytest.mark.usefixtures(
+        "mock_get_mcp_tool_name_in_request",
+        "mock_declared_scopes_for_one_tool",
+    )
+    async def test_skip_validation_if_no_user_found_in_request_scope(
+        self,
+        mock_get_user_from_request_scope: Mock,
+    ) -> None:
+        mock_get_user_from_request_scope.return_value = None
+
+        request = Mock()
+        mock_call_next = AsyncMock()
+        middleware = OAuthMCPToolCallScopeValidationMiddleware(app=Mock())
+
+        await middleware.dispatch(request, mock_call_next)
+
+        mock_call_next.assert_called_once_with(request)
+
+    @pytest.mark.usefixtures(
+        "mock_get_mcp_tool_name_in_request",
+    )
+    async def test_run_claim_validation_fails(
+        self,
+        mock_get_user_from_request_scope: Mock,
+        mock_jwt_token_claims_validator_cls: Mock,
+        mock_build_http_response_from_auth_error: Mock,
+        mock_build_well_known_protected_resource_url: Mock,
+        mock_declared_scopes_for_one_tool: AsyncMock,
+        mock_request: Mock,
+    ) -> None:
+        claim_validator = mock_jwt_token_claims_validator_cls.return_value
+        expected_error_message = "dasfdaw"
+        claim_validator.validate_mcp_tool_scope_claims.side_effect = (
+            MCPToolScopeClaimValidationError(expected_error_message)
+        )
+        expected_scopes = ["scope"]
+        mock_declared_scopes_for_one_tool.return_value = expected_scopes
+
+        mock_call_next = AsyncMock()
+        middleware = OAuthMCPToolCallScopeValidationMiddleware(app=Mock())
+        await middleware.dispatch(mock_request, mock_call_next)
+
+        mock_get_user_from_request_scope.assert_called_once_with(mock_request)
+        mock_user = mock_get_user_from_request_scope.return_value
+        mock_jwt_token_claims_validator_cls.assert_called_once_with(mock_user)
+        mock_build_http_response_from_auth_error.assert_called_once_with(
+            status_code=HTTPStatus.FORBIDDEN,
+            auth_error_response=AuthErrorResponse(
+                resource_metadata=mock_build_well_known_protected_resource_url.return_value,
+                error_code=ErrorCodeInAuthErrorResponse.INSUFFICIENT_SCOPE,
+                error_description=expected_error_message,
+                scopes=sorted(expected_scopes),
+            ),
+        )
+
         mock_call_next.assert_not_called()

--- a/tests/drmcp/unit/core/test_middleware.py
+++ b/tests/drmcp/unit/core/test_middleware.py
@@ -232,7 +232,11 @@ class TestOAuthJWTTokenHandlerMiddleware:
         client = TestClient(mock_app())
         response = client.get("/")
 
-        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert response.json() == {
+            "error": ErrorCodeInAuthErrorResponse.INVALID_TOKEN.to_value(),
+            "error_description": "Invalid JWT token.",
+        }
         mock_parse_to_access_token.assert_called_once_with(
             OAuthJWTTokenHandlerMiddleware.HTTP_HEADER_TO_VALIDATE,
             ANY,

--- a/tests/drmcp/unit/test_dr_mcp_server.py
+++ b/tests/drmcp/unit/test_dr_mcp_server.py
@@ -27,6 +27,7 @@ from datarobot_genai.drmcp.core.mcp_instance import DataRobotMCP
 from datarobot_genai.drmcp.core.mcp_instance import mcp
 from datarobot_genai.drmcp.core.middleware import GeneralOAuthClaimValidationMiddleware
 from datarobot_genai.drmcp.core.middleware import OAuthJWTTokenHandlerMiddleware
+from datarobot_genai.drmcp.core.middleware import OAuthMCPToolCallScopeValidationMiddleware
 from datarobot_genai.drmcp.core.telemetry import OtelASGIMiddleware
 from datarobot_genai.drmcpbase.dynamic_tools.deployment.adapters.default import Metadata
 from datarobot_genai.drmcputils.routes import TrailingSlashNormalizer
@@ -432,6 +433,7 @@ class TestDataRobotMCPServer:
             TrailingSlashNormalizer,
             OAuthJWTTokenHandlerMiddleware,
             GeneralOAuthClaimValidationMiddleware,
+            OAuthMCPToolCallScopeValidationMiddleware,
             RequestHeadersMiddleware,
             OtelASGIMiddleware,
         ]

--- a/tests/drmcpbase/unit/auth/test_jwt.py
+++ b/tests/drmcpbase/unit/auth/test_jwt.py
@@ -21,6 +21,7 @@ import pytest
 from fastmcp.server.auth import AccessToken
 
 from datarobot_genai.drmcpbase.auth.exceptions import AudienceClaimValidationError
+from datarobot_genai.drmcpbase.auth.exceptions import MCPToolScopeClaimValidationError
 from datarobot_genai.drmcpbase.auth.jwt import AuthorizationClaims
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenClaimsValidator
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenHandler
@@ -41,6 +42,7 @@ class TestAuthorizationClaims:
         )
         claims = AuthorizationClaims.from_access_token(access_token)
         assert claims.audience == "audience"
+        assert claims.scopes == frozenset(["scope"])
 
     @pytest.mark.parametrize(
         "claim, is_none",
@@ -99,6 +101,41 @@ class TestAuthorizationClaims:
         )
         claims = AuthorizationClaims.from_access_token(access_token)
         assert claims.contain_expected_audience("expected_aud") is contain_expected_audience
+
+    @pytest.mark.parametrize(
+        "scopes, has_scope",
+        [(["dsafa"], True), ([], False)],
+        ids=str,
+    )
+    def test_has_scope_claims(self, scopes: list[str], has_scope: bool) -> None:
+        access_token = AccessToken(
+            token="token",
+            client_id="client_id",
+            scopes=scopes,
+            claims={},
+        )
+        claims = AuthorizationClaims.from_access_token(access_token)
+        assert claims.has_scope_claims() is has_scope
+
+    @pytest.mark.parametrize(
+        "expected_scopes, is_subset_of_expected_scopes",
+        [
+            (frozenset(["expected_scope_one"]), True),
+            (frozenset(["expected_scope_one", "expected_scope_two"]), True),
+            (frozenset([]), True),
+            (frozenset(["expected_scope_unknown"]), False),
+        ],
+        ids=str,
+    )
+    def test_are_expected_scopes_subset_of_scope_claims(
+        self, expected_scopes: frozenset[str], is_subset_of_expected_scopes
+    ) -> None:
+        scope_claims = ["expected_scope_one", "expected_scope_two"]
+        authorization_claims = AuthorizationClaims(scopes=frozenset(scope_claims))
+        assert (
+            authorization_claims.are_expected_scopes_subset_of_scope_claims(expected_scopes)
+            is is_subset_of_expected_scopes
+        )
 
 
 class TestJWTTokenHandler:
@@ -437,6 +474,7 @@ class TestJWTTokenClaimsValidator:
     ) -> None:
         audience_value = "expected-aud"
         mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=frozenset(),
             audience=audience_value,
         )
 
@@ -450,6 +488,7 @@ class TestJWTTokenClaimsValidator:
         mock_logger: Mock,
     ) -> None:
         mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=frozenset(),
             audience="expected-aud",
         )
 
@@ -465,6 +504,7 @@ class TestJWTTokenClaimsValidator:
         mock_authorization_claims_from_access_token: Mock,
     ) -> None:
         mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=frozenset(),
             audience="other-aud",
         )
 
@@ -477,9 +517,70 @@ class TestJWTTokenClaimsValidator:
         mock_authorization_claims_from_access_token: Mock,
     ) -> None:
         mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=frozenset(),
             audience=None,
         )
 
         validator = JWTTokenClaimsValidator(Mock())
         with pytest.raises(AudienceClaimValidationError):
             validator.validate_audience_claim(ANY)
+
+    def test_validate_mcp_tool_scope_claim_passes(
+        self,
+        mock_authorization_claims_from_access_token: Mock,
+        mock_logger: Mock,
+    ) -> None:
+        expected_scope_value = frozenset(["expected-scope"])
+        mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=expected_scope_value,
+        )
+
+        validator = JWTTokenClaimsValidator(Mock())
+        validator.validate_mcp_tool_scope_claims(expected_scope_value)
+        mock_logger.info.assert_called_once_with("MCP tool scope claim validation succeeded.")
+
+    @pytest.mark.parametrize("expected_scopes", [frozenset([]), None], ids=str)
+    def test_validate_mcp_tool_scope_claim_ignored_when_no_expected_scope_is_provided(
+        self,
+        expected_scopes: frozenset[str] | None,
+        mock_authorization_claims_from_access_token: Mock,
+        mock_logger: Mock,
+    ) -> None:
+        mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=frozenset(["scope-to-validate"]),
+        )
+
+        validator = JWTTokenClaimsValidator(Mock())
+        validator.validate_mcp_tool_scope_claims(expected_scopes)
+        mock_logger.info.assert_called_once_with(
+            "Authorization MCP tool scope claim validation is not executed. "
+            "There is no expected scope claim provided."
+        )
+
+    def test_validate_mcp_tool_scope_claim_fails_when_scope_mismatches(
+        self,
+        mock_authorization_claims_from_access_token: Mock,
+        mock_logger: Mock,
+    ) -> None:
+        expected_scope_value = frozenset(["expected-scope"])
+        mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=expected_scope_value,
+        )
+
+        validator = JWTTokenClaimsValidator(Mock())
+        with pytest.raises(MCPToolScopeClaimValidationError):
+            scope_to_validate = frozenset(["not-expected-scope"])
+            validator.validate_mcp_tool_scope_claims(scope_to_validate)
+
+    def test_validate_mcp_tool_scope_claim_fails_if_no_valid_claim(
+        self,
+        mock_authorization_claims_from_access_token: Mock,
+    ) -> None:
+        mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
+            scopes=frozenset(),
+            audience=None,
+        )
+
+        validator = JWTTokenClaimsValidator(Mock())
+        with pytest.raises(MCPToolScopeClaimValidationError):
+            validator.validate_mcp_tool_scope_claims(frozenset(["scope-to-validate"]))

--- a/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_entities.py
+++ b/tests/drmcpbase/unit/oauth_protected_resource_metadata/test_entities.py
@@ -13,15 +13,20 @@
 # limitations under the License.
 from dataclasses import dataclass
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD,
 )
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import AuthErrorResponse
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import BaseDataClass
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     CrossApplicationAccessMetadata,
+)
+from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
+    ErrorCodeInAuthErrorResponse,
 )
 from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import (
     MCPOAuthProtectedResourceMetadata,
@@ -329,3 +334,62 @@ class TestMCPOAuthProtectedResourceMetadata:
             "bearer_methods_supported": ["header"],
             "cross_application_access": cross_application_access_in_dict,
         }
+
+
+class TestErrorCodeInAuthErrorResponse:
+    @pytest.mark.parametrize(
+        "error_code",
+        [error_code for error_code in ErrorCodeInAuthErrorResponse],
+        ids=str,
+    )
+    def test_to_value(self, error_code: ErrorCodeInAuthErrorResponse) -> None:
+        error_code_and_value_map = {
+            ErrorCodeInAuthErrorResponse.INVALID_REQUEST: "invalid_request",
+            ErrorCodeInAuthErrorResponse.INVALID_TOKEN: "invalid_token",
+            ErrorCodeInAuthErrorResponse.INSUFFICIENT_SCOPE: "insufficient_scope",
+            ErrorCodeInAuthErrorResponse.UNKNOWN: "unknown",
+        }
+        assert error_code.to_value() == error_code_and_value_map[error_code]
+
+
+class TestAuthErrorResponse:
+    @pytest.mark.parametrize(
+        "scopes_arg, expected_scopes",
+        [(["A", "B"], "A B"), (None, None)],
+        ids=str,
+    )
+    def test_get_scopes_string_representation(
+        self,
+        scopes_arg: list[str] | None,
+        expected_scopes: str | None,
+    ) -> None:
+        assert (
+            AuthErrorResponse(Mock(), scopes=scopes_arg).get_scopes_string_representation()
+            == expected_scopes
+        )
+
+    def test_get_header_name(self) -> None:
+        assert AuthErrorResponse.get_header_name() == "WWW-Authenticate"
+
+    def test_to_header_value(self) -> None:
+        expected_resource_metadata = "resource_metadata"
+        expected_scopes = ["A", "B"]
+        expected_error_description = "error_description"
+        error_response = AuthErrorResponse(
+            resource_metadata=expected_resource_metadata,
+            error_code=ErrorCodeInAuthErrorResponse.INVALID_TOKEN,
+            scopes=expected_scopes,
+            error_description=expected_error_description,
+        )
+        assert error_response.to_header_value() == (
+            'Bearer resource_metadata="resource_metadata", '
+            'scope="A B", error="invalid_token", error_description="error_description"'
+        )
+
+    def test_to_header_value_not_include_error_code_if_unknown(self) -> None:
+        expected_resource_metadata = "resource_metadata"
+        error_response = AuthErrorResponse(
+            resource_metadata=expected_resource_metadata,
+            error_code=ErrorCodeInAuthErrorResponse.UNKNOWN,
+        )
+        assert error_response.to_header_value() == 'Bearer resource_metadata="resource_metadata"'

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.18"
+version = "0.29.19"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE
This PR re-worked some of the MCP scope claim validation logic done during the Hackathon week.

#### AuthZ validation chain design
The scope claim validation was incorporated into the AuthZ chain design I had earlier. which is

```
        Middleware(OAuthJWTTokenHandlerMiddleware),  # parse JWT (no AuthN. But can be extended to AuthN)
        Middleware(GeneralOAuthClaimValidationMiddleware),  # aud claim validation
        Middleware(OAuthMCPToolCallScopeValidationMiddleware), # MCP tool call scope validation
```


#### Run scope validation at the right place
All middleware is based on ASGI middleware at the Starlette level. Why not at the FastMCP middleware level or FastMCP too calling logic (the existing implementation) ? The FastMCP middleware is application level middleware. Any AuthN & AuthZ validation (serving as the guardrail of application) should happen before that. Also based on my code review and testing, the error within FastMCP middleware ends up with a 200 response with error indicator. This doesn't align with the business need that returning 403 error response when AuthZ fails.

#### Return well-known 
I also added the well-known metadata in 403 error response.

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes MCP OAuth authorization behavior (403 contract, audience error shape) and adds JWT scope enforcement on tools/call when claim validation is enabled, which can deny previously accepted tool calls.
> 
> **Overview**
> **MCP OAuth failures now return RFC-style 403 responses** that point clients at protected-resource metadata. Audience validation in `GeneralOAuthClaimValidationMiddleware` no longer uses the generic `ErrorResponse` / 401 path; it builds an `AuthErrorResponse` with **`WWW-Authenticate`** (including `resource_metadata` for `/.well-known/oauth-protected-resource`) and a JSON body with `error` / `error_description` (`invalid_token`).
> 
> **Per-tool OAuth scope enforcement** is added for MCP **`tools/call`** only via new `OAuthMCPToolCallScopeValidationMiddleware` (wired into the Starlette stack after JWT parsing and audience checks). The middleware parses the POST body for `method` + tool name, loads declared scopes from the FastMCP catalog (`declared_scopes_for_one_tool`), and validates JWT scope claims through `JWTTokenClaimsValidator.validate_mcp_tool_scope_claims`; insufficient scope returns **403** with `insufficient_scope` and required scopes in the auth error header/body.
> 
> Supporting changes: `AuthorizationClaims` carries token scopes, new `MCPToolScopeClaimValidationError`, shared helpers (`build_well_known_protected_resource_url`, `build_http_response_from_auth_error`), and version **0.29.15**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d8987c1b451e78c43daecfc96f56ace832d0acc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->