### PR TITLE
[MODEL-24701] Fix mcp deployment resolve logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+
+## 0.29.26
+- `drmcp/core/runtime_identity.py`: Fix logic of resolving MCP deployment URL
+
 ## 0.29.24
 - `dragent`: agent card registry MemorySpace L2 and the Mem0 DataRobot memory client talk to the enclave memory service when `DR_WORKLOAD_EXTERNAL_URL_HOST` and `DR_WORKLOAD_EXTERNAL_URL_PREFIX` are set. Both use `{host}/api/v2` instead of `DATAROBOT_PUBLIC_API_ENDPOINT` / `DATAROBOT_ENDPOINT`, which point at the control hub and are unreachable from an isolated enclave.
 - `dragent`: agent tracing now sets `datarobot.session_id` from AG-UI `thread_id`, and tool-call spans now carry `gen_ai.agent.name` so Datavolt can attribute tool usage to the invoking agent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.25"
+version = "0.29.26"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/deployment_config.py
+++ b/src/datarobot_genai/drmcp/core/deployment_config.py
@@ -1,0 +1,44 @@
+# Copyright 2026 DataRobot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import os
+from enum import Enum
+from enum import auto
+
+
+class MCPDeploymentType(Enum):
+    MLOPS = auto()
+    WORKLOAD = auto()
+
+
+class DeploymentConfig(Enum):
+    WORKLOAD_ID = auto()
+    MLOPS_DEPLOYMENT_ID = auto()
+    DATAROBOT_PUBLIC_API_ENDPOINT = auto()
+    DATAROBOT_ENDPOINT = auto()
+    DR_WORKLOAD_EXTERNAL_URL_HOST = auto()
+
+    def get_from_os_env(self) -> str | None:
+        return os.getenv(self.name, "").strip() or None
+
+    @staticmethod
+    def get_datarobot_public_api_endpoint() -> str | None:
+        """Prefer ``DATAROBOT_PUBLIC_API_ENDPOINT`` over ``DATAROBOT_ENDPOINT``; see
+        the module docstring for why that order matters and why there is no default.
+        """
+        return (
+            DeploymentConfig.DATAROBOT_PUBLIC_API_ENDPOINT.get_from_os_env()
+            or DeploymentConfig.DATAROBOT_ENDPOINT.get_from_os_env()
+        )

--- a/src/datarobot_genai/drmcp/core/deployment_config.py
+++ b/src/datarobot_genai/drmcp/core/deployment_config.py
@@ -35,8 +35,16 @@ class DeploymentConfig(Enum):
 
     @staticmethod
     def get_datarobot_public_api_endpoint() -> str | None:
-        """Prefer ``DATAROBOT_PUBLIC_API_ENDPOINT`` over ``DATAROBOT_ENDPOINT``; see
-        the module docstring for why that order matters and why there is no default.
+        """
+        ``DATAROBOT_PUBLIC_API_ENDPOINT`` wins over ``DATAROBOT_ENDPOINT``
+        An on-prem install commonly points ``DATAROBOT_ENDPOINT`` at an internal
+        cluster address. A resource identifier built from it is one no external
+        client can reach, and RFC 9728 §7.3 has the client compare the metadata URL
+        it fetched against ``resource``, so a wrong value fails discovery outright.
+
+        When neither variable is set this returns ``None`` rather than guessing a
+        default host. The value is published as this server's identity, and a
+        confidently wrong identity is worse than an absent one.
         """
         return (
             DeploymentConfig.DATAROBOT_PUBLIC_API_ENDPOINT.get_from_os_env()

--- a/src/datarobot_genai/drmcp/core/middleware.py
+++ b/src/datarobot_genai/drmcp/core/middleware.py
@@ -108,9 +108,9 @@ class ErrorResponse(Enum):
 
 
 def build_well_known_protected_resource_url(request: Request) -> str:
-    self_url = DeploymentEndpointResolver().get_deployment_url()
-    if self_url:
-        return f"{self_url.rstrip('/')}/.well-known/oauth-protected-resource"
+    well_known_url = DeploymentEndpointResolver().get_well_known_protected_resource_metadata_url()
+    if well_known_url:
+        return well_known_url
     return str(
         request.url.replace(
             path=prefix_mount_path("/.well-known/oauth-protected-resource"),

--- a/src/datarobot_genai/drmcp/core/middleware.py
+++ b/src/datarobot_genai/drmcp/core/middleware.py
@@ -32,7 +32,7 @@ from starlette.responses import Response
 from starlette.types import Scope
 
 from datarobot_genai.drmcp.core.config import get_config
-from datarobot_genai.drmcp.core.runtime_identity import resolve_self_url
+from datarobot_genai.drmcp.core.runtime_identity import DeploymentEndpointResolver
 from datarobot_genai.drmcpbase.auth.exceptions import AudienceClaimValidationError
 from datarobot_genai.drmcpbase.auth.exceptions import MCPToolScopeClaimValidationError
 from datarobot_genai.drmcpbase.auth.jwt import JWTTokenClaimsValidator
@@ -108,7 +108,7 @@ class ErrorResponse(Enum):
 
 
 def build_well_known_protected_resource_url(request: Request) -> str:
-    self_url = resolve_self_url()
+    self_url = DeploymentEndpointResolver().get_deployment_url()
     if self_url:
         return f"{self_url.rstrip('/')}/.well-known/oauth-protected-resource"
     return str(

--- a/src/datarobot_genai/drmcp/core/oauth_metadata.py
+++ b/src/datarobot_genai/drmcp/core/oauth_metadata.py
@@ -28,7 +28,7 @@ from datarobot_genai.drmcpbase.oauth_protected_resource_metadata.entities import
 from datarobot_genai.drmcpbase.oauth_scopes import derived_scopes
 
 from .config import get_config
-from .runtime_identity import resolve_self_url
+from .runtime_identity import DeploymentEndpointResolver
 
 
 def build_protected_resource_metadata_config() -> MCPOAuthProtectedResourceMetadataConfig:
@@ -45,7 +45,7 @@ def build_protected_resource_metadata_config() -> MCPOAuthProtectedResourceMetad
     """
     config = get_config()
     return MCPOAuthProtectedResourceMetadataConfig.from_settings(
-        resource=config.mcp_oauth_resource or resolve_self_url(),
+        resource=config.mcp_oauth_resource or DeploymentEndpointResolver().get_deployment_url(),
         authorization_servers=config.mcp_oauth_authorization_servers,
         scopes_supported=derived_scopes(),
         xaa_trusted_issuer=config.mcp_xaa_trusted_issuer,

--- a/src/datarobot_genai/drmcp/core/oauth_scopes.py
+++ b/src/datarobot_genai/drmcp/core/oauth_scopes.py
@@ -50,7 +50,7 @@ from datarobot_genai.drmcputils.constants import RUNTIME_PARAM_ENV_VAR_NAME_PREF
 
 from .config import MCPServerConfig
 from .config import get_config
-from .runtime_identity import resolve_self_url
+from .runtime_identity import DeploymentEndpointResolver
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +147,11 @@ def build_scope_settings(config: MCPServerConfig | None = None) -> ScopeSettings
         source=ScopeSource.parse(config.mcp_oauth_scope_source),
         tag_scopes=read_tag_scopes(),
         issuer=issuers[0] if issuers else None,
-        audience=config.mcp_oauth_audience or config.mcp_oauth_resource or resolve_self_url(),
+        audience=(
+            config.mcp_oauth_audience
+            or config.mcp_oauth_resource
+            or DeploymentEndpointResolver().get_deployment_url()
+        ),
         jwks_uri=config.mcp_oauth_jwks_uri,
     )
 

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -101,7 +101,7 @@ class GatewayType(Enum):
 
 
 class DeploymentEndpointResolver:
-    def __init__(self):
+    def __init__(self) -> None:
         self.mcp_path_suffix = prefix_mount_path(MCP_PATH_ENDPOINT).strip("/")
         self.gateway_url = self.get_gateway_url()
         self.gateway_type = self.get_gateway_type()

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -49,6 +49,8 @@ independently evolvable is worth more than removing this much duplication.
 from __future__ import annotations
 
 import os
+from enum import Enum
+from enum import auto
 
 WORKLOAD_ID_ENV = "WORKLOAD_ID"
 DEPLOYMENT_ID_ENV = "MLOPS_DEPLOYMENT_ID"
@@ -100,21 +102,125 @@ def build_workload_url(endpoint: str, workload_id: str, path: str) -> str:
     return f"{base}/{WORKLOAD_ENDPOINTS_SEGMENT}/{workload_id}/{path}"
 
 
-def resolve_self_url(path: str = DEFAULT_MCP_PATH) -> str | None:
-    """Return this server's own externally reachable URL for ``path``.
+class DeploymentRelatedConfig(Enum):
+    WORKLOAD_ID = auto()
+    MLOPS_DEPLOYMENT_ID = auto()
+    DATAROBOT_PUBLIC_API_ENDPOINT = auto()
+    DATAROBOT_ENDPOINT = auto()
+    DR_WORKLOAD_EXTERNAL_URL_HOST = auto()
+    DR_WORKLOAD_EXTERNAL_URL_PREFIX = auto()
 
-    Returns ``None`` when the process is not in a DataRobot-hosted runtime, or
-    when the endpoint is unset. That is the local-development case: there is no
-    platform-assigned id to compose a URL from, and the caller decides what to
-    publish instead.
-    """
-    endpoint = resolve_datarobot_endpoint()
-    if not endpoint:
-        return None
+    def get_from_os_env(self) -> str | None:
+        return os.getenv(self.name, "").strip() or None
 
