### PR TITLE
[MODEL-24702] Add OAUTH_CLAIM_VALIDATION as MCP deployment env var mod…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
-## 0.29.20
-- `drmcp/core/middleware`: `oauth_claim_validation` is now a pure gate over **every** AuthZ validator, not just the token handler. `should_run_claim_validation` is the single predicate — flag on, path not exempt — and each validator middleware consults it directly rather than relying on an empty request scope to skip it. `OAuthJWTTokenHandlerMiddleware.to_run_jwt_token_handling` is renamed `should_run_jwt_token_handling`.
-- `drmcpbase/auth/jwt.py`: **`validate_audience_claim` now rejects when no expected audience is configured** instead of logging and passing. With the gate on and `mcp_xaa_token_audience` unset the server previously demanded a JWT on every non-exempt route and then accepted any audience on it; those requests now fail closed. Each validator owns whether its own configuration is usable.
+## 0.29.27
+- `drmcp/core/config`: **`oauth_claim_validation` is renamed `mcp_enable_oauth_claim_validation for MCP. The Agent config (oauth_claim_validation) stays the same.
+- `drmcp/core/middleware`: the flag now gates **every** AuthZ validator, not just the token handler. `BaseAuthZMiddleware` applies it once in `dispatch`; subclasses implement `run_authz`.
 
 
 ## 0.29.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
 ## 0.29.20
-- `drmcp/core/config`: **`oauth_claim_validation` now requires `mcp_xaa_token_audience`**  Matches the a2a side.
+- `drmcp/core/middleware`: `oauth_claim_validation` is now a pure gate over **every** AuthZ validator, not just the token handler. `should_run_claim_validation` is the single predicate — flag on, path not exempt — and each validator middleware consults it directly rather than relying on an empty request scope to skip it. `OAuthJWTTokenHandlerMiddleware.to_run_jwt_token_handling` is renamed `should_run_jwt_token_handling`.
+- `drmcpbase/auth/jwt.py`: **`validate_audience_claim` now rejects when no expected audience is configured** instead of logging and passing. With the gate on and `mcp_xaa_token_audience` unset the server previously demanded a JWT on every non-exempt route and then accepted any audience on it; those requests now fail closed. Each validator owns whether its own configuration is usable.
 
 
 ## 0.29.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
+## 0.29.20
+- `drmcp/core/config`: **`oauth_claim_validation` now requires `mcp_xaa_token_audience`**  Matches the a2a side.
 
 
 ## 0.29.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
-## 0.29.27
+## 0.29.28
 - `drmcp/core/config`: **`oauth_claim_validation` is renamed `mcp_enable_oauth_claim_validation for MCP. The Agent config (oauth_claim_validation) stays the same.
 - `drmcp/core/middleware`: the flag now gates **every** AuthZ validator, not just the token handler. `BaseAuthZMiddleware` applies it once in `dispatch`; subclasses implement `run_authz`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.27"
+version = "0.29.28"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.26"
+version = "0.29.27"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -23,6 +23,7 @@ from fastmcp.settings import DuplicateBehavior
 from pydantic import Field
 from pydantic import ValidationInfo
 from pydantic import field_validator
+from pydantic import model_validator
 from pydantic_settings import SettingsConfigDict
 
 from datarobot_genai.drmcputils.constants import DEFAULT_DATAROBOT_ENDPOINT
@@ -326,6 +327,17 @@ class MCPServerConfig(DataRobotAppFrameworkBaseSettings):
         default=False,
         description="Enable OAuth claim validation (e.g., audience, scope)",
     )
+
+    @model_validator(mode="after")
+    def _require_audience_for_claim_validation(self) -> "MCPServerConfig":
+        """Require an audience for claim validation."""
+        if self.oauth_claim_validation and not self.mcp_xaa_token_audience:
+            raise ValueError(
+                "oauth_claim_validation is true but no expected audience is configured. "
+                "Set mcp_xaa_token_audience (MCP_XAA_TOKEN_AUDIENCE), or turn "
+                "oauth_claim_validation off."
+            )
+        return self
 
 
 # Global configuration instance

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -322,7 +322,7 @@ class MCPServerConfig(DataRobotAppFrameworkBaseSettings):
         env_ignore_empty=True,
     )
 
