### PR TITLE
[MODEL-24523] Add more logging in oauth jwt middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
 
+## 0.29.34
+- `drmcp/core/middleware`: Add more logging in MCP OAuth JWT middleware
+
 ## 0.29.33 - 2026-09-08
 - Raise the minimum `banks` version from `>=2.4.2` to `>=2.4.5`.
 - Add a minimum version for `langchain-core`: `>=1.3.3`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.33"
+version = "0.29.34"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/drmcpbase/auth/jwt.py
+++ b/src/datarobot_genai/drmcpbase/auth/jwt.py
@@ -45,6 +45,7 @@ class JWTTokenHandler:
         elif bearer_token_header_can_be_missing:
             return bearer_token_header
         else:
+            logger.info("No Bearer token value found")
             return None
 
     @staticmethod
@@ -104,6 +105,7 @@ class JWTTokenHandler:
             except (jwt.exceptions.PyJWTError, ValueError, TypeError):
                 logger.error("Failed to decode JWT", exc_info=True)
                 return None
+        logger.info("No JWT bearer token found in inbound request")
         return None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1131,7 +1131,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.33"
+version = "0.29.34"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
INFO: Comment "/build" to build a dev package
-->

# RATIONALE
This PR improved the MCP JWT token handling middleware error handling.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive info-level logging on the OAuth JWT path only; no changes to token parsing, claim validation, or authorization decisions.
> 
> **Overview**
> Release **0.29.34** with changelog and lockfile version bumps only beyond the functional change.
> 
> **MCP OAuth JWT handling** (`drmcpbase/auth/jwt.py`, consumed by `OAuthJWTTokenHandlerMiddleware`) now logs at **info** when inbound auth cannot be parsed as a JWT bearer: missing/invalid Bearer scheme (when a strict Bearer value is required) and when no JWT is present after header parsing. Existing decode failures still log at **error** with stack traces; validation behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b523b7dc293dfde2199f122738f6bb51ee9531f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->