### PR TITLE
[BUZZOK-32245] Use enclave endpoint for L2 agent card cache and agent memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.29.24
+- `dragent`: agent card registry MemorySpace L2 talks to the enclave memory service when `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX` are set. The DataRobot client uses `{host}/api/v2` instead of `DATAROBOT_PUBLIC_API_ENDPOINT` / `DATAROBOT_ENDPOINT`, which point at the control hub and are unreachable from an isolated enclave.
+
 ## 0.29.23 - 2026-09-03
 - `dragent`: fixed the `X-DataRobot-Model-Monitoring` response header never being set when the server runs under a `--root_path`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## 0.29.24
-- `dragent`: agent card registry MemorySpace L2 talks to the enclave memory service when `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX` are set. The DataRobot client uses `{host}/api/v2` instead of `DATAROBOT_PUBLIC_API_ENDPOINT` / `DATAROBOT_ENDPOINT`, which point at the control hub and are unreachable from an isolated enclave.
+- `dragent`: agent card registry MemorySpace L2 and the Mem0 DataRobot memory client talk to the enclave memory service when `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX` are set. Both use `{host}/api/v2` instead of `DATAROBOT_PUBLIC_API_ENDPOINT` / `DATAROBOT_ENDPOINT`, which point at the control hub and are unreachable from an isolated enclave.
 
 ## 0.29.23 - 2026-09-03
 - `dragent`: fixed the `X-DataRobot-Model-Monitoring` response header never being set when the server runs under a `--root_path`.

--- a/e2e-tests/uv.lock
+++ b/e2e-tests/uv.lock
@@ -948,7 +948,7 @@ core = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.23"
+version = "0.29.24"
 source = { editable = "../" }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.23"
+version = "0.29.24"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/deployment_urls.py
+++ b/src/datarobot_genai/dragent/deployment_urls.py
@@ -19,6 +19,12 @@ a DataRobot-hosted A2A agent and to look up its agent card from the central
 registry.  Both the server side (advertising its own URL in the agent card) and
 the client side (deriving the RPC base URL from a ``deployment_id``) use these
 functions so that the patterns stay in sync automatically.
+
+When a workload is served from an Envoy-fronted enclave,
+:func:`resolve_external_workload_base` is the agent's own gateway route and
+:func:`resolve_external_workload_api_endpoint` is the enclave's ``/api/v2``
+base (memory service, and so on) — distinct from the control-hub
+``DATAROBOT_ENDPOINT``.
 """
 
 import os
@@ -99,6 +105,22 @@ def resolve_datarobot_endpoint(require: bool = False) -> str | None:
     return _DEFAULT_DATAROBOT_ENDPOINT
 
 
+def _external_workload_host() -> str | None:
+    """Return the Envoy host with a scheme, or *None* when the gateway vars are incomplete.
+
+    Both ``DR_WORKLOAD_EXTERNAL_URL_HOST`` and ``DR_WORKLOAD_EXTERNAL_URL_PREFIX`` are
+    required — the same presence signal as :func:`resolve_external_workload_base`.  The
+    prefix is this workload's own route and is not returned here.
+    """
+    host = os.getenv(WORKLOAD_EXTERNAL_HOST_ENV, "").strip()
+    prefix = os.getenv(WORKLOAD_EXTERNAL_PREFIX_ENV, "").strip()
+    if not (host and prefix):
+        return None
+    if "://" not in host:
+        host = f"https://{host}"
+    return host.rstrip("/")
+
+
 def resolve_external_workload_base() -> str | None:
     """Return the API gateway's base URL for this workload, or *None* when not behind one.
 
