### PR TITLE
Update the tags and the routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 
+## 0.29.27
+- `drtools`: reworked every tool's gallery tags into human-readable UI tags (e.g. `DataRobot, Predictive, Catalog`; action tags like `Delete`/`Promote` on the run-action tools), replacing the lowercase functional tags. Tags are now declared as ordered tuples so the gallery reports them in declaration order.
+- `drtools/perplexity`: renamed the `perplexity_search` display name from "Perplexity — Search" to "Perplexity — Search Web".
+- `drmcputils` tool gallery (`GET /toolGallery/*`):
+  - `tools/` items report `tags` in declaration order (no longer alphabetized), a new `ui_display_name` (the action half of the display name, e.g. "Workload — List bundles" → "List bundles"), and a new `provider_name` carrying the provider's brand ("DataRobot", "Perplexity", "Atlassian", ...; `null` for proxied user-MCP tools).
+  - each item's `categories` entries are now `{name, label, kind}` dicts (`kind` is `parent` or `leaf`) instead of bare `dr_*` strings; `categories_for_tool` returns the same shape.
+  - `categories/` nodes (and their children) are ordered alphabetically by label.
+  - `providers/` label for `third_party` is now "Third-party".
+
 ## 0.29.26
 - `drmcp/core/runtime_identity.py`: Fix logic of resolving MCP deployment URL
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.26"
+version = "0.29.27"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcp/core/drtools_registry.py
+++ b/src/datarobot_genai/drmcp/core/drtools_registry.py
@@ -72,6 +72,11 @@ def register_drtools_function(func: Callable, metadata: dict[str, Any]) -> None:
     for key in DRTOOLS_PRIVATE_METADATA_KEYS:
         metadata.pop(key, None)
 
+    # @tool_metadata declares tags as an ordered tuple (the gallery reports them in
+    # declaration order); FastMCP wants a set.
+    if metadata.get("tags") is not None:
+        metadata["tags"] = set(metadata["tags"])
+
     # Apply the dr_mcp_tool decorator with the metadata
     dr_mcp_tool(tool_category=DataRobotMCPToolCategory.BUILT_IN_TOOL, **metadata)(func)
 

--- a/src/datarobot_genai/drmcputils/categories.py
+++ b/src/datarobot_genai/drmcputils/categories.py
@@ -598,9 +598,20 @@ def _build_tool_to_categories() -> dict[str, frozenset[str]]:
 TOOL_TO_CATEGORIES: dict[str, frozenset[str]] = _build_tool_to_categories()
 
 
-def categories_for_tool(tool_name: str) -> list[str]:
-    """Return the sorted category labels (leaf + parent) for *tool_name*.
+def category_kind(name: str) -> str:
+    """Return ``"parent"`` for a category that owns leaf children, ``"leaf"`` otherwise."""
+    return "parent" if name in PARENT_TO_CHILDREN else "leaf"
 
-    Empty list for hosted/dynamic tools and any name not in the static taxonomy.
+
+def category_entry(name: str) -> dict[str, str]:
+    """Serialise one category as the ``{name, label, kind}`` dict the REST responses carry."""
+    return {"name": str(name), "label": category_label(name), "kind": category_kind(name)}
+
+
+def categories_for_tool(tool_name: str) -> list[dict[str, str]]:
+    """Return the categories (leaf + parent) for *tool_name* as ``{name, label, kind}`` dicts.
+
+    Sorted by category name. Empty list for hosted/dynamic tools and any name not in
+    the static taxonomy.
     """
-    return sorted(TOOL_TO_CATEGORIES.get(tool_name, frozenset()))
+    return [category_entry(name) for name in sorted(TOOL_TO_CATEGORIES.get(tool_name, frozenset()))]

--- a/src/datarobot_genai/drmcputils/category_tree.py
+++ b/src/datarobot_genai/drmcputils/category_tree.py
@@ -55,9 +55,6 @@ from datarobot_genai.drmcputils.categories import category_label
 from datarobot_genai.drmcputils.tool_gallery import build_tool_gallery_items
 from datarobot_genai.drmcputils.tool_gallery import merge_tool_info
 
-# Enum definition order → stable ordering for both top-level categories and children.
-_ENUM_ORDER: dict[str, int] = {category.value: i for i, category in enumerate(MCPToolCategory)}
-
 # Parents own leaf children; ``_CHILDREN`` is every leaf that appears under a parent.
 _PARENTS: frozenset[str] = frozenset(str(parent) for parent in PARENT_TO_CHILDREN)
 _CHILDREN: frozenset[str] = frozenset(
@@ -93,19 +90,14 @@ def build_category_tree(tools: Sequence[Any]) -> tuple[list[dict[str, Any]], int
 
 
 def ordered_top_level() -> list[str]:
-    """Top-level categories: parents first, then standalone leaves, dynamic last.
+    """Top-level categories, ordered alphabetically by display label.
 
     Derived from the taxonomy (not hard-coded) so a new category flows through to
-    the filter panel by existing; within each group, enum-definition order is
-    preserved. This mirrors the picker layout.
+    the filter panel by existing. Alphabetical (case-insensitive, value as the
+    tie-breaker) so the response order matches how a picker lists them.
     """
     tops = [c.value for c in MCPToolCategory if c.value in _PARENTS or c.value not in _CHILDREN]
-
-    def sort_key(name: str) -> tuple[bool, bool, int]:
-        # (dynamic last, non-parents after parents, then enum order)
-        return (name in _DYNAMIC_CATEGORIES, name not in _PARENTS, _ENUM_ORDER[name])
-
-    return sorted(tops, key=sort_key)
+    return sorted(tops, key=_label_sort_key)
 
 
 def _category_to_tools(tools: Sequence[Any]) -> dict[str, set[str]]:
@@ -127,15 +119,20 @@ def _category_to_tools(tools: Sequence[Any]) -> dict[str, set[str]]:
     mapping: dict[str, set[str]] = defaultdict(set)
     merged = [merge_tool_info(tool, {}) for tool in tools]
     for item in build_tool_gallery_items(merged):
-        for name in item["categories"]:
-            mapping[str(name)].add(item["name"])
+        for category in item["categories"]:
+            mapping[str(category["name"])].add(item["name"])
     return mapping
 
 
+def _label_sort_key(name: str) -> tuple[str, str]:
+    """Alphabetical-by-label ordering (case-insensitive), value as the tie-breaker."""
+    return (category_label(name).casefold(), name)
+
+
 def _ordered_children(parent: str) -> list[str]:
-    """Leaf children of *parent* in enum-definition order ([] for a leaf)."""
+    """Leaf children of *parent*, alphabetical by label ([] for a leaf)."""
     children = [str(child) for child in PARENT_TO_CHILDREN.get(parent, frozenset())]
-    return sorted(children, key=lambda name: _ENUM_ORDER[name])
+    return sorted(children, key=_label_sort_key)
 
 
 def _category_node(name: str, by_category: dict[str, set[str]]) -> dict[str, Any]:

