### PR TITLE
[BUZZOK-32163] Send moderation OTel metrics from dragent agents in workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.15
+- `dragent`: **moderation OTel metrics (`datarobot.moderations.*`) now export from agents running as DataRobot Workloads.** Set `OTEL_EXPORTER_OTLP_ENDPOINT` to the `<host>/otel` base and `instrument()` installs a global OTel `MeterProvider` in hosted runtimes; metrics attribute to `workload-<id>` or `deployment-<id>` (deployment wins when both are set). Previously no `MeterProvider` was ever installed, so `datarobot_dome`'s guardrail instruments recorded into the default no-op proxy and nothing left the process — dead in deployments too, masked there by the deployment-only custom-metrics path. DataRobot custom metrics remain deployment-only; `datarobot_dome` has no workload equivalent.
+- `docs/src/dragent/tracing.md`: added a moderation-metrics section, documented `WORKLOAD_ID` in the entity-id fallback table, and replaced the `datarobot_api_key` / `datarobot_entity_id` `workflow.yaml` fields — which no longer exist on `DataRobotOtelCollectorTelemetryExporter` — with a description of the headers they used to set and how to override them.
+
 ## 0.29.14 - 2026-08-31
 - Raise the `nltk` floor from `>=3.10.0` to `>=3.10.2`.
 

--- a/docs/src/dragent/tracing.md
+++ b/docs/src/dragent/tracing.md
@@ -49,10 +49,17 @@ Fields:
 |---|---|---|---|
 | `project` | yes | — | OTel `service.name` for spans emitted by this workflow. |
 | `endpoint` | no | `<DATAROBOT_(PUBLIC_)ENDPOINT>/otel/v1/traces` | Full OTLP/HTTP endpoint override. |
-| `datarobot_api_key` | no | `DATAROBOT_API_TOKEN` env var | Sent as the `X-DataRobot-Api-Key` header. |
-| `datarobot_entity_id` | no | `deployment-<MLOPS_DEPLOYMENT_ID>` | Sent as the `X-DataRobot-Entity-Id` header. Non-empty values must keep the `deployment-` prefix. |
 | `extra_headers` | no | `{}` | Additional headers; keys here win on collision with the DataRobot defaults. |
 | `resource_attributes` | no | `{}` | Extra OTel resource attributes; keys here win on collision. |
+
+### Auth and entity headers
+
+The exporter always sends two DataRobot headers. They are **not** `workflow.yaml` fields — the exporter resolves them from the environment on every startup, then merges `extra_headers` over the top, so `extra_headers` is how you override either one.
+
+| Header | Resolved from | Notes |
+|---|---|---|
+| `X-DataRobot-Api-Key` | `DATAROBOT_API_TOKEN` | Omitted (along with the entity header) when the token is missing. |
+| `X-DataRobot-Entity-Id` | `MLOPS_DEPLOYMENT_ID` → `deployment-<id>`, or `WORKLOAD_ID` → `workload-<id>` | Deployment wins when both are set. The `deployment-` / `workload-` prefix is required by the ingest and added for you. Overrides are **not** validated locally, so an unprefixed value is sent as-is and the ingest drops the spans. |
 
 Batch-tuning knobs (`batch_size`, `flush_interval`, `max_queue_size`, etc.) are inherited from NAT's `BatchConfigMixin`; defaults are fine for most agents.
 
@@ -92,7 +99,7 @@ When the OTLP vars are not set, the runtime **falls back** to deriving the endpo
 | Fallback variable | Used for | Missing → |
 |---|---|---|
 | `DATAROBOT_API_TOKEN` | `X-DataRobot-Api-Key` header | Silent no-op; no spans reach DataRobot. |
