### PR TITLE
[BUZZOK-32226] Generate workload enclave entrypoint in agent card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.20
+- `dragent`: the A2A agent card's `url` now honours the API gateway route. Envoy-fronted clusters serve a workload from a per-enclave host and path prefix that `DATAROBOT_ENDPOINT` cannot derive, so the composed `{endpoint}/endpoints/workloads/{id}/a2a/` URL is unreachable there. When both `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX` are set, the card advertises `{host}/{prefix}/a2a/` instead; otherwise nothing changes.
+
 ## 0.29.19
 - `drmcp/core/middleware.py`: Add well-known metadata info in MCP 403 authorization error response
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.19"
+version = "0.29.20"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/deployment_urls.py
+++ b/src/datarobot_genai/dragent/deployment_urls.py
@@ -31,6 +31,11 @@ MCP_PATH = "mcp"
 _DEFAULT_DATAROBOT_ENDPOINT = "https://app.datarobot.com/api/v2"
 _API_V2_SUFFIX = "/api/v2"
 
+#: Enclave host an Envoy API gateway serves this workload from. Injected only there.
+WORKLOAD_EXTERNAL_HOST_ENV = "DR_WORKLOAD_EXTERNAL_URL_HOST"
+#: Path prefix the Envoy API gateway routes to this workload. Injected only there.
+WORKLOAD_EXTERNAL_PREFIX_ENV = "DR_WORKLOAD_EXTERNAL_URL_PREFIX"
+
 
 def normalize_api_v2_endpoint(endpoint: str) -> str:
     """Return ``endpoint`` with exactly one trailing ``/api/v2`` and no trailing slash.
@@ -92,6 +97,31 @@ def resolve_datarobot_endpoint(require: bool = False) -> str | None:
     if require:
         raise ValueError("DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set.")
     return _DEFAULT_DATAROBOT_ENDPOINT
+
+
+def resolve_external_workload_base() -> str | None:
+    """Return the API gateway's base URL for this workload, or *None* when not behind one.
+
+    An Envoy API gateway serves a workload from a per-enclave host and path prefix that
+    ``DATAROBOT_ENDPOINT`` cannot derive, so it injects both as env vars.  Their presence is
+    the signal that the URLs composed elsewhere in this module are unreachable; both are
+    required.  The host is accepted with or without a scheme (``https://`` assumed).
+
+    Returns
+    -------
+    str | None
+        ``https://{host}/{prefix}``, no trailing slash, or *None* when either var is unset.
+    """
+    host = os.getenv(WORKLOAD_EXTERNAL_HOST_ENV, "").strip()
+    prefix = os.getenv(WORKLOAD_EXTERNAL_PREFIX_ENV, "").strip()
+
+    if not (host and prefix):
+        return None
+
+    if "://" not in host:
+        host = f"https://{host}"
+
+    return f"{host.rstrip('/')}/{prefix.strip('/')}"
 
 
 def build_deployment_a2a_url(endpoint: str, deployment_id: str) -> str:

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -54,6 +54,7 @@ from datarobot_genai.dragent.cross_app_access_config import CrossApplicationAcce
 from datarobot_genai.dragent.deployment_urls import build_deployment_a2a_url
 from datarobot_genai.dragent.deployment_urls import build_workload_a2a_url
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
+from datarobot_genai.dragent.deployment_urls import resolve_external_workload_base
 
 from .register import DRAgentA2AExternalConfig
 from .session import _a2a_headers
@@ -114,11 +115,20 @@ _IDENTITY_EXTENSION_URIS = frozenset({INTERNAL_IDENTITY_URI, EXTERNAL_IDENTITY_U
 def get_a2a_endpoint_url(host: str, port: int) -> str:
     """Construct the A2A endpoint URL for the running server.
 
-    In a DataRobot deployment (``MLOPS_DEPLOYMENT_ID`` is set), uses the
-    deployment's direct-access URL built from ``DATAROBOT_PUBLIC_API_ENDPOINT``
-    / ``DATAROBOT_ENDPOINT``.  Otherwise falls back to the local
-    ``http://{host}:{port}/a2a/`` URL.
+    Three tiers, most specific first:
+
+    1. Behind an Envoy API gateway (``DR_WORKLOAD_EXTERNAL_URL_HOST`` and
+       ``DR_WORKLOAD_EXTERNAL_URL_PREFIX`` are both injected), the gateway's own
+       route is the only externally reachable one, so it wins in every hosting
+       mode.
+    2. In a DataRobot deployment (``MLOPS_DEPLOYMENT_ID`` is set) or workload
+       (``WORKLOAD_ID``), composes the platform URL from
+       ``DATAROBOT_PUBLIC_API_ENDPOINT`` / ``DATAROBOT_ENDPOINT``.
+    3. Otherwise falls back to the local ``http://{host}:{port}/a2a/`` URL.
     """
+    if external_base := resolve_external_workload_base():
+        return f"{external_base}/{A2A_MOUNT_PATH}/"
+
     deployment_id = get_deployment_id()
     workload_id = get_workload_id()
 

--- a/tests/dragent/frontends/test_a2a.py
+++ b/tests/dragent/frontends/test_a2a.py
@@ -24,6 +24,8 @@ from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from datarobot_genai.dragent.cross_app_access_config import CrossApplicationAccessConfig
 from datarobot_genai.dragent.cross_app_access_config import CrossAppTokenExchange
 from datarobot_genai.dragent.cross_app_access_config import CrossAppTokenRequest
+from datarobot_genai.dragent.deployment_urls import WORKLOAD_EXTERNAL_HOST_ENV
+from datarobot_genai.dragent.deployment_urls import WORKLOAD_EXTERNAL_PREFIX_ENV
 from datarobot_genai.dragent.frontends.a2a import BEARER_SECURITY_DESCRIPTION
 from datarobot_genai.dragent.frontends.a2a import BEARER_SECURITY_SCHEME_NAME
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_EXTENSION_DESCRIPTION
@@ -159,6 +161,16 @@ class TestCreateAgentCard:
         assert card.description == "Does things"
         assert card.version == "2.0.0"
         assert card.url == "http://localhost:9000/a2a/"
+
+    async def test_agent_card_url_uses_api_gateway_route(self, a2a_frontend_config):
+        env = {
+            "WORKLOAD_ID": "abc123",
+            WORKLOAD_EXTERNAL_HOST_ENV: "enclave-x.datarobot.com",
+            WORKLOAD_EXTERNAL_PREFIX_ENV: "/workloads/abc123",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            card = await create_agent_card(a2a_frontend_config, cross_app_access=None, skills=[])
+        assert str(card.url) == "https://enclave-x.datarobot.com/workloads/abc123/a2a/"
 
     async def test_security_schemes_set_when_cross_application_access_present(
         self, a2a_frontend_config
@@ -554,3 +566,80 @@ class TestGetA2aEndpointUrl:
                 ValueError, match="DATAROBOT_PUBLIC_API_ENDPOINT or DATAROBOT_ENDPOINT must be set"
             ):
                 get_a2a_endpoint_url("localhost", 8000)
+
+    @pytest.mark.parametrize(
+        "env,expected",
+        [
+            (
+                {
+                    "WORKLOAD_ID": "abc123",
+                    "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+                },
+                "https://app.datarobot.com/api/v2/endpoints/workloads/abc123/a2a/",
+            ),
+            (
+                {
+                    "WORKLOAD_ID": "abc123",
+                    "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2/",
+                },
+                "https://app.datarobot.com/api/v2/endpoints/workloads/abc123/a2a/",
+            ),
+        ],
+    )
+    def test_workload(self, env, expected):
+        with patch.dict(os.environ, env, clear=True):
+            assert get_a2a_endpoint_url("localhost", 8000) == expected
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            # Behind the gateway on a workload.
+            {
+                "WORKLOAD_ID": "abc123",
+                "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+                WORKLOAD_EXTERNAL_HOST_ENV: "enclave-x.datarobot.com",
+                WORKLOAD_EXTERNAL_PREFIX_ENV: "/workloads/abc123",
+            },
+            # The gateway route wins in deployment mode too.
+            {
+                "MLOPS_DEPLOYMENT_ID": "dep123",
+                "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+                WORKLOAD_EXTERNAL_HOST_ENV: "enclave-x.datarobot.com",
+                WORKLOAD_EXTERNAL_PREFIX_ENV: "/workloads/abc123",
+            },
+            # No DataRobot endpoint at all: the gateway vars are self-sufficient.
+            {
+                "WORKLOAD_ID": "abc123",
+                WORKLOAD_EXTERNAL_HOST_ENV: "enclave-x.datarobot.com",
+                WORKLOAD_EXTERNAL_PREFIX_ENV: "/workloads/abc123",
+            },
+            # Not hosted at all — still no reason to publish a localhost URL.
+            {
+                WORKLOAD_EXTERNAL_HOST_ENV: "https://enclave-x.datarobot.com/",
+                WORKLOAD_EXTERNAL_PREFIX_ENV: "workloads/abc123/",
+            },
+        ],
+    )
+    def test_api_gateway_route_wins(self, env):
+        with patch.dict(os.environ, env, clear=True):
+            assert (
+                get_a2a_endpoint_url("localhost", 8000)
+                == "https://enclave-x.datarobot.com/workloads/abc123/a2a/"
+            )
+
+    @pytest.mark.parametrize(
+        "gateway_env",
+        [
+            {WORKLOAD_EXTERNAL_HOST_ENV: "enclave-x.datarobot.com"},
+            {WORKLOAD_EXTERNAL_PREFIX_ENV: "/workloads/abc123"},
+        ],
+    )
+    def test_partial_gateway_config_falls_back(self, gateway_env):
+        env = {
+            "WORKLOAD_ID": "abc123",
+            "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2",
+            **gateway_env,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            url = get_a2a_endpoint_url("localhost", 8000)
+        assert url == "https://app.datarobot.com/api/v2/endpoints/workloads/abc123/a2a/"

--- a/tests/dragent/test_deployment_urls.py
+++ b/tests/dragent/test_deployment_urls.py
@@ -31,6 +31,7 @@ from datarobot_genai.dragent.deployment_urls import build_workload_a2a_url
 from datarobot_genai.dragent.deployment_urls import build_workload_agent_card_url
 from datarobot_genai.dragent.deployment_urls import normalize_api_v2_endpoint
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
+from datarobot_genai.dragent.deployment_urls import resolve_external_workload_base
 from datarobot_genai.dragent.deployment_urls import workload_mcp_url_from_endpoint
 
 
@@ -258,6 +259,81 @@ class TestResolveDataRobotEndpoint:
         }
         with patch.dict(os.environ, env, clear=True):
             assert resolve_datarobot_endpoint() == "https://app.datarobot.com/api/v2"
+
+
+HOST_ENV = "DR_WORKLOAD_EXTERNAL_URL_HOST"
+PREFIX_ENV = "DR_WORKLOAD_EXTERNAL_URL_PREFIX"
+
+
+class TestResolveExternalWorkloadBase:
+    @pytest.mark.parametrize(
+        "host,prefix,expected",
+        [
+            # Host with a scheme, prefix with a leading slash — the documented shape.
+            (
+                "https://enclave-x.datarobot.com",
+                "/workloads/abc123",
+                "https://enclave-x.datarobot.com/workloads/abc123",
+            ),
+            # Bare host: https:// is assumed.
+            (
+                "enclave-x.datarobot.com",
+                "/workloads/abc123",
+                "https://enclave-x.datarobot.com/workloads/abc123",
+            ),
+            # Slashes on either side of the join are normalised, not doubled.
+            (
+                "https://enclave-x.datarobot.com/",
+                "workloads/abc123/",
+                "https://enclave-x.datarobot.com/workloads/abc123",
+            ),
+            (
+                "enclave-x.datarobot.com/",
+                "/workloads/abc123/",
+                "https://enclave-x.datarobot.com/workloads/abc123",
+            ),
+            # Surrounding whitespace from the injected value is stripped.
+            (
+                "  enclave-x.datarobot.com  ",
+                "  /workloads/abc123  ",
+                "https://enclave-x.datarobot.com/workloads/abc123",
+            ),
+            # An explicit http:// scheme is preserved rather than replaced.
+            (
+                "http://enclave-x.local:8080",
+                "/wl/1",
+                "http://enclave-x.local:8080/wl/1",
+            ),
+            # Multi-segment prefix survives verbatim.
+            (
+                "https://enclave-x.datarobot.com",
+                "/api/v2/endpoints/workloads/abc123",
+                "https://enclave-x.datarobot.com/api/v2/endpoints/workloads/abc123",
+            ),
+        ],
+    )
+    def test_builds_base_url(self, host, prefix, expected):
+        env = {HOST_ENV: host, PREFIX_ENV: prefix}
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_external_workload_base() == expected
+
+    def test_returns_none_when_neither_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_external_workload_base() is None
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {HOST_ENV: "enclave-x.datarobot.com"},
+            {PREFIX_ENV: "/workloads/abc123"},
+            {HOST_ENV: "enclave-x.datarobot.com", PREFIX_ENV: ""},
+            {HOST_ENV: "", PREFIX_ENV: "/workloads/abc123"},
+            {HOST_ENV: "   ", PREFIX_ENV: "   "},
+        ],
+    )
+    def test_returns_none_unless_both_are_set(self, env):
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_external_workload_base() is None
 
 
 class TestUrlConsistency:

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.19"
+version = "0.29.20"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
The A2A agent card's `url` field always composed the agent's entrypoint from `DATAROBOT_ENDPOINT` plus the platform-assigned id (`{endpoint}/endpoints/workloads/{id}/a2a/`). 

Behind an Envoy API gateway that composition is wrong — the workload is served from a per-enclave host and path prefix that `DATAROBOT_ENDPOINT` cannot derive — so the card advertised a URL no client could reach. The gateway injects the real route as `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX`; 

Their presence is now the signal that we're behind it, and when both are set the card advertises `{host}/{prefix}/a2a/` instead. This is checked before the deployment/workload branching, so the gateway route wins in every hosting mode; with neither variable set, or only one, the existing composed URL stands unchanged, as does an explicit `external.url` config override.

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cba3cfab03846dc6930c5409d098f715b39ed3a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->