-    path = path.strip("/")
-    if deployment_id := get_deployment_id():
-        return build_deployment_url(endpoint, deployment_id, path)
-    if workload_id := get_workload_id():
-        return build_workload_url(endpoint, workload_id, path)
-    return None
+    @staticmethod
+    def get_datarobot_public_api_endpoint() -> str | None:
+        return (
+            DeploymentRelatedConfig.DATAROBOT_PUBLIC_API_ENDPOINT.get_from_os_env()
+            or DeploymentRelatedConfig.DATAROBOT_ENDPOINT.get_from_os_env()
+        )
+
+    @staticmethod
+    def get_workload_deployment_path_segment() -> str | None:
+        return DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_PREFIX.get_from_os_env()
+
+
+class DeploymentEndpointResolver:
+    def __init__(self, mcp_path_segment: str = DEFAULT_MCP_PATH):
+        self.mcp_path_segment = mcp_path_segment.strip("/")
+
+    @staticmethod
+    def get_workload_deployment_id() -> str | None:
+        return DeploymentRelatedConfig.WORKLOAD_ID.get_from_os_env()
+
+    @staticmethod
+    def get_mlops_deployment_id() -> str | None:
+        return DeploymentRelatedConfig.MLOPS_DEPLOYMENT_ID.get_from_os_env()
+
+    @staticmethod
+    def is_workload_deployment() -> bool:
+        return DeploymentEndpointResolver.get_workload_deployment_id() is not None
+
+    @staticmethod
+    def get_deployment_id() -> str | None:
+        return (
+            DeploymentEndpointResolver.get_workload_deployment_id()
+            or DeploymentEndpointResolver.get_mlops_deployment_id()
+        )
+
+    @staticmethod
+    def get_non_public_api_based_gateway_url() -> str | None:
+        return DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env()
+
+    @staticmethod
+    def get_public_api_based_gateway_url() -> str | None:
+        return DeploymentRelatedConfig.get_datarobot_public_api_endpoint()
+
+    @staticmethod
+    def is_deployed_behind_non_public_api_based_gateway() -> bool:
+        return DeploymentEndpointResolver.get_non_public_api_based_gateway_url() is not None
+
+    @staticmethod
+    def get_gateway_url() -> str | None:
+        return (
+            DeploymentEndpointResolver.get_non_public_api_based_gateway_url()
+            or DeploymentEndpointResolver.get_public_api_based_gateway_url()
+        )
+
+    def build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
+        self, gateway_url: str, deployment_id: str
+    ) -> str:
+        gateway_url = gateway_url.rstrip("/")
+        return f"{gateway_url}/deployments/{deployment_id}/directAccess/{self.mcp_path_segment}"
+
+    def build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
+        self, gateway_url: str, workload_id: str
+    ) -> str:
+        gateway_url = gateway_url.rstrip("/")
+        return f"{gateway_url}/endpoints/workloads/{workload_id}/{self.mcp_path_segment}"
+
+    def build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
+        self, gateway_url: str, workload_deployment_segment: str
+    ) -> str:
+        gateway_url = gateway_url.rstrip("/")
+        workload_deployment_segment = workload_deployment_segment.rstrip("/")
+        url_segment = f"{workload_deployment_segment}/{self.mcp_path_segment}"
+        return f"{gateway_url}/{url_segment}"
+
+    @staticmethod
+    def is_workload_deployment_behind_non_public_api_gateway() -> bool:
+        return (
+            DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_PREFIX.get_from_os_env() is not None
+            and DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env() is not None
+        )
+
+    def get_deployment_url(self) -> str | None:
+        gateway_url = self.get_gateway_url()
+        if not gateway_url:
+            return None
+        deployment_id = self.get_deployment_id()
+        if not deployment_id:
+            return None
+
+        # DR_WORKLOAD_EXTERNAL_URL_HOST/_PREFIX are only ever set by the platform for
+        # a genuine workload deployment (MLOps deployments are only ever valid behind
+        # the public API gateway), so no separate deployment-type cross-check is
+        # needed here — this trusts that platform-level invariant rather than
+        # re-verifying it.
+        if self.is_workload_deployment_behind_non_public_api_gateway():
+            workload_deployment_url_segment = (
+                DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_PREFIX.get_from_os_env()
+            )
+            return self.build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
+                gateway_url,
+                workload_deployment_url_segment,
+            )
+        if self.is_workload_deployment():
+            return self.build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
+                gateway_url,
+                deployment_id,
+            )
+        return self.build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
+            gateway_url,
+            deployment_id,
+        )

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -53,6 +53,8 @@ from enum import Enum
 from enum import auto
 
 from datarobot_genai.drmcp.core.constants import MCP_PATH_ENDPOINT
+from datarobot_genai.drmcp.core.deployment_config import DeploymentConfig
+from datarobot_genai.drmcp.core.deployment_config import MCPDeploymentType
 from datarobot_genai.drmcp.core.routes_utils import prefix_mount_path
 
 WORKLOAD_ID_ENV = "WORKLOAD_ID"
@@ -102,27 +104,6 @@ def build_workload_url(endpoint: str, workload_id: str, path: str) -> str:
     return f"{base}/{WORKLOAD_ENDPOINTS_SEGMENT}/{workload_id}/{path}"
 
 
-class DeploymentRelatedConfig(Enum):
-    WORKLOAD_ID = auto()
-    MLOPS_DEPLOYMENT_ID = auto()
-    DATAROBOT_PUBLIC_API_ENDPOINT = auto()
-    DATAROBOT_ENDPOINT = auto()
-    DR_WORKLOAD_EXTERNAL_URL_HOST = auto()
-
-    def get_from_os_env(self) -> str | None:
-        return os.getenv(self.name, "").strip() or None
-
-    @staticmethod
-    def get_datarobot_public_api_endpoint() -> str | None:
-        """Prefer ``DATAROBOT_PUBLIC_API_ENDPOINT`` over ``DATAROBOT_ENDPOINT``; see
-        the module docstring for why that order matters and why there is no default.
-        """
-        return (
-            DeploymentRelatedConfig.DATAROBOT_PUBLIC_API_ENDPOINT.get_from_os_env()
-            or DeploymentRelatedConfig.DATAROBOT_ENDPOINT.get_from_os_env()
-        )
-
-
 class GatewayType(Enum):
     """It is the gateway behind which MCP is deployed."""
 
@@ -146,11 +127,6 @@ class GatewayType(Enum):
             )
 
 
-class MCPDeploymentType(Enum):
-    MLOPS = auto()
-    WORKLOAD = auto()
-
-
 class DeploymentEndpointResolver:
     def __init__(self):
         self.mcp_path_suffix = prefix_mount_path(MCP_PATH_ENDPOINT).strip("/")
@@ -162,8 +138,8 @@ class DeploymentEndpointResolver:
     @staticmethod
     def get_gateway_url() -> str | None:
         gateway_url = (
-            DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env()
-            or DeploymentRelatedConfig.get_datarobot_public_api_endpoint()
+            DeploymentConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env()
+            or DeploymentConfig.get_datarobot_public_api_endpoint()
         )
         if gateway_url and "://" not in gateway_url:
             gateway_url = f"https://{gateway_url}"
@@ -173,7 +149,7 @@ class DeploymentEndpointResolver:
 
     @staticmethod
     def get_gateway_type() -> GatewayType:
-        if DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env() is not None:
+        if DeploymentConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env() is not None:
             return GatewayType.NON_PUBLIC_API_BASED_GATEWAY
         else:
             return GatewayType.PUBLIC_API_BASED_GATEWAY
@@ -181,13 +157,13 @@ class DeploymentEndpointResolver:
     @staticmethod
     def get_deployment_id() -> str | None:
         return (
-            DeploymentRelatedConfig.WORKLOAD_ID.get_from_os_env()
-            or DeploymentRelatedConfig.MLOPS_DEPLOYMENT_ID.get_from_os_env()
+            DeploymentConfig.WORKLOAD_ID.get_from_os_env()
+            or DeploymentConfig.MLOPS_DEPLOYMENT_ID.get_from_os_env()
         )
 
     @staticmethod
     def get_deployment_type() -> MCPDeploymentType:
-        if DeploymentRelatedConfig.WORKLOAD_ID.get_from_os_env() is not None:
+        if DeploymentConfig.WORKLOAD_ID.get_from_os_env() is not None:
             return MCPDeploymentType.WORKLOAD
         else:
             return MCPDeploymentType.MLOPS

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -52,6 +52,9 @@ import os
 from enum import Enum
 from enum import auto
 
