### PR TITLE
[MODEL-24701] Fix mcp deployment url generation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
+
+## 0.29.30
+- `drmcp/core/runtime_identity.py`: Fix MCP deployment URL generation error (URL_PREFIX related)
+
 ## 0.29.29
 - `dragent/frontends`: **an agent that has not opted in to unauthenticated agent-card access now returns the generic `404 {"detail": "Not Found"}`, not a `401` explaining the opt-in.** The old refusal was an existence oracle twice over: the status code alone distinguished a live, not-opted-in agent from a nonexistent one, so an anonymous scanner could enumerate agents without reading a body, and the body then named `enable_unauthenticated_well_known_route` and its two required scopes. A blocked request is now indistinguishable from one for an agent that does not exist. The reason is logged server-side instead, so the refusal stays debuggable. Behaviour is unchanged for authenticated callers (full card) and for agents that have opted in (redacted card).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.29"
+version = "0.29.30"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/runtime_identity.py
+++ b/src/datarobot_genai/drmcp/core/runtime_identity.py
@@ -28,7 +28,6 @@ from enum import auto
 from datarobot_genai.drmcp.core.constants import MCP_PATH_ENDPOINT
 from datarobot_genai.drmcp.core.deployment_config import DeploymentConfig
 from datarobot_genai.drmcp.core.deployment_config import MCPDeploymentType
-from datarobot_genai.drmcp.core.routes_utils import prefix_mount_path
 
 WORKLOAD_ID_ENV = "WORKLOAD_ID"
 DEPLOYMENT_ID_ENV = "MLOPS_DEPLOYMENT_ID"
@@ -102,7 +101,7 @@ class GatewayType(Enum):
 
 class DeploymentEndpointResolver:
     def __init__(self) -> None:
-        self.mcp_path_suffix = prefix_mount_path(MCP_PATH_ENDPOINT).strip("/")
+        self.mcp_path_suffix = MCP_PATH_ENDPOINT.strip("/")
         self.gateway_url = self.get_gateway_url()
         self.gateway_type = self.get_gateway_type()
         self.deployment_id = self.get_deployment_id()
@@ -158,5 +157,5 @@ class DeploymentEndpointResolver:
         if not self.gateway_url or not self.deployment_id:
             return None
         deployment_segment_url = self.get_deployment_segment_url(self.deployment_id)
-        sub_path = prefix_mount_path(".well-known/oauth-protected-resource").lstrip("/")
+        sub_path = ".well-known/oauth-protected-resource"
         return f"{self.gateway_url}/{deployment_segment_url}/{sub_path}"

--- a/tests/drmcp/unit/test_runtime_identity.py
+++ b/tests/drmcp/unit/test_runtime_identity.py
@@ -241,6 +241,31 @@ class TestDeploymentEndpointResolver:
         mock_get_deployment_segment_url.assert_called_once_with(resolver.deployment_id)
         assert output == f"{expected_gateway_url}/{expected_deployment_segment_url}/mcp"
 
+    @patch("datarobot_genai.drmcp.core.routes_utils.get_config")
+    @pytest.mark.usefixtures(
+        "mock_get_gateway_url",
+        "mock_get_deployment_id",
+    )
+    def test_get_deployment_url_ignores_the_container_local_url_prefix(
+        self,
+        mock_get_config: Mock,
+        mock_get_gateway_url: Mock,
+        mock_get_deployment_segment_url: Mock,
+    ) -> None:
+        mock_config = Mock()
+        mock_config.mount_path = "/6a99e1b61797dcf7df5b0c84/6a99e1d136348c69953581fc"
+        mock_get_config.return_value = mock_config
+
+        expected_gateway_url = "https://gateway_url"
+        mock_get_gateway_url.return_value = expected_gateway_url
+        expected_deployment_segment_url = "deployments/dep1/directAccess"
+        mock_get_deployment_segment_url.return_value = expected_deployment_segment_url
+
+        resolver = DeploymentEndpointResolver()
+        output = resolver.get_deployment_url()
+
+        assert output == f"{expected_gateway_url}/{expected_deployment_segment_url}/mcp"
+
     def test_get_well_known_url_return_none_when_gateway_url_is_none(
         self,
         mock_get_gateway_url: Mock,
@@ -277,6 +302,34 @@ class TestDeploymentEndpointResolver:
         output = resolver.get_well_known_protected_resource_metadata_url()
 
         mock_get_deployment_segment_url.assert_called_once_with(resolver.deployment_id)
+        assert output == (
+            f"{expected_gateway_url}/{expected_deployment_segment_url}"
+            "/.well-known/oauth-protected-resource"
+        )
+
+    @patch("datarobot_genai.drmcp.core.routes_utils.get_config")
+    @pytest.mark.usefixtures(
+        "mock_get_gateway_url",
+        "mock_get_deployment_id",
+    )
+    def test_get_well_known_url_ignores_the_container_local_url_prefix(
+        self,
+        mock_get_config: Mock,
+        mock_get_gateway_url: Mock,
+        mock_get_deployment_segment_url: Mock,
+    ) -> None:
+        mock_config = Mock()
+        mock_config.mount_path = "/6a99e1b61797dcf7df5b0c84/6a99e1d136348c69953581fc"
+        mock_get_config.return_value = mock_config
+
+        expected_gateway_url = "https://gateway_url"
+        mock_get_gateway_url.return_value = expected_gateway_url
+        expected_deployment_segment_url = "deployments/dep1/directAccess"
+        mock_get_deployment_segment_url.return_value = expected_deployment_segment_url
+
+        resolver = DeploymentEndpointResolver()
+        output = resolver.get_well_known_protected_resource_metadata_url()
+
         assert output == (
             f"{expected_gateway_url}/{expected_deployment_segment_url}"
             "/.well-known/oauth-protected-resource"

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.29"
+version = "0.29.30"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
# RATIONALE

 `URL_PREFIX` (only available at MLOps deployment container) identifies this container to the platform's internal
routing (e.g. workload/session-scoped ids); it must not leak into the externally published deployment URL as well as well-known URL. This PR fixes it.



## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow URL-building fix with new regression tests; OAuth and routing behavior inside the container are unchanged aside from correcting advertised external URLs.
> 
> **Overview**
> **Fixes MCP deployment and OAuth discovery URLs incorrectly including the MLOps container’s local mount/`URL_PREFIX` segment**, which is only for in-platform routing and must not appear on externally advertised links.
> 
> `DeploymentEndpointResolver` now builds the MCP path suffix from `MCP_PATH_ENDPOINT` directly and uses a fixed `.well-known/oauth-protected-resource` subpath, instead of `prefix_mount_path` (which prepends `mount_path` from server config). **Published** `get_deployment_url()` and `get_well_known_protected_resource_metadata_url()` therefore stay gateway-relative only.
> 
> Release **0.29.27** (changelog, `pyproject.toml`, `uv.lock`). Unit tests assert that a configured `mount_path` does not change those external URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3575c9d9e13f7187ba33f721e6528869113ae5c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->