### PR TITLE
[MODEL-24907] Fix mcp well known endpoint in nat mcp xaa client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\
 
+## 0.29.38
+- `dragent/plugins/datarobot_user_mcp_xaa_client` Fixed MCP well-known endpoint in NAT MCP XAA client.
+
 ## 0.29.37
 - Removed `register_metadata_routes` from `drmcpbase/routes` — global-mcp owns `GET /metadata` locally. user-mcp's inline `/metadata` route in `drmcp/core/routes.py` is unchanged.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datarobot-genai"
-version = "0.29.37"
+version = "0.29.38"
 description = "Generic helpers for GenAI"
 readme = "README.md"
 requires-python = ">=3.11, <3.14"

--- a/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xaa_client.py
+++ b/src/datarobot_genai/dragent/plugins/datarobot_user_mcp_xaa_client.py
@@ -121,10 +121,10 @@ def get_mcp_auth_server_metadata_url(
 ) -> str:
     mcp_server_url = str(config.server.url)
     url_split = urlsplit(mcp_server_url)
-    return (
-        f"{url_split.scheme}://{url_split.netloc}"
-        f"/.well-known/oauth-protected-resource{url_split.path}"
-    )
+    url_path = url_split.path.rstrip("/")
+    if url_path.endswith("/mcp"):
+        url_path = url_path[: -len("/mcp")]
+    return f"{url_split.scheme}://{url_split.netloc}{url_path}/.well-known/oauth-protected-resource"
 
 
 async def get_xaa_params_from_mcp_auth_server_metadata(

--- a/tests/dragent/plugins/test_datarobot_user_mcp_xaa_client.py
+++ b/tests/dragent/plugins/test_datarobot_user_mcp_xaa_client.py
@@ -241,11 +241,22 @@ class TestSetupAuthProvider:
         ) as mock_func:
             yield mock_func
 
-    def test_get_mcp_auth_server_metadata_url(self) -> None:
+    @pytest.mark.parametrize(
+        "server_url",
+        [
+            "https://foo:8081/bar/mcp",
+            "https://foo:8081/bar/mcp/",
+            "https://foo:8081/bar",
+            # workload_id segment happens to start with "mcp" - must not be truncated early
+            "https://foo:8081/bar/mcp-workload-1/mcp",
+        ],
+    )
+    def test_get_mcp_auth_server_metadata_url(self, server_url: str) -> None:
         config = Mock()
-        config.server.url = "https://foo:8081/bar/mcp"
+        config.server.url = server_url
         output = get_mcp_auth_server_metadata_url(config)
-        assert output == "https://foo:8081/.well-known/oauth-protected-resource/bar/mcp"
+        expected_path = "/bar/mcp-workload-1" if "mcp-workload-1" in server_url else "/bar"
+        assert output == f"https://foo:8081{expected_path}/.well-known/oauth-protected-resource"
 
     def test_get_xaa_params_from_config(self) -> None:
         xaa_config = Mock()

--- a/uv.lock
+++ b/uv.lock
@@ -1131,7 +1131,7 @@ wheels = [
 
 [[package]]
 name = "datarobot-genai"
-version = "0.29.37"
+version = "0.29.38"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION

# RATIONALE
This PR fixed mcp well known endpoint in nat mcp xaa client. It followed the following rule
 - original url: https://app.datarobot.com/api/v2/endpoints/workloads/{workload_id}/mcp
 - well-known url: https://app.datarobot.com/api/v2/endpoints/workloads/{workload_id}/.well-known/oauth-protected-resource


## CHANGES

## Checklist
- [ ] Reviewed [guideline](https://datarobot.atlassian.net/wiki/spaces/BUZOK/pages/7305920528/REVIEW+BEFORE+COMMIT+Working+with+agentic+starter+application+and+its+components)
- [ ] Updated Changelog
- [ ] New tools in `src/datarobot_genai/drtools/` require to add `integration` tests in `tests/drmcp/integration/` and `acceptance` tests in `tests/drmcp/acceptance/` (this is a MUST)

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the NAT MCP XAA client discovers OAuth protected-resource metadata; a wrong URL would break cross-app token setup, though behavior is narrow and covered by new parametrized tests.
> 
> **Overview**
> Fixes **OAuth protected-resource discovery** for the NAT `mcp_client_with_xaa_support` plugin so the well-known URL matches workload MCP routing.
> 
> `get_mcp_auth_server_metadata_url` no longer inserts `/.well-known/oauth-protected-resource` after the full MCP path (which produced URLs like `…/.well-known/oauth-protected-resource/bar/mcp`). It now normalizes the server path (strip trailing `/`, drop a trailing `/mcp` segment only) and appends `/.well-known/oauth-protected-resource` on the workload base—e.g. `…/workloads/{id}/mcp` → `…/workloads/{id}/.well-known/oauth-protected-resource`.
> 
> Release **0.29.38** with changelog; unit tests cover trailing slashes, paths without `/mcp`, and workload IDs that contain `mcp` in the segment name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40d0e4db8fdcdcd598621303ed02666e41e12ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->