-| `MLOPS_DEPLOYMENT_ID` | `X-DataRobot-Entity-Id` (auto-prefixed `deployment-<id>`) | Silent no-op; no spans reach DataRobot. |
+| `MLOPS_DEPLOYMENT_ID` **or** `WORKLOAD_ID` | `X-DataRobot-Entity-Id` (auto-prefixed `deployment-<id>` / `workload-<id>`; deployment wins when both are set) | Silent no-op; no spans reach DataRobot. |
 | `DATAROBOT_ENDPOINT` (or `DATAROBOT_PUBLIC_API_ENDPOINT`) | endpoint base; `/otel/v1/traces` appended | Silent no-op; no spans reach DataRobot. |
 
 Two caveats regardless of which path supplies the endpoint/headers:
@@ -124,9 +131,33 @@ after `dr auth login` in that terminal:
 dr xp --entity-id <use-case-id>
 ```
 
+## Moderation metrics
+
+When your agent runs the `datarobot_moderation` middleware, `datarobot_dome` can also export
+guardrail **metrics** over OTel, alongside the spans above. This works for agents running as
+DataRobot **workloads**, not just deployments.
+
+It is opt-in: set `OTEL_EXPORTER_OTLP_ENDPOINT` to the `<host>/otel` base. That single variable
+switches on both halves — `datarobot_dome` creates its OTel metric session, and `instrument()`
+installs the global `MeterProvider` those instruments record into. With the variable unset, both
+stay off and nothing is exported.
+
+| | |
+|---|---|
+| **Turn on with** | `OTEL_EXPORTER_OTLP_ENDPOINT=<host>/otel` (the same base the traces path uses) |
+| **What is exported** | `datarobot.moderations.*` counters, gauges, and histograms — one per guard metric |
+| **Attributed to** | the same entity as spans: `workload-<id>` or `deployment-<id>`, deployment winning when both env vars are set |
+| **Export cadence** | `OTEL_METRIC_EXPORT_INTERVAL` (standard OTel variable; the SDK default is 60s) |
+| **Ingest path** | `<host>/otel/v1/metrics`, appended by the OTLP exporter |
+
+DataRobot **custom metrics** are a separate mechanism and remain deployment-only: they upload
+through a deployment-scoped route that needs `MLOPS_DEPLOYMENT_ID`, and `datarobot_dome` has no
+workload equivalent. In a workload, OTel metrics are the moderation-metrics path.
+
 ## Troubleshooting
 
 - **Data Exploration tab is empty**: Confirm the export is configured — `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` (primary) or the `DATAROBOT_*` fallback. Both span paths silently skip when neither supplies an endpoint and headers.
 - **NAT lifecycle spans appear but framework spans don't**: the framework `instrument()` (e.g. `datarobot_genai.langgraph.telemetry.instrument`) was not called, or was called after the framework imported. Move the call to the top of `register.py`.
 - **Framework or memory spans appear in a separate trace from workflow spans**: confirm `datarobot_otelcollector` is enabled in `workflow.yaml` and `instrument()` is called in `register.py` before the framework imports. The exporter bridges NAT context into the SDK and the bootstrap wraps the global `TracerProvider` so LangChain/LangGraph, HTTP `POST`, and memory spans share the active workflow trace.
-- **`datarobot_entity_id must be of the form 'deployment-<id>'`**: You set `datarobot_entity_id` manually without the `deployment-` prefix. Either add the prefix or omit the field inside a deployment — it auto-derives from `MLOPS_DEPLOYMENT_ID`.
+- **Spans stop arriving after setting `extra_headers`**: an `X-DataRobot-Entity-Id` override must keep the `deployment-` / `workload-` / `experiment_container-` prefix. Nothing validates it locally, so a malformed value fails silently at the ingest.
+- **Moderation metrics don't appear**: `OTEL_EXPORTER_OTLP_ENDPOINT` is not set. Both `datarobot_dome` and the `instrument()` meter-provider bootstrap read that variable and stay off without it — see [Moderation metrics](#moderation-metrics).

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "../" }
 
 [package.metadata]

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -948,7 +948,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/core/telemetry/agent.py
+++ b/src/datarobot_genai/core/telemetry/agent.py
@@ -48,8 +48,9 @@ def _instrument_http_clients() -> None:
     try:
         requests_module = importlib.import_module("opentelemetry.instrumentation.requests")
         requests_instrumentor = getattr(requests_module, "RequestsInstrumentor")
-        # Don't trace the OTel exporter's own POST to the collector
-        requests_instrumentor().instrument(excluded_urls="otel/v1/traces")
+        # Don't trace the OTel exporters' own POSTs to the collector — the span
+        # exporter's and the metric exporter's, both of which go through requests.
+        requests_instrumentor().instrument(excluded_urls="otel/v1/traces,otel/v1/metrics")
     except Exception as e:
         logger.debug(f"requests instrumentation skipped: {e}")
     try:

--- a/src/datarobot_genai/core/telemetry/agent.py
+++ b/src/datarobot_genai/core/telemetry/agent.py
@@ -106,9 +106,16 @@ def instrument() -> None:
     # (via setup_otel_env_variables) are not double-bootstrapped. See
     # https://github.com/datarobot/datarobot-user-models/blob/master/public_dropin_environments/python311_genai_agents/run_agent.py#L188
     if is_hosted_runtime():
+        from .datarobot_otel import bootstrap_otel_metrics_provider_for_datarobot
         from .datarobot_otel import bootstrap_otel_provider_for_datarobot
 
         bootstrap_otel_provider_for_datarobot()
+
+        # Must run before datarobot_dome builds its pipeline: OtelMetricSession
+        # captures get_meter_provider() at construction and binds force_flush to a
+        # no-op when the provider has none. instrument() runs at register.py import
+        # time and the middleware builds the pipeline later, so this already holds.
+        bootstrap_otel_metrics_provider_for_datarobot()
 
     _instrument_threading()
     _instrument_http_clients()

--- a/src/datarobot_genai/core/telemetry/datarobot_otel.py
+++ b/src/datarobot_genai/core/telemetry/datarobot_otel.py
@@ -26,6 +26,8 @@ the framework-instrumentor bootstrap (``datarobot_genai.core.telemetry.agent``):
 * ``bootstrap_otel_provider_for_datarobot`` — install a global OTel SDK
   ``TracerProvider`` pointed at the DataRobot ingest so framework
   auto-instrumentors actually export spans.
+* ``bootstrap_otel_metrics_provider_for_datarobot`` — the same for a
+  ``MeterProvider``, so ``datarobot_dome``'s moderation instruments export.
 """
 
 from __future__ import annotations
@@ -48,6 +50,10 @@ logger = logging.getLogger(__name__)
 # process — short-circuit on this flag and don't trip OTel's "overriding"
 # warning.
 _BOOTSTRAP_STATE: dict[str, bool] = {"installed": False}
+
+# Same, for the metrics bootstrap. Separate flag: the two have different
+# preconditions, so a skip on one must not block the other.
+_METRICS_BOOTSTRAP_STATE: dict[str, bool] = {"installed": False}
 
 # The DataRobot OTel ingest expects entity ids (and deployment-derived service
 # names) in the ``deployment-<id>`` or ``workload-<id>`` shape. Single source
@@ -271,6 +277,83 @@ def bootstrap_otel_provider_for_datarobot() -> bool:
         "DataRobot OTel span processor %s → %s (entity_id=%s)",
         action,
         endpoint,
+        lower_headers.get("x-datarobot-entity-id", ""),
+    )
+    return True
+
+
+def bootstrap_otel_metrics_provider_for_datarobot() -> bool:
+    """Install a global OTel MeterProvider so moderation metrics reach DataRobot.
+
+    The metrics counterpart to bootstrap_otel_provider_for_datarobot. datarobot_dome
+    builds its guardrail instruments from the global meter provider, which dragent never
+    installed, so everything they recorded was quietly dropped.
+
+    Metrics are opt-in through OTEL_EXPORTER_OTLP_ENDPOINT — the same variable
+    dome checks before creating its metric session, so the two switch on together. They
+    are attributed to whichever entity the agent runs as, a workload or a deployment,
+    preferring the deployment when both are set.
+
+    Returns False, logging the reason, when credentials or an endpoint are missing, when
+    another MeterProvider is already installed, when it has already run, or when setup
+    failed.
+    """
+    # Not datarobot_opentelemetry.integrations.configure(), which does the same thing for
+    # metrics but also for traces and logs, with no way to ask for one signal. It would add
+    # a second span processor to the provider the tracer bootstrap just installed, so every
+    # span would export twice, and it would ship all agent logs to DataRobot as well.
+    if _METRICS_BOOTSTRAP_STATE["installed"]:
+        return False
+
+    # Opt-in switch; also stops the exporter falling back to its localhost default.
+    if not os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        logger.info(
+            "Skipping OTel MeterProvider bootstrap: OTEL_EXPORTER_OTLP_ENDPOINT "
+            "not set. Moderation metrics are opt-in."
+        )
+        return False
+
+    headers = resolve_datarobot_headers_from_env()
+    if not headers:
+        logger.info(
+            "Skipping OTel MeterProvider bootstrap: DataRobot auth/entity headers "
+            "not resolvable (MLOPS_DEPLOYMENT_ID or WORKLOAD_ID / DATAROBOT_API_TOKEN)."
+        )
+        return False
+
+    # Imported lazily, matching the tracer bootstrap above.
+    from opentelemetry import metrics
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    try:
+        # Check the slot before building anything: the reader spawns a ticker thread
+        # at construction, so it must not be built on the skip path.
+        if isinstance(metrics.get_meter_provider(), MeterProvider):
+            logger.debug(
+                "Skipping OTel MeterProvider bootstrap: an SDK MeterProvider is "
+                "already installed; OTel does not allow overriding it."
+            )
+            return False
+
+        # No endpoint kwarg: standard OTLP resolution appends /v1/metrics to the
+        # <host>/otel base, landing on the DataRobot ingest path.
+        exporter = OTLPMetricExporter(headers=headers)
+        # No export_interval_millis — OTEL_METRIC_EXPORT_INTERVAL governs cadence.
+        reader = PeriodicExportingMetricReader(exporter)
+        resource = Resource.create({"service.name": _resolve_service_name()})
+        metrics.set_meter_provider(MeterProvider(metric_readers=[reader], resource=resource))
+    except Exception:
+        # Never let telemetry setup take down the agent.
+        logger.exception("Failed to bootstrap DataRobot OTel MeterProvider")
+        return False
+
+    _METRICS_BOOTSTRAP_STATE["installed"] = True
+    lower_headers = {k.lower(): v for k, v in headers.items()}
+    logger.info(
+        "DataRobot OTel MeterProvider installed (entity_id=%s)",
         lower_headers.get("x-datarobot-entity-id", ""),
     )
     return True

--- a/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_otelcollector.py
@@ -38,8 +38,10 @@ Inside a DataRobot deployment, the minimal ``workflow.yaml`` is::
           _type: datarobot_otelcollector
           project: "agent"
 
-Explicit overrides for any of the three auto-derived fields are honored —
-pin them in ``workflow.yaml`` to point at a non-default collector.
+``endpoint`` is the only auto-derived field; pin it in ``workflow.yaml`` to
+point at a non-default collector. Auth and entity headers are resolved from the
+environment by the factory below and merged with ``extra_headers``, which wins
+on collision.
 """
 
 from __future__ import annotations

--- a/tests/core/test_datarobot_otel.py
+++ b/tests/core/test_datarobot_otel.py
@@ -15,7 +15,10 @@
 from __future__ import annotations
 
 import pytest
+from opentelemetry import metrics
 from opentelemetry import trace
+from opentelemetry.metrics._internal import _ProxyMeterProvider
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace import ProxyTracerProvider
 from opentelemetry.util._once import Once
@@ -31,6 +34,7 @@ _ENV_VARS = (
     "DATAROBOT_PUBLIC_API_ENDPOINT",
     "OTEL_SERVICE_NAME",
     "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
     "OTEL_EXPORTER_OTLP_HEADERS",
 )
 
@@ -46,6 +50,35 @@ def clean_env(monkeypatch):
     monkeypatch.setattr("opentelemetry.trace._TRACER_PROVIDER_SET_ONCE", Once())
     monkeypatch.setitem(datarobot_otel._BOOTSTRAP_STATE, "installed", False)
     return monkeypatch
+
+
+@pytest.fixture
+def clean_metrics_env(clean_env):
+    """clean_env plus a fresh global MeterProvider slot.
+
+    Unlike traces, the metrics globals live in opentelemetry.metrics._internal rather
+    than on the package itself, so patching opentelemetry.metrics._METER_PROVIDER would
+    raise AttributeError.
+    """
+    clean_env.setattr("opentelemetry.metrics._internal._METER_PROVIDER", None)
+    clean_env.setattr("opentelemetry.metrics._internal._METER_PROVIDER_SET_ONCE", Once())
+    # set_meter_provider also caches the provider on the module-level proxy, which
+    # outlives the test. Swap in a throwaway so the real one never sees a provider
+    # this test shuts down — otherwise later get_meter() calls return a NoOpMeter.
+    clean_env.setattr(
+        "opentelemetry.metrics._internal._PROXY_METER_PROVIDER", _ProxyMeterProvider()
+    )
+    clean_env.setitem(datarobot_otel._METRICS_BOOTSTRAP_STATE, "installed", False)
+    # A PeriodicExportingMetricReader ticks on a background thread and registers
+    # an atexit flush. Push the interval past any plausible test-suite runtime
+    # and shut the provider down afterwards so neither fires.
+    clean_env.setenv("OTEL_METRIC_EXPORT_INTERVAL", "600000")
+
+    yield clean_env
+
+    installed = metrics._internal._METER_PROVIDER
+    if isinstance(installed, SdkMeterProvider):
+        installed.shutdown()
 
 
 class TestEnvResolvers:
@@ -368,3 +401,158 @@ class TestBootstrapOtelProvider:
         self._set_full_env(clean_env)
         assert datarobot_otel.bootstrap_otel_provider_for_datarobot() is False
         assert trace.get_tracer_provider() is third_party
+
+
+class TestBootstrapOtelMetricsProvider:
+    @staticmethod
+    def _set_full_env(monkeypatch):
+        monkeypatch.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
+        monkeypatch.setenv("DATAROBOT_API_TOKEN", "tok")
+        monkeypatch.setenv("DATAROBOT_ENDPOINT", "https://example.test/api/v2")
+
+    @staticmethod
+    def _spy_exporter(monkeypatch):
+        # The import is local inside the bootstrap function, so the symbol doesn't
+        # exist at module level. Patch it on the source module instead.
+        from opentelemetry.exporter.otlp.proto.http import metric_exporter as exporter_module
+
+        real_exporter_cls = exporter_module.OTLPMetricExporter
+        captured: dict = {}
+
+        def spy(**kwargs):
+            captured.update(kwargs)
+            exporter = real_exporter_cls(**kwargs)
+            captured["_exporter"] = exporter
+            return exporter
+
+        monkeypatch.setattr(exporter_module, "OTLPMetricExporter", spy)
+        return captured
+
+    def test_skips_when_no_otlp_endpoint(self, clean_metrics_env):
+        # The opt-in contract: a fully configured DataRobot env is NOT enough.
+        # Without the endpoint var dome creates no metric session to feed us.
+        self._set_full_env(clean_metrics_env)
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is False
+        assert not isinstance(metrics.get_meter_provider(), SdkMeterProvider)
+
+    def test_metrics_specific_endpoint_alone_does_not_satisfy_gate(self, clean_metrics_env):
+        # datarobot_dome only reads OTEL_EXPORTER_OTLP_ENDPOINT, so the signal-specific
+        # variable on its own would give us a provider dome never feeds.
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv(
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "https://example.test/otel/v1/metrics"
+        )
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is False
+        assert not isinstance(metrics.get_meter_provider(), SdkMeterProvider)
+
+    def test_installs_provider_with_workload_env(self, clean_metrics_env):
+        # The case this whole change exists for.
+        captured = self._spy_exporter(clean_metrics_env)
+        clean_metrics_env.setenv("WORKLOAD_ID", "wkl42")
+        clean_metrics_env.setenv("DATAROBOT_API_TOKEN", "tok")
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is True
+
+        provider = metrics.get_meter_provider()
+        assert isinstance(provider, SdkMeterProvider)
+        assert provider._sdk_config.resource.attributes["service.name"] == "workload-wkl42"
+        assert captured["headers"]["X-DataRobot-Api-Key"] == "tok"
+        assert captured["headers"]["X-DataRobot-Entity-Id"] == "workload-wkl42"
+
+    def test_installs_provider_with_deployment_env(self, clean_metrics_env):
+        captured = self._spy_exporter(clean_metrics_env)
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is True
+
+        provider = metrics.get_meter_provider()
+        assert provider._sdk_config.resource.attributes["service.name"] == "deployment-abc123"
+        assert captured["headers"]["X-DataRobot-Entity-Id"] == "deployment-abc123"
+
+    def test_deployment_wins_over_workload(self, clean_metrics_env):
+        captured = self._spy_exporter(clean_metrics_env)
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv("WORKLOAD_ID", "wkl99")
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is True
+        assert captured["headers"]["X-DataRobot-Entity-Id"] == "deployment-abc123"
+
+    def test_no_endpoint_kwarg_passed_to_exporter(self, clean_metrics_env):
+        # Endpoint resolution is delegated to the exporter's standard OTLP
+        # handling: OTEL_EXPORTER_OTLP_ENDPOINT + /v1/metrics, which lands on
+        # the DataRobot ingest's /otel/v1/metrics path.
+        captured = self._spy_exporter(clean_metrics_env)
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is True
+        assert "endpoint" not in captured
+        # ...and that delegation actually lands on the DataRobot ingest path.
+        assert captured["_exporter"]._endpoint == "https://example.test/otel/v1/metrics"
+
+    def test_skips_when_credentials_missing(self, clean_metrics_env):
+        # Endpoint set but no API token: the ingest would reject the export.
+        clean_metrics_env.setenv("WORKLOAD_ID", "wkl42")
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is False
+        assert not isinstance(metrics.get_meter_provider(), SdkMeterProvider)
+
+    def test_skips_when_entity_id_missing(self, clean_metrics_env):
+        clean_metrics_env.setenv("DATAROBOT_API_TOKEN", "tok")
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is False
+
+    def test_idempotent_second_call(self, clean_metrics_env):
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is True
+        provider_first = metrics.get_meter_provider()
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is False
+        assert metrics.get_meter_provider() is provider_first
+
+    def test_exporter_failure_does_not_propagate(self, clean_metrics_env):
+        # Telemetry setup must never take down the agent.
+        from opentelemetry.exporter.otlp.proto.http import metric_exporter as exporter_module
+
+        def boom(**kwargs):
+            raise RuntimeError("exporter is unhappy")
+
+        clean_metrics_env.setattr(exporter_module, "OTLPMetricExporter", boom)
+
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is False
+        assert not isinstance(metrics.get_meter_provider(), SdkMeterProvider)
+
+    def test_explicit_otel_service_name_wins(self, clean_metrics_env):
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv("OTEL_SERVICE_NAME", "my-pinned-service")
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is True
+        provider = metrics.get_meter_provider()
+        assert provider._sdk_config.resource.attributes["service.name"] == "my-pinned-service"
+
+    def test_skips_when_meter_provider_already_installed(self, clean_metrics_env):
+        # There is no public API to attach a reader to an existing
+        # MeterProvider, and OTel refuses to override the global slot — so we
+        # leave whoever got there first alone rather than logging a bogus
+        # "installed".
+        from opentelemetry.sdk.metrics import MeterProvider as SdkProvider
+
+        pre_existing = SdkProvider(shutdown_on_exit=False)
+        metrics.set_meter_provider(pre_existing)
+
+        self._set_full_env(clean_metrics_env)
+        clean_metrics_env.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.test/otel")
+
+        assert datarobot_otel.bootstrap_otel_metrics_provider_for_datarobot() is False
+        assert metrics.get_meter_provider() is pre_existing

--- a/tests/core/test_telemetry_agent.py
+++ b/tests/core/test_telemetry_agent.py
@@ -14,6 +14,7 @@
 
 from unittest.mock import patch
 
+from datarobot_genai.core.telemetry.agent import _INSTRUMENTATION_STATE
 from datarobot_genai.core.telemetry.agent import instrument
 
 
@@ -79,3 +80,24 @@ def test_instrument_skips_metrics_bootstrap_without_hosted_runtime(monkeypatch) 
     ) as mock:
         instrument()
     mock.assert_not_called()
+
+
+def test_otel_exporter_posts_are_not_traced(monkeypatch) -> None:
+    # Both exporters POST through requests, so without the exclusion every periodic
+    # metric export would come back as an HTTP client span in the traces pipeline.
+    from opentelemetry.util.http import parse_excluded_urls
+
+    from datarobot_genai.core.telemetry.agent import _instrument_http_clients
+
+    monkeypatch.setitem(_INSTRUMENTATION_STATE, "http", False)
+    with patch("opentelemetry.instrumentation.requests.RequestsInstrumentor") as instrumentor:
+        _instrument_http_clients()
+
+    kwargs = instrumentor.return_value.instrument.call_args.kwargs
+    excluded = parse_excluded_urls(kwargs["excluded_urls"])
+    for url in (
+        "https://app.datarobot.com/otel/v1/traces",
+        "https://app.datarobot.com/otel/v1/metrics",
+    ):
+        assert excluded.url_disabled(url), url
+    assert not excluded.url_disabled("https://api.example.com/v1/chat/completions")

--- a/tests/core/test_telemetry_agent.py
+++ b/tests/core/test_telemetry_agent.py
@@ -35,8 +35,47 @@ def test_instrument_skips_bootstrap_without_deployment_id(monkeypatch) -> None:
 
 def test_instrument_bootstraps_when_deployment_id_set(monkeypatch) -> None:
     monkeypatch.setenv("MLOPS_DEPLOYMENT_ID", "abc123")
-    with patch(
-        "datarobot_genai.core.telemetry.datarobot_otel.bootstrap_otel_provider_for_datarobot"
-    ) as mock:
+    # Both bootstraps are patched: an unpatched one would install a real global
+    # provider whenever the developer's environment happens to be fully configured.
+    with (
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel."
+            "bootstrap_otel_metrics_provider_for_datarobot"
+        ),
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel.bootstrap_otel_provider_for_datarobot"
+        ) as mock,
+    ):
         instrument()
     mock.assert_called_once()
+
+
+def test_instrument_bootstraps_metrics_provider_in_workload_mode(monkeypatch) -> None:
+    # Moderation metrics are the reason this exists: dome's OtelMetricSession
+    # records into the global meter provider, so a workload needs one installed.
+    monkeypatch.delenv("MLOPS_DEPLOYMENT_ID", raising=False)
+    monkeypatch.setenv("WORKLOAD_ID", "wkl42")
+    # Patch the tracer bootstrap too, so this test can't install a real global
+    # TracerProvider that leaks into the rest of the session.
+    with (
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel.bootstrap_otel_provider_for_datarobot"
+        ),
+        patch(
+            "datarobot_genai.core.telemetry.datarobot_otel."
+            "bootstrap_otel_metrics_provider_for_datarobot"
+        ) as mock,
+    ):
+        instrument()
+    mock.assert_called_once()
+
+
+def test_instrument_skips_metrics_bootstrap_without_hosted_runtime(monkeypatch) -> None:
+    monkeypatch.delenv("MLOPS_DEPLOYMENT_ID", raising=False)
+    monkeypatch.delenv("WORKLOAD_ID", raising=False)
+    with patch(
+        "datarobot_genai.core.telemetry.datarobot_otel."
+        "bootstrap_otel_metrics_provider_for_datarobot"
+    ) as mock:
+        instrument()
+    mock.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.14"
+version = "0.29.15"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Moderation metrics (`datarobot.moderations.*`) now export from dragent agents running as DataRobot **Workloads**.

`instrument()` only ever installed a `TracerProvider`. `datarobot_dome`'s `OtelMetricSession` captures `get_meter_provider()` at construction, which stayed `_ProxyMeterProvider` — so every guardrail instrument recorded into a no-op. This was true in deployments too; the deployment-only custom-metrics path masked it there.

## Changes

- **`core/telemetry/datarobot_otel.py`** — new `bootstrap_otel_metrics_provider_for_datarobot()`, mirroring the tracer bootstrap's contract: idempotent, lazy imports, silent `False` on every skip path, never raises. Reuses the existing header/service-name resolvers, so `workload-<id>` attribution comes for free (deployment wins when both are set).
- **`core/telemetry/agent.py`** — called from the existing `is_hosted_runtime()` block, after the tracer bootstrap. Ordering is load-bearing and commented: `OtelMetricSession` binds `force_flush` to a no-op if built before a provider exists.
- **Docs** — new *Moderation metrics* section; `WORKLOAD_ID` added to the entity-id fallback table; dropped the `datarobot_api_key` / `datarobot_entity_id` fields that no longer exist on the exporter.

## Enabling

Set **`OTEL_EXPORTER_OTLP_ENDPOINT`** to the `<host>/otel` base (injected via `af-component-agent`). We gate on the same variable `datarobot_dome` reads, so both sides switch together and nothing changes for anyone who leaves it unset. Custom metrics remain deployment-only — no workload equivalent exists upstream (verified against `datarobot-moderations` 11.2.47 and 11.3.4).

## Testing

`task test` — 4685 passed, coverage 86.92%. `ruff` / `mypy` / `check_imports` clean. New cases cover entity attribution, the no-opt-in no-op, missing credentials, idempotency, and an exporter that raises.


## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in telemetry bootstrap that no-ops without OTLP config and skips when a MeterProvider is already installed; failures are caught so agents keep running.
> 
> **Overview**
> **Release 0.29.8** wires **`datarobot.moderations.*`** guardrail metrics out of dragent on **DataRobot workloads**, not only deployments. Previously `instrument()` installed a global `TracerProvider` but never a `MeterProvider`, so `datarobot_dome`'s `OtelMetricSession` bound to the default no-op proxy and moderation OTel metrics never left the process (deployments could still look fine via deployment-only custom metrics).
> 
> Adds **`bootstrap_otel_metrics_provider_for_datarobot()`** in `datarobot_otel.py` (idempotent, lazy SDK imports, same env/header resolution as traces, including **`workload-<id>`** / **`deployment-<id>`** with deployment winning). **`instrument()`** calls it in the existing **`is_hosted_runtime()`** block **after** the tracer bootstrap so dome's pipeline sees a real provider when moderation middleware builds later.
> 
> Export stays **opt-in**: both dome and the new bootstrap require **`OTEL_EXPORTER_OTLP_ENDPOINT`** (or metrics-specific OTLP endpoint); unset means no change. Docs gain a **Moderation metrics** section, **`WORKLOAD_ID`** in the entity-id fallback table, and removal of obsolete **`datarobot_api_key` / `datarobot_entity_id`** exporter YAML fields (auth/entity come from env). Tests cover workload vs deployment attribution, gates, idempotency, and exporter failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a9441d74642511993debaf23a935de140089ab5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->