@@ -112,16 +134,30 @@ def resolve_external_workload_base() -> str | None:
     str | None
         ``https://{host}/{prefix}``, no trailing slash, or *None* when either var is unset.
     """
-    host = os.getenv(WORKLOAD_EXTERNAL_HOST_ENV, "").strip()
-    prefix = os.getenv(WORKLOAD_EXTERNAL_PREFIX_ENV, "").strip()
-
-    if not (host and prefix):
+    host = _external_workload_host()
+    if host is None:
         return None
+    prefix = os.getenv(WORKLOAD_EXTERNAL_PREFIX_ENV, "").strip()
+    return f"{host}/{prefix.strip('/')}"
 
-    if "://" not in host:
-        host = f"https://{host}"
 
-    return f"{host.rstrip('/')}/{prefix.strip('/')}"
+def resolve_external_workload_api_endpoint() -> str | None:
+    """Return the enclave API gateway's ``/api/v2`` endpoint, or *None* when not behind one.
+
+    Same presence signal as :func:`resolve_external_workload_base` (both host and prefix).
+    The prefix is this workload's own route and is not part of the platform API base —
+    only the host is used, so the DataRobot client talks to services on the enclave
+    (memory, and so on) rather than the control hub.
+
+    Returns
+    -------
+    str | None
+        ``https://{host}/api/v2``, no trailing slash, or *None* when either var is unset.
+    """
+    host = _external_workload_host()
+    if host is None:
+        return None
+    return normalize_api_v2_endpoint(host)
 
 
 def build_deployment_a2a_url(endpoint: str, deployment_id: str) -> str:

--- a/src/datarobot_genai/dragent/memory_space_cache.py
+++ b/src/datarobot_genai/dragent/memory_space_cache.py
@@ -83,6 +83,7 @@ from datarobot.models.memory import Session
 from pydantic import Field
 
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
+from datarobot_genai.dragent.deployment_urls import resolve_external_workload_api_endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -202,12 +203,26 @@ def configure_datarobot_memory_client(
     endpoint: str | None = None,
     api_token: str | None = None,
 ) -> None:
-    """Configure the process-global DataRobot client for memory Session API calls."""
+    """Configure the process-global DataRobot client for memory Session API calls.
+
+    Endpoint resolution, most specific first:
+
+    1. Explicit ``endpoint`` argument.
+    2. Enclave API gateway (``DR_WORKLOAD_EXTERNAL_URL_HOST`` +
+       ``DR_WORKLOAD_EXTERNAL_URL_PREFIX``) — ``{host}/api/v2``, so L2 talks to
+       the memory service on this enclave rather than the control hub.
+    3. ``DATAROBOT_PUBLIC_API_ENDPOINT`` / ``DATAROBOT_ENDPOINT``.
+    """
     cfg = MemorySpaceCacheConfig()
     token = api_token or cfg.datarobot_api_token or os.getenv("DATAROBOT_API_TOKEN")
     if not token:
         raise ValueError("DATAROBOT_API_TOKEN is required when using memory_space cache backends.")
-    base = cast(str, endpoint or resolve_datarobot_endpoint(require=True))
+    base = cast(
+        str,
+        endpoint
+        or resolve_external_workload_api_endpoint()
+        or resolve_datarobot_endpoint(require=True),
+    )
     dr.Client(token=token, endpoint=base.rstrip("/"))
 
 

--- a/src/datarobot_genai/dragent/plugins/datarobot_mem0_memory.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_mem0_memory.py
@@ -20,9 +20,12 @@ interface so ``auto_memory_agent`` can store and retrieve long-term memory.
 Backend selection is driven by config:
 
 * ``agent_memory_space_id`` → the DataRobot Memory Service's mem0-compatible API,
-  reached at ``{DATAROBOT_ENDPOINT}/memory/{agent_memory_space_id}/`` and
-  authenticated with the DataRobot API token. See PBMP-7431 ("Agentic Memory
-  Service"), section "Connect to DataRobot memory" / "API Layout".
+  reached at ``{endpoint}/memory/{agent_memory_space_id}/`` and authenticated
+  with the DataRobot API token. The endpoint is the enclave ``{host}/api/v2``
+  when ``DR_WORKLOAD_EXTERNAL_URL_HOST`` and ``DR_WORKLOAD_EXTERNAL_URL_PREFIX``
+  are set, otherwise ``DATAROBOT_PUBLIC_API_ENDPOINT`` / ``DATAROBOT_ENDPOINT``.
+  See PBMP-7431 ("Agentic Memory Service"), section "Connect to DataRobot
+  memory" / "API Layout".
 * ``api_key`` (or ``MEM0_API_KEY``) → Mem0's hosted SaaS at
   ``https://api.mem0.ai``. Used when no ``agent_memory_space_id`` is configured.
 
@@ -60,6 +63,7 @@ from datarobot_genai.core.config import resolve_config
 from datarobot_genai.core.telemetry.memory import trace_memory_operation
 from datarobot_genai.core.telemetry.memory import truncate_memory_text
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
+from datarobot_genai.dragent.deployment_urls import resolve_external_workload_api_endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -141,8 +145,10 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
 
     * If ``agent_memory_space_id`` is set, requests go to the DataRobot Memory
       Service's mem0-compatible endpoint at
-      ``{datarobot_endpoint}/memory/{agent_memory_space_id}/`` authenticated with
-      ``datarobot_api_token`` (or ``DATAROBOT_API_TOKEN``).
+      ``{endpoint}/memory/{agent_memory_space_id}/`` authenticated with
+      ``datarobot_api_token`` (or ``DATAROBOT_API_TOKEN``). The endpoint prefers
+      the enclave API gateway when present, otherwise ``DATAROBOT_PUBLIC_API_ENDPOINT``
+      / ``DATAROBOT_ENDPOINT``.
     * Otherwise, ``api_key`` (or ``MEM0_API_KEY``) is used against Mem0's
       hosted SaaS (``host`` defaults to ``https://api.mem0.ai``).
     """
