### PR TITLE
BUZZOK-32311: fix: broken docs/README.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Follow [quickstart.ipynb](e2e-tests/examples/quickstart.ipynb) to walk through a
 * Running the agent with an AG-UI interface.
 
 ## In-depth documentation
-See [docs/README.md](docs/README.md) for guides on every framework and feature in `datarobot-genai`.
+See [genai.datarobot.com](https://genai.datarobot.com/) for guides on every framework and feature in `datarobot-genai`.
 
 # Develop
 You need Python 3.11–3.13, uv, Task CLI, and pre-commit.


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE

The README's "In-depth documentation" section links to `docs/README.md`, which no longer exists — docs were migrated to mkdocs hosted at genai.datarobot.com and the link was left unchanged. Reported in Slack: https://datarobot.slack.com/archives/C07DQSG302C/p1788550581961139

## CHANGES

- Point the "In-depth documentation" link to https://genai.datarobot.com/ instead of the removed `docs/README.md`

## Checklist
- [x] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation URL change with no runtime or security impact.
> 
> **Overview**
> Fixes a broken **In-depth documentation** link in the root `README.md`.
> 
> The section previously pointed at `docs/README.md`, which was removed when documentation moved to MkDocs. It now links to [genai.datarobot.com](https://genai.datarobot.com/) for framework and feature guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3595ab4d79bc5bd7825865ab2cf3203535d25b6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->