-    oauth_claim_validation: bool = Field(
+    mcp_enable_oauth_claim_validation: bool = Field(
         default=False,
         description="Enable OAuth claim validation (e.g., audience, scope)",
     )

--- a/src/datarobot_genai/drmcp/core/config.py
+++ b/src/datarobot_genai/drmcp/core/config.py
@@ -23,7 +23,6 @@ from fastmcp.settings import DuplicateBehavior
 from pydantic import Field
 from pydantic import ValidationInfo
 from pydantic import field_validator
-from pydantic import model_validator
 from pydantic_settings import SettingsConfigDict
 
 from datarobot_genai.drmcputils.constants import DEFAULT_DATAROBOT_ENDPOINT
@@ -327,17 +326,6 @@ class MCPServerConfig(DataRobotAppFrameworkBaseSettings):
         default=False,
         description="Enable OAuth claim validation (e.g., audience, scope)",
     )
-
-    @model_validator(mode="after")
-    def _require_audience_for_claim_validation(self) -> "MCPServerConfig":
-        """Require an audience for claim validation."""
-        if self.oauth_claim_validation and not self.mcp_xaa_token_audience:
-            raise ValueError(
-                "oauth_claim_validation is true but no expected audience is configured. "
-                "Set mcp_xaa_token_audience (MCP_XAA_TOKEN_AUDIENCE), or turn "
-                "oauth_claim_validation off."
-            )
-        return self
 
 
 # Global configuration instance

--- a/src/datarobot_genai/drmcp/core/middleware.py
+++ b/src/datarobot_genai/drmcp/core/middleware.py
@@ -16,6 +16,8 @@
 
 import json
 import logging
+from abc import ABC
+from abc import abstractmethod
 from enum import Enum
 from enum import auto
 from http import HTTPMethod
@@ -70,10 +72,11 @@ def is_path_exempt_from_oauth_validation(path: str) -> bool:
 def should_run_claim_validation(request: Request) -> bool:
     """Whether the AuthZ validators run for this request.
 
-    ``oauth_claim_validation`` gates all of them; exempt paths never run one.
+    ``mcp_enable_oauth_claim_validation`` gates all of them; exempt paths never run one.
     """