+from datarobot_genai.drmcp.core.constants import MCP_PATH_ENDPOINT
+from datarobot_genai.drmcp.core.routes_utils import prefix_mount_path
+
 WORKLOAD_ID_ENV = "WORKLOAD_ID"
 DEPLOYMENT_ID_ENV = "MLOPS_DEPLOYMENT_ID"
 PUBLIC_ENDPOINT_ENV = "DATAROBOT_PUBLIC_API_ENDPOINT"
@@ -61,9 +64,6 @@ ENDPOINT_ENV = "DATAROBOT_ENDPOINT"
 DEPLOYMENT_DIRECT_ACCESS_SEGMENT = "directAccess"
 #: Prefix the platform routes workload traffic through.
 WORKLOAD_ENDPOINTS_SEGMENT = "endpoints/workloads"
-
-#: Path this server is served from, relative to whichever prefix its mode uses.
-DEFAULT_MCP_PATH = "mcp"
 
 
 def _env(name: str) -> str | None:
@@ -115,115 +115,100 @@ class DeploymentRelatedConfig(Enum):
 
     @staticmethod
     def get_datarobot_public_api_endpoint() -> str | None:
+        """Prefer ``DATAROBOT_PUBLIC_API_ENDPOINT`` over ``DATAROBOT_ENDPOINT``; see
+        the module docstring for why that order matters and why there is no default.
+        """
         return (
             DeploymentRelatedConfig.DATAROBOT_PUBLIC_API_ENDPOINT.get_from_os_env()
             or DeploymentRelatedConfig.DATAROBOT_ENDPOINT.get_from_os_env()
         )
 
-    @staticmethod
-    def get_workload_deployment_path_segment() -> str | None:
-        return DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_PREFIX.get_from_os_env()
+
+class GatewayType(Enum):
+    """It is the gateway behind which MCP is deployed."""
+
+    PUBLIC_API_BASED_GATEWAY = auto()
+    NON_PUBLIC_API_BASED_GATEWAY = auto()
+
+    def get_workload_deployment_url_segment(self, deployment_id: str) -> str:
+        if self == GatewayType.PUBLIC_API_BASED_GATEWAY:
+            url_segment = f"/endpoints/workloads/{deployment_id}/"
+        else:
+            url_segment = f"/workloads/{deployment_id}/"
+        return url_segment.strip("/")
+
+    def get_mlops_deployment_url_segment(self, deployment_id: str) -> str:
+        if self == GatewayType.PUBLIC_API_BASED_GATEWAY:
+            url_segment = f"/deployments/{deployment_id}/directAccess/"
+            return url_segment.strip("/")
+        else:
+            raise ValueError(
+                "MLOps deployment URL is not supported in a non-public-API-based gateway."
+            )
+
+
+class MCPDeploymentType(Enum):
+    MLOPS = auto()
+    WORKLOAD = auto()
 
 
 class DeploymentEndpointResolver:
-    def __init__(self, mcp_path_segment: str = DEFAULT_MCP_PATH):
-        self.mcp_path_segment = mcp_path_segment.strip("/")
-
-    @staticmethod
-    def get_workload_deployment_id() -> str | None:
-        return DeploymentRelatedConfig.WORKLOAD_ID.get_from_os_env()
-
-    @staticmethod
-    def get_mlops_deployment_id() -> str | None:
-        return DeploymentRelatedConfig.MLOPS_DEPLOYMENT_ID.get_from_os_env()
-
-    @staticmethod
-    def is_workload_deployment() -> bool:
-        return DeploymentEndpointResolver.get_workload_deployment_id() is not None
-
-    @staticmethod
-    def get_deployment_id() -> str | None:
-        return (
-            DeploymentEndpointResolver.get_workload_deployment_id()
-            or DeploymentEndpointResolver.get_mlops_deployment_id()
-        )
-
-    @staticmethod
-    def get_non_public_api_based_gateway_url() -> str | None:
-        return DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env()
-
-    @staticmethod
-    def get_public_api_based_gateway_url() -> str | None:
-        return DeploymentRelatedConfig.get_datarobot_public_api_endpoint()
-
-    @staticmethod
-    def is_deployed_behind_non_public_api_based_gateway() -> bool:
-        return DeploymentEndpointResolver.get_non_public_api_based_gateway_url() is not None
+    def __init__(self):
+        self.mcp_path_suffix = prefix_mount_path(MCP_PATH_ENDPOINT).strip("/")
+        self.gateway_url = self.get_gateway_url()
+        self.gateway_type = self.get_gateway_type()
+        self.deployment_id = self.get_deployment_id()
+        self.deployment_type = self.get_deployment_type()
 
     @staticmethod
     def get_gateway_url() -> str | None:
         gateway_url = (
-            DeploymentEndpointResolver.get_non_public_api_based_gateway_url()
-            or DeploymentEndpointResolver.get_public_api_based_gateway_url()
+            DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env()
+            or DeploymentRelatedConfig.get_datarobot_public_api_endpoint()
         )
         if gateway_url and "://" not in gateway_url:
             gateway_url = f"https://{gateway_url}"
+        if gateway_url:
+            gateway_url = gateway_url.rstrip("/")
         return gateway_url
 
-    def build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
-        self, gateway_url: str, deployment_id: str
-    ) -> str:
-        gateway_url = gateway_url.rstrip("/")
-        return f"{gateway_url}/deployments/{deployment_id}/directAccess/{self.mcp_path_segment}"
-
-    def build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
-        self, gateway_url: str, workload_id: str
-    ) -> str:
-        gateway_url = gateway_url.rstrip("/")
-        return f"{gateway_url}/endpoints/workloads/{workload_id}/{self.mcp_path_segment}"
-
-    def build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
-        self, gateway_url: str, workload_deployment_segment: str
-    ) -> str:
-        gateway_url = gateway_url.rstrip("/")
-        workload_deployment_segment = workload_deployment_segment.strip("/")
-        url_segment = f"{workload_deployment_segment}/{self.mcp_path_segment}"
-        return f"{gateway_url}/{url_segment}"
+    @staticmethod
+    def get_gateway_type() -> GatewayType:
+        if DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env() is not None:
+            return GatewayType.NON_PUBLIC_API_BASED_GATEWAY
+        else:
+            return GatewayType.PUBLIC_API_BASED_GATEWAY
 
     @staticmethod
-    def is_workload_deployment_behind_non_public_api_gateway() -> bool:
+    def get_deployment_id() -> str | None:
         return (
-            DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_PREFIX.get_from_os_env() is not None
-            and DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_HOST.get_from_os_env() is not None
+            DeploymentRelatedConfig.WORKLOAD_ID.get_from_os_env()
+            or DeploymentRelatedConfig.MLOPS_DEPLOYMENT_ID.get_from_os_env()
+        )
+
+    @staticmethod
+    def get_deployment_type() -> MCPDeploymentType:
+        if DeploymentRelatedConfig.WORKLOAD_ID.get_from_os_env() is not None:
+            return MCPDeploymentType.WORKLOAD
+        else:
+            return MCPDeploymentType.MLOPS
+
+    def get_deployment_segment_url(self, deployment_id: str) -> str:
+        return (
+            self.gateway_type.get_workload_deployment_url_segment(deployment_id)
+            if self.deployment_type == MCPDeploymentType.WORKLOAD
+            else self.gateway_type.get_mlops_deployment_url_segment(deployment_id)
         )
 
     def get_deployment_url(self) -> str | None:
-        gateway_url = self.get_gateway_url()
-        if not gateway_url:
+        if not self.gateway_url or not self.deployment_id:
             return None
-        deployment_id = self.get_deployment_id()
-        if not deployment_id:
-            return None
+        deployment_segment_url = self.get_deployment_segment_url(self.deployment_id)
+        return f"{self.gateway_url}/{deployment_segment_url}/{self.mcp_path_suffix}"
 