@@ -172,7 +178,9 @@ class DRMem0MemoryClientConfig(  # type: ignore[call-arg]
         description=(
             "DataRobot API base URL used to build the mem0 endpoint when "
             "``agent_memory_space_id`` is set (e.g. ``https://app.datarobot.com/api/v2``). "
-            "Defaults to the ``DATAROBOT_ENDPOINT`` env var."
+            "When unset, prefers the enclave API gateway "
+            "(``DR_WORKLOAD_EXTERNAL_URL_HOST`` + ``DR_WORKLOAD_EXTERNAL_URL_PREFIX``) "
+            "over ``DATAROBOT_PUBLIC_API_ENDPOINT`` / ``DATAROBOT_ENDPOINT``."
         ),
     )
     datarobot_api_token: str | None = Field(
@@ -386,7 +394,16 @@ def _dr_mem0_endpoint(config: DRMem0MemoryClientConfig) -> str:
     """Build the DataRobot Memory Service mem0 endpoint for an agent memory space.
 
     Per PBMP-7431 ("API Layout"), the DR memory service exposes a
-    mem0-compatible API at ``{DATAROBOT_ENDPOINT}/memory/{agent_memory_space_id}``.
+    mem0-compatible API at ``{endpoint}/memory/{agent_memory_space_id}``.
+
+    Endpoint resolution, most specific first — same order as
+    :func:`datarobot_genai.dragent.memory_space_cache.configure_datarobot_memory_client`
+    so both memory clients talk to the same host:
+
+    1. Explicit ``config.datarobot_endpoint``.
+    2. Enclave API gateway (``DR_WORKLOAD_EXTERNAL_URL_HOST`` +
+       ``DR_WORKLOAD_EXTERNAL_URL_PREFIX``) — ``{host}/api/v2``.
+    3. ``DATAROBOT_PUBLIC_API_ENDPOINT`` / ``DATAROBOT_ENDPOINT``.
 
     No trailing slash: mem0's ``AsyncMemoryClient._validate_api_key`` builds
     its ping URL as ``f"{host}/v1/ping/"`` via raw string concat (it does not
@@ -397,7 +414,12 @@ def _dr_mem0_endpoint(config: DRMem0MemoryClientConfig) -> str:
     # substitutes the public app.datarobot.com default when nothing is configured, and
     # this host receives memory writes plus the API token, so "unset" has to stay
     # distinguishable from "configured".
-    base = cast(str, config.datarobot_endpoint or resolve_datarobot_endpoint(require=True))
+    base = cast(
+        str,
+        config.datarobot_endpoint
+        or resolve_external_workload_api_endpoint()
+        or resolve_datarobot_endpoint(require=True),
+    )
     return f"{base.rstrip('/')}/memory/{config.agent_memory_space_id}"
 
 

--- a/tests/dragent/plugins/test_datarobot_mem0_memory.py
+++ b/tests/dragent/plugins/test_datarobot_mem0_memory.py
@@ -633,10 +633,63 @@ def test_dr_mem0_endpoint_prefers_public_api_endpoint_over_internal_endpoint(
     )
 
 
+def test_dr_mem0_endpoint_enclave_gateway_wins_over_control_hub(monkeypatch: Any) -> None:
+    # GIVEN a workload on an Envoy-fronted enclave whose control-hub URLs
+    # still point at staging
+    monkeypatch.setenv(
+        "DATAROBOT_PUBLIC_API_ENDPOINT",
+        "https://staging.datarobot.com/api/v2",
+    )
+    monkeypatch.setenv("DATAROBOT_ENDPOINT", "http://datarobot-nginx/api/v2")
+    monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_HOST", "enclave-x.datarobot.com")
+    monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_PREFIX", "/workloads/abc123")
+    config = DRMem0MemoryClientConfig(agent_memory_space_id="space-123")
+
+    # WHEN the mem0 endpoint is built
+    # THEN it talks to the enclave memory service, not the control hub
+    assert (
+        datarobot_mem0_memory._dr_mem0_endpoint(config)
+        == "https://enclave-x.datarobot.com/api/v2/memory/space-123"
+    )
+
+
+def test_dr_mem0_endpoint_partial_gateway_config_falls_back_to_public_api(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv(
+        "DATAROBOT_PUBLIC_API_ENDPOINT",
+        "https://staging.datarobot.com/api/v2",
+    )
+    monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_HOST", "enclave-x.datarobot.com")
+    monkeypatch.delenv("DR_WORKLOAD_EXTERNAL_URL_PREFIX", raising=False)
+    config = DRMem0MemoryClientConfig(agent_memory_space_id="space-123")
+
+    assert (
+        datarobot_mem0_memory._dr_mem0_endpoint(config)
+        == "https://staging.datarobot.com/api/v2/memory/space-123"
+    )
+
+
+def test_dr_mem0_endpoint_explicit_endpoint_wins_over_enclave(monkeypatch: Any) -> None:
+    monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_HOST", "enclave-x.datarobot.com")
+    monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_PREFIX", "/workloads/abc123")
+    config = DRMem0MemoryClientConfig(
+        agent_memory_space_id="space-123",
+        datarobot_endpoint="https://override.example/api/v2",
+    )
+
+    assert (
+        datarobot_mem0_memory._dr_mem0_endpoint(config)
+        == "https://override.example/api/v2/memory/space-123"
+    )
+
+
 def test_dr_mem0_endpoint_requires_a_base_url(monkeypatch: Any) -> None:
     # GIVEN no datarobot_endpoint configured and no env var.
     monkeypatch.delenv("DATAROBOT_ENDPOINT", raising=False)
     monkeypatch.delenv("DATAROBOT_PUBLIC_API_ENDPOINT", raising=False)
+    monkeypatch.delenv("DR_WORKLOAD_EXTERNAL_URL_HOST", raising=False)
+    monkeypatch.delenv("DR_WORKLOAD_EXTERNAL_URL_PREFIX", raising=False)
     config = DRMem0MemoryClientConfig(agent_memory_space_id="space-xyz")
 
     # THEN the builder refuses to fabricate a URL — better to fail loud than to

--- a/tests/dragent/test_deployment_urls.py
+++ b/tests/dragent/test_deployment_urls.py
@@ -31,6 +31,7 @@ from datarobot_genai.dragent.deployment_urls import build_workload_a2a_url
 from datarobot_genai.dragent.deployment_urls import build_workload_agent_card_url
 from datarobot_genai.dragent.deployment_urls import normalize_api_v2_endpoint
 from datarobot_genai.dragent.deployment_urls import resolve_datarobot_endpoint
+from datarobot_genai.dragent.deployment_urls import resolve_external_workload_api_endpoint
 from datarobot_genai.dragent.deployment_urls import resolve_external_workload_base
 from datarobot_genai.dragent.deployment_urls import workload_mcp_url_from_endpoint
 
@@ -334,6 +335,75 @@ class TestResolveExternalWorkloadBase:
     def test_returns_none_unless_both_are_set(self, env):
         with patch.dict(os.environ, env, clear=True):
             assert resolve_external_workload_base() is None
+
+
+class TestResolveExternalWorkloadApiEndpoint:
+    @pytest.mark.parametrize(
+        "host,prefix,expected",
+        [
+            (
+                "https://enclave-x.datarobot.com",
+                "/workloads/abc123",
+                "https://enclave-x.datarobot.com/api/v2",
+            ),
+            (
+                "enclave-x.datarobot.com",
+                "/workloads/abc123",
+                "https://enclave-x.datarobot.com/api/v2",
+            ),
+            (
+                "https://enclave-x.datarobot.com/",
+                "workloads/abc123/",
+                "https://enclave-x.datarobot.com/api/v2",
+            ),
+            (
+                "http://enclave-x.local:8080",
+                "/wl/1",
+                "http://enclave-x.local:8080/api/v2",
+            ),
+            (
+                "https://enclave-x.datarobot.com/api/v2",
+                "/endpoints/workloads/abc123",
+                "https://enclave-x.datarobot.com/api/v2",
+            ),
+        ],
+    )
+    def test_builds_enclave_api_endpoint(self, host, prefix, expected):
+        # GIVEN an Envoy-fronted enclave (both gateway vars set)
+        # WHEN the memory/API endpoint is resolved
+        # THEN it is {host}/api/v2 — the workload prefix is this agent's route,
+        # not the platform API base, so it must not appear in the result
+        env = {HOST_ENV: host, PREFIX_ENV: prefix}
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_external_workload_api_endpoint() == expected
+
+    def test_returns_none_when_neither_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_external_workload_api_endpoint() is None
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {HOST_ENV: "enclave-x.datarobot.com"},
+            {PREFIX_ENV: "/workloads/abc123"},
+            {HOST_ENV: "enclave-x.datarobot.com", PREFIX_ENV: ""},
+            {HOST_ENV: "", PREFIX_ENV: "/workloads/abc123"},
+            {HOST_ENV: "   ", PREFIX_ENV: "   "},
+        ],
+    )
+    def test_returns_none_unless_both_are_set(self, env):
+        with patch.dict(os.environ, env, clear=True):
+            assert resolve_external_workload_api_endpoint() is None
+
+    def test_does_not_include_workload_prefix(self):
+        env = {
+            HOST_ENV: "enclave-x.datarobot.com",
+            PREFIX_ENV: "/api/v2/endpoints/workloads/abc123",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            endpoint = resolve_external_workload_api_endpoint()
+        assert endpoint == "https://enclave-x.datarobot.com/api/v2"
+        assert "workloads" not in endpoint
 
 
 class TestUrlConsistency:

--- a/tests/dragent/test_memory_space_cache.py
+++ b/tests/dragent/test_memory_space_cache.py
@@ -102,6 +102,60 @@ class TestConfigureDatarobotMemoryClient:
             endpoint="https://staging.datarobot.com/api/v2",
         )
 
+    def test_enclave_gateway_wins_over_control_hub(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # GIVEN a workload on an Envoy-fronted enclave whose control-hub URLs
+        # still point at staging
+        monkeypatch.setenv("DATAROBOT_API_TOKEN", "token")
+        monkeypatch.setenv(
+            "DATAROBOT_PUBLIC_API_ENDPOINT",
+            "https://staging.datarobot.com/api/v2",
+        )
+        monkeypatch.setenv("DATAROBOT_ENDPOINT", "http://datarobot-nginx/api/v2")
+        monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_HOST", "enclave-x.datarobot.com")
+        monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_PREFIX", "/workloads/abc123")
+
+        with patch("datarobot_genai.dragent.memory_space_cache.dr.Client") as client_mock:
+            configure_datarobot_memory_client()
+
+        # WHEN the L2 memory client is configured
+        # THEN it talks to the enclave API, not the control hub
+        client_mock.assert_called_once_with(
+            token="token",
+            endpoint="https://enclave-x.datarobot.com/api/v2",
+        )
+
+    def test_partial_gateway_config_falls_back_to_public_api(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DATAROBOT_API_TOKEN", "token")
+        monkeypatch.setenv(
+            "DATAROBOT_PUBLIC_API_ENDPOINT",
+            "https://staging.datarobot.com/api/v2",
+        )
+        monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_HOST", "enclave-x.datarobot.com")
+        monkeypatch.delenv("DR_WORKLOAD_EXTERNAL_URL_PREFIX", raising=False)
+
+        with patch("datarobot_genai.dragent.memory_space_cache.dr.Client") as client_mock:
+            configure_datarobot_memory_client()
+
+        client_mock.assert_called_once_with(
+            token="token",
+            endpoint="https://staging.datarobot.com/api/v2",
+        )
+
+    def test_explicit_endpoint_wins_over_enclave(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DATAROBOT_API_TOKEN", "token")
+        monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_HOST", "enclave-x.datarobot.com")
+        monkeypatch.setenv("DR_WORKLOAD_EXTERNAL_URL_PREFIX", "/workloads/abc123")
+
+        with patch("datarobot_genai.dragent.memory_space_cache.dr.Client") as client_mock:
+            configure_datarobot_memory_client(endpoint="https://override.example/api/v2")
+
+        client_mock.assert_called_once_with(
+            token="token",
+            endpoint="https://override.example/api/v2",
+        )
+
 
 class TestMemorySpaceKVCache:
     async def test_set_and_get_round_trip(self, kv_cache: MemorySpaceKVCache) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.23"
+version = "0.29.24"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
The memory service needs to be accessed on the enclave when the agent is deployed there.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Use `DR_WORKLOAD_EXTERNAL_URL_HOST` to access the memory service when both `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX` are set, indicating the agent is deployed to an enclave.
## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow endpoint-resolution change with existing fallbacks and new unit tests; behavior outside enclave gateway env is unchanged.
> 
> **Overview**
> **Release 0.29.22** — enclave-aware API base for the agent card registry’s MemorySpace (L2) cache.
> 
> When both `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX` are set (same signal as the 0.29.20 A2A gateway URLs), `configure_datarobot_memory_client` now points the process-global DataRobot client at **`{host}/api/v2`** via new `resolve_external_workload_api_endpoint()`, instead of `DATAROBOT_PUBLIC_API_ENDPOINT` / `DATAROBOT_ENDPOINT`, which target the control hub and are unreachable from an isolated enclave.
> 
> `deployment_urls` refactors shared gateway host parsing into `_external_workload_host()` (used by `resolve_external_workload_base` and the new resolver). The workload path prefix is **not** included in the platform API base—only the enclave host. Precedence is unchanged for callers: explicit `endpoint` wins, then enclave gateway when fully configured, then public/control-hub env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f04e9cea098ba8a1f270de6cd3ce145ef9a1116. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->