### PR TITLE
[BUZZOK-32179] Fix response for agent without enabled unauthenticated .well-known route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
+## 0.29.29
+- `dragent/frontends`: **an agent that has not opted in to unauthenticated agent-card access now returns the generic `404 {"detail": "Not Found"}`, not a `401` explaining the opt-in.** The old refusal was an existence oracle twice over: the status code alone distinguished a live, not-opted-in agent from a nonexistent one, so an anonymous scanner could enumerate agents without reading a body, and the body then named `enable_unauthenticated_well_known_route` and its two required scopes. A blocked request is now indistinguishable from one for an agent that does not exist. The reason is logged server-side instead, so the refusal stays debuggable. Behaviour is unchanged for authenticated callers (full card) and for agents that have opted in (redacted card).
+
 ## 0.29.28
 - `drmcp/core/config`: **`oauth_claim_validation` is renamed `mcp_enable_oauth_claim_validation for MCP. The Agent config (oauth_claim_validation) stays the same.
 - `drmcp/core/middleware`: the flag now gates **every** AuthZ validator, not just the token handler. `BaseAuthZMiddleware` applies it once in `dispatch`; subclasses implement `run_authz`.

--- a/docs/src/nat/a2a-auth.md
+++ b/docs/src/nat/a2a-auth.md
@@ -254,8 +254,9 @@ DataRobot API tokens, a non-JWT value there is ignored rather than rejected.
 - Signature, issuer and expiry are **not** re-verified — the gateway owns that.
 - No route is exempt, agent-card discovery included. Auth there is optional, so an
   unauthenticated request still reaches the handler and
-  `enable_unauthenticated_well_known_route` decides what it sees; a request that *does* carry a
-  token is validated first, and one naming another agent gets `401` instead of a card.
+  `enable_unauthenticated_well_known_route` decides whether it sees a redacted card or a
+  generic `404`; a request that *does* carry a token is validated first, and one naming
+  another agent gets `401` instead of a card.
 - Off unless `a2a.oauth_claim_validation: true` is set. With the flag on but no
   `cross_application_access.token_request.audience` to enforce, startup fails rather than
   pretending to. Either state is logged at startup.
@@ -285,10 +286,17 @@ Both must be enabled for anonymous callers to reach the agent card endpoint.
 The agent-side flag is enforced by the A2A server in this library; platform
 routing is enforced before the request reaches the agent process.
 
+When the agent-side flag is off, an anonymous request gets the same generic
+`404 {"detail": "Not Found"}` as a request for an agent that does not exist —
+never a `401`, and never a body naming the flag. A distinguishable refusal is an
+existence oracle: it would let an anonymous scanner enumerate live agents by
+status code alone and tell it which knob unlocks the card. The reason is logged
+server-side instead, so the refusal stays debuggable from the agent's own logs.
+
 | Field | Default | Purpose |
 |-------|---------|---------|
 | `oauth_claim_validation` | `false` | Opt in to enforcing the inbound token's claims — `aud` today, `scope` later — on every route, not just `/a2a`. The value enforced comes from `cross_application_access.token_request.audience`. Not published on the agent card. |
-| `enable_unauthenticated_well_known_route` | `false` | Per-agent developer opt-in. When `true`, unauthenticated requests that reach the agent receive a redacted agent card. When `false`, they receive 401. Authenticated callers always receive the full card regardless of this setting. |
+| `enable_unauthenticated_well_known_route` | `false` | Per-agent developer opt-in. When `true`, unauthenticated requests that reach the agent receive a redacted agent card. When `false`, they receive the generic `404 {"detail": "Not Found"}` — indistinguishable from a nonexistent agent, so the refusal reveals nothing. Authenticated callers always receive the full card regardless of this setting. |
 
 ### Client-side configuration reference: `okta_cross_app_access`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.28"
+version = "0.29.29"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/frontends/a2a.py
+++ b/src/datarobot_genai/dragent/frontends/a2a.py
@@ -106,6 +106,12 @@ EXTERNAL_IDENTITY_DESCRIPTION = (
 
 _IDENTITY_EXTENSION_URIS = frozenset({INTERNAL_IDENTITY_URI, EXTERNAL_IDENTITY_URI})
 
+# Body served for every negative agent-card case, including an agent that has not opted in to
+# unauthenticated discovery.  A distinguishable response is an oracle: a 401 confirms to an
+# anonymous scanner that the agent exists, and naming the opt-in flag hands it the knob that
+# unlocks the card.  A not-opted-in agent must look exactly like one that does not exist.
+AGENT_CARD_NOT_FOUND_BODY = {"detail": "Not Found"}
+
 
 # ---------------------------------------------------------------------------
 # Endpoint URL
@@ -496,17 +502,15 @@ class DRAgentA2AStarletteApplication(A2AStarletteApplication):
                 resolve_identity_from_headers(headers, on_invalid_auth_context="none") is None
                 and not self._enable_unauthenticated_well_known_route
             ):
-                return JSONResponse(
-                    status_code=401,
-                    content={
-                        "error": (
-                            "Unauthenticated access to /.well-known/agent-card.json is "
-                            "disabled. Set enable_unauthenticated_well_known_route: true in "
-                            "workflow.yaml to allow anonymous access (also requires "
-                            "platform-level opt-in per cluster)."
-                        ),
-                    },
+                # The reason belongs in the log, not the response: the caller is anonymous and
+                # telling it why it was refused is what leaks the agent's existence.
+                logger.info(
+                    "Serving 404 for unauthenticated agent-card request: "
+                    "enable_unauthenticated_well_known_route is disabled for this agent "
+                    "(set it to true in workflow.yaml to allow anonymous access; also "
+                    "requires platform-level opt-in per cluster)"
                 )
+                return JSONResponse(status_code=404, content=AGENT_CARD_NOT_FOUND_BODY)
             return await super()._handle_get_agent_card(request)
         finally:
             _a2a_headers.reset(token)
@@ -531,8 +535,10 @@ class DRAgentA2AFrontEndPluginWorker(A2AFrontEndPluginWorker):
         flag only.
 
         When the agent flag is disabled (default), unauthenticated callers receive
-        401. When enabled, they receive a redacted card. Authenticated callers
-        always receive the full card. ``extended_agent_card`` is also wired for
+        the generic 404 -- indistinguishable from a nonexistent agent, so the
+        refusal is not an existence oracle. When enabled, they receive a redacted
+        card. Authenticated callers always receive the full card.
+        ``extended_agent_card`` is also wired for
         ``agent/getAuthenticatedExtendedCard`` clients.
         """
         base_server = super().create_a2a_server(agent_card, agent_executor)

--- a/src/datarobot_genai/dragent/frontends/claim_validation.py
+++ b/src/datarobot_genai/dragent/frontends/claim_validation.py
@@ -29,9 +29,9 @@ provider reads the token from there regardless of which route it arrived on.
 
 Agent-card discovery needs no exemption because auth there is optional, which the pass-through
 above already models: an unauthenticated request reaches ``_handle_get_agent_card``, which
-applies ``enable_unauthenticated_well_known_route`` and serves a redacted card or a 401. A
-request that *does* present a token gets the full check first -- a token naming another agent is
-rejected rather than earning a card.
+applies ``enable_unauthenticated_well_known_route`` and serves a redacted card or a generic
+404. A request that *does* present a token gets the full check first -- a token naming another
+agent is rejected rather than earning a card.
 
 Installed by ``fastapi.DRAgentFastApiFrontEndPluginWorker.build_app``.
 """

--- a/src/datarobot_genai/dragent/frontends/register.py
+++ b/src/datarobot_genai/dragent/frontends/register.py
@@ -94,8 +94,10 @@ class DRAgentA2AConfig(BaseModel):
             "Per-agent developer opt-in for unauthenticated "
             "GET /.well-known/agent-card.json. Also requires platform-level "
             "opt-in per cluster to route unauthenticated traffic to the agent. "
-            "When disabled (default), unauthenticated requests receive 401. "
-            "When enabled, anonymous callers receive a redacted agent card."
+            "When disabled (default), unauthenticated requests receive the same "
+            "generic 404 as a nonexistent agent, so the refusal does not reveal "
+            "that the agent exists. When enabled, anonymous callers receive a "
+            "redacted agent card."
         ),
     )
 

--- a/tests/dragent/frontends/test_a2a.py
+++ b/tests/dragent/frontends/test_a2a.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import logging
 import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -26,6 +27,7 @@ from datarobot_genai.dragent.cross_app_access_config import CrossAppTokenExchang
 from datarobot_genai.dragent.cross_app_access_config import CrossAppTokenRequest
 from datarobot_genai.dragent.deployment_urls import WORKLOAD_EXTERNAL_HOST_ENV
 from datarobot_genai.dragent.deployment_urls import WORKLOAD_EXTERNAL_PREFIX_ENV
+from datarobot_genai.dragent.frontends.a2a import AGENT_CARD_NOT_FOUND_BODY
 from datarobot_genai.dragent.frontends.a2a import BEARER_SECURITY_DESCRIPTION
 from datarobot_genai.dragent.frontends.a2a import BEARER_SECURITY_SCHEME_NAME
 from datarobot_genai.dragent.frontends.a2a import CROSS_APP_EXTENSION_DESCRIPTION
@@ -498,13 +500,37 @@ class TestUnauthenticatedWellKnownRoute:
             enable_unauthenticated_well_known_route=enable_unauthenticated_well_known_route,
         )
 
-    async def test_unauthenticated_without_opt_in_returns_401(self, a2a_frontend_config):
+    async def test_unauthenticated_without_opt_in_returns_generic_404(self, a2a_frontend_config):
+        """A not-opted-in agent must be indistinguishable from one that does not exist."""
         server = await self._make_server(a2a_frontend_config)
         response = await server._handle_get_agent_card(self._make_request())
-        assert response.status_code == 401
-        body = json.loads(response.body)
-        assert "error" in body
-        assert "enable_unauthenticated_well_known_route" in body["error"]
+        assert response.status_code == 404
+        assert json.loads(response.body) == AGENT_CARD_NOT_FOUND_BODY
+
+    async def test_unauthenticated_without_opt_in_leaks_nothing_in_the_body(
+        self, a2a_frontend_config
+    ):
+        """The refusal must not name the opt-in flag, the agent, or the reason it was refused."""
+        server = await self._make_server(a2a_frontend_config)
+        response = await server._handle_get_agent_card(self._make_request())
+        body = response.body.decode()
+        for leak in (
+            "enable_unauthenticated_well_known_route",
+            "workflow.yaml",
+            "unauthenticated",
+            "platform-level",
+            a2a_frontend_config.name,
+        ):
+            assert leak.lower() not in body.lower(), f"agent-card 404 leaks {leak!r}"
+
+    async def test_unauthenticated_without_opt_in_logs_the_reason_server_side(
+        self, a2a_frontend_config, caplog
+    ):
+        """The reason stays debuggable in the log even though it is kept out of the response."""
+        server = await self._make_server(a2a_frontend_config)
+        with caplog.at_level(logging.INFO, logger="datarobot_genai.dragent.frontends.a2a"):
+            await server._handle_get_agent_card(self._make_request())
+        assert "enable_unauthenticated_well_known_route" in caplog.text
 
     async def test_unauthenticated_with_opt_in_returns_redacted_card(self, a2a_frontend_config):
         server = await self._make_server(

--- a/uv.lock
+++ b/uv.lock
@@ -1130,7 +1130,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.28"
+version = "0.29.29"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION


<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [x] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped security hardening on optional anonymous agent-card discovery; authenticated and opt-in behaviors are unchanged. Callers that relied on 401 + explanatory JSON for debugging must use server logs instead.
> 
> **Overview**
> **Anonymous** `GET /.well-known/agent-card.json` on agents with `enable_unauthenticated_well_known_route: false` now returns **`404 {"detail": "Not Found"}`** instead of **`401`** with a body that named the opt-in flag and platform requirements. That closes an **existence oracle** (status + body let scanners enumerate live agents and learn how to unlock the card).
> 
> The refusal reason is **logged at INFO** on the agent so operators can still debug. **Authenticated** callers still get the full card; agents that **have** opted in still serve a **redacted** card to anonymous callers. Docs, config field descriptions, and tests (body must not leak config/agent name; log must mention the flag) are updated; release **0.29.29**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3bc2addbd29b7f04088b4fc942cfec494833f05. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->