-        # DR_WORKLOAD_EXTERNAL_URL_HOST/_PREFIX are only ever set by the platform for
-        # a genuine workload deployment (MLOps deployments are only ever valid behind
-        # the public API gateway), so no separate deployment-type cross-check is
-        # needed here — this trusts that platform-level invariant rather than
-        # re-verifying it.
-        if self.is_workload_deployment_behind_non_public_api_gateway():
-            workload_deployment_url_segment = (
-                DeploymentRelatedConfig.DR_WORKLOAD_EXTERNAL_URL_PREFIX.get_from_os_env()
-            )
-            return self.build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
-                gateway_url,
-                workload_deployment_url_segment,  # type: ignore[arg-type]
-            )
-        if self.is_workload_deployment():
-            return self.build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
-                gateway_url,
-                deployment_id,
-            )
-        return self.build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
-            gateway_url,
-            deployment_id,
-        )
+    def get_well_known_protected_resource_metadata_url(self) -> str | None:
+        if not self.gateway_url or not self.deployment_id:
+            return None
+        deployment_segment_url = self.get_deployment_segment_url(self.deployment_id)
+        sub_path = prefix_mount_path(".well-known/oauth-protected-resource").lstrip("/")
+        return f"{self.gateway_url}/{deployment_segment_url}/{sub_path}"

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -12,35 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Where this MCP server is reachable from outside.
-
-Neither hosting mode knows its own public URL when the image is built, because
-the id is assigned at deploy time. Both can compose it once running, from the id
-DataRobot injects into the container and the platform's fixed routing patterns:
-
-===========  =====================================================
-deployment   ``{endpoint}/deployments/{id}/directAccess/{path}``
-workload     ``{endpoint}/endpoints/workloads/{id}/{path}``
-===========  =====================================================
-
-Both are routed through the DataRobot API host, so composing the URL needs no
-API call: there is nothing to time out, retry, or cache, and a server can always
-answer the question about itself.
-
-Two deliberate choices worth knowing about:
-
-``DATAROBOT_PUBLIC_API_ENDPOINT`` wins over ``DATAROBOT_ENDPOINT``
-    An on-prem install commonly points ``DATAROBOT_ENDPOINT`` at an internal
-    cluster address. A resource identifier built from it is one no external
-    client can reach, and RFC 9728 §7.3 has the client compare the metadata URL
-    it fetched against ``resource``, so a wrong value fails discovery outright.
-
-No fallback endpoint
-    When neither variable is set this returns ``None`` rather than guessing a
-    default host. The value is published as this server's identity, and a
-    confidently wrong identity is worse than an absent one.
-
-This module is intentionally standalone: ``drmcp`` does not depend on
+"""
+The module is intentionally standalone: ``drmcp`` does not depend on
 ``datarobot_genai.core`` or on ``dragent``, so the few env var names and URL
 patterns are restated here rather than shared. Keeping the MCP and agent trees
 independently evolvable is worth more than removing this much duplication.

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -108,7 +108,6 @@ class DeploymentRelatedConfig(Enum):
     DATAROBOT_PUBLIC_API_ENDPOINT = auto()
     DATAROBOT_ENDPOINT = auto()
     DR_WORKLOAD_EXTERNAL_URL_HOST = auto()
-    DR_WORKLOAD_EXTERNAL_URL_PREFIX = auto()
 
     def get_from_os_env(self) -> str | None:
         return os.getenv(self.name, "").strip() or None

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -162,10 +162,13 @@ class DeploymentEndpointResolver:
 
     @staticmethod
     def get_gateway_url() -> str | None:
-        return (
+        gateway_url = (
             DeploymentEndpointResolver.get_non_public_api_based_gateway_url()
             or DeploymentEndpointResolver.get_public_api_based_gateway_url()
         )
+        if gateway_url and "://" not in gateway_url:
+            gateway_url = f"https://{gateway_url}"
+        return gateway_url
 
     def build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
         self, gateway_url: str, deployment_id: str
@@ -183,7 +186,7 @@ class DeploymentEndpointResolver:
         self, gateway_url: str, workload_deployment_segment: str
     ) -> str:
         gateway_url = gateway_url.rstrip("/")
-        workload_deployment_segment = workload_deployment_segment.rstrip("/")
+        workload_deployment_segment = workload_deployment_segment.strip("/")
         url_segment = f"{workload_deployment_segment}/{self.mcp_path_segment}"
         return f"{gateway_url}/{url_segment}"
 
@@ -213,7 +216,7 @@ class DeploymentEndpointResolver:
             )
             return self.build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
                 gateway_url,
-                workload_deployment_url_segment,
+                workload_deployment_url_segment,  # type: ignore[arg-type]
             )
         if self.is_workload_deployment():
             return self.build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(

--- a/tests/drmcp/unit/test_runtime_identity.py
+++ b/tests/drmcp/unit/test_runtime_identity.py
@@ -14,16 +14,19 @@
 """Resolving this server's own externally reachable URL."""
 
 import os
+from collections.abc import Iterator
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
 
+from datarobot_genai.drmcp.core.runtime_identity import DeploymentEndpointResolver
+from datarobot_genai.drmcp.core.runtime_identity import DeploymentRelatedConfig
 from datarobot_genai.drmcp.core.runtime_identity import build_deployment_url
 from datarobot_genai.drmcp.core.runtime_identity import build_workload_url
 from datarobot_genai.drmcp.core.runtime_identity import get_deployment_id
 from datarobot_genai.drmcp.core.runtime_identity import get_workload_id
 from datarobot_genai.drmcp.core.runtime_identity import resolve_datarobot_endpoint
-from datarobot_genai.drmcp.core.runtime_identity import resolve_self_url
 
 PUBLIC = "https://public.datarobot.com/api/v2"
 INTERNAL = "https://internal.k8s.local/api/v2"
@@ -85,41 +88,274 @@ class TestPlatformIds:
             assert get_deployment_id() is None
 
 
-class TestResolveSelfUrl:
-    def test_deployment_mode(self) -> None:
-        env = {"DATAROBOT_ENDPOINT": PUBLIC, "MLOPS_DEPLOYMENT_ID": "dep1"}
-        with patch.dict(os.environ, env, clear=True):
-            assert resolve_self_url() == f"{PUBLIC}/deployments/dep1/directAccess/mcp"
+class TestDeploymentEndpointResolver:
+    @pytest.fixture
+    def mock_mcp_url_segment(self) -> str:
+        return "mcp"
 
-    def test_workload_mode(self) -> None:
-        env = {"DATAROBOT_ENDPOINT": PUBLIC, "WORKLOAD_ID": "wl1"}
-        with patch.dict(os.environ, env, clear=True):
-            assert resolve_self_url() == f"{PUBLIC}/endpoints/workloads/wl1/mcp"
+    @pytest.fixture
+    def mock_get_datarobot_public_api_endpoint(self) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentRelatedConfig, "get_datarobot_public_api_endpoint"
+        ) as mock_func:
+            yield mock_func
 
-    def test_deployment_wins_when_both_ids_are_present(self) -> None:
-        env = {"DATAROBOT_ENDPOINT": PUBLIC, "MLOPS_DEPLOYMENT_ID": "dep1", "WORKLOAD_ID": "wl1"}
-        with patch.dict(os.environ, env, clear=True):
-            assert "/deployments/dep1/" in str(resolve_self_url())
+    @pytest.fixture
+    def mock_is_workload_deployment(self) -> Iterator[Mock]:
+        with patch.object(DeploymentEndpointResolver, "is_workload_deployment") as mock_func:
+            yield mock_func
 
-    def test_uses_the_public_endpoint_for_the_published_identity(self) -> None:
-        env = {
-            "DATAROBOT_PUBLIC_API_ENDPOINT": PUBLIC,
-            "DATAROBOT_ENDPOINT": INTERNAL,
-            "MLOPS_DEPLOYMENT_ID": "dep1",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            assert str(resolve_self_url()).startswith(PUBLIC)
+    @pytest.fixture
+    def mock_is_workload_deployment_behind_non_public_api_gateway(self) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentEndpointResolver, "is_workload_deployment_behind_non_public_api_gateway"
+        ) as mock_func:
+            yield mock_func
 
-    def test_local_development_resolves_to_nothing(self) -> None:
-        """GIVEN no platform id, THEN the caller decides what to publish instead."""
-        with patch.dict(os.environ, {"DATAROBOT_ENDPOINT": PUBLIC}, clear=True):
-            assert resolve_self_url() is None
+    @pytest.fixture
+    def mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway(
+        self,
+    ) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentEndpointResolver,
+            "build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway",
+        ) as mock_func:
+            yield mock_func
 
-    def test_no_endpoint_resolves_to_nothing(self) -> None:
+    @pytest.fixture
+    def mock_build_url_of_mcp_workload_behind_public_api_based_gateway(
+        self,
+    ) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentEndpointResolver,
+            "build_url_of_mcp_workload_deployment_behind_public_api_based_gateway",
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
+        self,
+    ) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentEndpointResolver,
+            "build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway",
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_gateway_url(self) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentEndpointResolver,
+            "get_gateway_url",
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_deployment_id(self) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentEndpointResolver,
+            "get_deployment_id",
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_non_public_api_based_gateway_url(self) -> Iterator[Mock]:
+        with patch.object(
+            DeploymentEndpointResolver,
+            "get_non_public_api_based_gateway_url",
+        ) as mock_func:
+            yield mock_func
+
+    @pytest.mark.parametrize(
+        "mcp_path, output",
+        [("/mcp/", "mcp"), ("mcp", "mcp"), ("mcp/", "mcp")],
+        ids=str,
+    )
+    def test_init_strip_mcp_path_segment(self, mcp_path: str, output: str) -> None:
+        resolver = DeploymentEndpointResolver(mcp_path)
+        assert resolver.mcp_path_segment == output
+
+    def test_get_workload_deployment_id(self) -> None:
+        with patch.dict(os.environ, {"WORKLOAD_ID": "wl1"}, clear=True):
+            assert DeploymentEndpointResolver.get_workload_deployment_id() == "wl1"
+
+    def test_get_mlops_deployment_id(self) -> None:
         with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "dep1"}, clear=True):
-            assert resolve_self_url() is None
+            assert DeploymentEndpointResolver.get_mlops_deployment_id() == "dep1"
 
