### PR TITLE
[MMM-25197] ChatLiteLLM silently ignores base_url, causing external LLM calls to hit the wrong endpoint with a malformed auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
 
+## 0.29.32
+- `langgraph/llm`: fixed `base_url` being silently dropped when constructing an external `ChatLiteLLM` client.
+
 ## 0.29.31
 - `dragent`: A2A can now be mounted under a configurable `a2a.mount_path` (default `a2a`); the advertised agent card URL follows it across the gateway, deployment, workload and local-dev tiers. Mounting at the application root is rejected.
 - `dragent`: the agent card is also served at the root `/.well-known/agent-card.json` as a discovery fallback, whatever suffix A2A is mounted under. It shares the mounted route's handler, so the unauthenticated-access policy — including the generic `404` from 0.29.29 — holds on both paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.31"
+version = "0.29.32"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/langgraph/llm.py
+++ b/src/datarobot_genai/langgraph/llm.py
@@ -62,6 +62,14 @@ def _create_datarobot_chat_litellm(config: dict[str, Any]) -> Any:
     from langchain_litellm import ChatLiteLLM  # noqa: PLC0415
 
     config.pop("assume_native_tool_calling_when_unmapped", None)
+    # ChatLiteLLM's pydantic model has no `base_url` field (it's `api_base`) and is
+    # extra="ignore", so a `base_url` key here is silently dropped rather than raising --
+    # the client then falls back to litellm's default endpoint for the custom provider
+    # instead of the caller's real one. get_external_llm/get_datarobot_*_llm build this
+    # dict from an OpenAI-style config (`base_url`), so translate it here rather than at
+    # every call site.
+    if "base_url" in config:
+        config["api_base"] = config.pop("base_url")
     if config.get("streaming"):
         config["stream_options"] = {"include_usage": True}
     else:

--- a/tests/langgraph/test_llm.py
+++ b/tests/langgraph/test_llm.py
@@ -148,6 +148,20 @@ def test_get_external_llm_merges_parameters() -> None:
     assert llm.temperature == 0.7
 
 
+def test_get_external_llm_translates_base_url_to_api_base() -> None:
+    """Regression test: ChatLiteLLM has no `base_url` field (only `api_base`) and is
+    extra="ignore", so an untranslated `base_url` silently drops -- the client then
+    falls back to litellm's default endpoint for the custom provider instead of the
+    caller's real one, breaking LLM Gateway auth for any LangChain-framework NAT
+    agent using `datarobot-llm-component` with an explicit `base_url` (its config
+    class is `OpenAIModelConfig`-derived, so its field is `base_url`, not `api_base`).
+    """
+    llm = langgraph_llm.get_external_llm(
+        parameters={"base_url": "https://example.test/genai/llmgw"}
+    )
+    assert llm.api_base == "https://example.test/genai/llmgw"
+
+
 def test_get_llm_routes_to_gateway() -> None:
     config = MagicMock()
     config.get_llm_type.return_value = LLMType.GATEWAY


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how external LLM HTTP endpoints are chosen for gateway-backed agents; incorrect behavior previously broke auth routing, but the fix is a single chokepoint mapping plus a regression test.
> 
> **Overview**
> Fixes **external LangGraph LLM clients** silently ignoring an OpenAI-style **`base_url`** in merged parameters, which caused **ChatLiteLLM** to fall back to LiteLLM’s default host and break **LLM Gateway** routing/auth for NAT agents (e.g. `datarobot-llm-component` configs).
> 
> **`_create_datarobot_chat_litellm`** now renames **`base_url` → `api_base`** before instantiating ChatLiteLLM (Pydantic `extra="ignore"` otherwise drops `base_url`). A regression test asserts **`get_external_llm(parameters={"base_url": ...})`** sets **`llm.api_base`** correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c69408d93a5ab23327a63489201f1810ec0fe9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->