--- a/src/datarobot_genai/drmcputils/routes/tool_gallery.py
+++ b/src/datarobot_genai/drmcputils/routes/tool_gallery.py
@@ -161,7 +161,13 @@ def _apply_filters(
         items = [item for item in items if item.get("provider") in wanted]
     if categories is not None:
         wanted = set(categories)
-        items = [item for item in items if wanted.intersection(item.get("categories") or ())]
+        # Each item's categories are ``{name, label, kind}`` dicts; the filter matches
+        # on ``name`` — the same ``dr_*`` value the categories endpoint reports.
+        items = [
+            item
+            for item in items
+            if wanted.intersection(category["name"] for category in item.get("categories") or ())
+        ]
     return items
 
 

--- a/src/datarobot_genai/drmcputils/tool_gallery.py
+++ b/src/datarobot_genai/drmcputils/tool_gallery.py
@@ -21,6 +21,7 @@ imported by drtools, drmcputils, and drmcpbase alike.
 from typing import Any
 
 from datarobot_genai.drmcputils.categories import categories_for_tool
+from datarobot_genai.drmcputils.categories import category_entry
 
 # Keys present in @tool_metadata(...) that carry UI/gallery metadata. These must be stripped
 # before the metadata dict is forwarded to FastMCP's mcp.tool() call so agents / LLMs never see
@@ -58,7 +59,18 @@ PROVIDER_THIRD_PARTY = "third_party"
 # filter endpoint; the values match what ``build_tool_gallery_items`` emits as ``provider``.
 TOOL_PROVIDER_LABELS: dict[str, str] = {
     PROVIDER_DATAROBOT: "DataRobot",
-    PROVIDER_THIRD_PARTY: "Third party",
+    PROVIDER_THIRD_PARTY: "Third-party",
+}
+
+# ``auth_provider`` → the provider's brand name, reported as each item's
+# ``provider_name``. DataRobot-served tools (no ``auth_provider``) report "DataRobot".
+_PROVIDER_NAMES: dict[str, str] = {
+    "jira": "Atlassian",
+    "confluence": "Atlassian",
+    "gdrive": "Google",
+    "microsoft_graph": "Microsoft",
+    "perplexity": "Perplexity",
+    "tavily": "Tavily",
 }
 
 
@@ -78,15 +90,23 @@ TOOL_PROVIDER_LABELS: dict[str, str] = {
 _MARKED_TOOL_KINDS: dict[str, dict[str, Any]] = {
     "USER_TOOL": {
         "provider": PROVIDER_DATAROBOT,
+        "provider_name": "DataRobot",
         "category": "dr_user_tools",
         "hosted": False,
     },
     "USER_TOOL_DEPLOYMENT": {
         "provider": PROVIDER_DATAROBOT,
+        "provider_name": "DataRobot",
         "category": "dr_dynamic_tools",
         "hosted": True,
     },
-    "PROXIED_USER_MCP": {"provider": PROVIDER_THIRD_PARTY, "category": None, "hosted": True},
+    # Proxied tools come from a user's own MCP server — no brand name to report.
+    "PROXIED_USER_MCP": {
+        "provider": PROVIDER_THIRD_PARTY,
+        "provider_name": None,
+        "category": None,
+        "hosted": True,
+    },
 }
 
 
@@ -115,15 +135,21 @@ def merge_tool_info(tool: Any, ui_metadata: dict[str, dict[str, Any]]) -> dict[s
     Carries the raw ``tool_category`` marker and the tool's own ``description`` so the
     builder can classify hosted tools (provider/categories) and fall back to the MCP
     description when there is no curated UI copy.
+
+    Tags come from the drtools registry when available, preserving the declaration
+    order of ``@tool_metadata(tags=(...))``. FastMCP stores tags as a set, so tools
+    outside the registry fall back to a sorted list — the only deterministic order a
+    set can offer.
     """
     ui = ui_metadata.get(tool.name, {})
+    ordered_tags = ui.get("tags")
     return {
         "name": tool.name,
         "display_name": ui.get("display_name"),
         "description_ui": ui.get("description_ui"),
         "description": getattr(tool, "description", None),
         "auth_provider": ui.get("auth_provider"),
-        "tags": sorted(tool.tags or []),
+        "tags": list(ordered_tags) if ordered_tags else sorted(tool.tags or []),
         "categories": categories_for_tool(tool.name),
         "tool_category": _tool_category(tool),
         "hosted": is_hosted(tool),
@@ -142,6 +168,19 @@ def _provider_for(auth_provider: str | None) -> str:
     if auth_provider:
         return PROVIDER_THIRD_PARTY
     return PROVIDER_DATAROBOT
+
+
+def _provider_name_for(auth_provider: str | None) -> str:
+    """Return the provider's brand name (``provider_name`` on each gallery item).
+
+    DataRobot-served tools (no ``auth_provider``) are provided by DataRobot; third
+    parties map to their brand (jira/confluence → Atlassian, gdrive → Google, ...).
+    An unmapped ``auth_provider`` falls back to a humanised form of itself so a new
+    connector degrades to something readable instead of nothing.
+    """
+    if not auth_provider:
+        return "DataRobot"
+    return _PROVIDER_NAMES.get(auth_provider, auth_provider.replace("_", " ").title())
 
 
 def _oauth_provider_type_for(auth_provider: str | None) -> str | None:
@@ -177,6 +216,7 @@ def build_tool_gallery_items(tools: list[dict]) -> list[dict]:
             # Marker-classified tool (user/dynamic/proxied): classification comes from
             # its meta marker, not the static taxonomy or a drtools auth_provider.
             provider = kind["provider"]
+            provider_name = kind["provider_name"]
             oauth_provider_type = None
             # Proxied tools have no category (kind["category"] is None) → [].
             categories = [kind["category"]] if kind["category"] else []
@@ -184,21 +224,49 @@ def build_tool_gallery_items(tools: list[dict]) -> list[dict]:
         else:
             auth_provider = t.get("auth_provider")
             provider = _provider_for(auth_provider)
+            provider_name = _provider_name_for(auth_provider)
             oauth_provider_type = _oauth_provider_type_for(auth_provider)
             categories = list(t.get("categories") or [])
             hosted = bool(t.get("hosted", False))
+        display_name = t.get("display_name") or t["name"]
         items.append(
             {
                 "name": t["name"],
-                "display_name": t.get("display_name") or t["name"],
+                "display_name": display_name,
+                "ui_display_name": _ui_display_name(display_name),
                 # Prefer the curated UI copy (drtools ``description_ui``); fall back to the
                 # tool's own MCP description (the only copy dynamic/proxied tools carry).
                 "description": t.get("description_ui") or t.get("description") or "",
-                "tags": sorted(t.get("tags") or []),
-                "categories": categories,
+                # Declaration order, as merged from the drtools registry — never re-sorted.
+                "tags": list(t.get("tags") or []),
+                "categories": [_category_item(category) for category in categories],
                 "provider": provider,
+                "provider_name": provider_name,
                 "oauth_provider_type": oauth_provider_type,
                 "hosted": hosted,
             }
         )
     return items
+
+
+# Display names read "<group> — <action>" (em dash); ``ui_display_name`` is the action
+# half alone, e.g. "Workload — List bundles" → "List bundles".
+_DISPLAY_NAME_SEPARATOR = " — "
+
+
+def _ui_display_name(display_name: str) -> str:
+    """Strip the group prefix off a display name (identity when there is no separator)."""
+    _, separator, action = display_name.partition(_DISPLAY_NAME_SEPARATOR)
+    return action if separator else display_name
+
+
+def _category_item(category: Any) -> dict[str, str]:
+    """Normalise one category to the ``{name, label, kind}`` dict items report.
+
+    ``merge_tool_info`` already supplies dicts; bare ``dr_*`` strings (the marker
+    buckets, or callers feeding raw names) are expanded here so the response shape
+    is uniform.
+    """
+    if isinstance(category, dict):
+        return category
+    return category_entry(str(category))

--- a/src/datarobot_genai/drtools/confluence/tools.py
+++ b/src/datarobot_genai/drtools/confluence/tools.py
@@ -38,7 +38,7 @@ _FOOTER_COMMENTS_DOCS = (
 
 
 @tool_metadata(
-    tags={"confluence", "read", "get", "page"},
+    tags=("Atlassian", "Confluence"),
     description=(
         "[Confluence—get page] Use when you have a numeric page ID, or an exact page title plus "
         "space_key, and need the page body (storage HTML). Not CQL multi-page search "
@@ -86,7 +86,7 @@ async def confluence_get_page(
 
 
 @tool_metadata(
-    tags={"confluence", "write", "create", "page"},
+    tags=("Atlassian", "Confluence"),
     description=(
         "[Confluence—create page] Use when publishing a new page in a space (space_key, title, "
         "body storage format), optional parent page ID. Not updating an existing page "
@@ -134,7 +134,7 @@ async def confluence_create_page(
 
 
 @tool_metadata(
-    tags={"confluence", "write", "add", "comment"},
+    tags=("Atlassian", "Confluence"),
     description=(
         "[Confluence—comment] Use when appending a page-level comment on an existing page by "
         "numeric page_id. Not page body edits (confluence_update_page), not new pages "
@@ -180,7 +180,7 @@ async def confluence_add_comment(
 
 
 @tool_metadata(
-    tags={"confluence", "search", "content"},
+    tags=("Atlassian", "Confluence"),
     description=(
         "[Confluence—CQL search] Use when finding pages or content with Confluence Query Language "
         "(type, space, text filters). Optional full body per hit. "
@@ -247,7 +247,7 @@ async def confluence_search_space(
 
 
 @tool_metadata(
-    tags={"confluence", "write", "update", "page"},
+    tags=("Atlassian", "Confluence"),
     description=(
         "[Confluence—update page] Use when replacing page body content for an existing page_id; "
         "version_number must match current version from confluence_get_page (optimistic lock). "

--- a/src/datarobot_genai/drtools/core/tool_metadata.py
+++ b/src/datarobot_genai/drtools/core/tool_metadata.py
@@ -69,14 +69,17 @@ def get_registered_tools() -> list[tuple[Callable, dict[str, Any]]]:
 
 
 def get_tool_ui_metadata() -> dict[str, dict[str, Any]]:
-    """Build ``tool_name -> {display_name, description_ui, auth_provider}`` from the registry.
+    """Build ``tool_name -> {display_name, description_ui, auth_provider, tags}``.
 
-    These UI-only keys are stripped before FastMCP registration (see
+    The UI-only keys are stripped before FastMCP registration (see
     ``DRTOOLS_PRIVATE_METADATA_KEYS``), so agents/LLMs never see them. The tools-gallery
     route re-attaches them by calling this — it is injected into
     ``register_tool_gallery_routes`` as the ``ui_metadata_provider`` because ``drmcputils``
     (where the route lives) may not import ``drtools``. Owning this here keeps the metadata
     keys with the registry that defines them.
+
+    ``tags`` preserves the declaration order of ``@tool_metadata(tags=(...))`` — FastMCP
+    stores tags as a set, so this is the only place the gallery can read them ordered.
     """
     lookup: dict[str, dict[str, Any]] = {}
     for func, metadata in get_registered_tools():
@@ -85,5 +88,6 @@ def get_tool_ui_metadata() -> dict[str, dict[str, Any]]:
             "display_name": metadata.get("display_name"),
             "description_ui": metadata.get("description_ui"),
             "auth_provider": metadata.get("auth_provider"),
+            "tags": list(metadata.get("tags") or []),
         }
     return lookup

--- a/src/datarobot_genai/drtools/dr_docs/tools.py
+++ b/src/datarobot_genai/drtools/dr_docs/tools.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool_metadata(
-    tags={"dr_docs", "datarobot", "docs", "documentation", "search"},
+    tags=("DataRobot", "Documentation"),
     description=(
         "[DR docs—search] Use when the user asks about DataRobot agentic AI product behavior, "
         "setup, or APIs covered on the public agentic-AI documentation site. Returns page titles "
@@ -104,7 +104,7 @@ async def search_datarobot_agentic_docs(
 
 
 @tool_metadata(
-    tags={"dr_docs", "datarobot", "docs", "documentation", "fetch", "read"},
+    tags=("DataRobot", "Documentation"),
     description=(
         "[DR docs—fetch page] Use when you already have a full docs.datarobot.com English docs URL "
         "(e.g. from search results) and need the page body as text. Not keyword search across the "

--- a/src/datarobot_genai/drtools/files_api/imports_tools.py
+++ b/src/datarobot_genai/drtools/files_api/imports_tools.py
@@ -49,7 +49,7 @@ _IMPORT_STATUS_NOTE = (
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "import", "upload", "url", "data_source"},
+    tags=("DataRobot", "Files"),
     description=(
         "[Files—import] Start a background import into a catalog directory. "
         "Use for large or remote files instead of file_write. Returns immediately "
@@ -135,7 +135,7 @@ async def file_import(
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "import", "status"},
+    tags=("DataRobot", "Files"),
     description=(
         "[Files—import status] Fetch the current status of a background import "
         "started by file_import. Performs ONE non-blocking fetch — it does not "

--- a/src/datarobot_genai/drtools/files_api/mutations_tools.py
+++ b/src/datarobot_genai/drtools/files_api/mutations_tools.py
@@ -73,7 +73,7 @@ def _coerce_json_encoded_list(value: Any) -> Any:
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "write", "create", "upload"},
+    tags=("DataRobot", "Files"),
     description=(
         "[Files—write] Write content to a file at dr://<catalog_id>/path, creating "
         "parent folders implicitly (DataRobot has no empty directories). The path "
@@ -125,7 +125,7 @@ async def file_write(
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "upload", "local", "create", "write"},
+    tags=("DataRobot", "Files"),
     description=(
         "[Files—upload] Upload file(s) from the server's local disk into a catalog "
         "directory at dr://<catalog_id>/path. Content is streamed in chunks (no "
@@ -212,7 +212,7 @@ async def file_upload(
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "create", "delete", "copy", "move", "clone"},
+    tags=("DataRobot", "Files", "Clone", "Copy", "Create", "Delete", "Move"),
     description=(
         "[Files—manage] Run a structural action on the filesystem. action is one of:\n"
         "  'create_dir' — create a new empty catalog item directory; returns its "

--- a/src/datarobot_genai/drtools/files_api/read_tools.py
+++ b/src/datarobot_genai/drtools/files_api/read_tools.py
@@ -74,7 +74,7 @@ def _list_browse_hint(
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "list", "search", "glob", "tree"},
+    tags=("DataRobot", "Files"),
     description=(
         "[Files—list] Browse the DataRobot filesystem. Paths look like "
         "dr://<catalog_id>/path. Call with path='dr://' to list catalog items "
@@ -187,7 +187,7 @@ async def file_list(
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "info", "metadata"},
+    tags=("DataRobot", "Files"),
     description=(
         "[Files—info] Fetch metadata for a single file or directory: name, type "
         "('file'|'directory'), size in bytes, format, and created_at. Append a "
@@ -215,7 +215,7 @@ async def file_info(
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "read", "download"},
+    tags=("DataRobot", "Files"),
     description=(
         "[Files—read] Read a file's content. Content is returned as UTF-8 text "
         "when valid, otherwise base64 (check the 'encoding' field). Reads are "
@@ -300,7 +300,7 @@ async def file_read(
 
 
 @tool_metadata(
-    tags={"file", "datarobot", "sign", "url", "download"},
+    tags=("DataRobot", "Files", "URL"),
     description=(
         "[Files—sign] Create a temporary signed URL granting direct download "
         "access to a file. Use this for large files (over the inline read cap) "

--- a/src/datarobot_genai/drtools/gdrive/tools.py
+++ b/src/datarobot_genai/drtools/gdrive/tools.py
@@ -39,7 +39,7 @@ _DRIVE_PERMISSIONS_DOCS = "https://developers.google.com/drive/api/guides/manage
 
 
 @tool_metadata(
-    tags={"gdrive", "google", "list", "search", "files", "find", "contents"},
+    tags=("Google", "Google Drive"),
     description=(
         "[GDrive—find files] Use when the user needs Google Drive file names and IDs with "
         "optional folder scope, Drive query string, and pagination. Not file body text "
@@ -108,7 +108,7 @@ async def gdrive_find_contents(
 
 
 @tool_metadata(
-    tags={"gdrive", "google", "read", "content", "file", "download"},
+    tags=("Google", "Google Drive"),
     description=(
         "[GDrive—read file] Use when you have a Drive file_id (from gdrive_find_contents) and need "
         "exported text or markdown for Workspace types. Not listing files, not binary media "
@@ -151,7 +151,7 @@ async def gdrive_read_and_export_content(
 
 
 @tool_metadata(
-    tags={"gdrive", "google", "create", "write", "file", "folder"},
+    tags=("Google", "Google Drive"),
     enabled=False,
     description=(
         "[GDrive—create file] Use when creating a new Drive file or folder from name + MIME type, "
@@ -207,7 +207,7 @@ async def gdrive_create_file(
 
 
 @tool_metadata(
-    tags={"gdrive", "google", "update", "metadata", "rename", "star", "trash"},
+    tags=("Google", "Google Drive", "Rename", "Star", "Trash", "Update"),
     enabled=False,
     description=(
         "[GDrive—metadata] Use when renaming, starring, or trashing an existing "
@@ -267,7 +267,7 @@ async def gdrive_update_metadata(
 
 
 @tool_metadata(
-    tags={"gdrive", "google", "manage", "access", "acl"},
+    tags=("Google", "Google Drive"),
     enabled=False,
     description=(
         "[GDrive—permissions] Use when adding, changing, or removing sharing on "

--- a/src/datarobot_genai/drtools/jira/tools.py
+++ b/src/datarobot_genai/drtools/jira/tools.py
@@ -35,7 +35,7 @@ _JIRA_ISSUES_REST = "https://developer.atlassian.com/cloud/jira/platform/rest/v3
 
 
 @tool_metadata(
-    tags={"jira", "search", "issues"},
+    tags=("Atlassian", "Jira"),
     description=(
         "[Jira—search issues] Use when filtering many issues with JQL (project, status, text, "
         "dates, assignee, etc.). Returns matching issues as summaries. Not one known issue key "
@@ -76,7 +76,7 @@ async def jira_search_issues(
 
 
 @tool_metadata(
-    tags={"jira", "read", "get", "issue"},
+    tags=("Atlassian", "Jira"),
     description=(
         "[Jira—get issue] Use when you already have an issue key (e.g. PROJ-123) and need full "
         "fields and current values. Read-only. Not JQL multi-issue search (jira_search_issues).\n\n"
@@ -109,7 +109,7 @@ async def jira_get_issue(
 
 
 @tool_metadata(
-    tags={"jira", "create", "add", "issue"},
+    tags=("Atlassian", "Jira"),
     description=(
         "[Jira—create issue] Use when opening a new work item: project key, summary, and issue "
         "type name (Task/Bug/Story as configured). Optional description. Not status moves "
@@ -165,7 +165,7 @@ async def jira_create_issue(
 
 
 @tool_metadata(
-    tags={"jira", "update", "edit", "issue"},
+    tags=("Atlassian", "Jira"),
     description=(
         "[Jira—update fields] Use when changing field values on an existing issue (summary, "
         "description, custom fields) by key; values must match Jira field formats. Not workflow "
@@ -211,7 +211,7 @@ async def jira_update_issue(
 
 
 @tool_metadata(
-    tags={"jira", "update", "transition", "issue"},
+    tags=("Atlassian", "Jira"),
     description=(
         "[Jira—transition status] Use when moving an existing issue along its workflow by exact "
         "transition name (e.g. 'In Progress'). Not arbitrary field edits (jira_update_issue), "

--- a/src/datarobot_genai/drtools/microsoft_graph/tools.py
+++ b/src/datarobot_genai/drtools/microsoft_graph/tools.py
@@ -40,14 +40,7 @@ _MS_DRIVEITEM_PATCH = "https://learn.microsoft.com/en-us/graph/api/driveitem-upd
 
 
 @tool_metadata(
-    tags={
-        "microsoft_graph",
-        "microsoft",
-        "sharepoint",
-        "onedrive",
-        "search",
-        "files",
-    },
+    tags=("Microsoft", "Microsoft 365", "OneDrive", "Sharepoint"),
     description=(
         "[M365—search files] Use when the user needs SharePoint or OneDrive files and list items "
         "by keywords plus optional KQL filters, paginated. Scope with site_url or site_id when "
@@ -167,7 +160,7 @@ async def microsoft_graph_search_content(
 
 
 @tool_metadata(
-    tags={"microsoft_graph", "sharepoint", "onedrive", "share"},
+    tags=("Microsoft", "Microsoft 365", "OneDrive", "Sharepoint"),
     enabled=False,
     description=(
         "[M365—share item] Use when inviting people to an existing SharePoint/OneDrive file or "
@@ -234,7 +227,7 @@ async def microsoft_graph_share_item(
 
 
 @tool_metadata(
-    tags={"microsoft_graph", "sharepoint", "onedrive", "create", "file", "write"},
+    tags=("Microsoft", "Microsoft 365", "OneDrive", "Sharepoint"),
     enabled=False,
     description=(
         "[M365—create text file] Use when the user wants a new plain-text file in personal "
@@ -301,7 +294,7 @@ async def microsoft_graph_create_file(
 
 
 @tool_metadata(
-    tags={"microsoft_graph", "sharepoint", "onedrive", "metadata", "update"},
+    tags=("Microsoft", "Microsoft 365", "OneDrive", "Sharepoint"),
     enabled=False,
     description=(
         "[M365—update metadata] Use when renaming or updating list/drive item fields: either "

--- a/src/datarobot_genai/drtools/panels/compose.py
+++ b/src/datarobot_genai/drtools/panels/compose.py
@@ -81,7 +81,7 @@ def _instance_url(endpoint: str) -> str:
 
 
 @tool_metadata(
-    tags={"panels", "write", "catalog", "dataset", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—from catalog] Convert a DataRobot AI Catalog dataset into a Dataset panel "
         "(Parquet payload stored via the Files API) for use with the panel tools. Records "
@@ -135,7 +135,7 @@ async def create_dataset_panel_from_catalog(
 
 
 @tool_metadata(
-    tags={"panels", "read", "catalog", "dataset", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—to catalog] Upload a Dataset panel's tabular data to the DataRobot AI "
         "Catalog as a new dataset (CSV-backed). Name defaults to the panel title."
@@ -194,7 +194,7 @@ async def _materialize_frames(dataset_ids: list[str]) -> dict[str, pl.DataFrame]
 
 
 @tool_metadata(
-    tags={"panels", "write", "catalog", "dataset", "sql", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—query datasets] Query one or more DataRobot AI Catalog datasets with SQL "
         "and store the result as a Dataset panel. Datasets are bound positionally as t0, "
@@ -264,7 +264,7 @@ async def query_datasets_to_panel(
 
 
 @tool_metadata(
-    tags={"panels", "write", "deployment", "dataset", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—prediction history] Retrieve a deployment's stored prediction history "
         "and store it as a Dataset panel (in 'staging'). Supports limit/offset paging and "
@@ -324,7 +324,7 @@ async def get_prediction_history(
 
 
 @tool_metadata(
-    tags={"panels", "read", "modeling", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—autopilot status] Check the progress of an AutoPilot run: whether it is "
         "complete, queued/running model counts, leaderboard size, and the leaderboard URL. "
@@ -415,7 +415,7 @@ async def get_autopilot_status(
 
 
 @tool_metadata(
-    tags={"panels", "write", "deployment", "predictions", "dataset", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—predict] Make predictions using a DataRobot deployment on a scoring "
         "Dataset panel and store the results as a lineage-linked child Dataset panel "
@@ -643,7 +643,7 @@ async def _datetime_partition_columns(deployment_id: str) -> tuple[str, str | No
 
 
 @tool_metadata(
-    tags={"panels", "write", "deployment", "dataset", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—what-if] Apply deterministic what-if adjustments (mul/add/set, optionally "
         "scoped by inclusive date window and series) to a scoring Dataset panel and store "

--- a/src/datarobot_genai/drtools/panels/datasource.py
+++ b/src/datarobot_genai/drtools/panels/datasource.py
@@ -67,7 +67,7 @@ def _rows_to_parquet(rows: list[dict[str, Any]], columns: list[str] | None = Non
 
 
 @tool_metadata(
-    tags={"panels", "write", "connector", "dataset", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—from connector] Run SQL against a DataRobot connector/datastore and "
         "materialize the result as a Dataset panel (Parquet payload stored via the Files API). "
@@ -121,7 +121,7 @@ async def create_dataset_panel_from_connector(
 
 
 @tool_metadata(
-    tags={"panels", "read", "dataset", "preview", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—preview dataset] Preview a Dataset panel's tabular payload: columns, "
         "dtypes, row count, and the first sample_size rows. Read-only; tabular panels "

--- a/src/datarobot_genai/drtools/panels/review.py
+++ b/src/datarobot_genai/drtools/panels/review.py
@@ -58,7 +58,7 @@ def _node_summary(panel: Any) -> dict[str, Any]:
 
 
 @tool_metadata(
-    tags={"panels", "read", "lineage", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—inspect] Walk a panel's parent lineage recursively: execution context "
         "and parent graph for the panel and its ancestors, without reading payload data. "
@@ -110,7 +110,7 @@ async def inspect_panel(
 
 
 @tool_metadata(
-    tags={"panels", "read", "json", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—view json] View a Json panel's structured data (large structures are "
         "truncated to preserve shape: first 5 array items, 200-char strings, 6 levels). "

--- a/src/datarobot_genai/drtools/panels/timeseries.py
+++ b/src/datarobot_genai/drtools/panels/timeseries.py
@@ -517,7 +517,7 @@ def _infer_forecast_point(frame: pl.DataFrame, reqs: ScoringDataRequirements) ->
 
 
 @tool_metadata(
-    tags={"panels", "write", "dataset", "timeseries", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—TS scoring dataset] Prepare a Dataset panel for time-series scoring against "
         "a deployment: introspects the deployment's datetime partitioning + forecast settings "

--- a/src/datarobot_genai/drtools/panels/tools.py
+++ b/src/datarobot_genai/drtools/panels/tools.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool_metadata(
-    tags={"panels", "read", "list", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—list] List panels (metadata only) in a source ('main' committed, "
         "'staging' session-scoped). Read-only. Next step: get_panel for a single panel's "
@@ -81,7 +81,7 @@ async def list_panels(
 
 
 @tool_metadata(
-    tags={"panels", "read", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—get] Fetch a single panel's metadata by ID. Read-only. Bulky payloads "
         "(Dataset/Chart) are referenced by payload_files_id, not inlined here."
@@ -103,7 +103,7 @@ async def get_panel(
 
 
 @tool_metadata(
-    tags={"panels", "write", "create", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—create text] Create a Text panel (markdown narrative/report) in a source. "
         "Returns the created panel including its assigned ID."
@@ -128,7 +128,7 @@ async def create_text_panel(
 
 
 @tool_metadata(
-    tags={"panels", "write", "create", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—create json] Create a Json panel (structured dict payload) in a source. "
         "Returns the created panel including its assigned ID."
@@ -153,7 +153,7 @@ async def create_json_panel(
 
 
 @tool_metadata(
-    tags={"panels", "schemas", "read", "list", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—schemas] List registered Pydantic schemas available for Json panel "
         "validation, optionally filtered by namespace. Read-only. Next step: "
@@ -188,7 +188,7 @@ async def list_panel_schemas(
 
 
 @tool_metadata(
-    tags={"panels", "schemas", "read", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—schemas] Describe a registered schema in detail: fields with types and "
         "required status, the full JSON Schema, and an example value. Read-only."
@@ -216,7 +216,7 @@ async def describe_panel_schema(
 
 
 @tool_metadata(
-    tags={"panels", "schemas", "read", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—schemas] Validate data against a registered schema without creating a "
         "panel. Returns {valid: true, normalized_data} on success or {valid: false, "
@@ -252,7 +252,7 @@ async def validate_panel_data(
 
 
 @tool_metadata(
-    tags={"panels", "write", "move", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—move] Move a panel between sources (e.g. promote 'staging' to 'main') by "
         "retagging it in place. The panel id is preserved, so existing references stay valid."
@@ -277,7 +277,7 @@ async def move_panel(
 
 
 @tool_metadata(
-    tags={"panels", "write", "delete", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—delete] Delete a panel (manifest + payload) by ID. Returns the deleted ID."
     ),

--- a/src/datarobot_genai/drtools/panels/transform.py
+++ b/src/datarobot_genai/drtools/panels/transform.py
@@ -113,7 +113,7 @@ async def _run_transform(
 
 
 @tool_metadata(
-    tags={"panels", "write", "transform", "sandbox", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—transform] Run Python over a Dataset panel in the sandbox and save the result "
         "as a derived child panel (lineage preserved). The source dataset is bound as a polars "
@@ -140,7 +140,7 @@ async def transform_panel(
 
 
 @tool_metadata(
-    tags={"panels", "write", "filter", "sandbox", "daria"},
+    tags=("DataRobot", "Panels"),
     description=(
         "[Panels—filter] Filter a Dataset panel by a polars boolean expression in the sandbox, "
         "saving the filtered rows as a derived child panel. `where` is a polars expression over "

--- a/src/datarobot_genai/drtools/perplexity/tools.py
+++ b/src/datarobot_genai/drtools/perplexity/tools.py
@@ -38,7 +38,7 @@ _PPLX_STRUCTURED = "https://docs.perplexity.ai/guides/structured-outputs"
 
 
 @tool_metadata(
-    tags={"perplexity", "web", "search", "websearch", "daria"},
+    tags=("Perplexity",),
     description=(
         "[Perplexity—web search] Use when the user needs ranked web sources/snippets for a "
         "question or multi-part research (string or list of sub-queries), with optional domain "
@@ -49,7 +49,7 @@ _PPLX_STRUCTURED = "https://docs.perplexity.ai/guides/structured-outputs"
         f"and max_tokens_per_page (1-{MAX_TOKENS_PER_PAGE}).\n\n"
         f"Reference: {_PPLX_SEARCH_GUIDE}"
     ),
-    display_name="Perplexity — Search",
+    display_name="Perplexity — Search Web",
     description_ui=(
         "Search the public web and return ranked source URLs and snippets "
         "(not synthesized answers)."
@@ -167,7 +167,7 @@ async def perplexity_search(
 
 
 @tool_metadata(
-    tags={"perplexity", "think", "research", "answer", "daria"},
+    tags=("Perplexity", "Web Research"),
     description=(
         "[Perplexity—answer / reason] Use when the user wants a model-authored reply with "
         "citations: fast Q&A, deeper reasoning, or long research report (set model to one of "

--- a/src/datarobot_genai/drtools/predictive/data.py
+++ b/src/datarobot_genai/drtools/predictive/data.py
@@ -69,7 +69,7 @@ def _serialize_datastore_params(params: Any) -> dict[str, Any]:
 
 
 @tool_metadata(
-    tags={"predictive", "data", "write", "upload", "catalog", "daria"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Catalog—register new data] Use when the user has file bytes or a public HTTPS URL "
         "and needs a new AI Catalog dataset ID (nothing registered yet). Exactly one of "
@@ -156,7 +156,7 @@ async def catalog_upload_dataset(
 
 
 @tool_metadata(
-    tags={"predictive", "data", "read", "list", "catalog", "daria"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Catalog—list datasets] Use when the user needs catalog datasets they already have "
         "as ID-to-name map. Read-only. Not project-attached datasets "
@@ -222,7 +222,7 @@ async def catalog_list_datasets(
 
 
 @tool_metadata(
-    tags={"predictive", "data", "read", "dataset", "metadata", "daria"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Catalog—one dataset metadata] Use when you already have catalog dataset_id and "
         "need name, row count, timestamps, optional column list and sample rows. Read-only. "
@@ -268,7 +268,7 @@ async def catalog_get_preview(
 
 
 @tool_metadata(
-    tags={"predictive", "data", "read", "datastore", "list", "daria"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Datastore—list connections] Use when the user works with saved external connections "
         "(DB, warehouse, bucket, etc.) and needs datastore IDs. Returns JDBC, native-database, "
@@ -349,7 +349,7 @@ async def catalog_list_datastores(
 
 
 @tool_metadata(
-    tags={"predictive", "data", "read", "datastore", "browse", "daria"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Datastore—browse objects] Use after catalog_list_datastores when the user needs schemas, "
         "tables, or folders inside one connection. Read-only; optional path, search filter, "
@@ -414,7 +414,7 @@ async def catalog_browse_datastore(
 
 
 @tool_metadata(
-    tags={"predictive", "data", "read", "datastore", "query", "sql", "daria"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Datastore—run SQL] Use when the user wants to execute a SQL SELECT against "
         "one saved external connection. Requires datastore_id from catalog_list_datastores; "

--- a/src/datarobot_genai/drtools/predictive/deployment.py
+++ b/src/datarobot_genai/drtools/predictive/deployment.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "read", "management", "list", "daria"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—discover deployments] Use when the user needs their MLOps deployments as "
         "ID-to-label map. Read-only. Not modeling projects (modeling_list_projects), not logged "
@@ -54,7 +54,7 @@ async def deployment_get_list() -> dict[str, Any]:
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "read", "model", "info", "daria"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—model linkage] Use when the user wants the model record attached to a deployment "
         "(model ID, project linkage). Read-only and narrow. For input feature names, types, and "
@@ -79,7 +79,7 @@ async def deployment_get_model_info(
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "write", "model", "create", "daria"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—from leaderboard model] Use when the user wants a new live MLOps deployment "
         "from an existing trained leaderboard model_id "
@@ -204,7 +204,7 @@ async def deploy_custom_model(
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "read", "predictions", "history", "daria"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—prediction audit log] Use when the user asks for historical prediction rows "
         "already logged for a deployment (monitoring, audit). Read-only pagination; does not run "

--- a/src/datarobot_genai/drtools/predictive/deployment_info.py
+++ b/src/datarobot_genai/drtools/predictive/deployment_info.py
@@ -49,7 +49,7 @@ def _feature_importance_value(feature: Any) -> float:
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "read", "info", "metadata", "daria"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—scoring contract] Use when you need a deployment's scoring semantics: target "
         "name/type, model family, all input features (name, type, importance), plus time-series "
@@ -131,7 +131,7 @@ async def deployment_get_info(
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "read", "template", "data"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—sample prediction rows] Use whenever the user asks for sample/example/template "
         "rows, a payload skeleton, or what the scoring input should look like for one deployment. "
@@ -236,7 +236,7 @@ async def deployment_generate_prediction_sample(
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "read", "validation", "data"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—validate CSV only] Use when the user has inline CSV text and wants a schema "
         "check against one deployment before scoring (columns, basic types, time-series "
@@ -384,7 +384,7 @@ async def deployment_validate_prediction_data(
 
 
 @tool_metadata(
-    tags={"predictive", "deployment", "read", "features", "info"},
+    tags=("DataRobot", "Predictive", "Deployment"),
     description=(
         "[Deploy—features slice] Use when you only need feature list, target summary, and "
         "optional time_series_config for a deployment without the full scoring contract "

--- a/src/datarobot_genai/drtools/predictive/model.py
+++ b/src/datarobot_genai/drtools/predictive/model.py
@@ -173,7 +173,7 @@ class ModelEncoder(json.JSONEncoder):
 
 
 @tool_metadata(
-    tags={"predictive", "model", "read", "management", "info", "daria"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—pick best model] Use when the user wants the top leaderboard model for one "
         "modeling project, optionally ranked by a validation metric (e.g. AUC, LogLoss). "
@@ -247,7 +247,7 @@ async def models_get_bestmodel(
 
 
 @tool_metadata(
-    tags={"predictive", "model", "read", "scoring", "dataset"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—model vs catalog] Use when the user wants to score an AI Catalog dataset with a "
         "specific leaderboard model inside a modeling project (they give project_id, model_id, and "
@@ -296,7 +296,7 @@ async def modeling_score_dataset(
 
 
 @tool_metadata(
-    tags={"predictive", "model", "read", "management", "list", "daria"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—list models] Use when the user needs trained leaderboard models for a "
         "project (IDs, types, metrics), with optional offset/limit pagination. Read-only. Not "
@@ -358,7 +358,7 @@ async def modeling_list_models(
 
 
 @tool_metadata(
-    tags={"predictive", "model", "read", "details", "info", "daria"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—model diagnostics] Use when the user asks for training-time detail on one "
         "leaderboard model: target, project metric, validation metrics, optional feature impact "
@@ -418,7 +418,7 @@ async def modeling_get_modeldetails(
 
 
 @tool_metadata(
-    tags={"predictive", "model", "read", "timeseries", "validation", "daria"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Catalog—time series readiness] Use before starting time-series Autopilot: checks an "
         "AI Catalog dataset for row count, parsable datetime column, target null rate, optional "

--- a/src/datarobot_genai/drtools/predictive/predict.py
+++ b/src/datarobot_genai/drtools/predictive/predict.py
@@ -84,7 +84,7 @@ def _batch_job_submitted_payload(job: Any, deployment_id: str, input_desc: str) 
 
 
 @tool_metadata(
-    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    tags=("DataRobot", "Predictive", "Prediction"),
     description=(
         "[Predict—deployment + catalog dataset] Submits batch scoring of one AI Catalog tabular "
         "dataset through an MLOps deployment (deployment_id + dataset_id). Returns immediately "
@@ -132,7 +132,7 @@ async def predict_batch_predictions_from_dataset(
 
 
 @tool_metadata(
-    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    tags=("DataRobot", "Predictive", "Prediction"),
     description=(
         "[Predict—deployment + project splits] Submits batch predictions from a deployment using "
         "project data: training, holdout, validation, or allBacktest (partition), optional "
@@ -201,7 +201,7 @@ async def predict_batch_predictions_from_partition(
 
 
 @tool_metadata(
-    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    tags=("DataRobot", "Predictive", "Prediction"),
     description=(
         "[Predict—batch job status] REQUIRED polling step after "
         "predict_batch_predictions_from_dataset or "
@@ -261,7 +261,7 @@ async def predict_get_batch_job_status(
 
 
 @tool_metadata(
-    tags={"predictive", "prediction", "read", "scoring", "batch"},
+    tags=("DataRobot", "Predictive", "Prediction"),
     description=(
         "[Predict—fetch batch CSV] After predict_get_batch_job_status shows COMPLETED and "
         "url, returns scored CSV text inline for job_id when under the inline size cap. If too "

--- a/src/datarobot_genai/drtools/predictive/predict_realtime.py
+++ b/src/datarobot_genai/drtools/predictive/predict_realtime.py
@@ -45,7 +45,7 @@ def _parse_datetime(value: str) -> datetime:
 
 
 @tool_metadata(
-    tags={"predictive", "prediction", "realtime", "read", "scoring"},
+    tags=("DataRobot", "Predictive", "Prediction"),
     description=(
         "[Predict—deployment + catalog, synchronous rows] Use when the user already has an AI "
         "Catalog dataset_id and wants realtime-style scoring through a deployment with rows "
@@ -122,7 +122,7 @@ async def predict_score_catalog_realtime(
 
 
 @tool_metadata(
-    tags={"predictive", "prediction", "realtime", "read", "scoring"},
+    tags=("DataRobot", "Predictive", "Prediction"),
     description=(
         "[Predict—inline rows now] Use when the user pastes or embeds prediction rows directly "
         "in the conversation: a CSV snippet (header + rows) or a JSON array of row objects in "

--- a/src/datarobot_genai/drtools/predictive/project.py
+++ b/src/datarobot_genai/drtools/predictive/project.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool_metadata(
-    tags={"predictive", "project", "read", "management", "list"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—discover IDs] Use when the user needs their modeling projects as ID-to-name "
         "map (no single project_id yet). Read-only. Not for datasets inside one project "
@@ -48,7 +48,7 @@ async def modeling_list_projects() -> dict[str, Any]:
 
 
 @tool_metadata(
-    tags={"predictive", "project", "read", "data", "info"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—resolve dataset by name] Use when the user names or describes a dataset "
         "already attached to a modeling project (e.g. 'get the holdout dataset', 'dataset named "

--- a/src/datarobot_genai/drtools/predictive/training.py
+++ b/src/datarobot_genai/drtools/predictive/training.py
@@ -194,7 +194,7 @@ def _build_dataset_insights(df: pd.DataFrame) -> dict[str, Any]:
 
 
 @tool_metadata(
-    tags={"predictive", "training", "read", "analysis", "dataset"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Catalog—quick profile] Use for a fast structural overview of one AI Catalog dataset: "
         "row/column counts, inferred kinds (numeric, categorical, datetime, text), missingness, "
@@ -219,7 +219,7 @@ async def catalog_analyze_dataset(
 
 
 @tool_metadata(
-    tags={"predictive", "training", "read", "analysis", "usecase"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Catalog—use-case ideas] Use when the user wants ranked ML problem suggestions from one "
         "catalog dataset (name, suggested target, problem type, confidence). Read-only. Builds on "
@@ -253,7 +253,7 @@ async def catalog_suggest_ml_problems(
 
 
 @tool_metadata(
-    tags={"predictive", "training", "read", "analysis", "eda"},
+    tags=("DataRobot", "Predictive", "Catalog"),
     description=(
         "[Catalog—deep EDA] Use when the user wants richer exploratory stats on one catalog "
         "dataset: memory, per-column missingness, type groupings, optional target distribution "
@@ -609,7 +609,7 @@ def _analyze_target_for_use_cases(df: pd.DataFrame, target_col: str) -> list[Use
 
 
 @tool_metadata(
-    tags={"predictive", "training", "write", "autopilot", "model", "daria"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—start Autopilot] Use when the user wants to start or resume Autopilot for one "
         "tabular target: new project from dataset_id or public dataset_url plus project_name, or "
@@ -705,7 +705,7 @@ async def modeling_start_autopilot(
 
 
 @tool_metadata(
-    tags={"prediction", "training", "read", "model", "evaluation"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—ROC only] Use when the user wants ROC curve points for one binary classification "
         "leaderboard model; source must be string 'validation', 'holdout', or 'crossValidation'. "
@@ -776,7 +776,7 @@ async def modeling_get_model_roc(
 
 
 @tool_metadata(
-    tags={"predictive", "training", "read", "model", "evaluation"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—global feature impact] Use for training-time global feature impact on one "
         "leaderboard model (may wait while impact is computed). Read-only. Not per-row SHAP from "
@@ -814,7 +814,7 @@ async def modeling_get_model_feature_impact(
 
 
 @tool_metadata(
-    tags={"predictive", "training", "read", "model", "evaluation"},
+    tags=("DataRobot", "Predictive", "Modeling"),
     description=(
         "[Project—lift chart] Use for lift chart bins on one classification leaderboard model "
         "(actual vs predicted by score bucket); source must be 'validation', 'holdout', or "

--- a/src/datarobot_genai/drtools/tavily/tools.py
+++ b/src/datarobot_genai/drtools/tavily/tools.py
@@ -38,7 +38,7 @@ _TAVILY_CRAWL_API = "https://docs.tavily.com/documentation/api-reference/endpoin
 
 
 @tool_metadata(
-    tags={"tavily", "search", "web", "websearch"},
+    tags=("Tavily",),
     description=(
         "[Tavily—web search] Use when the user needs fresh facts from the public web by keyword "
         "(optional topic string: 'general', 'news', or 'finance'). Returns ranked snippets and "
@@ -119,7 +119,7 @@ async def tavily_search_web(
 
 
 @tool_metadata(
-    tags={"tavily", "extract", "web", "content"},
+    tags=("Tavily", "Web"),
     description=(
         "[Tavily—read URLs] Use when you already have one or more page URLs and need cleaned "
         "body text or reranked chunks (optional query for relevance). Not broad keyword web "
@@ -194,7 +194,7 @@ async def tavily_extract_text(
 
 
 @tool_metadata(
-    tags={"tavily", "map", "discovery"},
+    tags=("Tavily",),
     description=(
         "[Tavily—site map] Use when you need a structured list of links under one root URL "
         "(find sections or docs paths before reading). Optional instructions steer which branches "
@@ -242,7 +242,7 @@ async def tavily_list_links(
 
 
 @tool_metadata(
-    tags={"tavily", "crawl", "web", "rag"},
+    tags=("Tavily",),
     description=(
         "[Tavily—site crawl] Use when you need many related pages from one site guided by "
         "natural-language instructions (breadth/depth limits). Not single-URL read "

--- a/src/datarobot_genai/drtools/use_case/tools.py
+++ b/src/datarobot_genai/drtools/use_case/tools.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 @tool_metadata(
-    tags={"use_case", "read", "list", "daria"},
+    tags=("DataRobot", "Use Case"),
     description=(
         "[Use case—list] Use when the user needs DataRobot use cases (workspace bundles) as "
         "ID+name, optionally filtered by name search. Read-only. Not assets inside a known case "
@@ -71,7 +71,7 @@ async def datarobot_usecases_list(
 
 
 @tool_metadata(
-    tags={"use_case", "read", "assets", "daria"},
+    tags=("DataRobot", "Use Case"),
     description=(
         "[Use case—assets] Use when you have one or more use_case_id values and need what is "
         "linked: datasets, deployments, and experiments as ID+name per case. Read-only. Not "

--- a/src/datarobot_genai/drtools/vdb/tools.py
+++ b/src/datarobot_genai/drtools/vdb/tools.py
@@ -253,7 +253,7 @@ def _wait_for_new_vdb_deployment(
 
 
 @tool_metadata(
-    tags={"vdb", "read", "list", "daria"},
+    tags=("DataRobot", "Vector database"),
     description=(
         "[VDB—discover deployments] Use when the user needs deployed Vector Databases (VDBs) as "
         "ID/label/status records. Read-only. Filters deployments client-side to vector-database "
@@ -323,7 +323,7 @@ async def vdb_list(
 
 
 @tool_metadata(
-    tags={"vdb", "read", "query", "search", "daria"},
+    tags=("DataRobot", "Vector database"),
     description=(
         "[VDB—semantic search] Use when the user wants to retrieve documents from a deployed "
         "Vector Database via semantic similarity (deployment_id from vdb_list). "
@@ -458,7 +458,7 @@ def _resolve_chunking_parameters(
 
 
 @tool_metadata(
-    tags={"vdb", "write", "create"},
+    tags=("DataRobot", "Vector database"),
     description=(
         "[VDB—create] Use when the user wants to create a new DataRobot vector database from an "
         "AI Catalog dataset (dataset_id from catalog_list_datasets or catalog_upload_dataset) "
@@ -553,7 +553,7 @@ async def vdb_create(
 
 
 @tool_metadata(
-    tags={"vdb", "read", "status", "daria"},
+    tags=("DataRobot", "Vector database"),
     description=(
         "[VDB—status] REQUIRED polling step after vdb_create or vdb_deploy. Pass exactly one of "
         "vector_database_id (build status) or deployment_id (launch status). Performs ONE "
@@ -656,7 +656,7 @@ async def vdb_get(
 
 
 @tool_metadata(
-    tags={"vdb", "write", "deploy", "daria"},
+    tags=("DataRobot", "Vector database"),
     description=(
         "[VDB—deploy] Use when the user wants to deploy a built vector database "
         "(vector_database_id from vdb_create) to a live deployment for querying. "

--- a/src/datarobot_genai/drtools/workload/artifact_builds.py
+++ b/src/datarobot_genai/drtools/workload/artifact_builds.py
@@ -37,7 +37,7 @@ from datarobot_genai.drtools.workload.build_status import annotate_build_deploya
 
 
 @tool_metadata(
-    tags={"artifact", "build", "workload", "datarobot", "get", "list", "logs"},
+    tags=("DataRobot", "Workload", "Artifact"),
     description=(
         "[Artifact build—get] Read image builds for an artifact.\n"
         "  - Omit build_id to LIST builds (status, timestamps, build ID); paginated.\n"
@@ -112,7 +112,7 @@ async def artifact_get_build(
 
 
 @tool_metadata(
-    tags={"artifact", "build", "workload", "datarobot", "trigger", "delete"},
+    tags=("DataRobot", "Workload", "Artifact", "Build", "Delete", "Trigger"),
     description=(
         "[Artifact build—action] Run an action on artifact image builds. action is "
         "one of:\n"

--- a/src/datarobot_genai/drtools/workload/artifact_repositories.py
+++ b/src/datarobot_genai/drtools/workload/artifact_repositories.py
@@ -35,7 +35,7 @@ from datarobot_genai.drtools.pagination import merge_pagination_metadata
 
 
 @tool_metadata(
-    tags={"artifact", "repository", "workload", "datarobot", "get", "list"},
+    tags=("DataRobot", "Workload", "Artifact"),
     description=(
         "[Artifact repository—get] Read artifact repositories.\n"
         "  - Omit repository_id to LIST repositories (ID, name, type, timestamps); "
@@ -107,7 +107,7 @@ async def artifact_repository_get(
 
 
 @tool_metadata(
-    tags={"artifact", "repository", "workload", "datarobot", "delete"},
+    tags=("DataRobot", "Workload", "Artifact"),
     description=(
         "[Artifact repository—delete] Permanently delete an artifact repository. "
         "Artifacts within the repository are cascade-deleted unless they are locked "

--- a/src/datarobot_genai/drtools/workload/artifacts.py
+++ b/src/datarobot_genai/drtools/workload/artifacts.py
@@ -37,7 +37,7 @@ from datarobot_genai.drtools.pagination import merge_pagination_metadata
 
 
 @tool_metadata(
-    tags={"artifact", "workload", "datarobot", "get", "list"},
+    tags=("DataRobot", "Workload", "Artifact"),
     description=(
         "[Artifact—get] Read artifacts.\n"
         "  - Omit artifact_id to LIST artifacts (ID, name, status draft/locked, type, "
@@ -119,7 +119,7 @@ async def artifact_get(
 
 
 @tool_metadata(
-    tags={"artifact", "workload", "datarobot", "create"},
+    tags=("DataRobot", "Workload", "Artifact"),
     description=(
         "[Artifact—create] Create a new draft artifact from an InputArtifact payload. "
         "The payload must contain 'name' and 'spec'. 'spec' must have 'type' "
@@ -169,7 +169,7 @@ async def artifact_create(
 
 
 @tool_metadata(
-    tags={"artifact", "workload", "datarobot", "update"},
+    tags=("DataRobot", "Workload", "Artifact"),
     description=(
         "[Artifact—update] Partially update a draft artifact: name, description, "
         "or spec. Only the supplied fields are changed. At least one field is required. "
@@ -221,7 +221,7 @@ async def artifact_update(
 
 
 @tool_metadata(
-    tags={"artifact", "workload", "datarobot", "lock", "clone", "delete"},
+    tags=("DataRobot", "Workload", "Artifact", "Clone", "Delete", "Lock"),
     description=(
         "[Artifact—action] Run an action on an artifact. action is one of:\n"
         "  'lock'   — lock a draft artifact so it can be versioned and used in "

--- a/src/datarobot_genai/drtools/workload/openapi_spec.py
+++ b/src/datarobot_genai/drtools/workload/openapi_spec.py
@@ -199,7 +199,7 @@ def _overview(spec: dict[str, Any]) -> dict[str, Any]:
 
 
 @tool_metadata(
-    tags={"workload", "openapi", "spec", "datarobot", "get", "search"},
+    tags=("DataRobot", "Workload"),
     enabled=False,
     description=(
         "[Workload—OpenAPI spec] Query the Workload API OpenAPI specification. Use "

--- a/src/datarobot_genai/drtools/workload/workload_observability.py
+++ b/src/datarobot_genai/drtools/workload/workload_observability.py
@@ -36,7 +36,7 @@ from datarobot_genai.drtools.pagination import merge_pagination_metadata
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "stats"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—stats] Get aggregated performance statistics for a workload: "
         "request count, error rate, response time quantile, slow requests. "
@@ -97,7 +97,7 @@ async def workload_stats_get(
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "logs", "otel"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—logs] Retrieve OTel log lines for a workload. Supports "
         "filtering by log level, time window, body text (includes/excludes), "
@@ -187,7 +187,7 @@ _ACTIVITY_RESULT_KEY: dict[str, str] = {
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "history", "events", "related"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—activity] Inspect a workload's activity. kind is one of:\n"
         "  'history' — artifact deployment history (which version was deployed, "
@@ -254,7 +254,7 @@ async def workload_activity_get(
 
 
 @tool_metadata(
-    tags={"workload", "proton", "datarobot", "get", "list", "status", "debug"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—proton get] Inspect proton (deployed pod) instances for a "
         "workload.\n"

--- a/src/datarobot_genai/drtools/workload/workload_runtime.py
+++ b/src/datarobot_genai/drtools/workload/workload_runtime.py
@@ -34,7 +34,7 @@ from datarobot_genai.drtools.workload.build_status import raise_tool_error_for_w
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "settings", "get", "update"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—settings] Read or update a workload's runtime settings "
         "(containerGroups, replicaCount, resourceBundles). "
@@ -93,7 +93,7 @@ async def workload_settings(
 
 
 @tool_metadata(
-    tags={"workload", "replacement", "datarobot", "get", "create", "delete"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—replacement] Manage a rolling replacement (zero-downtime artifact "
         "swap) for a workload. Modes:\n"

--- a/src/datarobot_genai/drtools/workload/workloads.py
+++ b/src/datarobot_genai/drtools/workload/workloads.py
@@ -44,7 +44,7 @@ from datarobot_genai.drtools.workload.build_status import raise_tool_error_for_w
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "list", "search"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—list] Discover workloads: returns ID, name, status, "
         "artifactId, importance, and runtime for each. Use workload_get for a "
@@ -94,7 +94,7 @@ async def workload_list(
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "get", "status"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—get] Fetch a single workload by ID: status, runtime, artifact "
         "reference, endpoint URL, creator, and timestamps. This is also the status "
@@ -161,7 +161,7 @@ async def workload_get(
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "payload", "helper"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—build create payload] Build a valid workload create payload "
         "without making an API call. Pass the returned payload dict to "
@@ -314,7 +314,7 @@ async def workload_create_payload_build(
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "create"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—create] Create a new workload from a payload dict. "
         "Use workload_create_payload_build to build the payload first. "
@@ -364,7 +364,7 @@ async def workload_create(
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "update"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—update] Partially update a workload's name, description, or "
         "importance. Only supplied fields are changed. At least one field is required.\n\n"
@@ -416,7 +416,7 @@ _ACTION_TARGET_STATUS: dict[str, str] = {"start": "running", "stop": "stopped"}
 
 
 @tool_metadata(
-    tags={"workload", "datarobot", "start", "stop", "delete", "promote"},
+    tags=("DataRobot", "Workload", "Delete", "Promote", "Start", "Stop"),
     description=(
         "[Workload—action] Run a lifecycle action on a workload. action is one of:\n"
         "  'start'   — request a stopped workload to start (returns immediately, 202).\n"
@@ -479,7 +479,7 @@ async def workload_action_run(
 
 
 @tool_metadata(
-    tags={"workload", "bundle", "datarobot", "list"},
+    tags=("DataRobot", "Workload"),
     description=(
         "[Workload—bundle list] Discover available compute resource bundles "
         "(CPU count, memory, GPU type and VRAM). GPU type and VRAM are always "

--- a/tests/drmcpbase/routes/test_tool_gallery_http.py
+++ b/tests/drmcpbase/routes/test_tool_gallery_http.py
@@ -69,12 +69,12 @@ class TestToolGalleryRoute:
             body = client.get("/toolGallery/tools/").json()
         by_name = {t["name"]: t for t in body["tools"]}
         assert by_name["jira_search_issues"]["categories"] == [
-            "dr_connector_jira",
-            "dr_connectors",
+            {"name": "dr_connector_jira", "label": "Jira", "kind": "leaf"},
+            {"name": "dr_connectors", "label": "Data connectors", "kind": "parent"},
         ]
         assert by_name["perplexity_search"]["categories"] == [
-            "dr_web_search",
-            "dr_web_search_perplexity",
+            {"name": "dr_web_search", "label": "Web search", "kind": "parent"},
+            {"name": "dr_web_search_perplexity", "label": "Perplexity", "kind": "leaf"},
         ]
 
     def test_every_item_has_required_fields(self) -> None:
@@ -84,10 +84,12 @@ class TestToolGalleryRoute:
         required = {
             "name",
             "display_name",
+            "ui_display_name",
             "description",
             "tags",
             "categories",
             "provider",
+            "provider_name",
             "oauth_provider_type",
             "hosted",
         }
@@ -373,6 +375,19 @@ class TestToolGalleryCategoriesRoute:
         assert values == set(ordered_top_level())
         assert {"dr_user_tools", "dr_dynamic_tools", "dr_db", "dr_deployments"} <= values
 
+    def test_nodes_are_ordered_alphabetically_by_label(self) -> None:
+        # GIVEN the gallery routes
+        mcp = _make_server_with_route()
+        # WHEN the categories route is fetched
+        with TestClient(mcp.http_app()) as client:
+            body = client.get("/toolGallery/categories/").json()
+        # THEN top-level nodes and each parent's children are alphabetical by label
+        labels = [item["label"].casefold() for item in body["categories"]]
+        assert labels == sorted(labels)
+        for item in body["categories"]:
+            child_labels = [child["label"].casefold() for child in item["children"]]
+            assert child_labels == sorted(child_labels)
+
     def test_nodes_carry_live_counts_children_and_applies_to(self) -> None:
         # GIVEN a server exposing one jira tool
         mcp = _make_server_with_route()
@@ -420,7 +435,7 @@ class TestToolGalleryProvidersRoute:
         body = resp.json()
         assert body["count"] == len(body["providers"]) == 2
         by_value = {item["value"]: item["label"] for item in body["providers"]}
-        assert by_value == {"datarobot": "DataRobot", "third_party": "Third party"}
+        assert by_value == {"datarobot": "DataRobot", "third_party": "Third-party"}
 
 
 class TestToolGalleryEnumRoutesAreGated:

--- a/tests/drmcputils/routes/test_tool_gallery.py
+++ b/tests/drmcputils/routes/test_tool_gallery.py
@@ -45,6 +45,12 @@ class TestIsHosted:
         assert not is_hosted(_FakeTool("t", meta={}))
 
 
+_JIRA_CATEGORIES = [
+    {"name": "dr_connector_jira", "label": "Jira", "kind": "leaf"},
+    {"name": "dr_connectors", "label": "Data connectors", "kind": "parent"},
+]
+
+
 class TestMergeToolInfo:
     def test_merges_ui_metadata_and_derived_categories(self) -> None:
         tool = _FakeTool("jira_search_issues", tags={"jira", "search"})
@@ -61,8 +67,19 @@ class TestMergeToolInfo:
         assert merged["description_ui"] == "Find Jira issues matching a JQL query."
         assert merged["auth_provider"] == "jira"
         assert merged["tags"] == ["jira", "search"]
-        assert merged["categories"] == ["dr_connector_jira", "dr_connectors"]
+        assert merged["categories"] == _JIRA_CATEGORIES
         assert merged["hosted"] is False
+
+    def test_registry_tags_keep_declaration_order(self) -> None:
+        # The FastMCP tool carries tags as a set; the registry's ordered tags win.
+        tool = _FakeTool("jira_search_issues", tags={"jira", "atlassian"})
+        ui = {"jira_search_issues": {"tags": ["Atlassian", "Jira"]}}
+        merged = merge_tool_info(tool, ui)
+        assert merged["tags"] == ["Atlassian", "Jira"]
+
+    def test_tool_without_registry_tags_falls_back_to_sorted(self) -> None:
+        merged = merge_tool_info(_FakeTool("t", tags={"zeta", "alpha"}), {})
+        assert merged["tags"] == ["alpha", "zeta"]
 
     def test_tool_without_ui_metadata_gets_none_fields(self) -> None:
         merged = merge_tool_info(_FakeTool("jira_search_issues"), {})
@@ -70,7 +87,7 @@ class TestMergeToolInfo:
         assert merged["description_ui"] is None
         assert merged["auth_provider"] is None
         # Categories still derived from the static taxonomy.
-        assert merged["categories"] == ["dr_connector_jira", "dr_connectors"]
+        assert merged["categories"] == _JIRA_CATEGORIES
 
     def test_hosted_tool_has_no_categories(self) -> None:
         tool = _FakeTool("user_xyz", meta={"tool_category": "USER_TOOL_DEPLOYMENT"})

--- a/tests/drmcputils/test_categories.py
+++ b/tests/drmcputils/test_categories.py
@@ -287,40 +287,48 @@ class TestFilterableCategories:
         known = {category.value for category in MCPToolCategory}
         assert set(ordered_top_level()) <= known
 
-    def test_marker_buckets_sort_last(self) -> None:
-        # The predefined taxonomy comes first; the marker-resolved buckets
-        # (dr_user_tools / dr_dynamic_tools) trail it, matching the picker layout.
+    def test_top_level_is_alphabetical_by_label(self) -> None:
+        # The categories endpoint serves nodes in alphabetical label order, marker
+        # buckets included — the response order is the picker order.
         tops = ordered_top_level()
-        dynamic = {MCPToolCategory.DR_USER_TOOLS.value, MCPToolCategory.DR_DYNAMIC_TOOLS.value}
-        assert set(tops[-len(dynamic) :]) == dynamic
+        labels = [category_label(name).casefold() for name in tops]
+        assert labels == sorted(labels)
+        assert MCPToolCategory.DR_USER_TOOLS.value in tops
+        assert MCPToolCategory.DR_DYNAMIC_TOOLS.value in tops
 
 
 class TestCategoriesForTool:
-    """Reverse index: tool name → its leaf category plus parent (if any)."""
+    """Reverse index: tool name → its leaf category plus parent (if any), as dicts."""
 
     def test_tool_under_parented_leaf_returns_leaf_and_parent(self) -> None:
         # jira_search_issues → leaf dr_connector_jira → parent dr_connectors
         assert categories_for_tool("jira_search_issues") == [
-            "dr_connector_jira",
-            "dr_connectors",
+            {"name": "dr_connector_jira", "label": "Jira", "kind": "leaf"},
+            {"name": "dr_connectors", "label": "Data connectors", "kind": "parent"},
         ]
 
     def test_tool_under_standalone_leaf_returns_only_leaf(self) -> None:
         # dr_documentation is a leaf with no parent.
-        assert categories_for_tool("search_datarobot_agentic_docs") == ["dr_documentation"]
+        assert categories_for_tool("search_datarobot_agentic_docs") == [
+            {"name": "dr_documentation", "label": "Documentation", "kind": "leaf"}
+        ]
 
     def test_use_case_tool_returns_leaf_only(self) -> None:
-        assert categories_for_tool("datarobot_usecases_list") == ["dr_use_cases"]
+        assert [c["name"] for c in categories_for_tool("datarobot_usecases_list")] == [
+            "dr_use_cases"
+        ]
 
     def test_deployment_tool_returns_leaf_only(self) -> None:
-        assert categories_for_tool("deployment_get_list") == ["dr_deployments"]
+        assert [c["name"] for c in categories_for_tool("deployment_get_list")] == ["dr_deployments"]
 
     def test_predictive_tool_returns_leaf_and_predictive_parent(self) -> None:
-        assert categories_for_tool("modeling_list_models") == ["dr_modeling", "dr_predictive"]
+        result = categories_for_tool("modeling_list_models")
+        assert [c["name"] for c in result] == ["dr_modeling", "dr_predictive"]
+        assert [c["kind"] for c in result] == ["leaf", "parent"]
 
-    def test_result_is_sorted(self) -> None:
-        result = categories_for_tool("jira_search_issues")
-        assert result == sorted(result)
+    def test_result_is_sorted_by_name(self) -> None:
+        names = [c["name"] for c in categories_for_tool("jira_search_issues")]
+        assert names == sorted(names)
 
     def test_unknown_tool_returns_empty_list(self) -> None:
         assert categories_for_tool("not_a_real_tool") == []
@@ -334,4 +342,5 @@ class TestCategoriesForTool:
         # Each tool in every leaf category must report that leaf among its categories.
         for leaf, tools in LEAF_CATEGORY_TOOLS.items():
             for tool_name in tools:
-                assert leaf in categories_for_tool(tool_name)
+                names = {c["name"] for c in categories_for_tool(tool_name)}
+                assert str(leaf) in names

--- a/tests/drmcputils/test_category_tree.py
+++ b/tests/drmcputils/test_category_tree.py
@@ -43,7 +43,7 @@ def _filterable(tools: list[Any]) -> dict[str, set[str]]:
     mapping: dict[str, set[str]] = {}
     for item in build_tool_gallery_items([merge_tool_info(t, {}) for t in tools]):
         for category in item["categories"]:
-            mapping.setdefault(str(category), set()).add(item["name"])
+            mapping.setdefault(category["name"], set()).add(item["name"])
     return mapping
 
 

--- a/tests/drmcputils/test_tool_gallery.py
+++ b/tests/drmcputils/test_tool_gallery.py
@@ -48,7 +48,7 @@ class TestToolProvidersFilterEnum:
         # THEN it maps exactly the two provider values to their display labels
         assert TOOL_PROVIDER_LABELS == {
             PROVIDER_DATAROBOT: "DataRobot",
-            PROVIDER_THIRD_PARTY: "Third party",
+            PROVIDER_THIRD_PARTY: "Third-party",
         }
 
     def test_values_match_what_the_builder_emits(self) -> None:
@@ -72,10 +72,12 @@ class TestBuildToolGalleryItems:
         item = result[0]
         assert item["name"] == "my_tool"
         assert item["display_name"] == "my_tool"
+        assert item["ui_display_name"] == "my_tool"
         assert item["description"] == ""
         assert item["tags"] == []
         assert item["categories"] == []
         assert item["provider"] == "datarobot"
+        assert item["provider_name"] == "DataRobot"
         assert item["oauth_provider_type"] is None
         assert item["hosted"] is False
 
@@ -84,7 +86,7 @@ class TestBuildToolGalleryItems:
             "name": "jira_search_issues",
             "display_name": "Jira — Search Issues",
             "description_ui": "Find Jira issues matching a JQL query.",
-            "tags": ["jira", "search"],
+            "tags": ["Atlassian", "Jira"],
             "categories": ["dr_connectors", "dr_connector_jira"],
             "auth_provider": "jira",
             "hosted": False,
@@ -93,8 +95,10 @@ class TestBuildToolGalleryItems:
         item = result[0]
         assert item["name"] == "jira_search_issues"
         assert item["display_name"] == "Jira — Search Issues"
+        assert item["ui_display_name"] == "Search Issues"
         assert item["description"] == "Find Jira issues matching a JQL query."
         assert item["provider"] == "third_party"
+        assert item["provider_name"] == "Atlassian"
         assert item["oauth_provider_type"] == "jira"
         assert item["hosted"] is False
 
@@ -123,6 +127,51 @@ class TestBuildToolGalleryItems:
         )
         assert result[0]["display_name"] == "Human Friendly Name"
 
+    # ── ui_display_name (the action half of "<group> — <action>") ────────────
+
+    def test_ui_display_name_strips_the_group_prefix(self) -> None:
+        result = build_tool_gallery_items(
+            [{"name": "workload_bundle_list", "display_name": "Workload — List bundles"}]
+        )
+        assert result[0]["ui_display_name"] == "List bundles"
+
+    def test_ui_display_name_splits_on_the_first_separator_only(self) -> None:
+        result = build_tool_gallery_items(
+            [{"name": "t", "display_name": "Artifact Build — Run action"}]
+        )
+        assert result[0]["ui_display_name"] == "Run action"
+
+    def test_ui_display_name_without_separator_is_the_display_name(self) -> None:
+        result = build_tool_gallery_items([{"name": "t", "display_name": "Plain Name"}])
+        assert result[0]["ui_display_name"] == "Plain Name"
+
+    def test_ui_display_name_falls_back_to_name_with_display_name_absent(self) -> None:
+        result = build_tool_gallery_items([{"name": "raw_name"}])
+        assert result[0]["ui_display_name"] == "raw_name"
+
+    # ── provider_name (the provider's brand) ─────────────────────────────────
+
+    def test_provider_name_is_datarobot_without_auth_provider(self) -> None:
+        result = build_tool_gallery_items([{"name": "t"}])
+        assert result[0]["provider_name"] == "DataRobot"
+
+    def test_provider_name_maps_third_party_brands(self) -> None:
+        expected = {
+            "jira": "Atlassian",
+            "confluence": "Atlassian",
+            "gdrive": "Google",
+            "microsoft_graph": "Microsoft",
+            "perplexity": "Perplexity",
+            "tavily": "Tavily",
+        }
+        for auth_provider, brand in expected.items():
+            result = build_tool_gallery_items([{"name": "t", "auth_provider": auth_provider}])
+            assert result[0]["provider_name"] == brand
+
+    def test_provider_name_falls_back_to_humanised_auth_provider(self) -> None:
+        result = build_tool_gallery_items([{"name": "t", "auth_provider": "some_new_thing"}])
+        assert result[0]["provider_name"] == "Some New Thing"
+
     # ── description (sourced from description_ui) ────────────────────────────
 
     def test_description_absent_becomes_empty_string(self) -> None:
@@ -137,15 +186,17 @@ class TestBuildToolGalleryItems:
         result = build_tool_gallery_items([{"name": "t", "description_ui": "Search the web."}])
         assert result[0]["description"] == "Search the web."
 
-    # ── tags sorting ─────────────────────────────────────────────────────────
+    # ── tags order ───────────────────────────────────────────────────────────
 
-    def test_tags_are_sorted_alphabetically(self) -> None:
+    def test_tags_preserve_declaration_order(self) -> None:
+        # Tags are reported exactly as merged — declaration order, never re-sorted.
         result = build_tool_gallery_items([{"name": "t", "tags": ["zzz", "aaa", "mmm"]}])
-        assert result[0]["tags"] == ["aaa", "mmm", "zzz"]
+        assert result[0]["tags"] == ["zzz", "aaa", "mmm"]
 
-    def test_tags_set_input_is_sorted(self) -> None:
+    def test_tags_set_input_becomes_a_list(self) -> None:
+        # A set input carries no order to preserve; the members still all land in the list.
         result = build_tool_gallery_items([{"name": "t", "tags": {"beta", "alpha"}}])
-        assert result[0]["tags"] == ["alpha", "beta"]
+        assert sorted(result[0]["tags"]) == ["alpha", "beta"]
 
     def test_tags_absent_becomes_empty_list(self) -> None:
         result = build_tool_gallery_items([{"name": "t"}])
@@ -157,17 +208,22 @@ class TestBuildToolGalleryItems:
 
     # ── categories ───────────────────────────────────────────────────────────
 
-    def test_categories_list_preserved(self) -> None:
+    def test_categories_are_name_label_kind_dicts(self) -> None:
         cats = ["dr_connectors", "dr_connector_jira"]
         result = build_tool_gallery_items([{"name": "t", "categories": cats}])
-        assert result[0]["categories"] == cats
+        assert result[0]["categories"] == [
+            {"name": "dr_connectors", "label": "Data connectors", "kind": "parent"},
+            {"name": "dr_connector_jira", "label": "Jira", "kind": "leaf"},
+        ]
 
     def test_categories_frozenset_converted_to_list(self) -> None:
         result = build_tool_gallery_items(
             [{"name": "t", "categories": frozenset({"dr_connectors"})}]
         )
         assert isinstance(result[0]["categories"], list)
-        assert result[0]["categories"] == ["dr_connectors"]
+        assert result[0]["categories"] == [
+            {"name": "dr_connectors", "label": "Data connectors", "kind": "parent"}
+        ]
 
     def test_categories_absent_becomes_empty_list(self) -> None:
         result = build_tool_gallery_items([{"name": "t"}])
@@ -249,8 +305,11 @@ class TestHostedToolClassification:
         )
         item = result[0]
         assert item["provider"] == "datarobot"
+        assert item["provider_name"] == "DataRobot"
         assert item["oauth_provider_type"] is None
-        assert item["categories"] == ["dr_user_tools"]
+        assert item["categories"] == [
+            {"name": "dr_user_tools", "label": "Your own tools", "kind": "leaf"}
+        ]
         assert item["hosted"] is False
 
     def test_user_tool_deployment_is_datarobot_dynamic(self) -> None:
@@ -260,8 +319,11 @@ class TestHostedToolClassification:
         )
         item = result[0]
         assert item["provider"] == "datarobot"
+        assert item["provider_name"] == "DataRobot"
         assert item["oauth_provider_type"] is None
-        assert item["categories"] == ["dr_dynamic_tools"]
+        assert item["categories"] == [
+            {"name": "dr_dynamic_tools", "label": "Deployed tools", "kind": "leaf"}
+        ]
         assert item["hosted"] is True
 
     def test_proxied_user_mcp_is_third_party(self) -> None:
@@ -273,6 +335,8 @@ class TestHostedToolClassification:
         )
         item = result[0]
         assert item["provider"] == "third_party"
+        # No brand name is known for a tool proxied from a user's own MCP server.
+        assert item["provider_name"] is None
         assert item["oauth_provider_type"] is None
         assert item["categories"] == []
         assert item["hosted"] is True
@@ -289,7 +353,9 @@ class TestHostedToolClassification:
                 }
             ]
         )
-        assert result[0]["categories"] == ["dr_dynamic_tools"]
+        assert result[0]["categories"] == [
+            {"name": "dr_dynamic_tools", "label": "Deployed tools", "kind": "leaf"}
+        ]
         assert result[0]["provider"] == "datarobot"
         assert result[0]["oauth_provider_type"] is None
 

--- a/tests/drtools/unit/core/test_tool_metadata.py
+++ b/tests/drtools/unit/core/test_tool_metadata.py
@@ -36,6 +36,7 @@ class TestGetToolUiMetadata:
                     "display_name": "My Tool",
                     "description_ui": "Does a thing.",
                     "auth_provider": "jira",
+                    "tags": ("Atlassian", "Jira"),
                 },
             )
         ]
@@ -45,6 +46,8 @@ class TestGetToolUiMetadata:
             "display_name": "My Tool",
             "description_ui": "Does a thing.",
             "auth_provider": "jira",
+            # Declaration order preserved — the gallery reports tags in this order.
+            "tags": ["Atlassian", "Jira"],
         }
 
     def test_falls_back_to_func_name_when_no_name_key(self) -> None:
@@ -65,6 +68,7 @@ class TestGetToolUiMetadata:
             "display_name": None,
             "description_ui": None,
             "auth_provider": None,
+            "tags": [],
         }
 
     def test_empty_registry_returns_empty_lookup(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.26"
+version = "0.29.27"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

- `drtools`: reworked every tool's gallery tags into human-readable UI tags (e.g. `DataRobot, Predictive, Catalog`; action tags like `Delete`/`Promote` on the run-action tools), replacing the lowercase functional tags. Tags are now declared as ordered tuples so the gallery reports them in declaration order.
- `drtools/perplexity`: renamed the `perplexity_search` display name from "Perplexity — Search" to "Perplexity — Search Web".
- `drmcputils` tool gallery (`GET /toolGallery/*`):
  - `tools/` items report `tags` in declaration order (no longer alphabetized), a new `ui_display_name` (the action half of the display name, e.g. "Workload — List bundles" → "List bundles"), and a new `provider_name` carrying the provider's brand ("DataRobot", "Perplexity", "Atlassian", ...; `null` for proxied user-MCP tools).
  - each item's `categories` entries are now `{name, label, kind}` dicts (`kind` is `parent` or `leaf`) instead of bare `dr_*` strings; `categories_for_tool` returns the same shape.
  - `categories/` nodes (and their children) are ordered alphabetically by label.
  - `providers/` label for `third_party` is now "Third-party".

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tool gallery JSON contract changes (categories shape, tag ordering, new fields) can break consumers that assumed string categories or sorted tags; tool invocation paths are unchanged.
> 
> **Overview**
> **Improves the MCP tool gallery API and metadata** so UIs can show clearer labels, brands, and filters without changing how tools execute.
> 
> `GET /toolGallery/tools/` items now expose **`ui_display_name`** (text after the ` — ` in `display_name`), **`provider_name`** (e.g. Atlassian, Google; `null` for proxied user MCP tools), and **`categories`** as `{name, label, kind}` objects instead of bare `dr_*` strings. **`tags`** keep **`@tool_metadata(tags=(...))` declaration order** via the drtools registry rather than alphabetical sorting. Category tree responses order top-level nodes and children **alphabetically by label** (replacing enum order). The third-party provider label is **"Third-party"**.
> 
> Across **drtools**, gallery tags are reworked to **human-readable tuples** (e.g. `DataRobot`, `Predictive`, `Catalog`) instead of lowercase functional tags. **Perplexity — Search** is renamed to **Perplexity — Search Web**. Version **0.29.27** and changelog/tests are updated for the new shapes and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bbe6dba5991096edfca1d6da2bca67199da2ef6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->