-    def test_path_separators_are_not_doubled(self) -> None:
-        env = {"DATAROBOT_ENDPOINT": PUBLIC, "MLOPS_DEPLOYMENT_ID": "dep1"}
+    def test_is_workload_deployment_true(self) -> None:
+        with patch.dict(os.environ, {"WORKLOAD_ID": "wl1"}, clear=True):
+            assert DeploymentEndpointResolver.is_workload_deployment() is True
+
+    def test_is_workload_deployment_false(self) -> None:
+        with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "dep1"}, clear=True):
+            assert DeploymentEndpointResolver.is_workload_deployment() is False
+
+    def test_get_gateway_url_prefers_non_public_over_public(self) -> None:
+        env = {"DR_WORKLOAD_EXTERNAL_URL_HOST": "host", "DATAROBOT_PUBLIC_API_ENDPOINT": "afdafds"}
         with patch.dict(os.environ, env, clear=True):
-            assert resolve_self_url("/mcp/") == f"{PUBLIC}/deployments/dep1/directAccess/mcp"
+            assert DeploymentEndpointResolver.get_gateway_url() == "host"
+
+    def test_get_gateway_url_falls_back_to_public(self) -> None:
+        with patch.dict(os.environ, {"DATAROBOT_PUBLIC_API_ENDPOINT": "endpoint"}, clear=True):
+            assert DeploymentEndpointResolver.get_gateway_url() == "endpoint"
+
+    def test_get_gateway_url_none_when_nothing_configured(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            assert DeploymentEndpointResolver.get_gateway_url() is None
+
+    def test_get_deployment_id_prefers_workload_over_mlops(self) -> None:
+        env = {"WORKLOAD_ID": "wl1", "MLOPS_DEPLOYMENT_ID": "dep1"}
+        with patch.dict(os.environ, env, clear=True):
+            assert DeploymentEndpointResolver.get_deployment_id() == "wl1"
+
+    def test_get_deployment_id_falls_back_to_mlops(self) -> None:
+        with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "dep1"}, clear=True):
+            assert DeploymentEndpointResolver.get_deployment_id() == "dep1"
+
+    def test_get_deployment_id_none_when_neither_set(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            assert DeploymentEndpointResolver.get_deployment_id() is None
+
+    def test_get_non_public_api_based_gateway_url(self) -> None:
+        with patch.dict(os.environ, {"DR_WORKLOAD_EXTERNAL_URL_HOST": "host"}, clear=True):
+            assert DeploymentEndpointResolver.get_non_public_api_based_gateway_url() == "host"
+
+    def test_get_public_api_based_gateway_url(
+        self, mock_get_datarobot_public_api_endpoint: Mock
+    ) -> None:
+        output = DeploymentEndpointResolver.get_public_api_based_gateway_url()
+
+        mock_get_datarobot_public_api_endpoint.assert_called_once_with()
+        assert output == mock_get_datarobot_public_api_endpoint.return_value
+
+    @pytest.mark.parametrize(
+        "gateway_url, output",
+        [("dsafa", True), (None, False)],
+        ids=str,
+    )
+    def test_is_deployed_behind_non_public_api_based_gateway(
+        self,
+        gateway_url: str | None,
+        output: bool,
+        mock_get_non_public_api_based_gateway_url: Mock,
+    ) -> None:
+        mock_get_non_public_api_based_gateway_url.return_value = gateway_url
+
+        assert (
+            DeploymentEndpointResolver.is_deployed_behind_non_public_api_based_gateway() is output
+        )
+
+    def test_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
+        self, mock_mcp_url_segment: str
+    ) -> None:
+        resolver = DeploymentEndpointResolver(mock_mcp_url_segment)
+        gateway_url = "http://localhost/foo/bar"
+        deployment_id = "1234"
+        output = resolver.build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
+            gateway_url, deployment_id
+        )
+
+        assert (
+            output
+            == f"{gateway_url}/deployments/{deployment_id}/directAccess/{mock_mcp_url_segment}"
+        )
+
+    def test_build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
+        self, mock_mcp_url_segment: str
+    ) -> None:
+        resolver = DeploymentEndpointResolver(mock_mcp_url_segment)
+        gateway_url = "http://localhost/foo/bar"
+        deployment_id = "1234"
+        output = resolver.build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
+            gateway_url, deployment_id
+        )
+
+        assert output == f"{gateway_url}/endpoints/workloads/{deployment_id}/{mock_mcp_url_segment}"
+
+    def test_build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
+        self, mock_mcp_url_segment: str
+    ) -> None:
+        resolver = DeploymentEndpointResolver(mock_mcp_url_segment)
+        gateway_url = "http://localhost/foo/bar"
+        workload_deployment_segment = "workload/1234"
+        output = resolver.build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
+            gateway_url,
+            workload_deployment_segment,
+        )
+
+        assert output == f"{gateway_url}/{workload_deployment_segment}/{mock_mcp_url_segment}"
+
+    @pytest.mark.usefixtures("mock_get_deployment_id")
+    def test_return_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
+        self,
+        mock_is_workload_deployment_behind_non_public_api_gateway: Mock,
+        mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway: Mock,
+        mock_get_gateway_url: Mock,
+    ) -> None:
+        expected_mcp_workload_deployment_segment = "dsafda"
+        with patch.dict(
+            os.environ,
+            {"DR_WORKLOAD_EXTERNAL_URL_PREFIX": expected_mcp_workload_deployment_segment},
+            clear=True,
+        ):
+            mock_is_workload_deployment_behind_non_public_api_gateway.return_value = True
+
+            resolver = DeploymentEndpointResolver(Mock())
+            output = resolver.get_deployment_url()
+
+            mock_get_gateway_url.assert_called_once_with()
+            mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway.assert_called_once_with(
+                mock_get_gateway_url.return_value,
+                expected_mcp_workload_deployment_segment,
+            )
+            assert (
+                output
+                == mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway.return_value
+            )
+
+    def test_return_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
+        self,
+        mock_get_gateway_url: Mock,
+        mock_is_workload_deployment: Mock,
+        mock_get_deployment_id: Mock,
+        mock_is_workload_deployment_behind_non_public_api_gateway: Mock,
+        mock_build_url_of_mcp_workload_behind_public_api_based_gateway: Mock,
+    ) -> None:
+        mock_is_workload_deployment_behind_non_public_api_gateway.return_value = False
+
+        resolver = DeploymentEndpointResolver(Mock())
+        output = resolver.get_deployment_url()
+
+        mock_get_gateway_url.assert_called_once_with()
+        mock_get_deployment_id.assert_called_once_with()
+        mock_build_url_of_mcp_workload_behind_public_api_based_gateway.assert_called_once_with(
+            mock_get_gateway_url.return_value,
+            mock_get_deployment_id.return_value,
+        )
+        assert output == mock_build_url_of_mcp_workload_behind_public_api_based_gateway.return_value
+
+    def test_return_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
+        self,
+        mock_get_gateway_url: Mock,
+        mock_is_workload_deployment: Mock,
+        mock_get_deployment_id: Mock,
+        mock_is_workload_deployment_behind_non_public_api_gateway: Mock,
+        mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway: Mock,
+    ) -> None:
+        mock_is_workload_deployment_behind_non_public_api_gateway.return_value = False
+        mock_is_workload_deployment.return_value = False
+
+        resolver = DeploymentEndpointResolver(Mock())
+        output = resolver.get_deployment_url()
+
+        mock_get_gateway_url.assert_called_once_with()
+        mock_get_deployment_id.assert_called_once_with()
+        mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway.assert_called_once_with(
+            mock_get_gateway_url.return_value,
+            mock_get_deployment_id.return_value,
+        )
+        assert (
+            output
+            == mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway.return_value
+        )

--- a/tests/drmcp/unit/test_runtime_identity.py
+++ b/tests/drmcp/unit/test_runtime_identity.py
@@ -20,10 +20,10 @@ from unittest.mock import patch
 
 import pytest
 
+from datarobot_genai.drmcp.core.deployment_config import DeploymentConfig
+from datarobot_genai.drmcp.core.deployment_config import MCPDeploymentType
 from datarobot_genai.drmcp.core.runtime_identity import DeploymentEndpointResolver
-from datarobot_genai.drmcp.core.runtime_identity import DeploymentRelatedConfig
 from datarobot_genai.drmcp.core.runtime_identity import GatewayType
-from datarobot_genai.drmcp.core.runtime_identity import MCPDeploymentType
 from datarobot_genai.drmcp.core.runtime_identity import build_deployment_url
 from datarobot_genai.drmcp.core.runtime_identity import build_workload_url
 from datarobot_genai.drmcp.core.runtime_identity import get_deployment_id
@@ -93,12 +93,10 @@ class TestPlatformIds:
 class TestDeploymentRelatedConfig:
     @pytest.mark.parametrize(
         "enum_value",
-        [enum_value for enum_value in DeploymentRelatedConfig],
+        [enum_value for enum_value in DeploymentConfig],
         ids=str,
     )