-    return get_config().oauth_claim_validation and not is_path_exempt_from_oauth_validation(
-        request.url.path
+    return (
+        get_config().mcp_enable_oauth_claim_validation
+        and not is_path_exempt_from_oauth_validation(request.url.path)
     )
 
 
@@ -144,16 +147,36 @@ def get_user_from_request_scope(request: Request) -> AuthenticatedUser | None:
     return request.scope.get("user")
 
 
-class OAuthJWTTokenHandlerMiddleware(BaseHTTPMiddleware):
+class BaseAuthZMiddleware(BaseHTTPMiddleware, ABC):
+    """Applies the ``mcp_enable_oauth_claim_validation`` gate before any AuthZ work runs.
+
+    Subclasses implement ``run_authz`` and in order not to repeat the gate check, the
+    dispatch method is overridden to call the ``run_authz`` method.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Any,
+    ) -> Response:
+        if not should_run_claim_validation(request):
+            return await call_next(request)
+        return await self.run_authz(request, call_next)
+
+    @abstractmethod
+    async def run_authz(
+        self,
+        request: Request,
+        call_next: Any,
+    ) -> Response: ...
+
+
+class OAuthJWTTokenHandlerMiddleware(BaseAuthZMiddleware):
     """ASGI middleware parsing OAuth JWT token and setting it in request scope.
     The parsed JWT token can be reused in the downstream validation (e.g., audience, tool scope).
     """
 
     HTTP_HEADER_TO_VALIDATE = "x-datarobot-external-access-token"
-
-    @classmethod
-    def should_run_jwt_token_handling(cls, request: Request) -> bool:
-        return should_run_claim_validation(request)
 
     @staticmethod
     def update_scope_with_authenticated_user(
@@ -169,14 +192,11 @@ class OAuthJWTTokenHandlerMiddleware(BaseHTTPMiddleware):
     ) -> None:
         scope["auth"] = AuthCredentials(access_token.scopes)
 
-    async def dispatch(
+    async def run_authz(
         self,
         request: Request,
         call_next: Any,
     ) -> Response:
-        if not self.should_run_jwt_token_handling(request):
-            return await call_next(request)
-
         access_token = JWTTokenHandler.parse_to_access_token(
             self.HTTP_HEADER_TO_VALIDATE,
             request.headers,
@@ -198,7 +218,7 @@ class OAuthJWTTokenHandlerMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-class GeneralOAuthClaimValidationMiddleware(BaseHTTPMiddleware):
+class GeneralOAuthClaimValidationMiddleware(BaseAuthZMiddleware):
     """ASGI middleware validating the audience claim in a JWT token. The naming general in this
     context means claim validations in this middleware is not MCP protocol specific check to be only
     triggerd by a specific MCP protocol (e.g., call a tool).
@@ -211,14 +231,11 @@ class GeneralOAuthClaimValidationMiddleware(BaseHTTPMiddleware):
         mcp_server_config = get_config()
         return mcp_server_config.mcp_xaa_token_audience
 
-    async def dispatch(
+    async def run_authz(
         self,
         request: Request,
         call_next: Any,
     ) -> Response:
-        if not should_run_claim_validation(request):
-            return await call_next(request)
-
         user = get_user_from_request_scope(request)
         if not user:
             return await call_next(request)
@@ -241,7 +258,7 @@ class GeneralOAuthClaimValidationMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-class OAuthMCPToolCallScopeValidationMiddleware(BaseHTTPMiddleware):
+class OAuthMCPToolCallScopeValidationMiddleware(BaseAuthZMiddleware):
     """ASGI middleware validating the scope claim in a JWT token. It is now enforced only on
     ``tools/call`` requests.
     This middleware is expected to be triggered after OAuthJWTTokenHandlerMiddleware which
@@ -264,14 +281,11 @@ class OAuthMCPToolCallScopeValidationMiddleware(BaseHTTPMiddleware):
         name = params.get("name") if isinstance(params, dict) else None
         return name if isinstance(name, str) else None
 
-    async def dispatch(
+    async def run_authz(
         self,
         request: Request,
         call_next: Any,
     ) -> Response:
-        if not should_run_claim_validation(request):
-            return await call_next(request)
-
         mcp_tool_name = await self.get_mcp_tool_name_in_request(request)
         if not mcp_tool_name:
             return await call_next(request)

--- a/src/datarobot_genai/drmcp/core/middleware.py
+++ b/src/datarobot_genai/drmcp/core/middleware.py
@@ -67,6 +67,16 @@ def is_path_exempt_from_oauth_validation(path: str) -> bool:
     return path == health_path or path.startswith(well_known_prefix + "/")
 
 
+def should_run_claim_validation(request: Request) -> bool:
+    """Whether the AuthZ validators run for this request.
+
+    ``oauth_claim_validation`` gates all of them; exempt paths never run one.
+    """
+    return get_config().oauth_claim_validation and not is_path_exempt_from_oauth_validation(
+        request.url.path
+    )
+
+
 def create_oauth_middleware(
     extract_auth_context: AuthContextExtractor | None = None,
 ) -> OAuthMiddleWare:
@@ -142,11 +152,8 @@ class OAuthJWTTokenHandlerMiddleware(BaseHTTPMiddleware):
     HTTP_HEADER_TO_VALIDATE = "x-datarobot-external-access-token"
 
     @classmethod
-    def to_run_jwt_token_handling(cls, request: Request) -> bool:
-        is_oauth_claim_validation_enabled = get_config().oauth_claim_validation
-        return is_oauth_claim_validation_enabled and not is_path_exempt_from_oauth_validation(
-            request.url.path
-        )
+    def should_run_jwt_token_handling(cls, request: Request) -> bool:
+        return should_run_claim_validation(request)
 
     @staticmethod
     def update_scope_with_authenticated_user(
@@ -167,7 +174,7 @@ class OAuthJWTTokenHandlerMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Any,
     ) -> Response:
-        if not self.to_run_jwt_token_handling(request):
+        if not self.should_run_jwt_token_handling(request):
             return await call_next(request)
 
         access_token = JWTTokenHandler.parse_to_access_token(
@@ -209,6 +216,9 @@ class GeneralOAuthClaimValidationMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Any,
     ) -> Response:
+        if not should_run_claim_validation(request):
+            return await call_next(request)
+
         user = get_user_from_request_scope(request)
         if not user:
             return await call_next(request)
@@ -259,6 +269,9 @@ class OAuthMCPToolCallScopeValidationMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Any,
     ) -> Response:
+        if not should_run_claim_validation(request):
+            return await call_next(request)
+
         mcp_tool_name = await self.get_mcp_tool_name_in_request(request)
         if not mcp_tool_name:
             return await call_next(request)

--- a/src/datarobot_genai/drmcpbase/auth/jwt.py
+++ b/src/datarobot_genai/drmcpbase/auth/jwt.py
@@ -144,11 +144,9 @@ class JWTTokenClaimsValidator:
 
     def validate_audience_claim(self, expected_audience_claim: str | None) -> None:
         if expected_audience_claim is None:
-            logger.info(
-                "Authorization audience claim validation is not executed. "
-                "There is no expected audience claim provided."
-            )
-            return
+            error_message = "No expected audience claim is configured."
+            logger.error(error_message)
+            raise AudienceClaimValidationError(error_message)
         if self.claims.audience_is_none():
             error_message = (
                 "Authorization audience claim is not found in the inbound JWT bearer token."

--- a/src/datarobot_genai/drmcpbase/auth/jwt.py
+++ b/src/datarobot_genai/drmcpbase/auth/jwt.py
@@ -145,8 +145,8 @@ class JWTTokenClaimsValidator:
     def validate_audience_claim(self, expected_audience_claim: str | None) -> None:
         if expected_audience_claim is None:
             error_message = "No expected audience claim is configured."
-            logger.error(error_message)
-            raise AudienceClaimValidationError(error_message)
+            logger.warning(error_message)
+            return
         if self.claims.audience_is_none():
             error_message = (
                 "Authorization audience claim is not found in the inbound JWT bearer token."

--- a/tests/drmcp/unit/core/test_middleware.py
+++ b/tests/drmcp/unit/core/test_middleware.py
@@ -34,6 +34,7 @@ from datarobot_genai.drmcp.core.middleware import OAuthJWTTokenHandlerMiddleware
 from datarobot_genai.drmcp.core.middleware import OAuthMCPToolCallScopeValidationMiddleware
 from datarobot_genai.drmcp.core.middleware import build_http_response_from_auth_error
 from datarobot_genai.drmcp.core.middleware import is_path_exempt_from_oauth_validation
+from datarobot_genai.drmcp.core.middleware import should_run_claim_validation
 from datarobot_genai.drmcpbase.auth.exceptions import AudienceClaimValidationError
 from datarobot_genai.drmcpbase.auth.exceptions import MCPToolScopeClaimValidationError
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenClaimsValidator
@@ -133,19 +134,15 @@ class TestOAuthJWTTokenHandlerMiddleware:
             yield mock_func
 
     @pytest.fixture
-    def mock_should_run_jwt_token_handling(self, module_under_test: str) -> Iterator[Mock]:
-        with patch.object(
-            OAuthJWTTokenHandlerMiddleware, "should_run_jwt_token_handling"
-        ) as mock_func:
+    def mock_should_run_claim_validation(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.should_run_claim_validation") as mock_func:
             yield mock_func
 
     @pytest.fixture
-    def mock_should_run_jwt_token_handling_returns_true(
+    def mock_should_run_claim_validation_returns_true(
         self, module_under_test: str
     ) -> Iterator[Mock]:
-        with patch.object(
-            OAuthJWTTokenHandlerMiddleware, "should_run_jwt_token_handling"
-        ) as mock_func:
+        with patch(f"{module_under_test}.should_run_claim_validation") as mock_func:
             mock_func.return_value = True
             yield mock_func
 
@@ -166,35 +163,32 @@ class TestOAuthJWTTokenHandlerMiddleware:
             yield mock_func
 
     @pytest.mark.parametrize(
-        "is_path_exempt_from_validation, is_oauth_validation_enabled, should_run_handling",
+        "is_path_exempt_from_validation, is_oauth_validation_enabled, should_handle_claims",
         [(True, True, False), (True, False, False), (False, False, False), (False, True, True)],
         ids=str,
     )
-    def test_should_run_jwt_token_handling(
+    def test_should_run_claim_validation(
         self,
         is_path_exempt_from_validation: bool,
         is_oauth_validation_enabled: bool,
-        should_run_handling: bool,
+        should_handle_claims: bool,
         mock_get_config: Mock,
         mock_is_path_exempt_from_oauth_validation: Mock,
     ) -> None:
         mock_is_path_exempt_from_oauth_validation.return_value = is_path_exempt_from_validation
         mock_config = mock_get_config.return_value
-        mock_config.oauth_claim_validation = is_oauth_validation_enabled
+        mock_config.mcp_enable_oauth_claim_validation = is_oauth_validation_enabled
 
-        mock_request = Mock()
-        output = OAuthJWTTokenHandlerMiddleware.should_run_jwt_token_handling(mock_request)
-
-        assert output is should_run_handling
+        assert should_run_claim_validation(Mock()) is should_handle_claims
 
     def test_bypass_jwt_token_handling(
         self,
-        mock_should_run_jwt_token_handling: Mock,
+        mock_should_run_claim_validation: Mock,
         mock_parse_to_access_token: Mock,
         mock_update_scope_with_auth_credentials: Mock,
         mock_update_scope_with_authenticated_user: Mock,
     ) -> None:
-        mock_should_run_jwt_token_handling.return_value = False
+        mock_should_run_claim_validation.return_value = False
 
         client = TestClient(mock_app())
         response = client.get("/")
@@ -204,7 +198,7 @@ class TestOAuthJWTTokenHandlerMiddleware:
         mock_update_scope_with_auth_credentials.assert_not_called()
         mock_update_scope_with_authenticated_user.assert_not_called()
 
-    @pytest.mark.usefixtures("mock_should_run_jwt_token_handling_returns_true")
+    @pytest.mark.usefixtures("mock_should_run_claim_validation_returns_true")
     async def test_run_jwt_token_handling(
         self,
         mock_parse_to_access_token: Mock,
@@ -226,7 +220,7 @@ class TestOAuthJWTTokenHandlerMiddleware:
         )
         mock_call_next.assert_called_once_with(request)
 
-    @pytest.mark.usefixtures("mock_should_run_jwt_token_handling_returns_true")
+    @pytest.mark.usefixtures("mock_should_run_claim_validation_returns_true")
     def test_return_error_when_there_is_no_valid_jwt_token(
         self,
         mock_parse_to_access_token: Mock,

--- a/tests/drmcp/unit/core/test_middleware.py
+++ b/tests/drmcp/unit/core/test_middleware.py
@@ -133,13 +133,19 @@ class TestOAuthJWTTokenHandlerMiddleware:
             yield mock_func
 
     @pytest.fixture
-    def mock_to_run_jwt_token_handling(self, module_under_test: str) -> Iterator[Mock]:
-        with patch.object(OAuthJWTTokenHandlerMiddleware, "to_run_jwt_token_handling") as mock_func:
+    def mock_should_run_jwt_token_handling(self, module_under_test: str) -> Iterator[Mock]:
+        with patch.object(
+            OAuthJWTTokenHandlerMiddleware, "should_run_jwt_token_handling"
+        ) as mock_func:
             yield mock_func
 
     @pytest.fixture
-    def mock_to_run_jwt_token_handling_returns_true(self, module_under_test: str) -> Iterator[Mock]:
-        with patch.object(OAuthJWTTokenHandlerMiddleware, "to_run_jwt_token_handling") as mock_func:
+    def mock_should_run_jwt_token_handling_returns_true(
+        self, module_under_test: str
+    ) -> Iterator[Mock]:
+        with patch.object(
+            OAuthJWTTokenHandlerMiddleware, "should_run_jwt_token_handling"
+        ) as mock_func:
             mock_func.return_value = True
             yield mock_func
 
@@ -160,15 +166,15 @@ class TestOAuthJWTTokenHandlerMiddleware:
             yield mock_func
 
     @pytest.mark.parametrize(
-        "is_path_exempt_from_validation, is_oauth_validation_enabled, to_run_jwt_token_handling",
+        "is_path_exempt_from_validation, is_oauth_validation_enabled, should_run_handling",
         [(True, True, False), (True, False, False), (False, False, False), (False, True, True)],
         ids=str,
     )
-    def test_to_run_jwt_token_handling(
+    def test_should_run_jwt_token_handling(
         self,
         is_path_exempt_from_validation: bool,
         is_oauth_validation_enabled: bool,
-        to_run_jwt_token_handling: bool,
+        should_run_handling: bool,
         mock_get_config: Mock,
         mock_is_path_exempt_from_oauth_validation: Mock,
     ) -> None:
@@ -177,18 +183,18 @@ class TestOAuthJWTTokenHandlerMiddleware:
         mock_config.oauth_claim_validation = is_oauth_validation_enabled
 
         mock_request = Mock()
-        output = OAuthJWTTokenHandlerMiddleware.to_run_jwt_token_handling(mock_request)
+        output = OAuthJWTTokenHandlerMiddleware.should_run_jwt_token_handling(mock_request)
 
-        assert output is to_run_jwt_token_handling
+        assert output is should_run_handling
 
     def test_bypass_jwt_token_handling(
         self,
-        mock_to_run_jwt_token_handling: Mock,
+        mock_should_run_jwt_token_handling: Mock,
         mock_parse_to_access_token: Mock,
         mock_update_scope_with_auth_credentials: Mock,
         mock_update_scope_with_authenticated_user: Mock,
     ) -> None:
-        mock_to_run_jwt_token_handling.return_value = False
+        mock_should_run_jwt_token_handling.return_value = False
 
         client = TestClient(mock_app())
         response = client.get("/")
@@ -198,7 +204,7 @@ class TestOAuthJWTTokenHandlerMiddleware:
         mock_update_scope_with_auth_credentials.assert_not_called()
         mock_update_scope_with_authenticated_user.assert_not_called()
 
-    @pytest.mark.usefixtures("mock_to_run_jwt_token_handling_returns_true")
+    @pytest.mark.usefixtures("mock_should_run_jwt_token_handling_returns_true")
     async def test_run_jwt_token_handling(
         self,
         mock_parse_to_access_token: Mock,
@@ -220,7 +226,7 @@ class TestOAuthJWTTokenHandlerMiddleware:
         )
         mock_call_next.assert_called_once_with(request)
 
-    @pytest.mark.usefixtures("mock_to_run_jwt_token_handling_returns_true")
+    @pytest.mark.usefixtures("mock_should_run_jwt_token_handling_returns_true")
     def test_return_error_when_there_is_no_valid_jwt_token(
         self,
         mock_parse_to_access_token: Mock,
@@ -246,6 +252,12 @@ class TestOAuthJWTTokenHandlerMiddleware:
 
 
 class TestGeneralOAuthClaimValidationMiddleware:
+    @pytest.fixture(autouse=True)
+    def mock_should_run_claim_validation(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.should_run_claim_validation") as mock_func:
+            mock_func.return_value = True
+            yield mock_func
+
     @pytest.fixture
     def mock_get_config(self, module_under_test: str) -> Iterator[Mock]:
         with patch(f"{module_under_test}.get_config") as mock_func:
@@ -277,6 +289,24 @@ class TestGeneralOAuthClaimValidationMiddleware:
 
         mock_get_config.assert_called_once_with()
         assert output == mock_get_config.return_value.mcp_xaa_token_audience
+
+    async def test_skip_claim_validation_if_the_gate_is_off(
+        self,
+        mock_should_run_claim_validation: Mock,
+        mock_get_user_from_request_scope: Mock,
+        mock_jwt_token_claims_validator_cls: Mock,
+    ) -> None:
+        """OAUTH_CLAIM_VALIDATION gates this validator, not only the token handler."""
+        mock_should_run_claim_validation.return_value = False
+
+        request = Mock()
+        mock_call_next = AsyncMock()
+        middleware = GeneralOAuthClaimValidationMiddleware(app=Mock())
+        await middleware.dispatch(request, mock_call_next)
+
+        mock_get_user_from_request_scope.assert_not_called()
+        mock_jwt_token_claims_validator_cls.assert_not_called()
+        mock_call_next.assert_called_once_with(request)
 
     async def test_skip_claim_validation_if_no_user_to_validate_in_inbound_request(
         self,
@@ -350,6 +380,12 @@ class TestGeneralOAuthClaimValidationMiddleware:
 
 
 class TestOAuthMCPToolCallScopeValidationMiddleware:
+    @pytest.fixture(autouse=True)
+    def mock_should_run_claim_validation(self, module_under_test: str) -> Iterator[Mock]:
+        with patch(f"{module_under_test}.should_run_claim_validation") as mock_func:
+            mock_func.return_value = True
+            yield mock_func
+
     @pytest.fixture
     def mock_json_loads(self) -> Iterator[Mock]:
         with patch.object(json, "loads") as mock_func:
@@ -547,6 +583,22 @@ class TestOAuthMCPToolCallScopeValidationMiddleware:
             request.app.state.fastmcp_server,
             mock_get_mcp_tool_name_in_request.return_value,
         )
+        mock_call_next.assert_called_once_with(request)
+
+    async def test_skip_validation_if_the_gate_is_off(
+        self,
+        mock_should_run_claim_validation: Mock,
+        mock_get_mcp_tool_name_in_request: AsyncMock,
+    ) -> None:
+        """OAUTH_CLAIM_VALIDATION gates this validator, not only the token handler."""
+        mock_should_run_claim_validation.return_value = False
+
+        request = Mock()
+        mock_call_next = AsyncMock()
+        middleware = OAuthMCPToolCallScopeValidationMiddleware(app=Mock())
+        await middleware.dispatch(request, mock_call_next)
+
+        mock_get_mcp_tool_name_in_request.assert_not_called()
         mock_call_next.assert_called_once_with(request)
 
     @pytest.mark.usefixtures(

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -19,6 +19,7 @@ from typing import get_args
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from datarobot_genai.drmcp.core import config as config_module
 from datarobot_genai.drmcp.core.config import MCPServerConfig
@@ -485,6 +486,48 @@ class TestMCPCLIConfigs:
             assert config.tool_config.enable_files_api_tools is True
             assert config.tool_config.enable_workload_tools is False
             self._reset_config()
+
+
+class TestOAuthClaimValidation:
+    """The flag is refused without the audience it would enforce."""
+
+    @staticmethod
+    def _build(env: dict[str, str]) -> MCPServerConfig:
+        with patch.dict(os.environ, env, clear=True):
+            config_module._config = None
+            try:
+                return MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
+            finally:
+                config_module._config = None
+
+    def test_defaults_to_off(self) -> None:
+        assert self._build({}).oauth_claim_validation is False
+
+    def test_off_without_an_audience_is_valid(self) -> None:
+        assert self._build({"OAUTH_CLAIM_VALIDATION": "false"}).oauth_claim_validation is False
+
+    def test_on_with_an_audience_is_valid(self) -> None:
+        config = self._build(
+            {
+                "OAUTH_CLAIM_VALIDATION": "true",
+                "MCP_XAA_TOKEN_AUDIENCE": "https://mcp.example.com",
+            }
+        )
+
+        assert config.oauth_claim_validation is True
+        assert config.mcp_xaa_token_audience == "https://mcp.example.com"
+
+    def test_on_without_an_audience_is_refused(self) -> None:
+        """Otherwise every non-exempt route demands a JWT and validates nothing on it."""
+        with pytest.raises(ValidationError, match="oauth_claim_validation is true"):
+            self._build({"OAUTH_CLAIM_VALIDATION": "true"})
+
+    def test_on_via_runtime_parameter_is_refused_too(self) -> None:
+        """The deployment path sets it as MLOPS_RUNTIME_PARAM_, not a plain env var."""
+        with pytest.raises(ValidationError, match="oauth_claim_validation is true"):
+            self._build(
+                {"MLOPS_RUNTIME_PARAM_OAUTH_CLAIM_VALIDATION": '{"type":"boolean","payload":true}'}
+            )
 
 
 class TestOtelStandardFields:

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -19,7 +19,6 @@ from typing import get_args
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
 
 from datarobot_genai.drmcp.core import config as config_module
 from datarobot_genai.drmcp.core.config import MCPServerConfig
@@ -487,47 +486,6 @@ class TestMCPCLIConfigs:
             assert config.tool_config.enable_workload_tools is False
             self._reset_config()
 
-
-class TestOAuthClaimValidation:
-    """The flag is refused without the audience it would enforce."""
-
-    @staticmethod
-    def _build(env: dict[str, str]) -> MCPServerConfig:
-        with patch.dict(os.environ, env, clear=True):
-            config_module._config = None
-            try:
-                return MCPServerConfig(_env_file=None, tool_config=MCPToolConfig(_env_file=None))
-            finally:
-                config_module._config = None
-
-    def test_defaults_to_off(self) -> None:
-        assert self._build({}).oauth_claim_validation is False
-
-    def test_off_without_an_audience_is_valid(self) -> None:
-        assert self._build({"OAUTH_CLAIM_VALIDATION": "false"}).oauth_claim_validation is False
-
-    def test_on_with_an_audience_is_valid(self) -> None:
-        config = self._build(
-            {
-                "OAUTH_CLAIM_VALIDATION": "true",
-                "MCP_XAA_TOKEN_AUDIENCE": "https://mcp.example.com",
-            }
-        )
-
-        assert config.oauth_claim_validation is True
-        assert config.mcp_xaa_token_audience == "https://mcp.example.com"
-
-    def test_on_without_an_audience_is_refused(self) -> None:
-        """Otherwise every non-exempt route demands a JWT and validates nothing on it."""
-        with pytest.raises(ValidationError, match="oauth_claim_validation is true"):
-            self._build({"OAUTH_CLAIM_VALIDATION": "true"})
-
-    def test_on_via_runtime_parameter_is_refused_too(self) -> None:
-        """The deployment path sets it as MLOPS_RUNTIME_PARAM_, not a plain env var."""
-        with pytest.raises(ValidationError, match="oauth_claim_validation is true"):
-            self._build(
-                {"MLOPS_RUNTIME_PARAM_OAUTH_CLAIM_VALIDATION": '{"type":"boolean","payload":true}'}
-            )
 
 
 class TestOtelStandardFields:

--- a/tests/drmcp/unit/test_config.py
+++ b/tests/drmcp/unit/test_config.py
@@ -487,7 +487,6 @@ class TestMCPCLIConfigs:
             self._reset_config()
 
 
-
 class TestOtelStandardFields:
     """Test standard OTel env var fields on MCPServerConfig."""
 

--- a/tests/drmcpbase/unit/auth/test_jwt.py
+++ b/tests/drmcpbase/unit/auth/test_jwt.py
@@ -482,22 +482,20 @@ class TestJWTTokenClaimsValidator:
         validator.validate_audience_claim(audience_value)
         mock_logger.info.assert_called_once_with("Audience claim validation succeeded.")
 
-    def test_validate_audience_claim_fails_when_no_expected_audience_is_configured(
+    def test_validate_audience_claim_is_skipped_when_no_expected_audience_is_configured(
         self,
         mock_authorization_claims_from_access_token: Mock,
         mock_logger: Mock,
     ) -> None:
-        """The gate asked for validation, so an unconfigured audience fails closed."""
         mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
             scopes=frozenset(),
             audience="expected-aud",
         )
 
         validator = JWTTokenClaimsValidator(Mock())
-        with pytest.raises(
-            AudienceClaimValidationError, match="No expected audience claim is configured."
-        ):
-            validator.validate_audience_claim(None)
+        validator.validate_audience_claim(None)
+
+        mock_logger.warning.assert_called_once_with("No expected audience claim is configured.")
 
     def test_validate_audience_claim_fails_when_audience_mismatches(
         self,

--- a/tests/drmcpbase/unit/auth/test_jwt.py
+++ b/tests/drmcpbase/unit/auth/test_jwt.py
@@ -482,22 +482,22 @@ class TestJWTTokenClaimsValidator:
         validator.validate_audience_claim(audience_value)
         mock_logger.info.assert_called_once_with("Audience claim validation succeeded.")
 
-    def test_validate_audience_claim_ignored_when_no_expected_audience_is_provided(
+    def test_validate_audience_claim_fails_when_no_expected_audience_is_configured(
         self,
         mock_authorization_claims_from_access_token: Mock,
         mock_logger: Mock,
     ) -> None:
+        """The gate asked for validation, so an unconfigured audience fails closed."""
         mock_authorization_claims_from_access_token.return_value = AuthorizationClaims(
             scopes=frozenset(),
             audience="expected-aud",
         )
 
         validator = JWTTokenClaimsValidator(Mock())
-        validator.validate_audience_claim(None)
-        mock_logger.info.assert_called_once_with(
-            "Authorization audience claim validation is not executed. "
-            "There is no expected audience claim provided."
-        )
+        with pytest.raises(
+            AudienceClaimValidationError, match="No expected audience claim is configured."
+        ):
+            validator.validate_audience_claim(None)
 
     def test_validate_audience_claim_fails_when_audience_mismatches(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.26"
+version = "0.29.27"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.27"
+version = "0.29.28"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION

<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
OAuth claim validation is now one shared gate (should_run_claim_validation) for JWT parsing, audience checks, and MCP tool-scope checks—not only the JWT handler. Audience and scope middleware skip entirely when the flag is off or the path is exempt; they no longer depend on an empty request scope. The JWT handler predicate is renamed to should_run_jwt_token_handling and delegates to that gate.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and authorization middleware on MCP routes; enabling claim validation without a configured audience now rejects traffic that previously passed audience checks.
> 
> **Overview**
> **OAuth claim validation** is now one shared gate (`should_run_claim_validation`) for JWT parsing, audience checks, and MCP tool-scope checks—not only the JWT handler. Audience and scope middleware skip entirely when the flag is off or the path is exempt; they no longer depend on an empty request scope. The JWT handler predicate is renamed to `should_run_jwt_token_handling` and delegates to that gate.
> 
> **Audience validation fails closed** when `mcp_xaa_token_audience` is unset: `validate_audience_claim` raises instead of logging and passing. With `oauth_claim_validation` enabled, non-exempt routes previously required a JWT but accepted any `aud`; those calls now get a forbidden/validation error until audience is configured.
> 
> Release **0.29.20** (changelog, lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7fac7682e523ca0567af0fbc2030515fc483954. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->