-    def test_get_from_os_env_strip_surrounding_spaces(
-        self, enum_value: DeploymentRelatedConfig
-    ) -> None:
+    def test_get_from_os_env_strip_surrounding_spaces(self, enum_value: DeploymentConfig) -> None:
         expected_value = "value_without_surrounding_space"
         with patch.dict(
             os.environ,
@@ -114,7 +112,7 @@ class TestDeploymentRelatedConfig:
             {"DATAROBOT_PUBLIC_API_ENDPOINT": expected_value, "DATAROBOT_ENDPOINT": "dsafas"},
             clear=True,
         ):
-            assert DeploymentRelatedConfig.get_datarobot_public_api_endpoint() == expected_value
+            assert DeploymentConfig.get_datarobot_public_api_endpoint() == expected_value
 
     def test_get_public_api_endpoint_fallback_env_var_datarobot_endpoint(self) -> None:
         expected_value = "https://foo/bar"
@@ -123,7 +121,7 @@ class TestDeploymentRelatedConfig:
             {"DATAROBOT_ENDPOINT": expected_value},
             clear=True,
         ):
-            assert DeploymentRelatedConfig.get_datarobot_public_api_endpoint() == expected_value
+            assert DeploymentConfig.get_datarobot_public_api_endpoint() == expected_value
 
 
 class TestGatewayType:

--- a/tests/drmcp/unit/test_runtime_identity.py
+++ b/tests/drmcp/unit/test_runtime_identity.py
@@ -191,14 +191,29 @@ class TestDeploymentEndpointResolver:
         with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "dep1"}, clear=True):
             assert DeploymentEndpointResolver.is_workload_deployment() is False
 
-    def test_get_gateway_url_prefers_non_public_over_public(self) -> None:
-        env = {"DR_WORKLOAD_EXTERNAL_URL_HOST": "host", "DATAROBOT_PUBLIC_API_ENDPOINT": "afdafds"}
+    @pytest.mark.parametrize(
+        "url_host_env_var, output",
+        [("https://aaa/bbb", "https://aaa/bbb"), ("aaa/bbb", "https://aaa/bbb")],
+        ids=str,
+    )
+    def get_get_gateway_url(self, url_host_env_var: str, output: str) -> None:
+        env = {"DR_WORKLOAD_EXTERNAL_URL_HOST": url_host_env_var}
         with patch.dict(os.environ, env, clear=True):
-            assert DeploymentEndpointResolver.get_gateway_url() == "host"
+            assert DeploymentEndpointResolver.get_gateway_url() == output
+
+    def test_get_gateway_url_prefers_non_public_over_public(self) -> None:
+        env = {
+            "DR_WORKLOAD_EXTERNAL_URL_HOST": "https://aaa/bbb",
+            "DATAROBOT_PUBLIC_API_ENDPOINT": "afdafds",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert DeploymentEndpointResolver.get_gateway_url() == "https://aaa/bbb"
 
     def test_get_gateway_url_falls_back_to_public(self) -> None:
-        with patch.dict(os.environ, {"DATAROBOT_PUBLIC_API_ENDPOINT": "endpoint"}, clear=True):
-            assert DeploymentEndpointResolver.get_gateway_url() == "endpoint"
+        with patch.dict(
+            os.environ, {"DATAROBOT_PUBLIC_API_ENDPOINT": "https://aaa/bbb"}, clear=True
+        ):
+            assert DeploymentEndpointResolver.get_gateway_url() == "https://aaa/bbb"
 
     def test_get_gateway_url_none_when_nothing_configured(self) -> None:
         with patch.dict(os.environ, {}, clear=True):

--- a/tests/drmcp/unit/test_runtime_identity.py
+++ b/tests/drmcp/unit/test_runtime_identity.py
@@ -22,6 +22,8 @@ import pytest
 
 from datarobot_genai.drmcp.core.runtime_identity import DeploymentEndpointResolver
 from datarobot_genai.drmcp.core.runtime_identity import DeploymentRelatedConfig
+from datarobot_genai.drmcp.core.runtime_identity import GatewayType
+from datarobot_genai.drmcp.core.runtime_identity import MCPDeploymentType
 from datarobot_genai.drmcp.core.runtime_identity import build_deployment_url
 from datarobot_genai.drmcp.core.runtime_identity import build_workload_url
 from datarobot_genai.drmcp.core.runtime_identity import get_deployment_id
@@ -88,136 +90,239 @@ class TestPlatformIds:
             assert get_deployment_id() is None
 
 
+class TestDeploymentRelatedConfig:
+    @pytest.mark.parametrize(
+        "enum_value",
+        [enum_value for enum_value in DeploymentRelatedConfig],
+        ids=str,
+    )
+    def test_get_from_os_env_strip_surrounding_spaces(
+        self, enum_value: DeploymentRelatedConfig
+    ) -> None:
+        expected_value = "value_without_surrounding_space"
+        with patch.dict(
+            os.environ,
+            {enum_value.name: f" {expected_value} "},
+            clear=True,
+        ):
+            assert enum_value.get_from_os_env() == expected_value
+
+    def test_get_public_api_endpoint_prefer_env_var_datarobot_public_api_endpoint(self) -> None:
+        expected_value = "https://foo/bar"
+        with patch.dict(
+            os.environ,
+            {"DATAROBOT_PUBLIC_API_ENDPOINT": expected_value, "DATAROBOT_ENDPOINT": "dsafas"},
+            clear=True,
+        ):
+            assert DeploymentRelatedConfig.get_datarobot_public_api_endpoint() == expected_value
+
+    def test_get_public_api_endpoint_fallback_env_var_datarobot_endpoint(self) -> None:
+        expected_value = "https://foo/bar"
+        with patch.dict(
+            os.environ,
+            {"DATAROBOT_ENDPOINT": expected_value},
+            clear=True,
+        ):
+            assert DeploymentRelatedConfig.get_datarobot_public_api_endpoint() == expected_value
+
+
+class TestGatewayType:
+    def test_get_url_segment_of_workload_deployment_deployed_behind_non_public_api_based_gateway(
+        self,
+    ) -> None:
+        mock_deployment_id = "123"
+        output = GatewayType.NON_PUBLIC_API_BASED_GATEWAY.get_workload_deployment_url_segment(
+            mock_deployment_id
+        )
+
+        assert output == f"workloads/{mock_deployment_id}"
+
+    def test_get_url_segment_of_workload_deployment_deployed_behind_public_api_based_gateway(
+        self,
+    ) -> None:
+        mock_deployment_id = "123"
+        output = GatewayType.PUBLIC_API_BASED_GATEWAY.get_workload_deployment_url_segment(
+            mock_deployment_id,
+        )
+
+        assert output == f"endpoints/workloads/{mock_deployment_id}"
+
+    def test_get_url_segment_of_mlops_deployment_deployed_behind_non_public_api_based_gateway(
+        self,
+    ) -> None:
+        with pytest.raises(ValueError):
+            GatewayType.NON_PUBLIC_API_BASED_GATEWAY.get_mlops_deployment_url_segment(Mock())
+
+    def test_get_url_segment_of_mlops_deployment_deployed_behind_public_api_based_gateway(
+        self,
+    ) -> None:
+        mock_deployment_id = "123"
+        output = GatewayType.PUBLIC_API_BASED_GATEWAY.get_mlops_deployment_url_segment(
+            mock_deployment_id,
+        )
+
+        assert output == f"deployments/{mock_deployment_id}/directAccess"
+
+
 class TestDeploymentEndpointResolver:
     @pytest.fixture
-    def mock_mcp_url_segment(self) -> str:
-        return "mcp"
-
-    @pytest.fixture
-    def mock_get_datarobot_public_api_endpoint(self) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentRelatedConfig, "get_datarobot_public_api_endpoint"
-        ) as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_is_workload_deployment(self) -> Iterator[Mock]:
-        with patch.object(DeploymentEndpointResolver, "is_workload_deployment") as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_is_workload_deployment_behind_non_public_api_gateway(self) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentEndpointResolver, "is_workload_deployment_behind_non_public_api_gateway"
-        ) as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway(
-        self,
-    ) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentEndpointResolver,
-            "build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway",
-        ) as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_build_url_of_mcp_workload_behind_public_api_based_gateway(
-        self,
-    ) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentEndpointResolver,
-            "build_url_of_mcp_workload_deployment_behind_public_api_based_gateway",
-        ) as mock_func:
-            yield mock_func
-
-    @pytest.fixture
-    def mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
-        self,
-    ) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentEndpointResolver,
-            "build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway",
-        ) as mock_func:
-            yield mock_func
-
-    @pytest.fixture
     def mock_get_gateway_url(self) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentEndpointResolver,
-            "get_gateway_url",
-        ) as mock_func:
+        with patch.object(DeploymentEndpointResolver, "get_gateway_url") as mock_func:
+            yield mock_func
+
+    @pytest.fixture
+    def mock_get_gateway_type(self) -> Iterator[Mock]:
+        with patch.object(DeploymentEndpointResolver, "get_gateway_type") as mock_func:
             yield mock_func
 
     @pytest.fixture
     def mock_get_deployment_id(self) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentEndpointResolver,
-            "get_deployment_id",
-        ) as mock_func:
+        with patch.object(DeploymentEndpointResolver, "get_deployment_id") as mock_func:
             yield mock_func
 
     @pytest.fixture
-    def mock_get_non_public_api_based_gateway_url(self) -> Iterator[Mock]:
-        with patch.object(
-            DeploymentEndpointResolver,
-            "get_non_public_api_based_gateway_url",
-        ) as mock_func:
+    def mock_get_deployment_type(self) -> Iterator[Mock]:
+        with patch.object(DeploymentEndpointResolver, "get_deployment_type") as mock_func:
             yield mock_func
 
-    @pytest.mark.parametrize(
-        "mcp_path, output",
-        [("/mcp/", "mcp"), ("mcp", "mcp"), ("mcp/", "mcp")],
-        ids=str,
+    @pytest.fixture
+    def mock_get_deployment_segment_url(self) -> Iterator[Mock]:
+        with patch.object(DeploymentEndpointResolver, "get_deployment_segment_url") as mock_func:
+            yield mock_func
+
+    def test_init(
+        self,
+        mock_get_gateway_url: Mock,
+        mock_get_gateway_type: Mock,
+        mock_get_deployment_id: Mock,
+        mock_get_deployment_type: Mock,
+    ) -> None:
+        resolver = DeploymentEndpointResolver()
+
+        assert resolver.mcp_path_suffix == "mcp"
+        assert resolver.gateway_url == mock_get_gateway_url.return_value
+        assert resolver.gateway_type == mock_get_gateway_type.return_value
+        assert resolver.deployment_id == mock_get_deployment_id.return_value
+        assert resolver.deployment_type == mock_get_deployment_type.return_value
+
+    def test_get_deployment_url_return_none_when_gateway_url_is_none(
+        self,
+        mock_get_gateway_url: Mock,
+    ) -> None:
+        mock_get_gateway_url.return_value = None
+
+        resolver = DeploymentEndpointResolver()
+        assert resolver.get_deployment_url() is None
+
+    def test_get_deployment_url_return_none_when_deployment_id_is_none(
+        self,
+        mock_get_deployment_id: Mock,
+    ) -> None:
+        mock_get_deployment_id.return_value = None
+
+        resolver = DeploymentEndpointResolver()
+        assert resolver.get_deployment_url() is None
+
+    @pytest.mark.usefixtures(
+        "mock_get_gateway_url",
+        "mock_get_deployment_id",
     )
-    def test_init_strip_mcp_path_segment(self, mcp_path: str, output: str) -> None:
-        resolver = DeploymentEndpointResolver(mcp_path)
-        assert resolver.mcp_path_segment == output
+    def test_get_deployment_url(
+        self,
+        mock_get_gateway_url: Mock,
+        mock_get_deployment_segment_url: Mock,
+    ) -> None:
+        expected_gateway_url = "https://gateway_url"
+        mock_get_gateway_url.return_value = expected_gateway_url
+        expected_deployment_segment_url = "mcp/deployment"
+        mock_get_deployment_segment_url.return_value = expected_deployment_segment_url
 
-    def test_get_workload_deployment_id(self) -> None:
-        with patch.dict(os.environ, {"WORKLOAD_ID": "wl1"}, clear=True):
-            assert DeploymentEndpointResolver.get_workload_deployment_id() == "wl1"
+        resolver = DeploymentEndpointResolver()
+        output = resolver.get_deployment_url()
 
-    def test_get_mlops_deployment_id(self) -> None:
-        with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "dep1"}, clear=True):
-            assert DeploymentEndpointResolver.get_mlops_deployment_id() == "dep1"
+        mock_get_deployment_segment_url.assert_called_once_with(resolver.deployment_id)
+        assert output == f"{expected_gateway_url}/{expected_deployment_segment_url}/mcp"
 
-    def test_is_workload_deployment_true(self) -> None:
-        with patch.dict(os.environ, {"WORKLOAD_ID": "wl1"}, clear=True):
-            assert DeploymentEndpointResolver.is_workload_deployment() is True
+    def test_get_well_known_url_return_none_when_gateway_url_is_none(
+        self,
+        mock_get_gateway_url: Mock,
+    ) -> None:
+        mock_get_gateway_url.return_value = None
 
-    def test_is_workload_deployment_false(self) -> None:
-        with patch.dict(os.environ, {"MLOPS_DEPLOYMENT_ID": "dep1"}, clear=True):
-            assert DeploymentEndpointResolver.is_workload_deployment() is False
+        resolver = DeploymentEndpointResolver()
+        assert resolver.get_well_known_protected_resource_metadata_url() is None
 
-    @pytest.mark.parametrize(
-        "url_host_env_var, output",
-        [("https://aaa/bbb", "https://aaa/bbb"), ("aaa/bbb", "https://aaa/bbb")],
-        ids=str,
+    def test_get_well_known_url_return_none_when_deployment_id_is_none(
+        self,
+        mock_get_deployment_id: Mock,
+    ) -> None:
+        mock_get_deployment_id.return_value = None
+
+        resolver = DeploymentEndpointResolver()
+        assert resolver.get_well_known_protected_resource_metadata_url() is None
+
+    @pytest.mark.usefixtures(
+        "mock_get_gateway_url",
+        "mock_get_deployment_id",
     )
-    def get_get_gateway_url(self, url_host_env_var: str, output: str) -> None:
-        env = {"DR_WORKLOAD_EXTERNAL_URL_HOST": url_host_env_var}
-        with patch.dict(os.environ, env, clear=True):
-            assert DeploymentEndpointResolver.get_gateway_url() == output
+    def test_get_well_known_url(
+        self,
+        mock_get_gateway_url: Mock,
+        mock_get_deployment_segment_url: Mock,
+    ) -> None:
+        expected_gateway_url = "https://gateway_url"
+        mock_get_gateway_url.return_value = expected_gateway_url
+        expected_deployment_segment_url = "mcp/deployment"
+        mock_get_deployment_segment_url.return_value = expected_deployment_segment_url
 
-    def test_get_gateway_url_prefers_non_public_over_public(self) -> None:
-        env = {
-            "DR_WORKLOAD_EXTERNAL_URL_HOST": "https://aaa/bbb",
-            "DATAROBOT_PUBLIC_API_ENDPOINT": "afdafds",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            assert DeploymentEndpointResolver.get_gateway_url() == "https://aaa/bbb"
+        resolver = DeploymentEndpointResolver()
+        output = resolver.get_well_known_protected_resource_metadata_url()
 
-    def test_get_gateway_url_falls_back_to_public(self) -> None:
-        with patch.dict(
-            os.environ, {"DATAROBOT_PUBLIC_API_ENDPOINT": "https://aaa/bbb"}, clear=True
-        ):
-            assert DeploymentEndpointResolver.get_gateway_url() == "https://aaa/bbb"
+        mock_get_deployment_segment_url.assert_called_once_with(resolver.deployment_id)
+        assert output == (
+            f"{expected_gateway_url}/{expected_deployment_segment_url}"
+            "/.well-known/oauth-protected-resource"
+        )
 
-    def test_get_gateway_url_none_when_nothing_configured(self) -> None:
-        with patch.dict(os.environ, {}, clear=True):
-            assert DeploymentEndpointResolver.get_gateway_url() is None
+    def test_get_segment_url_of_mlops_deployment(
+        self,
+        mock_get_gateway_type: Mock,
+    ) -> None:
+        mock_gateway_type = mock_get_gateway_type.return_value
+
+        resolver = DeploymentEndpointResolver()
+        resolver.deployment_type = MCPDeploymentType.MLOPS
+
+        mock_deployment_id = Mock()
+        output = resolver.get_deployment_segment_url(mock_deployment_id)
+        mock_gateway_type.get_mlops_deployment_url_segment.assert_called_once_with(
+            mock_deployment_id
+        )
+        assert output == mock_gateway_type.get_mlops_deployment_url_segment.return_value
+
+    def test_get_segment_url_of_workload_deployment(
+        self,
+        mock_get_gateway_type: Mock,
+    ) -> None:
+        mock_gateway_type = mock_get_gateway_type.return_value
+
+        resolver = DeploymentEndpointResolver()
+        resolver.deployment_type = MCPDeploymentType.WORKLOAD
+
+        mock_deployment_id = Mock()
+        output = resolver.get_deployment_segment_url(mock_deployment_id)
+        mock_gateway_type.get_workload_deployment_url_segment.assert_called_once_with(
+            mock_deployment_id
+        )
+        assert output == mock_gateway_type.get_workload_deployment_url_segment.return_value
+
+    def test_get_deployment_type_return_mlops_type(self) -> None:
+        with patch.dict(os.environ, {"MLOPS": "adfsa"}, clear=True):
+            assert DeploymentEndpointResolver.get_deployment_type() == MCPDeploymentType.MLOPS
+
+    def test_get_deployment_type_return_workload_type(self) -> None:
+        with patch.dict(os.environ, {"WORKLOAD_ID": "adfsa"}, clear=True):
+            assert DeploymentEndpointResolver.get_deployment_type() == MCPDeploymentType.WORKLOAD
 
     def test_get_deployment_id_prefers_workload_over_mlops(self) -> None:
         env = {"WORKLOAD_ID": "wl1", "MLOPS_DEPLOYMENT_ID": "dep1"}
@@ -232,145 +337,30 @@ class TestDeploymentEndpointResolver:
         with patch.dict(os.environ, {}, clear=True):
             assert DeploymentEndpointResolver.get_deployment_id() is None
 
-    def test_get_non_public_api_based_gateway_url(self) -> None:
-        with patch.dict(os.environ, {"DR_WORKLOAD_EXTERNAL_URL_HOST": "host"}, clear=True):
-            assert DeploymentEndpointResolver.get_non_public_api_based_gateway_url() == "host"
+    def test_get_gateway_url_prefers_non_public_api_based_gateway(self) -> None:
+        env = {
+            "DR_WORKLOAD_EXTERNAL_URL_HOST": "https://aaa/bbb",
+            "DATAROBOT_PUBLIC_API_ENDPOINT": "afdafds",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert DeploymentEndpointResolver.get_gateway_url() == "https://aaa/bbb"
 
-    def test_get_public_api_based_gateway_url(
-        self, mock_get_datarobot_public_api_endpoint: Mock
-    ) -> None:
-        output = DeploymentEndpointResolver.get_public_api_based_gateway_url()
+    def test_get_gateway_url_falls_back_to_non_public_api_based_gateway(self) -> None:
+        with patch.dict(
+            os.environ, {"DATAROBOT_PUBLIC_API_ENDPOINT": "https://aaa/bbb"}, clear=True
+        ):
+            assert DeploymentEndpointResolver.get_gateway_url() == "https://aaa/bbb"
 
-        mock_get_datarobot_public_api_endpoint.assert_called_once_with()
-        assert output == mock_get_datarobot_public_api_endpoint.return_value
+    def test_get_gateway_url_none_when_nothing_configured(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            assert DeploymentEndpointResolver.get_gateway_url() is None
 
     @pytest.mark.parametrize(
-        "gateway_url, output",
-        [("dsafa", True), (None, False)],
+        "url_host_env_var",
+        ["https://aaa/bbb", "https://aaa/bbb/", "aaa/bbb"],
         ids=str,
     )
-    def test_is_deployed_behind_non_public_api_based_gateway(
-        self,
-        gateway_url: str | None,
-        output: bool,
-        mock_get_non_public_api_based_gateway_url: Mock,
-    ) -> None:
-        mock_get_non_public_api_based_gateway_url.return_value = gateway_url
-
-        assert (
-            DeploymentEndpointResolver.is_deployed_behind_non_public_api_based_gateway() is output
-        )
-
-    def test_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
-        self, mock_mcp_url_segment: str
-    ) -> None:
-        resolver = DeploymentEndpointResolver(mock_mcp_url_segment)
-        gateway_url = "http://localhost/foo/bar"
-        deployment_id = "1234"
-        output = resolver.build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
-            gateway_url, deployment_id
-        )
-
-        assert (
-            output
-            == f"{gateway_url}/deployments/{deployment_id}/directAccess/{mock_mcp_url_segment}"
-        )
-
-    def test_build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
-        self, mock_mcp_url_segment: str
-    ) -> None:
-        resolver = DeploymentEndpointResolver(mock_mcp_url_segment)
-        gateway_url = "http://localhost/foo/bar"
-        deployment_id = "1234"
-        output = resolver.build_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
-            gateway_url, deployment_id
-        )
-
-        assert output == f"{gateway_url}/endpoints/workloads/{deployment_id}/{mock_mcp_url_segment}"
-
-    def test_build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
-        self, mock_mcp_url_segment: str
-    ) -> None:
-        resolver = DeploymentEndpointResolver(mock_mcp_url_segment)
-        gateway_url = "http://localhost/foo/bar"
-        workload_deployment_segment = "workload/1234"
-        output = resolver.build_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
-            gateway_url,
-            workload_deployment_segment,
-        )
-
-        assert output == f"{gateway_url}/{workload_deployment_segment}/{mock_mcp_url_segment}"
-
-    @pytest.mark.usefixtures("mock_get_deployment_id")
-    def test_return_url_of_mcp_workload_deployment_behind_public_api_based_gateway(
-        self,
-        mock_is_workload_deployment_behind_non_public_api_gateway: Mock,
-        mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway: Mock,
-        mock_get_gateway_url: Mock,
-    ) -> None:
-        expected_mcp_workload_deployment_segment = "dsafda"
-        with patch.dict(
-            os.environ,
-            {"DR_WORKLOAD_EXTERNAL_URL_PREFIX": expected_mcp_workload_deployment_segment},
-            clear=True,
-        ):
-            mock_is_workload_deployment_behind_non_public_api_gateway.return_value = True
-
-            resolver = DeploymentEndpointResolver(Mock())
-            output = resolver.get_deployment_url()
-
-            mock_get_gateway_url.assert_called_once_with()
-            mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway.assert_called_once_with(
-                mock_get_gateway_url.return_value,
-                expected_mcp_workload_deployment_segment,
-            )
-            assert (
-                output
-                == mock_build_url_of_mcp_workload_behind_non_public_api_based_gateway.return_value
-            )
-
-    def test_return_url_of_mcp_workload_deployment_behind_non_public_api_based_gateway(
-        self,
-        mock_get_gateway_url: Mock,
-        mock_is_workload_deployment: Mock,
-        mock_get_deployment_id: Mock,
-        mock_is_workload_deployment_behind_non_public_api_gateway: Mock,
-        mock_build_url_of_mcp_workload_behind_public_api_based_gateway: Mock,
-    ) -> None:
-        mock_is_workload_deployment_behind_non_public_api_gateway.return_value = False
-
-        resolver = DeploymentEndpointResolver(Mock())
-        output = resolver.get_deployment_url()
-
-        mock_get_gateway_url.assert_called_once_with()
-        mock_get_deployment_id.assert_called_once_with()
-        mock_build_url_of_mcp_workload_behind_public_api_based_gateway.assert_called_once_with(
-            mock_get_gateway_url.return_value,
-            mock_get_deployment_id.return_value,
-        )
-        assert output == mock_build_url_of_mcp_workload_behind_public_api_based_gateway.return_value
-
-    def test_return_url_of_mcp_mlops_deployment_behind_public_api_based_gateway(
-        self,
-        mock_get_gateway_url: Mock,
-        mock_is_workload_deployment: Mock,
-        mock_get_deployment_id: Mock,
-        mock_is_workload_deployment_behind_non_public_api_gateway: Mock,
-        mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway: Mock,
-    ) -> None:
-        mock_is_workload_deployment_behind_non_public_api_gateway.return_value = False
-        mock_is_workload_deployment.return_value = False
-
-        resolver = DeploymentEndpointResolver(Mock())
-        output = resolver.get_deployment_url()
-
-        mock_get_gateway_url.assert_called_once_with()
-        mock_get_deployment_id.assert_called_once_with()
-        mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway.assert_called_once_with(
-            mock_get_gateway_url.return_value,
-            mock_get_deployment_id.return_value,
-        )
-        assert (
-            output
-            == mock_build_url_of_mcp_mlops_deployment_behind_public_api_based_gateway.return_value
-        )
+    def get_get_gateway_url(self, url_host_env_var: str) -> None:
+        env = {"DR_WORKLOAD_EXTERNAL_URL_HOST": url_host_env_var}
+        with patch.dict(os.environ, env, clear=True):
+            assert DeploymentEndpointResolver.get_gateway_url() == "https://aaa/bbb"

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.25"
+version = "0.29.26"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION

# RATIONALE
This PR improves the logic to determine the URL of MCP deployment within a MCP container. Basically, it determines the URL of MCP
- deployed in workload container behind a non public API based gateway (Envoy)
- deployed in workload container behind a public API based gateway (Pred API gateway)
- deployed in mlops container behind a public API based gateway (Pred API gateway)

Please note, MCP deployed in a mlops container behind a non public API based gateway (Envoy) is NOT supported and won't be supported.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OAuth `resource`, audience, and well-known URLs are computed for workload and Envoy-fronted deployments; incorrect env combinations could still advertise unreachable URLs, but the fix targets known mis-routing in auth metadata.
> 
> **Overview**
> **Replaces `resolve_self_url()` with `DeploymentEndpointResolver.get_deployment_url()`** so OAuth protected-resource metadata, 403 `resource_metadata` links, and JWT audience fallback all use the same rules.
> 
> Resolution now picks the **gateway** (`DR_WORKLOAD_EXTERNAL_URL_HOST` over `DATAROBOT_PUBLIC_API_ENDPOINT` / `DATAROBOT_ENDPOINT`), then builds one of three MCP base URLs: Envoy-style `{host}/{prefix}/mcp` when host and prefix are set; public API workload `{gateway}/endpoints/workloads/{id}/mcp` when `WORKLOAD_ID` is set; otherwise MLOps `{gateway}/deployments/{id}/directAccess/mcp`.
> 
> **Behavior change:** when both `WORKLOAD_ID` and `MLOPS_DEPLOYMENT_ID` are present, the published identity follows the **workload** path instead of always preferring MLOps—matching workload-hosted MCP. Version bumped to **0.29.22** with changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c6b9f57fc8cc05ea1a43d64d4c0ed255cbe600. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->